### PR TITLE
fix: lock icon 24dp → 32dp on KeysignPasswordScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
@@ -124,7 +124,7 @@ fun KeysignPasswordSheetContent(
 
         UiIcon(
             drawableResId = R.drawable.focus_lock,
-            size = 24.dp,
+            size = 32.dp,
             modifier = Modifier.align(alignment = Alignment.CenterHorizontally),
             tint = Theme.v2.colors.primary.accent4,
         )


### PR DESCRIPTION
## Summary
- Changed lock icon (IconFocusLock) size from 24dp to 32dp on the keysign password bottom sheet to match Figma

Fixes #3436

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Lock icon size | 24dp | 32dp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=57000-103683

## Test plan
- [ ] Verify lock icon on password entry screen is 32dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)