### PR TITLE
fix: remove trailing newline from currency screen title in all locales

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -187,7 +187,7 @@
     <string name="join_keysign_discovering_session_id">Sitzungs-ID ermitteln</string>
     <string name="join_keysign_discovery_service">Service entdecken</string>
     <string name="vault_settings_delete_subtitle">Löschen Sie Ihren Tresor dauerhaft.</string>
-    <string name="currency_unit_setting_screen_title">Währung\n</string>
+    <string name="currency_unit_setting_screen_title">Währung</string>
     <string name="share_qr_utils_choose_an_app">Wählen Sie eine App</string>
     <string name="vault_accounts_account_assets">%1$s Vermögenswerte</string>
     <string name="chain_token_screen_address_copied">%1$s in die Zwischenablage kopiert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,7 +119,7 @@
     <string name="settings_screen_share_the_app">Compartir La App</string>
     <string name="settings_screen_title">Configuración</string>
     <string name="language_setting_screen_title">Idioma</string>
-    <string name="currency_unit_setting_screen_title">Moneda\n</string>
+    <string name="currency_unit_setting_screen_title">Moneda</string>
     <string name="faq_setting_screen_title">Preguntas Frecuentes</string>
     <string name="verify_transaction_screen_title">Verificar</string>
     <string name="verify_transaction_from_title">De</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -187,7 +187,7 @@
     <string name="join_keysign_discovering_session_id">Otkrivanje ID-a sesije</string>
     <string name="join_keysign_discovery_service">Usluga otkrivanja</string>
     <string name="vault_settings_delete_subtitle">Trajno izbrišite svoj trezor.</string>
-    <string name="currency_unit_setting_screen_title">Valuta\n</string>
+    <string name="currency_unit_setting_screen_title">Valuta</string>
     <string name="share_qr_utils_choose_an_app">Odaberite aplikaciju</string>
     <string name="vault_accounts_account_assets">%1$s sredstva</string>
     <string name="chain_token_screen_address_copied">%1$s kopirano u međuspremnik</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -174,7 +174,7 @@
     <string name="settings_screen_share_the_app">앱 공유</string>
     <string name="settings_screen_title">설정</string>
     <string name="language_setting_screen_title">언어</string>
-    <string name="currency_unit_setting_screen_title">통화\n</string>
+    <string name="currency_unit_setting_screen_title">통화</string>
     <string name="faq_setting_screen_title">FAQ</string>
     <string name="verify_transaction_screen_title">확인</string>
     <string name="verify_transaction_from_title">보내는 주소</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -117,7 +117,7 @@
     <string name="settings_screen_share_the_app">Deel de app</string>
     <string name="settings_screen_title">Instellingen</string>
     <string name="language_setting_screen_title">Taal</string>
-    <string name="currency_unit_setting_screen_title">Valuta\n</string>
+    <string name="currency_unit_setting_screen_title">Valuta</string>
     <string name="faq_setting_screen_title">FAQ</string>
     <string name="verify_transaction_screen_title">Verifiëren</string>
     <string name="verify_transaction_from_title">Van</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -187,7 +187,7 @@
     <string name="join_keysign_discovering_session_id">Descobrindo o ID da sessão</string>
     <string name="join_keysign_discovery_service">Descobrindo o Serviço</string>
     <string name="vault_settings_delete_subtitle">Exclua seu cofre permanentemente.</string>
-    <string name="currency_unit_setting_screen_title">Moeda\n</string>
+    <string name="currency_unit_setting_screen_title">Moeda</string>
     <string name="share_qr_utils_choose_an_app">Escolha um aplicativo</string>
     <string name="vault_accounts_account_assets">Ativos de %1$s</string>
     <string name="chain_token_screen_address_copied">%1$s copiado para a área de transferência</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -117,7 +117,7 @@
     <string name="settings_screen_share_the_app">Поделиться приложением</string>
     <string name="settings_screen_title">Настройки</string>
     <string name="language_setting_screen_title">Язык</string>
-    <string name="currency_unit_setting_screen_title">Валюта\n</string>
+    <string name="currency_unit_setting_screen_title">Валюта</string>
     <string name="faq_setting_screen_title">ЧАВО</string>
     <string name="verify_transaction_screen_title">Проверить</string>
     <string name="verify_transaction_from_title">От</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -197,7 +197,7 @@
 
     <!-- Settings Titles -->
     <string name="language_setting_screen_title">语言</string>
-    <string name="currency_unit_setting_screen_title">货币\n</string>
+    <string name="currency_unit_setting_screen_title">货币</string>
     <string name="faq_setting_screen_title">常见问题</string>
 
     <!-- Verify Transaction -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,7 +173,7 @@
     <string name="settings_screen_share_the_app">Share the App</string>
     <string name="settings_screen_title">Settings</string>
     <string name="language_setting_screen_title">Language</string>
-    <string name="currency_unit_setting_screen_title">Currency\n</string>
+    <string name="currency_unit_setting_screen_title">Currency</string>
     <string name="faq_setting_screen_title">FAQ</string>
     <string name="verify_transaction_screen_title">Verify</string>
     <string name="verify_transaction_from_title">From</string>


### PR DESCRIPTION
## Summary
- Remove trailing `\n` from `currency_unit_setting_screen_title` across all locale files
- The newline was causing a blank line under the Currency screen title

Closes #3800

## Test plan
- Open currency settings screen and verify title renders without extra blank line
- Check on multiple locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)