### PR TITLE
Fix feeCoin when chain is Solana

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -139,6 +139,10 @@ internal class TokenRepositoryImpl @Inject constructor(
 
     override suspend fun getTokenByContract(chainId: String, contractAddress: String): Coin? {
         val chain = Chain.fromRaw(chainId)
+        if (chain == Chain.Solana)
+            return splTokenRepository.getTokenByContract(
+                contractAddress
+            ) ?: return null
         val rpcResponses = evmApiFactory.createEvmApi(chain)
             .findCustomToken(contractAddress)
         if (rpcResponses.isEmpty())


### PR DESCRIPTION
## Description

When performing a swap from Solana to Cronos, the fee calculation fails with the error:
Quote calculation failed.
This happens because `getTokenByContract` (https://github.com/vultisig/vultisig-android/pull/2177/files#diff-2f01af0f9fa20f2e2db53fece2babea8d696165b3d77c96e3f9dbd1a92f09e9dR1049-R1050 search tokens only in EVM)
searches for tokens only within EVM chains, which leads to incorrect or missing gas calculations for non-EVM chains like Solana.

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context