### PR TITLE
Fix join keysign error

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -265,21 +265,23 @@ internal class JoinKeysignViewModel @Inject constructor(
                 if (_useVultisigRelay) {
                     this@JoinKeysignViewModel._serverAddress = Endpoints.VULTISIG_RELAY
                     // when Payload is not in the QRCode
-                    routerApi.getPayload(_serverAddress, payloadId).let { payload ->
-                        if (payload.isNotEmpty()) {
-                            val rawPayload = decompressQr(payload.decodeBase64Bytes())
-                            val payloadProto =
-                                protoBuf.decodeFromByteArray<KeysignPayloadProto>(rawPayload)
-                            val keysignMsgProto = KeysignMessageProto(
-                                keysignPayload = payloadProto,
-                                sessionId = tempKeysignMessageProto!!.sessionId,
-                                serviceName = tempKeysignMessageProto!!.serviceName,
-                                encryptionKeyHex = tempKeysignMessageProto!!.encryptionKeyHex,
-                                useVultisigRelay = _useVultisigRelay,
-                                payloadId = payloadId
-                            )
-                            if (!loadKeysignMessage(keysignMsgProto)) {
-                                return@launch
+                    if (!payloadProto.payloadId.isEmpty()) {
+                        routerApi.getPayload(_serverAddress, payloadId).let { payload ->
+                            if (payload.isNotEmpty()) {
+                                val rawPayload = decompressQr(payload.decodeBase64Bytes())
+                                val payloadProto =
+                                    protoBuf.decodeFromByteArray<KeysignPayloadProto>(rawPayload)
+                                val keysignMsgProto = KeysignMessageProto(
+                                    keysignPayload = payloadProto,
+                                    sessionId = tempKeysignMessageProto!!.sessionId,
+                                    serviceName = tempKeysignMessageProto!!.serviceName,
+                                    encryptionKeyHex = tempKeysignMessageProto!!.encryptionKeyHex,
+                                    useVultisigRelay = _useVultisigRelay,
+                                    payloadId = payloadId
+                                )
+                                if (!loadKeysignMessage(keysignMsgProto)) {
+                                    return@launch
+                                }
                             }
                         }
                     }
@@ -578,6 +580,8 @@ internal class JoinKeysignViewModel @Inject constructor(
                     }
                 }
             }
+        } else {
+            currentState.value = JoinKeysignState.JoinKeysign
         }
 
         // discovery finished


### PR DESCRIPTION
This issue is caused by #1288 
1. When KeysignPayload is already in KeysignMessage , and present in QR code , should not fetch payload from relay server
2. When JoinKeysign when initiate device is using Local mode , it should be able to join keysign 