### PR TITLE
fix: correct bodyS font weight to 550 to match Figma (#3392)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/theme/Typography.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/Typography.kt
@@ -478,7 +478,7 @@ internal data class SatoshiPriceTypography(
         ),
     val bodyS: TextStyle =
         TextStyle(
-            fontWeight = FontWeight.SemiBold,
+            fontWeight = FontWeight(550),
             fontSize = 14.sp,
             lineHeight = 20.sp,
             letterSpacing = (0.2).sp,


### PR DESCRIPTION
## Summary
- Change `bodyS` font weight from `FontWeight.SemiBold` (600) to `FontWeight(550)` in `Typography.kt` to match Figma spec
- Closes #3392

## Test plan
- [ ] Verify account list fiat amounts render correctly on home screen
- [ ] Check other screens using `bodyS` style (collapsed topbar balance, etc.)
- [ ] Compare font rendering against Figma design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted font weight for body text elements to refine visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->