### PR TITLE
Display the Correct Error Message Instead of `Failed to Join Keysign`

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -949,7 +949,7 @@ internal class JoinKeysignViewModel @Inject constructor(
                 } catch (e: Exception) {
                     Timber.tag("JoinKeysignViewModel")
                         .e("Failed to join keysign: %s", e.stackTraceToString())
-                    currentState.value = JoinKeysignState.Error(JoinKeysignError.FailedToStart(e.stackTraceToString()))
+                    currentState.value = JoinKeysignState.Error(JoinKeysignError.FailedToStart(e.message.toString()))
                 }
             }
         }


### PR DESCRIPTION

## Description
The original issue could not be reproduced.
However, the code has been updated so that the application now displays the actual exception message instead of always showing the generic “Failed to Join Keysign” error.


Please include a summary of the change and which issue is fixed. 

Fixes #2897

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for key-signing startup failures: error messages now include exception details so users and support get clearer diagnostics when initialization fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->