### PR TITLE
Correct Dai fiat value display

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -95,7 +95,7 @@ internal class TokenPriceRepositoryImpl @Inject constructor(
         val currency = appCurrencyRepository.currency.first().ticker.lowercase()
         val currencies = listOf(currency)
 
-        val tokensByPriceProviderIds = tokens.groupBy { it.priceProviderID }
+        val tokensByPriceProviderIds = tokens.groupBy { it.priceProviderID.lowercase() }
         val tokensByContractAddress = tokens.associateBy { it.contractAddress.lowercase() }
 
         val priceProviderIds = mutableListOf<String>()
@@ -115,7 +115,7 @@ internal class TokenPriceRepositoryImpl @Inject constructor(
         val pricesWithProviderIds = coinGeckoApi.getCryptoPrices(priceProviderIds, currencies)
             .asSequence()
             .mapNotNull { (priceProviderId, value) ->
-                val tokenIds = tokensByPriceProviderIds[priceProviderId]?.map { it.id }
+                val tokenIds = tokensByPriceProviderIds[priceProviderId.lowercase()]?.map { it.id }
                 tokenIds?.map { tokenId -> tokenId to value }
             }
             .flatten()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2419

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures token prices load correctly by making provider ID matching case-insensitive. This prevents missed or incorrect price updates when provider IDs differ in casing between app and API. Users should see more consistent and accurate token pricing across the app, especially for tokens that previously showed missing data or outdated values. No changes to user settings or workflows are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->