### PR TITLE
fix: correct grammar errors in English string resources

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="chain_account_view_send">SEND</string>
     <string name="vault_settings_error_backup_file">an error occurred</string>
     <string name="vault_settings_success_backup_file">file saved in Downloads/%1$s</string>
-    <string name="vault_edit_this_name_already_exist">this name already exist</string>
+    <string name="vault_edit_this_name_already_exist">This name already exists</string>
     <string name="send_screen_max">MAX</string>
     <string name="ok">OK</string>
     <string name="dialog_default_error_title">Error</string>
@@ -372,8 +372,8 @@
     <string name="scan_qr_upload_from_gallery">Upload QR</string>
     <string name="no_barcodes_found">No barcodes found</string>
     <string name="reshare_start_join_reshare_button">Join Reshare</string>
-    <string name="deposit_error_invalid_lpunits">LP units is invalid</string>
-    <string name="deposit_error_invalid_assets">Assets is invalid</string>
+    <string name="deposit_error_invalid_lpunits">LP units are invalid</string>
+    <string name="deposit_error_invalid_assets">Assets are invalid</string>
     <string name="deposit_error_has_not_reached_maturity">This deposit has not reached its maturity period yet</string>
     <string name="deposit_form_screen_assets">Asset</string>
     <string name="deposit_form_screen_asset_selection">Asset selection</string>
@@ -410,13 +410,13 @@
     <string name="swap_screen_invalid_quote_calculation">Quote calculation failed</string>
     <string name="swap_screen_invalid_vault">Transaction will likely fail, vault could not be loaded.</string>
     <string name="edit_address_title">Edit Address</string>
-    <string name="join_keysign_failed_connect_to_server">Failed connect to server</string>
+    <string name="join_keysign_failed_connect_to_server">Failed to connect to server</string>
     <string name="network_connection_lost">Network connection lost. Please check your internet connection</string>
     <string name="send_form_polka_reaping_warning">Ensure you leave enough funds to cover the fees. If an account balance falls below 1 DOT (Existential Deposit), the account will be deactivated (reaped) and any remaining funds will be lost. You can reactivate the address with a new deposit larger than the existential deposit at any time. However, this will not recover the lost funds.</string>
 
 
     <string name="verify_sign_message_method_field_title">Method</string>
-    <string name="signing_error_transaction_timeout">Transaction time out due to slow signing. Please try again.</string>
+    <string name="signing_error_transaction_timeout">Transaction timed out due to slow signing. Please try again.</string>
     <string name="verify_sign_message_message_field_title">Message</string>
     <string name="hint_signing_method">Signing method</string>
     <string name="verify_sign_message_signing_method">Signing method</string>
@@ -699,7 +699,7 @@
     <string name="referral_view_edit_referral">Edit referral</string>
     <string name="referral_view_your_friend_referral">Your Friend Referral Code</string>
     <string name="referral_view_collected_rewards">Collected Rewards</string>
-    <string name="referral_view_add_friend">Add a Friends Referral</string>
+    <string name="referral_view_add_friend">Add a Friend\'s Referral</string>
     <string name="referral_view_save">Save</string>
     <string name="referral_view_on_swaps">on swaps now</string>
     <string name="faq_settings_q7">Is Vultisig open source and audited?</string>
@@ -1025,7 +1025,7 @@
     <string name="welcome_best_balance_desc">The perfect mix between convenience and security. Signing transactions takes at least 2 devices. One backup device.</string>
     <string name="welcome_best_balance_highlight">at least 2 devices.</string>
     <string name="welcome_maximum_security">Maximum security</string>
-    <string name="welcome_maximum_security_desc">Highest security and perfect for treasuries or DAOs. Signing transactions take at least 3 devices.</string>
+    <string name="welcome_maximum_security_desc">Highest security and perfect for treasuries or DAOs. Signing transactions takes at least 3 devices.</string>
     <string name="welcome_maximum_security_highlight">at least 3 devices.</string>
     <string name="vault_setup_your_vault_setup">Your vault setup</string>
     <string name="vault_setup_fast_vault">Fast Vault</string>
@@ -1077,9 +1077,9 @@
     <string name="vault_setup_perfect_balance_desc">Perfect balance for most users. 2 signers and 1 backup device. Store assets without stress.</string>
     <string name="vault_setup_perfect_for_users_with_only_2_devices">Perfect setup for users with only 2 devices.</string>
     <string name="vault_setup_3_device_or_more_signing">3-Device or more Signing</string>
-    <string name="vault_setup_3_device_or_more_signing_desc">Vaults need 67% of devices to sign a transaction. Have as many signers you want.</string>
+    <string name="vault_setup_3_device_or_more_signing_desc">Vaults need 67% of devices to sign a transaction. Have as many signers as you want.</string>
     <string name="vault_setup_dynamic_device_management">Dynamic device management</string>
-    <string name="vault_setup_add_as_many_devices_as_you_want">Add as many devices you want and receive institutional grade security.</string>
+    <string name="vault_setup_add_as_many_devices_as_you_want">Add as many devices as you want and receive institutional-grade security.</string>
     <string name="vault_setup_built_for_teams_and_treasuries">Built for teams and treasuries</string>
     <string name="vault_setup_back_up_each_device">Back up each device</string>
     <string name="vault_setup_you_ll_create_n_backups_in_total">You’ll create %1$d backups in total. You will do this on each device.</string>


### PR DESCRIPTION
## Summary

Fixes 9 English grammar and text errors in user-facing strings (`app/src/main/res/values/strings.xml`):

- `vault_edit_this_name_already_exist`: capitalized first letter, added missing "s" ("This name already exists")
- `deposit_error_invalid_assets`: fixed subject-verb agreement ("Assets are invalid")
- `deposit_error_invalid_lpunits`: fixed subject-verb agreement ("LP units are invalid")
- `join_keysign_failed_connect_to_server`: added missing "to" ("Failed to connect to server")
- `signing_error_transaction_timeout`: corrected tense ("Transaction timed out...")
- `vault_setup_3_device_or_more_signing_desc`: added missing "as" ("Have as many signers as you want")
- `vault_setup_add_as_many_devices_as_you_want`: added missing "as" and hyphenated compound adjective ("as many devices as you want", "institutional-grade")
- `welcome_maximum_security_desc`: fixed subject-verb agreement ("Signing transactions takes...")
- `referral_view_add_friend`: added possessive apostrophe ("Add a Friend's Referral")

Closes #3790

## Test plan

- [ ] Verify the app builds without resource errors
- [ ] Spot-check each affected screen to confirm the corrected strings render properly
- [ ] Confirm no string key names were changed (only values), so translations are unaffected