### PR TITLE
fix: replace requireNotNull with safe null check in VaultListViewModel

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/home/VaultListViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/home/VaultListViewModel.kt
@@ -190,7 +190,7 @@ constructor(
     private fun collectCurrentVaultAndFolder(vaultId: VaultId) {
         viewModelScope.launch {
             val vaultOrder = vaultOrderRepository.find(name = vaultId)
-            val vault = requireNotNull(vaultRepository.get(vaultId))
+            val vault = vaultRepository.get(vaultId) ?: return@launch
             state.update {
                 it.copy(
                     currentVaultId = vaultId,


### PR DESCRIPTION
## Summary
- Replace `requireNotNull(vaultRepository.get(vaultId))` with `vaultRepository.get(vaultId) ?: return@launch` in `collectCurrentVaultAndFolder`
- Prevents crash when a vault is deleted between navigation and data loading

## Test plan
- [ ] Verify vault list loads correctly
- [ ] Verify no crash when vault data is missing

Closes #3723

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to gracefully manage scenarios where vault information may be unavailable, preventing application errors and ensuring smoother user experience in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->