### PR TITLE
Fix the language is not matching with Figma 

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/settings/AppLanguage.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/settings/AppLanguage.kt
@@ -13,6 +13,7 @@ enum class AppLanguage(val mainName: String, val engName: String?) {
     companion object {
         fun String.fromName(): AppLanguage {
             return when (this) {
+                "English UK" -> EN
                 "English" -> EN
                 "Deutsch" -> DE
                 "Espanol" -> ES


### PR DESCRIPTION
Changed the mainName for EN from 'English UK' to 'English' and set engName to '(UK)' for consistency with other language entries.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2447

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated English language labeling and mapping: the app now displays the variant as “English (UK)” and treats “English” as that UK variant in language selection and settings, improving consistency and clarity for users while preserving existing stored preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->