### PR TITLE
fix: TransactionTypeButton spacing 4dp → 8dp (Figma)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
@@ -73,7 +73,7 @@ fun TransactionTypeButton(
             UiIcon(drawableResId = logo, size = 24.dp, tint = Theme.v2.colors.text.primary)
         }
 
-        UiSpacer(4.dp)
+        UiSpacer(8.dp)
 
         Text(
             text = stringResource(title),


### PR DESCRIPTION
## Summary
- Changed gap between icon container and label text from 4dp to 8dp in TransactionTypeButton per Figma

Fixes #3364

## Before / After

| Property | Before | After |
|----------|--------|-------|
| Icon-to-label gap | 4dp | 8dp |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766

## Test plan
- [ ] Verify Swap/Buy/Send/Receive/Functions buttons on home screen have 8dp gap between icon and label

🤖 Generated with [Claude Code](https://claude.com/claude-code)