### PR TITLE
Fix XRP tx completion for initializing device

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -66,12 +66,14 @@ internal class RippleApiImp @Inject constructor(
                     }
                 }
                 return resultMessage ?: ""
+            } else {
+                val hash = rpcResp.result.txJson?.hash
+                return if (hash?.isNotEmpty() == true) {
+                    hash
+                } else {
+                    resultMessage ?: ""
+                }
             }
-
-            if (rpcResp.result.txJson?.hash?.isNotEmpty() == true) {
-                return resultMessage ?: ""
-            }
-            return ""
         } catch (e: Exception) {
             Timber.e(
                 e.message,


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1886

## Which feature is affected?
- [ ] Send XRP (tx https://livenet.xrpl.org/transactions/ED4DAB90AA736A6B3DE38221BE2F77750DABA62A5E6C613BD1FDB621C2D23373)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of transaction broadcast results for Ripple, ensuring that successful transactions now display the transaction hash when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->