### PR TITLE
[Fix]: ClearText Connection

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
@@ -12,5 +12,4 @@
             <certificates src="@raw/cloudflare_tls_issuing_ecc_ca_1" />
         </trust-anchors>
     </domain-config>
-
 </network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false">
+    <base-config>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
@@ -11,11 +11,6 @@
             <certificates src="system" />
             <certificates src="@raw/cloudflare_tls_issuing_ecc_ca_1" />
         </trust-anchors>
-    </domain-config>
-
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">127.0.0.1</domain>
-        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 
 </network-security-config>


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2574

- Keep previous behaviour regarding clear traffic (main manifest decide) for Android N < Versions  https://github.com/vultisig/vultisig-android/blob/86fe19f760058bc56b8fe6bec4fe8db6328753af/app/src/main/AndroidManifest.xml#L42
- Add clearText in new network config, as for Android N or higher the default is false

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - App now permits cleartext (HTTP) network traffic, enabling connections to services that don’t use HTTPS.
- Chores
  - Updated network security configuration to allow cleartext traffic globally.
  - Removed the explicit localhost/127.0.0.1 exception from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->