### PR TITLE
[Fix]: Move Icon Outside QR

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -268,7 +268,8 @@ internal fun PeerDiscoveryScreen(
                                 UiIcon(
                                     drawableResId = R.drawable.enlarge,
                                     size = 20.dp,
-                                    tint = Theme.colors.text.primary
+                                    tint = Theme.colors.text.primary,
+                                    contentDescription = "Enlarge QR code"
                                 )
                             }
                         }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

<img width="300" height="700" alt="Screenshot_1761815863" src="https://github.com/user-attachments/assets/501234b4-9055-4d07-9a82-cb6222e6b209" />




## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved QR enlargement control from the QR container to the peer discovery screen, making enlargement driven by local screen state.
  * Simplified the QR display to a plain image in the container.
  * Repositioned the device count into a centered row with improved spacing and an optional enlargement button shown only when a QR is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->