### PR TITLE
fix: migrate DiscountTiersScreen to V2Scaffold (#3377)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -203,10 +203,7 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
 
         composable<Route.FAQSetting> { FaqSettingScreen(navController = navController) }
 
-        composable<Route.DiscountTiers> {
-            val vaultId = it.toRoute<Route.DiscountTiers>().vaultId
-            DiscountTiersScreen(navController = navController, vaultId = vaultId)
-        }
+        composable<Route.DiscountTiers> { DiscountTiersScreen() }
 
         composable<Route.LanguageSetting> { LanguageSettingScreen(navController = navController) }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -36,7 +35,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -44,7 +42,7 @@ import com.vultisig.wallet.ui.components.v2.buttons.DesignType
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
-import com.vultisig.wallet.ui.components.v2.topbar.V2Topbar
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.sharelink.TierDiscountBottomSheet
 import com.vultisig.wallet.ui.screens.v2.components.VsButton
 import com.vultisig.wallet.ui.theme.Theme
@@ -54,38 +52,26 @@ import java.text.NumberFormat
 import java.util.Locale
 
 @Composable
-internal fun DiscountTiersScreen(
-    navController: NavHostController,
-    vaultId: String,
-    model: DiscountTiersViewModel = hiltViewModel(),
-) {
+internal fun DiscountTiersScreen(model: DiscountTiersViewModel = hiltViewModel()) {
     val uriHandler = VsUriHandler()
     val state by model.state.collectAsState()
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.secondary),
-        topBar = {
-            V2Topbar(
-                title = stringResource(R.string.vault_settings_discounts),
-                onBackClick = { navController.popBackStack() },
-                actions = {
-                    VsCircleButton(
-                        icon = R.drawable.settings_globe,
-                        onClick = { uriHandler.openUri(VsAuxiliaryLinks.VULT_TOKEN_DOCS) },
-                        type = VsCircleButtonType.Secondary,
-                        designType = DesignType.Shined,
-                        size = VsCircleButtonSize.Small,
-                        hasBorder = false,
-                    )
-                },
+    V2Scaffold(
+        title = stringResource(R.string.vault_settings_discounts),
+        onBackClick = model::back,
+        actions = {
+            VsCircleButton(
+                icon = R.drawable.settings_globe,
+                onClick = { uriHandler.openUri(VsAuxiliaryLinks.VULT_TOKEN_DOCS) },
+                type = VsCircleButtonType.Secondary,
+                designType = DesignType.Shined,
+                size = VsCircleButtonSize.Small,
+                hasBorder = false,
             )
         },
     ) {
         Column(
-            modifier =
-                Modifier.padding(it)
-                    .padding(horizontal = 16.dp, vertical = 16.dp)
-                    .verticalScroll(rememberScrollState()),
+            modifier = Modifier.verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.Start,
         ) {
             Box(
@@ -174,7 +160,7 @@ internal fun DiscountTiersScreen(
             tier = state.tierClicked!!,
             onContinue = {
                 model.dismissBottomSheet()
-                model.navigateToSwaps(navController, vaultId)
+                model.navigateToSwaps()
             },
             onDismissRequest = { model.dismissBottomSheet() },
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersViewModel.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.ui.screens.settings
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.blockchain.TierRemoteNFTService
 import com.vultisig.wallet.data.models.Chain
@@ -19,7 +18,10 @@ import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.GOL
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.PLATINUM_TIER_THRESHOLD
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_TIER_THRESHOLD
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.ULTIMATE_TIER_THRESHOLD
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigInteger
 import javax.inject.Inject
@@ -51,6 +53,7 @@ constructor(
     private val tiersNFTRepository: TiersNFTRepository,
     private val remoteNFTService: TierRemoteNFTService,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val navigator: Navigator<Destination>,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -158,7 +161,11 @@ constructor(
         }
     }
 
-    fun navigateToSwaps(navController: NavHostController, vaultId: String) {
+    fun back() {
+        viewModelScope.launch { navigator.back() }
+    }
+
+    fun navigateToSwaps() {
         viewModelScope.launch {
             try {
                 val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
@@ -190,7 +197,7 @@ constructor(
                     }
                 }
 
-                navController.navigate(
+                navigator.route(
                     Route.Swap(
                         vaultId = vaultId,
                         chainId = Chain.Ethereum.id,
@@ -200,7 +207,7 @@ constructor(
                 )
             } catch (e: Exception) {
                 Timber.e(e, "Error preparing swap navigation")
-                navController.navigate(
+                navigator.route(
                     Route.Swap(
                         vaultId = vaultId,
                         chainId = Chain.Ethereum.id,


### PR DESCRIPTION
## Summary
- Replace legacy `Scaffold` + `V2Topbar` with `V2Scaffold` for consistent gradient background and standard toolbar
- Inject `Navigator<Destination>` into `DiscountTiersViewModel` and add `back()` method
- Refactor `navigateToSwaps()` to use `navigator.route()` instead of `navController.navigate()`
- Remove `navController` and `vaultId` parameters from `DiscountTiersScreen` composable
- Simplify `NavGraph.kt` registration to `DiscountTiersScreen()` with no arguments

Closes #3377

## Test plan
- [ ] Open Vault Settings → Discount Tiers screen and verify gradient background matches other screens
- [ ] Verify back button navigates correctly
- [ ] Verify globe icon opens VULT token docs URL
- [ ] Tap a tier → Unlock → verify bottom sheet appears and "Continue" navigates to Swap screen
- [ ] Expand/collapse tier cards still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal navigation architecture for the discount tiers feature, simplifying component dependencies and enhancing code maintainability through dependency injection patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->