### PR TITLE
fix: adjust maxOtherDevices calculation to handle minimumDevices edge…

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -420,7 +420,9 @@ constructor(
                     val existingDevices = currentState.devices.toSet()
                     val newDevices = devices - existingDevices
 
-                    val maxOtherDevices = currentState.minimumDevices - 1
+                    val maxOtherDevices =
+                        if (currentState.minimumDevices > 1) currentState.minimumDevices - 1
+                        else currentState.minimumDevices
                     val remainingSlots = maxOtherDevices - currentState.selectedDevices.size
                     val devicesToAutoSelect = newDevices.take(remainingSlots.coerceAtLeast(0))
                     val selectedDevices = currentState.selectedDevices.toSet() + devicesToAutoSelect


### PR DESCRIPTION
… case

## Description

fastvault creation is broken , this PR is to fix it

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- Agent-authored PRs: fill in the section below -->
<!-- Human-authored PRs: delete this section -->

## Agent Metadata (if applicable)
- **Agent**: <!-- e.g. Claude Code, OpenClaw -->
- **Issue**: <!-- #number -->
- **Confidence**: <!-- high / medium / low -->
- **Needs human review for**: <!-- e.g. "TSS logic", "migration", "none" -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device auto-selection logic during participant discovery to correctly handle edge cases when the minimum device requirement is 1 or lower.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->