### PR TITLE
Add new depositOptions to TON chain

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -276,7 +276,6 @@ internal class DepositFormViewModel @Inject constructor(
                 DepositOption.MintYRUNE,
                 DepositOption.RedeemYTCY,
                 DepositOption.RedeemYRUNE,
-                DepositOption.SecuredAsset,
                 DepositOption.WithdrawSecuredAsset,
             )
 
@@ -297,6 +296,12 @@ internal class DepositFormViewModel @Inject constructor(
                 DepositOption.TransferIbc,
                 DepositOption.Switch,
             )
+            Chain.Ton -> {
+                listOf(
+                    DepositOption.Stake,
+                    DepositOption.Unstake
+                )
+            }
             else ->
                 buildList {
 //                    add(DepositOption.Stake)


### PR DESCRIPTION
## Description
The reason I removed the Secure Asset option from Thorchain is that the chain does not support Secured Asset transaction ,only non- THORChain chains can  perform Secure Asset transactions.

Stake transaction
https://tonviewer.com/transaction/0611bf7087d0c63278b1987f44a74b9ff742fa4a963c0d324e53c4df69636ceb

UnStake transaction
https://tonviewer.com/transaction/3faa7c0654c0fa02aeb949c850a96c829816f9489797da18f5498c82cc54cdc4

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context