### PR TITLE
fix: camera button size 64dp → 62dp, icon 20dp → 24dp

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -17,6 +17,7 @@ import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
+import com.vultisig.wallet.ui.screens.v2.home.components.CameraButton
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionType
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionTypeButton
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
@@ -30,6 +31,7 @@ class PreviewActivity : ComponentActivity() {
                 when (screen) {
                     "swap_confirm" -> SwapConfirmPreview()
                     "transaction_type_button" -> TransactionTypeButtonPreview()
+                    "camera_button" -> CameraButton(onClick = {})
                     else -> SwapConfirmPreview()
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CameraButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CameraButton.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.v2.home.components
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
@@ -11,8 +12,9 @@ import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 internal fun CameraButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
     VsCircleButton(
         onClick = onClick,
-        icon = R.drawable.camera_2,
-        size = VsCircleButtonSize.Medium,
+        drawableResId = R.drawable.camera_2,
+        size = VsCircleButtonSize.Custom(62.dp),
+        iconSize = 24.dp,
         modifier = modifier,
     )
 }


### PR DESCRIPTION
## Summary
- Changed CameraButton size from `VsCircleButtonSize.Medium` (64dp) to `Custom(62.dp)` per Figma
- Changed icon size from 20dp to 24dp per Figma spec
- Added camera button preview to PreviewActivity

Fixes #3483

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/3CaIRXp.png) | ![after](https://i.imgur.com/QWqdeVN.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify camera button on home screen is 62dp diameter
- [ ] Verify camera icon inside is 24dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)