### PR TITLE
Make LVN only transferable through Osmosis

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -169,7 +169,7 @@ internal interface DepositMemo {
             }
 
             Chain.Osmosis -> when (dstChain) {
-                Chain.GaiaChain -> "channel-141"
+                Chain.GaiaChain -> "channel-0"
                 else -> ""
             }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -33,7 +33,7 @@ class CosmosHelper(
         private const val DEFAULT_GAS_LIMIT = 200000L
 
         fun getChainGasLimit(chain: Chain): Long = when (chain) {
-            Chain.Terra, Chain.TerraClassic -> 300000L
+            Chain.Terra, Chain.TerraClassic, Chain.Osmosis -> 300000L
             else -> DEFAULT_GAS_LIMIT
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -141,7 +141,8 @@ val Chain.IsSwapSupported: Boolean
 
 val Chain.isDepositSupported: Boolean
     get() = when (this) {
-        Chain.ThorChain, Chain.MayaChain, Chain.Ton, Chain.Kujira, Chain.GaiaChain -> true
+        Chain.ThorChain, Chain.MayaChain, Chain.Ton,
+        Chain.Kujira, Chain.GaiaChain, Chain.Osmosis -> true
         else -> false
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1673,7 +1673,22 @@ object Coins {
             contractAddress = "",
             isNativeToken = true,
         )
-    ) + gaiaTokens + terraTokens + terraClassicTokens + tronCoins + thorTokens
+    ) + gaiaTokens + terraTokens + terraClassicTokens + tronCoins + thorTokens + kujiraTokens
+
+    private val kujiraTokens
+        get() = listOf(
+            Coin(
+                chain = Chain.Kujira,
+                ticker = "LVN",
+                logo = "lvn",
+                decimal = 6,
+                priceProviderID = "levana-protocol",
+                contractAddress = "ibc/B64A07C006C0F5E260A8AD50BD53568F1FD4A0D75B7A9F8765C81BEAFDA62053",
+                isNativeToken = false,
+                address = "",
+                hexPublicKey = "",
+            ),
+        )
 
     private val gaiaTokens
         get() = listOf(
@@ -1738,7 +1753,7 @@ object Coins {
                 logo = "lvn",
                 decimal = 6,
                 priceProviderID = "levana-protocol",
-                contractAddress = "ibc/CE26C8060F437C6F2157D7A7AF2B2ECA6CBFAA268755504E038A4D085BA70EFC",
+                contractAddress = "ibc/6C95083ADD352D5D47FB4BA427015796E5FEF17A829463AD05ECD392EB38D889",
                 isNativeToken = false,
                 address = "",
                 hexPublicKey = "",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -264,7 +264,7 @@ internal class BlockChainSpecificRepositoryImpl @Inject constructor(
                     )
                 }
 
-                Chain.GaiaChain -> {
+                Chain.GaiaChain, Chain.Osmosis -> {
                     if (transactionType == TransactionType.TRANSACTION_TYPE_IBC_TRANSFER) {
                         val timeout = Clock.System.now().plus(10.minutes)
                             .toEpochMilliseconds().milliseconds.inWholeNanoseconds


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deposits on the Osmosis chain.
  - Introduced the "LVN" token on the Kujira chain and updated its contract address for the GaiaChain.
  - Enabled IBC transfers between Osmosis and GaiaChain with updated channel mapping.

- **Improvements**
  - Enhanced deposit options and dynamic destination chain selection based on token and chain.
  - Added a gas limit for Osmosis chain transactions to match other supported chains.

- **Bug Fixes**
  - Updated IBC channel mapping for Osmosis-to-GaiaChain transfers to ensure correct routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->