### PR TITLE
fix: add missing swap providers for Mantle, Optimism, and Polygon

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -535,8 +535,8 @@ constructor(
 
                 Chain.Optimism,
                 Chain.Polygon,
+                Chain.Mantle -> setOf(SwapProvider.LIFI, SwapProvider.ONEINCH, SwapProvider.KYBER)
                 Chain.ZkSync -> setOf(SwapProvider.ONEINCH, SwapProvider.LIFI)
-                Chain.Mantle -> setOf(SwapProvider.LIFI, SwapProvider.KYBER)
                 Chain.ThorChain -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA)
 
                 Chain.Bitcoin -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA)


### PR DESCRIPTION
## Summary

Aligns swap provider configuration with iOS:

| Chain | Before (Android) | After (matching iOS) |
|-------|-----------------|---------------------|
| Mantle | LIFI, KYBER | LIFI, ONEINCH, KYBER |
| Optimism | ONEINCH, LIFI | LIFI, ONEINCH, KYBER |
| Polygon | ONEINCH, LIFI | LIFI, ONEINCH, KYBER |

Users on these chains now have access to more swap routes and potentially better rates.

Closes #3837

## Test plan
- [ ] Swap MNT on Mantle — verify 1inch quotes appear alongside LiFi/Kyber
- [ ] Swap on Optimism — verify KyberSwap quotes appear
- [ ] Swap on Polygon — verify KyberSwap quotes appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded swap provider support on Mantle chain with the addition of a new swap provider option, giving users more choices for token exchanges on this network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->