### PR TITLE
fix: HeaderDeFiWidget icon size 36dp → 48dp to match Figma (#3435)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -501,7 +501,7 @@ internal fun HeaderDeFiWidget(
             Image(
                 painter = painterResource(id = iconRes),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(48.dp),
             )
 
             UiSpacer(12.dp)
@@ -581,7 +581,7 @@ internal fun HeaderDeFiWidget(
             Image(
                 painter = painterResource(id = iconRes),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(48.dp),
             )
 
             UiSpacer(12.dp)


### PR DESCRIPTION
## Summary
Fixes #3435

- Increased coin icon size in both `HeaderDeFiWidget` overloads from `36.dp` to `48.dp` to match Figma spec (node `50776:152904`)

## Figma Reference
[HeaderDeFiWidget](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=55295-176708)

## Changes
| Property | Before | After (Figma) |
|----------|--------|---------------|
| Coin icon size | 36dp | **48dp** |

## Before / After

> ⚠️ No emulator was available for real Android screenshots. Please verify visually on device.

### Text-based comparison
- `DeFiComponents.kt:504` — `Modifier.size(36.dp)` → `Modifier.size(48.dp)` (first overload)
- `DeFiComponents.kt:584` — `Modifier.size(36.dp)` → `Modifier.size(48.dp)` (second overload)

## Test Plan
- [ ] Visual comparison against Figma design on DeFi THORChain Bonded tab
- [ ] Visual comparison on Circle Deposited tab
- [ ] No regressions on adjacent DeFi screens
- [ ] Verify icon renders at 48x48dp on different screen densities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual prominence of icon elements within DeFi interface widgets, improving their visibility and overall presentation for better user interaction clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->