### PR TITLE
Remove buy WEWE button

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -50,7 +50,6 @@ internal data class ChainTokensUiModel(
     val canSwap: Boolean = true,
     val canSelectTokens: Boolean = false,
     val isBalanceVisible: Boolean = true,
-    val isBuyWeweVisible: Boolean = false,
 )
 
 @Immutable
@@ -121,7 +120,6 @@ internal class ChainTokensViewModel @Inject constructor(
         }
     }
 
-
     fun deposit() {
         viewModelScope.launch {
             navigator.navigate(
@@ -163,21 +161,6 @@ internal class ChainTokensViewModel @Inject constructor(
                     vaultId = vaultId,
                     chainId = chainRaw,
                     tokenId = model.id,
-                )
-            )
-        }
-    }
-
-    fun buyWewe() {
-        viewModelScope.launch {
-            if (!tokens.value.contains(Tokens.wewe)) {
-                enableTokenUseCase(vaultId, Tokens.wewe)
-            }
-            navigator.route(
-                Route.Swap(
-                    vaultId = vaultId,
-                    chainId = chainRaw,
-                    dstTokenId = Tokens.wewe.id,
                 )
             )
         }
@@ -242,8 +225,7 @@ internal class ChainTokensViewModel @Inject constructor(
                         totalBalance = totalBalance,
                         canDeposit = chain.isDepositSupported,
                         canSwap = chain.IsSwapSupported,
-                        canSelectTokens = chain.canSelectTokens,
-                        isBuyWeweVisible = chain == Chain.Base
+                        canSelectTokens = chain.canSelectTokens
                     )
                 }
             }.onCompletion {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ChainTokensScreen.kt
@@ -92,7 +92,6 @@ internal fun ChainTokensScreen(
         onDeposit = viewModel::deposit,
         onSelectTokens = viewModel::selectTokens,
         onTokenClick = viewModel::openToken,
-        onBuyWeweClick = viewModel::buyWewe,
         onQrBtnClick = viewModel::navigateToQrAddressScreen,
         onShowReviewPopUp = {
             reviewManager.showReviewPopUp(context)
@@ -110,7 +109,7 @@ private fun ChainTokensScreen(
     onDeposit: () -> Unit = {},
     onSelectTokens: () -> Unit = {},
     onTokenClick: (ChainTokenUiModel) -> Unit = {},
-    onBuyWeweClick: () -> Unit = {},
+
     onQrBtnClick: () -> Unit = {},
     onShowReviewPopUp: () -> Unit = {},
 ) {
@@ -138,43 +137,7 @@ private fun ChainTokensScreen(
                     startIcon = R.drawable.ic_caret_left,
                 )
             },
-            bottomBar = {
-                if (uiModel.isBuyWeweVisible) {
-                    MultiColorButton(
-                        minHeight = 44.dp,
-                        backgroundColor = appColor.turquoise800,
-                        textColor = appColor.oxfordBlue800,
-                        iconColor = appColor.turquoise800,
-                        textStyle = Theme.montserrat.subtitle1,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(
-                                start = 16.dp,
-                                end = 16.dp,
-                                bottom = 16.dp,
-                            ),
-                        content = {
-                            Row(
-                                horizontalArrangement = Arrangement.Center,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Image(
-                                    painter = painterResource(id = R.drawable.ic_wewe),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(40.dp),
-                                )
-                                Spacer(modifier = Modifier.width(16.dp))
-                                Text(
-                                    text = stringResource(id = R.string.chain_account_buy_wewe),
-                                    color = MaterialTheme.colorScheme.onPrimary,
-                                    style = Theme.montserrat.subtitle1
-                                )
-                            }
-                        },
-                        onClick = onBuyWeweClick
-                    )
-                }
-            }
+            bottomBar = {}
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -147,7 +147,6 @@
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
-    <string name="chain_account_buy_wewe">$VULT KAUFEN</string>
     <string name="send_amount_currency">Betrag (in %s)</string>
     <string name="vault_settings_backup_subtitle">Sichern Sie Ihre Tresorfreigabe</string>
     <string name="chains">Ketten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -140,7 +140,6 @@
     <string name="chains">Cadenas</string>
     <string name="vault_settings_backup_subtitle">Realice una copia de seguridad de su recurso compartido de bóveda</string>
     <string name="send_amount_currency">Cantidad (en %s)</string>
-    <string name="chain_account_buy_wewe">COMPRAR $VULT</string>
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
     <string name="send_error_no_address">La dirección no es válida</string>
     <string name="verify_transaction_value">Valor</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -147,7 +147,6 @@
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
-    <string name="chain_account_buy_wewe">KUPITE $VULT</string>
     <string name="send_amount_currency">Iznos (u %s)</string>
     <string name="vault_settings_backup_subtitle">Sigurnosno kopirajte svoj udio u trezoru</string>
     <string name="chains">Lanci</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -147,7 +147,6 @@
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">L\’indirizzo non è valido</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
-    <string name="chain_account_buy_wewe">ACQUISTA $VULT</string>
     <string name="send_amount_currency">Importo (in %s)</string>
     <string name="vault_settings_backup_subtitle">Esegui il backup della condivisione del vault</string>
     <string name="chains">Catene</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -38,7 +38,6 @@
     <string name="chain_account_view_send">STUREN</string>
     <string name="chain_account_view_swap">WISSELEN</string>
     <string name="chain_account_view_deposit">STORTEN</string>
-    <string name="chain_account_buy_wewe">KOOP $VULT</string>
     <string name="vault_settings_error_backup_file">er is een fout opgetreden</string>
     <string name="vault_settings_success_backup_file">bestand opgeslagen in Downloads/%1$s</string>
     <string name="vault_edit_this_name_already_exist">deze naam bestaat al</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -147,7 +147,6 @@
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
-    <string name="chain_account_buy_wewe">COMPRE $VULT</string>
     <string name="send_amount_currency">Quantidade (em %s)</string>
     <string name="vault_settings_backup_subtitle">Faça backup do seu compartilhamento de cofre</string>
     <string name="chains">Correntes</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -38,7 +38,6 @@
     <string name="chain_account_view_send">ОТПРАВИТЬ</string>
     <string name="chain_account_view_swap">ОБМЕН</string>
     <string name="chain_account_view_deposit">ДЕПОЗИТ</string>
-    <string name="chain_account_buy_wewe">КУПИТЬ $VULT</string>
     <string name="vault_settings_error_backup_file">произошла ошибка</string>
     <string name="vault_settings_success_backup_file">файл сохранен в Загрузках/%1$s</string>
     <string name="vault_edit_this_name_already_exist">это имя уже существует</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="chain_account_view_send">SEND</string>
     <string name="chain_account_view_swap">SWAP</string>
     <string name="chain_account_view_deposit">FUNCTION</string>
-    <string name="chain_account_buy_wewe">BUY $WEWE</string>
+
     <string name="vault_settings_error_backup_file">an error occurred</string>
     <string name="vault_settings_success_backup_file">file saved in Downloads/%1$s</string>
     <string name="vault_edit_this_name_already_exist">this name already exist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,6 @@
     <string name="chain_account_view_send">SEND</string>
     <string name="chain_account_view_swap">SWAP</string>
     <string name="chain_account_view_deposit">FUNCTION</string>
-
     <string name="vault_settings_error_backup_file">an error occurred</string>
     <string name="vault_settings_success_backup_file">file saved in Downloads/%1$s</string>
     <string name="vault_edit_this_name_already_exist">this name already exist</string>


### PR DESCRIPTION
Removing the "Buy "WEWE" button and logic on Base `ChainTokenScreen`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the "Buy WEWE" button and all related functionality from the token screen.
	- The option to buy WEWE tokens is no longer visible or accessible in the app.
- **Style**
	- Updated the interface to remove references to buying WEWE tokens.
- **Chores**
	- Removed unused string resources related to the "Buy WEWE" feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->