### PR TITLE
fix: use footnote text style in SwapTransactionOverview details

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -180,7 +180,7 @@ internal fun TextDetails(title: String, subtitle: String, showAllContent: Boolea
     Details(title = title, modifier = Modifier.padding(vertical = 12.dp)) {
         Text(
             text = subtitle,
-            style = Theme.brockmann.body.s.medium,
+            style = Theme.brockmann.supplementary.footnote,
             color = Theme.v2.colors.text.primary,
             overflow = if (showAllContent) TextOverflow.Visible else TextOverflow.MiddleEllipsis,
             textAlign = TextAlign.End,


### PR DESCRIPTION
## Summary
- Fixes #3507
- Changed `TextDetails` value text style from `body.s.medium` to `supplementary.footnote` in `SwapTransactionOverviewScreen.kt`
- This matches the `VerifySwapScreen` styling and the Figma design spec

## Test plan
- [ ] Open a swap transaction overview screen and verify detail text (From, To, Total Fees) uses the smaller footnote style
- [ ] Compare with VerifySwapScreen to confirm consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text styling in the swap transaction overview screen for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->