### PR TITLE
Fix/crash on duplicate vault

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileEvent.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileEvent.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.presenter.import_file
 
 import android.net.Uri
+import com.vultisig.wallet.common.UiText
 
 sealed class ImportFileEvent {
     data class FileSelected(val uri: Uri?) : ImportFileEvent()

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
@@ -218,7 +218,7 @@ Box(Modifier.padding(it)) {
 
             UiSpacer(weight = 1f)
 
-        }/*re*/
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
@@ -23,8 +23,10 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
@@ -35,6 +37,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -45,6 +48,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.vultisig.wallet.R
+import com.vultisig.wallet.common.asString
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.FileSelected
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.OnContinueClick
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.RemoveSelectedFile
@@ -60,6 +64,16 @@ internal fun ImportFileScreen(
     viewModel: ImportFileViewModel = hiltViewModel(),
 ) {
     val uiModel by viewModel.uiModel.collectAsState()
+    val snackBarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.snackBarChannelFlow.collect { snackBarMessage ->
+                snackBarMessage?.let {
+                    snackBarHostState.showSnackbar(it.asString(context))
+                }
+        }
+    }
 
     val launcher =
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
@@ -77,7 +91,8 @@ internal fun ImportFileScreen(
         },
         onContinue = {
             viewModel.onEvent(OnContinueClick)
-        }
+        },
+        snackBarHostState=snackBarHostState
     )
 }
 
