### PR TITLE
fix: replace hardcoded Banner border colors with theme tokens

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/Banner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/Banner.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -87,10 +86,12 @@ internal fun Banner(
                     width = 1.dp,
                     color =
                         when (variant) {
-                            BannerVariant.Warning -> Color(0x40FFC25C)
+                            BannerVariant.Warning ->
+                                Theme.v2.colors.alerts.warning.copy(alpha = 0.25f)
                             BannerVariant.Info -> Theme.v2.colors.border.light
-                            BannerVariant.Error -> Color(0x40FF5C5C)
-                            BannerVariant.Success -> Color(0x4013C89D)
+                            BannerVariant.Error -> Theme.v2.colors.alerts.error.copy(alpha = 0.25f)
+                            BannerVariant.Success ->
+                                Theme.v2.colors.alerts.success.copy(alpha = 0.25f)
                         },
                     shape = shape,
                 )


### PR DESCRIPTION
## Summary
- Replace hardcoded `Color(0x40...)` border colors in `Banner.kt` with `Theme.v2.colors.alerts.{warning,error,success}.copy(alpha = 0.25f)`
- Remove unused `Color` import
- Closes #3514

## Test plan
- [ ] Verify Warning, Error, and Success banners render with identical border colors as before
- [ ] Confirm no visual regression across screens using the Banner component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated banner styling to use consistent theme-based colors for warning, error, and success states, ensuring better visual alignment across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->