### PR TITLE
Handle Camera Bug on Back Navigation

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -205,6 +206,18 @@ private fun QrCameraScreen(
     val cameraProviderFuture = remember {
         ProcessCameraProvider.getInstance(localContext)
     }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            cameraProviderFuture.addListener(
+                {
+                    cameraProviderFuture.get().unbindAll()
+                },
+                ContextCompat.getMainExecutor(localContext)
+            )
+        }
+    }
+
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = { context ->


### PR DESCRIPTION
This PR addresses a bug in the camera handling in the ScanQrScreen. Previously, pressing back to ScanQrScreen did not properly unbind the camera provider, leading to a black screen
![Screenshot_20240630_113544](https://github.com/vultisig/vultisig-android/assets/32006742/52c05f73-0e30-4756-b224-5bc54d91f65e)
