### PR TITLE
Fix send max amount in utxo

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/chains/utxoHelper.kt
+++ b/app/src/main/java/com/vultisig/wallet/chains/utxoHelper.kt
@@ -78,7 +78,7 @@ internal class utxoHelper(
         val utxo = keysignPayload.blockChainSpecific as BlockChainSpecific.UTXO
         signingInput
             .setHashType(BitcoinScript.hashTypeForCoin(coinType))
-            .setUseMaxAmount(false)
+            .setUseMaxAmount(keysignPayload.blockChainSpecific.sendMaxAmount)
             .setByteFee(utxo.byteFee.toLong())
         for (item in keysignPayload.utxos) {
             val lockScript =
@@ -130,7 +130,7 @@ internal class utxoHelper(
         val input = Bitcoin.SigningInput.newBuilder()
             .setHashType(BitcoinScript.hashTypeForCoin(coinType))
             .setAmount(keysignPayload.toAmount.toLong())
-            .setUseMaxAmount(false)
+            .setUseMaxAmount(keysignPayload.blockChainSpecific.sendMaxAmount)
             .setToAddress(keysignPayload.toAddress)
             .setChangeAddress(keysignPayload.coin.address)
             .setByteFee(utxo.byteFee.toLong())

--- a/app/src/main/java/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -30,6 +30,7 @@ internal interface BlockChainSpecificRepository {
         token: Coin,
         gasFee: TokenValue,
         isSwap: Boolean,
+        isMaxAmountEnabled: Boolean,
     ): BlockChainSpecificAndUtxo
 
 }
@@ -50,6 +51,7 @@ internal class BlockChainSpecificRepositoryImpl @Inject constructor(
         token: Coin,
         gasFee: TokenValue,
         isSwap: Boolean,
+        isMaxAmountEnabled: Boolean,
     ): BlockChainSpecificAndUtxo = when (chain.standard) {
         TokenStandard.THORCHAIN -> {
             val account = if (chain == Chain.mayaChain) {
@@ -117,7 +119,7 @@ internal class BlockChainSpecificRepositoryImpl @Inject constructor(
             BlockChainSpecificAndUtxo(
                 blockChainSpecific = BlockChainSpecific.UTXO(
                     byteFee = gasFee.value,
-                    sendMaxAmount = false,
+                    sendMaxAmount = isMaxAmountEnabled,
                 ),
                 utxos = utxos?.utxos?.sortedBy { it.value }?.toList()?.map {
                     UtxoInfo(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -269,7 +269,14 @@ internal class DepositFormViewModel @Inject constructor(
         )
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -342,7 +349,14 @@ internal class DepositFormViewModel @Inject constructor(
         )
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -392,7 +406,14 @@ internal class DepositFormViewModel @Inject constructor(
         )
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -445,7 +466,14 @@ internal class DepositFormViewModel @Inject constructor(
         val memo = DepositMemo.DepositPool
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -492,7 +520,14 @@ internal class DepositFormViewModel @Inject constructor(
         )
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -532,7 +567,14 @@ internal class DepositFormViewModel @Inject constructor(
         )
 
         val specific = blockChainSpecificRepository
-            .getSpecific(chain, srcAddress, selectedToken, gasFee, isSwap = false)
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+            )
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -203,6 +203,7 @@ internal class SwapFormViewModel @Inject constructor(
                     srcToken,
                     gasFee,
                     isSwap = true,
+                    isMaxAmountEnabled = false,
                 )
 
                 val transaction = when (quote) {


### PR DESCRIPTION
Fix #668 

useMaxAmount was false by default but it should be true in the case that use wants to use all his utxo (https://developer.trustwallet.com/developer/wallet-core/integration-guide/wallet-core-usage#bitcoin-transaction-signing)

We have the same logic for IOS
https://github.com/vultisig/vultisig-ios/blob/c1d034ca1425be74e367a2ad24ee478faf35a509/VultisigApp/VultisigApp/Chains/UTXOChainsHelper.swift#L118