### PR TITLE
Fix fast vault password hint on two lines

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsTextInputField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsTextInputField.kt
@@ -193,8 +193,6 @@ internal fun VsTextInputField(
                         }
                     )
 
-                    UiSpacer(1f)
-
                     if (textFieldState.text.isNotEmpty()) {
                         Icon(
                             painter = painterResource(


### PR DESCRIPTION
Fixes #1954



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the layout of the password input field by removing a small vertical space between the password field and the visibility toggle icon. This results in a more compact appearance for the input area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->