### PR TITLE
Update the clipboard content after resuming the app from a paused state

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/LiveClipboardManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/LiveClipboardManager.kt
@@ -43,6 +43,8 @@ private fun onClipDataChanged(onPrimaryClipChanged: ClipData?.() -> Unit) {
     val isWindowFocused = windowInfo.isWindowFocused
 
     LaunchedEffect(context, isWindowFocused) {
+        if (isWindowFocused.not())
+            return@LaunchedEffect
         val clipboardManager =
             context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         onPrimaryClipChanged(clipboardManager.primaryClip)


### PR DESCRIPTION
## Description

Currently, when the app is paused and a text is copied from outside, the clipboard doesn’t update upon resuming the app

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Refactor**
  * Improved the clipboard monitoring mechanism for better reliability and responsiveness when window focus changes. No visible changes to the user interface or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->