### PR TITLE
fix: CryptoConnectionSelect background and blur to match Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CryptoConnectionSelect.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/CryptoConnectionSelect.kt
@@ -1,5 +1,8 @@
 package com.vultisig.wallet.ui.screens.v2.home.components
 
+import android.graphics.RenderEffect
+import android.graphics.Shader
+import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
@@ -23,9 +26,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,36 +57,38 @@ internal fun CryptoConnectionSelect(
     val isWalletSelected = activeType == CryptoConnectionType.Wallet
 
     LookaheadScope {
-        val c1 = Color(0xFF284570)
-        val c2 = Theme.v2.colors.backgrounds.secondary
-        Box(
-            modifier =
-                Modifier.clip(CircleShape)
-                    .background(
-                        brush = Brush.sweepGradient(colors = listOf(c2, c1, c1, c1, c2, c2))
-                    )
-                    .padding(1.dp)
-        ) {
+        Box(modifier = Modifier.clip(CircleShape).background(Color(0xFF061B3A)).padding(1.dp)) {
             Box(
                 modifier =
                     modifier
                         .height(64.dp)
                         .width(92.dp * availableCryptoTypes.size)
                         .clip(CircleShape)
-                        .background(Color(0xFF0d2446))
+                        .background(Color(0x99132E56))
+                        .then(
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                Modifier.graphicsLayer {
+                                    renderEffect =
+                                        RenderEffect.createBlurEffect(8f, 8f, Shader.TileMode.CLAMP)
+                                            .asComposeRenderEffect()
+                                }
+                            } else Modifier
+                        )
                         .padding(all = 4.dp)
             ) {
                 Box(
                     modifier =
                         Modifier.animatePlacementInScope(this@LookaheadScope)
                             .clip(CircleShape)
-                            .background(Color(0xFF1e3250))
-                            .shadow(
-                                elevation = 1.dp,
-                                shape = CircleShape,
-                                spotColor = Theme.v2.colors.neutrals.n100.copy(alpha = 0.2f),
-                                clip = true,
-                            )
+                            .background(Color.White.copy(alpha = 0.06f))
+                            .drawWithContent {
+                                drawContent()
+                                drawRoundRect(
+                                    color = Color.White.copy(alpha = 0.1f),
+                                    cornerRadius = CornerRadius(size.height / 2),
+                                    style = Stroke(width = 4.dp.toPx()),
+                                )
+                            }
                             .fillMaxHeight()
                             .fillMaxWidth(1f / availableCryptoTypes.size)
                             .align(


### PR DESCRIPTION
## Summary
- Replace sweep gradient border with solid `#061B3A` per Figma spec
- Change inner background from solid `#0D2446` to semi-transparent `rgba(19,46,86,0.6)` with backdrop blur (API 31+, graceful fallback)
- Change selected tab background from solid `#1E3250` to `White @ 6%` opacity
- Replace elevation shadow on selected tab with inner stroke glow (`White @ 10%` opacity)

Closes #3449

## Test plan
- [ ] Verify CryptoConnectionSelect renders correctly on API 31+ device (blur visible)
- [ ] Verify graceful fallback on API 26–30 (no blur, semi-transparent bg still applied)
- [ ] Verify selected tab indicator animates between Wallet/DeFi tabs
- [ ] Compare visually against Figma node `49057-161766`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the crypto connection selection component with modernized visual styling and updated background appearance for improved aesthetics. Visual effects have been refined with new platform-adaptive blur rendering capability now available for newer Android versions. Enhanced overall interface presentation provides a more contemporary and polished look with an improved visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->