### PR TITLE
Add IBC send, switch and merge

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -165,15 +165,15 @@ internal interface DepositMemo {
                 Chain.Dydx -> "channel-118"
                 Chain.Noble -> "channel-62"
                 Chain.Osmosis -> "channel-3"
-                else -> error("Unsupported chain $dstChain")
+                else -> ""
             }
 
             Chain.Osmosis -> when (dstChain) {
                 Chain.GaiaChain -> "channel-141"
-                else -> error("Unsupported chain $dstChain")
+                else -> ""
             }
 
-            else -> error("Unsupported chain $srcChain")
+            else -> ""
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -143,4 +143,39 @@ internal interface DepositMemo {
         override fun toString(): String = memo
     }
 
+    data class TransferIbc(
+        val srcChain: Chain,
+        val dstChain: Chain,
+        val dstAddress: String,
+
+        val memo: String?,
+    ) : DepositMemo {
+        override fun toString(): String =
+            buildString {
+                append("${dstChain.raw}:${ibcChannel}:${dstAddress}")
+                if (memo != null) {
+                    append(":$memo")
+                }
+            }
+
+        private val ibcChannel: String = when (srcChain) {
+            Chain.Kujira -> when (dstChain) {
+                Chain.GaiaChain -> "channel-0"
+                Chain.Akash -> "channel-64"
+                Chain.Dydx -> "channel-118"
+                Chain.Noble -> "channel-62"
+                Chain.Osmosis -> "channel-3"
+                else -> error("Unsupported chain $dstChain")
+            }
+
+            Chain.Osmosis -> when (dstChain) {
+                Chain.GaiaChain -> "channel-141"
+                else -> error("Unsupported chain $dstChain")
+            }
+
+            else -> error("Unsupported chain $srcChain")
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.DepositMemo
 import com.vultisig.wallet.data.models.DepositMemo.Bond
@@ -19,10 +18,8 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.GasFeeRepository
-import com.vultisig.wallet.data.utils.TextFieldUtils
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
-import com.vultisig.wallet.ui.models.deposit.DepositChain.Maya
-import com.vultisig.wallet.ui.models.deposit.DepositChain.Thor
+import com.vultisig.wallet.data.utils.TextFieldUtils
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.navigation.Destination
@@ -32,11 +29,11 @@ import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import vultisig.keysign.v1.TransactionType
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
@@ -49,19 +46,9 @@ internal enum class DepositOption {
     Stake,
     Unstake,
     Custom,
-}
-
-internal enum class DepositChain {
-    Maya, Thor, Ton;
-
-    companion object {
-        fun from(chain: Chain) = when (chain) {
-            Chain.MayaChain -> Maya
-            Chain.ThorChain -> Thor
-            Chain.Ton -> Ton
-            else -> error("chain is invalid")
-        }
-    }
+    TransferIbc,
+    Switch,
+    Merge,
 }
 
 @Immutable
@@ -69,7 +56,7 @@ internal data class DepositFormUiModel(
     val depositMessage: UiText = UiText.Empty,
     val depositOption: DepositOption = DepositOption.Bond,
     val depositOptions: List<DepositOption> = emptyList(),
-    val depositChain: DepositChain? = null,
+    val depositChain: Chain? = null,
     val errorText: UiText? = null,
     val tokenAmountError: UiText? = null,
     val nodeAddressError: UiText? = null,
@@ -81,6 +68,16 @@ internal data class DepositFormUiModel(
     val lpUnitsError: UiText? = null,
     val isLoading: Boolean = false,
     val balance :UiText= UiText.Empty,
+
+    val selectedDstChain: Chain = Chain.ThorChain,
+    val dstChainList: List<Chain> = emptyList(),
+    val dstAddressError: UiText? = null,
+    val amountError: UiText? = null,
+    val memoError: UiText? = null,
+    val thorAddressError: UiText? = null,
+
+    val selectedCoin: TokenMergeInfo = tokensToMerge.first(),
+    val coinList: List<TokenMergeInfo> = tokensToMerge,
 )
 
 @HiltViewModel
@@ -107,6 +104,7 @@ internal class DepositFormViewModel @Inject constructor(
     val basisPointsFieldState = TextFieldState()
     val lpUnitsFieldState = TextFieldState()
     val assetsFieldState = TextFieldState()
+    val thorAddressFieldState = TextFieldState()
 
     val state = MutableStateFlow(DepositFormUiModel())
     var isLoading: Boolean
@@ -124,49 +122,75 @@ internal class DepositFormViewModel @Inject constructor(
         val chain = chainId.let(Chain::fromRaw)
         this.chain = chain
 
-        val depositChain = DepositChain.from(chain)
+        val depositOptions = when (chain) {
+            Chain.ThorChain -> listOf(
+                DepositOption.Bond,
+                DepositOption.Unbond,
+                DepositOption.Leave,
+                DepositOption.Custom,
+                DepositOption.Merge
+            )
 
-        val depositOptions =
-            when (chain) {
-                Chain.ThorChain -> listOf(
-                    DepositOption.Bond,
-                    DepositOption.Unbond,
-                    DepositOption.Leave,
-                    DepositOption.Custom,
-                )
-                Chain.MayaChain -> listOf(
-                    DepositOption.Bond,
-                    DepositOption.Unbond,
-                    DepositOption.Leave,
-                    DepositOption.Custom,
-                )
-                else -> listOf(
-                    DepositOption.Stake,
-                    DepositOption.Unstake,
-                )
-            }
+            Chain.MayaChain -> listOf(
+                DepositOption.Bond,
+                DepositOption.Unbond,
+                DepositOption.Leave,
+                DepositOption.Custom,
+            )
+
+            Chain.Kujira -> listOf(
+                DepositOption.TransferIbc,
+            )
+
+            Chain.GaiaChain -> listOf(
+                DepositOption.TransferIbc,
+                DepositOption.Switch,
+            )
+
+            else -> listOf(
+                DepositOption.Stake,
+                DepositOption.Unstake,
+            )
+        }
         val depositOption = depositOptions.first()
         state.update {
             it.copy(
                 depositMessage = R.string.deposit_message_deposit_title.asUiText(chain.raw),
                 depositOptions = depositOptions,
                 depositOption = depositOption,
-                depositChain = depositChain
+                depositChain = chain
+            )
+        }
+
+        val dstChainList = listOf(
+            Chain.GaiaChain, Chain.Kujira, Chain.Osmosis,
+            Chain.Noble, Chain.Akash, Chain.Dydx
+        ).filter { it != chain }
+
+        state.update {
+            it.copy(
+                selectedDstChain = dstChainList.first(),
+                dstChainList = dstChainList,
             )
         }
 
         viewModelScope.launch {
-            accountsRepository.loadAddress(
-                vaultId,
-                chain
-            ).collect { addresses ->
-                    addresses.accounts.firstOrNull { it.token.isNativeToken }?.tokenValue?.let(mapTokenValueToStringWithUnit)
-                        ?.let { tokenValue ->
-                            state.update {
-                                it.copy(balance = tokenValue.asUiText())
+            try {
+                accountsRepository.loadAddress(vaultId, chain)
+                    .collect { addresses ->
+                        addresses.accounts
+                            .firstOrNull { it.token.isNativeToken }
+                            ?.tokenValue
+                            ?.let(mapTokenValueToStringWithUnit)
+                            ?.let { tokenValue ->
+                                state.update {
+                                    it.copy(balance = tokenValue.asUiText())
+                                }
                             }
-                        }
-                }
+                    }
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
         }
     }
 
@@ -174,6 +198,12 @@ internal class DepositFormViewModel @Inject constructor(
         resetTextFields()
         state.update {
             it.copy(depositOption = option)
+        }
+    }
+
+    fun selectDstChain(chain: Chain) {
+        state.update {
+            it.copy(selectedDstChain = chain)
         }
     }
 
@@ -265,6 +295,9 @@ internal class DepositFormViewModel @Inject constructor(
                     DepositOption.Custom -> createCustomTransaction()
                     DepositOption.Stake -> createStakeTransaction()
                     DepositOption.Unstake -> createUnstakeTransaction()
+                    DepositOption.TransferIbc -> createTransferIbcTx()
+                    DepositOption.Switch -> createSwitchTx()
+                    DepositOption.Merge -> createMergeTx()
                 }
 
                 Timber.d("Transaction: $transaction")
@@ -311,7 +344,7 @@ internal class DepositFormViewModel @Inject constructor(
             .toString()
             .toBigDecimalOrNull()
 
-        if (depositChain == Thor && (tokenAmount == null || tokenAmount <= BigDecimal.ZERO)) {
+        if (depositChain == Chain.ThorChain && (tokenAmount == null || tokenAmount <= BigDecimal.ZERO)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_amount)
             )
@@ -319,7 +352,7 @@ internal class DepositFormViewModel @Inject constructor(
 
         val assets = assetsFieldState.text.toString()
 
-        if (depositChain == Maya && !isAssetCharsValid(assets)) {
+        if (depositChain == Chain.MayaChain && !isAssetCharsValid(assets)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_assets)
             )
@@ -327,7 +360,7 @@ internal class DepositFormViewModel @Inject constructor(
 
         val lpUnits = lpUnitsFieldState.text.toString()
 
-        if (depositChain == Maya && !isLpUnitCharsValid(lpUnits)) {
+        if (depositChain == Chain.MayaChain && !isLpUnitCharsValid(lpUnits)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_lpunits)
             )
@@ -348,7 +381,7 @@ internal class DepositFormViewModel @Inject constructor(
                 ?.toBigInteger() ?: BigInteger.ONE
 
         val operatorFeeValue = operatorFeeAmount
-            ?.movePointRight(if (depositChain == Thor) 2 else 0)
+            ?.movePointRight(if (depositChain == Chain.ThorChain) 2 else 0)
             ?.toInt()
 
         val srcAddress = selectedToken.address
@@ -359,14 +392,14 @@ internal class DepositFormViewModel @Inject constructor(
         val provider = providerText.ifBlank { null }
 
         val memo = when (depositChain) {
-            Maya -> Bond.Maya(
+            Chain.MayaChain -> Bond.Maya(
                 nodeAddress = nodeAddress,
                 providerAddress = provider,
                 lpUnits = lpUnits.toIntOrNull(),
                 assets = assets
             )
 
-            Thor -> Bond.Thor(
+            Chain.ThorChain -> Bond.Thor(
                 nodeAddress = nodeAddress,
                 providerAddress = provider,
                 operatorFee = operatorFeeValue,
@@ -424,7 +457,7 @@ internal class DepositFormViewModel @Inject constructor(
 
         val assets = assetsFieldState.text.toString()
 
-        if (depositChain == Maya && !isAssetCharsValid(assets)) {
+        if (depositChain == Chain.MayaChain && !isAssetCharsValid(assets)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_assets)
             )
@@ -432,7 +465,7 @@ internal class DepositFormViewModel @Inject constructor(
 
         val lpUnits = lpUnitsFieldState.text.toString()
 
-        if (depositChain == Maya && !isLpUnitCharsValid(lpUnits)) {
+        if (depositChain == Chain.MayaChain && !isLpUnitCharsValid(lpUnits)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_lpunits)
             )
@@ -442,7 +475,7 @@ internal class DepositFormViewModel @Inject constructor(
             .toString()
             .toBigDecimalOrNull()
 
-        if (depositChain == Thor && (tokenAmount == null || tokenAmount <= BigDecimal.ZERO)) {
+        if (depositChain == Chain.ThorChain && (tokenAmount == null || tokenAmount <= BigDecimal.ZERO)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_amount)
             )
@@ -466,14 +499,14 @@ internal class DepositFormViewModel @Inject constructor(
         val provider = providerText.ifBlank { null }
 
         val memo = when (state.value.depositChain) {
-            Maya -> Unbond.Maya(
+            Chain.MayaChain -> Unbond.Maya(
                 nodeAddress = nodeAddress,
                 providerAddress = provider,
                 assets = assets,
                 lpUnits = lpUnits.toIntOrNull(),
             )
 
-            Thor -> Unbond.Thor(
+            Chain.ThorChain -> Unbond.Thor(
                 nodeAddress = nodeAddress,
                 srcTokenValue = TokenValue(
                     value = tokenAmountInt,
@@ -645,7 +678,7 @@ internal class DepositFormViewModel @Inject constructor(
 
         val depositChain = state.value.depositChain
 
-        if (depositChain != DepositChain.Ton) {
+        if (depositChain != Chain.Ton) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.error_invalid_chain)
             )
@@ -719,6 +752,206 @@ internal class DepositFormViewModel @Inject constructor(
     private suspend fun createUnstakeTransaction(): DepositTransaction =
         createTonDepositTransaction(DepositMemo.Unstake)
 
+    private suspend fun createMergeTx(): DepositTransaction {
+        val chain = chain
+            ?: throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_address)
+            )
+
+        val address = accountsRepository.loadAddress(vaultId, chain)
+            .first()
+
+        val selectedToken = address.accounts.first { it.token.isNativeToken }.token
+
+        val srcAddress = selectedToken.address
+
+        val gasFee = gasFeeRepository.getGasFee(chain, srcAddress)
+
+        val mergeToken = state.value.selectedCoin
+        val dstAddr = mergeToken.contract
+
+        val memo = "merge:${mergeToken.denom}"
+
+        val tokenAmount = tokenAmountFieldState.text
+            .toString()
+            .toBigDecimalOrNull()
+
+        if (tokenAmount == null || tokenAmount < BigDecimal.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val tokenAmountInt =
+            tokenAmount
+                .movePointRight(selectedToken.decimal)
+                .toBigInteger()
+
+        val specific = blockChainSpecificRepository
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+                transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+            )
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddr,
+
+            memo = memo,
+            srcTokenValue = TokenValue(
+                value = tokenAmountInt,
+                token = selectedToken,
+            ),
+            estimatedFees = gasFee,
+            blockChainSpecific = specific.blockChainSpecific,
+        )
+    }
+
+    private suspend fun createSwitchTx(): DepositTransaction {
+        val chain = chain
+            ?: throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_address)
+            )
+
+        val address = accountsRepository.loadAddress(vaultId, chain)
+            .first()
+
+        val selectedToken = address.accounts.first { it.token.isNativeToken }.token
+
+        val srcAddress = selectedToken.address
+
+        val gasFee = gasFeeRepository.getGasFee(chain, srcAddress)
+
+        val dstAddr = nodeAddressFieldState.text.toString()
+
+        val memo = "SWITCH:${thorAddressFieldState.text}"
+
+        val tokenAmount = tokenAmountFieldState.text
+            .toString()
+            .toBigDecimalOrNull()
+
+        if (tokenAmount == null || tokenAmount < BigDecimal.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val tokenAmountInt =
+            tokenAmount
+                .movePointRight(selectedToken.decimal)
+                .toBigInteger()
+
+        val specific = blockChainSpecificRepository
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+                transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+            )
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddr,
+
+            memo = memo,
+            srcTokenValue = TokenValue(
+                value = tokenAmountInt,
+                token = selectedToken,
+            ),
+            estimatedFees = gasFee,
+            blockChainSpecific = specific.blockChainSpecific,
+        )
+    }
+
+    private suspend fun createTransferIbcTx(): DepositTransaction {
+        val chain = chain
+            ?: throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_address)
+            )
+
+        val address = accountsRepository.loadAddress(vaultId, chain)
+            .first()
+
+        val selectedToken = address.accounts.first { it.token.isNativeToken }.token
+
+        val srcAddress = selectedToken.address
+
+        val gasFee = gasFeeRepository.getGasFee(chain, srcAddress)
+
+        val dstAddr = nodeAddressFieldState.text.toString()
+
+        val memo = DepositMemo.TransferIbc(
+            srcChain = chain,
+            dstChain = state.value.selectedDstChain,
+            dstAddress = dstAddr,
+
+            memo = customMemoFieldState.text.toString()
+                .takeIf { it.isNotBlank() },
+        )
+
+        val tokenAmount = tokenAmountFieldState.text
+            .toString()
+            .toBigDecimalOrNull()
+
+        if (tokenAmount == null || tokenAmount < BigDecimal.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val tokenAmountInt =
+            tokenAmount
+                .movePointRight(selectedToken.decimal)
+                .toBigInteger()
+
+        val specific = blockChainSpecificRepository
+            .getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+                transactionType = TransactionType.TRANSACTION_TYPE_IBC_TRANSFER,
+            )
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddr,
+
+            memo = memo.toString(),
+            srcTokenValue = TokenValue(
+                value = tokenAmountInt,
+                token = selectedToken,
+            ),
+            estimatedFees = gasFee,
+            blockChainSpecific = specific.blockChainSpecific,
+        )
+    }
+
     private fun showError(text: UiText) {
         state.update { it.copy(errorText = text) }
     }
@@ -783,3 +1016,34 @@ internal class DepositFormViewModel @Inject constructor(
 
 }
 
+internal data class TokenMergeInfo(
+    val denom: String,
+    val contract: String,
+)
+
+private val tokensToMerge = listOf(
+    TokenMergeInfo(
+        denom = "thor.kuji",
+        contract = "thor14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s3p2nzy"
+    ),
+    TokenMergeInfo(
+        denom = "thor.rkuji",
+        contract = "thor1yyca08xqdgvjz0psg56z67ejh9xms6l436u8y58m82npdqqhmmtqrsjrgh"
+    ),
+    TokenMergeInfo(
+        denom = "thor.fuzn",
+        contract = "thor1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsw5xx2d"
+    ),
+    TokenMergeInfo(
+        denom = "thor.nstk",
+        contract = "thor1cnuw3f076wgdyahssdkd0g3nr96ckq8cwa2mh029fn5mgf2fmcmsmam5ck"
+    ),
+    TokenMergeInfo(
+        denom = "thor.wink",
+        contract = "thor1yw4xvtc43me9scqfr2jr2gzvcxd3a9y4eq7gaukreugw2yd2f8tsz3392y"
+    ),
+    TokenMergeInfo(
+        denom = "thor.lvn",
+        contract = "thor1ltd0maxmte3xf4zshta9j5djrq9cl692ctsp9u5q0p9wss0f5lms7us4yf"
+    ),
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -972,7 +972,7 @@ internal class SendFormViewModel @Inject constructor(
                 accounts,
             ) { token, accounts ->
                 val address = token.address
-                val hasMemo = token.isNativeToken
+                val hasMemo = token.isNativeToken || token.chain.standard == TokenStandard.COSMOS
 
                 val uiModel = accountToTokenBalanceUiModelMapper.map(SendSrc(
                     Address(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/function/MergeFunctionScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/function/MergeFunctionScreen.kt
@@ -1,0 +1,44 @@
+package com.vultisig.wallet.ui.screens.function
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.library.form.FormSelection
+import com.vultisig.wallet.ui.components.library.form.FormTextFieldCard
+import com.vultisig.wallet.ui.models.deposit.TokenMergeInfo
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
+
+@Composable
+internal fun MergeFunctionScreen(
+    selectedToken: TokenMergeInfo,
+    coinList: List<TokenMergeInfo>,
+    onSelectCoin: (TokenMergeInfo) -> Unit,
+
+    balance: UiText,
+    amountFieldState: TextFieldState,
+    onAmountLostFocus: () -> Unit,
+    amountError: UiText?,
+) {
+    FormSelection(
+        selected = selectedToken,
+        options = coinList,
+        mapTypeToString = { it.denom },
+        onSelectOption = onSelectCoin,
+    )
+
+
+    FormTextFieldCard(
+        title = stringResource(
+            R.string.deposit_form_amount_title,
+            balance.asString()
+        ),
+        hint = stringResource(R.string.send_amount_currency_hint),
+        keyboardType = KeyboardType.Number,
+        textFieldState = amountFieldState,
+        onLostFocus = onAmountLostFocus,
+        error = amountError,
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/function/SwitchFunctionScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/function/SwitchFunctionScreen.kt
@@ -1,0 +1,90 @@
+package com.vultisig.wallet.ui.screens.function
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.library.form.FormTextFieldCard
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
+
+@Composable
+fun SwitchFunctionScreen(
+    dstAddress: TextFieldState,
+    onDstAddressLostFocus: () -> Unit,
+    dstAddressError: UiText?,
+    onSetDstAddress: (String) -> Unit,
+
+    thorAddress: TextFieldState,
+    onThorAddressLostFocus: () -> Unit,
+    thorAddressError: UiText?,
+    onSetThorAddress: (String) -> Unit,
+
+    balance: UiText,
+    amountFieldState: TextFieldState,
+    onAmountLostFocus: () -> Unit,
+    amountError: UiText?,
+) {
+    FormTextFieldCard(
+        title = stringResource(R.string.function_transfer_ibc_dst_address_input_title),
+        hint = stringResource(R.string.function_transfer_ibc_dst_address_input_title),
+        keyboardType = KeyboardType.Text,
+        textFieldState = dstAddress,
+        onLostFocus = onDstAddressLostFocus,
+        error = dstAddressError,
+    ) {
+        val clipboard = LocalClipboardManager.current
+
+        UiIcon(
+            drawableResId = R.drawable.ic_paste,
+            size = 20.dp,
+            onClick = {
+                clipboard.getText()
+                    ?.toString()
+                    ?.let(onSetDstAddress)
+            }
+        )
+
+        UiSpacer(size = 8.dp)
+    }
+
+    FormTextFieldCard(
+        title = stringResource(R.string.function_switch_thorchain_address),
+        hint = stringResource(R.string.function_switch_thorchain_address),
+        keyboardType = KeyboardType.Text,
+        textFieldState = thorAddress,
+        onLostFocus = onThorAddressLostFocus,
+        error = thorAddressError,
+    ) {
+        val clipboard = LocalClipboardManager.current
+
+        /*UiIcon(
+            drawableResId = R.drawable.ic_paste,
+            size = 20.dp,
+            onClick = {
+                clipboard.getText()
+                    ?.toString()
+                    ?.let(onSetThorAddress)
+            }
+        )*/
+
+        UiSpacer(size = 8.dp)
+    }
+
+    FormTextFieldCard(
+        title = stringResource(
+            R.string.deposit_form_amount_title,
+            balance.asString()
+        ),
+        hint = stringResource(R.string.send_amount_currency_hint),
+        keyboardType = KeyboardType.Number,
+        textFieldState = amountFieldState,
+        onLostFocus = onAmountLostFocus,
+        error = amountError,
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/function/TransferIbcFunctionScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/function/TransferIbcFunctionScreen.kt
@@ -1,0 +1,88 @@
+package com.vultisig.wallet.ui.screens.function
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.library.form.FormSelection
+import com.vultisig.wallet.ui.components.library.form.FormTextFieldCard
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
+
+@Composable
+fun TransferIbcFunctionScreen(
+    selectedChain: Chain,
+    chainList: List<Chain>,
+    onSelectChain: (Chain) -> Unit,
+
+    dstAddress: TextFieldState,
+    onDstAddressLostFocus: () -> Unit,
+    dstAddressError: UiText?,
+    onSetDstAddress: (String) -> Unit,
+
+    balance: UiText,
+    amountFieldState: TextFieldState,
+    onAmountLostFocus: () -> Unit,
+    amountError: UiText?,
+
+    memoFieldState: TextFieldState,
+    onMemoLostFocus: () -> Unit,
+    memoError: UiText?,
+) {
+    FormSelection(
+        selected = selectedChain,
+        options = chainList,
+        mapTypeToString = { it.name },
+        onSelectOption = onSelectChain,
+    )
+
+    FormTextFieldCard(
+        title = stringResource(R.string.function_transfer_ibc_dst_address_input_title),
+        hint = stringResource(R.string.function_transfer_ibc_dst_address_input_title),
+        keyboardType = KeyboardType.Text,
+        textFieldState = dstAddress,
+        onLostFocus = onDstAddressLostFocus,
+        error = dstAddressError,
+    ) {
+        val clipboard = LocalClipboardManager.current
+
+        UiIcon(
+            drawableResId = R.drawable.ic_paste,
+            size = 20.dp,
+            onClick = {
+                clipboard.getText()
+                    ?.toString()
+                    ?.let(onSetDstAddress)
+            }
+        )
+
+        UiSpacer(size = 8.dp)
+    }
+
+    FormTextFieldCard(
+        title = stringResource(
+            R.string.deposit_form_amount_title,
+            balance.asString()
+        ),
+        hint = stringResource(R.string.send_amount_currency_hint),
+        keyboardType = KeyboardType.Number,
+        textFieldState = amountFieldState,
+        onLostFocus = onAmountLostFocus,
+        error = amountError,
+    )
+
+    FormTextFieldCard(
+        title = stringResource(R.string.deposit_form_custom_memo_title),
+        hint = stringResource(R.string.deposit_form_custom_memo_title),
+        keyboardType = KeyboardType.Text,
+        textFieldState = memoFieldState,
+        onLostFocus = onMemoLostFocus,
+        error = memoError,
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -535,4 +535,6 @@
     <string name="backup_password_request_no_password_action" translatable="false">Backup without password</string>
     <string name="backup_password_request_with_password_action" translatable="false">Use password</string>
     <string name="backup_password_topbar_title" translatable="false">Password</string>
+    <string name="function_transfer_ibc_dst_address_input_title" translatable="false">Destination Address</string>
+    <string name="function_switch_thorchain_address" translatable="false">THORChain Address</string>
 </resources>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -130,7 +130,8 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                         accountNumber = BigInteger(it.accountNumber.toString()),
                         sequence = BigInteger(it.sequence.toString()),
                         gas = BigInteger(it.gas.toString()),
-                        ibcDenomTraces = it.ibcDenomTraces
+                        ibcDenomTraces = it.ibcDenomTraces,
+                        transactionType = it.transactionType,
                     )
                 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -82,6 +82,8 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     accountNumber = specific.accountNumber.toString().toULong(),
                     sequence = specific.sequence.toString().toULong(),
                     gas = specific.gas.toString().toULong(),
+                    transactionType = specific.transactionType,
+                    ibcDenomTraces = specific.ibcDenomTraces,
                 )
             } else null,
             solanaSpecific = if (specific is BlockChainSpecific.Solana) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -9,8 +9,8 @@ import com.vultisig.wallet.data.models.TokenStandard.SUBSTRATE
 import com.vultisig.wallet.data.models.TokenStandard.SUI
 import com.vultisig.wallet.data.models.TokenStandard.THORCHAIN
 import com.vultisig.wallet.data.models.TokenStandard.TON
-import com.vultisig.wallet.data.models.TokenStandard.UTXO
 import com.vultisig.wallet.data.models.TokenStandard.TRC20
+import com.vultisig.wallet.data.models.TokenStandard.UTXO
 import wallet.core.jni.CoinType
 
 typealias ChainId = String
@@ -138,7 +138,7 @@ val Chain.IsSwapSupported: Boolean
 
 val Chain.isDepositSupported: Boolean
     get() = when (this) {
-        Chain.ThorChain, Chain.MayaChain, Chain.Ton -> true
+        Chain.ThorChain, Chain.MayaChain, Chain.Ton, Chain.Kujira, Chain.GaiaChain -> true
         else -> false
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1442,17 +1442,6 @@ object Coins {
             isNativeToken = true,
         ),
         Coin(
-            chain = Chain.GaiaChain,
-            ticker = "ATOM",
-            logo = "atom",
-            address = "",
-            decimal = 6,
-            hexPublicKey = "",
-            priceProviderID = "cosmos",
-            contractAddress = "",
-            isNativeToken = true,
-        ),
-        Coin(
             chain = Chain.Kujira,
             ticker = "KUJI",
             logo = "kuji",
@@ -1695,7 +1684,33 @@ object Coins {
             contractAddress = "",
             isNativeToken = true,
         )
-    ) + terraTokens + terraClassicTokens + tronCoins
+    ) + gaiaTokens + terraTokens + terraClassicTokens + tronCoins
+
+    private val gaiaTokens
+        get() = listOf(
+            Coin(
+                chain = Chain.GaiaChain,
+                ticker = "ATOM",
+                logo = "atom",
+                decimal = 6,
+                priceProviderID = "cosmos",
+                contractAddress = "",
+                isNativeToken = true,
+                address = "",
+                hexPublicKey = "",
+            ),
+            Coin(
+                chain = Chain.GaiaChain,
+                ticker = "KUJI",
+                logo = "kuji",
+                decimal = 6,
+                priceProviderID = "kujira",
+                contractAddress = "ibc/4CC44260793F84006656DD868E017578F827A492978161DA31D7572BCB3F4289",
+                isNativeToken = false,
+                address = "",
+                hexPublicKey = "",
+            )
+        )
 
     private val terraTokens
         get() = listOf(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/BlockChainSpecfic.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/BlockChainSpecfic.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.models.payload
 
 import vultisig.keysign.v1.CosmosIbcDenomTrace
 import vultisig.keysign.v1.SuiCoin
+import vultisig.keysign.v1.TransactionType
 import java.math.BigInteger
 
 sealed class BlockChainSpecific {
@@ -35,6 +36,7 @@ sealed class BlockChainSpecific {
         val sequence: BigInteger,
         val gas: BigInteger,
         val ibcDenomTraces: CosmosIbcDenomTrace?,
+        val transactionType: TransactionType,
     ) : BlockChainSpecific()
 
     data class Solana(


### PR DESCRIPTION
Fix #1858 
Fix #1859 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new deposit options: IBC Transfer, Switch, and Merge, expanding cross-chain functionality and token management.
  - Added dedicated screens for IBC Transfer, Switch, and Merge operations with tailored input forms and selection components.
  - Enabled deposit support for Kujira and GaiaChain, alongside existing supported chains.
  - Added support for merging tokens and switching addresses directly from the deposit interface.

- **Enhancements**
  - Improved error handling and validation for deposit forms, including destination chain and address, amount, and memo fields.
  - Unified and streamlined chain selection and token management in the UI.
  - Expanded Cosmos transaction support to handle IBC transfers with proper channel and timeout handling.
  - Enhanced deposit transaction creation logic with new transaction types and memo formats.
  - Broadened memo field visibility to include Cosmos token standards.
  - Improved deposit detection logic for Cosmos transactions.

- **Bug Fixes**
  - Improved balance loading reliability with better error logging.

- **Documentation**
  - Added new localized strings for IBC transfer and Thorchain address input fields.

- **Refactor**
  - Modularized GaiaChain token definitions and improved transaction type handling for Cosmos and Thorchain operations.
  - Updated chain enum usage and unified deposit chain representation across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->