### PR TITLE
[Unmerge]: Automatically prefill unmerge amount

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -1347,6 +1347,8 @@ internal class DepositFormViewModel @Inject constructor(
         state.update {
             it.copy(sharesBalance = amountText.asUiText())
         }
+
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd(amountText)
     }
 
     private fun requireTokenAmount(


### PR DESCRIPTION
## Description

Prefill the amount to unmerge for users. Shares can have up to 8 decimal places, which can be a bit annoying, as most users typically want to unmerge the maximum amount

Fixes #2160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the token amount field in the deposit form updates immediately to reflect the latest shares balance, with the cursor placed at the end of the text for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->