### PR TITLE
Remove redundant RiveInitializer metadata from AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,11 @@
                 tools:node="remove" />
 
             <meta-data
+                android:name="app.rive.runtime.kotlin.RiveInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+
+            <meta-data
                 android:name="com.vultisig.wallet.app.startup.WorkManagerInitializer"
                 android:value="androidx.startup" />
         </provider>


### PR DESCRIPTION
App uses the Rive animation library and manually initializes it in VoltixApplication.kt with Rive.init(this). However, the Rive library can also auto-initialize via Android's androidx.startup.InitializationProvider. 
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2527


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context