### PR TITLE
fix: CryptoConnectionSelect tab labels 12sp → 10sp (#3461)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CryptoConnectionSelect.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CryptoConnectionSelect.kt
@@ -165,7 +165,7 @@ private fun WalletEarnOption(
         UiIcon(drawableResId = icon, size = 24.dp, tint = contentColorAnimated)
         Text(
             text = text,
-            style = Theme.brockmann.supplementary.caption,
+            style = Theme.brockmann.supplementary.captionSmall,
             color = contentColorAnimated,
         )
     }


### PR DESCRIPTION
## Summary
- Change "Wallet" / "DeFi" tab label style from `supplementary.caption` (12sp) to `supplementary.captionSmall` (10sp) to match Figma spec
- Closes #3461

## Test plan
- [ ] Verify "Wallet" and "DeFi" tab labels on the home screen render at 10sp
- [ ] Confirm tab labels still align correctly within the bottom tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined text styling for wallet connection options to enhance visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->