### PR TITLE
in case scan barcodes failed try to add borders to cover edge case

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -62,8 +62,6 @@ import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.addWhiteBorder
 import com.vultisig.wallet.ui.utils.uriToBitmap
 import timber.log.Timber
-import java.io.FileDescriptor
-import java.io.IOException
 
 internal const val ARG_QR_CODE = "qr_code"
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -128,8 +128,9 @@ internal fun ScanQrScreen(
                     val bitmap = requireNotNull(uriToBitmap(context.contentResolver, uri))
                         .addWhiteBorder(2F)
                     val inputImage = InputImage.fromBitmap(bitmap, 0)
+                    val resultBarcodes = scanImage(inputImage)
                     bitmap.recycle()
-                    scanImage(inputImage)
+                    resultBarcodes
                 } else result
                 onSuccess(barcodes)
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -3,7 +3,6 @@
 package com.vultisig.wallet.ui.screens
 
 import android.content.Context
-import android.net.Uri
 import android.util.Size
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -127,6 +127,7 @@ internal fun ScanQrScreen(
                 val barcodes = if (result.isEmpty()) {
                     val bitmap = requireNotNull(uriToBitmap(context.contentResolver, uri))
                     val inputImage = InputImage.fromBitmap(bitmap.addWhiteBorder(2F), 0)
+                    bitmap.recycle()
                     scanImage(inputImage)
                 } else result
                 onSuccess(barcodes)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -126,7 +126,8 @@ internal fun ScanQrScreen(
                 val result = scanImage(InputImage.fromFilePath(context, uri))
                 val barcodes = if (result.isEmpty()) {
                     val bitmap = requireNotNull(uriToBitmap(context.contentResolver, uri))
-                    val inputImage = InputImage.fromBitmap(bitmap.addWhiteBorder(2F), 0)
+                        .addWhiteBorder(2F)
+                    val inputImage = InputImage.fromBitmap(bitmap, 0)
                     bitmap.recycle()
                     scanImage(inputImage)
                 } else result

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ScanQrScreen.kt
@@ -2,12 +2,7 @@
 
 package com.vultisig.wallet.ui.screens
 
-import android.content.ContentResolver
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Color
 import android.net.Uri
 import android.util.Size
 import androidx.activity.compose.rememberLauncherForActivityResult

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/Bitmap.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/Bitmap.kt
@@ -1,0 +1,32 @@
+package com.vultisig.wallet.ui.utils
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.net.Uri
+import java.io.FileDescriptor
+import java.io.IOException
+
+internal fun uriToBitmap(contentResolver: ContentResolver, selectedFileUri: Uri): Bitmap? {
+    try {
+        val parcelFileDescriptor = contentResolver.openFileDescriptor(selectedFileUri, "r")
+        val fileDescriptor: FileDescriptor = requireNotNull(parcelFileDescriptor).fileDescriptor
+        val image = BitmapFactory.decodeFileDescriptor(fileDescriptor)
+        parcelFileDescriptor.close()
+        return image
+    } catch (e: IOException) {
+        e.printStackTrace()
+    }
+    return null
+}
+
+internal fun Bitmap.addWhiteBorder(borderSize: Float): Bitmap {
+    val bmpWithBorder =
+        Bitmap.createBitmap(width + (borderSize * 2).toInt(), height + (borderSize * 2).toInt(), config)
+    val canvas = Canvas(bmpWithBorder)
+    canvas.drawColor(Color.WHITE)
+    canvas.drawBitmap(this, borderSize, borderSize, null)
+    return bmpWithBorder
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/Bitmap.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/Bitmap.kt
@@ -11,11 +11,11 @@ import java.io.IOException
 
 internal fun uriToBitmap(contentResolver: ContentResolver, selectedFileUri: Uri): Bitmap? {
     try {
-        val parcelFileDescriptor = contentResolver.openFileDescriptor(selectedFileUri, "r")
-        val fileDescriptor: FileDescriptor = requireNotNull(parcelFileDescriptor).fileDescriptor
-        val image = BitmapFactory.decodeFileDescriptor(fileDescriptor)
-        parcelFileDescriptor.close()
-        return image
+        contentResolver.openFileDescriptor(selectedFileUri, "r").use {
+            val fileDescriptor: FileDescriptor = requireNotNull(it).fileDescriptor
+            val image = BitmapFactory.decodeFileDescriptor(fileDescriptor)
+            return image
+        }
     } catch (e: IOException) {
         e.printStackTrace()
     }
@@ -28,5 +28,6 @@ internal fun Bitmap.addWhiteBorder(borderSize: Float): Bitmap {
     val canvas = Canvas(bmpWithBorder)
     canvas.drawColor(Color.WHITE)
     canvas.drawBitmap(this, borderSize, borderSize, null)
+    this.recycle()
     return bmpWithBorder
 }


### PR DESCRIPTION
#565
I have fixed here edge case when importing borderless qrcode image
by just adding borders when scan returns no barcodes