### PR TITLE
[TON]: Map sendMax in TonSpecific (failed transaction)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -132,6 +132,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     sequenceNumber = specific.sequenceNumber,
                     expireAt = specific.expireAt,
                     bounceable = specific.bounceable,
+                    sendMaxAmount = specific.sendMaxAmount,
                 )
             } else null,
             tronSpecific = if (specific is BlockChainSpecific.Tron) {


### PR DESCRIPTION
## Description

- Map missing parameter for isMax transfer
- iOS fix: https://github.com/vultisig/vultisig-ios/pull/2568

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `sendMaxAmount` property is now included when handling TON blockchain-specific payloads, ensuring more comprehensive data representation in related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->