### PR TITLE
Remove max button from swap screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -429,12 +429,6 @@ internal fun SwapScreen(
                                     onSelectSrcPercentage(0.75f)
                                 },
                             )
-                            PercentageItem(
-                                title = "MAX",
-                                onClick = {
-                                    onSelectSrcPercentage(1f)
-                                },
-                            )
                         }
                     }
                 } else {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2351

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI**
  * Simplified the swap percentage picker by removing the MAX option.
  * Quick-select options now include 25%, 50%, and 75% only.
  * Balanced three-button layout improves clarity and reduces the chance of unintentionally selecting the full balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->