### PR TITLE
[Fix]: Update friend referral code when navigating back

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -70,7 +70,13 @@ internal fun ReferralViewScreen(
 
     ReferralViewScreen(
         state = state,
-        onBackPressed = navController::popBackStack,
+        onBackPressed = {
+            val code = model.state.value.referralFriendCode
+            navController.previousBackStackEntry
+                ?.savedStateHandle
+                ?.set(NEW_EXTERNAL_REFERRAL_CODE, code)
+            navController.popBackStack()
+        },
         onClickFriendReferralBanner = model::navigateToStoreFriendReferralBanner,
         onEditFriendReferralCode = model::navigateToStoreFriendReferralBanner,
         onDismissErrorDialog = model::onDismissErrorDialog,


### PR DESCRIPTION
## Description

- Update Friend's referral code when going back from ReferralViewScreen

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Going back from the Referral screen now returns your entered friend referral code to the previous screen, ensuring it’s immediately available and not lost.
  * Improves reliability of back navigation without affecting other referral actions (banner tap, edit code, dismiss error, copy code).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->