### PR TITLE
fix: correct border.light color to match Figma (#3405)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Colors.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Colors.kt
@@ -91,7 +91,7 @@ data class TextButton(
 
 data class Border(
     val normal: Color = Color(0xFF1B3F73),
-    val light: Color = Color(0xFF12284A),
+    val light: Color = Color(0xFF11284A),
     val extraLight: Color = Color(0xFF02122B),
     val primaryAccent4: Color = Color(0xFF4879FD),
     val disabled: Color = Color(0x992155DF),


### PR DESCRIPTION
## Summary
- Fix `Border.light` color from `#12284A` to `#11284A` to match the Figma `--borders/light` variable
- Resolves internal inconsistency where `Variables.bordersLight` already used the correct `#11284A` value

Closes #3405

## Test plan
- [ ] Verify borders on Homepage, Account List, and other screens using `border.light` render correctly
- [ ] Confirm no visual regression (difference is 1 in the red channel, extremely subtle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Style**
  * Updated the light theme border color in the app interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->