### PR TITLE
fix: banner close button opacity 20% → 5% (Figma)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -20,6 +20,8 @@ import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
 import com.vultisig.wallet.ui.screens.v2.home.components.CameraButton
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionType
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionTypeButton
+import com.vultisig.wallet.ui.screens.v2.home.pager.banner.UpgradeBanner
+import com.vultisig.wallet.ui.screens.v2.home.pager.container.HomePagePagerContainer
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 
 class PreviewActivity : ComponentActivity() {
@@ -32,6 +34,7 @@ class PreviewActivity : ComponentActivity() {
                     "swap_confirm" -> SwapConfirmPreview()
                     "transaction_type_button" -> TransactionTypeButtonPreview()
                     "camera_button" -> CameraButton(onClick = {})
+                    "banner" -> BannerPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -47,6 +50,11 @@ private fun TransactionTypeButtonPreview() {
         TransactionTypeButton(txType = TransactionType.RECEIVE, isSelected = false)
         TransactionTypeButton(txType = TransactionType.BUY, isSelected = false)
     }
+}
+
+@Composable
+private fun BannerPreview() {
+    HomePagePagerContainer { UpgradeBanner {} }
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/container/HomePagePagerContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/container/HomePagePagerContainer.kt
@@ -36,9 +36,9 @@ internal fun HomePagePagerContainer(
                 size = VsCircleButtonSize.Custom(size = 40.dp),
                 type =
                     VsCircleButtonType.Custom(
-                        color = Theme.v2.colors.neutrals.n100.copy(alpha = 0.2f)
+                        color = Theme.v2.colors.neutrals.n100.copy(alpha = 0.05f)
                     ),
-                modifier = Modifier.align(alignment = Alignment.TopEnd).padding(all = 8.dp),
+                modifier = Modifier.align(alignment = Alignment.TopEnd).padding(all = 7.dp),
             )
         }
     }


### PR DESCRIPTION
## Summary
- Reduced banner close button background opacity from `0.2f` to `0.05f` to match Figma spec (`rgba(255,255,255,0.05)`)
- Adjusted padding from 8dp to 7dp per Figma design
- Added banner preview to PreviewActivity

Fixes #3509

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/1LRTnyW.png) | ![after](https://i.imgur.com/vHXl4GL.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify banner close button is barely visible (5% opacity) on home screen
- [ ] Verify close button still functions correctly when tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a banner preview to the app preview tooling so the new upgrade banner can be inspected.

* **Style**
  * Refined home-page button visuals with reduced highlight opacity and slightly adjusted spacing for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->