### PR TITLE
fix: use tertiary text color for notification description (#3350)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
@@ -125,7 +125,7 @@ private fun MasterNotificationToggle(isChecked: Boolean, onToggle: (Boolean) -> 
                             .get_notified_when_your_signature_is_required_or_a_device_requests_access
                     ),
                 style = Theme.brockmann.supplementary.footnote,
-                color = Theme.v2.colors.text.primary,
+                color = Theme.v2.colors.text.tertiary,
             )
         }
         UiSpacer(size = 70.dp)


### PR DESCRIPTION
## Summary
- Change notification description text color from `text.primary` to `text.tertiary` in `NotificationsSettingsScreen.kt`
- Fixes visual hierarchy mismatch where the description was indistinct from the title

Closes #3350

## Test plan
- [ ] Open Settings → Notifications and verify the description text "Get notified when your signature is required..." appears in a subdued/tertiary color
- [ ] Verify the title "Push Notifications" still uses the primary text color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted text color in the Notifications Settings screen for improved visual hierarchy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->