### PR TITLE
fix: make vault list total balance reactive

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/home/VaultListViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/home/VaultListViewModel.kt
@@ -85,18 +85,18 @@ constructor(
     }
 
     private fun collectTotalVaultAndBalance() {
-
         viewModelScope.launch {
-            val vaults = vaultRepository.getAll()
-            val fiatValues = vaults.mapNotNull { vaultAndBalanceUseCase(it).balanceFiatValue }
+            vaultRepository.getAllAsFlow().collect { vaults ->
+                val fiatValues = vaults.mapNotNull { vaultAndBalanceUseCase(it).balanceFiatValue }
 
-            val totalBalance = fiatValues.reduceOrNull { acc, value -> acc + value }
+                val totalBalance = fiatValues.reduceOrNull { acc, value -> acc + value }
 
-            state.update {
-                it.copy(
-                    totalVaultsCount = vaults.size,
-                    totalBalance = totalBalance?.let { fiatValueToStringMapper(totalBalance) },
-                )
+                state.update {
+                    it.copy(
+                        totalVaultsCount = vaults.size,
+                        totalBalance = totalBalance?.let { fiatValueToStringMapper(totalBalance) },
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Refactor `collectTotalVaultAndBalance` to collect from `vaultRepository.getAllAsFlow()` instead of calling `getAll()` once
- Total balance now updates reactively when vaults are added, deleted, or balances refresh

## Test plan
- [ ] Verify total balance updates after adding/removing a vault
- [ ] Verify total balance updates after balance refresh

Closes #3720

🤖 Generated with [Claude Code](https://claude.com/claude-code)