### PR TITLE
[Referral]: Adjust Affiliate Fees

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -148,11 +148,12 @@ internal class ThorChainApiImpl @Inject constructor(
         isAffiliate: Boolean,
         referralCode: String,
     ): THORChainSwapQuoteDeserialized {
-        val affiliateBPS = if (isAffiliate) {
-            THORChainSwaps.AFFILIATE_FEE_RATE
-        } else {
-            "0"
+        val affiliateBPS = when {
+            isAffiliate && referralCode.isNotEmpty() -> THORChainSwaps.AFFILIATE_FEE_RATE_PARTIAL
+            isAffiliate -> THORChainSwaps.AFFILIATE_FEE_RATE
+            else -> "0"
         }
+
         val response = httpClient
             .get("https://thornode.ninerealms.com/thorchain/quote/swap") {
                 parameter("from_asset", fromAsset)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/THORChainSwaps.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/THORChainSwaps.kt
@@ -22,6 +22,7 @@ class THORChainSwaps(
     companion object {
         const val AFFILIATE_FEE_ADDRESS = "va"
         const val AFFILIATE_FEE_RATE = "50" // 50 BP
+        const val AFFILIATE_FEE_RATE_PARTIAL = "35"
         const val AFFILIATE_FEE_REFERRAL_RATE = "10"
     }
 


### PR DESCRIPTION
## Description

- Adjust bps for "va" when referral code is present

Fixes #2007
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for referral codes in swaps, applying a discounted affiliate fee when a valid code is used.
  * Introduced more granular affiliate fee rates, improving accuracy of displayed swap quotes and potentially lowering fees for eligible users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->