### PR TITLE
Add Artifact Upload Step to GitHub Workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,3 +29,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.TRUSTWALLET_PAT }}
         GITHUB_USER: ${{ secrets.TRUSTWALLET_USER }}
       run: ./gradlew build
+    - name: Archive code analysis reports
+      uses: actions/upload-artifact@v2
+      with:
+        name: Lint-Reports
+        path: app/build/reports/lint-results-debug.html


### PR DESCRIPTION
The Pr Introduces a new step in the GitHub workflow to archive and upload the lint analysis reports. The lint report, lint-results-debug.html, is now uploaded as an artifact named 'Lint-Reports' after each workflow run. This allows for easier access and review of the lint reports directly from the GitHub interface