### PR TITLE
fix: remove paired sign long-hold from fast vault verify screens

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -38,7 +38,6 @@ import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
-import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
@@ -274,15 +273,8 @@ internal fun VerifyDepositScreen(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
             ) {
                 if (state.hasFastSign) {
-                    Text(
-                        text = stringResource(R.string.verify_deposit_hold_paired),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                        textAlign = TextAlign.Center,
-                    )
-                    VsHoldableButton(
+                    VsButton(
                         label = stringResource(R.string.verify_deposit_sign_transaction),
-                        onLongClick = onConfirm,
                         onClick = onFastSignClick,
                         modifier = Modifier.fillMaxWidth(),
                     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -36,7 +36,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsCheckField
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
-import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBadget
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBottomSheet
@@ -135,18 +134,11 @@ internal fun VerifySendScreen(
                     )
                 }
                 if (state.hasFastSign) {
-                    Text(
-                        text = stringResource(R.string.verify_deposit_hold_paired),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                        textAlign = TextAlign.Center,
-                    )
-                    VsHoldableButton(
+                    VsButton(
                         label = stringResource(R.string.verify_swap_sign_button),
-                        onLongClick = onConfirm,
                         onClick = onFastSignClick,
                         modifier = Modifier.fillMaxWidth(),
-                        enabled =
+                        state =
                             if (isConsentsEnabled && !state.hasAllConsents) {
                                 VsButtonState.Disabled
                             } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -53,7 +53,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsCheckField
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
-import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBadget
@@ -318,19 +317,11 @@ private fun VerifySwapScreen(
                 }
 
                 if (hasFastSign) {
-                    Text(
-                        text = stringResource(R.string.verify_deposit_hold_paired),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                        textAlign = TextAlign.Center,
-                    )
-
-                    VsHoldableButton(
+                    VsButton(
                         label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onFastSignClick,
-                        onLongClick = onConfirm,
-                        enabled =
+                        state =
                             if (isConsentsEnabled && !hasAllConsents) {
                                 VsButtonState.Disabled
                             } else {


### PR DESCRIPTION
## Description

Fast vaults use server-assisted signing (password/biometric → api.vultisig.com). The "Hold for paired sign" long-hold button on verify screens incorrectly routes to the QR/paired signing path, which hangs forever at "Waiting on devices..." since no second device will ever join.

### Root Cause

All three verify screens (Send, Deposit, Swap) render a `VsHoldableButton` for fast vaults with:
- `onClick = onFastSignClick` → correct fast sign path (password prompt)
- `onLongClick = onConfirm` → incorrect paired/QR sign path (dead end)

### Fix

Replace `VsHoldableButton` with a plain `VsButton` calling `onFastSignClick` for fast vaults. Remove the "Hold for paired sign" hint text. The long-hold / `joinKeySign()` path becomes unreachable for fast vaults.

Secure vault behavior is unchanged — they still use the existing `VsButton` with `onConfirm`.

## Risk

Low — only changes the fast vault branch of the if/else. Secure vault path untouched.

## Testing

### Engineering
- Verify Send, Deposit, and Swap screens show plain "Sign Transaction" button for fast vaults
- Verify tapping the button prompts for password/biometric and completes fast sign
- Verify secure vaults still show the correct signing flow

### Operations
- Test fast vault send flow end-to-end (amount → verify → sign → broadcast)
- Confirm no "Hold for paired sign" text appears for fast vaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Fast sign button interaction simplified from hold-and-press to single-click across deposit, send, and swap verification screens.
  * Removed descriptive hint text related to fast sign functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->