### PR TITLE
Show successful XRP tx when it was broadcasted by co-signer

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -49,8 +49,14 @@ internal class RippleApiImp @Inject constructor(
 
             val rpcResp = response.body<RippleBroadcastResponseResponseJson>()
 
+            val resultMessage = rpcResp.result.engineResultMessage
+
             if (rpcResp.result.engineResult != "tesSUCCESS") {
-                if (rpcResp.result.engineResultMessage.equals(
+                if (
+                    resultMessage?.contains(
+                        "The transaction was applied", ignoreCase = true
+                    ) == true ||
+                    resultMessage.equals(
                         "This sequence number has already passed.",
                         ignoreCase = true
                     )
@@ -59,16 +65,17 @@ internal class RippleApiImp @Inject constructor(
                         return rpcResp.result.txJson.hash
                     }
                 }
-                return rpcResp.result.engineResultMessage ?: ""
+                return resultMessage ?: ""
             }
+
             if (rpcResp.result.txJson?.hash?.isNotEmpty() == true) {
-                return rpcResp.result.engineResultMessage ?: ""
+                return resultMessage ?: ""
             }
             return ""
         } catch (e: Exception) {
             Timber.e(
+                e.message,
                 "Error in Broadcast XRP Transaction",
-                e.message
             )
             error(e.message ?: "Error in Broadcast XRP Transaction")
         }


### PR DESCRIPTION
## Description

This should fix the transaction was applied error when co-signer broadcasted XRP tx before current device

Fixes #1886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Ripple transaction responses, ensuring more accurate feedback is provided in cases where transactions are applied or have already passed, even if not marked as fully successful.
  - Enhanced error messages for failed transactions to offer clearer information to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->