### PR TITLE
Fix auto-compound unStake

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -1762,10 +1762,10 @@ internal class DepositFormViewModel @Inject constructor(
         // For unstaking (TCY-:XXXX), we send zero amount - gas is covered by RUNE
         // For staking (TCY+), we send the full amount entered by user
         val tokenAmountInt = if (isUnStake) {
-            if (tcyAutoCompoundAmount?.toBigIntegerOrNull()?.let { it > BigInteger.ONE } != true) {
-                throw InvalidTransactionDataException(
-                    UiText.StringResource(R.string.unstake_tcy_zero_error)
-                )
+            val totalUnits = tcyAutoCompoundAmount?.toBigIntegerOrNull()
+                ?: throw InvalidTransactionDataException(UiText.StringResource(R.string.unstake_tcy_zero_error))
+            if (totalUnits < BigInteger.ONE) {
+                throw InvalidTransactionDataException(UiText.StringResource(R.string.unstake_tcy_zero_error))
             }
             // For unstaking, send zero TCY as gas is covered by RUNE
             BigInteger.ZERO

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -1762,7 +1762,7 @@ internal class DepositFormViewModel @Inject constructor(
         // For unstaking (TCY-:XXXX), we send zero amount - gas is covered by RUNE
         // For staking (TCY+), we send the full amount entered by user
         val tokenAmountInt = if (isUnStake) {
-            if (tcyAutoCompoundAmount?.toBigIntegerOrNull()?.let { it > BigInteger.ZERO } != true) {
+            if (tcyAutoCompoundAmount?.toBigIntegerOrNull()?.let { it > BigInteger.ONE } != true) {
                 throw InvalidTransactionDataException(
                     UiText.StringResource(R.string.unstake_tcy_zero_error)
                 )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -492,5 +492,5 @@
     <string name="vultisig_community">Vultisig-Community</string>
     <string name="vault_management">Tresorverwaltung</string>
     <string name="other">Sonstiges</string>
-    <string name="unstake_tcy_zero_error">Bei einem Nullsaldo kann kein Unstaking durchgeführt werden</string>
+    <string name="unstake_tcy_zero_error">Das Aufheben der Einsätze kann nicht durchgeführt werden, wenn der Kontostand unter 1 liegt</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -492,4 +492,5 @@
     <string name="vultisig_community">Vultisig-Community</string>
     <string name="vault_management">Tresorverwaltung</string>
     <string name="other">Sonstiges</string>
+    <string name="unstake_tcy_zero_error">Bei einem Nullsaldo kann kein Unstaking durchgeführt werden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -492,5 +492,5 @@
     <string name="vultisig_community">Comunidad de Vultisig</string>
     <string name="vault_management">Gestión de bóvedas</string>
     <string name="other">Otros</string>
-    <string name="unstake_tcy_zero_error">No se puede deshacer el staking con un saldo cero</string>
+    <string name="unstake_tcy_zero_error">No se puede deshacer el staking si el saldo es inferior a 1</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -492,4 +492,5 @@
     <string name="vultisig_community">Comunidad de Vultisig</string>
     <string name="vault_management">Gestión de bóvedas</string>
     <string name="other">Otros</string>
+    <string name="unstake_tcy_zero_error">No se puede deshacer el staking con un saldo cero</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -492,4 +492,5 @@
     <string name="vultisig_community">Vultisig zajednica</string>
     <string name="vault_management">Upravljanje trezorom</string>
     <string name="other">Ostalo</string>
+    <string name="unstake_tcy_zero_error">Uklanjanje uloga nije moguće s nultim stanjem</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -492,5 +492,5 @@
     <string name="vultisig_community">Vultisig zajednica</string>
     <string name="vault_management">Upravljanje trezorom</string>
     <string name="other">Ostalo</string>
-    <string name="unstake_tcy_zero_error">Uklanjanje uloga nije moguće s nultim stanjem</string>
+    <string name="unstake_tcy_zero_error">Uklanjanje uloga nije moguće ako je stanje ispod 1</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -492,4 +492,5 @@
     <string name="vultisig_community">Community Vultisig</string>
     <string name="vault_management">Gestione del caveau</string>
     <string name="other">Altro</string>
+    <string name="unstake_tcy_zero_error">Non è possibile effettuare l\'unstaking con un saldo pari a zero</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -492,5 +492,5 @@
     <string name="vultisig_community">Community Vultisig</string>
     <string name="vault_management">Gestione del caveau</string>
     <string name="other">Altro</string>
-    <string name="unstake_tcy_zero_error">Non è possibile effettuare l\'unstaking con un saldo pari a zero</string>
+    <string name="unstake_tcy_zero_error">L\'annullamento dello staking non può essere eseguito se il saldo è inferiore a 1</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -501,5 +501,5 @@
     <string name="vultisig_community">Vultisig Community</string>
     <string name="vault_management">Vaultbeheer</string>
     <string name="other">Overig</string>
-    <string name="unstake_tcy_zero_error">Het uitzetten kan niet worden uitgevoerd als het saldo lager is dan 1</string>
+    <string name="unstake_tcy_zero_error">Unstake kan niet worden uitgevoerd als het saldo lager is dan 1</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -501,5 +501,5 @@
     <string name="vultisig_community">Vultisig Community</string>
     <string name="vault_management">Vaultbeheer</string>
     <string name="other">Overig</string>
-    <string name="unstake_tcy_zero_error">Het is niet mogelijk om de staking ongedaan te maken met een saldo van nul</string>
+    <string name="unstake_tcy_zero_error">Het uitzetten kan niet worden uitgevoerd als het saldo lager is dan 1</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -501,4 +501,5 @@
     <string name="vultisig_community">Vultisig Community</string>
     <string name="vault_management">Vaultbeheer</string>
     <string name="other">Overig</string>
+    <string name="unstake_tcy_zero_error">Het is niet mogelijk om de staking ongedaan te maken met een saldo van nul</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -490,5 +490,5 @@
     <string name="vultisig_community">Comunidade Vultisig</string>
     <string name="vault_management">Gestão de Cofres</string>
     <string name="other">Outros</string>
-    <string name="unstake_tcy_zero_error">Não é possível realizar o desinvestimento com saldo zero</string>
+    <string name="unstake_tcy_zero_error">Não é possível anular a aposta se o saldo for inferior a 1</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -490,4 +490,5 @@
     <string name="vultisig_community">Comunidade Vultisig</string>
     <string name="vault_management">Gestão de Cofres</string>
     <string name="other">Outros</string>
+    <string name="unstake_tcy_zero_error">Não é possível realizar o desinvestimento com saldo zero</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -501,5 +501,5 @@
     <string name="vultisig_community">Сообщество Vultisig</string>
     <string name="vault_management">Управление хранилищем</string>
     <string name="other">Другое</string>
-    <string name="unstake_tcy_zero_error">Отмена стейкинга невозможна при нулевом балансе</string>
+    <string name="unstake_tcy_zero_error">Отмена ставки невозможна, если баланс ниже 1</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -501,4 +501,5 @@
     <string name="vultisig_community">Сообщество Vultisig</string>
     <string name="vault_management">Управление хранилищем</string>
     <string name="other">Другое</string>
+    <string name="unstake_tcy_zero_error">Отмена стейкинга невозможна при нулевом балансе</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -737,4 +737,5 @@
     <string name="vultisig_community">Vultisig Community</string>
     <string name="vault_management">Vault Management</string>
     <string name="other">Other</string>
+    <string name="unstake_tcy_zero_error">Unstaking cannot be performed with a zero balance</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -737,5 +737,5 @@
     <string name="vultisig_community">Vultisig Community</string>
     <string name="vault_management">Vault Management</string>
     <string name="other">Other</string>
-    <string name="unstake_tcy_zero_error">Unstaking cannot be performed with a zero balance</string>
+    <string name="unstake_tcy_zero_error">Unstaking cannot be performed if balance is below 1</string>
 </resources>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
@@ -159,13 +159,13 @@ object ThorchainFunctions {
     }
 
     fun unStakeTcyCompound(
-        units: Int,
+        units: BigInteger,
         stakingContract: String,
         fromAddress: String,
     ): WasmExecuteContractPayload {
         require(fromAddress.isNotEmpty()) { "FromAddress cannot be empty" }
         require(stakingContract.isNotEmpty()) { "stakingContract cannot be empty" }
-        require(units >= 1) { "units cannot be lower than 1" }
+        require(units >= BigInteger.ONE) { "units cannot be lower than 1" }
 
         return WasmExecuteContractPayload(
             senderAddress = fromAddress,


### PR DESCRIPTION
## Description
https://thorchain.net/tx/2D17816E3AB081DA0AAFE06556D3E92A9C65ED306CF2D293A2631F6A263B2BB0


The issue arises because the currenct  calculation uses integer multiplication, which lead to  integer overflow. 
Example

`100.times(217649147) // result: 290078220 (incorrect due to overflow)
`

Solution
`100L.times(217649147L) // result: 21764914700 (correct)
`

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate unstake unit calculation to prevent incorrect amounts for large balances.
  * Added a guard that shows an error when attempting to unstake with zero/insufficient TCY.

* **Refactor**
  * Unstake request updated to use stronger numeric handling and includes origin address for execution.

* **Localization**
  * New unstake-zero error translations added (de, es, hr, it, nl, pt, ru, en).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->