### PR TITLE
fix: reduce tip icon size from 16dp to 12dp to match Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -132,7 +132,7 @@ private fun Tip() {
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.fillMaxWidth(),
     ) {
-        UiIcon(drawableResId = R.drawable.tip, size = 16.dp, tint = Theme.v2.colors.alerts.info)
+        UiIcon(drawableResId = R.drawable.tip, size = 12.dp, tint = Theme.v2.colors.alerts.info)
         UiSpacer(size = 8.dp)
         Text(
             text = stringResource(R.string.welcome_tip),


### PR DESCRIPTION
## Summary
- Fixes #3450
- Changed tip icon size in `ChooseDeviceCountScreen` from 16dp to 12dp to match Figma spec (node 62435:108602)

## Test plan
- [ ] Open the "Amount of Devices" screen during vault creation and verify the tip icon appears at 12dp size
- [ ] Confirm the tip row layout (icon + 8dp gap + text) looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined icon sizing in the onboarding interface to improve visual spacing and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->