### PR TITLE
Fix bitcoincash swap issue

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -132,7 +132,10 @@ internal class SwapFormViewModel @Inject constructor(
             val gasFee = gasFee.value ?: return
 
             val srcToken = selectedSrc.account.token
-            val dstToken = selectedDst.account.token
+            val dstToken =
+                selectedDst.account.token.copy(
+                    address = selectedDst.address.address.replace("bitcoincash:", "")
+                )
 
             if (srcToken == dstToken) {
                 throw InvalidTransactionDataException(


### PR DESCRIPTION
Bitcoin Cash addresses have a prefix of `bitcoincash:`. These addresses work perfectly with the Blockchain API to get balances and also with the Thorchain quote service to get fees and swap quotes. However, the memo is invalid because the destination asset has the `bitcoincash:` prefix. Thorchain/Maya split the memo based on `:` and attempt to use `bitcoincash` as the destination address. 

Here is an example of a swap error from Thornode:

`Error: Failed to execute message; message index: 0: invalid memo: 2 errors occurred: * internal error * memo: =:bch.bch:bitcoincash:qz0eq6q07e77hjvn7ehrc60dq32qg4jj3uappp3ljl:0/1/0 parse failure(s): cannot parse 'bitcoincash' as an address: bitcoincash is not recognizable-cannot parse 'qz0eq6q07e77hjvn7ehrc60dq32qg4jj3uappp3ljl' as an uint with sci notation: number has no digits-cannot parse '0/1/0' as an address: 0/1/0 is not recognizable : internal error
`