### PR TITLE
fix: referral vault avatar size 20dp → 28dp per Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -422,7 +422,7 @@ fun VaultItem(name: String, onVaultClicked: () -> Unit) {
         SubcomposeAsyncImage(
             model = R.drawable.referral_vault_avatar,
             contentDescription = null,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(28.dp),
         )
 
         UiSpacer(12.dp)


### PR DESCRIPTION
## Summary
- Changed vault avatar icon size in ReferralViewScreen from 20dp to 28dp to match Figma spec (28x28dp)

Fixes #3468

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/2nC0oIs.png) | ![after](https://i.imgur.com/Xis4rOG.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=46203-87527

## Test plan
- [ ] Verify vault avatar in the referral vault selector row is 28dp
- [ ] Confirm vault name text and arrow icon still display correctly next to the avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)