### PR TITLE
fix: AccountItem chain-to-address gap 4dp → 2dp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
@@ -67,7 +67,7 @@ internal fun AccountItem(
 
             CopiableAddress(
                 address = account.address,
-                modifier = Modifier.padding(top = 4.dp),
+                modifier = Modifier.padding(top = 2.dp),
                 onAddressCopied = onCopy,
             )
         }


### PR DESCRIPTION
## Summary
- Changed vertical gap between chain name and address in AccountItem from 4dp to 2dp per Figma

Fixes #3537

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Chain name → address gap | 4dp | 2dp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify account items on home screen show tighter spacing between chain name and address

🤖 Generated with [Claude Code](https://claude.com/claude-code)