### PR TITLE
[Fix]: Fix Color Referral Body (new settings)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/referral/ReferralCodeBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/referral/ReferralCodeBottomSheet.kt
@@ -103,6 +103,7 @@ internal fun ReferralCodeBottomSheetContent(
             text = stringResource(R.string.referral_invite_sheet_description),
             style = Theme.brockmann.body.s.medium,
             textAlign = TextAlign.Center,
+            color = Theme.colors.text.light,
             modifier = Modifier
                 .padding(horizontal = 32.dp)
                 .fillMaxWidth()


### PR DESCRIPTION
## Description

- Set body color, seems after new settings something might trigger different default color. TBC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Unified the description text color in the referral invite sheet for consistent appearance across themes and screens.
  - Improved contrast and readability of the referral description text.

- **Bug Fixes**
  - Resolved occasional inconsistencies where the referral description text could appear with unintended colors in certain modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->