### PR TITLE
Disable sign until all the checkboxes are ticked

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -50,7 +50,10 @@ internal data class VerifyTransactionUiModel(
     val blowfishShow: Boolean = false,
     val blowfishWarnings: List<String> = emptyList(),
     val hasFastSign: Boolean = false,
-)
+) {
+    val hasAllConsents: Boolean
+        get() = consentAddress && consentAmount && consentDst
+}
 
 @HiltViewModel
 internal class VerifyTransactionViewModel @Inject constructor(
@@ -126,11 +129,7 @@ internal class VerifyTransactionViewModel @Inject constructor(
     private fun keysign(
         keysignInitType: KeysignInitType,
     ) {
-        val hasAllConsents = uiState.value.let {
-            it.consentAddress && it.consentAmount && it.consentDst
-        }
-
-        if (hasAllConsents) {
+        if (uiState.value.hasAllConsents) {
             viewModelScope.launch {
                 val transaction = transaction.filterNotNull().first()
                 navigator.navigate (

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -37,7 +37,10 @@ internal data class VerifySwapUiModel(
     val consentAllowance: Boolean = false,
     val errorText: UiText? = null,
     val hasFastSign: Boolean = false,
-)
+) {
+    val hasAllConsents: Boolean
+        get() = consentAmount && consentReceiveAmount && (consentAllowance || !swapTransactionUiModel.hasConsentAllowance)
+}
 
 @HiltViewModel
 internal class VerifySwapViewModel @Inject constructor(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifyTransactionScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifyTransactionScreen.kt
@@ -112,6 +112,7 @@ internal fun VerifyTransactionScreen(
                         textColor = Theme.colors.oxfordBlue800,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !state.hasAllConsents,
                         onClick = onFastSignClick,
                     )
 
@@ -125,6 +126,7 @@ internal fun VerifyTransactionScreen(
                         borderSize = 1.dp,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !state.hasAllConsents,
                         onClick = onConfirm
                     )
                 } else {
@@ -133,6 +135,7 @@ internal fun VerifyTransactionScreen(
                         textColor = Theme.colors.oxfordBlue800,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !state.hasAllConsents,
                         onClick = onConfirm,
                     )
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -89,6 +89,7 @@ internal fun VerifySwapScreen(
     VerifySwapScreen(
         provider = state.provider.asString(),
         swapTransactionUiModel = state.swapTransactionUiModel,
+        hasAllConsents = state.hasAllConsents,
         consentAmount = state.consentAmount,
         consentReceiveAmount = state.consentReceiveAmount,
         consentAllowance = state.consentAllowance,
@@ -107,6 +108,7 @@ internal fun VerifySwapScreen(
 private fun VerifySwapScreen(
     provider: String,
     swapTransactionUiModel: SwapTransactionUiModel,
+    hasAllConsents: Boolean,
     consentAmount: Boolean,
     consentReceiveAmount: Boolean,
     consentAllowance: Boolean,
@@ -135,6 +137,7 @@ private fun VerifySwapScreen(
                         textColor = Theme.colors.oxfordBlue800,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !hasAllConsents,
                         onClick = onFastSignClick,
                     )
 
@@ -148,6 +151,7 @@ private fun VerifySwapScreen(
                         borderSize = 1.dp,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !hasAllConsents,
                         onClick = onConfirm
                     )
                 } else {
@@ -156,6 +160,7 @@ private fun VerifySwapScreen(
                         textColor = Theme.colors.oxfordBlue800,
                         modifier = Modifier
                             .fillMaxWidth(),
+                        disabled = !hasAllConsents,
                         onClick = onConfirm,
                     )
                 }
@@ -238,6 +243,7 @@ private fun VerifySwapScreen(
 private fun VerifySwapScreenPreview() {
     VerifySwapScreen(
         provider = "THORChain",
+        hasAllConsents = false,
         consentAmount = true,
         consentReceiveAmount = false,
         swapTransactionUiModel = SwapTransactionUiModel(


### PR DESCRIPTION
Fixes 
`iOS disables the signing buttons until all the checkboxes are ticked, while android lets you click them and shows a popup saying you need to check them all - iOS seems like a nice touch there`
https://discord.com/channels/1203844257220395078/1244701510873387149/1313013108389838970