### PR TITLE
Fix  duplicate name of vaults

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/NameVaultViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/NameVaultViewModel.kt
@@ -85,7 +85,7 @@ internal class NameVaultViewModel @Inject constructor(
     }
 
     private fun validate() = viewModelScope.launch {
-        val name = nameFieldState.text.toString()
+        val name = nameFieldState.text.toString().trim()
 
         val errorMessage = when {
             !isNameValid(name) -> StringResource(R.string.naming_vault_screen_invalid_name)
@@ -107,7 +107,7 @@ internal class NameVaultViewModel @Inject constructor(
     }
 
     private fun isNameAvailable(name: String): Boolean =
-        vaultNamesList.none { it == name.trim() }
+        vaultNamesList.none { it == name }
 
     fun navigateToEmail() {
         val name = nameFieldState.text.toString()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2584

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault name validation now trims leading/trailing spaces before checks, so names that only differ by whitespace are not treated as unique.
  * The “Next” button state correctly reflects the trimmed validation result, reducing accidental progression with invalid or duplicate names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->