### PR TITLE
fix: correct balance largeTitle font weight and letterSpacing (#3386)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/theme/Typography.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/Typography.kt
@@ -455,10 +455,10 @@ internal data class SatoshiTypography(val price: SatoshiPriceTypography = Satosh
 internal data class SatoshiPriceTypography(
     val largeTitle: TextStyle =
         TextStyle(
-            fontWeight = FontWeight.Medium,
+            fontWeight = FontWeight.Normal,
             fontSize = 34.sp,
             lineHeight = 37.sp,
-            letterSpacing = (-0.86).sp,
+            letterSpacing = (-0.68).sp,
             fontFamily = satoshiFontFamily,
         ),
     val title1: TextStyle =


### PR DESCRIPTION
## Summary
Fixes #3386

- Changed `largeTitle` font weight from `Medium` (500) to `Normal` (400) to match Figma
- Changed `largeTitle` letter spacing from `-0.86sp` to `-0.68sp` to match Figma

## Figma Reference
[Price/Large Title](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=49057-161766)

## Before / After

| Property | Before | After (Figma) |
|----------|--------|---------------|
| `fontWeight` | `Medium` (500) | `Normal` (400) |
| `letterSpacing` | `-0.86.sp` | `-0.68.sp` |

> ⚠️ Real Android screenshots could not be captured (no emulator available). Please verify visually on device.

## Test Plan
- [ ] Visual comparison of home screen balance text against Figma design
- [ ] Verify balance text appears lighter (Regular vs Medium weight)
- [ ] Check other screens using `satoshi.price.largeTitle` (BalanceBanner)
- [ ] No regressions on screens using `brockmann.headings.largeTitle` (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted large title typography styling with lighter font weight and modified letter spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->