### PR TITLE
fix: correct ChooseVaultButton padding to match Figma (#3369)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/ChooseVaultButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/ChooseVaultButton.kt
@@ -14,8 +14,8 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
-import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType.*
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType.*
+import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType.Bordered
+import com.vultisig.wallet.ui.components.v2.containers.ContainerType.SECONDARY
 import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.theme.Theme
@@ -34,7 +34,7 @@ internal fun ChooseVaultButton(
         type = SECONDARY,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             UiIcon(


### PR DESCRIPTION
## Summary
- Fix ChooseVaultButton internal padding from `14dp/12dp` to `12dp/8dp` to match the Figma design spec
- Clean up wildcard imports to explicit imports

Closes #3369

## Test plan
- [ ] Verify the vault selector pill on the home screen matches the Figma design
- [ ] Confirm the button is visually smaller/tighter than before
- [ ] Check that both fast vault (thunder icon) and standard vault (shield icon) variants render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing adjustments in the vault selection component for improved visual consistency and layout refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->