### PR TITLE
fix: show green validation border on vault name input

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
@@ -373,6 +373,7 @@ constructor(
                     validateNameInput()
                 } else {
                     nameErrorMessage.value = null
+                    nameInnerState.value = VsTextInputFieldInnerState.Default
                     uiState.update { currentState ->
                         currentState.copy(isNextButtonEnabled = false)
                     }
@@ -395,7 +396,7 @@ constructor(
             val isNextButtonEnabled = errorMessage == null
             nameInnerState.value =
                 if (errorMessage != null) VsTextInputFieldInnerState.Error
-                else VsTextInputFieldInnerState.Default
+                else VsTextInputFieldInnerState.Success
             nameErrorMessage.value = errorMessage
             uiState.update { it.copy(isNextButtonEnabled = isNextButtonEnabled) }
         }


### PR DESCRIPTION
## What

When the vault name is valid, the input field now shows a green success border (`VsTextInputFieldInnerState.Success`) matching iOS and Extension behavior. Previously it stayed at `Default` (gray) even when a valid name was entered.

## How

One line change in `EnterVaultInfoViewModel.validateNameInput()`:
```diff
- else VsTextInputFieldInnerState.Default
+ else VsTextInputFieldInnerState.Success
```

The `VsTextInputField` component already supports the `Success` inner state which maps to `Theme.v2.colors.alerts.success` (green). The ViewModel just wasn't using it for the name field, while the email field correctly did.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://files.catbox.moe/lmwha2.png) | ![after](https://files.catbox.moe/e5fjiv.png) |

Part of the Vultisig cross-platform drift audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual feedback for the vault name input: a success state is now shown when the entered name validates.
  * When the name is cleared, the input returns to its default visual state before progression is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->