### PR TITLE
Fix copy of transaction hash

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -190,7 +190,7 @@ internal fun TxDetails(
             )
 
             CopyIcon(
-                textToCopy = hash,
+                textToCopy = link,
                 size = 12.dp,
                 onCopyCompleted = onTxHashCopied
             )


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2344

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In the transaction details view, the copy action now places the full transaction link into the clipboard instead of the raw hash.
  * The hash remains visible in the UI for reference.
  * The existing open-link action is unchanged.
  * No other layout or interaction changes.
  * Affects only the copy behavior within the transaction overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->