### PR TITLE
[SelectNetwork]: Apply latest changes from figma (padding adjustment)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkScreen.kt
@@ -88,6 +88,8 @@ private fun SelectNetworkScreen(
             ) {
                 item {
                     Row {
+                        UiSpacer(18.dp)
+
                         Text(
                             text = stringResource(R.string.select_chain_chain_title),
                             style = Theme.brockmann.supplementary.caption,


### PR DESCRIPTION
## Description

After conversation with Mia, padding was adjusted

<img width="419" height="218" alt="Screenshot 2025-07-17 at 18 51 50" src="https://github.com/user-attachments/assets/05688ec1-8d37-4102-b8b9-3fe2004f4bc6" />

<img width="304" height="82" alt="Screenshot 2025-07-17 at 18 53 53" src="https://github.com/user-attachments/assets/cc300fa9-3a89-4b21-b27b-672ee32c87b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added extra horizontal spacing before the header text in the network selection screen for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->