### PR TITLE
Remove caret_left icon from AddVaultScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/AddVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/AddVaultScreen.kt
@@ -71,7 +71,6 @@ private fun AddVaultScreen(
             TopBar(
                 navController = navController,
                 centerText = "",
-                startIcon = R.drawable.caret_left,
                 endIcon = R.drawable.question,
                 onEndIconClick = onOpenHelp,
             )


### PR DESCRIPTION
Closes #357

Remove caret_left icon from AddVaultScreen based on the latest Figma design update

![image](https://github.com/vultisig/vultisig-android/assets/32006742/b4609f81-7685-4308-8de4-7a51c8d7bfb7)
