### PR TITLE
Fix the cross-platrom Kyber swap issue between iOS and Android

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumGasHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumGasHelper.kt
@@ -26,18 +26,31 @@ object EthereumGasHelper {
             chainId = ByteString.copyFrom(BigInteger(coinType.chainId()).toByteArray())
             nonce = ByteString.copyFrom((ethSpecifc.nonce + nonceIncrement).toByteArray())
         }
-        if(keysignPayload.coin.chain == Chain.BscChain) {
-            signingInputBuilder.apply  {
+        if (keysignPayload.coin.chain == Chain.BscChain) {
+            signingInputBuilder.apply {
                 txMode = Ethereum.TransactionMode.Legacy
-                setGasPrice(ByteString.copyFrom(gasPrice.toByteArray()))
-                gasLimit =ByteString.copyFrom(gas.toByteArray())
+                if (gas.toLong() != EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT && gasPrice != BigInteger.ZERO) {
+                    gasLimit = ByteString.copyFrom(gas.toByteArray())
+                    setGasPrice(ByteString.copyFrom(gasPrice.toByteArray()))
+                } else {
+                    gasLimit = ByteString.copyFrom(ethSpecifc.gasLimit.toByteArray())
+                    setGasPrice(ByteString.copyFrom(ethSpecifc.maxFeePerGasWei.toByteArray()))
+                }
             }
         } else {
             signingInputBuilder.apply {
                 txMode = Ethereum.TransactionMode.Enveloped
-                gasLimit = ByteString.copyFrom(ethSpecifc.gasLimit.toByteArray())
-                maxFeePerGas = ByteString.copyFrom(ethSpecifc.maxFeePerGasWei.toByteArray())
-                maxInclusionFeePerGas = ByteString.copyFrom(ethSpecifc.priorityFeeWei.toByteArray())
+                if (gas.toLong() != EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT && gasPrice != BigInteger.ZERO) {
+                    gasLimit = ByteString.copyFrom(gas.toByteArray())
+                    maxFeePerGas = ByteString.copyFrom(gasPrice.toByteArray())
+                    maxInclusionFeePerGas =
+                        ByteString.copyFrom(ethSpecifc.priorityFeeWei.toByteArray())
+                } else {
+                    gasLimit = ByteString.copyFrom(ethSpecifc.gasLimit.toByteArray())
+                    maxFeePerGas = ByteString.copyFrom(ethSpecifc.maxFeePerGasWei.toByteArray())
+                    maxInclusionFeePerGas =
+                        ByteString.copyFrom(ethSpecifc.priorityFeeWei.toByteArray())
+                }
             }
         }
         return signingInputBuilder


### PR DESCRIPTION
## Description

https://snowtrace.io/tx/0xfd8b15d64401a91f8082271f36f54bdb131527f883d8d60a326e64c7204adcca?chainid=43114
https://bscscan.com/tx/0x04500225016be3231a0f63befcb6f7bd614550810a33148456e31e2c4ad254d9

To reproduce the issue:
Create a swap transaction between AVAX tokens on iOS.

Join the transaction from an Android device.

You'll see a "Signature empty" error.
Fixes #2147

The root cause appears to be a mismatch in how gas parameters are set between iOS and Android.

On iOS, the gas parameters are defined here:
🔗 https://github.com/vultisig/vultisig-ios/blame/2c82f64a62ae5d5e20c1478c245607f645253430/VultisigApp/VultisigApp/Chains/evm.swift#L47-L66



## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gas parameters for Ethereum-based transactions, ensuring gas values are only overridden when meaningful values are provided. This results in more accurate transaction fee calculations and prevents unintended overrides with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->