### PR TITLE
fix: update explorer URLs to match iOS (ThorChain, Zcash, Mantle)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -51,7 +51,9 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
             when (this) {
                 Chain.BitcoinCash,
                 Chain.Dash,
+                Chain.Dogecoin,
                 Chain.Litecoin,
+                Chain.Zcash,
                 Chain.Ton,
                 Chain.Tron,
                 Chain.Cardano -> "${explorerUrl}transaction/"


### PR DESCRIPTION
## Summary

Update block explorer URLs to match iOS for cross-platform consistency:

| Chain | Before | After |
|-------|--------|-------|
| ThorChain (explorer) | `thorchain.net` | `runescan.io` |
| ThorChain (swap progress) | `thorchain.net/tx/` | `runescan.io/tx/` |
| Zcash | `blockexplorer.one/zcash/mainnet/` | `blockchair.com/zcash/` |
| Mantle | `explorer.mantle.xyz` | `mantlescan.xyz` |

All URLs verified live and functional. ThorChain swap progress now strips `0x` prefix to match iOS behavior.

Closes #3838

## Test plan
- [ ] Open a ThorChain transaction — verify link goes to runescan.io
- [ ] Complete a THORChain swap — verify swap progress link goes to runescan.io
- [ ] Open a Zcash transaction — verify link goes to blockchair.com/zcash
- [ ] Open a Mantle transaction — verify link goes to mantlescan.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated blockchain explorer URLs so ThorChain, Zcash, and Mantle transaction/address links resolve to current explorer services.
  * Swap progress links for ThorChain now open the RUNEscan explorer.
  * Transaction links now normalize transaction IDs (remove hex prefix when present) and include Dogecoin in the UTXO-style transaction URL pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->