### PR TITLE
[ETH]: Improve eth_getBlockByNumber speed

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -406,8 +406,8 @@ class EvmApiImp(
         val response = fetch<EvmRpcResponseJson<EvmBaseFeeJson>>(
             method = "eth_getBlockByNumber",
             params = buildJsonArray {
-                add("pending")
-                add(true)
+                add("latest")
+                add(false)
             }
         )
         return response.result.baseFeePerGas.convertToBigIntegerOrZero()


### PR DESCRIPTION
## Description

- Improve `eth_getBlockByNumber` speed.
- Since 2024, we've been setting `add(true)`. This parameter is unnecessary because it requests all transaction objects per block, which we don’t need — we only use `eth_getBlockByNumber `to get the gas data. This adds extra processing time and indexing, which becomes more noticeable during network congestion.
 
<img width="710" height="34" alt="Screenshot 2025-10-27 at 22 13 36" src="https://github.com/user-attachments/assets/0571dcbf-2c6f-403b-89af-c67834b74690" />

<img width="596" height="97" alt="Screenshot 2025-10-27 at 22 27 38" src="https://github.com/user-attachments/assets/f664e7df-7052-4d8a-8472-7063bdf4211c" />

- Setting status as `"latest"`. Although "pending" would be slightly more optimal, it seems our provider still doesn’t allow it for Base/OP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas fee estimation by updating base fee retrieval to use the latest confirmed block data, resulting in more accurate and consistent transaction fee calculations across the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->