### PR TITLE
fix: align string labels with iOS/Extension (DRIFT-006, 015, 017)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="send_error_insufficient_native_balance_with_fees">Insufficient %1$s balance</string>
     <string name="settings_screen_language">Language</string>
     <string name="settings_screen_currency">Currency</string>
-    <string name="settings_screen_share_the_app">Share The App</string>
+    <string name="settings_screen_share_the_app">Share the App</string>
     <string name="settings_screen_title">Settings</string>
     <string name="language_setting_screen_title">Language</string>
     <string name="currency_unit_setting_screen_title">Currency\n</string>
@@ -823,7 +823,7 @@
     <string name="chain_selection_no_chains_found">No chains found</string>
     <string name="chain_selection_key_import_warning">Due to technical limitations of key import and seed-based wallets, only pre-generated chains can be selected.</string>
     <string name="transaction_type_button_send">Send</string>
-    <string name="transaction_type_button_functions">Functions</string>
+    <string name="transaction_type_button_functions">Function</string>
     <string name="copy_address">Copy Address</string>
     <string name="chain_tokens_qr_receive_label">Receive %1$s</string>
     <string name="address_copied">%1$s address copied</string>
@@ -898,7 +898,7 @@
     <string name="vault_confirmation_well_done">Well done.</string>
     <string name="vault_confirmation_you_re_ready_to_use_a_new_wallet_standard">You’re ready to use a new wallet standard.</string>
     <string name="vault_detail_vault_info">Vault Info</string>
-    <string name="vault_details_keys">keys</string>
+    <string name="vault_details_keys">Keys</string>
     <string name="vault_password_biometeric_enable_biometrics_fast_signing">Enable Biometrics Fast Signing</string>
     <string name="verify_send_send_overview">Send overview</string>
     <string name="verify_swap_swap_overview">Swap overview</string>


### PR DESCRIPTION
## Description

Batch fix for 3 string consistency drifts identified in the cross-platform audit.

### DRIFT-006: "Functions" → "Function"
ETH detail action button — iOS and Extension use singular "Function", Android used plural.

### DRIFT-015: "Share The App" → "Share the App"
Settings screen — iOS uses "Share the App" (sentence case), Android had title case "The".

### DRIFT-017: "keys" → "Keys"
Vault Details — iOS and Extension capitalize "Keys", Android had lowercase.

## Changes

Single file: `strings.xml` — 3 string values updated.

## Screenshots

### DRIFT-006: ETH Detail — "Function" button

**Before** (Android shows "Functions", iOS/Extension show "Function"):
![Before](https://litter.catbox.moe/oa3phq.png)

**After** (all show "Function"):
![After](https://litter.catbox.moe/o1ybh0.png)

### DRIFT-015: Settings — "Share the App"

**Before** (Android shows "Share The App", iOS shows "Share the App"):
![Before](https://litter.catbox.moe/7nemh0.png)

**After** (all show "Share the App"):
![After](https://litter.catbox.moe/kk2npj.png)

### DRIFT-017: Vault Details — "Keys" section

**Before** (Android shows "keys" lowercase, iOS/Extension show "Keys"):
![Before](https://litter.catbox.moe/lkqscn.png)

**After** (all show "Keys"):
![After](https://litter.catbox.moe/2d07yy.png)