### PR TITLE
When gas is zero , hide gas field on verify transaction screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/on_board/db/OrderDB.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/on_board/db/OrderDB.kt
@@ -60,7 +60,7 @@ class OrderDB @Inject constructor(@ApplicationContext context: Context, private 
 
     fun removeOrder(key: String) {
         ordersFolder.listFiles()?.forEach { fileLocation ->
-            val order = gson.fromJson(fileLocation.readText(), Order::class.java)
+            val order = gson.fromJson(fileLocation.readText(), Order::class.java) ?: return
             val updatedPositions =
                 order.positions.toMutableList().apply { removeIf { it.key == key } }
             fileLocation.writeText(gson.toJson(order.copy(positions = updatedPositions.toList())))

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -30,6 +30,7 @@ data class TransactionUiModel(
     val fiatValue: String = "",
     val fiatCurrency: String = "",
     val gasValue: String = "",
+    val showGasField: Boolean = true,
 )
 
 @Immutable

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TokenValueToDecimalUiStringMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TokenValueToDecimalUiStringMapper.kt
@@ -19,7 +19,7 @@ internal class TokenValueToDecimalUiStringMapperImpl @Inject constructor() :
     }
 
     companion object {
-        private const val MAX_UI_TOKEN_VALUE_DECIMALS = 6
+        private const val MAX_UI_TOKEN_VALUE_DECIMALS = 8
     }
 
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -26,6 +26,7 @@ internal class TransactionToUiModelMapperImpl @Inject constructor(
             fiatValue = fiatValueString,
             fiatCurrency = fiatValue.currency,
             gasValue = gasFeeString,
+            showGasField = from.gasFee.value > 0.toBigInteger()
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/VerifyTransactionScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/VerifyTransactionScreen.kt
@@ -129,12 +129,13 @@ internal fun VerifyTransactionScreen(
                         ),
                         value = state.transaction.fiatValue,
                     )
-
-                    OtherField(
-                        title = stringResource(R.string.verify_transaction_gas_title),
-                        value = state.transaction.gasValue,
-                        divider = false
-                    )
+                    if (state.transaction.showGasField) {
+                        OtherField(
+                            title = stringResource(R.string.verify_transaction_gas_title),
+                            value = state.transaction.gasValue,
+                            divider = false
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,7 +176,7 @@
     <string name="this_device">(This Device)</string>
     <string name="device_list_of_vault">%1$s of %2$s Vault</string>
     <string name="vault_settings_delete_vault_caution1">I am aware that the vault will be deleted permanetly</string>
-    <string name="vault_settings_delete_vault_caution2">I am aware that I can loose funds</string>
+    <string name="vault_settings_delete_vault_caution2">I am aware that I can lost funds</string>
     <string name="vault_settings_delete_vault_caution3">I have made a vault backup</string>
     <string name="confirm_delete_permanent_delete_message">You are permanently deleting your vault</string>
     <string name="confirm_delete_delete_vault">Delete Vault</string>


### PR DESCRIPTION
1. When gas is zero , hide gas field on verify transaction screen
2. Fix the bug that delete vault cause the app to crash
3. a typo on delete vault screen 