### PR TITLE
fix: keysign password screen spacing per Figma (#3444)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
@@ -129,7 +129,7 @@ fun KeysignPasswordSheetContent(
             tint = Theme.v2.colors.primary.accent4,
         )
 
-        UiSpacer(size = 20.dp)
+        UiSpacer(size = 10.dp)
 
         if (title != null) {
             Text(
@@ -138,7 +138,7 @@ fun KeysignPasswordSheetContent(
                 style = Theme.brockmann.headings.title3,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             )
-            UiSpacer(20.dp)
+            UiSpacer(12.dp)
         }
 
         FadingHorizontalDivider()
@@ -223,7 +223,7 @@ fun KeysignPasswordSheetContent(
                 }
             }
 
-            UiSpacer(size = 12.dp)
+            UiSpacer(size = 10.dp)
         }
 
         VsButton(


### PR DESCRIPTION
## Summary
- Lock icon → title spacing: 20dp → 10dp
- Title → divider spacing: 20dp → 12dp
- Hint section → button spacing: 12dp → 10dp

Closes #3444

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/K9LCFEd.png) | ![After](https://i.imgur.com/Pr91rzY.png) |

## Test plan
- [ ] Open keysign password screen and verify spacing matches Figma
- [ ] Verify password hint toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized vertical spacing throughout the password entry screen for a more compact and visually refined interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->