### PR TITLE
 Add tokens to Mayachain swap provider

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.repositories
 
+import androidx.compose.ui.text.toUpperCase
 import com.vultisig.wallet.data.api.JupiterApi
 import com.vultisig.wallet.data.api.LiFiChainApi
 import com.vultisig.wallet.data.api.MayaChainApi
@@ -440,11 +441,6 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
     }
 
     override fun resolveProvider(srcToken: Coin, dstToken: Coin): SwapProvider? {
-        if (hasNotProvider(
-                srcToken,
-                dstToken
-            )
-        ) return null
         return srcToken.swapProviders
             .intersect(dstToken.swapProviders)
             .firstOrNull {
@@ -460,14 +456,6 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
 
     private fun isCrossChainSwap(srcToken: Coin, dstToken: Coin) =
         srcToken.chain != dstToken.chain
-
-    private fun hasNotProvider(
-        srcToken: Coin,
-        dstToken: Coin,
-    ) = !srcToken.isNativeToken && srcToken.chain in listOf(
-        Chain.Ethereum,
-        Chain.Arbitrum
-    ) && dstToken.chain == Chain.MayaChain
 
     private val thorEthTokens = listOf(
         "ETH",
@@ -486,7 +474,10 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         "AAVE",
         "FOX",
         "DPI",
-        "SNX"
+        "SNX",
+        "PEPE",
+        "LLD",
+        "WSTETH"
     )
     private val thorBscTokens = listOf(
         "BNB",
@@ -499,16 +490,16 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         "USDT",
         "SOL"
     )
-    private val mayaEthTokens = listOf("ETH","USDC")
+    private val mayaEthTokens = listOf("ETH","USDC","SNX","PEPE","LLD","WSTETH")
     private val mayaArbTokens = listOf(
-        "ETH","DAI"
+        "ETH","DAI","GNS","GMX","SUSHI","ARB","WSTETH","LINK","PEPE","WBTC","USDT","GLD","TGT","LEO","YUM","USDC"
     )
 
     private val Coin.swapProviders: Set<SwapProvider>
         get() = when (chain) {
             Chain.MayaChain, Chain.Dash, Chain.Kujira -> setOf(SwapProvider.MAYA)
             Chain.Ethereum -> when {
-                ticker in thorEthTokens && ticker in mayaEthTokens -> setOf(
+                ticker.uppercase() in thorEthTokens && ticker.uppercase() in mayaEthTokens -> setOf(
                     SwapProvider.THORCHAIN,
                     SwapProvider.ONEINCH,
                     SwapProvider.KYBER,
@@ -516,14 +507,14 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
                     SwapProvider.MAYA,
                 )
 
-                ticker in thorEthTokens -> setOf(
+                ticker.uppercase() in thorEthTokens -> setOf(
                     SwapProvider.THORCHAIN,
                     SwapProvider.ONEINCH,
                     SwapProvider.KYBER,
                     SwapProvider.LIFI,
                 )
 
-                ticker in mayaEthTokens -> setOf(
+                ticker.uppercase() in mayaEthTokens -> setOf(
                     SwapProvider.ONEINCH,
                     SwapProvider.KYBER,
                     SwapProvider.LIFI,
@@ -587,7 +578,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
 
             Chain.Zcash -> setOf(SwapProvider.MAYA)
 
-            Chain.Arbitrum -> if (ticker in mayaArbTokens) setOf(
+            Chain.Arbitrum -> if (ticker.uppercase() in mayaArbTokens) setOf(
                 SwapProvider.LIFI,
                 SwapProvider.MAYA
             ) else setOf(SwapProvider.LIFI)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -501,7 +501,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
     )
     private val mayaEthTokens = listOf("ETH","USDC")
     private val mayaArbTokens = listOf(
-        "ETH",
+        "ETH","DAI"
     )
 
     private val Coin.swapProviders: Set<SwapProvider>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -499,7 +499,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         "USDT",
         "SOL"
     )
-    private val mayaEthTokens = listOf("ETH")
+    private val mayaEthTokens = listOf("ETH","USDC")
     private val mayaArbTokens = listOf(
         "ETH",
     )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -474,10 +474,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         "AAVE",
         "FOX",
         "DPI",
-        "SNX",
-        "PEPE",
         "LLD",
-        "WSTETH"
     )
     private val thorBscTokens = listOf(
         "BNB",
@@ -490,9 +487,23 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         "USDT",
         "SOL"
     )
-    private val mayaEthTokens = listOf("ETH","USDC","SNX","PEPE","LLD","WSTETH")
+    private val mayaEthTokens = listOf(
+        "ETH",
+        "USDC",
+        "LLD",
+    )
     private val mayaArbTokens = listOf(
-        "ETH","DAI","GNS","GMX","SUSHI","ARB","WSTETH","LINK","PEPE","WBTC","USDT","GLD","TGT","LEO","YUM","USDC"
+        "ETH",
+        "ARB",
+        "WSTETH",
+        "LINK",
+        "PEPE",
+        "WBTC",
+        "GLD",
+        "TGT",
+        "LEO",
+        "YUM",
+        "USDC"
     )
 
     private val Coin.swapProviders: Set<SwapProvider>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.data.repositories
 
-import androidx.compose.ui.text.toUpperCase
 import com.vultisig.wallet.data.api.JupiterApi
 import com.vultisig.wallet.data.api.LiFiChainApi
 import com.vultisig.wallet.data.api.MayaChainApi


### PR DESCRIPTION
## Description


DASH <> ETH.USDC 👇  https://www.mayascan.org/tx/54cb2790ccbe5def195f7af4bc4cf202f01ff21e3ecd5a02fe7ec1a69b1e2f40

The added tokens were tested and have valid swap quotes
Fixes #2023

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional tokens when swapping, including updates to token lists.
* **Bug Fixes**
  * Improved token matching for swaps by making ticker checks case-insensitive.
* **Refactor**
  * Simplified provider selection logic for token swaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->