### PR TITLE
[Fix]: Blast Miner Tip Fees

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -162,9 +162,11 @@ class EthereumFeeService @Inject constructor(
                 // Arb and Mantle requires no miner tip
                 Chain.Arbitrum, Chain.Mantle -> BigInteger.ZERO
 
+                // Blast is a dead chain, with empty blocks with 0 miner tips
+                Chain.Blast -> maxOf(rewardsFeeHistory.maxOrNull() ?: BigInteger.ZERO, DEFAULT_MAX_PRIORITY_FEE_BLAST)
+
                 // picked max from 10 previous blocks, then ensure inclusion. For l2 is quite low
                 Chain.Base,
-                Chain.Blast,
                 Chain.Optimism, -> rewardsFeeHistory.maxOrNull() ?: DEFAULT_MAX_PRIORITY_FEE_PER_GAS_L2
 
                 // polygon has min of 30 gwei, but some blocks comes with less rewards
@@ -205,6 +207,7 @@ class EthereumFeeService @Inject constructor(
 
         private val DEFAULT_MAX_PRIORITY_FEE_PER_GAS_L2 = "20".toBigInteger()
         private val DEFAULT_MAX_PRIORITY_FEE_POLYGON = "30".toBigInteger()
+        private val DEFAULT_MAX_PRIORITY_FEE_BLAST = BigInteger.TEN.pow(7) // 0.01 GWEI
 
         val DEFAULT_SWAP_LIMIT = "600000".toBigInteger()
         val DEFAULT_COIN_TRANSFER_LIMIT = "23000".toBigInteger()


### PR DESCRIPTION
## Description

Fixes #3125

Fix Blast gas tip is 0, therefore we cannot broadcast the tx. 

The chain is dead and spam empty blocks and dummy transaction to network. So when fetching latest history is always 0.

<img width="908" height="483" alt="Screenshot 2026-01-20 at 17 07 56" src="https://github.com/user-attachments/assets/db9fa54a-0f6b-4eda-b0db-f8e3a4dad27c" />




## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized transaction fee calculation handling for the Blast blockchain network.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->