### PR TITLE
Fix empty chain list when selecting chains manually during import scan

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeyImportChainsSetupViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeyImportChainsSetupViewModel.kt
@@ -10,13 +10,13 @@ import com.vultisig.wallet.data.repositories.ChainImportSetting
 import com.vultisig.wallet.data.repositories.DerivationPath
 import com.vultisig.wallet.data.repositories.KeyImportRepository
 import com.vultisig.wallet.data.usecases.ScanChainBalancesUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -89,71 +89,8 @@ constructor(
         else chains.filter { it.chain.raw.contains(query, ignoreCase = true) }
 
     private fun startScanning() {
-        viewModelScope.launch {
-            try {
-                val mnemonic = keyImportRepository.get()?.mnemonic ?: error("No mnemonic found")
-
-                val results = withContext(Dispatchers.IO) { scanChainBalances(mnemonic) }
-                val activeResults = results.filter { it.hasBalance }
-
-                // Build the full chain list for CustomizeChains screen, pre-selecting
-                // chains that have balance. Use the active result's derivation path
-                // (e.g. Phantom for Solana) if one was found with balance.
-                val allChainItems =
-                    Chain.keyImportSupportedChains.map { chain ->
-                        val hasBalance = activeResults.any { it.chain == chain }
-                        ChainItemUiModel(
-                            chain = chain,
-                            derivationPath =
-                                results
-                                    .firstOrNull { it.chain == chain && it.hasBalance }
-                                    ?.derivationPath ?: DerivationPath.Default,
-                            isSelected = hasBalance,
-                        )
-                    }
-
-                _state.update { current ->
-                    if (current.screenState == ChainsSetupState.CustomizeChains) {
-                        val updatedAllChains =
-                            current.allChains.map { item ->
-                                val scannedPath =
-                                    allChainItems
-                                        .firstOrNull { it.chain == item.chain }
-                                        ?.derivationPath ?: item.derivationPath
-                                item.copy(derivationPath = scannedPath)
-                            }
-                        current.copy(
-                            allChains = updatedAllChains,
-                            filteredChains = applyFilter(updatedAllChains),
-                        )
-                    } else if (activeResults.isNotEmpty()) {
-                        val activeItems =
-                            activeResults.map { result ->
-                                ChainItemUiModel(
-                                    chain = result.chain,
-                                    derivationPath = result.derivationPath,
-                                    isSelected = true,
-                                )
-                            }
-                        current.copy(
-                            screenState = ChainsSetupState.ActiveChains,
-                            activeChains = activeItems,
-                            allChains = allChainItems,
-                            filteredChains = allChainItems,
-                            selectedCount = activeItems.size,
-                        )
-                    } else {
-                        current.copy(
-                            screenState = ChainsSetupState.NoActiveChains,
-                            allChains = allChainItems,
-                            filteredChains = allChainItems,
-                            selectedCount = 0,
-                        )
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
+        viewModelScope.safeLaunch(
+            onError = { e ->
                 Timber.e(e, "Failed to scan chain balances")
                 _state.update { current ->
                     // If user is already in CustomizeChains, don't disturb them
@@ -174,6 +111,66 @@ constructor(
                             filteredChains = allChainItems,
                         )
                     }
+                }
+            }
+        ) {
+            val mnemonic = keyImportRepository.get()?.mnemonic ?: error("No mnemonic found")
+
+            val results = withContext(Dispatchers.IO) { scanChainBalances(mnemonic) }
+            val activeResults = results.filter { it.hasBalance }
+
+            // Build the full chain list for CustomizeChains screen, pre-selecting
+            // chains that have balance. Use the active result's derivation path
+            // (e.g. Phantom for Solana) if one was found with balance.
+            val allChainItems =
+                Chain.keyImportSupportedChains.map { chain ->
+                    val hasBalance = activeResults.any { it.chain == chain }
+                    ChainItemUiModel(
+                        chain = chain,
+                        derivationPath =
+                            results
+                                .firstOrNull { it.chain == chain && it.hasBalance }
+                                ?.derivationPath ?: DerivationPath.Default,
+                        isSelected = hasBalance,
+                    )
+                }
+
+            _state.update { current ->
+                if (current.screenState == ChainsSetupState.CustomizeChains) {
+                    val updatedAllChains =
+                        current.allChains.map { item ->
+                            val scannedPath =
+                                allChainItems.firstOrNull { it.chain == item.chain }?.derivationPath
+                                    ?: item.derivationPath
+                            item.copy(derivationPath = scannedPath)
+                        }
+                    current.copy(
+                        allChains = updatedAllChains,
+                        filteredChains = applyFilter(updatedAllChains),
+                    )
+                } else if (activeResults.isNotEmpty()) {
+                    val activeItems =
+                        activeResults.map { result ->
+                            ChainItemUiModel(
+                                chain = result.chain,
+                                derivationPath = result.derivationPath,
+                                isSelected = true,
+                            )
+                        }
+                    current.copy(
+                        screenState = ChainsSetupState.ActiveChains,
+                        activeChains = activeItems,
+                        allChains = allChainItems,
+                        filteredChains = allChainItems,
+                        selectedCount = activeItems.size,
+                    )
+                } else {
+                    current.copy(
+                        screenState = ChainsSetupState.NoActiveChains,
+                        allChains = allChainItems,
+                        filteredChains = allChainItems,
+                        selectedCount = 0,
+                    )
                 }
             }
         }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keygen/KeyImportChainsSetupViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keygen/KeyImportChainsSetupViewModelTest.kt
@@ -19,6 +19,9 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,9 +34,6 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 internal class KeyImportChainsSetupViewModelTest {
 


### PR DESCRIPTION
## Description

Fix empty chain list when selecting chains manually during import scan

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

  - when allChains is empty (scan in progress), populate it with all supported chains using `DerivationPath.Default` before switching to customize
  - if user already navigated to CustomizeChains, only merge derivation paths (e.g. Solana
  Phantom) from scan results. We don't overwrite screen state or user selections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual chain selection flow to let users switch to customize chains and assign default derivation paths.

* **Bug Fixes**
  * Better preserves user selections and UI state when scans succeed or fail, including during ongoing scans.
  * More consistent error recovery and state transitions after scan errors.

* **Tests**
  * Expanded deterministic tests covering scanning + manual selection, merging behaviors, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->