### PR TITLE
Reverted changes of the selecting device BOX

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/presenter/keygen/components/DeviceInfo.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/keygen/components/DeviceInfo.kt
@@ -43,8 +43,8 @@ fun DeviceInfo(
 ) {
     Column(
         modifier = Modifier
-            .width(80.dp)
-            .height(120.dp)
+            .width(122.dp)
+            .height(165.dp)
             .clip(shape = RoundedCornerShape(size = MaterialTheme.dimens.small1))
             .background(MaterialTheme.appColor.oxfordBlue600Main)
             .clickable {
@@ -96,6 +96,7 @@ fun DeviceInfo(
             modifier = Modifier.align(CenterHorizontally),
             text = name,
             overflow = TextOverflow.Ellipsis,
+            maxLines = 2,
             color = MaterialTheme.appColor.neutral0,
             style = MaterialTheme.montserratFamily.titleMedium,
             textAlign = TextAlign.Center


### PR DESCRIPTION
Somebody changed the Layout specs. I just reverted the changes.

Reverting back to: https://github.com/vultisig/vultisig-android/issues/27

Actual changed layout when selecting device:
![Screenshot_1715192682](https://github.com/vultisig/vultisig-android/assets/168392124/7a5d7e34-63a3-4416-ad69-0ea8068deb03)

