### PR TITLE
fix: SOL to USDC swap fails with route not available (#3623)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -556,7 +556,9 @@ constructor(
                 Chain.Blast,
                 Chain.CronosChain -> setOf(SwapProvider.LIFI)
                 Chain.Solana ->
-                    setOf(SwapProvider.THORCHAIN, SwapProvider.JUPITER, SwapProvider.LIFI)
+                    if (isNativeToken)
+                        setOf(SwapProvider.THORCHAIN, SwapProvider.JUPITER, SwapProvider.LIFI)
+                    else setOf(SwapProvider.JUPITER, SwapProvider.LIFI)
 
                 Chain.Ripple -> setOf(SwapProvider.THORCHAIN)
                 Chain.Tron -> setOf(SwapProvider.THORCHAIN)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
@@ -1,0 +1,127 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SwapProvider
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SwapQuoteRepositoryTest {
+
+    private val repository =
+        SwapQuoteRepositoryImpl(
+            thorChainApi = mockk(),
+            mayaChainApi = mockk(),
+            oneInchApi = mockk(),
+            liFiChainApi = mockk(),
+            jupiterApi = mockk(),
+            kyberApi = mockk(),
+        )
+
+    private fun coin(
+        chain: Chain,
+        ticker: String,
+        contractAddress: String = "",
+        isNativeToken: Boolean = contractAddress.isEmpty(),
+    ) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = "",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contractAddress,
+            isNativeToken = isNativeToken,
+        )
+
+    @Test
+    fun `SOL to USDC resolves to JUPITER not THORCHAIN`() {
+        val sol = coin(Chain.Solana, "SOL")
+        val usdc =
+            coin(
+                Chain.Solana,
+                "USDC",
+                contractAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            )
+
+        val provider = repository.resolveProvider(sol, usdc)
+
+        assertNotNull(provider)
+        assertEquals(SwapProvider.JUPITER, provider)
+    }
+
+    @Test
+    fun `USDC to SOL resolves to JUPITER not THORCHAIN`() {
+        val sol = coin(Chain.Solana, "SOL")
+        val usdc =
+            coin(
+                Chain.Solana,
+                "USDC",
+                contractAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            )
+
+        val provider = repository.resolveProvider(usdc, sol)
+
+        assertNotNull(provider)
+        assertEquals(SwapProvider.JUPITER, provider)
+    }
+
+    @Test
+    fun `SOL to SOL cross-chain resolves to THORCHAIN`() {
+        val sol = coin(Chain.Solana, "SOL")
+        val btc = coin(Chain.Bitcoin, "BTC")
+
+        val provider = repository.resolveProvider(sol, btc)
+
+        assertNotNull(provider)
+        assertEquals(SwapProvider.THORCHAIN, provider)
+    }
+
+    @Test
+    fun `Solana USDC to ETH cross-chain resolves to LIFI`() {
+        val usdc =
+            coin(
+                Chain.Solana,
+                "USDC",
+                contractAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            )
+        val eth = coin(Chain.Ethereum, "ETH")
+
+        val provider = repository.resolveProvider(usdc, eth)
+
+        assertNotNull(provider)
+        assertEquals(SwapProvider.LIFI, provider)
+    }
+
+    @Test
+    fun `Solana SPL token gets JUPITER and LIFI but not THORCHAIN`() {
+        val usdt =
+            coin(
+                Chain.Solana,
+                "USDT",
+                contractAddress = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            )
+        val sol = coin(Chain.Solana, "SOL")
+
+        val provider = repository.resolveProvider(usdt, sol)
+
+        assertNotNull(provider)
+        assertTrue(provider == SwapProvider.JUPITER || provider == SwapProvider.LIFI)
+    }
+
+    @Test
+    fun `unsupported chain returns null`() {
+        val sui1 = coin(Chain.Sui, "SUI")
+        val sui2 = coin(Chain.Sui, "USDC", contractAddress = "0xabc")
+
+        val provider = repository.resolveProvider(sui1, sui2)
+
+        assertNull(provider)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3623

SOL to USDC swap on Solana fails with "swap route not available" because `resolveProvider` picks ThorChain as the first provider for all Solana tokens. ThorChain only supports native SOL on Solana and rejects SPL tokens like USDC.

Fixed by gating ThorChain behind `isNativeToken` for the Solana chain. Native SOL gets `{THORCHAIN, JUPITER, LIFI}` while SPL tokens (USDC, USDT etc.) get `{JUPITER, LIFI}`.

## Screenshots

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/abe25049-78ec-4361-a911-e5a8fac70f98" />


## Test plan

- [x] `./gradlew assembleDebug` succeeds
- [x] Unit tests cover SOL→USDC, USDC→SOL, SOL→BTC cross chain, Solana USDC→ETH cross chain, SPL token routing
- [x] Manually verified SOL→USDC swap route resolves on device



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified swap provider availability for Solana tokens: native tokens retain full provider access while non-native tokens now have restricted provider selection for improved performance.

* **Tests**
  * Added comprehensive test suite validating swap provider resolution across multiple token types, including cross-chain swap scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->