### PR TITLE
Fix a keysign issue with UTXO chain

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -201,6 +201,9 @@ internal class KeysignViewModel(
                     service.keysignEdDSA(keysignReq)
                 }
             }
+            if (keysignResp.r.isNullOrEmpty() || keysignResp.s.isNullOrEmpty()) {
+                throw Exception("Failed to sign message")
+            }
             this.signatures[message] = keysignResp
             keysignVerify.markLocalPartyKeysignComplete(message, keysignResp)
             this._messagePuller?.stop()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -46,6 +46,7 @@ class UtxoHelper(
             throw Exception(preSigningOutput.errorMessage)
         }
         return preSigningOutput.hashPublicKeysList.map { Numeric.toHexStringNoPrefix(it.dataHash.toByteArray()) }
+            .sorted()
     }
 
     @OptIn(ExperimentalStdlibApi::class)


### PR DESCRIPTION
1.for UTXO chain , if we have multiple UTXOs need to be signed , then we need to sort the keysign images , so multiple devices can agree on the signing order
2. When Keysign timeout , it doesn't throw exception , which result it can't be retry