### PR TITLE
Display Join Keygen Errors

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
@@ -202,8 +202,12 @@ internal class JoinKeygenViewModel @Inject constructor(
                         }
                     }
                     else -> {
-                        state.update{
-                            it.copy(error = UnknownError(e.message ?: "something went wrong"))
+                        state.update {
+                            it.copy(
+                                error = UnknownError(
+                                    e.message ?: "An unexpected error occurred"
+                                )
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -39,7 +39,7 @@ internal fun JoinKeygenScreen(
     } else {
         ErrorView(
             errorLabel = error.message.asString(),
-            buttonText = "back",
+            buttonText = "Back",
             onButtonClick = model::navigateBack
         )
     }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1990

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling in the join key generation flow with clear, user-friendly error messages.
  * The join key generation screen now displays specific error views when issues occur, with an option to navigate back.

* **Refactor**
  * Centralized and standardized error management for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->