### PR TITLE
Fix FileHelper and search token crashes

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
@@ -167,12 +167,11 @@ fun Uri.fileContent(context: Context): String? {
 
 fun Uri.fileName(context: Context): String {
     val cursor = context.contentResolver.query(this, null, null, null, null)
-    cursor.use {
-        val nameColumnIndex = it!!.getColumnIndex(DISPLAY_NAME)
+    return cursor?.use {
+        val nameColumnIndex = it.getColumnIndex(DISPLAY_NAME)
         it.moveToFirst()
-        val fileName = it.getString(nameColumnIndex)
-        return fileName ?: ""
-    }
+        it.getString(nameColumnIndex)
+    } ?: ""
 }
 
 internal fun Bitmap.compressPng(stream: OutputStream) =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -37,7 +37,7 @@ internal class SearchTokenUseCaseImpl @Inject constructor(
             chain.standard == EVM -> searchEvmToken(chainId, contractAddress)
             chain.standard == SOL -> searchSolToken(contractAddress)
             chain == Chain.Kujira -> searchKujiToken(contractAddress)
-            else -> error("search token not supported for $chain")
+            else -> return null
         } ?: return null
 
         val rawPrice = searchedToken.price


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for retrieving file names to improve clarity and reliability.
- **Bug Fixes**
	- Adjusted the token search behavior so that unsupported scenarios now safely return a null result instead of causing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->