### PR TITLE
fix: align Mantle swapAssetName with iOS

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -357,7 +357,7 @@ fun Chain.swapAssetName(): String {
         Chain.Tron -> "TRON"
         Chain.Zcash -> "ZEC"
         Chain.Cardano -> "ADA"
-        Chain.Mantle -> "MNT"
+        Chain.Mantle -> "MANTLE"
         Chain.Sei -> "SEI"
         Chain.Hyperliquid -> "HYPE"
     }


### PR DESCRIPTION
## Summary

Change Mantle's `swapAssetName()` from `"MNT"` to `"MANTLE"` to match iOS's `swapAsset` value.

Mantle isn't currently routed through THORChain/MayaChain, so this is a consistency alignment — ensures both platforms produce the same swap asset identifier if/when Mantle is added to a cross-chain DEX.

Closes #3837

## Test plan
- [ ] Build succeeds
- [ ] Mantle swaps still work via LiFi/KyberSwap (these use chain IDs, not swapAssetName)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Mantle chain swap asset identifier to use "MANTLE" instead of "MNT" for proper asset recognition in swap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->