### PR TITLE
HotFix: Correct QR Code Handling in Swap Screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -95,7 +95,6 @@ internal fun SwapScreen(
         navController = topBarNavController,
         title = title,
         progress = progress,
-        endIcon = qrCodeResult?.let { R.drawable.qr_share },
         endIcon = qrCodeResult?.takeIf { it.isNotEmpty() }?.let { R.drawable.qr_share },
         onEndIconClick = qrCodeResult?.let {
             {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -96,6 +96,7 @@ internal fun SwapScreen(
         title = title,
         progress = progress,
         endIcon = qrCodeResult?.let { R.drawable.qr_share },
+        endIcon = qrCodeResult?.takeIf { it.isNotEmpty() }?.let { R.drawable.qr_share },
         onEndIconClick = qrCodeResult?.let {
             {
                 val qrBitmap = generateQrBitmap(it)


### PR DESCRIPTION
The QR code was being incorrectly handled when `qrCodeResult` was empty, leasing to unexpected behavior.

