### PR TITLE
fix: correct icon size and spacing in TransactionTypeButton (#3322)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -3,7 +3,12 @@ package com.vultisig.wallet.debug
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
@@ -12,6 +17,8 @@ import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
+import com.vultisig.wallet.ui.screens.v2.home.components.TransactionType
+import com.vultisig.wallet.ui.screens.v2.home.components.TransactionTypeButton
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 
 class PreviewActivity : ComponentActivity() {
@@ -22,10 +29,21 @@ class PreviewActivity : ComponentActivity() {
             OnBoardingComposeTheme {
                 when (screen) {
                     "swap_confirm" -> SwapConfirmPreview()
+                    "transaction_type_button" -> TransactionTypeButtonPreview()
                     else -> SwapConfirmPreview()
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun TransactionTypeButtonPreview() {
+    Row(horizontalArrangement = Arrangement.spacedBy(16.dp), modifier = Modifier.padding(24.dp)) {
+        TransactionTypeButton(txType = TransactionType.SWAP, isSelected = true)
+        TransactionTypeButton(txType = TransactionType.SEND, isSelected = false)
+        TransactionTypeButton(txType = TransactionType.RECEIVE, isSelected = false)
+        TransactionTypeButton(txType = TransactionType.BUY, isSelected = false)
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
@@ -70,10 +70,10 @@ fun TransactionTypeButton(
                     .background(backgroundColor),
             contentAlignment = Alignment.Center,
         ) {
-            UiIcon(drawableResId = logo, size = 24.dp, tint = Theme.v2.colors.text.primary)
+            UiIcon(drawableResId = logo, size = 20.dp, tint = Theme.v2.colors.text.primary)
         }
 
-        UiSpacer(4.dp)
+        UiSpacer(8.dp)
 
         Text(
             text = stringResource(title),


### PR DESCRIPTION
## Summary
- Fix icon size inside `TransactionTypeButton` from 24dp → 20dp to match Figma spec
- Fix gap between icon container and label from 4dp → 8dp to match Figma spec
- Add `transaction_type_button` preview case to `PreviewActivity` for future ADB screenshot captures

Fixes #3322

## Test plan
- [ ] Build and install debug APK
- [ ] Navigate to Chain Detail or Token Detail page and verify Swap/Send/Receive/Buy buttons look correct
- [ ] Optionally capture preview via `adb shell am start -n com.vultisig.wallet/.debug.PreviewActivity --es screen "transaction_type_button"` and compare against Figma [node 49057:159311](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-159311)

> ⚠️ No emulator was available during implementation — please verify visually on device. Adding `needs-visual-review` label recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined TransactionTypeButton visual appearance with improved icon sizing and spacing for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->