### PR TITLE
[XRP]: Support Reserved Balance (failed swap with small amount)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -90,16 +90,14 @@ internal class RippleApiImp @Inject constructor(
 
     override suspend fun getBalance(coin: Coin): BigInteger = supervisorScope {
         try {
-            val accountInfoDeferred = async { fetchAccountsInfo(coin.address) }
+            val accountInfoDeferred = async { fetchAccountsInfo("rhhh49pFH96roGyuC4E5P4CHaNjS1k8gzM") }
             val reservedBalanceDeferred = async { serverState() }
-            // TODO: Create extensions
             val balance =
                 accountInfoDeferred.await()?.result?.accountData?.balance?.toBigInteger()
                     ?: BigInteger.ZERO
             val reservedBalance =
                 reservedBalanceDeferred.await().result?.state?.validateLedger?.reservedBase?.toBigInteger()
                     ?: BigInteger.ZERO
-            // TODO: Calculate number of slots * reserve_inc in case we support tokens
             maxOf(balance - reservedBalance, BigInteger.ZERO)
         } catch (e: Exception) {
             Timber.e("Error in getBalance: ${e.message}")
@@ -143,7 +141,8 @@ internal class RippleApiImp @Inject constructor(
             method = "server_state",
             params = buildJsonArray { }
         )
-        http.post(rpcUrl2) {
+
+        return http.post(rpcUrl2) {
             setBody(payload)
         }.bodyOrThrow<RippleServerStateResponseJson>()
     }
@@ -190,7 +189,7 @@ data class RippleServerStateResultJson(
 ) {
     @Serializable
     data class RippleStateJson(
-        @SerialName("validateLedger")
+        @SerialName("validated_ledger")
         val validateLedger: RippleValidateLedger,
     ) {
         @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -88,7 +88,7 @@ internal class RippleApiImp @Inject constructor(
     override suspend fun getBalance(coin: Coin): BigInteger = supervisorScope {
         try {
             val accountInfoDeferred =
-                async { fetchAccountsInfo("rhhh49pFH96roGyuC4E5P4CHaNjS1k8gzM") }
+                async { fetchAccountsInfo(coin.address) }
             val reservedBalanceDeferred =
                 async { fetchServerState() }
 


### PR DESCRIPTION
## Description
Fixes #2202

- Properly support reserved balance to display the actual spendable balance to users.
- Reserved balance cannot be spent.
- It is calculated as: base reserve + (owner count * incremental reserve).
- Although we don't currently support NFTs or tokens, we may in the future—so I've added owner count handling preemptively.

<img width="891" height="376" alt="Screenshot 2025-07-22 at 13 22 17" src="https://github.com/user-attachments/assets/eeb32bc4-9a60-4290-be75-bf6627079d80" />
<img width="891" height="376" alt="Screenshot 2025-07-22 at 13 22 23" src="https://github.com/user-attachments/assets/91ecd207-252b-4336-b070-5195e2b8bb5b" />


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved balance accuracy for Ripple accounts by accounting for reserved XRP amounts based on the latest server reserve requirements.

* **Refactor**
  * Enhanced performance and reliability of balance calculations through concurrent data fetching and robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->