### PR TITLE
Fix edge cases for VsHoldableButton button (fast sign & pairing QR code)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
@@ -57,7 +57,6 @@ fun VsHoldableButton(
                 },
                 onLongClick = {
                     isLongPressed = true
-                    // Ensure the animation completes before calling onLongClick
                     scope.launch {
                         progress.animateTo(1f, tween(holdDuration.toInt(), easing = LinearEasing))
                         onLongClick()

--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
@@ -72,7 +72,7 @@ fun VsHoldableButton(
                         val up = waitForUpOrCancellation()
 
                         if (up != null && !isLongPressed) {
-                            if (progress.value < 0.2f) {
+                            if (progress.value < 0.25f) {
                                 onClick()
                             }
                         }


### PR DESCRIPTION
## Description

- Improve current implementation by avoiding edge cases, click/long click events triggered wrongly
- Trigger only long press click after animation is finished and manage click state. Before is called immediately after the animateTo function is initiated. It did not wait for the animation to complete

Fixes #2129

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of distinguishing between short clicks and long presses on holdable buttons.
  * Enhanced button responsiveness and animation handling, ensuring smoother user interactions and preventing unintended actions during interrupted gestures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->