### PR TITLE
[Blockaid]: Add support for Solana+ SUI and prepare BTC

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -48,7 +48,6 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.securityscanner.BLOCKAID_PROVIDER
 import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
 import com.vultisig.wallet.data.securityscanner.isChainSupported
-import com.vultisig.wallet.data.securityscanner.toSecurityScannerTransaction
 import com.vultisig.wallet.data.usecases.BroadcastTxUseCase
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.DecompressQrUseCase
@@ -759,7 +758,8 @@ internal class JoinKeysignViewModel @Inject constructor(
 
             try {
                 // run scanner and update UI widget
-                val securityScannerTransaction = transaction.toSecurityScannerTransaction()
+                val securityScannerTransaction =
+                    securityScannerService.createSecurityScannerTransaction(transaction)
                 val scanResult = withContext(Dispatchers.IO) {
                     securityScannerService.scanTransaction(securityScannerTransaction)
                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/PublicKeyHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/PublicKeyHelper.kt
@@ -10,5 +10,4 @@ internal object PublicKeyHelper {
     ): String {
         return Tss.getDerivedPubKey(hexPublicKey, hexChainCode, derivePath, false)
     }
-
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -33,7 +33,6 @@ class SolanaHelper(
     }
 
     private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
-
         val solanaSpecific = keysignPayload.blockChainSpecific as? BlockChainSpecific.Solana
             ?: error("Invalid blockChainSpecific")
         if (keysignPayload.coin.chain != Chain.Solana) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -88,9 +88,8 @@ object SuiHelper {
         val hashes = TransactionCompiler.preImageHashes(coinType, inputData)
         val preSigningOutput =
             wallet.core.jni.proto.TransactionCompiler.PreSigningOutput.parseFrom(hashes)
-                .checkError() // Assuming checkError() handles throwing if there's an error
+                .checkError()
 
-        // Although checkError() might throw, an explicit check here can be good for clarity
         require(preSigningOutput.errorMessage.isEmpty()) { preSigningOutput.errorMessage }
 
         return preSigningOutput

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
@@ -1,8 +1,11 @@
 package com.vultisig.wallet.data.securityscanner
 
+import com.vultisig.wallet.data.models.Transaction
+
 interface SecurityScannerContract {
     suspend fun scanTransaction(transaction: SecurityScannerTransaction): SecurityScannerResult
     suspend fun isSecurityServiceEnabled(): Boolean
+    fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
     fun getDisabledProviders(): List<String>
     fun getEnabledProviders(): List<String>
     fun disableProviders(providersToDisable: List<String>)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
@@ -5,7 +5,7 @@ import com.vultisig.wallet.data.models.Transaction
 interface SecurityScannerContract {
     suspend fun scanTransaction(transaction: SecurityScannerTransaction): SecurityScannerResult
     suspend fun isSecurityServiceEnabled(): Boolean
-    fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
+    suspend fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
     fun getDisabledProviders(): List<String>
     fun getEnabledProviders(): List<String>
     fun disableProviders(providersToDisable: List<String>)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerExtensions.kt
@@ -22,35 +22,6 @@ internal suspend fun <T> runSecurityScan(
     }
 }
 
-fun Transaction.toSecurityScannerTransaction(): SecurityScannerTransaction {
-    val transferType: SecurityTransactionType
-    val amount: BigInteger
-    val data: String
-    val to: String
-
-    if (this.token.contractAddress.isNotEmpty()) {
-        val tokenAmount = this.tokenValue.value
-        transferType = SecurityTransactionType.TOKEN_TRANSFER
-        amount = BigInteger.ZERO
-        data = EthereumFunction.transferErc20(this.dstAddress, tokenAmount)
-        to = this.token.contractAddress
-    } else {
-        transferType = SecurityTransactionType.COIN_TRANSFER
-        amount = this.tokenValue.value
-        data = "0x"
-        to = this.dstAddress
-    }
-
-    return SecurityScannerTransaction(
-        chain = this.token.chain,
-        type = transferType,
-        from = this.srcAddress,
-        to = to,
-        amount = amount,
-        data = data,
-    )
-}
-
 fun List<SecurityScannerSupport>.isChainSupported(chain: Chain): Boolean {
     return any { support ->
         support.feature.any { feature ->

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.securityscanner
 
+import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.repositories.OnChainSecurityScannerRepository
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClient
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClientContract
@@ -17,8 +18,8 @@ object SecurityScannerModule {
 
     @Singleton
     @Provides
-    fun provideSecurityScannerTransactionFactory(): SecurityScannerTransactionFactoryContract {
-        return SecurityScannerTransactionFactory()
+    fun provideSecurityScannerTransactionFactory(solanaApi: SolanaApi): SecurityScannerTransactionFactoryContract {
+        return SecurityScannerTransactionFactory(solanaApi)
     }
 
     @Singleton

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.securityscanner
 
 import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.repositories.OnChainSecurityScannerRepository
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClient
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClientContract
@@ -18,8 +19,8 @@ object SecurityScannerModule {
 
     @Singleton
     @Provides
-    fun provideSecurityScannerTransactionFactory(solanaApi: SolanaApi): SecurityScannerTransactionFactoryContract {
-        return SecurityScannerTransactionFactory(solanaApi)
+    fun provideSecurityScannerTransactionFactory(solanaApi: SolanaApi, suiApi: SuiApi): SecurityScannerTransactionFactoryContract {
+        return SecurityScannerTransactionFactory(solanaApi, suiApi)
     }
 
     @Singleton

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.securityscanner
 
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.OnChainSecurityScannerRepository
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClient
 import com.vultisig.wallet.data.securityscanner.blockaid.BlockaidRpcClientContract
@@ -19,8 +20,12 @@ object SecurityScannerModule {
 
     @Singleton
     @Provides
-    fun provideSecurityScannerTransactionFactory(solanaApi: SolanaApi, suiApi: SuiApi): SecurityScannerTransactionFactoryContract {
-        return SecurityScannerTransactionFactory(solanaApi, suiApi)
+    fun provideSecurityScannerTransactionFactory(
+        solanaApi: SolanaApi,
+        suiApi: SuiApi,
+        blockChainSpecificRepository: BlockChainSpecificRepository
+    ): SecurityScannerTransactionFactoryContract {
+        return SecurityScannerTransactionFactory(solanaApi, suiApi, blockChainSpecificRepository)
     }
 
     @Singleton
@@ -43,6 +48,10 @@ object SecurityScannerModule {
         securityScannerTransactionFactory: SecurityScannerTransactionFactoryContract,
     ): SecurityScannerContract {
         val providers = listOf(blockaidScannerService)
-        return SecurityScannerService(providers, onChainSecurityScannerRepository, securityScannerTransactionFactory)
+        return SecurityScannerService(
+            providers,
+            onChainSecurityScannerRepository,
+            securityScannerTransactionFactory
+        )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
@@ -23,9 +23,8 @@ object SecurityScannerModule {
     fun provideSecurityScannerTransactionFactory(
         solanaApi: SolanaApi,
         suiApi: SuiApi,
-        blockChainSpecificRepository: BlockChainSpecificRepository
     ): SecurityScannerTransactionFactoryContract {
-        return SecurityScannerTransactionFactory(solanaApi, suiApi, blockChainSpecificRepository)
+        return SecurityScannerTransactionFactory(solanaApi, suiApi)
     }
 
     @Singleton

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerModule.kt
@@ -17,6 +17,12 @@ object SecurityScannerModule {
 
     @Singleton
     @Provides
+    fun provideSecurityScannerTransactionFactory(): SecurityScannerTransactionFactoryContract {
+        return SecurityScannerTransactionFactory()
+    }
+
+    @Singleton
+    @Provides
     fun provideBlockaidRpcClient(httpClient: HttpClient): BlockaidRpcClientContract {
         return BlockaidRpcClient(httpClient)
     }
@@ -32,8 +38,9 @@ object SecurityScannerModule {
     fun provideSecurityScannerService(
         blockaidScannerService: ProviderScannerServiceContract,
         onChainSecurityScannerRepository: OnChainSecurityScannerRepository,
+        securityScannerTransactionFactory: SecurityScannerTransactionFactoryContract,
     ): SecurityScannerContract {
         val providers = listOf(blockaidScannerService)
-        return SecurityScannerService(providers, onChainSecurityScannerRepository)
+        return SecurityScannerService(providers, onChainSecurityScannerRepository, securityScannerTransactionFactory)
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.securityscanner
 
+import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.repositories.OnChainSecurityScannerRepository
 import timber.log.Timber
 import java.util.concurrent.ConcurrentSkipListSet
@@ -7,6 +8,7 @@ import java.util.concurrent.ConcurrentSkipListSet
 class SecurityScannerService(
     private val providers: List<ProviderScannerServiceContract>,
     private val repository: OnChainSecurityScannerRepository,
+    private val factory: SecurityScannerTransactionFactoryContract,
 ) : SecurityScannerContract {
     private val disabledProvidersNames: MutableSet<String> = ConcurrentSkipListSet()
 
@@ -26,6 +28,10 @@ class SecurityScannerService(
 
     override suspend fun isSecurityServiceEnabled(): Boolean {
         return repository.getSecurityScannerStatus()
+    }
+
+    override fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+        return factory.createSecurityScannerTransaction(transaction)
     }
 
     override fun getDisabledProviders(): List<String> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
@@ -30,7 +30,7 @@ class SecurityScannerService(
         return repository.getSecurityScannerStatus()
     }
 
-    override fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+    override suspend fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
         return factory.createSecurityScannerTransaction(transaction)
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -20,7 +20,6 @@ import java.math.BigInteger
 class SecurityScannerTransactionFactory(
     private val solanaApi: SolanaApi,
     private val suiApi: SuiApi,
-    private val blockchainSpecificRepository: BlockChainSpecificRepository,
 ) : SecurityScannerTransactionFactoryContract {
     override suspend fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
         val chain = transaction.token.chain

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -1,0 +1,77 @@
+package com.vultisig.wallet.data.securityscanner
+
+import com.vultisig.wallet.data.chains.helpers.EthereumFunction
+import com.vultisig.wallet.data.chains.helpers.SolanaHelper
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import wallet.core.jni.Base58
+import java.math.BigInteger
+
+class SecurityScannerTransactionFactory : SecurityScannerTransactionFactoryContract {
+    override fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+        val chain = transaction.token.chain
+        return when (chain.standard) {
+            TokenStandard.EVM -> createEVMSecurityScannerTransaction(transaction)
+            TokenStandard.SOL -> createSOLSecurityScannerTransaction(transaction)
+            else -> error("Not supported")
+        }
+    }
+
+    private fun createEVMSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+        val transferType: SecurityTransactionType
+        val amount: BigInteger
+        val data: String
+        val to: String
+
+        if (transaction.token.contractAddress.isNotEmpty()) {
+            val tokenAmount = transaction.tokenValue.value
+            transferType = SecurityTransactionType.TOKEN_TRANSFER
+            amount = BigInteger.ZERO
+            data = EthereumFunction.transferErc20(transaction.dstAddress, tokenAmount)
+            to = transaction.token.contractAddress
+        } else {
+            transferType = SecurityTransactionType.COIN_TRANSFER
+            amount = transaction.tokenValue.value
+            data = "0x"
+            to = transaction.dstAddress
+        }
+
+        return SecurityScannerTransaction(
+            chain = transaction.token.chain,
+            type = transferType,
+            from = transaction.srcAddress,
+            to = to,
+            amount = amount,
+            data = data,
+        )
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun createSOLSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+        val vaultHexPubKey = Base58.decodeNoCheck(transaction.srcAddress).toHexString()
+        val solanaHelper = SolanaHelper(vaultHexPubKey)
+
+        val keySignPayload = KeysignPayload(
+            coin = transaction.token,
+            toAddress = transaction.dstAddress,
+            toAmount = transaction.tokenValue.value,
+            blockChainSpecific = transaction.blockChainSpecific,
+            memo = transaction.memo,
+            vaultPublicKeyECDSA = "", // no need for SOL prehash
+            vaultLocalPartyID = "", // no need for SOL prehash
+            libType = null, // no need for SOL prehash
+        )
+
+        val transactionZeroX = solanaHelper.getZeroSignedTransaction(keySignPayload)
+
+        return SecurityScannerTransaction(
+            chain = transaction.token.chain,
+            type = SecurityTransactionType.COIN_TRANSFER,
+            from = transaction.srcAddress,
+            to = transaction.dstAddress,
+            amount = BigInteger.ZERO, // encoded in tx
+            data = transactionZeroX,
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -1,15 +1,20 @@
 package com.vultisig.wallet.data.securityscanner
 
+import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
+import kotlinx.coroutines.coroutineScope
 import wallet.core.jni.Base58
 import java.math.BigInteger
 
-class SecurityScannerTransactionFactory : SecurityScannerTransactionFactoryContract {
-    override fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+class SecurityScannerTransactionFactory(
+    private val solanaApi: SolanaApi,
+): SecurityScannerTransactionFactoryContract {
+    override suspend fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
         val chain = transaction.token.chain
         return when (chain.standard) {
             TokenStandard.EVM -> createEVMSecurityScannerTransaction(transaction)
@@ -48,15 +53,37 @@ class SecurityScannerTransactionFactory : SecurityScannerTransactionFactoryContr
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    private fun createSOLSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction {
+    private suspend fun createSOLSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction = coroutineScope {
         val vaultHexPubKey = Base58.decodeNoCheck(transaction.srcAddress).toHexString()
         val solanaHelper = SolanaHelper(vaultHexPubKey)
+
+        val solanaBlockchainSpecific = transaction.blockChainSpecific
+        require(solanaBlockchainSpecific is BlockChainSpecific.Solana) {
+            "Error Blockchain Specific is not Solana ${transaction.blockChainSpecific}"
+        }
+
+        val solanaUpdatedSpecific: BlockChainSpecific = if (transaction.token.isNativeToken) {
+            transaction.blockChainSpecific
+        } else {
+            val fromAddressPubKey =
+                solanaApi.getTokenAssociatedAccountByOwner(
+                    transaction.token.address,
+                    transaction.token.contractAddress
+                )
+            BlockChainSpecific.Solana(
+                recentBlockHash = solanaBlockchainSpecific.recentBlockHash,
+                priorityFee = solanaBlockchainSpecific.priorityFee,
+                fromAddressPubKey = fromAddressPubKey.first,
+                toAddressPubKey = solanaBlockchainSpecific.toAddressPubKey,
+                programId = solanaBlockchainSpecific.programId,
+            )
+        }
 
         val keySignPayload = KeysignPayload(
             coin = transaction.token,
             toAddress = transaction.dstAddress,
             toAmount = transaction.tokenValue.value,
-            blockChainSpecific = transaction.blockChainSpecific,
+            blockChainSpecific = solanaUpdatedSpecific,
             memo = transaction.memo,
             vaultPublicKeyECDSA = "", // no need for SOL prehash
             vaultLocalPartyID = "", // no need for SOL prehash
@@ -65,7 +92,7 @@ class SecurityScannerTransactionFactory : SecurityScannerTransactionFactoryContr
 
         val transactionZeroX = solanaHelper.getZeroSignedTransaction(keySignPayload)
 
-        return SecurityScannerTransaction(
+         SecurityScannerTransaction(
             chain = transaction.token.chain,
             type = SecurityTransactionType.COIN_TRANSFER,
             from = transaction.srcAddress,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
@@ -1,0 +1,7 @@
+package com.vultisig.wallet.data.securityscanner
+
+import com.vultisig.wallet.data.models.Transaction
+
+interface SecurityScannerTransactionFactoryContract {
+    fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
@@ -3,5 +3,5 @@ package com.vultisig.wallet.data.securityscanner
 import com.vultisig.wallet.data.models.Transaction
 
 interface SecurityScannerTransactionFactoryContract {
-    fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
+    suspend fun createSecurityScannerTransaction(transaction: Transaction): SecurityScannerTransaction
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidExtensions.kt
@@ -7,6 +7,8 @@ import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
 import com.vultisig.wallet.data.securityscanner.SecurityWarning
 import timber.log.Timber
 
+// Solana has different payload, for simplicity, avoid confusion and any potential bug
+// we'll keep it separated. Other chains such as SUI and BTC shared the same EVM payload
 fun BlockaidTransactionScanResponseJson.toSolanaSecurityScannerResult(provider: String): SecurityScannerResult {
     when {
         status.equals("error", ignoreCase = true) || !error.isNullOrEmpty() -> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidExtensions.kt
@@ -38,17 +38,19 @@ fun BlockaidTransactionScanResponseJson.toSecurityScannerResult(provider: String
 private fun BlockaidTransactionScanResponseJson.toValidationRiskLevel(): SecurityRiskLevel {
     val hasFeatures = validation?.features?.isEmpty() == false
     val classification = validation?.classification
-    val status = validation?.status
+    val validationStatus = validation?.status
+    val globalStatus = status
     val resultType = validation?.resultType
 
-    if (status.equals("error", true)
+    if (validationStatus.equals("error", true)
         || resultType.equals("error", true)
+        || globalStatus.equals("error", ignoreCase = true)
     ) {
         val errorMessage = validation?.error ?: "Scanning failed"
         throw SecurityScannerException("SecurityScanner $errorMessage , payload: $this")
     }
 
-    val isBenign = status.equals("success", ignoreCase = true) &&
+    val isBenign = validationStatus.equals("success", ignoreCase = true) &&
             resultType.equals("benign", ignoreCase = true) &&
             !hasFeatures
     if (isBenign) return SecurityRiskLevel.NONE

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
@@ -103,6 +103,8 @@ data class BlockaidTransactionScanResponseJson(
     val validation: BlockaidValidationJson?,
     @SerialName("result")
     val result: BlockaidSolanaResultJson?,
+    @SerialName("error")
+    val error: String?,
 ) {
     @Serializable
     data class BlockaidSolanaResultJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
@@ -16,7 +16,9 @@ data class SolanaScanTransactionRequestJson(
     @SerialName("encoding")
     val encoding: String,
     @SerialName("transactions")
-    val transactions: List<String>
+    val transactions: List<String>,
+    @SerialName("method")
+    val method: String,
 )
 
 @Serializable
@@ -99,7 +101,14 @@ data class BlockaidTransactionScanResponseJson(
     val status: String?,
     @SerialName("validation")
     val validation: BlockaidValidationJson?,
+    @SerialName("result")
+    val result: BlockaidSolanaResult?,
 ) {
+    @Serializable
+    data class BlockaidSolanaResult(
+        val x: String,
+    )
+
     @Serializable
     data class BlockaidValidationJson(
         @SerialName("status")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
@@ -102,12 +102,33 @@ data class BlockaidTransactionScanResponseJson(
     @SerialName("validation")
     val validation: BlockaidValidationJson?,
     @SerialName("result")
-    val result: BlockaidSolanaResult?,
+    val result: BlockaidSolanaResultJson?,
 ) {
     @Serializable
-    data class BlockaidSolanaResult(
-        val x: String,
-    )
+    data class BlockaidSolanaResultJson(
+        @SerialName("validation")
+        val validation: BlockaidSolanaValidationJson,
+    ) {
+        @Serializable
+        data class BlockaidSolanaValidationJson(
+            @SerialName("result_type")
+            val resultType: String,
+            @SerialName("reason")
+            val reason: String,
+            @SerialName("features")
+            val features: List<String> = emptyList(),
+            @SerialName("extended_features")
+            val extendedFeatures: BlockaidSolanaExtendedFeaturesJson,
+        ) {
+            @Serializable
+            data class BlockaidSolanaExtendedFeaturesJson(
+                @SerialName("type")
+                val type: String,
+                @SerialName("description")
+                val description: String,
+            )
+        }
+    }
 
     @Serializable
     data class BlockaidValidationJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidModels.kt
@@ -120,7 +120,7 @@ data class BlockaidTransactionScanResponseJson(
             @SerialName("features")
             val features: List<String> = emptyList(),
             @SerialName("extended_features")
-            val extendedFeatures: BlockaidSolanaExtendedFeaturesJson,
+            val extendedFeatures: List<BlockaidSolanaExtendedFeaturesJson> = emptyList(),
         ) {
             @Serializable
             data class BlockaidSolanaExtendedFeaturesJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidRpcClient.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidRpcClient.kt
@@ -55,7 +55,7 @@ class BlockaidRpcClient(
 
         return httpClient.post(BLOCKAID_BASE_URL) {
             url {
-                appendPathSegments("/solana/address/scan")
+                appendPathSegments("/solana/message/scan")
             }
             contentType(ContentType.Application.Json)
             setBody(solanaRequest)
@@ -119,14 +119,15 @@ class BlockaidRpcClient(
         serializedMessage: String
     ): SolanaScanTransactionRequestJson {
         return SolanaScanTransactionRequestJson(
-            chain = Chain.Solana.toName(),
+            chain = SOLANA_CHAIN,
             metadata = CommonMetadataJson(
                 url = VULTISIG_DOMAIN,
             ),
             options = listOf("validation"),
             accountAddress = address,
-            encoding = "base64",
+            encoding = SOLANA_ENCODING,
             transactions = listOf(serializedMessage),
+            method = SOLANA_SIGN_AND_SEND
         )
     }
 
@@ -148,6 +149,10 @@ class BlockaidRpcClient(
     private companion object {
         private const val BLOCKAID_BASE_URL = "https://api.vultisig.com/blockaid/v0"
         private const val VULTISIG_DOMAIN = "vultisig.com"
+
+        private const val SOLANA_SIGN_AND_SEND = "signAndSendTransaction"
+        private const val SOLANA_ENCODING = "base58"
+        private const val SOLANA_CHAIN = "mainnet"
 
         private fun Chain.toName(): String {
             return when (this) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidRpcClient.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidRpcClient.kt
@@ -136,7 +136,7 @@ class BlockaidRpcClient(
         serializedTransaction: String
     ): SuiScanTransactionRequestJson {
         return SuiScanTransactionRequestJson(
-            chain = Chain.Sui.toName(),
+            chain = SUI_CHAIN,
             metadata = CommonMetadataJson(
                 url = VULTISIG_DOMAIN,
             ),
@@ -153,6 +153,8 @@ class BlockaidRpcClient(
         private const val SOLANA_SIGN_AND_SEND = "signAndSendTransaction"
         private const val SOLANA_ENCODING = "base58"
         private const val SOLANA_CHAIN = "mainnet"
+
+        private const val SUI_CHAIN = "mainnet"
 
         private fun Chain.toName(): String {
             return when (this) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
@@ -99,7 +99,7 @@ class BlockaidScannerService(private val blockaidRpcClient: BlockaidRpcClientCon
             Chain.Optimism,
             Chain.Polygon,
             // Chain.Sui,
-            // Chain.Solana,
+            Chain.Solana,
         )
 
         private val PROVIDER_NAME = "blockaid"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
@@ -98,7 +98,7 @@ class BlockaidScannerService(private val blockaidRpcClient: BlockaidRpcClientCon
             Chain.Ethereum,
             Chain.Optimism,
             Chain.Polygon,
-            // Chain.Sui,
+            Chain.Sui,
             Chain.Solana,
         )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidScannerService.kt
@@ -54,7 +54,7 @@ class BlockaidScannerService(private val blockaidRpcClient: BlockaidRpcClientCon
             blockaidRpcClient.scanSolanaTransaction(
                 address = transaction.from,
                 serializedMessage = transaction.data,
-            ).toSecurityScannerResult(PROVIDER_NAME)
+            ).toSolanaSecurityScannerResult(PROVIDER_NAME)
         }
     }
 


### PR DESCRIPTION
## Description
- Add support for Solana & SUI in Blockaid
- Add new method for SUI to handle 0x transactions
- Create factory to build security scanner transactions
- Add specific JSON structure and objects for Solana — Blockaid’s API behaves slightly differently for this chain
- Prepare code for BTC support. Pending clarification on whether PSBT is required, since prehash does not work with their API. This will likely mean migrating to the WalletCore v2 BTC API
Fixes #2116

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for security scanning of Solana and Sui transactions.
  * Enhanced Solana transaction validation with detailed risk assessment and feature reporting.
  * Introduced zero-signed transaction generation for Sui to improve simulation and scanning accuracy.

* **Bug Fixes**
  * Improved handling and validation of Solana transaction scan responses.

* **Refactor**
  * Streamlined transaction conversion by introducing a dedicated factory for creating security scanner transactions.
  * Updated internal logic to use explicit service-based transaction creation.

* **Chores**
  * Minor code cleanup, including removal of unused extension functions and extra blank lines.
  * Updated Solana and Sui scan request formats for improved consistency and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->