### PR TITLE
[Fix]: Load IPFS Token Logos

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
@@ -54,4 +54,4 @@ internal fun TokenLogo(
 }
 
 private const val USER_AGENT = "User-Agent"
-private const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Android) AppleWebKit/537.36 Chrome/119.0 Mobile Safari/537.36"
+private const val DEFAULT_USER_AGENT = "Vultisig/1.0 (Android 14; Pixel 7 Pro)"

--- a/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -19,8 +21,19 @@ internal fun TokenLogo(
     logo: ImageModel,
     title: String
 ) {
+    val context = LocalContext.current
+
+    val imageRequest = if (logo is String && logo.contains("ipfs.io", ignoreCase = true)) {
+        ImageRequest.Builder(context)
+            .data(logo)
+            .addHeader(USER_AGENT, DEFAULT_USER_AGENT)
+            .build()
+    } else {
+        logo
+    }
+
     SubcomposeAsyncImage(
-        model = logo,
+        model = imageRequest,
         contentDescription = null,
          modifier = modifier
              .clip(CircleShape)
@@ -39,3 +52,6 @@ internal fun TokenLogo(
         }
     )
 }
+
+private const val USER_AGENT = "User-Agent"
+private const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Android) AppleWebKit/537.36 Chrome/119.0 Mobile Safari/537.36"


### PR DESCRIPTION
## Description

- Fix loading all IPFS logos, which are blocked by 403 for not setting user agent on Coil
- It seems to be only with ipfs.io , web3 works fine

<img width="250" height="750" alt="Screenshot_1758185557" src="https://github.com/user-attachments/assets/3b62c963-c320-407c-89f1-3c9a5c9d7af6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of token logo loading from IPFS by adding appropriate request headers, reducing failed or blocked image fetches.
  * Enhanced image request handling to better support external logo URLs.

* **Style**
  * Updated token logo appearance with a subtle neutral background and circular shape for a cleaner, more consistent look across the app.
  * Ensured logo rendering uses the updated image request path for smoother visual loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->