### PR TITLE
fix: match vault notification toggle row sizing to Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
@@ -141,13 +141,13 @@ private fun VaultNotificationToggle(
 ) {
     Column() {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             VaultIcon(
                 isFastVault = vault.isFastVault,
-                size = 20.dp,
+                size = 16.dp,
                 contentDescription = null,
                 modifier =
                     Modifier.border(


### PR DESCRIPTION
## Summary
- Change row vertical padding from 12dp to 16dp for correct 72dp row height
- Change VaultIcon size from 20dp to 16dp for correct 40dp container (16 + 12*2)

Closes #3354

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug` passes)
- [ ] Open Notifications Settings screen
- [ ] Verify vault toggle rows have correct height and icon sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **UI Layout Adjustments**
  * Fine-tuned spacing and icon sizing in the notifications settings screen for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->