### PR TITLE
fix: add missing trailing slash to Noble explorer URL

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -103,7 +103,7 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
                 Chain.Osmosis -> "https://www.mintscan.io/osmosis/"
                 Chain.Terra -> "https://www.mintscan.io/terra/"
                 Chain.TerraClassic -> "https://finder.terra.money/classic/"
-                Chain.Noble -> "https://www.mintscan.io/noble"
+                Chain.Noble -> "https://www.mintscan.io/noble/"
                 Chain.Ripple -> "https://xrpscan.com/"
                 Chain.Akash -> "https://www.mintscan.io/akash/"
                 Chain.Tron -> "https://tronscan.org/#/"


### PR DESCRIPTION
## Summary

Noble explorer base URL was missing a trailing slash producing broken links like `mintscan.io/nobletx/HASH` instead of `mintscan.io/noble/tx/HASH`.

## Test plan

- [ ] Send a Noble transaction and tap the explorer link
- [ ] Verify it opens the correct mintscan page

Closes #3769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed explorer link formatting for the Noble chain to ensure transaction and address links function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->