### PR TITLE
fix: hide balance button text 14sp → 12sp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/BalanceBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/BalanceBanner.kt
@@ -78,7 +78,7 @@ internal fun ToggleBalanceVisibilityButton(
                     if (isVisible) stringResource(R.string.hide_balance)
                     else stringResource(R.string.show_balance),
                 color = Theme.v2.colors.text.button.dim,
-                style = Theme.brockmann.button.medium.medium,
+                style = Theme.brockmann.supplementary.caption,
             )
         }
     }


### PR DESCRIPTION
## Summary
- Changed "Hide balance" / "Show balance" button text style from `button.medium.medium` (14sp/18sp) to `supplementary.caption` (12sp/16sp) matching Figma's Button/XS (Medium) spec

Fixes #3437

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Font size | 14sp | 12sp |
| Line height | 18sp | 16sp |
| Font weight | Medium | Medium |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify "Hide balance" / "Show balance" text is smaller (12sp) on home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)