### PR TITLE
 Fix subtracting network fee from max amount

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GasFeeToEstimatedFeeUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GasFeeToEstimatedFeeUseCase.kt
@@ -47,8 +47,8 @@ internal class GasFeeToEstimatedFeeUseCaseImpl @Inject constructor(
         tokenValue = when {
             chain.standard == TokenStandard.EVM ->
                 tokenValue.copy(
-                    value = tokenValue.value.divide(BigInteger.TEN.pow(9)),
                     unit = nativeToken.ticker,
+                    decimals = nativeToken.decimal
                 )
 
             chain == Chain.Bitcoin && from.perUnit->

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -338,7 +338,7 @@ internal fun SwapScreen(
                                     color = Theme.colors.neutral100,
                                 )
                             ) {
-                                append(state.gas)
+                                append(state.networkFee)
                             }
                             append(" ")
                             withStyle(
@@ -347,8 +347,8 @@ internal fun SwapScreen(
                                 )
                             ) {
                                 append(
-                                    if (state.fiatGas.isNotEmpty())
-                                        "(~${state.fiatGas})"
+                                    if (state.networkFeeFiat.isNotEmpty())
+                                        "(~${state.networkFeeFiat})"
                                     else ""
                                 )
                             }


### PR DESCRIPTION
## Description
https://cronoscan.com/tx/0x13bd8b6cdd0b869aff3273439bbbf2b6fa154fc8f8d3ae53526200893f9212c8

Currently when the user presses "Max Amount" on EVM chains.  the app subtracst gas cost , not the  full network fee.
As shown in the  screenshot , the correct max amount should be

`4.32153671 - 0.340875 = 3.98066171
`

However, the app displays 4.3, which leads to a failed transaction due to insufficient fees.



Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
<img width="563" height="1000" alt="Screenshot_20250726_121859" src="https://github.com/user-attachments/assets/36a7148f-e901-4d89-8a03-03d22d35629e" />


## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all references of "gas fee" to "network fee" throughout the swap form and swap screen interfaces for improved clarity and consistency.
  * Adjusted how network fee values are displayed and calculated, aligning terminology and UI elements with the new naming.
  * Modified the calculation of estimated fees for EVM-standard chains to better represent token decimals without scaling values.

* **Style**
  * Updated UI labels to reflect the terminology change from "gas fee" to "network fee".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->