### PR TITLE
feat: add notification service API client and repository

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class VultisigFirebaseMessagingService : FirebaseMessagingService() {
@@ -20,13 +19,12 @@ class VultisigFirebaseMessagingService : FirebaseMessagingService() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onNewToken(token: String) {
-        Timber.d("FCM token refreshed : $token")
-
         serviceScope.launch { notificationTokenRepository.setToken(token) }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        Timber.d("FCM message received from: ${message.from}")
+        // TODO: Handle incoming messages if needed. For now, we rely on the system to display
+        // notifications based on the payload.
     }
 
     override fun onDestroy() {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
@@ -67,4 +67,6 @@ internal interface ApiModule {
     @Binds @Singleton fun bindKyberApi(impl: KyberApiImpl): KyberApi
 
     @Binds @Singleton fun circleApi(impl: CircleApiImpl): CircleApi
+
+    @Binds @Singleton fun bindNotificationApi(impl: NotificationApiImpl): NotificationApi
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/NotificationApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/NotificationApi.kt
@@ -1,0 +1,49 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.models.NotifyRequestJson
+import com.vultisig.wallet.data.api.models.RegisterDeviceRequestJson
+import com.vultisig.wallet.data.api.models.UnregisterDeviceRequestJson
+import com.vultisig.wallet.data.api.utils.throwIfUnsuccessful
+import com.vultisig.wallet.data.common.Endpoints
+import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.isSuccess
+import javax.inject.Inject
+
+interface NotificationApi {
+    suspend fun register(request: RegisterDeviceRequestJson)
+
+    suspend fun unregister(request: UnregisterDeviceRequestJson)
+
+    suspend fun isVaultRegistered(vaultId: String): Boolean
+
+    suspend fun notify(request: NotifyRequestJson)
+}
+
+internal class NotificationApiImpl @Inject constructor(private val http: HttpClient) :
+    NotificationApi {
+
+    override suspend fun register(request: RegisterDeviceRequestJson) {
+        http.post("$URL/register") { setBody(request) }.throwIfUnsuccessful()
+    }
+
+    override suspend fun unregister(request: UnregisterDeviceRequestJson) {
+        http.delete("$URL/unregister") { setBody(request) }.throwIfUnsuccessful()
+    }
+
+    override suspend fun isVaultRegistered(vaultId: String): Boolean {
+        val response = http.get("$URL/vault/$vaultId")
+        return response.status.isSuccess()
+    }
+
+    override suspend fun notify(request: NotifyRequestJson) {
+        http.post("$URL/notify") { setBody(request) }.throwIfUnsuccessful()
+    }
+
+    companion object {
+        private const val URL = Endpoints.VULTISIG_NOTIFICATION_URL
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/NotificationJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/NotificationJson.kt
@@ -1,0 +1,34 @@
+package com.vultisig.wallet.data.api.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class DeviceType {
+    @SerialName("android") Android,
+    @SerialName("apple") Apple,
+    @SerialName("web") Web,
+}
+
+@Serializable
+data class RegisterDeviceRequestJson(
+    @SerialName("vault_id") val vaultId: String,
+    @SerialName("party_name") val partyName: String,
+    @SerialName("token") val token: String,
+    @SerialName("device_type") val deviceType: DeviceType,
+)
+
+@Serializable
+data class UnregisterDeviceRequestJson(
+    @SerialName("vault_id") val vaultId: String,
+    @SerialName("party_name") val partyName: String,
+    @SerialName("token") val token: String? = null,
+)
+
+@Serializable
+data class NotifyRequestJson(
+    @SerialName("vault_id") val vaultId: String,
+    @SerialName("vault_name") val vaultName: String,
+    @SerialName("local_party_id") val localPartyId: String,
+    @SerialName("qr_code_data") val qrCodeData: String,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/Endpoints.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/Endpoints.kt
@@ -5,4 +5,5 @@ object Endpoints {
     const val LOCAL_MEDIATOR_SERVER_URL = "http://127.0.0.1:18080"
     const val THORCHAIN_BROADCAST_TX: String =
         "https://thornode.ninerealms.com/cosmos/tx/v1beta1/txs"
+    const val VULTISIG_NOTIFICATION_URL: String = "https://api.vultisig.com/notification"
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/NotificationRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/NotificationRepository.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.NotificationApi
+import com.vultisig.wallet.data.api.models.DeviceType
+import com.vultisig.wallet.data.api.models.NotifyRequestJson
+import com.vultisig.wallet.data.api.models.RegisterDeviceRequestJson
+import com.vultisig.wallet.data.api.models.UnregisterDeviceRequestJson
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+
+interface NotificationRepository {
+    suspend fun registerDevice(vaultId: String, partyName: String)
+
+    suspend fun unregisterDevice(vaultId: String, partyName: String)
+
+    suspend fun isVaultRegistered(vaultId: String): Boolean
+
+    suspend fun notifyParties(
+        vaultId: String,
+        vaultName: String,
+        localPartyId: String,
+        qrCodeData: String,
+    )
+}
+
+internal class NotificationRepositoryImpl
+@Inject
+constructor(
+    private val notificationApi: NotificationApi,
+    private val notificationTokenRepository: NotificationTokenRepository,
+) : NotificationRepository {
+
+    override suspend fun registerDevice(vaultId: String, partyName: String) {
+        val token = notificationTokenRepository.token.firstOrNull() ?: return
+        notificationApi.register(
+            RegisterDeviceRequestJson(
+                vaultId = vaultId,
+                partyName = partyName,
+                token = token,
+                deviceType = DeviceType.Android,
+            )
+        )
+    }
+
+    override suspend fun unregisterDevice(vaultId: String, partyName: String) {
+        val token = notificationTokenRepository.token.firstOrNull()
+        notificationApi.unregister(
+            UnregisterDeviceRequestJson(vaultId = vaultId, partyName = partyName, token = token)
+        )
+    }
+
+    override suspend fun isVaultRegistered(vaultId: String): Boolean =
+        notificationApi.isVaultRegistered(vaultId)
+
+    override suspend fun notifyParties(
+        vaultId: String,
+        vaultName: String,
+        localPartyId: String,
+        qrCodeData: String,
+    ) {
+        notificationApi.notify(
+            NotifyRequestJson(
+                vaultId = vaultId,
+                vaultName = vaultName,
+                localPartyId = localPartyId,
+                qrCodeData = qrCodeData,
+            )
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -235,6 +235,10 @@ internal interface RepositoriesModule {
     fun bindNotificationTokenRepository(
         impl: NotificationTokenRepositoryImpl
     ): NotificationTokenRepository
+
+    @Binds
+    @Singleton
+    fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
 }
 
 @Qualifier @Retention(AnnotationRetention.BINARY) annotation class PrettyJson


### PR DESCRIPTION
## Summary
- Add `NotificationApi` interface + `NotificationApiImpl` that communicates with `api.vultisig.com/notification` (register, unregister, vault status check, notify)
- Add `NotifyRequestJson`, `RegisterDeviceRequestJson`, `UnregisterDeviceRequestJson`, `DeviceType` serializable models in `NotificationJson.kt`
- Add `NotificationRepository` interface + `NotificationRepositoryImpl` that combines `NotificationApi` with the existing `NotificationTokenRepository` (FCM token storage)
- Add `VULTISIG_NOTIFICATION_URL` constant to `Endpoints`
- Wire both new types into `ApiModule` and `RepositoriesModule` via `@Binds @Singleton`

## Test Plan
- [x] `./gradlew :data:compileDebugKotlin` — compiles without errors
- [x] `./gradlew lint` — lint passes
- [ ] Inject `NotificationRepository` into a ViewModel and call `registerDevice(vault.pubKeyECDSA, vault.localPartyID)` after vault creation; confirm `POST /register` reaches the backend with correct payload (logcat + network inspector)
- [ ] Call `notifyParties(...)` and confirm `POST /notify` is delivered to other signers

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device notification management capabilities enabling registration and management of notification devices.
  * Added vault registration status verification.
  * Added notification delivery system for collaborative transaction updates.

* **Chores**
  * Removed verbose logging from Firebase messaging service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->