### PR TITLE
Update recent block hash after verifying a transaction

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.data.api.FeatureFlagApi
 import com.vultisig.wallet.data.api.ParticipantDiscovery
 import com.vultisig.wallet.data.api.RouterApi
 import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.signer.JoinKeysignRequestJson
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
@@ -124,6 +125,7 @@ internal class KeysignFlowViewModel @Inject constructor(
     private val routerApi: RouterApi,
     private val pullTssMessages: PullTssMessagesUseCase,
     private val broadcastTx: BroadcastTxUseCase,
+    private val solanaApi: SolanaApi,
 ) : ViewModel() {
     private val _sessionID: String = UUID.randomUUID().toString()
     private val _serviceName: String = generateServiceName()
@@ -208,12 +210,13 @@ internal class KeysignFlowViewModel @Inject constructor(
     ) {
         try {
             _currentVault = vault
-            _keysignPayload = keysignPayload
+            val modifiedKeysignPayload = updateSolanaKeysignPayload(keysignPayload)
+            _keysignPayload = modifiedKeysignPayload
             this.customMessagePayload = customMessagePayload
             messagesToSign = when {
-                keysignPayload != null ->
+                modifiedKeysignPayload != null ->
                     SigningHelper.getKeysignMessages(
-                        payload = keysignPayload,
+                        payload = modifiedKeysignPayload,
                         vault = vault,
                     )
 
@@ -234,6 +237,15 @@ internal class KeysignFlowViewModel @Inject constructor(
             moveToState(KeysignFlowState.Error(e.message.toString()))
         }
     }
+
+    private suspend fun updateSolanaKeysignPayload(keysignPayload: KeysignPayload?) =
+        keysignPayload?.takeIf { it.blockChainSpecific is BlockChainSpecific.Solana }
+            ?.let { payload ->
+                payload.copy(
+                    blockChainSpecific = (payload.blockChainSpecific as BlockChainSpecific.Solana)
+                        .copy(recentBlockHash = solanaApi.getRecentBlockHash())
+                )
+            } ?: keysignPayload
 
     @Suppress("ReplaceNotNullAssertionWithElvisReturn")
     private suspend fun updateKeysignPayload(context: Context) {


### PR DESCRIPTION
https://github.com/vultisig/vultisig-android/issues/1224
This PR adds functionality to update the recent block hash for Solana transactions after verifying a transaction