### PR TITLE
Change QR scanning resolution

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -273,7 +273,7 @@ private fun QrCameraScreen(
         factory = { context ->
             val previewView = PreviewView(context)
             val resolutionStrategy = ResolutionStrategy(
-                Size(1200, 1200),
+                Size(1280, 720),
                 ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
             )
             val resolutionSelector = ResolutionSelector.Builder()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -273,7 +273,7 @@ private fun QrCameraScreen(
         factory = { context ->
             val previewView = PreviewView(context)
             val resolutionStrategy = ResolutionStrategy(
-                Size(1280, 720),
+                Size(1920, 1280),
                 ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
             )
             val resolutionSelector = ResolutionSelector.Builder()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the camera preview resolution for QR scanning from a square to a rectangular format for improved compatibility and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->