### PR TITLE
fix: referral banner corner radius 16dp → 12dp (#3394)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -307,12 +307,12 @@ private fun FriendReferralBanner(onClick: () -> Unit) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(100.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .clickable { onClick() }
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = RoundedCornerShape(12.dp),
                 )
     ) {
         Image(
@@ -353,11 +353,11 @@ private fun ReferralRewardsBanner(rewards: String, isLoading: Boolean) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(110.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = RoundedCornerShape(12.dp),
                 )
     ) {
         SetBackgoundBanner(backgroundImageResId = R.drawable.referral_data_banner)


### PR DESCRIPTION
## Summary
- FriendReferralBanner corner radius: 16dp → 12dp
- ReferralRewardsBanner corner radius: 16dp → 12dp
- Matches the 12dp radius used by other cards on the screen

Closes #3394

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/pzVZAXg.png) | ![After](https://i.imgur.com/8vq4EXG.png) |

## Test plan
- [ ] Open referral view screen and verify banner corner radius matches Figma
- [ ] Verify both FriendReferralBanner and ReferralRewardsBanner look consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)