### PR TITLE
Change DKLS backup name from part to share

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.fileName
 import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
+import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.getVaultPart
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
@@ -139,9 +140,15 @@ internal class BackupPasswordViewModel @Inject constructor(
     }
 
     private fun generateFileName(vault: Vault): String {
+        val shareNamePart = when (vault.libType) {
+            SigningLibType.GG20 -> "part"
+            SigningLibType.DKLS -> "share"
+        }
+
         val fileName =
             "${vault.name}-${vault.pubKeyECDSA.takeLast(4)}" +
-                    "-part${vault.getVaultPart()}of${vault.signers.size}.vult"
+                    "-$shareNamePart${vault.getVaultPart()}of${vault.signers.size}.vult"
+
         return fileName
     }
 


### PR DESCRIPTION
Fix #1781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced backup file naming by dynamically adjusting the file name suffix based on vault type. This improvement results in more specific and meaningful backup file names for different vault configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->