### PR TITLE
Update clipboard text to use transactionLink instead of transactionHash in TransactionDoneScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -78,7 +78,7 @@ internal fun TransactionDoneView(
                         drawableResId = R.drawable.copy,
                         size = 20.dp,
                         onClick = {
-                            clipboard.setText(AnnotatedString(transactionHash))
+                            clipboard.setText(AnnotatedString(transactionLink))
                         }
                     )
 


### PR DESCRIPTION
Close #319 
