### PR TITLE
fix: correct German mistranslations and chain terminology

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,7 +11,7 @@
     <string name="vault_settings_delete_title">Löschen</string>
     <string name="select_asset_title">Asset auswählen</string>
     <string name="select_asset_no_result">Kein Ergebnis gefunden.</string>
-    <string name="select_chain_chain_title">Kette</string>
+    <string name="select_chain_chain_title">Blockchain</string>
     <string name="select_chain_balance_title">Guthaben</string>
     <string name="vault_settings_security_title">On-Chain-Sicherheit</string>
     <string name="vault_settings_security_subtitle">Verwalten Sie Ihre On-Chain-Sicherheit</string>
@@ -80,7 +80,7 @@
     <string name="send_from_address">Von</string>
     <string name="send_to_address">Zu</string>
     <string name="swap_form_on_chain">auf</string>
-    <string name="send_to_address_hint">Menge eingeben</string>
+    <string name="send_to_address_hint">Adresse hier eingeben</string>
     <string name="send_amount">Menge</string>
     <string name="send_amount_currency_hint">Menge eingeben</string>
     <string name="send_continue_button">Fortfahren</string>
@@ -169,7 +169,7 @@
     <string name="biometry_auth_login_button">Login mit Biometrie</string>
     <string name="feature_item_learn_more">Erfahren Sie mehr</string>
     <string name="keysign_screen_keysign_finished">Schlüsselsignatur fertig!</string>
-    <string name="keysign">Schlüsselzeichen</string>
+    <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Keygen fehlgeschlagen</string>
     <string name="bottom_warning_msg_keygen_error_screen">Behalten Sie die Geräte im selben WLAN-Netzwerk, korrigieren Sie den Tresor und koppeln Sie die Geräte.\nStellen Sie sicher, dass Vultisig auf keinem anderen Gerät ausgeführt wird.</string>
     <string name="naming_vault_screen_invalid_name">Ungültiger Name</string>
@@ -269,7 +269,7 @@
     <string name="password_should_not_be_empty">Das Passwort darf nicht leer sein</string>
     <string name="signing_error_insufficient_funds">Nicht genug Gas, um die Transaktionsgebühr zu decken.\n Bitte füllen Sie das Wallet auf.</string>
     <string name="signing_error_mixed_reshare">Gemischte Reshare-Signatur.\nBitte verwenden Sie Vault-Freigaben aus dem gleichen Reshare-Zyklus.</string>
-    <string name="verify_transaction_fast_sign_btn_title">Schnelles Zeichen</string>
+    <string name="verify_transaction_fast_sign_btn_title">Schnelle Signatur</string>
     <string name="keysign_sign_transaction">Transaktion unterschreiben</string>
     <string name="keysign_password_title">Passwort</string>
     <string name="start_screen_new">NEU</string>
@@ -298,7 +298,7 @@
     <string name="deposit_error_has_not_reached_maturity">Diese Einlage hat ihre Fälligkeit noch nicht erreicht.</string>
     <string name="deposit_form_screen_assets">Vermögenswert</string>
     <string name="deposit_form_screen_asset_selection">Anlagenauswahl</string>
-    <string name="deposit_form_screen_lpunits">LP-Geräte</string>
+    <string name="deposit_form_screen_lpunits">LP-Einheiten</string>
     <string name="join_keysign_error_wrong_vault_share">Dieselbe Tresorfreigabe. Bitte ändern Sie die Freigabe zum Signieren</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Tresor ändern</string>
     <string name="utxo_settings_byte_fee_title">Netzwerkrate (Sats/Vbyte)</string>
@@ -414,7 +414,7 @@
     <string name="reshare_step_generating_eddsa">Generieren eines EdDSA-Schlüssels</string>
     <string name="keygen_connecting_with_server">Mit Server verbinden …</string>
     <string name="keygen_step_generating_eddsa">Generieren eines EdDSA-Schlüssels</string>
-    <string name="keygen_step_generating_chain_keys">Ketten-Schlüssel generieren</string>
+    <string name="keygen_step_generating_chain_keys">Blockchain-Schlüssel generieren</string>
     <string name="reshare_step_generating_ecdsa">Generieren des ECDSA-Schlüssels</string>
     <string name="merge_account_doesnt_exist">Das ausgewählte Token wurde für diese Adresse nicht gefunden.</string>
     <string name="keygen_email_error">Falsche E-Mail, bitte überprüfen</string>
@@ -572,7 +572,7 @@
     <string name="vault_settings_back_up_your">Sichern Sie Ihre Vault‑Freigabe auf einem Gerät oder auf dem Server.</string>
     <string name="vault_settings_migrate_gg20">GG20‑Vault auf DKLS migrieren</string>
     <string name="vault_settings_reshare_change">Erneut teilen, Sicherheit verwalten oder Nachrichten signieren.</string>
-    <string name="vault_backup_summary_choose_chains">Wählen Sie Ketten</string>
+    <string name="vault_backup_summary_choose_chains">Blockchains auswählen</string>
     <string name="transaction_done_form_approve">Genehmigen</string>
     <string name="vault_settings_migration_title">Migrieren</string>
     <string name="transaction_buy">Kaufen</string>
@@ -585,13 +585,13 @@
     <string name="wallet">Wallet</string>
     <string name="hide_balance">Guthaben verbergen</string>
     <string name="show_balance">Guthaben anzeigen</string>
