### PR TITLE
[Ruji]: Disable APR

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/RujiStakingService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/RujiStakingService.kt
@@ -53,17 +53,12 @@ class RujiStakingService @Inject constructor(
     suspend fun getStakingDetailsFromNetwork(address: String): StakingDetails {
         return try {
             val rujiStakeInfo = thorChainApi.getRujiStakeBalance(address)
-            val apr = if (rujiStakeInfo.apr == 0.0) {
-                null
-            } else {
-                rujiStakeInfo.apr
-            }
 
             StakingDetails(
                 id = Coins.ThorChain.RUJI.generateId(),
                 coin = Coins.ThorChain.RUJI,
                 stakeAmount = rujiStakeInfo.stakeAmount,
-                apr = apr,
+                apr = null,
                 estimatedRewards = null, // Not available for Ruji
                 nextPayoutDate = null, // Not available for Ruji
                 rewards = rujiStakeInfo.rewardsAmount.toBigDecimal(),


### PR DESCRIPTION
## Description

- Disabled API till we know APR format and RUJI support rewards distribution
- Most of the time returns 0, although in some cases it returns crazy random number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staking details to reflect accurate Annual Percentage Rate (APR) availability for staking information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->