### PR TITLE
fix: staking/LP widget icon size 46dp → 48dp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -74,7 +74,7 @@ internal fun LpWidget(
             Image(
                 painter = painterResource(id = state.icon),
                 contentDescription = null,
-                modifier = Modifier.size(46.dp),
+                modifier = Modifier.size(48.dp),
             )
 
             UiSpacer(12.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
@@ -94,7 +94,7 @@ internal fun StakingWidget(
             Image(
                 painter = painterResource(id = getHeaderIcon(state.stakedAmountDisplay)),
                 contentDescription = null,
-                modifier = Modifier.size(46.dp),
+                modifier = Modifier.size(48.dp),
             )
 
             UiSpacer(12.dp)
@@ -254,7 +254,7 @@ internal fun StakingHeader(title: String, amount: String, icon: Int) {
         Image(
             painter = painterResource(id = icon),
             contentDescription = null,
-            modifier = Modifier.size(46.dp),
+            modifier = Modifier.size(48.dp),
         )
 
         UiSpacer(12.dp)


### PR DESCRIPTION
## Summary
- Changed StakingWidget coin icon from 46dp to 48dp
- Changed StakingHeader icon from 46dp to 48dp
- Changed LpWidget icon from 46dp to 48dp
- All three now match Figma spec of 48px

Fixes #3477

## Before / After

| Component | Before | After |
|-----------|--------|-------|
| StakingWidget icon | 46dp | 48dp |
| StakingHeader icon | 46dp | 48dp |
| LpWidget icon | 46dp | 48dp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=55295-176708

## Test plan
- [ ] Verify staking widget icon appears at 48dp on DeFi THORChain staked tab
- [ ] Verify LP widget icon appears at 48dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)