### PR TITLE
fix: SecurityScannerBadget remove hardcoded 14.sp, use theme footnote

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/securityscanner/SecurityScannerBadget.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/securityscanner/SecurityScannerBadget.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.securityscanner.BLOCKAID_PROVIDER
 import com.vultisig.wallet.ui.models.TransactionScanStatus
@@ -51,7 +50,6 @@ internal fun SecurityScannerBadget(status: TransactionScanStatus) {
 
                 Text(
                     text = stringResource(R.string.security_scanner_transaction_scanning),
-                    fontSize = 14.sp,
                     style = Theme.brockmann.supplementary.footnote,
                     color = Theme.v2.colors.text.secondary,
                 )
@@ -89,7 +87,6 @@ private fun ScanStatusContentWithLogo(
 
     Text(
         text = message,
-        fontSize = 14.sp,
         style = Theme.brockmann.supplementary.footnote,
         color = Theme.v2.colors.text.secondary,
     )


### PR DESCRIPTION
## Summary
- Removed hardcoded `fontSize = 14.sp` from SecurityScannerBadget text components
- Now relies solely on `Theme.brockmann.supplementary.footnote` style (13sp per design tokens)
- The explicit fontSize was overriding the theme style, creating inconsistency with the design system

Fixes #3474

## Before / After

| Before (Verify Send) | After (Verify Send) |
|--------|-------|
| ![before](https://i.imgur.com/3CrdS5q.png) | ![after](https://i.imgur.com/rgT6f7k.png) |

| Before (Swap Confirm) | After (Swap Confirm) |
|--------|-------|
| ![before](https://i.imgur.com/q9mLaZE.png) | ![after](https://i.imgur.com/CluX1NN.png) |

## Figma Reference
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=39852-63861

## Test plan
- [ ] Verify "Transaction scanned by" text on Verify Send screen uses footnote style (13sp)
- [ ] Verify "Scanning..." text on loading state uses footnote style (13sp)
- [ ] Confirm text is still readable and properly aligned with icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)