### PR TITLE
[Improvement]: Avoid re-fetching all balances when opening select network

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
@@ -131,7 +131,7 @@ internal class SelectNetworkViewModel @Inject constructor(
     }
 
     private fun loadAddressesWithBalances(): Flow<Map<Chain, String>> {
-        return accountRepository.loadAddresses(vaultId = vaultId)
+        return accountRepository.loadCachedAddresses(vaultId = vaultId)
             .catch {
                 Timber.e(it)
                 emit(emptyList())


### PR DESCRIPTION
## Description

- By calling loadAddresses (with refresh set to either true or false), it will eventually re-fetch the balances of all tokens. This can be spammy if user has many chains and tokens.
- On the Network Selection screen, we now need to display the total value. To calculate it, we require both token prices and balances. However, re-fetching this data can be quite spammy, especially considering that:
  1. Balances are already fetched on the Home screen.
  2. Balances are also fetched/refreshed when opening the Swap screen.
  3. Balances are also fetched/refreshed when opening the Send form.

For this reason I suggest to load only cached addresses and account when showing select network dialog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved address loading performance by introducing a faster, cached address retrieval method when selecting a network.

* **Bug Fixes**
  * Address loading now avoids unnecessary balance or price updates, resulting in a smoother and more responsive experience when viewing available addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->