### PR TITLE
fix: correct Dutch placeholder in password hint string

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -288,7 +288,7 @@
     <string name="qr_title_join_keysign_description">Kluis: %1$s\nBedrag: %2$s\nAan: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Kluis: %1$s\nVan: %2$s\nAan: %3$s</string>
     <string name="error_folder_must_have_at_least_one_vault">Map heeft minimaal één geselecteerde kluis nodig</string>
-    <string name="import_file_password_hint_text">Voer een hint in</string>
+    <string name="import_file_password_hint_text">Hint: %s</string>
     <string name="scan_qr_upload_from_gallery">Uploaden van\nGalerij</string>
     <string name="no_barcodes_found">Geen barcodes gevonden</string>
     <string name="reshare_start_join_reshare_button">Word lid van Reshare</string>


### PR DESCRIPTION
## Summary

- Fix missing `%s` placeholder in the Dutch translation of `import_file_password_hint_text`
- The Dutch string was `"Voer een hint in"` (a prompt to enter a hint) instead of `"Hint: %s"` (displaying the hint value), which would cause a crash or missing hint text when the app formats the string with `String.format()`
- Changed to `"Hint: %s"` to match the pattern used by all other locales

Closes #3785

## Test plan

- [ ] Set device language to Dutch (Nederlands)
- [ ] Import a vault file that has a password hint
- [ ] Verify the hint displays correctly with the hint value (e.g., "Hint: my hint text")
- [ ] Verify no crash occurs on the import screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Dutch translation for password import hint display text. The hint field now uses improved formatting to provide clearer, more consistent guidance when importing password-protected files, significantly enhancing the overall user experience and usability for Dutch language users throughout the entire file import process and all related dialog interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->