### PR TITLE
Make sure displays stays on when joining keygen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenUiModel
@@ -27,6 +28,8 @@ import com.vultisig.wallet.ui.theme.Theme
 internal fun JoinKeygenScreen(
     model: JoinKeygenViewModel = hiltViewModel()
 ) {
+    KeepScreenOn()
+
     val state by model.state.collectAsState()
 
     JoinKeygenScreen(


### PR DESCRIPTION
Fix #1759 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the key generation process by keeping the screen active, preventing automatic dimming or timeouts during use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->