### PR TITLE
Fix retry when local keygen fails

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
@@ -138,7 +138,9 @@ internal class KeygenViewModel @Inject constructor(
     }
 
     fun tryAgain() {
-        generateKey()
+        viewModelScope.launch {
+            navigator.navigate(Destination.Back)
+        }
     }
 
     private fun generateKey() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -270,7 +270,7 @@ internal class KeygenPeerDiscoveryViewModel @Inject constructor(
                 ),
                 opts = NavigationOptions(
                     popUpToRoute = Route.Keygen.PeerDiscovery::class,
-                    inclusive = true,
+                    inclusive = false,
                 )
             )
         }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2201
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the retry action in the key generation flow to navigate back instead of immediately retrying, improving user experience.
  * Adjusted navigation behavior during peer discovery to better preserve navigation history when proceeding to key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->