### PR TITLE
[Swap]: Fix L2 ETH Icons and Improve loading to VerifySwapScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -559,7 +559,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            srcNativeLogo = tokenRepository.getNativeLogo(srcToken),
                             dst = ValuedToken(
                                 value = mapTokenValueToDecimalUiString(dstTokenValue),
                                 token = dstToken,
@@ -571,7 +570,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            dstNativeLogo = tokenRepository.getNativeLogo(dstToken),
                             providerFee = ValuedToken(
                                 token = feeToken,
                                 value = value.toString(),
@@ -628,7 +626,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            srcNativeLogo = tokenRepository.getNativeLogo(srcToken),
                             dst = ValuedToken(
                                 value = mapTokenValueToDecimalUiString(dstTokenValue),
                                 token = dstToken,
@@ -640,7 +637,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            dstNativeLogo = tokenRepository.getNativeLogo(dstToken),
                             networkFee = ValuedToken(
                                 token = srcToken,
                                 value = mapTokenValueToDecimalUiString(estimatedNetworkGasFee.tokenValue),
@@ -699,7 +695,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            srcNativeLogo = tokenRepository.getNativeLogo(srcToken),
                             dst = ValuedToken(
                                 value = mapTokenValueToDecimalUiString(dstTokenValue),
                                 token = dstToken,
@@ -711,7 +706,6 @@ internal class JoinKeysignViewModel @Inject constructor(
                                     )
                                 ),
                             ),
-                            dstNativeLogo = tokenRepository.getNativeLogo(dstToken),
                             providerFee = ValuedToken(
                                 token = dstToken,
                                 value = quote.fees.value.toString(),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AccountToTokenBalanceUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AccountToTokenBalanceUiModelMapper.kt
@@ -40,5 +40,4 @@ internal class AccountToTokenBalanceUiModelMapperImpl @Inject constructor(
             Chain.BscChain -> "BEP20"
             else -> null
         }
-
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -1,7 +1,6 @@
 package com.vultisig.wallet.ui.models.mappers
 
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
-import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapTransaction
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
@@ -57,7 +56,6 @@ internal class SwapTransactionToUiModelMapperImpl @Inject constructor(
                     )
                 ),
             ),
-            srcNativeLogo = tokenRepository.getNativeLogo(from.srcToken),
             dst = ValuedToken(
                 value = mapTokenValueToDecimalUiString(from.expectedDstTokenValue),
                 token = from.dstToken,
@@ -69,7 +67,6 @@ internal class SwapTransactionToUiModelMapperImpl @Inject constructor(
                     )
                 ),
             ),
-            dstNativeLogo = tokenRepository.getNativeLogo(from.dstToken),
             hasConsentAllowance = from.isApprovalRequired,
             providerFee = ValuedToken(
                 token = tokenValue,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -104,6 +104,7 @@ internal data class SwapFormUiModel(
     val formError: UiText? = null,
     val isSwapDisabled: Boolean = false,
     val isLoading: Boolean = false,
+    val isLoadingNextScreen: Boolean = false,
     val expiredAt: Instant? = null,
 )
 
@@ -172,6 +173,14 @@ internal class SwapFormViewModel @Inject constructor(
             }
         }
 
+    private var isLoadingNextScreen: Boolean
+        get() = uiState.value.isLoadingNextScreen
+        set(value) {
+            uiState.update {
+                it.copy(isLoadingNextScreen = value)
+            }
+        }
+
     init {
         viewModelScope.launch {
             loadData(
@@ -199,8 +208,7 @@ internal class SwapFormViewModel @Inject constructor(
     fun swap() {
         try {
             // TODO verify swap info
-
-            isLoading = true
+            isLoadingNextScreen = true
             val vaultId = vaultId ?: throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.swap_screen_invalid_no_vault)
             )
@@ -478,10 +486,10 @@ internal class SwapFormViewModel @Inject constructor(
                         vaultId = vaultId,
                     )
                 )
-                isLoading = false
+                isLoadingNextScreen = false
             }
         } catch (e: InvalidTransactionDataException) {
-            isLoading = false
+            isLoadingNextScreen = false
             showError(e.text)
             return
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -29,9 +29,6 @@ internal data class SwapTransactionUiModel(
     val src: ValuedToken = ValuedToken.Empty,
     val dst: ValuedToken = ValuedToken.Empty,
 
-    val srcNativeLogo: String = "",
-    val dstNativeLogo: String = "",
-
     val networkFee: ValuedToken = ValuedToken.Empty,
     val providerFee: ValuedToken = ValuedToken.Empty,
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -274,7 +274,7 @@ internal fun SwapScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         AnimatedContent(
-                            targetState = state.isLoading,
+                            targetState = state.isLoading || state.isLoadingNextScreen,
                             transitionSpec = {
                                 fadeIn(animationSpec = tween(150)) togetherWith
                                         fadeOut(animationSpec = tween(150))

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -198,7 +198,7 @@ private fun VerifySwapScreen(
 
                     SwapToken(
                         valuedToken = tx.src,
-                        hasToShowOnNativeChain = true,
+                        isSwap = true,
                     )
 
                     Row(
@@ -251,7 +251,7 @@ private fun VerifySwapScreen(
 
                     SwapToken(
                         valuedToken = tx.dst,
-                        hasToShowOnNativeChain = true,
+                        isSwap = true,
                         isDestinationToken = true,
                     )
 
@@ -350,12 +350,12 @@ private fun VerifySwapScreen(
 @Composable
 internal fun SwapToken(
     valuedToken: ValuedToken,
-    hasToShowOnNativeChain: Boolean = false,
+    isSwap: Boolean = false,
     isDestinationToken: Boolean = false,
 ) {
     val token = valuedToken.token
     val value = valuedToken.value
-    val shouldShowOnChainLogo = hasToShowOnNativeChain
+    val shouldShowOnChainLogo = isSwap
             && (!token.isNativeToken || token.chain.isLayer2)
 
     Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -44,6 +44,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Tokens
 import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.models.isLayer2
+import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
@@ -196,7 +198,7 @@ private fun VerifySwapScreen(
 
                     SwapToken(
                         valuedToken = tx.src,
-                        chainLogo = tx.srcNativeLogo,
+                        hasToShowOnNativeChain = true,
                     )
 
                     Row(
@@ -249,7 +251,7 @@ private fun VerifySwapScreen(
 
                     SwapToken(
                         valuedToken = tx.dst,
-                        chainLogo = tx.dstNativeLogo,
+                        hasToShowOnNativeChain = true,
                         isDestinationToken = true,
                     )
 
@@ -348,11 +350,13 @@ private fun VerifySwapScreen(
 @Composable
 internal fun SwapToken(
     valuedToken: ValuedToken,
-    chainLogo: String? = null,
+    hasToShowOnNativeChain: Boolean = false,
     isDestinationToken: Boolean = false,
 ) {
     val token = valuedToken.token
     val value = valuedToken.value
+    val shouldShowOnChainLogo = hasToShowOnNativeChain
+            && (!token.isNativeToken || token.chain.isLayer2)
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -404,12 +408,12 @@ internal fun SwapToken(
             )
         }
 
-        if (!valuedToken.token.isNativeToken && !chainLogo.isNullOrEmpty()) {
+        if (shouldShowOnChainLogo) {
             UiSpacer(1f)
 
             Row(verticalAlignment = Alignment.CenterVertically) {
                 TokenLogo(
-                    logo = Tokens.getCoinLogo(chainLogo),
+                    logo = token.chain.logo,
                     title = token.ticker,
                     errorLogoModifier = Modifier
                         .size(16.dp),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -150,9 +150,7 @@ val Chain.isDepositSupported: Boolean
 
 val Chain.isLayer2: Boolean
     get() = when (this) {
-        Chain.Arbitrum, Chain.Avalanche, Chain.CronosChain, Chain.Base, Chain.Blast,
-        Chain.Optimism, Chain.Polygon, Chain.BscChain, Chain.ZkSync -> true
-
+        Chain.Arbitrum, Chain.Base, Chain.Blast, Chain.Optimism, Chain.ZkSync -> true
         else -> false
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Tokens
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.isLayer2
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -43,8 +44,6 @@ interface TokenRepository {
     suspend fun getTokensWithBalance(chain: Chain, address: String): List<Coin>
 
     suspend fun getRefreshTokens(chain: Chain, vault: Vault): List<Coin>
-
-    suspend fun getNativeLogo(coin: Coin): String
 
     val builtInTokens: Flow<List<Coin>>
 
@@ -259,13 +258,6 @@ internal class TokenRepositoryImpl @Inject constructor(
             }
     }
 
-    override suspend fun getNativeLogo(coin: Coin): String {
-        if (!coin.isNativeToken) {
-            return getNativeToken(coin.chain.id).logo
-        }
-        return coin.logo
-    }
-
     private suspend fun VultisigBalanceResultJson.toCoins(chain: Chain) = coroutineScope {
         val (supportedCoinsAndContracts, unsupportedCoins) = extractCoinsFromJson(
             this@toCoins,
@@ -395,9 +387,7 @@ internal class TokenRepositoryImpl @Inject constructor(
     private val enabledByDefaultTokens = listOf(Tokens.tcy)
         .groupBy { it.chain }
 
-
     companion object {
         private const val CUSTOM_TOKEN_RESPONSE_TICKER_ID = 2
     }
-
 }


### PR DESCRIPTION
## Description

- Show the origin chain when swapping with L2 networks (they use ETH as the base coin), as it can be confusing, for example, when swapping ETH → ETH (Base).
- Avoid showing all loading indicators when user clicks "Swap," since there's no quote update at that point. Instead, just display the main loading spinner.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated loading indicator for navigation to the next screen during swap operations, improving user feedback during transitions.

* **Improvements**
  * The display logic for on-chain logos in swap screens is now more consistent and simplified, with automatic detection based on token and chain properties.
  * Updated the classification of Layer 2 chains, affecting how certain chains are identified in the app.

* **Removals**
  * Native token logos are no longer shown in swap transaction details.
  * Removed unused methods related to fetching native token logos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->