### PR TITLE
Enable drag handle on backup bottom sheets

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/backup/BackupMethodBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/backup/BackupMethodBottomSheet.kt
@@ -36,7 +36,6 @@ internal fun BackupMethodBottomSheet(
 ) {
     VsModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        showDragHandle = false,
     ) {
         BackupMethodBottomSheetContent(
             onDeviceBackupClick = onDeviceBackupClick,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
@@ -348,7 +348,6 @@ private fun ServerBackupSuccessBottomSheet(
 
     VsModalBottomSheet(
         onDismissRequest = onClose,
-        showDragHandle = false,
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## Description

Enable drag-handle as agreed with Mia

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/41f086e5-cfca-4ff8-b30a-acdf2aea8653" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modal bottom sheets in backup-related screens now display drag handles by default. This change affects the backup method selection and server backup completion dialogs, providing clearer visual indication that these modals are interactive components users can manipulate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->