### PR TITLE
[Fix]: DKLSKeysign Retry

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -377,16 +377,9 @@ class DKLSKeysign(
                 signatures[messageToSign] = resp
             }
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            if (e.message?.contains("Request failed with status 404") == true) {
-                error("Signature computations differ across signing devices for chain path: $chainPath")
-            }
-            Timber.e("Failed to sign message ($messageToSign), error: ${e.localizedMessage}")
+            println("Failed to sign message ($messageToSign), error: ${e.localizedMessage}")
             if (attempt < 3) {
-                keysignOneMessageWithRetry(
-                    attempt + 1,
-                    messageToSign
-                )
+                keysignOneMessageWithRetry(attempt + 1, messageToSign)
             }
         }
     }


### PR DESCRIPTION
## Description

Fully Fixes  #3108

- Revert #2959 which do not perform any retry and exit the catch earlier, therefore making sometime failed DKLSKeysign when the initiator needs to upload 2 messages


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling logic for signing operations
  * Enhanced retry mechanism with streamlined invocation

* **Refactor**
  * Simplified internal error management and reporting approach

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->