### PR TITLE
All allbtc token on Osmosis

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1571,15 +1571,15 @@ object Coins {
             ),
             Coin(
                 chain = Chain.Osmosis,
-                ticker = "LVN",
-                logo = "levana",
+                ticker = "allBTC",
+                logo = "btc",
                 address = "",
-                decimal = 6,
+                decimal = 8,
                 hexPublicKey = "",
-                priceProviderID = "levana-protocol",
-                contractAddress = "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
+                priceProviderID = "osmosis-allbtc",
+                contractAddress = "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
                 isNativeToken = false,
-            ),
+            )
         ),
 
         Chain.Polkadot to listOf(


### PR DESCRIPTION


## Description

- All allbtc token
- Remove duplicate levana token
- Using submoudle https://github.com/vultisig/commondata/pull/43
 
Fixes #1985

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here

-   https://www.mintscan.io/osmosis/tx/AF73C48DCC771F3D30AB5686858023098DEFE00B18D21559C6492A418DF3FBFB?height=37564794

- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal reference for common data to a newer version.
- **New Features**
  - Replaced the Osmosis chain coin entry from "LVN" to "allBTC" with updated ticker, logo, decimal precision, price provider, and contract address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->