### PR TITLE
fix: deduplicate push notifications in keysign flow

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -394,7 +394,6 @@ constructor(
         if (uiState.value.resendCooldownSeconds > 0) return
         val currentQrData = _keysignMessage.value
         if (currentQrData == lastNotifiedQrData) return
-        lastNotifiedQrData = currentQrData
         viewModelScope.safeLaunch(
             onError = {
                 snackbarFlow.showMessage(
@@ -404,7 +403,8 @@ constructor(
             }
         ) {
             val vault = _currentVault ?: return@safeLaunch
-            pushNotificationManager.notifyVaultDevices(vault, _keysignMessage.value)
+            pushNotificationManager.notifyVaultDevices(vault, currentQrData)
+            lastNotifiedQrData = currentQrData
             snackbarFlow.showMessage(
                 message = context.getString(R.string.push_notifications_sent),
                 type = SnackbarType.Success,


### PR DESCRIPTION
 ## Summary
  - Add `lastNotifiedQrData` field to track the last notified QR payload
  - Skip sending push notifications when QR data hasn't changed, preventing
    duplicates from rapid programmatic calls to `updateKeysignPayload()`
  - Reset `lastNotifiedQrData` when cooldown expires so manual resend still works
  - Increase resend cooldown from 30s → 60s to match iOS implementation

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3304

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- Agent-authored PRs: fill in the section below -->
<!-- Human-authored PRs: delete this section -->

## Agent Metadata (if applicable)
- **Agent**: <!-- e.g. Claude Code, OpenClaw -->
- **Issue**: <!-- #number -->
- **Confidence**: <!-- high / medium / low -->
- **Needs human review for**: <!-- e.g. "TSS logic", "migration", "none" -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate notifications for the same QR signing request by tracking the last-notified QR payload.
  * Extended resend cooldown period from 30 to 60 seconds to reduce repeated alerts.
  * After the cooldown ends, the tracked QR payload is cleared so new identical requests can notify again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->