### PR TITLE
fix: limit decimal places when flipping swap tokens

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -882,11 +882,12 @@ constructor(
                 }
                 ?.srcAmount
 
-        // For the first flip (or after manual edits), fall back to raw quote decimal.
-        // Using the raw BigDecimal avoids locale-formatted strings (e.g. "3,000.5").
         val newSrcAmount =
             restoredAmount
-                ?: quote?.expectedDstValue?.decimal?.stripTrailingZeros()?.toPlainString()
+                ?: quote
+                    ?.expectedDstValue
+                    ?.decimal
+                    ?.formatFlippedAmount(selectedDst.value?.account?.token?.decimal)
 
         resetQuoteState()
 
@@ -1825,6 +1826,16 @@ constructor(
         private const val ARG_SELECTED_DST_TOKEN_ID = "ARG_SELECTED_DST_TOKEN_ID"
     }
 }
+
+private const val MAX_DISPLAY_DECIMALS = 8
+
+internal fun BigDecimal.formatFlippedAmount(tokenDecimals: Int? = null): String =
+    setScale(
+            (tokenDecimals ?: MAX_DISPLAY_DECIMALS).coerceAtMost(MAX_DISPLAY_DECIMALS),
+            RoundingMode.DOWN,
+        )
+        .stripTrailingZeros()
+        .toPlainString()
 
 internal fun MutableStateFlow<SendSrc?>.updateSrc(
     selectedTokenId: String?,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/FormatFlippedAmountTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/FormatFlippedAmountTest.kt
@@ -1,0 +1,48 @@
+package com.vultisig.wallet.ui.models.swap
+
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class FormatFlippedAmountTest {
+
+    @Test
+    fun `truncates to token decimals when less than max`() {
+        assertEquals("1.123456", BigDecimal("1.123456789012").formatFlippedAmount(6))
+    }
+
+    @Test
+    fun `truncates to max display decimals when token has more`() {
+        assertEquals("0.12345678", BigDecimal("0.12345678901234567890").formatFlippedAmount(18))
+    }
+
+    @Test
+    fun `strips trailing zeros`() {
+        assertEquals("5.1", BigDecimal("5.100000").formatFlippedAmount(8))
+    }
+
+    @Test
+    fun `handles whole number`() {
+        assertEquals("42", BigDecimal("42.000000").formatFlippedAmount(8))
+    }
+
+    @Test
+    fun `uses max display decimals when token decimals is null`() {
+        assertEquals("0.12345678", BigDecimal("0.123456789012").formatFlippedAmount())
+    }
+
+    @Test
+    fun `truncates down not rounds up`() {
+        assertEquals("1.999999", BigDecimal("1.999999999").formatFlippedAmount(6))
+    }
+
+    @Test
+    fun `handles very small amount`() {
+        assertEquals("0.00000001", BigDecimal("0.00000001").formatFlippedAmount(8))
+    }
+
+    @Test
+    fun `handles zero`() {
+        assertEquals("0", BigDecimal.ZERO.formatFlippedAmount(8))
+    }
+}


### PR DESCRIPTION
## Summary

When flipping tokens on the Swap page the destination amount was transferred with raw decimal precision producing values like `0.00345678901234567890`. Now capped to `min(tokenDecimals, 8)` using truncation (not rounding).

Extracted `BigDecimal.formatFlippedAmount()` extension with `MAX_DISPLAY_DECIMALS = 8` constant. Covered by 8 unit tests.

## Test plan

- [ ] Enter amount on swap screen
- [ ] Flip tokens
- [ ] Verify the new source amount has reasonable decimal places
- [ ] Flip back and verify amount restores correctly
- [ ] Verify percentage picker still works as before

Closes #3192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal precision handling when flipping tokens in swaps. Amounts are now formatted consistently with a maximum of 8 decimal places and trailing zeros removed for clearer display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->