### PR TITLE
[Crash]: Handle non existing account exception

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -130,11 +130,11 @@ internal class TokenDetailViewModel @Inject constructor(
                 updateRefreshing(false)
                 Timber.e(it)
             }.onEach { address ->
-                val token = address.accounts
-                    .first { it.token.id == tokenId }
-                    .let { account ->
+                address.accounts
+                    .firstOrNull { it.token.id == tokenId }
+                    ?.let { account ->
                         val token = account.token
-                        ChainTokenUiModel(
+                        val tokenUiModel = ChainTokenUiModel(
                             id = token.id,
                             name = token.ticker,
                             balance = account.tokenValue
@@ -145,18 +145,20 @@ internal class TokenDetailViewModel @Inject constructor(
                             tokenLogo = Tokens.getCoinLogo(token.logo),
                             chainLogo = chain.logo,
                             mergeBalance = mergedBalance,
-                            price =  account.price?.let { fiatValueToStringMapper(it) },
+                            price = account.price?.let { fiatValueToStringMapper(it) },
                             network = token.chain.raw,
                         )
-                    }
 
-                uiState.update {
-                    it.copy(
-                        token = token,
-                        canDeposit = chain.isDepositSupported,
-                        canSwap = chain.IsSwapSupported,
-                    )
-                }
+                        uiState.update {
+                            it.copy(
+                                token = tokenUiModel,
+                                canDeposit = chain.isDepositSupported,
+                                canSwap = chain.IsSwapSupported,
+                            )
+                        }
+                    } ?: run {
+                        updateRefreshing(false)
+                    }
             }.onCompletion {
                 updateRefreshing(false)
             }.collect()


### PR DESCRIPTION
## Description

#2514

- How to reproduce
- 1) Go to SOL, start adding as much token as possibles
- 2) Go back, before the token has been loaded (account created), click on the asset.
- 3) App crashes

Spend quite sometime reproducing it, it was a bit hard for me, has to be done quite fast.
There are potential solutions to approach the problem:
- Catch Error, show default screen while everything loads (no balanace as account in progress and balance). Then one user goes back or open it again everything is fine. (i think this is the one more straightforward)
- Block access from UI or keep retrying in background

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rare issue where Token Details could fail to load or cause instability when the related account isn’t available.
  * Refresh indicator now stops correctly if no matching account is found, preventing indefinite loading.
  * Prevents partial or incorrect token information from displaying in these cases, improving reliability of balances and fiat values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->