### PR TITLE
fix: BalanceBanner height 140dp → 118dp per Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -65,7 +65,7 @@ internal fun BalanceBanner(
     Box(
         modifier =
             Modifier.fillMaxWidth()
-                .height(140.dp)
+                .height(118.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .border(
                     width = 1.dp,


### PR DESCRIPTION
## Summary
- Changed BalanceBanner height from 140dp to 118dp to match Figma spec (`h-[118px]`)

Fixes #3430

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/ZKvLTzU.png) | ![after](https://i.imgur.com/b14HNLy.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=50776-152900

## Test plan
- [ ] Verify BalanceBanner on THORChain DeFi screen is 118dp tall
- [ ] Verify BalanceBanner on Circle DeFi screen is 118dp tall
- [ ] Confirm banner content (title, balance text, value) still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the DeFi balance banner height for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->