### PR TITLE
fix: unregister BroadcastReceiver leak and remove vaultId force-unwraps

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -131,27 +131,31 @@ constructor(
     }
 
     private fun keysign(keysignInitType: KeysignInitType) {
+        val txId = transactionId ?: return
+        val vault = vaultId ?: return
         viewModelScope.launch {
             launchKeysign(
                 keysignInitType,
-                transactionId!!,
+                txId,
                 password.value,
                 Route.Keysign.Keysign.TxType.Deposit,
-                vaultId!!,
+                vault,
             )
         }
     }
 
     private fun loadPassword() {
+        val vault = vaultId ?: return
         viewModelScope.launch {
             password.value =
-                withContext(Dispatchers.IO) { vaultPasswordRepository.getPassword(vaultId!!) }
+                withContext(Dispatchers.IO) { vaultPasswordRepository.getPassword(vault) }
         }
     }
 
     private fun loadFastSign() {
+        val vault = vaultId ?: return
         viewModelScope.launch {
-            val hasFastSign = withContext(Dispatchers.IO) { isVaultHasFastSignById(vaultId!!) }
+            val hasFastSign = withContext(Dispatchers.IO) { isVaultHasFastSignById(vault) }
             state.update { it.copy(hasFastSign = hasFastSign) }
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -712,6 +712,15 @@ constructor(
         }
     }
 
+    override fun onCleared() {
+        try {
+            context.unregisterReceiver(serviceStartedReceiver)
+        } catch (_: IllegalArgumentException) {
+            // Already unregistered
+        }
+        super.onCleared()
+    }
+
     private suspend fun isSessionStarted(): Boolean {
         return try {
             sessionApi.getParticipants(serverUrl, sessionId).isNotEmpty()


### PR DESCRIPTION
Two small safety fixes:

**BroadcastReceiver leak in KeygenPeerDiscoveryViewModel**

`serviceStartedReceiver` is registered in `startMediatorService()` but never unregistered. When the ViewModel is cleared the receiver stays alive and holds a reference to the context. Added `onCleared()` to unregister it (same pattern already used in `KeysignFlowViewModel`).

**Force-unwraps in VerifyDepositViewModel**

`vaultId!!` is used in `keysign()`, `loadPassword()` and `loadFastSign()`. The field is nullable so if any of these run before init completes the app crashes with NPE. Replaced with safe null checks and early returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null safety checks in deposit verification operations to prevent potential crashes.
  * Added automatic cleanup of background services in peer discovery functionality to prevent resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->