### PR TITLE
Update Aztec token decimals

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1797,7 +1797,7 @@ object Coins {
             ticker = "AZTEC",
             logo = "aztec",
             address = "",
-            decimal = 4,
+            decimal = 8,
             hexPublicKey = "",
             priceProviderID = "aztec",
             contractAddress = "aztec",


### PR DESCRIPTION
## Description

https://www.explorer.mayachain.info/tx/A286B50515618DD1B3E2C4CF2B2AF2124C0674617D6881BF821C3C8E6A768383

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted AZTEC token decimal precision to 8 decimal places, ensuring accurate balance and transaction calculations in the wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->