### PR TITLE
fix: add @ symbol to Follow banner button text

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -841,7 +841,7 @@
     <string name="send_tx_overview_add_to_address_book">Add to Address Book</string>
     <string name="invite_to_x_banner_title">Vultisig is building with you.</string>
     <string name="invite_to_x_banner_desc">Follow us on X</string>
-    <string name="invite_to_x_banner_button">Follow %s</string>
+    <string name="invite_to_x_banner_button">Follow @%s</string>
     <string name="home_defi_portfolio">DeFi Portfolio</string>
     <string name="home_page_no_chains_enabled">No chains enabled</string>
     <string name="home_page_no_chain_enabled_desc">You’ve disabled all chains. Make sure that at least one chain is enabled.</string>


### PR DESCRIPTION
## Description

Fixes the Follow banner button on the home screen to show `Follow @Vultisig` instead of `Follow Vultisig`, aligning Android with iOS and Extension.

**DRIFT-004** from the cross-platform drift audit.

## Changes

Single string change in `strings.xml`:
```
- Follow %s
+ Follow @%s
```

## Screenshots

### Before
Android shows "Follow Vultisig" while iOS and Extension both show "Follow @Vultisig":

![Before](https://litter.catbox.moe/0kzsq4.png)

### After
All three platforms now show "Follow @Vultisig":

![After](https://litter.catbox.moe/t10vw3.png)