### PR TITLE
[SOL]: Add Priority Price (Jupiter Swaps)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -50,8 +50,8 @@ internal class JupiterApiImpl @Inject constructor(
             put("dynamicComputeUnitLimit", true)
             put("prioritizationFeeLamports", buildJsonObject {
                 put("priorityLevelWithMaxLamports", buildJsonObject {
-                    put("maxLamports", 6000000)
-                    put("priorityLevel", "high")
+                    put("maxLamports", MAX_PRIORITY_FEE_LAMPORTS)
+                    put("priorityLevel", PRIORITY_LEVEL)
                 })
             })
         }
@@ -77,5 +77,7 @@ internal class JupiterApiImpl @Inject constructor(
 
     private companion object {
         val MIN_FEE_PRICE_SWAP = "150000".toBigInteger()
+        val MAX_PRIORITY_FEE_LAMPORTS = 6000000
+        val PRIORITY_LEVEL = "high"
     }
 }


### PR DESCRIPTION
### Description
Swap transactions coming from Jupiter currently have no priority fee.  
This PR adds a priority fee using `prioritizationFeeLamports` from Jupiter.

### Context
We enforce boundaries:

- **Floor:** 150K Lamports  
- **Ceiling:** 10M Lamports 

### Motivation
Ensure transactions include a reasonable priority fee while avoiding excessively high fees. Priority fees are critical for inclusion in blocks and avoid dropping transaction.

**Before**
<img width="1136" height="335" alt="Screenshot 2025-09-23 at 16 45 53" src="https://github.com/user-attachments/assets/9bfcf0b4-d3a1-429f-a8fb-aaf7895ca950" />

**After**
<img width="662" height="133" alt="Screenshot 2025-09-23 at 17 24 07" src="https://github.com/user-attachments/assets/f1354006-84a9-43e8-b2ad-5b7fba1b54cd" />


**Evidence**
https://solscan.io/tx/4fsGEucYkkHretxo7UHM9iEsw8cnTT6HRrgUE78y5uKPzsgPpBRMMkFSZuMVBANq87Ss9aAikbjXofPTzbUf1LAQ

**Upcoming PR**
Show proper fees for SOL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solana swaps now include a prioritization fee derived from the swap quote to improve confirmation speed and predictability during network congestion.

* **Bug Fixes**
  * A minimum fee threshold is enforced on swap submissions to prevent underpriced transactions that could stall or fail, improving reliability and consistency of swap execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->