### PR TITLE
fix: TransactionTypeButton label color to match Figma (#3324)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TransactionTypeButton.kt
@@ -78,7 +78,7 @@ fun TransactionTypeButton(
 
         Text(
             text = stringResource(title),
-            color = Theme.v2.colors.text.primary,
+            color = Theme.v2.colors.text.secondary,
             style = Theme.brockmann.supplementary.caption,
         )
     }


### PR DESCRIPTION
## Summary
- Fix TransactionTypeButton label text color from `text.primary` (#F0F4FC) → `text.secondary` (#C9D6E8) to match Figma spec
- Closes #3324

## Test plan
- [ ] Open Chain Detail / Token Detail page
- [ ] Verify action button labels (Send, Swap, Receive, etc.) use the lighter secondary color (#C9D6E8)
- [ ] Compare against Figma node [49057:159311](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-159311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color in transaction type buttons for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->