### PR TITLE
Enable ZCash swap

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -138,7 +138,7 @@ val Chain.IsSwapSupported: Boolean
 
         Chain.Avalanche, Chain.Base, Chain.BscChain, Chain.Ethereum, Chain.Optimism, Chain.Polygon,
 
-        Chain.Arbitrum, Chain.Blast, Chain.CronosChain, Chain.Solana, Chain.ZkSync,
+        Chain.Arbitrum, Chain.Blast, Chain.CronosChain, Chain.Solana, Chain.ZkSync, Chain.Zcash,
     )
 
 val Chain.isDepositSupported: Boolean

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -455,6 +455,8 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
                 SwapProvider.THORCHAIN
             )
 
+            Chain.Zcash -> setOf(SwapProvider.MAYA)
+
             Chain.Arbitrum -> if (ticker in mayaArbTokens) setOf(
                 SwapProvider.LIFI,
                 SwapProvider.MAYA
@@ -465,7 +467,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
 
             Chain.Polkadot, Chain.Dydx, Chain.Sui, Chain.Ton, Chain.Osmosis,
             Chain.Terra, Chain.TerraClassic, Chain.Noble, Chain.Ripple, Chain.Akash, Chain.Tron,
-            Chain.Zcash -> emptySet()
+                -> emptySet()
         }
 
 


### PR DESCRIPTION
## Description

Enable Zcash swap

Fixes #1970

## Which feature is affected?
- [ ] Swap

TX: https://www.xscanner.org/tx/59262b697a8f99e684c704189b79fdc58371d06da1a5ab52664ea658d788408d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled swap functionality for Zcash.
  - Added support for swapping Zcash via the MAYA provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->