### PR TITLE
Fix switching vault after scanning

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -328,13 +328,13 @@ internal class JoinKeysignViewModel @Inject constructor(
             val matchingVault = vaultRepository.getAll().firstOrNull {
                 it.pubKeyECDSA == pubKeyEcdsa
             }
-            currentState.value = JoinKeysignState.Error(
-                if (matchingVault != null)
-                    JoinKeysignError.WrongVault
-                else
+            if (matchingVault != null) {
+                switchToCorrectVault(matchingVault)
+                return true
+            } else
+                currentState.value = JoinKeysignState.Error(
                     JoinKeysignError.MissingRequiredVault
-            )
-
+                )
             return false
         }
 
@@ -349,6 +349,11 @@ internal class JoinKeysignViewModel @Inject constructor(
         }
 
         return true
+    }
+
+    private fun switchToCorrectVault(vault: Vault) {
+        _currentVault = vault
+        _localPartyID = vault.localPartyID
     }
 
     private suspend fun handleCustomMessage(


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2060

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vault selection by automatically switching to the correct vault when a match is found, instead of displaying an error. If no matching vault is found, an appropriate error is still shown. This results in a smoother and more intuitive user experience during keysign operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->