### PR TITLE
refactor: migrate SecurityScannerEnableScreen to V2Scaffold

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/security/SecurityScannerEnableScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/security/SecurityScannerEnableScreen.kt
@@ -3,8 +3,6 @@ package com.vultisig.wallet.ui.screens.vault_settings.components.security
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -16,10 +14,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.vultisig.wallet.R
-import com.vultisig.wallet.ui.components.TopBar
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsSwitch
 import com.vultisig.wallet.ui.components.securityscanner.SettingsSecurityScannerBottomSheet
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
@@ -31,7 +29,7 @@ internal fun SecurityScannerEnableScreen(
 
     SecurityScannerEnableScreen(
         uiModel = model,
-        navController = navController,
+        onNavigateBack = navController::navigateUp,
         onCheckChange = { viewModel.onCheckedChange(it) },
         onContinueAnyway = viewModel::onContinueSecurity,
         onGoBack = viewModel::onDismiss,
@@ -41,21 +39,16 @@ internal fun SecurityScannerEnableScreen(
 @Composable
 private fun SecurityScannerEnableScreen(
     uiModel: SecurityScannerEnableUiModel,
-    navController: NavController,
+    onNavigateBack: () -> Unit,
     onCheckChange: (Boolean) -> Unit = {},
     onGoBack: () -> Unit = {},
     onContinueAnyway: () -> Unit = {},
 ) {
-    Scaffold(
-        topBar = {
-            TopBar(
-                navController = navController,
-                centerText = stringResource(id = R.string.vault_settings_security_screen_title),
-                startIcon = R.drawable.ic_caret_left,
-            )
-        }
-    ) { padding ->
-        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+    V2Scaffold(
+        title = stringResource(id = R.string.vault_settings_security_screen_title),
+        onBackClick = onNavigateBack,
+    ) {
+        Column {
             Text(
                 text = stringResource(id = R.string.vault_settings_security_screen_title_switch),
                 style = Theme.brockmann.body.m.medium,


### PR DESCRIPTION
## Summary
- Replace legacy `Scaffold` + `TopBar` with `V2Scaffold` in `SecurityScannerEnableScreen`
- Remove `NavController` dependency from the inner composable, replaced with `onNavigateBack` lambda
- Toolbar now matches the style used by other settings sub-screens (back arrow + centered title)

Closes #3368

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Navigate to Settings → Security Scanner Enable screen and verify the toolbar renders correctly (back arrow + centered title)
- [ ] Verify back navigation works
- [ ] Compare toolbar appearance with other settings sub-screens (e.g., Notifications Settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal UI component structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->