### PR TITLE
feat: add /format skill for Kotlin import cleanup and formatting

### DIFF
--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: format
+description: Remove unused imports and format staged Kotlin files. Run before /commit to clean up code. Automatically downloads ktlint if not installed.
+disable-model-invocation: true
+allowed-tools: Bash
+---
+
+# Format Staged Kotlin Files
+
+Remove unused imports and auto-format all staged `.kt` files using `ktlint` before committing.
+
+## Step 1 — Get staged Kotlin files
+
+```bash
+git diff --cached --name-only --diff-filter=ACMR | grep '\.kt$'
+```
+
+If there are no staged `.kt` files, print "No staged Kotlin files to format." and stop.
+
+## Step 2 — Ensure ktlint is available
+
+Check if `ktlint` is on the PATH:
+
+```bash
+which ktlint 2>/dev/null
+```
+
+If not found, download it into the project-local `.ktlint/` directory (one-time setup):
+
+```bash
+mkdir -p .ktlint
+curl -sSLO --output-dir .ktlint \
+  https://github.com/pinterest/ktlint/releases/download/1.8.0/ktlint
+chmod +x .ktlint/ktlint
+echo "ktlint downloaded to .ktlint/ktlint"
+```
+
+Resolve the binary path:
+
+```bash
+KTLINT=$(which ktlint 2>/dev/null || echo ".ktlint/ktlint")
+```
+
+## Step 3 — Format each staged file
+
+Run ktlint with `--format` on all staged Kotlin files. This removes unused imports and applies the standard Kotlin style:
+
+```bash
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.kt$')
+echo "$STAGED" | xargs $KTLINT --format 2>&1
+```
+
+If ktlint exits with an error that is **not** about fixable style violations, print the output and stop. Formatting errors (exit code 1 when only auto-fixable issues are found) are expected and fine.
+
+## Step 4 — Re-stage the formatted files
+
+Re-add the files so the formatted versions are included in the commit:
+
+```bash
+echo "$STAGED" | xargs git add
+```
+
+## Step 5 — Show summary
+
+```bash
+echo ""
+echo "Formatted and re-staged Kotlin files:"
+echo "$STAGED" | sed 's/^/  ✓ /'
+echo ""
+echo "Ready to /commit"
+```
+
+## Notes
+
+- `ktlint --format` handles `no-unused-imports`, indentation, spacing, trailing commas, and all standard Kotlin style rules.
+- `.ktlint/` is gitignored by default if `.gitignore` has `/.ktlint/` — add it if it isn't already there.
+- If your project gains a `ktlint` Gradle task later, replace Step 2–3 with `./gradlew ktlintFormat`.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ fastlane/report.xml
 
 # Crush AI assistant
 .crush/
+
+# ktlint binary (downloaded by /format skill)
+/.ktlint/


### PR DESCRIPTION
## Summary
- Adds a new `/format` Claude Code skill that removes unused imports and auto-formats staged `.kt` files before committing
- Uses `ktlint --format` (v1.8.0) under the hood — auto-downloaded to `.ktlint/` if not on PATH
- Adds `/.ktlint/` to `.gitignore` so the binary is never committed

## Usage
```
/format   ← clean up staged .kt files
/commit   ← commit with clean code
```

## Test Plan
- [ ] Stage a `.kt` file with unused imports and run `/format` — imports should be removed and file re-staged
- [ ] Run `/format` with no staged `.kt` files — should print "No staged Kotlin files to format." and exit cleanly
- [ ] Verify `.ktlint/` binary is ignored by git after download

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Git pre-commit Kotlin code formatter that automatically formats staged Kotlin files before commits, with automatic local management of formatting tools.

* **Chores**
  * Updated configuration to exclude formatter binaries from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->