### PR TITLE
Fix swap error when swapping amount is small

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -994,6 +994,8 @@ internal class SwapFormViewModel @Inject constructor(
 
                             is SwapException.NetworkConnection ->
                                 UiText.StringResource(R.string.network_connection_lost)
+                            is SwapException.SmallSwapAmount ->
+                                UiText.StringResource(R.string.swap_error_small_swap_amount)
                         }
                         uiState.update {
                             it.copy(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -319,6 +319,8 @@
     <string name="insufficient_native_token">Nicht genügend %1$s</string>
     <string name="swap_error_amount_too_low">Swap-Betrag zu niedrig</string>
     <string name="swap_error_time_out">Die Swap-Anfrage ist abgelaufen. Bitte versuchen Sie es erneut.</string>
+    <string name="swap_error_small_swap_amount">Der Swap-Betrag ist zu gering. Bitte erhöhen Sie den Betrag, um tauschen zu können.</string>
+    <string name="swap_error_small_swap_amount">Der Swap-Betrag ist zu gering. Bitte erhöhen Sie den Betrag, um tauschen zu können.</string>
     <string name="keygen_verify_server_backup_invalid_code">Ungültiger Code</string>
     <string name="swap_screen_invalid_no_vault">Kein Tresor ausgewählt</string>
     <string name="swap_screen_invalid_no_src_error">Kein Quelltoken ausgewählt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -320,7 +320,6 @@
     <string name="swap_error_amount_too_low">Swap-Betrag zu niedrig</string>
     <string name="swap_error_time_out">Die Swap-Anfrage ist abgelaufen. Bitte versuchen Sie es erneut.</string>
     <string name="swap_error_small_swap_amount">Der Swap-Betrag ist zu gering. Bitte erhöhen Sie den Betrag, um tauschen zu können.</string>
-    <string name="swap_error_small_swap_amount">Der Swap-Betrag ist zu gering. Bitte erhöhen Sie den Betrag, um tauschen zu können.</string>
     <string name="keygen_verify_server_backup_invalid_code">Ungültiger Code</string>
     <string name="swap_screen_invalid_no_vault">Kein Tresor ausgewählt</string>
     <string name="swap_screen_invalid_no_src_error">Kein Quelltoken ausgewählt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -320,7 +320,6 @@
     <string name="swap_error_amount_too_low">El monto de intercambio es demasiado bajo</string>
     <string name="swap_error_time_out">Se agotó el tiempo de espera de la solicitud de intercambio. Inténtalo de nuevo</string>
     <string name="swap_error_small_swap_amount">El monto del intercambio es demasiado pequeño. Por favor, aumente el monto para poder intercambiar.</string>
-    <string name="swap_error_small_swap_amount">El monto del intercambio es demasiado pequeño. Por favor, aumente el monto para poder intercambiar.</string>
     <string name="keygen_verify_server_backup_invalid_code">Código inválido</string>
     <string name="swap_screen_invalid_no_vault">No se ha seleccionado ninguna bóveda</string>
     <string name="swap_screen_invalid_no_src_error">No se ha seleccionado ningún token de origen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -319,6 +319,8 @@
     <string name="insufficient_native_token">%1$s insuficientes</string>
     <string name="swap_error_amount_too_low">El monto de intercambio es demasiado bajo</string>
     <string name="swap_error_time_out">Se agotó el tiempo de espera de la solicitud de intercambio. Inténtalo de nuevo</string>
+    <string name="swap_error_small_swap_amount">El monto del intercambio es demasiado pequeño. Por favor, aumente el monto para poder intercambiar.</string>
+    <string name="swap_error_small_swap_amount">El monto del intercambio es demasiado pequeño. Por favor, aumente el monto para poder intercambiar.</string>
     <string name="keygen_verify_server_backup_invalid_code">Código inválido</string>
     <string name="swap_screen_invalid_no_vault">No se ha seleccionado ninguna bóveda</string>
     <string name="swap_screen_invalid_no_src_error">No se ha seleccionado ningún token de origen</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -319,6 +319,8 @@
     <string name="insufficient_native_token">Nedovoljno %1$s</string>
     <string name="swap_error_amount_too_low">Iznos zamjene je prenizak</string>
     <string name="swap_error_time_out">Zahtjev za zamjenu je istekao. Molimo pokušajte ponovno</string>
+    <string name="swap_error_small_swap_amount">Iznos zamjene premali. Povećajte iznos kako biste mogli zamijeniti</string>
+    <string name="swap_error_small_swap_amount">Iznos zamjene premali. Povećajte iznos kako biste mogli zamijeniti</string>
     <string name="keygen_verify_server_backup_invalid_code">Neispravan kod</string>
     <string name="swap_screen_invalid_no_vault">Trezor nije odabran</string>
     <string name="swap_screen_invalid_no_src_error">Nije odabran izvorni token</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -320,7 +320,6 @@
     <string name="swap_error_amount_too_low">Iznos zamjene je prenizak</string>
     <string name="swap_error_time_out">Zahtjev za zamjenu je istekao. Molimo pokušajte ponovno</string>
     <string name="swap_error_small_swap_amount">Iznos zamjene premali. Povećajte iznos kako biste mogli zamijeniti</string>
-    <string name="swap_error_small_swap_amount">Iznos zamjene premali. Povećajte iznos kako biste mogli zamijeniti</string>
     <string name="keygen_verify_server_backup_invalid_code">Neispravan kod</string>
     <string name="swap_screen_invalid_no_vault">Trezor nije odabran</string>
     <string name="swap_screen_invalid_no_src_error">Nije odabran izvorni token</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -319,6 +319,8 @@
     <string name="insufficient_native_token">%1$s insufficienti</string>
     <string name="swap_error_amount_too_low">Importo dello swap troppo basso</string>
     <string name="swap_error_time_out">La richiesta di scambio è scaduta. Riprova.</string>
+    <string name="swap_error_small_swap_amount">Importo dello swap troppo piccolo. Aumenta l\'importo per poter effettuare lo swap.</string>
+    <string name="swap_error_small_swap_amount">Importo dello swap troppo piccolo. Aumenta l\'importo per poter effettuare lo swap.</string>
     <string name="keygen_verify_server_backup_invalid_code">Codice non valido</string>
     <string name="swap_screen_invalid_no_vault">Nessun caveau selezionato</string>
     <string name="swap_screen_invalid_no_src_error">Nessun token sorgente selezionato</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -320,7 +320,6 @@
     <string name="swap_error_amount_too_low">Importo dello swap troppo basso</string>
     <string name="swap_error_time_out">La richiesta di scambio è scaduta. Riprova.</string>
     <string name="swap_error_small_swap_amount">Importo dello swap troppo piccolo. Aumenta l\'importo per poter effettuare lo swap.</string>
-    <string name="swap_error_small_swap_amount">Importo dello swap troppo piccolo. Aumenta l\'importo per poter effettuare lo swap.</string>
     <string name="keygen_verify_server_backup_invalid_code">Codice non valido</string>
     <string name="swap_screen_invalid_no_vault">Nessun caveau selezionato</string>
     <string name="swap_screen_invalid_no_src_error">Nessun token sorgente selezionato</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -331,7 +331,6 @@
     <string name="swap_error_amount_too_low">Swapbedrag te laag</string>
     <string name="swap_error_time_out">Swap-aanvraag is verlopen. Probeer het opnieuw.</string>
     <string name="swap_error_small_swap_amount">Het ruilbedrag is te klein. Verhoog het bedrag om te kunnen ruilen.</string>
-    <string name="swap_error_small_swap_amount">Het ruilbedrag is te klein. Verhoog het bedrag om te kunnen ruilen.</string>
     <string name="keygen_verify_server_backup_invalid_code">Ongeldige code</string>
     <string name="swap_screen_invalid_no_vault">Geen kluis geselecteerd</string>
     <string name="swap_screen_invalid_no_src_error">Geen brontoken geselecteerd</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -330,6 +330,8 @@
     <string name="insufficient_native_token">Onvoldoende %1$s</string>
     <string name="swap_error_amount_too_low">Swapbedrag te laag</string>
     <string name="swap_error_time_out">Swap-aanvraag is verlopen. Probeer het opnieuw.</string>
+    <string name="swap_error_small_swap_amount">Het ruilbedrag is te klein. Verhoog het bedrag om te kunnen ruilen.</string>
+    <string name="swap_error_small_swap_amount">Het ruilbedrag is te klein. Verhoog het bedrag om te kunnen ruilen.</string>
     <string name="keygen_verify_server_backup_invalid_code">Ongeldige code</string>
     <string name="swap_screen_invalid_no_vault">Geen kluis geselecteerd</string>
     <string name="swap_screen_invalid_no_src_error">Geen brontoken geselecteerd</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -319,6 +319,7 @@
     <string name="insufficient_native_token">%1$s insuficiente</string>
     <string name="swap_error_amount_too_low">Valor de swap muito baixo</string>
     <string name="swap_error_time_out">A solicitação de troca expirou. Por favor tente novamente</string>
+    <string name="swap_error_small_swap_amount">Valor de troca muito pequeno. Por favor aumente o valor para poder trocar</string>
     <string name="keygen_verify_server_backup_invalid_code">Código inválido</string>
     <string name="swap_screen_invalid_no_vault">Nenhum cofre selecionado</string>
     <string name="swap_screen_invalid_no_src_error">Nenhum token de origem selecionado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -330,6 +330,8 @@
     <string name="insufficient_native_token">Недостаточно %1$s</string>
     <string name="swap_error_amount_too_low">Сумма обмена слишком мала</string>
     <string name="swap_error_time_out">Запрос на обмен истек. Попробуйте еще раз</string>
+    <string name="swap_error_small_swap_amount">Сумма обмена слишком мала. Пожалуйста, увеличьте сумму, чтобы иметь возможность обмена</string>
+    <string name="swap_error_small_swap_amount">Сумма обмена слишком мала. Пожалуйста, увеличьте сумму, чтобы иметь возможность обмена</string>
     <string name="keygen_verify_server_backup_invalid_code">Неверный код</string>
     <string name="swap_screen_invalid_no_vault">Хранилище не выбрано</string>
     <string name="swap_screen_invalid_no_src_error">Исходный токен не выбран</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -331,7 +331,6 @@
     <string name="swap_error_amount_too_low">Сумма обмена слишком мала</string>
     <string name="swap_error_time_out">Запрос на обмен истек. Попробуйте еще раз</string>
     <string name="swap_error_small_swap_amount">Сумма обмена слишком мала. Пожалуйста, увеличьте сумму, чтобы иметь возможность обмена</string>
-    <string name="swap_error_small_swap_amount">Сумма обмена слишком мала. Пожалуйста, увеличьте сумму, чтобы иметь возможность обмена</string>
     <string name="keygen_verify_server_backup_invalid_code">Неверный код</string>
     <string name="swap_screen_invalid_no_vault">Хранилище не выбрано</string>
     <string name="swap_screen_invalid_no_src_error">Исходный токен не выбран</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,6 +367,7 @@
     <string name="insufficient_native_token">Insufficient %1$s</string>
     <string name="swap_error_amount_too_low">Swap Amount too low</string>
     <string name="swap_error_time_out">Swap request timed out. Please try again</string>
+    <string name="swap_error_small_swap_amount">Swap amount too small. Please increase the amount to be able to swap</string>
     <string name="keygen_verify_server_backup_invalid_code">Invalid code</string>
     <string name="swap_screen_invalid_no_vault">No vault selected</string>
     <string name="swap_screen_invalid_no_src_error">No source token selected</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -9,6 +9,7 @@ sealed class SwapException(message: String) : Exception(message) {
     class SwapRouteNotAvailable(message: String) : SwapException(message)
     class TimeOut(message: String) : SwapException(message)
     class NetworkConnection(message: String) : SwapException(message)
+    class SmallSwapAmount(message: String) : SwapException(message)
 
 
     companion object {
@@ -21,7 +22,8 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("not enough asset to pay for fees") -> InsufficentSwapAmount(error)
                     contains("outbound amount does not meet requirements") -> InsufficentSwapAmount(error)
                     contains("failed to simulate swap: pool") -> SwapRouteNotAvailable(error)
-                    contains("No available qoutes for the resquested") -> SwapRouteNotAvailable(error)
+                    contains("No available quotes for the resquested") -> SwapRouteNotAvailable(error)
+                    contains("amount less than dust threshold: invalid request") -> SmallSwapAmount(error)
                     contains("pool does not exist") -> SwapRouteNotAvailable(error)
                     contains("trading is halted") -> SwapRouteNotAvailable(error)
                     contains("timeout") -> TimeOut(error)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -22,7 +22,7 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("not enough asset to pay for fees") -> InsufficentSwapAmount(error)
                     contains("outbound amount does not meet requirements") -> InsufficentSwapAmount(error)
                     contains("failed to simulate swap: pool") -> SwapRouteNotAvailable(error)
-                    contains("No available quotes for the resquested") -> SwapRouteNotAvailable(error)
+                    contains("No available quotes for the requested") -> SwapRouteNotAvailable(error)
                     contains("amount less than dust threshold: invalid request") -> SmallSwapAmount(error)
                     contains("pool does not exist") -> SwapRouteNotAvailable(error)
                     contains("trading is halted") -> SwapRouteNotAvailable(error)


### PR DESCRIPTION
## Description

Fixes #1949

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new error message for swap transactions when the swap amount is too small, guiding users to increase the amount.
- **Localization**
  - Introduced translations for the new small swap amount error message in English, German, Spanish, Croatian, Italian, Dutch, Portuguese, and Russian.
- **Bug Fixes**
  - Corrected a typo in an error message related to swap quotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->