### PR TITLE
Add clickOnce modifier to switch modifier

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
@@ -229,6 +229,8 @@ internal fun SettingItem(
                 ) {
                     VsSwitch(
                         checked = isChecked,
+                        modifier = Modifier
+                            .clickOnce(onClick = onClick),
                         onCheckedChange = {})
                     Text(
                         text = if (isChecked) "ON" else "OFF",


### PR DESCRIPTION
Applied the clickOnce modifier to the VsSwitch component in SettingItem to ensure the onClick handler is triggered only once per click event.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context