### PR TITLE
fix: upgrade banner button text 14sp → 12sp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/UpgradeBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/UpgradeBanner.kt
@@ -44,7 +44,7 @@ internal fun UpgradeBanner(modifier: Modifier = Modifier, onUpgradeClick: () -> 
 
             Text(
                 text = stringResource(R.string.upgrade_banner_upgrade_now),
-                style = Theme.brockmann.button.medium.medium,
+                style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.backgrounds.primary,
                 modifier =
                     Modifier.clip(shape = CircleShape)


### PR DESCRIPTION
## Summary
- Changed "Upgrade now" button text style from `button.medium.medium` (14sp/18sp) to `supplementary.caption` (12sp/16sp) matching Figma's Button/XS (Medium) spec

Fixes #3516

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Font size | 14sp | 12sp |
| Line height | 18sp | 16sp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify "Upgrade now" button text is smaller (12sp) in the upgrade banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)