### PR TITLE
Disable estimate in OneInch API request

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
@@ -122,7 +122,7 @@ class OneInchApiImpl @Inject constructor(
         parameter("amount", amount)
         parameter("from", srcAddress)
         parameter("slippage", "0.5")
-        parameter("disableEstimate", false)
+        parameter("disableEstimate", true)
         parameter("includeGas", true)
         parameter("referrer", ONEINCH_REFERRER_ADDRESS)
         parameter("fee", if(isAffiliate) ONEINCH_REFERRER_FEE else "0")


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated 1inch swap and quote requests to skip the estimation step, resulting in faster quote retrieval and a smoother swap experience.
  - Improves responsiveness during quote generation without requiring any action or configuration changes from users.
  - No UI changes; existing swap and quote screens continue to function as before, with reduced waiting times and fewer background calculations.
  - No changes to public interfaces or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->