### PR TITLE
Avoid swap choose a none swappable token to crash the app

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -71,7 +71,7 @@ internal data class SwapFormUiModel(
     val gas: String = "",
     val fee: String = "",
     val estimatedTime: UiText = UiText.DynamicString(""),
-    val amountError: UiText? = null
+    val amountError: UiText? = null,
 )
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -329,7 +329,7 @@ internal class SwapFormViewModel @Inject constructor(
         selectedSrcTokenId: String? = null,
         selectedDstTokenId: String? = null,
         vaultId: String,
-        chainId: String?
+        chainId: String?,
     ) {
         this.vaultId = vaultId
         loadTokens(selectedSrcTokenId, selectedDstTokenId, vaultId, chainId)
@@ -344,7 +344,7 @@ internal class SwapFormViewModel @Inject constructor(
         selectedSrcTokenId: String? = null,
         selectedDstTokenId: String? = null,
         vaultId: String,
-        chainId: String?
+        chainId: String?,
     ) {
         val chain = chainId?.let(Chain::fromRaw)
 
@@ -357,8 +357,12 @@ internal class SwapFormViewModel @Inject constructor(
                     // TODO handle error
                     Timber.e(it)
                 }.collect { addresses ->
-                    selectedSrc.updateSrc(selectedSrcTokenId, addresses, chain)
-                    selectedDst.updateSrc(selectedDstTokenId, addresses, chain)
+                    try {
+                        selectedSrc.updateSrc(selectedSrcTokenId, addresses, chain)
+                        selectedDst.updateSrc(selectedDstTokenId, addresses, chain)
+                    } catch (ex: Exception) {
+                        Timber.e(ex)
+                    }
                 }
         }
     }


### PR DESCRIPTION
@yvebe this is a bandaid solution , but at least this will stop the crash no matter what
can you please raise a PR to filter out those can't be swapped token on token selection screen? 