### PR TITLE
Hide track button when there's not tracking URL

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -55,7 +55,7 @@ internal fun KeysignView(
                             transactionLink = transactionLink,
                             approveTransactionLink = approveTransactionLink,
                             onComplete = onComplete,
-                            progressLink = progressLink ?: "",
+                            progressLink = progressLink,
                             onBack = onBack,
                             transactionTypeUiModel = transactionTypeUiModel.swapTransactionUiModel,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -51,7 +51,7 @@ internal fun SwapTransactionOverviewScreen(
     transactionLink: String,
     approveTransactionLink: String,
     onComplete: () -> Unit,
-    progressLink: String,
+    progressLink: String?,
     onBack: () -> Unit = {},
     transactionTypeUiModel: SwapTransactionUiModel,
 ) {
@@ -170,16 +170,18 @@ internal fun SwapTransactionOverviewScreen(
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        VsButton(
-                            label = "Track",
-                            variant = VsButtonVariant.Secondary,
-                            size = VsButtonSize.Small,
-                            modifier = Modifier
-                                .weight(1f),
-                            onClick = {
-                                uriHandler.openUri(progressLink)
-                            }
-                        )
+                        if (progressLink != null && progressLink.isNotEmpty()) {
+                            VsButton(
+                                label = "Track",
+                                variant = VsButtonVariant.Secondary,
+                                size = VsButtonSize.Small,
+                                modifier = Modifier
+                                    .weight(1f),
+                                onClick = {
+                                    uriHandler.openUri(progressLink)
+                                }
+                            )
+                        }
 
                         VsButton(
                             label = "Done",


### PR DESCRIPTION
## Description

We don't provide tracking urls for some swaps, so I hid tracking button for that case.

Fixes #1906 

## Which feature is affected?
- [ ] Swap transaction overview


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The "Track" button on the swap transaction overview screen is now only shown when a valid tracking link is available, preventing issues with empty or missing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->