### PR TITLE
Enforce hardcoded default chains when default chains are empty

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/repositories/DefaultChainsRepository.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/repositories/DefaultChainsRepository.kt
@@ -30,7 +30,7 @@ internal class DefaultChainsRepositoryImpl @Inject constructor(
                 } catch (e: Throwable) {
                     Timber.e(e)
                     DEFAULT_CHAINS_LIST
-                }
+                }.ifEmpty { DEFAULT_CHAINS_LIST }
             }
 
     override suspend fun setSelectedDefaultChains(chains: List<Chain>) {


### PR DESCRIPTION
Fix #468