### PR TITLE
fix: remove third consent checkbox to match Figma (#3398)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -64,7 +64,6 @@ internal data class VerifyTransactionUiModel(
     val transaction: TransactionDetailsUiModel = TransactionDetailsUiModel(),
     val consentAddress: Boolean = false,
     val consentAmount: Boolean = false,
-    val consentDst: Boolean = false,
     val errorText: UiText? = null,
     val hasFastSign: Boolean = false,
     val functionSignature: String? = null,
@@ -74,7 +73,7 @@ internal data class VerifyTransactionUiModel(
     val isLoadingFees: Boolean = false,
 ) {
     val hasAllConsents: Boolean
-        get() = consentAddress && consentAmount && consentDst
+        get() = consentAddress && consentAmount
 }
 
 sealed class TransactionScanStatus {
@@ -179,10 +178,6 @@ constructor(
 
     fun checkConsentAmount(checked: Boolean) {
         viewModelScope.launch { uiState.update { it.copy(consentAmount = checked) } }
-    }
-
-    fun checkConsentDst(checked: Boolean) {
-        viewModelScope.launch { uiState.update { it.copy(consentDst = checked) } }
     }
 
     fun authFastSign() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -92,7 +92,6 @@ internal fun VerifySendScreen(viewModel: VerifyTransactionViewModel = hiltViewMo
         confirmTitle = stringResource(R.string.keysign_sign_transaction),
         onConsentAddress = viewModel::checkConsentAddress,
         onConsentAmount = viewModel::checkConsentAmount,
-        onConsentDst = viewModel::checkConsentDst,
         onConfirm = viewModel::joinKeySign,
         onBackClick = viewModel::back,
         onFastSignClick = viewModel::fastSign,
@@ -111,7 +110,6 @@ internal fun VerifySendScreen(
     onConfirm: () -> Unit,
     onConsentAddress: (Boolean) -> Unit = {},
     onConsentAmount: (Boolean) -> Unit = {},
-    onConsentDst: (Boolean) -> Unit = {},
     onBackClick: () -> Unit = {},
     onConfirmScanning: () -> Unit = {},
     onDismissScanning: () -> Unit = {},
@@ -328,12 +326,6 @@ internal fun VerifySendScreen(
                             isChecked = state.consentAmount,
                             onCheckedChange = onConsentAmount,
                         )
-
-                        VsCheckField(
-                            title = stringResource(R.string.verify_transaction_consent_correct_dst),
-                            isChecked = state.consentDst,
-                            onCheckedChange = onConsentDst,
-                        )
                     }
                 }
             }
@@ -425,7 +417,6 @@ private fun PreviewVerifySendScreen() {
         confirmTitle = stringResource(R.string.keysign_sign_transaction),
         onConsentAddress = {},
         onConsentAmount = {},
-        onConsentDst = {},
         onFastSignClick = {},
         onConfirm = {},
     )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -172,7 +172,6 @@
     <string name="keysign">Schlüsselzeichen</string>
     <string name="generating_key_screen_keygen_failed">Keygen fehlgeschlagen</string>
     <string name="bottom_warning_msg_keygen_error_screen">Behalten Sie die Geräte im selben WLAN-Netzwerk, korrigieren Sie den Tresor und koppeln Sie die Geräte.\nStellen Sie sicher, dass Vultisig auf keinem anderen Gerät ausgeführt wird.</string>
-    <string name="verify_transaction_consent_correct_dst">Ich sende nicht an einen Betrüger oder Hacker</string>
     <string name="naming_vault_screen_invalid_name">Ungültiger Name</string>
     <string name="rename_vault_invalid_name">Ungültiger Name</string>
     <string name="vault_name_too_long_error">Der Tresorname ist zu lang</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -130,7 +130,6 @@
     <string name="verify_transaction_join_keysign">Unirse a la firma de clave</string>
     <string name="verify_transaction_consent_address">Estoy enviando a la dirección correcta</string>
     <string name="verify_transaction_consent_amount">La cantidad es correcta</string>
-    <string name="verify_transaction_consent_correct_dst">No estoy enviando a una estafa ni a un hacker</string>
     <string name="verify_transaction_error_not_enough_consent">Por favor, revise todos los consentimientos</string>
     <string name="join_keysign_discovering_session_id">Descubriendo el ID de sesión</string>
     <string name="qr_address_screen_title">Dirección</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -173,7 +173,6 @@
     <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Keygen nije uspio</string>
     <string name="bottom_warning_msg_keygen_error_screen">Držite uređaje na istoj WiFi mreži, ispravite trezor i uparite uređaje.\nUvjerite se da nijedan drugi uređaj ne pokreće Vultisig.</string>
-    <string name="verify_transaction_consent_correct_dst">Ne šaljem prijevaru ili hakeru</string>
     <string name="naming_vault_screen_invalid_name">Nevažeći naziv</string>
     <string name="rename_vault_invalid_name">Nevažeći naziv</string>
     <string name="vault_name_too_long_error">Naziv trezora je predug</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -173,7 +173,6 @@
     <string name="keysign">Segno chiave</string>
     <string name="generating_key_screen_keygen_failed">Keygen non riuscito</string>
     <string name="bottom_warning_msg_keygen_error_screen">Mantieni i dispositivi sulla stessa rete WiFi, correggi il vault e associa i dispositivi.\nAssicurati che nessun altro dispositivo stia eseguendo Vultisig.</string>
-    <string name="verify_transaction_consent_correct_dst">Non sto inviando a una truffa o a un hacker</string>
     <string name="naming_vault_screen_invalid_name">Nome non valido</string>
     <string name="rename_vault_invalid_name">Nome non valido</string>
     <string name="vault_name_too_long_error">Il nome del caveau è troppo lungo</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -129,7 +129,6 @@
     <string name="verify_transaction_join_keysign">Doe mee met Keysign</string>
     <string name="verify_transaction_consent_address">Ik stuur naar het juiste adres</string>
     <string name="verify_transaction_consent_amount">Het bedrag is correct</string>
-    <string name="verify_transaction_consent_correct_dst">Ik stuur niet naar een oplichter of hacker</string>
     <string name="verify_transaction_error_not_enough_consent">Controleer alle toestemmingen</string>
     <string name="camera_permission_denied">Cameratoestemming niet verleend. Schakel deze in de instellingen in.</string>
     <string name="join_keysign_discovering_session_id">Sessienummer ontdekken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -172,7 +172,6 @@
     <string name="keysign">Sinal de chave</string>
     <string name="generating_key_screen_keygen_failed">Falha na geração de chaves</string>
     <string name="bottom_warning_msg_keygen_error_screen">Mantenha os dispositivos na mesma rede WiFi, corrija o cofre e pareie os dispositivos.\nCertifique-se de que nenhum outro dispositivo esteja executando o Vultisig.</string>
-    <string name="verify_transaction_consent_correct_dst">Não estou enviando para um golpe ou hacker</string>
     <string name="naming_vault_screen_invalid_name">Nome inválido</string>
     <string name="rename_vault_invalid_name">Nome inválido</string>
     <string name="vault_name_too_long_error">O nome do cofre é muito longo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -129,7 +129,6 @@
     <string name="verify_transaction_join_keysign">Присоединиться к ключевой подписи</string>
     <string name="verify_transaction_consent_address">Я отправляю на правильный адрес</string>
     <string name="verify_transaction_consent_amount">Сумма верна</string>
-    <string name="verify_transaction_consent_correct_dst">Я не отправляю мошеннику или хакеру</string>
     <string name="verify_transaction_error_not_enough_consent">Пожалуйста, проверьте все согласия</string>
     <string name="camera_permission_denied">Разрешение на камеру не предоставлено. Пожалуйста, включите его в настройках.</string>
     <string name="join_keysign_discovering_session_id">Обнаружение ID сессии</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -219,7 +219,6 @@
     <string name="verify_transaction_join_keysign">加入密钥签名</string>
     <string name="verify_transaction_consent_address">我正在发送到正确的地址</string>
     <string name="verify_transaction_consent_amount">金额正确</string>
-    <string name="verify_transaction_consent_correct_dst">我没有发送给诈骗者或黑客</string>
     <string name="verify_transaction_error_not_enough_consent">请检查所有同意项</string>
 
     <!-- Camera & QR -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,7 +193,6 @@
     <string name="verify_transaction_join_keysign">Join Keysign</string>
     <string name="verify_transaction_consent_address">I’m sending to the right address</string>
     <string name="verify_transaction_consent_amount">The amount is correct</string>
-    <string name="verify_transaction_consent_correct_dst">I’m not sending to a scam or hacker</string>
     <string name="verify_transaction_error_not_enough_consent">Please check all consents</string>
     <string name="camera_permission_denied">Camera permission not granted. Please, enable it in the settings.</string>
     <string name="join_keysign_discovering_session_id">Discovering Session ID</string>


### PR DESCRIPTION
## Summary
- Remove the third consent checkbox (`consentDst` — "I'm not sending to a scam or hacker") from VerifySendScreen to match Figma design which shows only 2 checkboxes
- Remove `consentDst` state property, `checkConsentDst()` callback, and update `hasAllConsents` in VerifyTransactionViewModel
- Delete `verify_transaction_consent_correct_dst` string resource from all 9 locale files

Closes #3398

## Test plan
- [ ] Open Send flow → Verify Send screen and confirm only 2 checkboxes appear: "I'm sending to the right address" and "The amount is correct"
- [ ] Verify both checkboxes must be checked before the Sign button enables
- [ ] Complete a send transaction end-to-end to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined transaction verification process by removing the destination validation consent requirement. Users will now only need to confirm the recipient address and transaction amount during verification.

* **Localization**
  * Updated translations across all supported languages to reflect the simplified verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->