### PR TITLE
fix: migrate TransactionDoneScreen to Brockmann design system

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -125,8 +125,8 @@ private fun TxLinkAndHash(
                     if (isApproved) R.string.transaction_done_form_approve
                     else R.string.transaction_done_form_title
                 ),
-            color = Theme.v2.colors.neutrals.n50,
-            style = Theme.montserrat.heading5,
+            color = Theme.v2.colors.text.primary,
+            style = Theme.brockmann.headings.subtitle,
         )
 
         CopyIcon(textToCopy = transactionLink)
@@ -139,8 +139,8 @@ private fun TxLinkAndHash(
     }
     Text(
         text = transactionHash,
-        color = Theme.v2.colors.backgrounds.teal,
-        style = Theme.menlo.subtitle3,
+        color = Theme.v2.colors.text.primary,
+        style = Theme.brockmann.body.s.medium,
     )
 }
 
@@ -210,10 +210,10 @@ private fun TransactionDetail(transaction: TransactionDetailsUiModel?) {
                     withStyle(
                         style =
                             SpanStyle(
-                                color = Theme.v2.colors.neutrals.n100,
+                                color = Theme.v2.colors.text.tertiary,
                                 fontSize = 14.sp,
-                                fontFamily = Theme.montserrat.subtitle1.fontFamily,
-                                fontWeight = Theme.montserrat.subtitle1.fontWeight,
+                                fontFamily = Theme.brockmann.body.s.medium.fontFamily,
+                                fontWeight = Theme.brockmann.body.s.medium.fontWeight,
                             )
                     ) {
                         append(stringResource(R.string.verify_transaction_network_fee))
@@ -224,10 +224,10 @@ private fun TransactionDetail(transaction: TransactionDetailsUiModel?) {
                     withStyle(
                         style =
                             SpanStyle(
-                                color = Theme.v2.colors.neutrals.n100,
+                                color = Theme.v2.colors.text.primary,
                                 fontSize = 14.sp,
-                                fontFamily = Theme.montserrat.subtitle1.fontFamily,
-                                fontWeight = Theme.montserrat.subtitle1.fontWeight,
+                                fontFamily = Theme.brockmann.body.s.medium.fontFamily,
+                                fontWeight = Theme.brockmann.body.s.medium.fontWeight,
                             )
                     ) {
                         append(transaction.networkFeeTokenValue)
@@ -235,10 +235,10 @@ private fun TransactionDetail(transaction: TransactionDetailsUiModel?) {
                     withStyle(
                         style =
                             SpanStyle(
-                                color = Theme.v2.colors.neutrals.n400,
+                                color = Theme.v2.colors.text.tertiary,
                                 fontSize = 14.sp,
-                                fontFamily = Theme.montserrat.subtitle1.fontFamily,
-                                fontWeight = Theme.montserrat.subtitle1.fontWeight,
+                                fontFamily = Theme.brockmann.body.s.medium.fontFamily,
+                                fontWeight = Theme.brockmann.body.s.medium.fontWeight,
                             )
                     ) {
                         append(" (~${transaction.networkFeeFiatValue})")

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -344,14 +344,18 @@ internal fun VerifySendScreen(
 @Composable
 internal fun AddressField(title: String, address: String, divider: Boolean = true) {
     Column {
-        Text(text = title, color = Theme.v2.colors.neutrals.n100, style = Theme.montserrat.heading5)
+        Text(
+            text = title,
+            color = Theme.v2.colors.text.tertiary,
+            style = Theme.brockmann.headings.subtitle,
+        )
 
         UiSpacer(size = 16.dp)
 
         Text(
             text = address,
-            style = Theme.montserrat.subtitle3,
-            color = Theme.v2.colors.backgrounds.teal,
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.primary,
         )
 
         if (divider) {
@@ -371,8 +375,8 @@ internal fun OtherField(title: String, value: String, divider: Boolean = true) {
         ) {
             Text(
                 text = title,
-                color = Theme.v2.colors.neutrals.n100,
-                style = Theme.montserrat.subtitle1,
+                color = Theme.v2.colors.text.tertiary,
+                style = Theme.brockmann.body.s.medium,
             )
 
             UiSpacer(weight = 1f)
@@ -381,8 +385,8 @@ internal fun OtherField(title: String, value: String, divider: Boolean = true) {
             Text(
                 text = value,
                 textAlign = TextAlign.End,
-                color = Theme.v2.colors.neutrals.n100,
-                style = Theme.menlo.subtitle1,
+                color = Theme.v2.colors.text.primary,
+                style = Theme.brockmann.body.s.medium,
             )
         }
 


### PR DESCRIPTION
## Summary
- Migrate `TransactionDoneScreen` and helper composables (`TxLinkAndHash`, `AddressField`, `OtherField`, `FormDetails`) from legacy Montserrat/Menlo fonts to Brockmann font family
- Replace old color tokens (`neutrals.n50/n100/n400`, `backgrounds.teal`) with v2 text tokens (`text.primary`, `text.tertiary`)
- Closes #3432

## Test plan
- [ ] Open a completed Send transaction → verify TransactionDoneScreen renders with correct Brockmann fonts and colors
- [ ] Verify transaction hash, address fields, and network fee all use updated typography
- [ ] Open a completed Deposit transaction → verify DepositTransactionDetail fields render correctly
- [ ] Open a completed SignMessage → verify CustomMessageDetail fields render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined text colors and typography styling on transaction confirmation and send verification screens for improved visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->