### PR TITLE
fix: ConnectingToServer title-subtitle spacing 16dp → 12dp (#3425)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -734,7 +734,7 @@ internal fun ConnectingToServer(isSuccess: Boolean) {
             textAlign = TextAlign.Center,
         )
 
-        UiSpacer(16.dp)
+        UiSpacer(12.dp)
 
         Text(
             text = stringResource(R.string.keygen_connecting_with_server_take_a_second),


### PR DESCRIPTION
## Summary
- Title to subtitle spacing in ConnectingToServer: 16dp → 12dp to match Figma

Closes #3425

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/pKAnRoI.png) | ![After](https://i.imgur.com/Vl8vN7a.png) |

## Test plan
- [ ] Start keygen flow and verify ConnectingToServer screen spacing matches Figma
- [ ] Verify both success and loading states look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)