### PR TITLE
[Fix]: Backup password screen is not responsive

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -87,6 +89,7 @@ internal fun BackupPasswordRequestScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding)
+                    .verticalScroll(rememberScrollState())
                     .padding(
                         all = 24.dp,
                     ),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,6 +55,7 @@ private fun BackupVaultScreen(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier
                     .padding(contentPadding)
+                    .verticalScroll(rememberScrollState())
                     .padding(
                         all = 24.dp,
                     )


### PR DESCRIPTION
## Description

Fixes #2209

- Tested on a small device using Android Studio, as well as a custom device (720 × 880)
- Forced content layout on large devices, by adding more description (copy/paste)
- Tested on large devices, it is only trigger when content can't fit.
- In the second screen, since the button is fixed at the bottom, it's better to apply scroll only to the content area. (this is done automatically as there is a bottom bar)
- In the first screen, the content is centered, so applying scroll to the entire screen makes more sense.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context