### PR TITLE
fix: unregister BroadcastReceiver in KeysignFlowViewModel.onCleared

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -679,6 +679,11 @@ constructor(
 
     override fun onCleared() {
         cleanQrAddress()
+        try {
+            context.unregisterReceiver(serviceStartedReceiver)
+        } catch (_: IllegalArgumentException) {
+            // receiver was already unregistered or never registered
+        }
         stopService(context)
         super.onCleared()
     }


### PR DESCRIPTION
## Summary
- Unregister `serviceStartedReceiver` in `onCleared()` to prevent resource leak
- Wrapped in try-catch to handle already-unregistered case

## Test plan
- [ ] Verify keysign flow works normally
- [ ] Verify no `IntentReceiverLeaked` warnings in logcat after leaving keysign screen

Closes #3714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup handling during app shutdown to prevent potential errors and improve overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->