### PR TITLE
Refine token balance and fiat value formatting in send form

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
@@ -20,7 +20,6 @@ internal class SaveVaultUseCaseImpl @Inject constructor(
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
 ) : SaveVaultUseCase {
     override suspend fun invoke(vault: Vault, shouldOverrideVault: Boolean) {
-        Timber.d("saveVault(vault = $vault)")
         if (shouldOverrideVault) {
             vaultRepository.upsert(vault)
         } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -488,6 +488,7 @@ internal class SendFormViewModel @Inject constructor(
         return availableTokenBalance?.decimal
             ?.multiply(percentage.toBigDecimal())
             ?.setScale(8, RoundingMode.DOWN)
+            ?.stripTrailingZeros()
     }
 
     fun dismissError() {
@@ -1127,7 +1128,8 @@ internal class SendFormViewModel @Inject constructor(
                 if (lastTokenValueUserInput != tokenString) {
                     val fiatValue =
                         convertValue(tokenString, selectedToken) { value, price, token ->
-                            value.multiply(price)
+                            // this is the fiat value , we should not keep too much decimal places
+                            value.multiply(price).setScale(3, RoundingMode.HALF_UP).stripTrailingZeros()
                         } ?: return@combine
 
                     lastTokenValueUserInput = tokenString


### PR DESCRIPTION
## Description

This PR update the app to display Fiat vault up to 3 digit after decimal point , and also remove trailing zero
Also remove the log that related to save vault

Fixes #2030

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context