### PR TITLE
Fix crash on language setting

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/settings/AppLanguage.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/settings/AppLanguage.kt
@@ -14,6 +14,7 @@ enum class AppLanguage(val mainName: String, val engName: String?) {
         fun String.fromName(): AppLanguage {
             return when (this) {
                 "English UK" -> EN
+                "English" -> EN
                 "Deutsch" -> DE
                 "Espanol" -> ES
                 "Italiano" -> IT


### PR DESCRIPTION
## Description

Even thought the locale was changed from "English UK" to  "English",  In some cases the following code still returns  "English UK"


https://github.com/vultisig/vultisig-android/blob/fb9ebe7e293a61250c36eaa42f6ccffa3a421dc7/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppLocaleRepository.kt#L24

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Language selection now correctly recognizes “English” as an English option, alongside existing variants. This ensures consistent selection in Settings, onboarding, and when parsing language inputs from the system or imports. Reduces cases where “English” labels could map to an unintended locale, providing a more predictable experience for English-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->