### PR TITLE
Add swap percentage picker

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/RequestQrScanUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/RequestQrScanUseCase.kt
@@ -3,8 +3,9 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
-import com.vultisig.wallet.ui.navigation.VsNavigator
 import javax.inject.Inject
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -14,7 +15,7 @@ fun interface RequestQrScanUseCase {
 }
 
 internal class RequestQrScanUseCaseImpl @Inject constructor(
-    private val navigator: VsNavigator,
+    private val navigator: Navigator<Destination>,
     private val requestResultRepo: RequestResultRepository,
 ) : RequestQrScanUseCase {
     override suspend fun invoke(): String? {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsBasicTextField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsBasicTextField.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.components.inputs
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -28,6 +29,7 @@ internal fun VsBasicTextField(
     lineLimits: TextFieldLineLimits = TextFieldLineLimits.Default,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     onKeyboardAction: KeyboardActionHandler? = null,
+    interactionSource: MutableInteractionSource? = null,
 ) {
     BasicTextField(
         state = textFieldState,
@@ -54,6 +56,7 @@ internal fun VsBasicTextField(
 
             textField()
         },
+        interactionSource = interactionSource,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.math.RoundingMode
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -560,6 +561,7 @@ internal class SwapFormViewModel @Inject constructor(
 
         val amount = TokenValue.createDecimal(maxUsableTokenAmount, srcTokenValue.decimals)
             .multiply(percentage.toBigDecimal())
+            .setScale(6, RoundingMode.DOWN)
 
         srcAmountState.setTextAndPlaceCursorAtEnd(amount.toString())
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.ui.models.swap
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -542,7 +543,25 @@ internal class SwapFormViewModel @Inject constructor(
             selectedSrc.value = selectedDst.value
             selectedDst.value = buffer
         }
+    }
 
+    fun selectSrcPercentage(percentage: Float) {
+        val selectedSrcAccount = selectedSrc.value?.account ?: return
+        val srcTokenValue = selectedSrcAccount.tokenValue ?: return
+
+        val srcToken = selectedSrcAccount.token
+
+        val swapFee =
+            quote?.fees?.value.takeIf { provider == SwapProvider.LIFI } ?: BigInteger.ZERO
+
+        val maxUsableTokenAmount =
+            srcTokenValue.value - swapFee - (gasFee.value?.value?.takeIf { srcToken.isNativeToken }
+                ?: BigInteger.ZERO)
+
+        val amount = TokenValue.createDecimal(maxUsableTokenAmount, srcTokenValue.decimals)
+            .multiply(percentage.toBigDecimal())
+
+        srcAmountState.setTextAndPlaceCursorAtEnd(amount.toString())
     }
 
     fun loadData(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinValues.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinValues.kt
@@ -20,8 +20,7 @@ data class TokenValue(
     val decimals: Int,
 ) {
     val decimal: BigDecimal
-        get() = BigDecimal(value)
-            .divide(BigDecimal(10).pow(decimals))
+        get() = createDecimal(value, decimals)
 
     constructor(
         value: BigInteger,
@@ -31,6 +30,14 @@ data class TokenValue(
         unit = token.ticker,
         decimals = token.decimal
     )
+
+    companion object {
+        fun createDecimal(
+            value: BigInteger,
+            decimals: Int,
+        ) = BigDecimal(value)
+            .divide(BigDecimal(10).pow(decimals))
+    }
 
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 25 15:45:47 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix #1866 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a percentage picker to the swap screen, allowing users to quickly select 25%, 50%, 75%, or 100% of their available balance when entering a swap amount.
  - Introduced a method to select source token amount by percentage in the swap form.
- **Improvements**
  - Enhanced text fields to support external interaction tracking for more responsive UI behavior.
- **Chores**
  - Upgraded Gradle version to 8.14 for improved build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->