### PR TITLE
[Swap]: Allow search chains by ticker symbol

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
@@ -10,10 +10,11 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.IsSwapSupported
+import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.logo
-import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -90,8 +91,8 @@ internal class SelectNetworkViewModel @Inject constructor(
             val filteredChains = chains
                 .asSequence()
                 .filter {
-                    it.raw.contains(query, ignoreCase = true) ||
-                            it.swapAssetName().contains(query, ignoreCase = true)
+                    it.raw.contains(query, ignoreCase = true)
+                            || it.coinType.symbol.contains(query, ignoreCase = true)
                 }
                 .let {
                     when (args.filters) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.IsSwapSupported
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
@@ -88,7 +89,10 @@ internal class SelectNetworkViewModel @Inject constructor(
         ) { chains, query ->
             val filteredChains = chains
                 .asSequence()
-                .filter { it.raw.contains(query, ignoreCase = true) }
+                .filter {
+                    it.raw.contains(query, ignoreCase = true) ||
+                            it.swapAssetName().contains(query, ignoreCase = true)
+                }
                 .let {
                     when (args.filters) {
                         Filters.SwapAvailable ->


### PR DESCRIPTION
## Description

Allow user search chains by ticker in swap chain selection
[#2139](https://github.com/vultisig/vultisig-android/issues/2139)

Symbols: https://github.com/trustwallet/wallet-core/blob/master/registry.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved search functionality when selecting a network. You can now search by both the network's name and its coin symbol for more flexible filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->