### PR TITLE
fix: DeFi warning banner corner radius 16dp → 12dp per Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -432,12 +432,12 @@ internal fun DeFiWarningBanner(text: String, onClickClose: (() -> Unit)? = null)
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(RoundedCornerShape(12.dp))
                     .background(Theme.v2.colors.backgrounds.secondary)
                     .border(
                         width = 1.dp,
-                        color = Theme.v2.colors.border.normal,
-                        shape = RoundedCornerShape(16.dp),
+                        color = Theme.v2.colors.border.light,
+                        shape = RoundedCornerShape(12.dp),
                     )
                     .padding(
                         start = 16.dp,


### PR DESCRIPTION
## Summary
- Changed DeFiWarningBanner corner radius from 16dp to 12dp to match Figma (`rounded-[12px]`)
- Changed border color from `border.normal` to `border.light` to match Figma (`borders/light, #11284a`)

Fixes #3462

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/F9Tyod3.png) | ![after](https://i.imgur.com/WJH6GYm.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=58774-154528

## Test plan
- [ ] Verify DeFi warning banner on Circle DeFi screen has 12dp corner radius
- [ ] Verify border uses `border.light` color (#11284A)
- [ ] Confirm close button and text still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual design of the DeFi warning banner with adjusted corner radius and border styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->