### PR TITLE
[Biometrics]: Toggeling off fast sign needs password

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -365,9 +365,9 @@ internal open class VaultSettingsViewModel @Inject constructor(
                     viewModelScope.launch {
                         vaultPasswordRepository.clearPassword(vaultId)
                         isBiometricFastSignEnabled = false
+                        showSnackbarMessage()
                     }
                 }
-                showSnackbarMessage()
             }
 
             VaultSettingsItem.Delete -> navigateToConfirmDeleteScreen()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -354,15 +354,13 @@ internal open class VaultSettingsViewModel @Inject constructor(
             }
 
             is VaultSettingsItem.BiometricFastSign -> {
-                if (!item.isBiometricEnabled) {
-                    val newItem = uiModel.value.copy(
-                        isBiometricFastSignBottomSheetVisible = true,
-                    )
-                    uiModel.update {
-                        newItem
-                    }
-                } else {
-                    viewModelScope.launch {
+                viewModelScope.launch {
+                    if (!item.isBiometricEnabled) {
+                        val newItem = uiModel.value.copy(
+                            isBiometricFastSignBottomSheetVisible = true,
+                        )
+                        uiModel.update { newItem }
+                    } else {
                         vaultPasswordRepository.clearPassword(vaultId)
                         isBiometricFastSignEnabled = false
                         showSnackbarMessage()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -354,11 +354,19 @@ internal open class VaultSettingsViewModel @Inject constructor(
             }
 
             is VaultSettingsItem.BiometricFastSign -> {
-                val newItem = uiModel.value.copy(
-                    isBiometricFastSignBottomSheetVisible = true,
-                )
-                uiModel.update {
-                    newItem
+                if (!item.isBiometricEnabled) {
+                    val newItem = uiModel.value.copy(
+                        isBiometricFastSignBottomSheetVisible = true,
+                    )
+                    uiModel.update {
+                        newItem
+                    }
+                } else {
+                    viewModelScope.launch {
+                        vaultPasswordRepository.clearPassword(vaultId)
+                        isBiometricFastSignEnabled = false
+                        showSnackbarMessage()
+                    }
                 }
             }
 
@@ -531,13 +539,8 @@ internal open class VaultSettingsViewModel @Inject constructor(
             isBiometricFastSignEnabled = true
             passwordTextFieldState.clearText()
             hideBiometricFastVaultBottomSheet()
-        } else {
-            vaultPasswordRepository.clearPassword(vaultId)
-            isBiometricFastSignEnabled = false
-            passwordTextFieldState.clearText()
-            hideBiometricFastVaultBottomSheet()
+            showSnackbarMessage()
         }
-        showSnackbarMessage()
     }
 
     private fun hideBiometricFastVaultBottomSheet() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -365,9 +365,9 @@ internal open class VaultSettingsViewModel @Inject constructor(
                     viewModelScope.launch {
                         vaultPasswordRepository.clearPassword(vaultId)
                         isBiometricFastSignEnabled = false
-                        showSnackbarMessage()
                     }
                 }
+                showSnackbarMessage()
             }
 
             VaultSettingsItem.Delete -> navigateToConfirmDeleteScreen()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2534

https://github.com/user-attachments/assets/5572c282-3a1d-41ee-bd24-0de9c45bdd06


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Biometric Fast Sign now prompts with a setup sheet when enabling.
- Bug Fixes
  - Disabling Biometric Fast Sign now provides a clear confirmation message via snackbar.
  - Avoids unnecessary notifications when changing biometric settings.
- UX
  - Streamlined enable/disable flow for Biometric Fast Sign, with clearer prompts and fewer interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->