### PR TITLE
Fix support for sending memo as an integer or a string on the Ripple chain

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
@@ -34,26 +34,82 @@ object RippleHelper {
             PublicKeyType.SECP256K1
         )
 
-        val operation = Ripple.OperationPayment.newBuilder()
+        val operationBuilder = Ripple.OperationPayment.newBuilder()
             .setDestination(keysignPayload.toAddress)
             .setAmount(keysignPayload.toAmount.toLong())
-            .let {
-                if (keysignPayload.memo != null)
-                    it.setDestinationTag(keysignPayload.memo.toLongOrNull() ?: 0L)
-                else it
-            }.build()
 
-        val input = Ripple.SigningInput.newBuilder()
-            .setFee(gas.toLong())
-            .setSequence(sequence.toInt())
-            .setLastLedgerSequence(lastLedgerSequence.toInt())
-            .setAccount(keysignPayload.coin.address)
-            .setPublicKey(
-                ByteString.copyFrom(publicKey.data())
-            )
-            .setOpPayment(operation)
-            .build()
-        return input.toByteArray()
+        val memoValue = keysignPayload.memo
+        val operation = operationBuilder.build()
+        if (memoValue != null) {
+            val memoAsLong = memoValue.toLongOrNull()
+            if (memoAsLong != null) {
+                operationBuilder.setDestinationTag(memoAsLong)
+
+                val input = Ripple.SigningInput
+                    .newBuilder()
+                    .setFee(gas.toLong())
+                    .setSequence(sequence.toInt())
+                    .setLastLedgerSequence(lastLedgerSequence.toInt())
+                    .setAccount(keysignPayload.coin.address)
+                    .setPublicKey(
+                        ByteString.copyFrom(publicKey.data())
+                    )
+                    .setOpPayment(operation)
+                    .build()
+                return input.toByteArray()
+
+            } else {
+                val txJson: MutableMap<String, Any> = mutableMapOf(
+                    "TransactionType" to "Payment",
+                    "Account" to keysignPayload.coin.address,
+                    "Destination" to keysignPayload.toAddress,
+                    "Amount" to keysignPayload.toAmount.toString(),
+                    "Fee" to gas.toString(),
+                    "Sequence" to sequence,
+                    "LastLedgerSequence" to lastLedgerSequence,
+                    "Memos" to listOf(
+                        mapOf(
+                            "Memo" to mapOf(
+                                "MemoData" to memoValue.toByteArray(Charsets.UTF_8)
+                                    .joinToString("") { "%02x".format(it) }
+                            )
+                        )
+                    )
+                )
+                val jsonData = try {
+                    org.json.JSONObject(txJson).toString()
+                } catch (e: Exception) {
+                    Timber.e("Failed to create JSON string ${e.message}")
+                    error("Failed to create JSON string ${e.message}")
+                }
+                val input = Ripple.SigningInput.newBuilder()
+                    .setFee(gas.toLong())
+                    .setSequence(sequence.toInt())
+                    .setAccount(keysignPayload.coin.address)
+                    .setPublicKey(ByteString.copyFrom(publicKey.data()))
+                    .setLastLedgerSequence(lastLedgerSequence.toInt())
+                    .setRawJson(jsonData) // Only if setRawJson exists in your proto
+                    .build()
+                return input.toByteArray()
+            }
+
+        } else {
+            // Standard transaction without memo
+            val operation = Ripple.OperationPayment.newBuilder()
+                .setDestination(keysignPayload.toAddress)
+                .setAmount(keysignPayload.toAmount.toLong())
+                .build()
+
+            val input = Ripple.SigningInput.newBuilder()
+                .setFee(gas.toLong())
+                .setSequence(sequence.toInt())
+                .setAccount(keysignPayload.coin.address)
+                .setPublicKey(ByteString.copyFrom(publicKey.data()))
+                .setOpPayment(operation)
+                .setLastLedgerSequence(lastLedgerSequence.toInt())
+                .build()
+            return input.toByteArray()
+        }
     }
 
     fun getPreSignedImageHash(keysignPayload: KeysignPayload): List<String> {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1996

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here https://xrpscan.com/tx/EA30DD80AD0638B0E06CF946BBC2E15248BF60D818E9264CEC9B49EE13701A01
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context