### PR TITLE
[Swap]: Load all tokens in asset selection screen, including disabled ones

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenSelectionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenSelectionViewModel.kt
@@ -62,7 +62,6 @@ internal class TokenSelectionViewModel @Inject constructor(
 
     val uiState = MutableStateFlow(TokenSelectionUiModel())
 
-
     val searchTextFieldState = TextFieldState()
 
     init {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -37,6 +37,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SendDst
+import com.vultisig.wallet.ui.screens.select.AssetSelected
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -316,7 +317,9 @@ internal class DepositFormViewModel @Inject constructor(
                     networkFilters = Route.SelectNetwork.Filters.DisableNetworkSelection
                 )
             )
-            val selectedToken = requestResultRepository.request<Coin?>(requestId)
+            val selectedAsset = requestResultRepository.request<AssetSelected?>(requestId)
+            val selectedToken = selectedAsset?.token
+
             if (selectedToken != null) {
                 state.update {
                     it.copy(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -62,6 +62,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
+import com.vultisig.wallet.ui.screens.select.AssetSelected
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import com.vultisig.wallet.ui.utils.textAsFlow
@@ -368,7 +369,8 @@ internal class SendFormViewModel @Inject constructor(
                 )
             )
 
-            val newToken = requestResultRepository.request<Coin?>(requestId)
+            val newAssetSelected = requestResultRepository.request<AssetSelected?>(requestId)
+            val newToken = newAssetSelected?.token
 
             if (newToken != null) {
                 selectToken(newToken)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -624,17 +624,10 @@ internal class SwapFormViewModel @Inject constructor(
         loadedAddress: String,
         loadedAccount: Account
     ) {
-        addresses.update { currentAddresses ->
-            currentAddresses.map { address ->
-                if (address.address == loadedAddress) {
-                    val updatedAccounts = address.accounts.map { account ->
-                        if (account.token.id == loadedAccount.token.id) {
-                            loadedAccount
-                        } else {
-                            account
-                        }
-                    }
-                    address.copy(accounts = updatedAccounts)
+        addresses.update { listOfAddreses ->
+            listOfAddreses.map { address ->
+                if (address.chain == loadedAccount.token.chain) {
+                    address.copy(accounts = address.accounts + listOf(loadedAccount))
                 } else {
                     address
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -54,6 +54,7 @@ import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.select.AssetSelected
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import com.vultisig.wallet.ui.utils.textAsFlow
@@ -594,7 +595,7 @@ internal class SwapFormViewModel @Inject constructor(
     }
 
     private suspend fun checkTokenSelectionResponse(targetArg: String) {
-        val result = requestResultRepository.request<Coin>(targetArg)?.id
+        val result = requestResultRepository.request<AssetSelected>(targetArg)?.token?.id
         if (targetArg == ARG_SELECTED_SRC_TOKEN_ID) {
             selectedSrcId.value = result
         } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -613,9 +613,10 @@ internal class SwapFormViewModel @Inject constructor(
             }
         }
 
-        when (targetArg) {
-            ARG_SELECTED_SRC_TOKEN_ID -> selectedSrcId.value = result.token.id
-            else -> selectedDstId.value = result.token.id
+        if (targetArg == ARG_SELECTED_SRC_TOKEN_ID) {
+            selectedSrcId.value = result.token.id
+        } else {
+            selectedDstId.value = result.token.id
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -666,7 +666,6 @@ internal class SwapFormViewModel @Inject constructor(
                     addresses.filter { it.chain.IsSwapSupported }
                 }
                 .catch {
-                    // TODO handle error
                     Timber.e(it)
                 }.collect(addresses)
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -603,8 +603,8 @@ internal class SwapFormViewModel @Inject constructor(
             uiState.update { it.copy(isLoading = true) }
             vaultId?.let {
                 try {
-                    val (address, account) = accountsRepository.loadAccount(vaultId!!, result.token)
-                    updateAccountInAddresses(address, account)
+                    val account = accountsRepository.loadAccount(vaultId!!, result.token)
+                    updateAccountInAddresses(account)
                     uiState.update { it.copy(isLoading = false) }
                 } catch (t: Throwable) {
                     uiState.update { it.copy(isLoading = false) }
@@ -621,7 +621,6 @@ internal class SwapFormViewModel @Inject constructor(
     }
 
     private fun updateAccountInAddresses(
-        loadedAddress: String,
         loadedAccount: Account
     ) {
         addresses.update { listOfAddreses ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -610,6 +610,8 @@ internal class SwapFormViewModel @Inject constructor(
                     uiState.update { it.copy(isLoading = false) }
                     return
                 }
+            } ?: run {
+                uiState.update { it.copy(isLoading = false) }
             }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -325,8 +325,6 @@ internal sealed class Route {
     data object ScanError
 
 
-    // transactions
-
     // select asset / network
     @Serializable
     data class SelectAsset(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
@@ -113,6 +113,7 @@ private fun SelectAssetScreen(
                         subtitle = item.subtitle,
                         amount = item.amount,
                         value = item.value,
+                        isDisabled = item.isDisabled,
                         modifier = Modifier
                             .clickable(onClick = {
                                 onAssetClick(item)
@@ -148,6 +149,7 @@ private fun AssetItem(
     subtitle: String,
     amount: String,
     value: String,
+    isDisabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -191,22 +193,26 @@ private fun AssetItem(
                 ),
         )
 
+
         Column(
             horizontalAlignment = Alignment.End,
             modifier = Modifier.weight(1f),
         ) {
-            Text(
-                text = amount,
-                style = Theme.brockmann.supplementary.footnote,
-                color = Theme.colors.text.primary,
-            )
+            if (!isDisabled) {
+                Text(
+                    text = amount,
+                    style = Theme.brockmann.supplementary.footnote,
+                    color = Theme.colors.text.primary,
+                )
 
-            Text(
-                text = value,
-                style = Theme.brockmann.supplementary.caption,
-                color = Theme.colors.text.extraLight,
-            )
+                Text(
+                    text = value,
+                    style = Theme.brockmann.supplementary.caption,
+                    color = Theme.colors.text.extraLight,
+                )
+            }
         }
+
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.Tokens
 import com.vultisig.wallet.ui.components.TokenLogo
+import com.vultisig.wallet.ui.components.UiGradientDivider
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
 import com.vultisig.wallet.ui.components.inputs.VsSearchTextField
@@ -128,9 +129,9 @@ private fun SelectAssetScreen(
                     )
 
                     if (!isLast) {
-                        HorizontalDivider(
-                            thickness = 1.dp,
-                            color = Theme.colors.borders.light,
+                        UiGradientDivider(
+                            initialColor = Theme.colors.backgrounds.secondary,
+                            endColor = Theme.colors.backgrounds.secondary,
                         )
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -103,10 +103,12 @@ internal class SelectAssetViewModel @Inject constructor(
 
     fun selectAsset(asset: AssetUiModel) {
         viewModelScope.launch {
-            if (asset.isDisabled) {
+            val isDisabled = asset.isDisabled
+            if (isDisabled) {
                 enableTokenUseCase.invoke(vaultId, asset.token)
             }
-            requestResultRepository.respond(args.requestId, asset.token)
+            val callbackAsset = AssetSelected(asset.token, isDisabled)
+            requestResultRepository.respond(args.requestId, callbackAsset)
             navigator.navigate(Destination.Back)
         }
     }
@@ -206,3 +208,8 @@ internal class SelectAssetViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 }
+
+data class AssetSelected(
+    val token: Coin,
+    val isDisabled: Boolean,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -146,6 +146,7 @@ internal class SelectAssetViewModel @Inject constructor(
             viewModelScope.launch {
                 val vault = vaultRepository.get(vaultId) ?: return@launch
                 tokenRepository.getChainTokens(state.value.selectedChain, vault)
+                    .catch { Timber.e(it) }
                     .map { coinList ->
                         coinList
                             .filter { !it.isNativeToken }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -56,7 +56,7 @@ internal data class AssetUiModel(
     val isDisabled: Boolean = false,
 )
 
-//TODO : Refactor current implementation for now it will only load all tokens for swap,
+//TODO : Refactor current implementation
 @HiltViewModel
 internal class SelectAssetViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -142,6 +142,7 @@ internal class SelectAssetViewModel @Inject constructor(
     }
 
     private fun loadAllAssets() {
+        // TODO: Enable for Send, Deposit in upcoming update
         if (filter == Route.SelectNetwork.Filters.SwapAvailable) {
             viewModelScope.launch {
                 val vault = vaultRepository.get(vaultId) ?: return@launch

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -142,7 +142,7 @@ internal class SelectAssetViewModel @Inject constructor(
     private fun loadAllAssets() {
         if (filter == Route.SelectNetwork.Filters.SwapAvailable) {
             viewModelScope.launch {
-                val vault = vaultRepository.get(vaultId) ?: error("Can't load vault")
+                val vault = vaultRepository.get(vaultId) ?: return@launch
                 tokenRepository.getChainTokens(state.value.selectedChain, vault)
                     .map { coinList ->
                         coinList

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -36,7 +36,7 @@ interface AccountsRepository {
     suspend fun loadAccount(
         vaultId: String,
         token: Coin
-    ): Account
+    ): Pair<String, Account>
 }
 
 internal class AccountsRepositoryImpl @Inject constructor(
@@ -193,7 +193,7 @@ internal class AccountsRepositoryImpl @Inject constructor(
         ))
     }
 
-    override suspend fun loadAccount(vaultId: String, token: Coin): Account = coroutineScope {
+    override suspend fun loadAccount(vaultId: String, token: Coin): Pair<String, Account> = coroutineScope {
         val vault = getVault(vaultId)
         val chain = token.chain
         val nativeCoin = Coins.coins[chain]?.find { it.isNativeToken }
@@ -228,7 +228,7 @@ internal class AccountsRepositoryImpl @Inject constructor(
             .getTokenBalance(finalAccount.address, token)
             .first()
 
-        accountToUpdate.applyBalance(balance)
+        finalAccount.address to accountToUpdate.applyBalance(balance)
     }
 
     private fun Account.applyBalance(balance: TokenBalance): Account = copy(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -183,15 +183,14 @@ internal class AccountsRepositoryImpl @Inject constructor(
 
         loadPrices.await()
 
-        emit(
-            account.copy(
-                accounts = account.accounts.map {
-                    val balance = balanceRepository.getTokenBalance(address, it.token)
-                        .first()
+        emit(account.copy(
+            accounts = account.accounts.map {
+                val balance = balanceRepository.getTokenBalance(address, it.token)
+                    .first()
 
-                    it.applyBalance(balance)
-                }
-            ))
+                it.applyBalance(balance)
+            }
+        ))
     }
 
     override suspend fun loadAccount(vaultId: String, token: Coin): Account = coroutineScope {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -196,7 +196,8 @@ internal class AccountsRepositoryImpl @Inject constructor(
     override suspend fun loadAccount(vaultId: String, token: Coin): Pair<String, Account> = coroutineScope {
         val vault = getVault(vaultId)
         val chain = token.chain
-        val nativeCoin = Coins.coins[chain]?.find { it.isNativeToken }
+        val vaultCoins = vault.coins.filter { it.chain == chain }
+        val nativeCoin = vaultCoins.find { it.isNativeToken }
             ?: error("Missing native token for chain: $chain")
         val coins = if (token.isNativeToken) listOf(token) else listOf(nativeCoin, token)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -205,8 +205,7 @@ internal class AccountsRepositoryImpl @Inject constructor(
             ?: error("Failed to map address for chain: $chain with coins: $coins")
 
         val (finalCoins, finalAccount) = if (chain == Chain.Solana) {
-            val splCoins = getSPLCoins(coins, vault)
-            val combinedCoins = coins + splCoins
+            val combinedCoins = coins + getSPLCoins(coins, vault)
             val remappedAccount = chainAndTokensToAddressMapper
                 .map(ChainAndTokens(chain, combinedCoins))
                 ?: error("Failed to map updated Solana account with SPL tokens")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -208,22 +208,12 @@ internal class AccountsRepositoryImpl @Inject constructor(
             listOf(nativeCoin, updatedCoin) to updatedCoin
         }
 
-        val initialAccount = chainAndTokensToAddressMapper
+        val finalAccount = chainAndTokensToAddressMapper
             .map(ChainAndTokens(chain, coins))
             ?: error("Failed to map address for chain: $chain with coins: $coins")
 
-        val (finalCoins, finalAccount) = if (chain == Chain.Solana) {
-            val combinedCoins = coins + getSPLCoins(coins, vault)
-            val remappedAccount = chainAndTokensToAddressMapper
-                .map(ChainAndTokens(chain, combinedCoins))
-                ?: error("Failed to map updated Solana account with SPL tokens")
-            combinedCoins to remappedAccount
-        } else {
-            coins to initialAccount
-        }
-
         runCatching {
-            tokenPriceRepository.refresh(finalCoins)
+            tokenPriceRepository.refresh(coins)
         }.onFailure {
             Timber.e(it, "Failed to refresh token prices for chain: $chain")
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -36,7 +36,7 @@ interface AccountsRepository {
     suspend fun loadAccount(
         vaultId: String,
         token: Coin
-    ): Pair<String, Account>
+    ): Account
 }
 
 internal class AccountsRepositoryImpl @Inject constructor(
@@ -193,7 +193,7 @@ internal class AccountsRepositoryImpl @Inject constructor(
         ))
     }
 
-    override suspend fun loadAccount(vaultId: String, token: Coin): Pair<String, Account> = coroutineScope {
+    override suspend fun loadAccount(vaultId: String, token: Coin): Account = coroutineScope {
         val vault = getVault(vaultId)
         val chain = token.chain
         val vaultCoins = vault.coins.filter { it.chain == chain }
@@ -236,7 +236,7 @@ internal class AccountsRepositoryImpl @Inject constructor(
             .getTokenBalance(finalAccount.address, updatedToken)
             .first()
 
-        finalAccount.address to accountToUpdate.applyBalance(balance)
+        accountToUpdate.applyBalance(balance)
     }
 
     private fun Account.applyBalance(balance: TokenBalance): Account = copy(


### PR DESCRIPTION
## Description

- Load all assets in swap selection screen
- Allow user to select one asset, enable, fetch balance, and update quotes during swap, without need to go to asset screen and enable the token
- Load individual balance, price and update at repository level

Example with Mock Address
https://github.com/user-attachments/assets/3bdd1d43-6398-425c-af1a-424ecc6051de




## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [s] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and enabling disabled tokens in the asset selection screen, including enhanced filtering and search for tokens available for swap.
  * Disabled tokens are now visually distinguished, and users can enable them directly when selecting assets.
  * Asset dividers now use a gradient style for improved visual appearance.

* **Bug Fixes**
  * Improved handling of token selection and account loading for disabled tokens in swap, deposit, and send forms.

* **Chores**
  * Minor formatting and code cleanup in several files.
  * Added new account loading functionality to fetch account details and balances based on vault and token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->