### PR TITLE
fix: clean up unreachable click handlers in VaultSettingsViewModel

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -90,30 +90,6 @@ internal sealed class VaultSettingsItem(
             enabled = isEnabled,
         )
 
-    data object Security :
-        VaultSettingsItem(
-            value =
-                SettingsItemUiModel(
-                    title = UiText.StringResource(R.string.vault_settings_security_screen_title),
-                    subTitle = UiText.StringResource(R.string.vault_settings_enable_biometric),
-                    trailingIcon = R.drawable.ic_small_caret_right,
-                    leadingIcon = R.drawable.security,
-                ),
-            enabled = false,
-        )
-
-    data object PasswordHint :
-        VaultSettingsItem(
-            value =
-                SettingsItemUiModel(
-                    title = UiText.StringResource(R.string.vault_settings_password_hint),
-                    subTitle = UiText.StringResource(R.string.vault_settings_set_a_password),
-                    trailingIcon = R.drawable.ic_small_caret_right,
-                    leadingIcon = R.drawable.pass_hint,
-                ),
-            enabled = false,
-        )
-
     data object BackupVaultShare :
         VaultSettingsItem(
             value =
@@ -226,12 +202,7 @@ constructor(
             ),
             VaultSettingsGroupUiModel(
                 title = UiText.StringResource(R.string.vault_settings_security_screen_title),
-                items =
-                    listOf(
-                        VaultSettingsItem.Security,
-                        VaultSettingsItem.PasswordHint,
-                        VaultSettingsItem.BackupVaultShare,
-                    ),
+                items = listOf(VaultSettingsItem.BackupVaultShare),
             ),
             VaultSettingsGroupUiModel(
                 title = UiText.StringResource(R.string.other),
@@ -375,9 +346,7 @@ constructor(
             VaultSettingsItem.Delete -> navigateToConfirmDeleteScreen()
             VaultSettingsItem.Details -> openDetails()
             is VaultSettingsItem.Migrate -> migrate()
-            VaultSettingsItem.PasswordHint -> Unit
             VaultSettingsItem.Rename -> openRename()
-            VaultSettingsItem.Security -> Unit
             VaultSettingsItem.OnChainSecurity -> navigateToOnChainSecurityScreen()
             is VaultSettingsItem.Reshare -> navigateToReshareStartScreen()
             VaultSettingsItem.Sign -> signMessage()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -558,9 +558,6 @@
     <string name="transaction_type_button_receive">Erhalten</string>
     <string name="vault_settings_view_vault">Tresorname, -teil und -typ anzeigen</string>
     <string name="vault_settings_biometric_fast">Fast Sign mit Biometrie</string>
-    <string name="vault_settings_enable_biometric">Biometrie für Fast Sign aktivieren</string>
-    <string name="vault_settings_password_hint">Passworthinweis</string>
-    <string name="vault_settings_set_a_password">Legen Sie einen Passworthinweis zum Schutz Ihres Tresors fest</string>
     <string name="vault_settings_backup_vault">Vault‑Freigabe sichern</string>
     <string name="vault_settings_back_up_your">Sichern Sie Ihre Vault‑Freigabe auf einem Gerät oder auf dem Server.</string>
     <string name="vault_settings_migrate_gg20">GG20‑Vault auf DKLS migrieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -558,9 +558,6 @@
     <string name="transaction_type_button_receive">Recibir</string>
     <string name="vault_settings_view_vault">Ver el nombre, la parte y el tipo de tu bóveda</string>
     <string name="vault_settings_biometric_fast">Biometría para la firma rápida</string>
-    <string name="vault_settings_enable_biometric">Habilitar la biometría para la firma rápida</string>
-    <string name="vault_settings_password_hint">Pista de contraseña</string>
-    <string name="vault_settings_set_a_password">Configurar una pista de contraseña para proteger la bóveda</string>
     <string name="vault_settings_backup_vault">Copia de seguridad del recurso compartido de bóveda</string>
     <string name="vault_settings_back_up_your">Realice una copia de seguridad del recurso compartido de bóveda en un dispositivo o servidor</string>
     <string name="vault_settings_migrate_gg20">Migrar bóveda GG20 a DKLS</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -557,9 +557,6 @@
     <string name="transaction_type_button_receive">Primi</string>
     <string name="vault_settings_view_vault">Prikaz naziva, dijela i vrste trezora</string>
     <string name="vault_settings_biometric_fast">Biometrijski brzi potpis</string>
-    <string name="vault_settings_enable_biometric">Omogući biometrijski pristup za brzi potpis</string>
-    <string name="vault_settings_password_hint">Podsjetnik za lozinku</string>
-    <string name="vault_settings_set_a_password">Postavi podsjetnik za lozinku kako bi zaštitio svoj trezor</string>
     <string name="vault_settings_backup_vault">Sigurnosna kopija dijeljenog trezora</string>
     <string name="vault_settings_back_up_your">Sigurnosna kopija dijeljenog trezora na uređaj ili poslužitelj.</string>
     <string name="vault_settings_migrate_gg20">Migracija DKLS-a trezora GG20</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -556,9 +556,6 @@
     <string name="transaction_type_button_receive">Ricevi</string>
     <string name="vault_settings_view_vault">Visualizza nome, parte e tipo del vault</string>
     <string name="vault_settings_biometric_fast">Firma rapida biometrica</string>
-    <string name="vault_settings_enable_biometric">Abilita la firma biometrica per la firma rapida</string>
-    <string name="vault_settings_password_hint">Suggerimento password</string>
-    <string name="vault_settings_set_a_password">Imposta un suggerimento password per proteggere il tuo vault</string>
     <string name="vault_settings_backup_vault">Esegui il backup della condivisione del vault</string>
     <string name="vault_settings_back_up_your">Esegui il backup della condivisione del vault su dispositivo o server.</string>
     <string name="vault_settings_migrate_gg20">Esegui la migrazione del vault DKLS GG20</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -754,9 +754,6 @@
     <string name="transaction_type_button_receive">받기</string>
     <string name="vault_settings_view_vault">볼트 이름, 파트 및 유형 보기</string>
     <string name="vault_settings_biometric_fast">생체 인증 빠른 서명</string>
-    <string name="vault_settings_enable_biometric">빠른 서명을 위한 생체 인증 활성화</string>
-    <string name="vault_settings_password_hint">비밀번호 힌트</string>
-    <string name="vault_settings_set_a_password">볼트를 보호하기 위한 비밀번호 힌트 설정</string>
     <string name="vault_settings_backup_vault">볼트 공유 백업</string>
     <string name="vault_settings_back_up_your">기기 또는 서버에 볼트 공유를 백업합니다.</string>
     <string name="vault_settings_migrate_gg20">GG20 볼트를 DKLS로 마이그레이션</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -553,9 +553,6 @@
     <string name="transaction_type_button_receive">Ontvangen</string>
     <string name="vault_settings_view_vault">Bekijk kluisnaam, onderdeel en type</string>
     <string name="vault_settings_biometric_fast">Biometrische snelle ondertekening</string>
-    <string name="vault_settings_enable_biometric">Schakel biometrie in voor snelle ondertekening</string>
-    <string name="vault_settings_password_hint">Wachtwoordhint</string>
-    <string name="vault_settings_set_a_password">Stel een wachtwoordhint in om uw kluis te beschermen</string>
     <string name="vault_settings_backup_vault">Back-up maken van Vault Share</string>
     <string name="vault_settings_back_up_your">Maak een back-up van uw Vault Share naar een apparaat of server.</string>
     <string name="vault_settings_migrate_gg20">Migreer GG20-kluis DKLS</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -555,9 +555,6 @@
     <string name="transaction_type_button_receive">Receber</string>
     <string name="vault_settings_view_vault">Visualizar nome, parte e tipo do cofre</string>
     <string name="vault_settings_biometric_fast">Assinatura biométrica rápida</string>
-    <string name="vault_settings_enable_biometric">Ativar biometria para assinatura rápida</string>
-    <string name="vault_settings_password_hint">Dica de palavra-passe</string>
-    <string name="vault_settings_set_a_password">Defina uma dica de palavra-passe para proteger o seu cofre</string>
     <string name="vault_settings_backup_vault">Fazer backup da Partilha do Cofre</string>
     <string name="vault_settings_back_up_your">Faça o backup da Partilha do Cofre para um dispositivo ou servidor.</string>
     <string name="vault_settings_migrate_gg20">Migrar DKLS do cofre GG20</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -555,9 +555,6 @@
     <string name="transaction_type_button_receive">Получить</string>
     <string name="vault_settings_view_vault">Просмотр имени, части и типа хранилища</string>
     <string name="vault_settings_biometric_fast">Биометрическая быстрая подпись</string>
-    <string name="vault_settings_enable_biometric">Включить биометрию для быстрой подписи</string>
-    <string name="vault_settings_password_hint">Подсказка для пароля</string>
-    <string name="vault_settings_set_a_password">Установите подсказку для пароля для защиты хранилища</string>
     <string name="vault_settings_backup_vault">Резервное копирование общего ресурса хранилища</string>
     <string name="vault_settings_back_up_your">Создание резервной копии общего ресурса хранилища на устройстве или сервере.</string>
     <string name="vault_settings_migrate_gg20">Миграция хранилища GG20 DKLS</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -921,9 +921,6 @@
     <!-- Vault Settings -->
     <string name="vault_settings_view_vault">查看金库名称、部分和类型</string>
     <string name="vault_settings_biometric_fast">生物识别快速签名</string>
-    <string name="vault_settings_enable_biometric">启用生物识别快速签名</string>
-    <string name="vault_settings_password_hint">密码提示</string>
-    <string name="vault_settings_set_a_password">设置密码提示以保护您的金库</string>
     <string name="vault_settings_backup_vault">备份金库份额</string>
     <string name="vault_settings_back_up_your">将您的金库份额备份到设备或服务器。</string>
     <string name="vault_settings_migrate_gg20">将 GG20 金库迁移到 DKLS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -751,9 +751,6 @@
     <string name="transaction_type_button_receive">Receive</string>
     <string name="vault_settings_view_vault">View vault name, part and type</string>
     <string name="vault_settings_biometric_fast">Biometrics fast sign</string>
-    <string name="vault_settings_enable_biometric">Enable biometric for fast sign</string>
-    <string name="vault_settings_password_hint">Password hint</string>
-    <string name="vault_settings_set_a_password">Set a password hint to protect your vault</string>
     <string name="vault_settings_backup_vault">Backup Vault Share</string>
     <string name="vault_settings_back_up_your">Back up your Vault Share to device or server.</string>
     <string name="vault_settings_migrate_gg20">Migrate GG20 vault DKLS</string>


### PR DESCRIPTION
## Summary
- Remove disabled `Security` and `PasswordHint` sealed class entries from `VaultSettingsItem`
- Remove their empty `-> Unit` click handler branches from `onSettingsItemClick`
- Remove their entries from the settings group list (they were already filtered out by `enabled = false`)
- Remove 3 exclusively-used string resources (`vault_settings_enable_biometric`, `vault_settings_password_hint`, `vault_settings_set_a_password`) from all 10 locale files

## Test plan
- [ ] Verify vault settings screen loads correctly
- [ ] Verify all clickable settings items still work

Closes #3724

🤖 Generated with [Claude Code](https://claude.com/claude-code)