### PR TITLE
Fix Swap  NoSuchElementException

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -1339,13 +1339,19 @@ internal fun List<Address>.firstSendSrc(
     filterByChain: Chain?,
 ): SendSrc {
     val address = when {
-        !selectedTokenId.isNullOrBlank() -> first { it -> it.accounts.any { it.token.id == selectedTokenId } }
+        !selectedTokenId.isNullOrBlank() -> firstOrNull() { it ->
+            it.accounts.any {
+                it.token.id == selectedTokenId
+            }
+        } ?: this.first()
+
         filterByChain != null -> first { it.chain == filterByChain }
         else -> first()
     }
-
     val account = when {
-        !selectedTokenId.isNullOrBlank() -> address.accounts.first { it.token.id == selectedTokenId }
+        !selectedTokenId.isNullOrBlank() -> address.accounts.firstOrNull() { it.token.id == selectedTokenId }
+            ?: address.accounts.first()
+
         filterByChain != null -> address.accounts.first { it.token.isNativeToken }
         else -> address.accounts.first()
     }


### PR DESCRIPTION
## Description

Fixes #2470
Immediately after importing a vault, if you proceed to the Swap screen and attempt to change the From address, the app crashes.

The crash occurs because the following expression can return null, leading to a NullPointerException:

`it -> it.accounts.any { it.token.id == selectedTokenId }
`

```
  java.util.NoSuchElementException: Collection contains no element matching the predicate.
                                                                                                    	at com.vultisig.wallet.ui.models.swap.SwapFormViewModelKt.firstSendSrc(SwapFormViewModel.kt:1380)
                                                                                                    	at com.vultisig.wallet.ui.models.swap.SwapFormViewModelKt.findCurrentSrc(SwapFormViewModel.kt:1373)
                                                                                                    	at com.vultisig.wallet.ui.models.swap.SwapFormViewModelKt.updateSrc(SwapFormViewModel.kt:1332)

```


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

https://github.com/user-attachments/assets/ff666e9e-0c61-42a5-9ef4-a8d3d4247dc1


## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token and account selection logic in swap operations with better fallback handling to prevent crashes when specific tokens or accounts aren't immediately available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->