### PR TITLE
Fix vault deletion logic by checking concession status first

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -713,6 +713,7 @@ internal class SwapFormViewModel @Inject constructor(
                 }
                 .catch {
                     Timber.e(it)
+                    emit(emptyList())
                 }.collect(addresses)
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -713,7 +713,6 @@ internal class SwapFormViewModel @Inject constructor(
                 }
                 .catch {
                     Timber.e(it)
-                    emit(emptyList())
                 }.collect(addresses)
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/delete/ConfirmDeleteScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/delete/ConfirmDeleteScreen.kt
@@ -36,6 +36,7 @@ import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
@@ -108,6 +109,8 @@ internal fun ConfirmDeleteScreen(
         bottomBar = {
             VsButton(
                 onClick = onConfirmClick,
+                state = if (isDeleteButtonActive.not()) VsButtonState.Disabled else
+                    VsButtonState.Enabled,
                 label = stringResource(R.string.confirm_delete_delete_vault),
                 variant = VsButtonVariant.Error,
                 modifier = Modifier


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2277

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The delete confirmation button now visually and functionally enables or disables based on user actions, improving clarity during the delete process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->