### PR TITLE
fix: display swap transaction details on TransactionDoneScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -181,42 +181,40 @@ private fun DepositTransactionDetail(depositTransaction: DepositTransactionUiMod
 }
 
 @Composable
-private fun SwapTransactionDetail(swapTransaction: SwapTransactionUiModel?) {
-    if (swapTransaction != null) {
-        UiHorizontalDivider()
+private fun SwapTransactionDetail(swapTransaction: SwapTransactionUiModel) {
+    UiHorizontalDivider()
 
+    OtherField(
+        title = stringResource(R.string.swap_form_from_title),
+        value = "${swapTransaction.src.value} ${swapTransaction.src.token.ticker}",
+    )
+
+    OtherField(
+        title = stringResource(R.string.swap_form_dst_token_title),
+        value = "${swapTransaction.dst.value} ${swapTransaction.dst.token.ticker}",
+    )
+
+    if (swapTransaction.provider.isNotEmpty()) {
         OtherField(
-            title = stringResource(R.string.swap_form_from_title),
-            value = "${swapTransaction.src.value} ${swapTransaction.src.token.ticker}",
-        )
-
-        OtherField(
-            title = stringResource(R.string.swap_form_dst_token_title),
-            value = "${swapTransaction.dst.value} ${swapTransaction.dst.token.ticker}",
-        )
-
-        if (swapTransaction.provider.isNotEmpty()) {
-            OtherField(
-                title = stringResource(R.string.swap_screen_provider_title),
-                value = swapTransaction.provider,
-            )
-        }
-
-        OtherField(
-            title = stringResource(R.string.swap_form_estimated_fees_title),
-            value = swapTransaction.providerFee.fiatValue,
-        )
-
-        OtherField(
-            title = stringResource(R.string.verify_transaction_network_fee),
-            value = swapTransaction.networkFeeFormatted,
-        )
-
-        OtherField(
-            title = stringResource(R.string.verify_swap_screen_total_fees),
-            value = swapTransaction.totalFee,
+            title = stringResource(R.string.swap_screen_provider_title),
+            value = swapTransaction.provider,
         )
     }
+
+    OtherField(
+        title = stringResource(R.string.swap_form_estimated_fees_title),
+        value = swapTransaction.providerFee.fiatValue,
+    )
+
+    OtherField(
+        title = stringResource(R.string.verify_transaction_network_fee),
+        value = swapTransaction.networkFeeFormatted,
+    )
+
+    OtherField(
+        title = stringResource(R.string.verify_swap_screen_total_fees),
+        value = swapTransaction.totalFee,
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Add `Swap` case to the transaction type `when` block on `TransactionDoneScreen`
- Swap completion now shows source/destination tokens and amounts, provider, swap fee, network fee, and total fee

## Test plan
- [ ] Complete a swap transaction and verify the done screen shows swap details
- [ ] Verify Send and Deposit done screens still work correctly

Closes #3716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap transactions now display detailed completion information including source and destination amounts, tokens, provider details, and associated fees (provider and network).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->