### PR TITLE
fix: migrate ReshareStartScreen to V2 design system

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/reshare/ReshareStartViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/reshare/ReshareStartViewModel.kt
@@ -24,6 +24,10 @@ constructor(
 
     private val vaultId: String = savedStateHandle.toRoute<Route.ReshareStartScreen>().vaultId
 
+    fun back() {
+        viewModelScope.launch { navigator.navigate(Destination.Back) }
+    }
+
     fun start() {
         viewModelScope.launch {
             val vault = vaultRepository.get(vaultId) ?: error("Vault $vaultId does not exist")

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -219,7 +219,7 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
 
         dialog<Route.CustomToken> { CustomTokenScreen() }
 
-        composable<Route.ReshareStartScreen> { ReshareStartScreen(navController) }
+        composable<Route.ReshareStartScreen> { ReshareStartScreen() }
 
         composable<Route.BiometricsEnable> { BiometricsEnableScreen(navController) }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/reshare/ReshareStartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/reshare/ReshareStartScreen.kt
@@ -1,106 +1,72 @@
 package com.vultisig.wallet.ui.screens.reshare
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.GradientInfoCard
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
-import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.components.vultiGradient
 import com.vultisig.wallet.ui.models.reshare.ReshareStartViewModel
 import com.vultisig.wallet.ui.theme.Theme
-import com.vultisig.wallet.ui.theme.v2.V2.colors
 
 @Composable
-internal fun ReshareStartScreen(
-    navController: NavController,
-    model: ReshareStartViewModel = hiltViewModel(),
-) {
+internal fun ReshareStartScreen(model: ReshareStartViewModel = hiltViewModel()) {
 
     ReshareStartScreen(
+        onBackClick = model::back,
         onStartClick = model::start,
         onJoinClick = model::join,
-        navController = navController,
     )
 }
 
 @Composable
 private fun ReshareStartScreen(
-    navController: NavController,
+    onBackClick: () -> Unit,
     onStartClick: () -> Unit,
     onJoinClick: () -> Unit,
 ) {
-    Scaffold(
-        containerColor = colors.backgrounds.primary,
+    V2Scaffold(
+        title = stringResource(id = R.string.reshare_start_screen_title),
+        onBackClick = onBackClick,
         content = {
             Column(
-                modifier = Modifier.fillMaxSize().padding(top = 20.dp),
-                verticalArrangement = Arrangement.Top,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Box(modifier = Modifier.fillMaxWidth()) {
-                    IconButton(
-                        modifier = Modifier.align(Alignment.CenterStart),
-                        onClick = clickOnce(navController::popBackStack),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_caret_left),
-                            contentDescription = null,
-                            tint = colors.neutrals.n50,
-                        )
-                    }
-                    Image(
-                        modifier = Modifier.align(Alignment.Center),
-                        painter = painterResource(id = R.drawable.vultisig_icon_text),
-                        contentDescription = "Reshare Image",
-                    )
-                }
-            }
-            Column(
-                modifier = Modifier.fillMaxSize().padding(it).padding(horizontal = 16.dp),
+                modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
                     text = stringResource(id = R.string.reshare_start_screen_title),
-                    color = colors.neutrals.n50,
-                    style = Theme.montserrat.heading4,
+                    color = Theme.v2.colors.text.primary,
+                    style = Theme.brockmann.headings.title2,
                     textAlign = TextAlign.Center,
                 )
                 Text(
                     modifier = Modifier.padding(top = 16.dp),
                     text = stringResource(id = R.string.reshare_start_screen_body),
-                    color = colors.neutrals.n50,
-                    style = Theme.montserrat.body1,
+                    color = Theme.v2.colors.text.primary,
+                    style = Theme.brockmann.body.s.medium,
                     textAlign = TextAlign.Center,
                 )
             }
             Column(
-                modifier = Modifier.fillMaxSize().imePadding().padding(horizontal = 16.dp),
+                modifier = Modifier.fillMaxSize().imePadding(),
                 verticalArrangement = Arrangement.Bottom,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -116,22 +82,6 @@ private fun ReshareStartScreen(
                 )
 
                 UiSpacer(size = 12.dp)
-
-                /* fast&active vaults are temporarily disabled
-                MultiColorButton(
-                    text = stringResource(R.string.reshare_start_start_with_vultisigner_button),
-                    backgroundColor = colors.backgrounds.primary,
-                    textColor = colors.turquoise800,
-                    iconColor = colors.backgrounds.primary,
-                    borderSize = 1.dp,
-                    textStyle = Theme.montserrat.subtitle1,
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    onClick = onStartWithServerClick,
-                )
-
-                UiSpacer(size = 12.dp)
-                 */
 
                 VsButton(
                     label = stringResource(R.string.reshare_start_join_reshare_button),
@@ -149,5 +99,5 @@ private fun ReshareStartScreen(
 @Preview
 @Composable
 private fun PreviewReshareScreen() {
-    ReshareStartScreen(onStartClick = {}, onJoinClick = {}, navController = rememberNavController())
+    ReshareStartScreen(onBackClick = {}, onStartClick = {}, onJoinClick = {})
 }


### PR DESCRIPTION
## Summary
- Replace `Scaffold` + custom back button/logo header with `V2Scaffold` and Brockmann toolbar
- Replace `Theme.montserrat.heading4` with `Theme.brockmann.headings.title2`
- Replace `Theme.montserrat.body1` with `Theme.brockmann.body.s.medium`
- Replace `colors.neutrals.n50` with `Theme.v2.colors.text.primary`
- Remove `navController` dependency, use ViewModel-based navigation via `back()`
- Remove commented-out dead code (fast & active vaults block)

Closes #3357

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug` passes)
- [ ] Navigate to Reshare Start screen from Vault Settings
- [ ] Back button navigates back correctly
- [ ] "Start Reshare" button initiates reshare flow
- [ ] "Join Reshare" button opens QR scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced reshare screen navigation architecture and component structure to reduce dependencies and improve modularity

* **Style**
  * Refreshed reshare screen visual design with updated theme colors, typography tokens, and layout spacing for consistency with the current design system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->