### PR TITLE
[Fix]: Adjust Retry Request

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
@@ -10,13 +10,13 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.isSuccess
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 interface SessionApi {
     suspend fun checkCommittee(serverUrl: String, sessionId: String): List<String>
@@ -219,7 +219,7 @@ internal class SessionApiImpl @Inject constructor(
             }
             if (attempt < MAX_RETRIES - 1) {
                 Timber.e("Retry setup-message request attempt: ${attempt + 1}")
-                delay(1000L * (attempt + 1))
+                delay(1000L)
             }
         }
         throw lastException ?: Exception("Failed to get setup message after $MAX_RETRIES retries")


### PR DESCRIPTION
## Description

- Previous retry did not trigger because plugin was not installed in commonData
- When installing it overrides the config but it applies to all network request
- Implement isolate solution, other option might be in the plugin create interceptor and filter per url request but might require more time

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved retry logic for setup message retrieval: more robust repeated attempts with delays, better error handling and logging, and proper propagation of cancellations to reduce transient failures and provide clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->