### PR TITLE
fix: backup vault title-to-description gap 32dp → 16dp (#3402)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
@@ -57,7 +57,7 @@ internal fun BackupVaultScreen(model: BackupVaultViewModel = hiltViewModel()) {
 }
 
 @Composable
-private fun BackupVaultScreen(title: String, isFastVault: Boolean, onBackupClick: () -> Unit) {
+internal fun BackupVaultScreen(title: String, isFastVault: Boolean, onBackupClick: () -> Unit) {
     var isNextEnabled by remember { mutableStateOf(false) }
     V3Scaffold(
         onBackClick = {},
@@ -87,7 +87,7 @@ private fun BackupVaultScreen(title: String, isFastVault: Boolean, onBackupClick
                     textAlign = TextAlign.Center,
                 )
 
-                UiSpacer(size = 32.dp)
+                UiSpacer(size = 16.dp)
 
                 Text(
                     text =


### PR DESCRIPTION
## Summary
- Title to description spacing: 32dp → 16dp to match Figma

Closes #3402

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/C7BxeUH.png) | ![After](https://i.imgur.com/V80C5A8.png) |

## Test plan
- [ ] Open backup vault screen and verify title-to-description gap matches Figma
- [ ] Verify both fast vault and regular vault variants look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)