### PR TITLE
fix: localize hardcoded Overview title on TransactionDoneScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -55,7 +55,7 @@ internal fun TransactionDoneView(
         applyScaffoldPaddings = true,
         topBar = {
             if (showToolbar) {
-                VsTopAppBar(title = "Overview")
+                VsTopAppBar(title = stringResource(R.string.transaction_done_overview))
             }
         },
         content = {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,6 +108,7 @@
     <string name="verify_transaction_consent_address">Ich sende an die richtige Adresse</string>
     <string name="verify_transaction_consent_amount">Die Menge ist korrekt</string>
     <string name="transaction_done_title">Fertig</string>
+    <string name="transaction_done_overview">Übersicht</string>
     <string name="transaction_done_complete">Fortfahren</string>
     <string name="transaction_done_form_title">Transaktion</string>
     <string name="import_file_screen_title">Importieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -129,6 +129,7 @@
     <string name="verify_transaction_error_not_enough_consent">Por favor, revise todos los consentimientos</string>
     <string name="join_keysign_discovering_session_id">Descubriendo el ID de sesión</string>
     <string name="transaction_done_title">Hecho</string>
+    <string name="transaction_done_overview">Resumen</string>
     <string name="transaction_done_complete">Completo</string>
     <string name="transaction_done_form_title">Transacción</string>
     <string name="vault_list_vaults_list">Bóvedas</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -106,6 +106,7 @@
     <string name="verify_transaction_consent_address">Šaljem na pravu adresu</string>
     <string name="verify_transaction_consent_amount">Iznos je točan</string>
     <string name="transaction_done_title">Gotovo</string>
+    <string name="transaction_done_overview">Pregled</string>
     <string name="transaction_done_complete">Dovršeno</string>
     <string name="transaction_done_form_title">Transakcija</string>
     <string name="import_file_screen_title">Uvoz</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,6 +106,7 @@
     <string name="verify_transaction_consent_address">Sto inviando all\'indirizzo corretto</string>
     <string name="verify_transaction_consent_amount">La quantità è corretta</string>
     <string name="transaction_done_title">Fatto</string>
+    <string name="transaction_done_overview">Panoramica</string>
     <string name="transaction_done_complete">Completo</string>
     <string name="transaction_done_form_title">Transazione</string>
     <string name="import_file_screen_title">Importa</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -184,6 +184,7 @@
     <string name="camera_permission_denied">카메라 권한이 부여되지 않았습니다. 설정에서 활성화해 주세요.</string>
     <string name="join_keysign_discovering_session_id">세션 ID 검색 중</string>
     <string name="transaction_done_title">완료</string>
+    <string name="transaction_done_overview">개요</string>
     <string name="transaction_done_complete">완료됨</string>
     <string name="transaction_done_form_title">거래</string>
     <string name="vault_list_vaults_list">볼트</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -129,6 +129,7 @@
     <string name="camera_permission_denied">Cameratoestemming niet verleend. Schakel deze in de instellingen in.</string>
     <string name="join_keysign_discovering_session_id">Sessienummer ontdekken</string>
     <string name="transaction_done_title">Gedaan</string>
+    <string name="transaction_done_overview">Overzicht</string>
     <string name="transaction_done_complete">Voltooid</string>
     <string name="transaction_done_form_title">Transactie</string>
     <string name="vault_list_vaults_list">Kluizen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -110,6 +110,7 @@
     <string name="verify_transaction_consent_address">Estou enviando para o endereço correto</string>
     <string name="verify_transaction_consent_amount">A quantidade está correta</string>
     <string name="transaction_done_title">Concluído</string>
+    <string name="transaction_done_overview">Visão geral</string>
     <string name="transaction_done_complete">Continuar</string>
     <string name="transaction_done_form_title">Transação</string>
     <string name="vault_list_vaults_list">Cofres</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -129,6 +129,7 @@
     <string name="camera_permission_denied">Разрешение на камеру не предоставлено. Пожалуйста, включите его в настройках.</string>
     <string name="join_keysign_discovering_session_id">Обнаружение ID сессии</string>
     <string name="transaction_done_title">Готово</string>
+    <string name="transaction_done_overview">Обзор</string>
     <string name="transaction_done_complete">Завершено</string>
     <string name="transaction_done_form_title">Транзакция</string>
     <string name="vault_list_vaults_list">Хранилища</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -213,6 +213,7 @@
 
     <!-- Transaction Done -->
     <string name="transaction_done_title">完成</string>
+    <string name="transaction_done_overview">概览</string>
     <string name="transaction_done_complete">完成</string>
     <string name="transaction_done_form_title">交易</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="camera_permission_denied">Camera permission not granted. Please, enable it in the settings.</string>
     <string name="join_keysign_discovering_session_id">Discovering Session ID</string>
     <string name="transaction_done_title">Done</string>
+    <string name="transaction_done_overview">Overview</string>
     <string name="transaction_done_complete">Complete</string>
     <string name="transaction_done_form_title">Transaction</string>
     <string name="vault_list_vaults_list">Vaults</string>


### PR DESCRIPTION
## Summary
- Replace hardcoded "Overview" string with `stringResource(R.string.transaction_done_overview)` in `TransactionDoneScreen.kt`
- Add `transaction_done_overview` key with translations to all 10 locale files

## Test plan
- [ ] Verify title shows correctly in English
- [ ] Switch language and verify translated title appears

Closes #3722

🤖 Generated with [Claude Code](https://claude.com/claude-code)