### PR TITLE
Increase gas for KyberSwap transactions on Ethereum

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJson.kt.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJson.kt.kt
@@ -34,8 +34,7 @@ data class KyberSwapQuoteJson(
 fun KyberSwapQuoteJson.gasForChain(chain: Chain): Long {
     val baseGas = data.gas?.toLongOrNull() ?: 600_000L
     val gasMultiplierTimes10 = when (chain) {
-        Chain.Ethereum -> 14L
-        Chain.Arbitrum, Chain.Optimism, Chain.Base, Chain.Polygon, Chain.Avalanche, Chain.BscChain -> 20L
+        Chain.Ethereum, Chain.Arbitrum, Chain.Optimism, Chain.Base, Chain.Polygon, Chain.Avalanche, Chain.BscChain -> 20L
         else -> 16L
     }
     return (baseGas * gasMultiplierTimes10) / 10


### PR DESCRIPTION
## Description

Based on
https://github.com/vultisig/vultisig-ios/blob/22cfc746fc3ac47baa5411c81fc2086f29458e8f/VultisigApp/VultisigApp/Services/KyberSwap/KyberSwapQuote.swift#L38-L42
Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal calculation to standardize gas multipliers across supported chains, resulting in more consistent gas estimates for users. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->