### PR TITLE
Fix keygen and keysign setup message upload on retry attempts

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -270,7 +270,7 @@ class DKLSKeygen(
         try {
             val keygenSetupMsg: ByteArray
 
-            if (isInitiateDevice) {
+            if (isInitiateDevice && attempt == 0) {
                 keygenSetupMsg = getDklsSetupMessage()
 
                 sessionApi.uploadSetupMessage(
@@ -452,7 +452,7 @@ class DKLSKeygen(
             }
 
             val reshareSetupMsg: ByteArray
-            if (isInitiateDevice) {
+            if (isInitiateDevice && attempt == 0) {
                 reshareSetupMsg = getDklsReshareSetupMessage(keyshareHandle)
 
                 sessionApi.uploadSetupMessage(

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -286,7 +286,7 @@ class DKLSKeysign(
         try {
             val keysignSetupMsg: ByteArray
 
-            if (isInitiateDevice) {
+            if (isInitiateDevice && attempt == 0) {
                 keysignSetupMsg = getDKLSKeysignSetupMessage(messageToSign)
 
                 sessionApi.uploadSetupMessage(

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.tss.TssMessenger
 import com.vultisig.wallet.data.usecases.Encryption
 import com.vultisig.wallet.data.utils.Numeric
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -39,7 +40,6 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
-import kotlinx.coroutines.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -388,7 +388,7 @@ class SchnorrKeygen(
             }
 
             val reshareSetupMsg: ByteArray
-            if (isInitiatingDevice) {
+            if (isInitiatingDevice && attempt == 0) {
                 // DKLS/Schnorr reshare needs to upload a different setup message, thus here pass in an additional header as "eddsa" to make sure
                 // DKLS and Schnorr setup messages will be saved differently
                 reshareSetupMsg = getSchnorrReshareSetupMessage(keyshareHandle)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context