### PR TITLE
fix: match ChainTokensScreen top bar gradient to Figma (#3348)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/ExpandedTopbarContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/ExpandedTopbarContainer.kt
@@ -3,7 +3,9 @@ package com.vultisig.wallet.ui.components.v2.containers
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -55,11 +57,11 @@ internal fun ExpandedTopbarContainer(
 @Composable
 private fun ExpandedTopbarContainerPreview() {
     ExpandedTopbarContainer(
-        shineSpotColor = Color(0xFF0439C7).copy(alpha = 0.35f),
+        shineSpotColor = Theme.v2.colors.primary.accent2.copy(alpha = 0.35f),
         shineSpotCenterXRatio = 0.92f,
         shineSpotCenterYRatio = -0.15f,
         shineSpotRadiusRatio = 0.45f,
     ) {
-        // preview content
+        Spacer(modifier = Modifier.height(112.dp))
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -60,8 +59,6 @@ import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.KeyboardAware
 import com.vultisig.wallet.ui.utils.VsUriHandler
 import com.vultisig.wallet.ui.utils.showReviewPopUp
-
-private val ChainTokensTopbarShineColor = Color(0xFF0439C7).copy(alpha = 0.35f)
 
 @Composable
 internal fun ChainTokensScreen(
@@ -126,7 +123,7 @@ internal fun ChainTokensScreen(
         backgroundColor = Theme.v2.colors.backgrounds.primary,
         topBarExpandedContent = {
             ExpandedTopbarContainer(
-                shineSpotColor = ChainTokensTopbarShineColor,
+                shineSpotColor = Theme.v2.colors.primary.accent2.copy(alpha = 0.35f),
                 shineSpotCenterXRatio = 0.92f,
                 shineSpotCenterYRatio = -0.15f,
                 shineSpotRadiusRatio = 0.45f,


### PR DESCRIPTION
## Summary
- Add configurable `shineSpotCenterXRatio`, `shineSpotCenterYRatio`, and `shineSpotRadiusRatio` parameters to `ExpandedTopbarContainer` with backward-compatible defaults
- Customize `ChainTokensScreen` gradient to match Figma: top-right positioned ellipse (0.92, -0.15) with radius ratio 0.45 and color `rgba(4,57,199,0.35)`

Closes #3348

## Test plan
- [ ] Open any chain detail page and verify the top gradient glow appears at the upper-right corner (not center)
- [ ] Verify the gradient color is a subtle blue matching Figma specs
- [ ] Open the home vault screen and verify its top bar gradient is unchanged (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Topbar container now supports configurable gradient shine position and size via new optional parameters for flexible visual adjustments.
* **New Features**
  * Chain tokens screen applies a tailored shine color and specific shine position/size to the topbar for a more polished, consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->