### PR TITLE
Improve Debounce Click Handling

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -12,32 +11,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import kotlinx.coroutines.delay
 
+private const val COOL_DOWN_PERIOD = 1200L
+private var lastClickTime = 0L
 
-fun Modifier.clickOnce(enabled: Boolean = true, onClick: () -> Unit) =
-    this.composed {
-        var enableAgain by remember { mutableStateOf(true) }
-        LaunchedEffect(enableAgain, block = {
-            if (enableAgain) return@LaunchedEffect
-            delay(timeMillis = 500L)
-            enableAgain = true
-        })
-        Modifier.clickable(enabled = enabled) {
-            if (enableAgain) {
-                enableAgain = false
-                onClick()
-            }
-        }
+fun Modifier.clickOnce(enabled: Boolean = true, onClick: () -> Unit) = this.composed {
+    var enableAgain by remember { mutableStateOf(true) }
+
+    LaunchedEffect(enableAgain) {
+        if (enableAgain) return@LaunchedEffect
+        delay(timeMillis = COOL_DOWN_PERIOD)
+        enableAgain = true
     }
 
-@Composable
-fun ClickOnce(
-    onClick: () -> Unit
-): () -> Unit {
-    var lastClickTime by remember { mutableLongStateOf(0L) }
+    Modifier.clickable(enabled = enabled) {
+        val currentTime = System.currentTimeMillis()
+        if (enableAgain && currentTime - lastClickTime >= COOL_DOWN_PERIOD) {
+            lastClickTime = currentTime
+            enableAgain = false
+            onClick()
+        }
+    }
+}
 
+@Composable
+fun ClickOnce(onClick: () -> Unit): () -> Unit {
     return {
         val currentTime = System.currentTimeMillis()
-        if (currentTime - lastClickTime >= 500L) {
+        if (currentTime - lastClickTime >= COOL_DOWN_PERIOD) {
             lastClickTime = currentTime
             onClick()
         }

--- a/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import kotlinx.coroutines.delay
 
-private const val COOL_DOWN_PERIOD = 1700L
+private const val COOL_DOWN_PERIOD = 1400L
 private var lastClickTime = 0L
 
 fun Modifier.clickOnce(enabled: Boolean = true, onClick: () -> Unit) = this.composed {

--- a/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/common/Onclick.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import kotlinx.coroutines.delay
 
-private const val COOL_DOWN_PERIOD = 1200L
+private const val COOL_DOWN_PERIOD = 1700L
 private var lastClickTime = 0L
 
 fun Modifier.clickOnce(enabled: Boolean = true, onClick: () -> Unit) = this.composed {

--- a/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/presenter/import_file/ImportFileScreen.kt
@@ -123,7 +123,7 @@ private fun ImportFileScreen(
                 .padding(
                     vertical = 16.dp,
                 ),
-            onClick = ClickOnce(onContinue),
+            onClick = onContinue,
         )
     }) {
 Box(Modifier.padding(it)) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.models.Vault
+import com.vultisig.wallet.presenter.common.ClickOnce
 import com.vultisig.wallet.presenter.common.clickOnce
 import com.vultisig.wallet.ui.components.library.form.FormCard
 import com.vultisig.wallet.ui.theme.Theme
@@ -31,7 +32,9 @@ internal fun VaultCeil(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .clickOnce(onClick = { onSelectVault(vault.id) })
+                .clickOnce(onClick = ClickOnce {
+                    onSelectVault(vault.id)
+                })
                 .padding(all = 14.dp)
         ) {
             Icon(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/ConfirmDeleteScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/ConfirmDeleteScreen.kt
@@ -120,9 +120,7 @@ internal fun ConfirmDeleteScreen(
                         bottom = 16.dp,
                     ),
                 text = stringResource(R.string.confirm_delete_delete_vault),
-                onClick = ClickOnce {
-                    onConfirmClick()
-                },
+                onClick = onConfirmClick,
                 disabled = isDeleteButtonActive.not()
             )
         }


### PR DESCRIPTION
Fixes https://github.com/vultisig/vultisig-android/issues/265#issuecomment-2178010949
This PR introduces an enhancement to the debounce click handling mechanism in our application. Previously, the cooldown period was not shared between different views, which could lead to inconsistent behavior when rapidly switching between views and clicking on different elements.

  **Changes include:**  

- Refactoring the clickOnce function in Onclick.kt to ensure that the cooldown period is shared across all views. This prevents rapid, successive clicks from being registered in different views during the cooldown period.
- Adjusting the COOL_DOWN_PERIOD constant to fine-tune the length of the cooldown period based on user interaction testing.
- This change improves the user experience by ensuring consistent click handling across the application, regardless of how quickly a user may switch between views or click on different elements.