### PR TITLE
fix: rename bondedRaw to totalRaw in updateTotalFiatValue

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -382,11 +382,11 @@ constructor(
         }
     }
 
-    private fun updateTotalFiatValue(bondedRaw: BigInteger) {
+    private fun updateTotalFiatValue(totalRaw: BigInteger) {
         viewModelScope.launch {
             try {
                 val currency = appCurrencyRepository.currency.first()
-                val totalInCacao = bondedRaw.toValue(Coins.MayaChain.CACAO.decimal)
+                val totalInCacao = totalRaw.toValue(Coins.MayaChain.CACAO.decimal)
                 val fiatValue = createFiatValue(totalInCacao, Coins.MayaChain.CACAO, currency)
                 val currencyFormat =
                     withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }


### PR DESCRIPTION
## Summary
- Renamed `bondedRaw` parameter to `totalRaw` in `updateTotalFiatValue()` to accurately reflect that it represents the combined bonded + staking total, not just the bonded amount

Fixes #3708

## Test plan
- [ ] Verify Maya DeFi positions screen loads and displays total fiat value correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calculation of total fiat value for DeFi positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->