### PR TITLE
Fix backup password handling more information

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal data class BackupPasswordState(
+    var isMoreInfoVisible: Boolean = false,
     val passwordErrorMessage: UiText? = null,
     val isPasswordVisible: Boolean = false,
     val isConfirmPasswordVisible: Boolean = false,
@@ -71,6 +72,12 @@ internal class BackupPasswordViewModel @Inject constructor(
     val state = MutableStateFlow(BackupPasswordState())
 
     val createDocumentRequestFlow = MutableSharedFlow<String>()
+
+    private var isMoreInfoVisible: Boolean
+        get() = state.value.isMoreInfoVisible
+        set(value) = state.update {
+            it.copy(isMoreInfoVisible = value)
+        }
 
     init {
         viewModelScope.launch {
@@ -115,6 +122,13 @@ internal class BackupPasswordViewModel @Inject constructor(
             val fileName = createVaultBackupFileName(vault)
             createDocumentRequestFlow.emit(fileName)
         }
+    }
+    fun showMoreInfo() {
+        isMoreInfoVisible = true
+    }
+
+    fun hideMoreInfo() {
+        isMoreInfoVisible = false
     }
 
     fun togglePasswordVisibility() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/BackupPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/BackupPasswordScreen.kt
@@ -46,6 +46,7 @@ internal fun BackupPasswordScreen(
     FastVaultPasswordScreen(
         title = stringResource(R.string.backup_password_topbar_title),
         state = FastVaultPasswordUiModel(
+            isMoreInfoVisible = state.isMoreInfoVisible,
             isPasswordVisible = state.isPasswordVisible,
             isConfirmPasswordVisible = state.isConfirmPasswordVisible,
             isNextButtonEnabled = state.isNextButtonEnabled,
@@ -58,9 +59,8 @@ internal fun BackupPasswordScreen(
         confirmPasswordTextFieldState = model.confirmPasswordTextFieldState,
         onBackClick = model::back,
         onNextClick = model::backupEncryptedVault,
-        // TODO more info for backup password screen
-        onShowMoreInfo = {},
-        onHideMoreInfo = {},
+        onShowMoreInfo =model::showMoreInfo,
+        onHideMoreInfo = model::hideMoreInfo,
         onTogglePasswordVisibilityClick = model::togglePasswordVisibility,
         onToggleConfirmPasswordVisibilityClick = model::toggleConfirmPasswordVisibility
     )


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2270

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “More info” section to the backup password screen, with clear show/hide controls for additional guidance.
  - The screen now retains and reflects the visibility state of the “More info” panel, ensuring a consistent experience when interacting with help content.
  - Improved on-screen actions to toggle help content directly from the backup password UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->