### PR TITLE
Add loading indicator before loading the secure assets

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -542,31 +542,10 @@ internal class DepositFormViewModel @Inject constructor(
 
                 DepositOption.WithdrawSecuredAsset -> {
                     viewModelScope.launch {
-                        val address = this@DepositFormViewModel.address.value ?: return@launch
-                        thorAddressFieldState.setTextAndPlaceCursorAtEnd(address.address)
-                        val availableSecuredAssets = address.accounts.filter { account ->
-                            account.token.isSecuredAsset()
-                        }.map {
-                            TokenWithdrawSecureAsset(
-                                ticker = it.token.ticker,
-                                contract = it.token.contractAddress,
-                                coin = it.token,
-                                tokenValue = it.tokenValue
-                            )
-                        }
-                        if (availableSecuredAssets.isNotEmpty()) {
-                            val selectedSecuredAsset = availableSecuredAssets.first()
-                            val balance = selectedSecuredAsset.tokenValue?.let(
-                                mapTokenValueToStringWithUnit
-                            )
-                            state.update {
-                                it.copy(
-                                    availableSecuredAssets = availableSecuredAssets,
-                                    selectedSecuredAsset = selectedSecuredAsset,
-                                    balance = balance?.asUiText() ?: UiText.Empty,
-                                )
+                        this@DepositFormViewModel.address
+                            .filterNotNull().collect { address ->
+                                handleWithdrawSecuredAsset(address)
                             }
-                        }
                     }
                 }
 
@@ -579,6 +558,33 @@ internal class DepositFormViewModel @Inject constructor(
             }
         }
 
+    }
+
+    private fun handleWithdrawSecuredAsset(address: Address) {
+        thorAddressFieldState.setTextAndPlaceCursorAtEnd(address.address)
+        val availableSecuredAssets = address.accounts.filter { account ->
+            account.token.isSecuredAsset()
+        }.map {
+            TokenWithdrawSecureAsset(
+                ticker = it.token.ticker,
+                contract = it.token.contractAddress,
+                coin = it.token,
+                tokenValue = it.tokenValue
+            )
+        }
+        if (availableSecuredAssets.isNotEmpty()) {
+            val selectedSecuredAsset = availableSecuredAssets.first()
+            val balance = selectedSecuredAsset.tokenValue?.let(
+                mapTokenValueToStringWithUnit
+            )
+            state.update {
+                it.copy(
+                    availableSecuredAssets = availableSecuredAssets,
+                    selectedSecuredAsset = selectedSecuredAsset,
+                    balance = balance?.asUiText() ?: UiText.Empty,
+                )
+            }
+        }
     }
 
     private fun collectSecuredAssetAddresses() {


### PR DESCRIPTION
… selection logic

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3196
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved deposit workflow by using in-memory cached addresses to populate destination address and available secured assets, reducing redundant reloads and improving responsiveness when selecting a secured-asset withdrawal. Internal handling of selection and balance population was streamlined for more consistent UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->