### PR TITLE
Change Mayachain Explorer Link

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -42,7 +42,7 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
         payload: SwapPayload?,
     ): String? = when (payload) {
         is SwapPayload.ThorChain -> "https://thorchain.net/tx/$tx"
-        is SwapPayload.MayaChain -> "https://www.xscanner.org/tx/${tx.removePrefix("0x")}"
+        is SwapPayload.MayaChain -> "https://www.mayascan.org/tx/${tx.removePrefix("0x")}"
         is SwapPayload.OneInch -> {
             if (payload.data.quote.tx.swapFee.toBigIntegerOrNull() != null) {
                 if (payload.data.fromCoin.chain == payload.data.toCoin.chain && payload.data.fromCoin.chain == Chain.Solana) {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1986

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
https://www.mayascan.org/tx/5EF3E2805636D85861C1468AA84CC3E3882EB945FAE3367D3DF1A12ADD8217E1
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the transaction link for MayaChain swaps to direct users to the correct explorer website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->