### PR TITLE
Update: Token and Chain logo

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/models/Coin.kt
+++ b/app/src/main/java/com/vultisig/wallet/models/Coin.kt
@@ -289,7 +289,7 @@ object Coins {
         Coin(
             chain = Chain.base,
             ticker = "ETH",
-            logo = "eth_base",
+            logo = "eth",
             address = "",
             decimal = 18,
             hexPublicKey = "",
@@ -300,7 +300,7 @@ object Coins {
         Coin(
             chain = Chain.arbitrum,
             ticker = "ETH",
-            logo = "eth_arbitrum",
+            logo = "eth",
             address = "",
             decimal = 18,
             hexPublicKey = "",
@@ -344,7 +344,7 @@ object Coins {
         Coin(
             chain = Chain.optimism,
             ticker = "ETH",
-            logo = "eth_optimism",
+            logo = "eth",
             address = "",
             decimal = 18,
             hexPublicKey = "",
@@ -410,7 +410,7 @@ object Coins {
         Coin(
             chain = Chain.blast,
             ticker = "ETH",
-            logo = "eth_blast",
+            logo = "eth",
             address = "",
             decimal = 18,
             hexPublicKey = "",


### PR DESCRIPTION
This update resolves Chain logo issue in ChainTokensScreen.kt

### Before:

 <img width="315" alt="Screenshot 2024-05-28 at 14 51 58" src="https://github.com/vultisig/vultisig-android/assets/32006742/0432295f-16f6-40b7-a78b-09aca7f82b14">
<img width="316" alt="Screenshot 2024-05-28 at 14 52 04" src="https://github.com/vultisig/vultisig-android/assets/32006742/c38fa3ed-4992-488c-b821-11a6d8fff448">

### After:

<img width="366" alt="Screenshot 2024-05-28 at 14 53 07" src="https://github.com/vultisig/vultisig-android/assets/32006742/df587b2b-60c1-4e5d-9972-b781665219b9">
<img width="386" alt="Screenshot 2024-05-28 at 14 53 12" src="https://github.com/vultisig/vultisig-android/assets/32006742/caac842f-90ed-491b-a72f-22df403397b3">
