### PR TITLE
ci: run lint as a fast-fail gate before build and tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,22 +13,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: gradle
-      
+
       - name: git submodule update
         run: git submodule update --init --recursive
-      
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run lint
+        env:
+          TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
+          TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
+        run: ./gradlew lint --no-daemon
+
+      - name: Archive lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Lint-Reports
+          path: |
+            app/build/reports/lint-results-debug.html
+            app/build/intermediates/lint_intermediate_text_report/debug/lintReportDebug/lint-results-debug.txt
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: git submodule update
+        run: git submodule update --init --recursive
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -36,8 +71,8 @@ jobs:
       - name: Free disk space
         run: |
           echo "Freeing disk space..."
-          sudo rm -rf /usr/share/dotnet || true                    
-          sudo rm -rf /usr/local/lib/nodejs || true  
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/nodejs || true
           sudo apt-get clean
           df -h
 
@@ -88,13 +123,3 @@ jobs:
           script: |
             # Run ALL instrumented tests
             ./gradlew app:connectedDebugAndroidTest --stacktrace
-
-      # Archive lint reports
-      - name: Archive code analysis reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Lint-Reports
-          path: |
-            app/build/reports/lint-results-debug.html
-            app/build/intermediates/lint_intermediate_text_report/debug/lintReportDebug/lint-results-debug.txt


### PR DESCRIPTION
## Summary
- Split lint into its own job that runs first
- `build-and-test` now has `needs: lint` so it only runs if lint passes
- Avoids spinning up the emulator on lint failures, saving CI time

## Test plan
- [ ] Verify lint job runs and fails fast on lint errors
- [ ] Verify build-and-test job is skipped when lint fails
- [ ] Verify both jobs pass on a clean branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)