### PR TITLE
Fix Wrong QR in Production APK

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -79,6 +79,9 @@
 # Keep classes that extend TypeReference.
 -keep class * extends org.web3j.abi.TypeReference
 
+# Umbrella protection
 -keep class org.web3j.** { *; }
-# Keep Web3j data types. This prevents obfuscation/removal of the specific Solidity type classes.
+
+# Keep Web3j data types, sometimes previous statements is not enough and leakes.
+# This prevents obfuscation/removal of the specific Solidity type classes.
 -keep class org.web3j.abi.datatypes.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -74,9 +74,10 @@
 # Umbrella protection
 -keep class org.web3j.** { *; }
 
+# Sometimes previous statements is not enough and leakes.
 # Keep classes that extend TypeReference.
 -keep class * extends org.web3j.abi.TypeReference
 
 # Keep Web3j data types, sometimes previous statements is not enough and leakes.
-# This prevents obfuscation/removal of the specific Solidity type classes.
+# Keeps data types
 -keep class org.web3j.abi.datatypes.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -76,6 +76,9 @@
 # starting point for web3j to ensure core functionality is not stripped.
 -keep class org.web3j.** { *; }
 
--keep class org.web3j.** { *; }
 # Keep classes that extend TypeReference.
 -keep class * extends org.web3j.abi.TypeReference
+
+-keep class org.web3j.** { *; }
+# Keep Web3j data types. This prevents obfuscation/removal of the specific Solidity type classes.
+-keep class org.web3j.abi.datatypes.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -71,16 +71,11 @@
 -keep class okhttp3.** { *; }
 -keep interface okhttp3.** { *; }
 
-# Web3j specific rules
-# Keep all classes and members within the org.web3j package.
-# starting point for web3j to ensure core functionality is not stripped.
+# Umbrella protection
 -keep class org.web3j.** { *; }
 
 # Keep classes that extend TypeReference.
 -keep class * extends org.web3j.abi.TypeReference
-
-# Umbrella protection
--keep class org.web3j.** { *; }
 
 # Keep Web3j data types, sometimes previous statements is not enough and leakes.
 # This prevents obfuscation/removal of the specific Solidity type classes.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -6,7 +6,8 @@
 -keepattributes InnerClasses
 # Keep EnclosingMethod for inner class reflection
 -keepattributes EnclosingMethod
-
+# CRUCIAL for web3j to correctly determine generic type parameters at runtime.
+-keepattributes Signature
 
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
@@ -72,15 +73,9 @@
 
 # Web3j specific rules
 # Keep all classes and members within the org.web3j package.
-# This is often a good starting point for web3j to ensure core functionality is not stripped.
+# starting point for web3j to ensure core functionality is not stripped.
 -keep class org.web3j.** { *; }
 
-# Keep the Signature attribute for TypeReference and generic types.
-# CRUCIAL for web3j to correctly determine generic type parameters at runtime.
--keepattributes Signature
-
+-keep class org.web3j.** { *; }
 # Keep classes that extend TypeReference.
 -keep class * extends org.web3j.abi.TypeReference
-
-# Keep Web3j data types. This prevents obfuscation/removal of the specific Solidity type classes.
--keep class org.web3j.abi.datatypes.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,5 +1,12 @@
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
+# Keep all annotations (especially runtime annotations like @Inject, etc.)
+-keepattributes *Annotation*
+# Keep InnerClasses attribute to help with anonymous inner classes reflection
+-keepattributes InnerClasses
+# Keep EnclosingMethod for inner class reflection
+-keepattributes EnclosingMethod
+
 
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
@@ -59,7 +66,21 @@
 -dontwarn org.ietf.jgss.GSSName
 -dontwarn org.ietf.jgss.Oid
 
-
 # OkHttp
 -keep class okhttp3.** { *; }
 -keep interface okhttp3.** { *; }
+
+# Web3j specific rules
+# Keep all classes and members within the org.web3j package.
+# This is often a good starting point for web3j to ensure core functionality is not stripped.
+-keep class org.web3j.** { *; }
+
+# Keep the Signature attribute for TypeReference and generic types.
+# CRUCIAL for web3j to correctly determine generic type parameters at runtime.
+-keepattributes Signature
+
+# Keep classes that extend TypeReference.
+-keep class * extends org.web3j.abi.TypeReference
+
+# Keep Web3j data types. This prevents obfuscation/removal of the specific Solidity type classes.
+-keep class org.web3j.abi.datatypes.** { *; }


### PR DESCRIPTION
## Description

<img width="1006" alt="Screenshot 2025-07-06 at 19 37 34" src="https://github.com/user-attachments/assets/976b50be-9273-4819-a728-16183c7fa718" />

This problem usually happens because of how Android apps are prepared for release. A tool called ProGuard/R8 makes your app smaller and faster. But sometimes, it removes important information that web3j needs to understand the type of data it's working with (like Address or Uint256). When this information is missing, web3j gets confused and throws the 'Missing type parameter' error.

This PR aims to fix the issue with Web3. As a next step, we should probably avoid using it, since WalletCore already provides sufficient tooling. The library also seems to be more Java-oriented than Android-focused.


**Test Evidence**
<img src="https://github.com/user-attachments/assets/d5684d43-3e35-4e25-8edc-d6505dd29f4a" width="400" />


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Proguard settings to improve compatibility with Web3j and ensure essential runtime metadata and classes are preserved during code shrinking and obfuscation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->