### PR TITLE
Fix ticker to FUZN

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1476,7 +1476,7 @@ object Coins {
         ),
         Coin(
             chain = Chain.Kujira,
-            ticker="fuzion",
+            ticker="FUZN",
             logo="fuzion",
             address = "",
             decimal = 6,


### PR DESCRIPTION
Fix https://github.com/vultisig/vultisig-android/issues/1768#issuecomment-2717212268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the coin ticker for the Kujira-associated asset, changing its display from "fuzion" to "FUZN". This update ensures users see the corrected coin identifier consistently within the wallet interface, contributing to a clearer and more accurate asset overview. Users viewing their portfolio and transaction details will notice this enhancement, which supports a smoother and more trustworthy experience when managing digital coins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->