### PR TITLE
[Fix]: Avoid adding unsupported chains in swap carrousel

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.IsSwapSupported
 import com.vultisig.wallet.data.models.Tokens
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.logo
@@ -206,6 +207,11 @@ internal class SelectAssetViewModel @Inject constructor(
                     logo = chain.logo,
                     title = chain.name,
                 )
+            }.filter {
+                when (filter) {
+                    Route.SelectNetwork.Filters.SwapAvailable -> it.chain.IsSwapSupported
+                    else -> true
+                }
             }.sortedByDescending { it.chain.id == state.value.selectedChain.id }
 
             state.update {


### PR DESCRIPTION
## Description


Fixes #2590 , and also
https://github.com/vultisig/vultisig-android/issues/2511

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Network selection: when the “Swap available” filter is active, only networks that support swaps are shown. This makes it easier to find compatible networks for swapping assets.
  * When the filter is not applied, all networks remain visible as before, preserving the full browsing experience.
  * Overall selection experience is more relevant and streamlined when looking specifically for swap-capable networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->