### PR TITLE
[Refactor]: Unify EVM Payloads

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
@@ -9,7 +9,7 @@ import OneinchTransaction
 import SwapPayload
 import ThorchainSwapPayload
 import WasmExecuteContractPayload
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SigningLibType
@@ -228,7 +228,7 @@ fun SwapPayload.toInternalSwapPayload(): com.vultisig.wallet.data.models.payload
         return com.vultisig.wallet.data.models.payload.SwapPayload.MayaChain(it.toInternalThorChainSwapPayload())
     }
     this.oneinchSwapPayload?.let{
-        return com.vultisig.wallet.data.models.payload.SwapPayload.OneInch(it.toInternalOneInchSwapPayload())
+        return com.vultisig.wallet.data.models.payload.SwapPayload.EVM(it.toInternalOneInchSwapPayload())
     }
     error("SwapPayload is nil")
 }
@@ -249,8 +249,8 @@ fun ThorchainSwapPayload.toInternalThorChainSwapPayload(): com.vultisig.wallet.d
         isAffiliate = this.isAffiliate,
     )
 }
-fun OneinchSwapPayload.toInternalOneInchSwapPayload(): com.vultisig.wallet.data.models.OneInchSwapPayloadJson {
-    return com.vultisig.wallet.data.models.OneInchSwapPayloadJson(
+fun OneinchSwapPayload.toInternalOneInchSwapPayload(): com.vultisig.wallet.data.models.EVMSwapPayloadJson {
+    return com.vultisig.wallet.data.models.EVMSwapPayloadJson(
         fromCoin = this.fromCoin.toInternalCoinPayload(),
         toCoin = this.toCoin.toInternalCoinPayload(),
         fromAmount = this.fromAmount.toBigInteger(),
@@ -258,8 +258,8 @@ fun OneinchSwapPayload.toInternalOneInchSwapPayload(): com.vultisig.wallet.data.
         quote = this.quote.toInternalOneInchQuote()
     )
 }
-fun OneinchQuote.toInternalOneInchQuote(): OneInchSwapQuoteJson {
-    return OneInchSwapQuoteJson(
+fun OneinchQuote.toInternalOneInchQuote(): EVMSwapQuoteJson {
+    return EVMSwapQuoteJson(
         dstAmount = this.dstAmount,
         tx = this.tx.toInternalOneInchTransaction()
     )

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
@@ -255,7 +255,8 @@ fun OneinchSwapPayload.toInternalOneInchSwapPayload(): com.vultisig.wallet.data.
         toCoin = this.toCoin.toInternalCoinPayload(),
         fromAmount = this.fromAmount.toBigInteger(),
         toAmountDecimal = this.toAmountDecimal.toBigDecimal(),
-        quote = this.quote.toInternalOneInchQuote()
+        quote = this.quote.toInternalOneInchQuote(),
+        provider = this.provider,
     )
 }
 fun OneinchQuote.toInternalOneInchQuote(): EVMSwapQuoteJson {

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
@@ -325,7 +325,9 @@ data class OneinchSwapPayload(
     @SerialName("to_amount_limit")
     val toAmountLimit: String = "0",
     @SerialName("quote")
-    val quote: OneinchQuote
+    val quote: OneinchQuote,
+    @SerialName("provider")
+    val provider: String = "",
 )
 @Serializable
 data class OneinchQuote(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -463,6 +463,7 @@ internal class JoinKeysignViewModel @Inject constructor(
                 val vaultName = _currentVault.name
 
                 when (swapPayload) {
+                    // TODO: Remove this once all clients migrate from Kyber to 1inch payload
                     is SwapPayload.Kyber -> {
                         val kyberSwapTxJson = swapPayload.data.quote.tx
                         // Calculate fee from Kyber quote data
@@ -535,7 +536,7 @@ internal class JoinKeysignViewModel @Inject constructor(
                             )
                         )
                     }
-                    is SwapPayload.OneInch -> {
+                    is SwapPayload.EVM -> {
                         val oneInchSwapTxJson = swapPayload.data.quote.tx
                         //if swapFee is not null then it provider is Lifi otherwise 1inch
                         val value = if (!oneInchSwapTxJson.swapFee.isNullOrEmpty() &&

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -980,7 +980,7 @@ internal class SwapFormViewModel @Inject constructor(
                                     token = srcNativeToken
                                 )
 
-                                this@SwapFormViewModel.quote = SwapQuote.Kyber(
+                                this@SwapFormViewModel.quote = SwapQuote.OneInch(
                                     expectedDstValue = expectedDstValue,
                                     fees = tokenFees,
                                     data = quote,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -29,6 +29,7 @@ import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KyberSwapPayloadJson
 import com.vultisig.wallet.data.models.payload.SwapPayload
@@ -485,8 +486,8 @@ internal class SwapFormViewModel @Inject constructor(
                                     fromAmount = srcTokenValue.value,
                                     toAmountDecimal = dstTokenValue.decimal,
                                     quote = quote.data,
-                                    provider = "", // TODO: Map provider
-                                )
+                                    provider = quote.provider,
+                                ),
                             )
                         )
                     }
@@ -986,15 +987,6 @@ internal class SwapFormViewModel @Inject constructor(
                                     expiredAt = Clock.System.now() + expiredAfter
                                 )
 
-                                /*
-                                SwapQuote.OneInch(
-                                    expectedDstValue = expectedDstValue,
-                                    fees = tokenFees,
-                                    data = quote,
-                                    expiredAt = Clock.System.now() + expiredAfter
-                                )
-                                 */
-
                                 val fiatFees =
                                     convertTokenValueToFiat(srcNativeToken, tokenFees, currency)
                                 swapFeeFiat.value = fiatFees
@@ -1056,7 +1048,8 @@ internal class SwapFormViewModel @Inject constructor(
                                     expectedDstValue = expectedDstValue,
                                     fees = tokenFees,
                                     data = quote,
-                                    expiredAt = Clock.System.now() + expiredAfter
+                                    expiredAt = Clock.System.now() + expiredAfter,
+                                    provider = provider.getSwapProviderId(),
                                 )
 
                                 val fiatFees =
@@ -1129,7 +1122,8 @@ internal class SwapFormViewModel @Inject constructor(
                                     expectedDstValue = expectedDstValue,
                                     fees = tokenFees,
                                     data = quote,
-                                    expiredAt = Clock.System.now() + expiredAfter
+                                    expiredAt = Clock.System.now() + expiredAfter,
+                                    provider = provider.getSwapProviderId(),
                                 )
 
                                 val fiatFees =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -984,7 +984,8 @@ internal class SwapFormViewModel @Inject constructor(
                                     expectedDstValue = expectedDstValue,
                                     fees = tokenFees,
                                     data = quote,
-                                    expiredAt = Clock.System.now() + expiredAfter
+                                    expiredAt = Clock.System.now() + expiredAfter,
+                                    provider = provider.getSwapProviderId(),
                                 )
 
                                 val fiatFees =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -20,7 +20,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.IsSwapSupported
-import com.vultisig.wallet.data.models.OneInchSwapPayloadJson
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
@@ -478,13 +478,14 @@ internal class SwapFormViewModel @Inject constructor(
                             memo = null,
                             isApprovalRequired = isApprovalRequired,
                             gasFeeFiatValue = gasFeeFiatValue,
-                            payload = SwapPayload.OneInch(
-                                OneInchSwapPayloadJson(
+                            payload = SwapPayload.EVM(
+                                EVMSwapPayloadJson(
                                     fromCoin = srcToken,
                                     toCoin = dstToken,
                                     fromAmount = srcTokenValue.value,
                                     toAmountDecimal = dstTokenValue.decimal,
                                     quote = quote.data,
+                                    provider = "", // TODO: Map provider
                                 )
                             )
                         )
@@ -953,7 +954,6 @@ internal class SwapFormViewModel @Inject constructor(
                                 }
                             }
 
-
                             SwapProvider.KYBER -> {
                                 val srcUsdFiatValue = convertTokenValueToFiat(
                                     srcToken,
@@ -985,6 +985,15 @@ internal class SwapFormViewModel @Inject constructor(
                                     data = quote,
                                     expiredAt = Clock.System.now() + expiredAfter
                                 )
+
+                                /*
+                                SwapQuote.OneInch(
+                                    expectedDstValue = expectedDstValue,
+                                    fees = tokenFees,
+                                    data = quote,
+                                    expiredAt = Clock.System.now() + expiredAfter
+                                )
+                                 */
 
                                 val fiatFees =
                                     convertTokenValueToFiat(srcNativeToken, tokenFees, currency)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/EVMSwapQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/EVMSwapQuoteJson.kt
@@ -3,14 +3,14 @@ package com.vultisig.wallet.data.api.models.quotes
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-sealed class OneInchSwapQuoteDeserialized {
-    data class Result(val data: OneInchSwapQuoteJson) : OneInchSwapQuoteDeserialized()
-    data class Error(val error: String) : OneInchSwapQuoteDeserialized()
+sealed class EVMSwapQuoteDeserialized {
+    data class Result(val data: EVMSwapQuoteJson) : EVMSwapQuoteDeserialized()
+    data class Error(val error: String) : EVMSwapQuoteDeserialized()
 }
 
 
 @Serializable
-data class OneInchSwapQuoteJson(
+data class EVMSwapQuoteJson(
     @SerialName("dstAmount")
     val dstAmount: String,
     @SerialName("tx")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
@@ -1,6 +1,6 @@
 package com.vultisig.wallet.data.api.swapAggregators
 
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.OneInchTokenJson
 import com.vultisig.wallet.data.api.models.OneInchTokensJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteErrorResponse
@@ -30,7 +30,7 @@ interface OneInchApi {
         srcAddress: String,
         amount: String,
         isAffiliate: Boolean,
-    ): OneInchSwapQuoteDeserialized
+    ): EVMSwapQuoteDeserialized
 
     suspend fun getTokens(
         chain: Chain,
@@ -61,7 +61,7 @@ class OneInchApiImpl @Inject constructor(
         srcAddress: String,
         amount: String,
         isAffiliate: Boolean,
-    ): OneInchSwapQuoteDeserialized = coroutineScope {
+    ): EVMSwapQuoteDeserialized = coroutineScope {
         try {
             val baseSwapQuoteUrl = "https://api.vultisig.com/1inch/swap/v6.1/${chain.oneInchChainId()}"
             val requestParams: HttpRequestBuilder.() -> Unit = {
@@ -87,7 +87,7 @@ class OneInchApiImpl @Inject constructor(
                         responses.forEach { response ->
                             if (!response.status.isSuccess()) {
                                 val resp = response.body<OneInchSwapQuoteErrorResponse>()
-                                return@coroutineScope OneInchSwapQuoteDeserialized.Error(
+                                return@coroutineScope EVMSwapQuoteDeserialized.Error(
                                     error = resp.description
                                 )
                             }
@@ -102,7 +102,7 @@ class OneInchApiImpl @Inject constructor(
                 }
             )
         } catch (e: Exception) {
-            OneInchSwapQuoteDeserialized.Error(error = e.message ?: "Unknown error")
+            EVMSwapQuoteDeserialized.Error(error = e.message ?: "Unknown error")
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchSwap.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchSwap.kt
@@ -56,13 +56,14 @@ class OneInchSwap(
                     .setContractGeneric(
                         Transaction.ContractGeneric.newBuilder()
                             .setAmount(
-                                quote.tx.value.toBigInteger().toByteArray().toByteString()
+                                quote.tx.value.toBigIntegerOrNull()?.toByteArray()?.toByteString()
+                                    ?: BigInteger.ZERO.toByteArray().toByteString()
                             )
-                            .setData(quote.tx.data.toHexBytesInByteString())
+                            .setData(quote.tx.data.removePrefix("0x").toHexBytesInByteString())
                     )
             )
 
-        val gasPrice = quote.tx.gasPrice.toBigInteger()
+        val gasPrice = quote.tx.gasPrice.toBigIntegerOrNull() ?: BigInteger.ZERO
         val gas = (quote.tx.gas.takeIf { it != 0L }
             ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT).toBigInteger()
         return EthereumGasHelper.setGasParameters(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchSwap.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchSwap.kt
@@ -1,12 +1,11 @@
 package com.vultisig.wallet.data.api.swapAggregators
 
-import com.google.protobuf.ByteString
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.chains.helpers.EthereumGasHelper
 import com.vultisig.wallet.data.chains.helpers.EvmHelper
 import com.vultisig.wallet.data.common.toByteString
 import com.vultisig.wallet.data.common.toHexBytesInByteString
-import com.vultisig.wallet.data.models.OneInchSwapPayloadJson
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.wallet.Swaps
@@ -21,7 +20,7 @@ class OneInchSwap(
 ) {
 
     fun getPreSignedImageHash(
-        swapPayload: OneInchSwapPayloadJson,
+        swapPayload: EVMSwapPayloadJson,
         keysignPayload: KeysignPayload,
         nonceIncrement: BigInteger,
     ): List<String> {
@@ -34,7 +33,7 @@ class OneInchSwap(
     }
 
     fun getSignedTransaction(
-        swapPayload: OneInchSwapPayloadJson,
+        swapPayload: EVMSwapPayloadJson,
         keysignPayload: KeysignPayload,
         signatures: Map<String, KeysignResponse>,
         nonceIncrement: BigInteger,
@@ -46,7 +45,7 @@ class OneInchSwap(
     }
 
     private fun getPreSignedInputData(
-        quote: OneInchSwapQuoteJson,
+        quote: EVMSwapQuoteJson,
         keysignPayload: KeysignPayload,
         nonceIncrement: BigInteger,
     ): ByteArray {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -62,7 +62,7 @@ object SigningHelper {
                         .getPreSignedImageHash(swapPayload.data, payload, nonceAcc)
                 }
 
-                is SwapPayload.OneInch -> {
+                is SwapPayload.EVM -> {
                     val message = if (payload.coin.chain == Chain.Solana) {
                         SolanaSwap(vault.pubKeyEDDSA)
                             .getPreSignedImageHash(
@@ -199,7 +199,7 @@ object SigningHelper {
                         )
                 }
 
-                is SwapPayload.OneInch -> {
+                is SwapPayload.EVM -> {
                     return if (keysignPayload.blockChainSpecific is BlockChainSpecific.Solana)
                         SolanaSwap(vault.pubKeyEDDSA)
                             .getSignedTransaction(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaSwap.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaSwap.kt
@@ -1,9 +1,9 @@
 package com.vultisig.wallet.data.chains.helpers
 
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.OneInchSwapPayloadJson
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -20,7 +20,7 @@ class SolanaSwap(
 ) {
 
     fun getPreSignedImageHash(
-        swapPayload: OneInchSwapPayloadJson,
+        swapPayload: EVMSwapPayloadJson,
         keysignPayload: KeysignPayload,
     ): List<String> {
         val inputData = getPreSignedInputData(swapPayload.quote, keysignPayload)
@@ -30,7 +30,7 @@ class SolanaSwap(
     }
 
     fun getSignedTransaction(
-        swapPayload: OneInchSwapPayloadJson,
+        swapPayload: EVMSwapPayloadJson,
         keysignPayload: KeysignPayload,
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
@@ -41,8 +41,9 @@ class SolanaSwap(
         return helper.getSwapSignedTransaction(inputData, signatures)
     }
 
+    // TODO: Refactor Quote for SOL
     private fun getPreSignedInputData(
-        quote: OneInchSwapQuoteJson,
+        quote: EVMSwapQuoteJson,
         keysignPayload: KeysignPayload,
     ): ByteArray {
         if (keysignPayload.coin.chain != Chain.Solana)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -2,11 +2,11 @@ package com.vultisig.wallet.data.mappers
 
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteData
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJson
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.OneInchSwapPayloadJson
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
@@ -57,14 +57,14 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             skipBroadcast = from.skipBroadcast ?: false,
             swapPayload = when {
                 from.oneinchSwapPayload != null -> from.oneinchSwapPayload.let { it ->
-                    SwapPayload.OneInch(
-                        OneInchSwapPayloadJson(
+                    SwapPayload.EVM(
+                        EVMSwapPayloadJson(
                             fromCoin = requireNotNull(it.fromCoin).toCoin(),
                             toCoin = requireNotNull(it.toCoin).toCoin(),
                             fromAmount = BigInteger(it.fromAmount),
                             toAmountDecimal = BigDecimal(it.toAmountDecimal),
                             quote = requireNotNull(it.quote).let { it ->
-                                OneInchSwapQuoteJson(
+                                EVMSwapQuoteJson(
                                     dstAmount = it.dstAmount,
                                     tx = requireNotNull(it.tx).let {
                                         OneInchSwapTxJson(
@@ -83,6 +83,7 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                         )
                     )
                 }
+                // TODO: Migrate mapping once all clients use 1inch payload
                 from.kyberswapSwapPayload != null -> from.kyberswapSwapPayload.let { it ->
                     SwapPayload.Kyber(
                         KyberSwapPayloadJson(
@@ -239,7 +240,6 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                         ttl = it.ttl
                     )
                 }
-
 
                 else -> error("No supported BlockChainSpecific in proto $from")
             },

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -79,6 +79,7 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                                     },
                                 )
                             },
+                            provider = it.provider,
                         )
                     )
                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -213,7 +213,8 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                                 )
                             }
                         )
-                    }
+                    },
+                    provider = from.provider,
                 )
             } else null,
             kyberswapSwapPayload = if(swapPayload is SwapPayload.Kyber) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -191,7 +191,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     isAffiliate = from.isAffiliate,
                 )
             } else null,
-            oneinchSwapPayload = if (swapPayload is SwapPayload.OneInch) {
+            oneinchSwapPayload = if (swapPayload is SwapPayload.EVM) {
                 val from = swapPayload.data
                 OneInchSwapPayload(
                     fromCoin = from.fromCoin.toCoinProto(),
@@ -217,7 +217,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     provider = from.provider,
                 )
             } else null,
-            kyberswapSwapPayload = if(swapPayload is SwapPayload.Kyber) {
+            /*kyberswapSwapPayload = if(swapPayload is SwapPayload.Kyber) {
                 val from = swapPayload.data
                 KyberSwapPayload(
                     fromCoin = from.fromCoin.toCoinProto(),
@@ -243,7 +243,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         )
                     }
                 )
-            } else null,
+            } else null */
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,
             erc20ApprovePayload = if (approvePayload is ERC20ApprovePayload) {
                 Erc20ApprovePayload(
@@ -267,5 +267,4 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
         hexPublicKey = hexPublicKey,
         logo = logo,
     )
-
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -217,33 +217,6 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     provider = from.provider,
                 )
             } else null,
-            /*kyberswapSwapPayload = if(swapPayload is SwapPayload.Kyber) {
-                val from = swapPayload.data
-                KyberSwapPayload(
-                    fromCoin = from.fromCoin.toCoinProto(),
-                    toCoin = from.toCoin.toCoinProto(),
-                    fromAmount = from.fromAmount.toString(),
-                    toAmountDecimal = from.toAmountDecimal.toPlainString(),
-                    quote =
-                        from.quote.let { it ->
-
-                        KyberSwapQuote(
-                            dstAmount = it.dstAmount,
-                            tx = it.tx.let {
-                                KyberSwapTransaction(
-                                    from = it.from,
-                                    to = it.to,
-                                    `data` = it.data,
-                                    `value` = it.value,
-                                    gasPrice = it.gasPrice,
-                                    gas = it.gas,
-                                    fee = it.fee,
-                                )
-                            },
-                        )
-                    }
-                )
-            } else null */
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,
             erc20ApprovePayload = if (approvePayload is ERC20ApprovePayload) {
                 Erc20ApprovePayload(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/EVMSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/EVMSwapPayloadJson.kt
@@ -1,14 +1,14 @@
 package com.vultisig.wallet.data.models
 
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import java.math.BigDecimal
 import java.math.BigInteger
 
-data class OneInchSwapPayloadJson(
+data class EVMSwapPayloadJson(
     val fromCoin: Coin,
     val toCoin: Coin,
     val fromAmount: BigInteger,
     val toAmountDecimal: BigDecimal,
-    val quote: OneInchSwapQuoteJson,
+    val quote: EVMSwapQuoteJson,
     val provider: String,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/OneInchSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/OneInchSwapPayloadJson.kt
@@ -10,4 +10,5 @@ data class OneInchSwapPayloadJson(
     val fromAmount: BigInteger,
     val toAmountDecimal: BigDecimal,
     val quote: OneInchSwapQuoteJson,
+    val provider: String,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapProvider.kt
@@ -8,3 +8,14 @@ enum class SwapProvider {
     ONEINCH,
     THORCHAIN,
 }
+
+fun SwapProvider.getSwapProviderId(): String {
+    return when(this) {
+        SwapProvider.JUPITER -> "Jupiter"
+        SwapProvider.KYBER -> "KyberSwap"
+        SwapProvider.LIFI -> "LI.FI"
+        SwapProvider.MAYA -> "Maya"
+        SwapProvider.ONEINCH -> "1Inch"
+        SwapProvider.THORCHAIN -> "Thorchain"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -1,7 +1,7 @@
 package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJson
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.minutes
@@ -11,7 +11,6 @@ sealed class SwapQuote {
     abstract val expectedDstValue: TokenValue
     abstract val fees: TokenValue
     abstract val expiredAt: Instant
-
 
     data class Kyber(
         override val expectedDstValue: TokenValue,
@@ -24,7 +23,7 @@ sealed class SwapQuote {
         override val expectedDstValue: TokenValue,
         override val fees: TokenValue,
         override val expiredAt: Instant,
-        val data: OneInchSwapQuoteJson,
+        val data: EVMSwapQuoteJson,
     ) : SwapQuote()
 
     data class ThorChain(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -24,6 +24,7 @@ sealed class SwapQuote {
         override val fees: TokenValue,
         override val expiredAt: Instant,
         val data: EVMSwapQuoteJson,
+        val provider: String,
     ) : SwapQuote()
 
     data class ThorChain(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -12,6 +12,7 @@ sealed class SwapQuote {
     abstract val fees: TokenValue
     abstract val expiredAt: Instant
 
+    @Deprecated("Use OneInch")
     data class Kyber(
         override val expectedDstValue: TokenValue,
         override val fees: TokenValue,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
@@ -114,7 +114,5 @@ sealed class SwapPayload {
                     .toBigInteger(),
                 token = dstToken,
             )
-
     }
-
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
@@ -1,7 +1,7 @@
 package com.vultisig.wallet.data.models.payload
 
 import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.OneInchSwapPayloadJson
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenValue
 
@@ -65,8 +65,8 @@ sealed class SwapPayload {
 
     }
 
-    data class OneInch(
-        val data: OneInchSwapPayloadJson
+    data class EVM(
+        val data: EVMSwapPayloadJson
     ) : SwapPayload() {
 
         override val srcToken: Coin

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -43,7 +43,7 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
     ): String? = when (payload) {
         is SwapPayload.ThorChain -> "https://thorchain.net/tx/$tx"
         is SwapPayload.MayaChain -> "https://www.mayascan.org/tx/${tx.removePrefix("0x")}"
-        is SwapPayload.OneInch -> {
+        is SwapPayload.EVM -> {
             if (payload.data.quote.tx.swapFee.toBigIntegerOrNull() != null) {
                 if (payload.data.fromCoin.chain == payload.data.toCoin.chain && payload.data.fromCoin.chain == Chain.Solana) {
                     "https://solana.fm/tx/${tx}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -49,7 +49,7 @@ interface SwapQuoteRepository {
         dstToken: Coin,
         tokenValue: TokenValue,
         isAffiliate: Boolean,
-    ): KyberSwapQuoteJson
+    ): EVMSwapQuoteJson
 
     suspend fun getOneInchSwapQuote(
         srcToken: Coin,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -9,8 +9,8 @@ import com.vultisig.wallet.data.api.models.KyberSwapRouteResponse
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.gasForChain
@@ -55,7 +55,7 @@ interface SwapQuoteRepository {
         dstToken: Coin,
         tokenValue: TokenValue,
         isAffiliate: Boolean,
-    ): OneInchSwapQuoteJson
+    ): EVMSwapQuoteJson
 
     suspend fun getMayaSwapQuote(
         dstAddress: String,
@@ -71,14 +71,14 @@ interface SwapQuoteRepository {
         srcToken: Coin,
         dstToken: Coin,
         tokenValue: TokenValue,
-    ): OneInchSwapQuoteJson
+    ): EVMSwapQuoteJson
 
     suspend fun getJupiterSwapQuote(
         srcAddress: String,
         srcToken: Coin,
         dstToken: Coin,
         tokenValue: TokenValue,
-    ): OneInchSwapQuoteJson
+    ): EVMSwapQuoteJson
 
     fun resolveProvider(
         srcToken: Coin,
@@ -101,7 +101,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         dstToken: Coin,
         tokenValue: TokenValue,
         isAffiliate: Boolean,
-    ): OneInchSwapQuoteJson {
+    ): EVMSwapQuoteJson {
         val oneInchQuote = oneInchApi.getSwapQuote(
             chain = srcToken.chain,
             srcTokenContractAddress = srcToken.contractAddress,
@@ -111,11 +111,11 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
             isAffiliate = isAffiliate,
         )
         when (oneInchQuote) {
-            is OneInchSwapQuoteDeserialized.Error -> throw SwapException.handleSwapException(
+            is EVMSwapQuoteDeserialized.Error -> throw SwapException.handleSwapException(
                 oneInchQuote.error
             )
 
-            is OneInchSwapQuoteDeserialized.Result -> {
+            is EVMSwapQuoteDeserialized.Result -> {
                 oneInchQuote.data.error?.let { throw SwapException.handleSwapException(it) }
                 return oneInchQuote.data
             }
@@ -163,6 +163,24 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         routeSummary: KyberSwapRouteResponse.RouteSummary,
         response: KyberSwapQuoteJson,
     ): KyberSwapQuoteJson {
+        /*
+        return EVMSwapQuoteJson(
+                    dstAmount = liFiQuote.estimate.toAmount,
+                    tx = OneInchSwapTxJson(
+                        from = liFiQuote.transactionRequest.from ?: "",
+                        to = liFiQuote.transactionRequest.to ?: "",
+                        data = liFiQuote.transactionRequest.data,
+                        gas = liFiQuote.transactionRequest.gasLimit?.substring(startIndex = 2)
+                            ?.hexToLong() ?: 0,
+                        value = liFiQuote.transactionRequest.value?.substring(startIndex = 2)
+                            ?.convertToBigIntegerOrZero().toString(),
+                        gasPrice = liFiQuote.transactionRequest.gasPrice?.substring(startIndex = 2)
+                            ?.hexToLong()?.toString() ?: "0",
+                        swapFee = swapFee?.amount ?: "0",
+                        swapFeeTokenContract = swapFeeToken,
+                    )
+                )
+         */
         val gasPrice = routeSummary.gasPrice
         val calculatedGas = response.gasForChain(chain)
         val finalGas =
@@ -291,7 +309,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         srcToken: Coin,
         dstToken: Coin,
         tokenValue: TokenValue,
-    ): OneInchSwapQuoteJson {
+    ): EVMSwapQuoteJson {
 
         val fromToken =
             srcToken.contractAddress.ifEmpty { srcToken.ticker }
@@ -334,7 +352,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
                     ?: ""
 
                 liFiQuote.message?.let { throw SwapException.handleSwapException(it) }
-                return OneInchSwapQuoteJson(
+                return EVMSwapQuoteJson(
                     dstAmount = liFiQuote.estimate.toAmount,
                     tx = OneInchSwapTxJson(
                         from = liFiQuote.transactionRequest.from ?: "",
@@ -359,7 +377,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
         srcToken: Coin,
         dstToken: Coin,
         tokenValue: TokenValue,
-    ): OneInchSwapQuoteJson {
+    ): EVMSwapQuoteJson {
 
         val fromToken =
             srcToken.contractAddress.ifEmpty { SOLANA_DEFAULT_CONTRACT_ADDRESS }
@@ -382,7 +400,7 @@ internal class SwapQuoteRepositoryImpl @Inject constructor(
             .firstOrNull { it.swapInfo.feeMint == fromToken }?.swapInfo?.feeAmount ?: "0"
 
 
-        return OneInchSwapQuoteJson(
+        return EVMSwapQuoteJson(
             dstAmount = jupiterQuote.dstAmount,
             tx = OneInchSwapTxJson(
                 from = "",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.data.securityscanner
 
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.chains.SuiApi
-import com.vultisig.wallet.data.api.models.quotes.tx
 import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.chains.helpers.UtxoHelper
@@ -45,7 +44,7 @@ class SecurityScannerTransactionFactory(
 
     private fun createEVMSecurityScannerTransaction(transaction: SwapTransaction): SecurityScannerTransaction {
         return when (val payload = transaction.payload) {
-            is SwapPayload.OneInch ->
+            is SwapPayload.EVM ->
                 buildSwapSecurityScannerTransaction(
                     srcToken = transaction.srcToken,
                     from = payload.data.quote.tx.from,
@@ -54,15 +53,6 @@ class SecurityScannerTransactionFactory(
                     data = payload.data.quote.tx.data,
                     isApprovalRequired = transaction.isApprovalRequired
             )
-            is SwapPayload.Kyber ->
-                buildSwapSecurityScannerTransaction(
-                    srcToken = transaction.srcToken,
-                    from = payload.data.quote.tx.from,
-                    to = payload.data.quote.tx.to,
-                    amount = payload.data.quote.tx.value,
-                    data = payload.data.quote.tx.data,
-                    isApprovalRequired = transaction.isApprovalRequired
-                )
 
             else -> throw SecurityScannerException("Not supported provider for EVM")
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/Serializer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/Serializer.kt
@@ -5,8 +5,8 @@ import com.vultisig.wallet.data.api.models.KyberSwapRouteResponse
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteError
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteJson
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.OneInchSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.SplTokenJson
 import com.vultisig.wallet.data.api.models.SplTokenResponseJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
@@ -18,7 +18,6 @@ import com.vultisig.wallet.data.api.models.cosmos.THORChainAccountJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapErrorResponse
 import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJson
 import com.vultisig.wallet.data.models.SplTokenDeserialized
 import com.vultisig.wallet.data.models.SplTokenDeserialized.Error
 import com.vultisig.wallet.data.models.SplTokenDeserialized.Result
@@ -150,24 +149,24 @@ class LiFiSwapQuoteResponseSerializerImpl @Inject constructor(private val json: 
     }
 }
 
-interface OneInchSwapQuoteResponseJsonSerializer : DefaultSerializer<OneInchSwapQuoteDeserialized>
+interface OneInchSwapQuoteResponseJsonSerializer : DefaultSerializer<EVMSwapQuoteDeserialized>
 
 class OneInchSwapQuoteResponseJsonSerializerImpl @Inject constructor(private val json: Json) :
     OneInchSwapQuoteResponseJsonSerializer {
     override val descriptor: SerialDescriptor =
         buildClassSerialDescriptor("OneInchSwapQuoteResponseJsonSerializer")
 
-    override fun deserialize(decoder: Decoder): OneInchSwapQuoteDeserialized {
+    override fun deserialize(decoder: Decoder): EVMSwapQuoteDeserialized {
         val input = decoder as JsonDecoder
         val jsonObject = input.decodeJsonElement().jsonObject
         val swapJsonObject = jsonObject["swap"]?.jsonObject
         val quoteJsonObject = jsonObject["quote"]?.jsonObject
         return if (swapJsonObject != null && quoteJsonObject != null) {
-            val swapJson = json.decodeFromJsonElement<OneInchSwapQuoteJson>(swapJsonObject)
+            val swapJson = json.decodeFromJsonElement<EVMSwapQuoteJson>(swapJsonObject)
             val quoteJson = json.decodeFromJsonElement<OneInchQuoteJson>(quoteJsonObject)
-            OneInchSwapQuoteDeserialized.Result(swapJson.copy(tx = swapJson.tx.copy(gas = quoteJson.gas)))
+            EVMSwapQuoteDeserialized.Result(swapJson.copy(tx = swapJson.tx.copy(gas = quoteJson.gas)))
         } else {
-            OneInchSwapQuoteDeserialized.Error(
+            EVMSwapQuoteDeserialized.Error(
                 json.decodeFromJsonElement<String>(jsonObject)
             )
         }


### PR DESCRIPTION
## Description

- Create Generic EVM Quotes for (1inch, kyber, Lifi)
- Include new field provider on it
- Aligned with iOS

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Swap quotes now include a visible provider label across all aggregators.
  - Unified EVM swap flow supports multiple providers with consistent quote/payload format.

- Refactor
  - Consolidated OneInch/Kyber/LiFi/Jupiter swap handling into a single EVM-based model for quotes and payloads.
  - Streamlined signing and transaction creation paths to use the unified EVM swap model.

- Deprecations
  - Kyber-specific quote type marked as deprecated in favor of the unified OneInch-style quote with provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->