### PR TITLE
Update reshare condition to check for two signers in vault

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -34,7 +34,7 @@ internal open class VaultSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val vault = vaultRepository.get(vaultId)
             val hasMigration = vault?.libType == SigningLibType.GG20
-            val hasFastSign = isVaultHasFastSignById(vaultId)
+            val hasFastSign = isVaultHasFastSignById(vaultId) && vault?.signers?.count() == 2
             uiModel.update {
                 it.copy(
                     hasReshare = !hasFastSign,


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Fast Sign eligibility: now only available for vaults with exactly two signers and active Fast Sign, preventing incorrect availability when there are fewer or more signers.
  * Updated Reshare visibility to align with Fast Sign status, ensuring it appears only when Fast Sign is not available.
  * Improves consistency of options shown in Vault Settings for multi-sig configurations, reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->