### PR TITLE
fix: referral rewards icon 24dp → 20dp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -365,7 +365,7 @@ private fun ReferralRewardsBanner(rewards: String, isLoading: Boolean) {
         Column(modifier = Modifier.align(Alignment.CenterStart).padding(start = 16.dp)) {
             UiIcon(
                 drawableResId = R.drawable.ic_cup,
-                size = 24.dp,
+                size = 20.dp,
                 tint = Theme.v2.colors.primary.accent4,
             )
 


### PR DESCRIPTION
## Summary
- Changed trophy/cup icon size from 24dp to 20dp in the referral rewards banner per Figma

Fixes #3471

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Trophy icon size | 24dp | 20dp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=46203-87527

## Test plan
- [ ] Verify trophy icon in referral rewards banner is 20dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)