### PR TITLE
fix: remove stray literal in formatCacaoReward

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -600,7 +600,6 @@ private fun mayaPoolChainPrefixToChain(prefix: String): Chain? =
     }
 
 private fun formatCacaoReward(reward: Double): String {
-    22
     val rewardBase = BigDecimal.valueOf(reward).setScale(0, RoundingMode.DOWN).toBigInteger()
     val cacaoAmount =
         rewardBase.toValue(Coins.MayaChain.CACAO.decimal).setScale(4, RoundingMode.DOWN)


### PR DESCRIPTION
## Summary
- Removed stray `22` literal from `formatCacaoReward()` — leftover from debugging with no functional effect

Fixes #3706

## Test plan
- [ ] Verify Maya DeFi positions screen displays CACAO rewards correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reward formatting calculation to remove extraneous values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->