### PR TITLE
fix: correct disabled button colors to match Figma (#3401)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Colors.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Colors.kt
@@ -28,7 +28,7 @@ data class Buttons(
     val primary: Color = Color(0xFF33E6BF),
     val secondary: Color = Color(0xFF061B3A),
     val tertiary: Color = Color(0xFF2155DF),
-    val disabled: Color = Color(0xFF0B1A3A),
+    val disabled: Color = Color(0xFF0F1E36),
     val disabledError: Color = Color(0xFF501E1E),
     val ctaPrimary: Color = Color(0xFF0B4EFF),
     val ctaDisabled: Color = Color(0xFF23376D),
@@ -85,7 +85,7 @@ data class Text(
 data class TextButton(
     val dark: Color = Color(0xFF02122B),
     val primary: Color = Color(0xFFF0F4FC),
-    val disabled: Color = Color(0xFF718096),
+    val disabled: Color = Color(0xFF4D5F75),
     val dim: Color = Color(0xFF5180FC),
 )
 


### PR DESCRIPTION
## Summary
- Update `Buttons.disabled` from `#0B1A3A` to `#0F1E36` to match Figma `--buttons/disabled`
- Update `TextButton.disabled` from `#718096` to `#4D5F75` to match Figma `--text/button/disabled`

Closes #3401

## Test plan
- [ ] Verify disabled button background on VerifySendScreen matches Figma
- [ ] Verify disabled button text color matches Figma
- [ ] Check other screens with disabled buttons for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual appearance of disabled button states by updating color values for both button components and button text elements. These adjustments enhance visual clarity, distinction, and consistency across the entire interface, improving the overall design aesthetics and user experience of disabled interactive elements throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->