### PR TITLE
fix: resize BackupVaultScreen animation to match Figma (#3397)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/BackupVaultScreen.kt
@@ -70,7 +70,7 @@ internal fun BackupVaultScreen(title: String, isFastVault: Boolean, onBackupClic
 
                 RiveAnimation(
                     animation = R.raw.riv_backup_vault_splash,
-                    modifier = Modifier.size(width = 266.dp, height = 170.dp),
+                    modifier = Modifier.size(width = 340.dp, height = 240.dp),
                     fit = Fit.COVER,
                 )
 


### PR DESCRIPTION
## Summary
- Resize Rive animation area from 266x170dp to 340x240dp to match Figma spec

Closes #3397

## Test plan
- [ ] Verify BackupVaultScreen animation displays at the correct 340x240dp size
- [ ] Confirm animation fits properly without clipping on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enlarged the visual display element on the backup vault screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->