### PR TITLE
fix: migrate KeysignLoadingScreen to Brockmann and Rive

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.keysign
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -10,12 +11,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.library.UiCirclesLoader
+import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
@@ -27,11 +29,16 @@ internal fun KeysignLoadingScreen(text: String, modifier: Modifier = Modifier) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Text(text = text, color = Theme.v2.colors.neutrals.n50, style = Theme.menlo.subtitle1)
+        RiveAnimation(animation = R.raw.riv_connecting_with_server, modifier = Modifier.size(24.dp))
 
-        UiSpacer(size = 32.dp)
+        UiSpacer(size = 16.dp)
 
-        UiCirclesLoader()
+        Text(
+            text = text,
+            color = Theme.v2.colors.text.primary,
+            style = Theme.brockmann.headings.title2,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace legacy `Theme.menlo.subtitle1` with `Theme.brockmann.headings.title2`
- Replace `Theme.v2.colors.neutrals.n50` with `Theme.v2.colors.text.primary`
- Replace `UiCirclesLoader()` with `RiveAnimation(riv_connecting_with_server)` at 24dp
- Reorder layout: spinner above text with 16dp spacing (matching `VsSigningProgressIndicator` pattern)
- Closes #3422

## Test plan
- [ ] Trigger keysign flow → verify loading screen shows Rive spinner animation above text
- [ ] Verify text uses Brockmann font and correct color
- [ ] Verify center alignment on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced loading screen with improved animation and typography.
  * Optimized visual layout with better spacing and centered loading text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->