### PR TITLE
fix: match TokenDetailScreen action button spacing to Figma (#3340)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -133,8 +133,8 @@ private fun TokenDetailsContent(
 
         Row(
             horizontalArrangement =
-                Arrangement.spacedBy(space = 12.dp, alignment = Alignment.CenterHorizontally),
-            modifier = Modifier.fillMaxWidth(),
+                Arrangement.spacedBy(space = 20.dp, alignment = Alignment.CenterHorizontally),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
         ) {
             if (uiModel.canSwap) {
                 TransactionTypeButton(


### PR DESCRIPTION
## Summary
- Update action button row spacing from 12dp to 20dp in `TokenDetailScreen`
- Add 24dp horizontal padding to the button row
- Matches Figma design spec (node 49057-160029)

Closes #3340

## Test plan
- [ ] Open Token Detail bottom sheet and verify action buttons (Swap, Buy, Send, Bridge) have correct spacing
- [ ] Compare visually against Figma design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the layout of transaction type buttons in the token details screen with adjusted spacing and padding for improved visual organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->