### PR TITLE
Refactor key generation completion logic to ensure proper task cancel…

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -215,8 +215,6 @@ class DKLSKeygen(
                 error("timeout: failed to create vault within 60 seconds")
             }
         }
-
-        return false
     }
 
     @Throws(Exception::class)
@@ -346,8 +344,7 @@ class DKLSKeygen(
             }
             val isFinished = pullInboundMessages(handler)
             if (isFinished) {
-                setKeygenDone(true)
-                task.cancel()
+
                 val keyshareHandler = Handle()
                 val keyShareResult = dkls_keygen_session_finish(handler, keyshareHandler)
                 if (keyShareResult != LIB_OK) {
@@ -363,7 +360,9 @@ class DKLSKeygen(
                 )
                 Timber.d("publicKeyECDSA: ${publicKeyECDSA.toHexString()}")
                 Timber.d("chaincode: ${chainCodeBytes.toHexString()}")
-                // dkls_keyshare_free(keyshareHandler)
+                delay(500 ) // wait for the last message to be sent
+                setKeygenDone(true)
+                task.cancel()
             }
         } catch (e: Exception) {
             Timber.d("Failed to generate key, error: ${e.localizedMessage}")
@@ -494,8 +493,7 @@ class DKLSKeygen(
             }
             val isFinished = pullInboundMessages(handler)
             if (isFinished) {
-                setKeygenDone(true)
-                task.cancel()
+
                 val newKeyshareHandler = Handle()
                 val keyShareResult = dkls_qc_session_finish(handler, newKeyshareHandler)
                 if (keyShareResult != LIB_OK) {
@@ -509,6 +507,9 @@ class DKLSKeygen(
                     keyshare = Base64.Default.encode(keyshareBytes),
                     chaincode = chainCodeBytes.toHexString()
                 )
+                delay(500)
+                setKeygenDone(true)
+                task.cancel()
                 Timber.d("reshare ECDSA key successfully")
                 Timber.d("publicKeyECDSA: ${publicKeyECDSA.toHexString()}")
                 Timber.d("chaincode: ${chainCodeBytes.toHexString()}")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -180,8 +180,6 @@ class SchnorrKeygen(
                 error("timeout: failed to create vault within 60 seconds")
             }
         }
-
-        return false
     }
 
     private suspend fun processInboundMessage(handle: Handle, msgs: List<Message>): Boolean {
@@ -280,8 +278,6 @@ class SchnorrKeygen(
             }
             val isFinished = pullInboundMessages(handler)
             if (isFinished) {
-                setKeygenDone(true)
-                task.cancel()
                 val keyshareHandler = Handle()
                 val keyShareResult = schnorr_keygen_session_finish(handler, keyshareHandler)
                 if (keyShareResult != LIB_OK) {
@@ -295,6 +291,10 @@ class SchnorrKeygen(
                     chaincode = ""
                 )
                 Timber.d("publicKeyEdDSA: ${publicKeyEdDSA.toHexString()}")
+                // slightly delay to give local party time to process outbound messages
+                delay(500)
+                setKeygenDone(true)
+                task.cancel()
             }
         } catch (e: Exception) {
             Timber.d("Failed to generate key, error: ${e.localizedMessage}")
@@ -436,8 +436,6 @@ class SchnorrKeygen(
             }
             val isFinished = pullInboundMessages(handler)
             if (isFinished) {
-                setKeygenDone(true)
-                task.cancel()
                 val newKeyshareHandler = Handle()
                 val keyShareResult = schnorr_qc_session_finish(handler, newKeyshareHandler)
                 if (keyShareResult != LIB_OK) {
@@ -452,6 +450,9 @@ class SchnorrKeygen(
                     chaincode = ""
                 )
                 Timber.d("publicKeyEdDSA: ${publicKeyEdDSA.toHexString()}")
+                delay(500) // slightly delay to give local party time to process outbound messages
+                setKeygenDone(true)
+                task.cancel()
             }
         } catch (e: Exception) {
             Timber.d("Failed to reshare key, error: ${e.localizedMessage}")


### PR DESCRIPTION
…lation and add delays for message processing

## Description

Apply slightly delay after local keygen finish , so another thread has the opportunity to send request to relay server

Fixes #2347 

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of ECDSA and Schnorr key generation and re-sharing by finalizing only after all messages are sent.
  - Prevented premature completion that could lead to missing key shares.
  - Reduced timeouts and stuck states during key generation flows.
  - More consistent completion signaling and cleanup, minimizing rare app hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->