### PR TITLE
Fix OTP paste button alignment on FastVault verification

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultVerificationScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultVerificationScreen.kt
@@ -7,11 +7,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -133,7 +130,7 @@ private fun FastVaultVerificationScreen(
                 UiSpacer(32.dp)
 
                 Row(
-                    modifier = Modifier.height(IntrinsicSize.Min).fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement =
                         Arrangement.spacedBy(6.dp, alignment = Alignment.CenterHorizontally),
                     verticalAlignment = CenterVertically,
@@ -154,12 +151,10 @@ private fun FastVaultVerificationScreen(
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier =
-                            Modifier.fillMaxHeight()
-                                .background(
+                            Modifier.background(
                                     color = Theme.v2.colors.backgrounds.secondary,
                                     shape = CircleShape,
                                 )
-                                .padding(horizontal = 17.dp, vertical = 12.dp)
                                 .clickable(
                                     enabled = hasClipContent,
                                     onClick = {
@@ -167,7 +162,8 @@ private fun FastVaultVerificationScreen(
                                             onPasteClick(textToPaste.toString())
                                         }
                                     },
-                                ),
+                                )
+                                .padding(horizontal = 17.dp, vertical = 12.dp),
                     ) {
                         Text(
                             text = stringResource(R.string.vault_backup_screen_paste),


### PR DESCRIPTION
## Summary

Fixes the Paste button being visually misaligned with the OTP input field on the FastVault verification screen (#3588).

**Root cause:** The Paste button used `fillMaxHeight()` which stretched it vertically to match the OTP input boxes, making it unnaturally tall. Additionally, the `clickable` modifier was applied after `padding`, so only the text area was tappable instead of the full button.

**Fix:**
- Removed `fillMaxHeight()` so the button wraps its content and is vertically centered by the Row's `CenterVertically` alignment
- Reordered modifiers: `background` -> `clickable` -> `padding`, so the entire button area is tappable
- Removed unused `IntrinsicSize.Min` height constraint from the parent Row
- Cleaned up unused imports

## Test plan
- [ ] Open Fast Vault creation flow
- [ ] Navigate to OTP verification screen
- [ ] Verify the Paste button is vertically centered with the OTP input boxes
- [ ] Verify the Paste button has a natural height (not stretched)
- [ ] Verify tapping the full Paste button area works (not just the text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal layout code structure to improve maintainability. Visual appearance and user interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->