### PR TITLE
fix: biometrics screen font and color per Figma (#3420)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/biometrics/BiometricsEnableScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/biometrics/BiometricsEnableScreen.kt
@@ -88,8 +88,8 @@ private fun BiometricsEnableScreen(
             UiSpacer(16.dp)
             Text(
                 text = stringResource(id = R.string.vault_settings_biometrics_screen_description),
-                style = Theme.montserrat.body1,
-                color = Theme.v2.colors.neutrals.n50,
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.tertiary,
             )
             UiSpacer(8.dp)
             FormBasicSecureTextField(
@@ -119,8 +119,8 @@ private fun BiometricsEnableScreen(
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = uiModel.passwordHint.asString(),
-                    color = Theme.v2.colors.neutrals.n50,
-                    style = Theme.menlo.body2,
+                    color = Theme.v2.colors.text.tertiary,
+                    style = Theme.brockmann.supplementary.footnote,
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Description text: `Theme.montserrat.body1` → `Theme.brockmann.body.s.medium`, `neutrals.n50` → `text.tertiary`
- Password hint: `Theme.menlo.body2` → `Theme.brockmann.supplementary.footnote`, `neutrals.n50` → `text.tertiary`

Closes #3420

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/DHVnBTW.png) | ![After](https://i.imgur.com/RxmJVMx.png) |

## Test plan
- [ ] Open biometrics enable screen and verify font styles match Figma
- [ ] Verify description text and password hint use Brockmann font family
- [ ] Verify text colors use the theme's text.tertiary token

🤖 Generated with [Claude Code](https://claude.com/claude-code)