-    <string name="no_chains_found">Keine Ketten gefunden</string>
-    <string name="no_chain_make_sure_that">Stellen Sie sicher, dass die gesuchte Kette aktiviert ist.</string>
-    <string name="no_chain_customize_chains">Ketten anpassen</string>
+    <string name="no_chains_found">Keine Blockchains gefunden</string>
+    <string name="no_chain_make_sure_that">Stellen Sie sicher, dass die gesuchte Blockchain aktiviert ist.</string>
+    <string name="no_chain_customize_chains">Blockchains anpassen</string>
     <string name="search_bar_search">Suche</string>
-    <string name="chain_selection_select_chains">Ketten auswählen</string>
-    <string name="chain_selection_select_defi_chains">DeFi-Ketten auswählen</string>
-    <string name="chain_selection_no_chains_found">Keine Ketten gefunden</string>
+    <string name="chain_selection_select_chains">Blockchains auswählen</string>
+    <string name="chain_selection_select_defi_chains">DeFi-Blockchains auswählen</string>
+    <string name="chain_selection_no_chains_found">Keine Blockchains gefunden</string>
     <string name="chain_selection_key_import_warning">Aufgrund technischer Einschränkungen von Schlüsselimport- und Seed-basierten Wallets können nur vorab generierte Blockchains ausgewählt werden.</string>
     <string name="transaction_type_button_functions">Funktionen</string>
     <string name="copy_address">Adresse kopieren</string>
@@ -659,7 +659,7 @@
     <string name="referral_code_linked_successfully">Empfehlungscode erfolgreich verknüpft</string>
     <string name="fast_vault_invalid_password">Ungültiges Passwort</string>
     <string name="folder">Ordner</string>
-    <string name="home_page_no_chain_enabled_desc">Sie haben alle Ketten deaktiviert. Stellen Sie sicher, dass mindestens eine Kette aktiviert ist.</string>
+    <string name="home_page_no_chain_enabled_desc">Sie haben alle Blockchains deaktiviert. Stellen Sie sicher, dass mindestens eine Blockchain aktiviert ist.</string>
     <string name="address_book_saved_addresses">Gespeicherte Adressen</string>
     <string name="address_book_my_vaults">Meine Tresore</string>
     <string name="address_entry_select">Auswählen</string>
@@ -713,7 +713,7 @@
     <string name="address_bookmark_error_empty_label">Das Label darf nicht leer sein</string>
     <string name="address_bookmark_error_invalid_label">Das Label muss zwischen 1 und %d Zeichen haben</string>
     <string name="send_form_ripple_reaping_warning">Stellen Sie sicher, dass Ihr Konto ausreichend Guthaben zur Deckung der Gebühren aufweist. Fällt Ihr Kontostand unter 1 XRP (Einzahlung), wird das Konto deaktiviert (eingezogen) und das verbleibende Guthaben geht verloren. Sie können die Adresse jederzeit mit einer neuen Einzahlung, die höher als die Mindesteinzahlung ist, reaktivieren. Dadurch werden die verlorenen Guthaben jedoch nicht wiederhergestellt.</string>
-    <string name="error_invalid_chain">Die Kette ist ungültig</string>
+    <string name="error_invalid_chain">Die Blockchain ist ungültig</string>
     <string name="vault_backup_verifying_pin">Code wird überprüft, bitte warten</string>
     <string name="select_vault_type_next">Weiter</string>
     <string name="select_vault_type_choose_setup">Wähle „Einrichtung“</string>
@@ -792,7 +792,7 @@
     <string name="enter_email_screen_next">Weiter</string>
     <string name="scan_qr_code_modal_next">Weiter</string>
     <string name="peer_discovery_action_next_title">Weiter</string>
-    <string name="home_page_no_chains_enabled">Keine Ketten aktiviert</string>
+    <string name="home_page_no_chains_enabled">Keine Blockchains aktiviert</string>
     <string name="onboarding_desc_page_3_part_3">Ein Tresor freigeben</string>
     <string name="select_vault_type_fast_title">Schnelle Einrichtung mit nur einem Gerät</string>
     <string name="select_vault_type_fast_desc_1">Nur 1 Gerät erforderlich</string>


### PR DESCRIPTION
## Summary

- Replace all instances of "Kette"/"Ketten" (literal "chain") with "Blockchain"/"Blockchains" in German locale strings — affects 12 keys including `select_chain_chain_title`, `no_chains_found`, `chain_selection_select_chains`, `home_page_no_chains_enabled`, and others
- Fix `verify_transaction_fast_sign_btn_title`: "Schnelles Zeichen" (fast character) → "Schnelle Signatur" (fast signature)
- Fix `send_to_address_hint`: "Menge eingeben" (enter quantity) → "Adresse hier eingeben" (enter address here)
- Fix `deposit_form_screen_lpunits`: "LP-Geräte" (LP devices) → "LP-Einheiten" (LP units)
- Fix `keysign`: "Schlüsselzeichen" (key character) → "Keysign" (keep English term, as used elsewhere)

Closes #3787

## Test plan

- [ ] Switch device language to German
- [ ] Verify chain selection screen shows "Blockchain"/"Blockchains" instead of "Kette"/"Ketten"
- [ ] Verify the send screen address hint shows "Adresse hier eingeben"
- [ ] Verify fast sign button shows "Schnelle Signatur"
- [ ] Verify deposit form LP units label shows "LP-Einheiten"
- [ ] Verify keysign label shows "Keysign"