### PR TITLE
[SOL]: Set Optimal Proper CU Limit for Jupiter Swaps

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -46,6 +46,7 @@ internal class JupiterApiImpl @Inject constructor(
         val quoteSwapRequestBody = buildJsonObject {
             put("quoteResponse", json.encodeToJsonElement(body))
             put("userPublicKey", fromAddress)
+            put("dynamicComputeUnitLimit", true)
         }
         val quoteSwapData = httpClient.post("https://quote-api.jup.ag/v6/swap") {
             setBody(quoteSwapRequestBody)
@@ -57,5 +58,4 @@ internal class JupiterApiImpl @Inject constructor(
             routePlan = routePlan
         )
     }
-
 }


### PR DESCRIPTION
## Description

**Context**
By Default Jupiter adds maximum limit allowed by network, which its not ideal at all. The purpose of this PR is to set proper CU limit, to improve transaction landing. As per 1.18: "_**In the upcoming Solana client v1.18 update, [transactions requiring fewer Compute Units will be given higher priority](https://github.com/solana-labs/solana/pull/34888)**_."

"_However, requesting too many compute units upfront can make it harder to schedule transactions efficiently because the scheduler doesn't know how much compute is left in a block until the transaction is executed. To avoid this, developers should set better-scoped CU requests that match the transaction requirements..._"

**Before**
https://solscan.io/tx/cqdQUREJdoCuJyGZa24zABNAkSxNQS3QZ5gcFw4rRFz8HtasNLhoi7sY2SJNs42iBz4cKszgxdprekuJ5wD9oZA

Jupiter sets 1.4M (max limit allowed by network)
<img width="959" height="173" alt="Screenshot 2025-09-18 at 17 53 58" src="https://github.com/user-attachments/assets/1255d723-145d-4829-86ec-a7bbd870822b" />

**After**
https://solscan.io/tx/4Yat5GPNVoKEQY3MdJj34P2Kr4QMCnHmPsHomh48gxv4xo1hTEKQzSB6rFxtAZiNsEt4nQmktThCMPRczh4QG2pK
Jupiter simulates and set proper limit
<img width="959" height="173" alt="Screenshot 2025-09-18 at 17 55 25" src="https://github.com/user-attachments/assets/d0c56a26-c4fa-414a-a72e-98b28fffab96" />

