### PR TITLE
fix: log correct destination variable in Navigator

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigator.kt
@@ -52,7 +52,7 @@ internal class NavigatorImpl<Dst> @Inject constructor() : Navigator<Dst> {
     }
 
     override suspend fun navigate(dst: Dst, opts: NavigationOptions) {
-        Timber.d("navigate($destination, $opts)")
+        Timber.d("navigate($dst, $opts)")
         this.destination.emit(NavigateAction(dst, opts))
     }
 }


### PR DESCRIPTION
## Summary
- Fix `Timber.d` call in `Navigator.navigate(dst, opts)` to log the `dst` parameter instead of the `destination` MutableSharedFlow field

## Test plan
- [ ] Verify navigation debug logs show actual route names instead of MutableSharedFlow object representation

Closes #3721

🤖 Generated with [Claude Code](https://claude.com/claude-code)