### PR TITLE
fix: expand bottom sheet to full screen on Edit Folder

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/bottomsheets/vaultlist/VaultListBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/bottomsheets/vaultlist/VaultListBottomSheet.kt
@@ -2,8 +2,7 @@ package com.vultisig.wallet.ui.screens.v2.home.bottomsheets.vaultlist
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v2.bottomsheets.navhost.VsBottomSheetNavHost
@@ -16,8 +15,7 @@ import com.vultisig.wallet.ui.screens.v2.home.bottomsheets.vaultlist.components.
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun VaultListBottomSheet(vaultList: Route.VaultList, onDismiss: () -> Unit) {
-    val sheetState =
-        rememberStandardBottomSheetState(initialValue = SheetValue.Hidden, skipHiddenState = false)
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     V2BottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         val navController = rememberVsBottomSheetNavController(initialRoute = vaultList)


### PR DESCRIPTION
## Summary
- Replaced `rememberStandardBottomSheetState` with `rememberModalBottomSheetState(skipPartiallyExpanded = true)` in `VaultListBottomSheet`
- `skipPartiallyExpanded = true` ensures the sheet always opens at full height instead of stopping halfway
- `rememberModalBottomSheetState` sets `containsIme = true` so the sheet properly resizes when the keyboard appears, preventing content from being hidden

Fixes #3670

## Test plan
- [ ] Open a folder and tap Edit — bottom sheet should open at full screen height
- [ ] Verify the folder name text field is visible and not hidden behind the keyboard
- [ ] Verify the sheet still opens/closes correctly for VaultList and FolderList routes
- [ ] `./gradlew assembleDebug` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vault list bottom sheet modal behavior by updating state management to prevent unwanted partially-expanded states and improve overall interaction consistency.

* **Refactor**
  * Streamlined bottom sheet state initialization mechanism for better modal state handling and more predictable user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->