@@ -88,12 +103,27 @@ private fun ImportFileScreen(
     onImportFile: () -> Unit = {},
     onRemoveSelectedFile: () -> Unit = {},
     onContinue: () -> Unit = {},
-    snackBarSatate : SnackbarHostState
+    snackBarHostState : SnackbarHostState = remember { SnackbarHostState() }
 ) {
     val appColor = Theme.colors
     val menloFamily = Theme.menlo
 
-    Scaffold(snackbarHost = SnackbarHost{snackBarSatate}) {
+    Scaffold(snackbarHost = {
+        SnackbarHost(snackBarHostState)
+    }, bottomBar = {
+        MultiColorButton(
+            text = stringResource(R.string.send_continue_button),
+            textColor = Theme.colors.oxfordBlue800,
+            disabled = uiModel.fileName == null,
+            minHeight = 44.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 16.dp,
+                ),
+            onClick = onContinue,
+        )
+    }) {
 Box(Modifier.padding(it)) {
 
     UiBarContainer(
@@ -188,18 +218,6 @@ Box(Modifier.padding(it)) {
 
             UiSpacer(weight = 1f)
 
-            MultiColorButton(
-                text = stringResource(R.string.send_continue_button),
-                textColor = Theme.colors.oxfordBlue800,
-                disabled = uiModel.fileName == null,
-                minHeight = 44.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        vertical = 16.dp,
-                    ),
-                onClick = onContinue,
-            )
         }/*re*/
     }
 }
@@ -214,5 +232,6 @@ private fun ImportFilePreview() {
     ImportFileScreen(
         navController = navController,
         uiModel = ImportFileState(),
+        snackBarHostState = SnackbarHostState()
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -85,9 +88,13 @@ private fun ImportFileScreen(
     onImportFile: () -> Unit = {},
     onRemoveSelectedFile: () -> Unit = {},
     onContinue: () -> Unit = {},
+    snackBarSatate : SnackbarHostState
 ) {
     val appColor = Theme.colors
     val menloFamily = Theme.menlo
+
+    Scaffold(snackbarHost = SnackbarHost{snackBarSatate}) {
+Box(Modifier.padding(it)) {
 
     UiBarContainer(
         navController = navController,
@@ -193,7 +200,10 @@ private fun ImportFileScreen(
                     ),
                 onClick = onContinue,
             )
-        }
+        }/*re*/
+    }
+}
+
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileViewModel.kt
@@ -1,10 +1,14 @@
 package com.vultisig.wallet.presenter.import_file
 
 import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.gson.Gson
+import com.vultisig.wallet.R
+import com.vultisig.wallet.common.UiText
 import com.vultisig.wallet.common.decodeFromHex
 import com.vultisig.wallet.common.fileContent
 import com.vultisig.wallet.common.fileName
@@ -14,14 +18,18 @@ import com.vultisig.wallet.models.IOSVaultRoot
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.FileSelected
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.OnContinueClick
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.RemoveSelectedFile
+import com.vultisig.wallet.presenter.vault_setting.vault_edit.VaultEditUiEvent
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
 
 @HiltViewModel
 internal class ImportFileViewModel @Inject constructor(
@@ -33,6 +41,8 @@ internal class ImportFileViewModel @Inject constructor(
 ) : ViewModel() {
     val uiModel = MutableStateFlow(ImportFileState())
 
+    private val channel = Channel<VaultEditUiEvent>()
+    val channelFlow = channel.receiveAsFlow()
     fun onEvent(event: ImportFileEvent) {
         when (event) {
             is FileSelected -> fetchFileName(event.uri)
@@ -45,14 +55,19 @@ internal class ImportFileViewModel @Inject constructor(
         if (fileContent == null)
             return
         viewModelScope.launch {
-            val fromJson = gson.fromJson(fileContent.decodeFromHex(), IOSVaultRoot::class.java)
-            val vault = vaultIOSToAndroidMapper(fromJson)
-            vaultRepository.add(vault)
-            navigator.navigate(
-                Destination.Home(
-                    openVaultId = vault.id,
+            try {
+                val fromJson = gson.fromJson(fileContent.decodeFromHex(), IOSVaultRoot::class.java)
+                val vault = vaultIOSToAndroidMapper(fromJson)
+                vaultRepository.add(vault)
+                navigator.navigate(
+                    Destination.Home(
+                        openVaultId = vault.id,
+                    )
                 )
-            )
+                } catch (e: SQLiteConstraintException) {
+                    channel.send(VaultEditUiEvent.ShowSnackBar(UiText.StringResource(R.string.import_file_screen_duplicate_vault)))
+            }
+
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileViewModel.kt
@@ -3,12 +3,12 @@ package com.vultisig.wallet.presenter.import_file
 import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
-import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.gson.Gson
 import com.vultisig.wallet.R
 import com.vultisig.wallet.common.UiText
+import com.vultisig.wallet.common.asString
 import com.vultisig.wallet.common.decodeFromHex
 import com.vultisig.wallet.common.fileContent
 import com.vultisig.wallet.common.fileName
@@ -18,7 +18,6 @@ import com.vultisig.wallet.models.IOSVaultRoot
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.FileSelected
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.OnContinueClick
 import com.vultisig.wallet.presenter.import_file.ImportFileEvent.RemoveSelectedFile
-import com.vultisig.wallet.presenter.vault_setting.vault_edit.VaultEditUiEvent
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -41,8 +40,8 @@ internal class ImportFileViewModel @Inject constructor(
 ) : ViewModel() {
     val uiModel = MutableStateFlow(ImportFileState())
 
-    private val channel = Channel<VaultEditUiEvent>()
-    val channelFlow = channel.receiveAsFlow()
+    private val snackBarChannel = Channel<UiText?>()
+    val snackBarChannelFlow = snackBarChannel.receiveAsFlow()
     fun onEvent(event: ImportFileEvent) {
         when (event) {
             is FileSelected -> fetchFileName(event.uri)
@@ -65,7 +64,7 @@ internal class ImportFileViewModel @Inject constructor(
                     )
                 )
                 } catch (e: SQLiteConstraintException) {
-                    channel.send(VaultEditUiEvent.ShowSnackBar(UiText.StringResource(R.string.import_file_screen_duplicate_vault)))
+                    snackBarChannel.send(UiText.StringResource(R.string.import_file_screen_duplicate_vault))
             }
 
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="import_file_screen_enter_your_previously_created_vault_share">Enter your previously created vault share</string>
     <string name="import_file_screen_upload_file_text_or_image">Upload file, text or image</string>
     <string name="import_file_screen_continue">Continue</string>
+    <string name="import_file_screen_duplicate_vault">The vault is duplicate</string>
     <string name="create_new_vault_screen_vultisig">Vultisig</string>
     <string name="create_new_vault_screen_secure_crypto_vault">SECURE CRYPTO VAULT</string>
     <string name="create_new_vault_screen_create_a_new_vault">Create a New Vault</string>


### PR DESCRIPTION
Handle the scenario where importing a duplicate vault causes a crash by displaying a SnackBar message to inform the user about the duplicate vault
