### PR TITLE
[Fix]: Wrong Error Message Insufficient Funds (EVM)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -177,7 +177,7 @@ internal class BlockChainSpecificRepositoryImpl @Inject constructor(
                 val nonce = evmApi.getNonce(address)
 
                 val gasLimitFee = gasLimit ?: max(defaultGasLimit, estimateGasLimit)
-                val fees = feeServiceComposite.calculateFees(chain, estimateGasLimit, isSwap)
+                val fees = feeServiceComposite.calculateFees(chain, gasLimitFee, isSwap)
 
                 val (maxFeePerGas, priorityFeeWei) = when (fees) {
                     is Eip1559 -> fees.maxFeePerGas to fees.maxPriorityFeePerGas


### PR DESCRIPTION
## Description

#2861


- When fee simulation fails for a native coin transfer: This usually happens when the amount to send is close to the maximum. The simulation throws "Not enough funds for transfer", and estimateGasLimit becomes 0. Then the fee calculation service throws the message "0 invalid limit".

- How to solve it: Use the gas limit from `val gasLimitFee = gasLimit ?: max(defaultGasLimit, estimateGasLimit)`. If the simulation fails, we fall back to the default value, allowing the user to see a proper error message

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced EVM transaction fee calculation for improved accuracy. Transaction fees are now properly calculated based on the actual gas limit specified for each transaction, resulting in more predictable and reliable fee estimates. This adjustment ensures that your fees better reflect the true cost of transactions on Ethereum-compatible networks, providing clearer cost visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->