### PR TITLE
fix: move search bar cancel button inside the field

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/searchbar/SearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/searchbar/SearchBar.kt
@@ -47,6 +47,7 @@ internal fun SearchBar(
     isInitiallyFocused: Boolean,
     isPasteEnabled: Boolean = false,
     onPasteClick: (String) -> Unit = {},
+    onCancelClick: (() -> Unit)? = null,
 ) {
     var isFocusedState by remember { mutableStateOf(isInitiallyFocused) }
     val focusManager = LocalFocusManager.current
@@ -119,7 +120,18 @@ internal fun SearchBar(
                                 drawableResId = R.drawable.close_circle,
                                 size = 18.dp,
                                 tint = Theme.v2.colors.neutrals.n300,
-                                onClick = { state.clearText() },
+                                onClick = {
+                                    state.clearText()
+                                    onCancelClick?.invoke()
+                                },
+                            )
+                        } else if (onCancelClick != null) {
+                            UiSpacer(size = 8.dp)
+                            UiIcon(
+                                drawableResId = R.drawable.close_circle,
+                                size = 18.dp,
+                                tint = Theme.v2.colors.neutrals.n300,
+                                onClick = onCancelClick,
                             )
                         } else if (isPasteEnabled) {
                             PasteIcon(onPaste = onPasteClick)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tab/TabMenuAndSearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tab/TabMenuAndSearchBar.kt
@@ -1,28 +1,15 @@
 package com.vultisig.wallet.ui.components.v2.tab
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import com.vultisig.wallet.R
-import com.vultisig.wallet.ui.components.UiIcon
-import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.animation.slideAndFadeSpec
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.searchbar.SearchBar
-import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
 internal fun TabMenuAndSearchBar(
@@ -36,35 +23,12 @@ internal fun TabMenuAndSearchBar(
     AnimatedContent(targetState = isTabMenu, transitionSpec = slideAndFadeSpec()) {
         if (it) tabMenuContent()
         else {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            SearchBar(
                 modifier = modifier.fillMaxWidth(),
-            ) {
-                SearchBar(
-                    modifier = Modifier.weight(1f),
-                    state = searchTextFieldState,
-                    isInitiallyFocused = isInitiallyFocused,
-                )
-                UiSpacer(size = 8.dp)
-                V2Container(
-                    type = ContainerType.SECONDARY,
-                    cornerType = CornerType.Circular,
-                    modifier =
-                        Modifier.clickOnce(
-                            onClick = {
-                                searchTextFieldState.clearText()
-                                onCancelSearchClick()
-                            }
-                        ),
-                ) {
-                    UiIcon(
-                        drawableResId = R.drawable.close_2,
-                        size = 16.dp,
-                        tint = Theme.v2.colors.text.primary,
-                        modifier = Modifier.padding(all = 12.dp),
-                    )
-                }
-            }
+                state = searchTextFieldState,
+                isInitiallyFocused = isInitiallyFocused,
+                onCancelClick = onCancelSearchClick,
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #3625

## Summary
- Move the cancel/close button from a separate external container into the `SearchBar` component, matching the Figma design
- Add optional `onCancelClick` callback to `SearchBar` — when provided, the close icon appears inside the field and handles both clearing text and dismissing search
- Remove the external `V2Container` cancel button and unused imports from `TabMenuAndSearchBar`
- Backward compatible: existing `SearchBar` callers without `onCancelClick` are unaffected

## Test plan
- [ ] `./gradlew assembleDebug` succeeds
- [ ] Open the main screen, tap search — cancel button appears inside the search field
- [ ] With text entered, tapping close clears text and exits search
- [ ] With empty text, tapping close exits search
- [ ] Other screens using SearchBar (e.g. custom token search) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cancel functionality to the search bar
* **Refactor**
  * Improved search bar behavior for enhanced UI consistency and cleaner close icon handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->