### PR TITLE
Handle coroutine cancellation in Schnorr keygen/keysign

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -171,6 +172,9 @@ class SchnorrKeygen(
                     delay(1000)
                 }
             } catch (e: Exception) {
+                if(e is CancellationException){
+                    throw e
+                }
                 Timber.e(e, "Failed to get messages")
                 delay(1000)
             }

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.tss.TssMessenger
 import com.vultisig.wallet.data.usecases.Encryption
 import com.vultisig.wallet.data.utils.Numeric
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -209,6 +210,9 @@ class SchnorrKeysign(
                     delay(100)
                 }
             } catch (e: Exception) {
+                if(e is CancellationException){
+                    throw e
+                }
                 Timber.e(e, "Failed to get messages")
             }
 


### PR DESCRIPTION
When a CancellationException occurs, the app continuously sends an infinite stream of CancellationException logs in the background, which leads to unnecessary resource usage




- Added explicit checks for CancellationException in SchnorrKeygen and SchnorrKeysign to ensure coroutine cancellation is properly propagated and not logged as errors.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context