### PR TITLE
fix: replace legacy theme tokens in ScanQrScreen permission text

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -196,8 +196,8 @@ internal fun ScanQrScreen(
                         Text(
                             text = stringResource(R.string.camera_permission_denied),
                             textAlign = TextAlign.Center,
-                            color = Theme.v2.colors.neutrals.n100,
-                            style = Theme.montserrat.subtitle1,
+                            color = Theme.v2.colors.text.primary,
+                            style = Theme.brockmann.body.m.medium,
                             modifier = Modifier.fillMaxWidth(0.5f),
                         )
                     }


### PR DESCRIPTION
## Summary
- Fixes #3487
- Replaced `Theme.v2.colors.neutrals.n100` → `Theme.v2.colors.text.primary` for camera permission denied text color
- Replaced `Theme.montserrat.subtitle1` → `Theme.brockmann.body.m.medium` for text style
- Aligns ScanQrScreen with the app-wide Brockmann typography migration

## Test plan
- [ ] Deny camera permission and verify the "Camera permission denied" text displays correctly with updated styling
- [ ] Confirm text color and font match the Brockmann design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the visual styling of the camera permission denied message for improved readability and consistency with the app's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->