### PR TITLE
Add hold to sign button and animation

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
@@ -1,0 +1,120 @@
+package com.vultisig.wallet.ui.components.buttons
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.components.buttons.VsButtonSize.Medium
+import com.vultisig.wallet.ui.components.buttons.VsButtonSize.Mini
+import com.vultisig.wallet.ui.components.buttons.VsButtonSize.Small
+import com.vultisig.wallet.ui.theme.Theme
+import kotlinx.coroutines.launch
+
+@Composable
+fun VsHoldableButton(
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    holdDuration: Long = 800,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    val backgroundColor = Theme.colors.primary.accent3
+    val fillColor = Theme.colors.primary.accent2
+
+    val scope = rememberCoroutineScope()
+    val progress = remember { Animatable(0f) }
+
+    Box(
+        modifier = modifier
+            .pointerInput(Unit) {
+                forEachGesture {
+                    awaitPointerEventScope {
+                        val down = awaitFirstDown()
+                        scope.launch {
+                            progress.animateTo(
+                                1f,
+                                tween(holdDuration.toInt(), easing = LinearEasing)
+                            )
+                            onLongClick()
+                        }
+
+                        val up = waitForUpOrCancellation()
+
+                        if (up != null) {
+                            if (progress.value < 1f) onClick()
+                        }
+
+                        scope.launch {
+                            progress.snapTo(0f)
+                        }
+                    }
+                }
+            }
+            .background(backgroundColor, RoundedCornerShape(percent = 100)),
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .clip(RoundedCornerShape(percent = 100))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(progress.value)
+                    .background(fillColor)
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 14.dp, horizontal = 32.dp)
+        ) {
+            val contentColor = Theme.colors.text.primary
+            if (label != null) {
+                Text(
+                    text = label,
+                    style = Theme.brockmann.button.semibold,
+                    color = contentColor,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun VsHoldableButtonPreview() {
+    VsHoldableButton(
+        label = "Hold",
+        onLongClick = {},
+        onClick = {},
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -36,6 +36,7 @@ import com.vultisig.wallet.ui.components.VsCheckField
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
+import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
 import com.vultisig.wallet.ui.models.SendTxUiModel
@@ -262,6 +263,7 @@ internal fun VerifySendScreen(
         bottomBar = {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
@@ -269,39 +271,21 @@ internal fun VerifySendScreen(
                         vertical = 12.dp
                     )
             ) {
-                val buttonState = if (isConsentsEnabled && !state.hasAllConsents)
-                    VsButtonState.Disabled
-                else VsButtonState.Enabled
-
                 if (state.hasFastSign) {
-
-                    VsButton(
-                        label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
-                        state = buttonState,
-                        onClick = onFastSignClick,
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                    )
-
-                    UiSpacer(size = 12.dp)
-
-                    VsButton(
-                        label = confirmTitle,
-                        state = buttonState,
-                        variant = VsButtonVariant.Secondary,
-                        onClick = onConfirm,
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                    )
-                } else {
-                    VsButton(
-                        label = confirmTitle,
-                        state = buttonState,
-                        onClick = onConfirm,
-                        modifier = Modifier
-                            .fillMaxWidth(),
+                    Text(
+                        text = "Hold for paired sign",
+                        style = Theme.brockmann.body.s.medium,
+                        color = Theme.colors.text.extraLight,
+                        textAlign = TextAlign.Center,
                     )
                 }
+
+                VsHoldableButton(
+                    label = "Sign transaction",
+                    onLongClick = onConfirm,
+                    onClick = if (state.hasFastSign) onFastSignClick else onConfirm,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new hold-to-activate button, allowing users to trigger actions by holding the button for a set duration, with visual progress feedback.

- **Refactor**
  - Updated the transaction signing screen to use the new holdable button, streamlining the interface and improving clarity for signing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->