### PR TITLE
fix: chain names hidden in chain/DeFi selection grids

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.components.v2.tokenitem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -140,11 +141,12 @@ internal fun <T> TokenSelectionList(
             if (groups.isEmpty() || (groups.size == 1 && groups[0].items.isEmpty())) {
                 notFoundContent()
             } else
-                Box(modifier = if (bannerContent != null) Modifier.weight(1f) else Modifier) {
+                Box(modifier = Modifier.weight(1f)) {
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(minSize = 74.dp),
                         verticalArrangement = Arrangement.spacedBy(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        contentPadding = PaddingValues(bottom = 60.dp),
                     ) {
                         groups.forEach { (title, items, mapper, plusUiModel) ->
                             title?.let {


### PR DESCRIPTION
## Summary
- `Box` wrapping `LazyVerticalGrid` in `TokenSelectionList` had no size modifier when `bannerContent == null` (both `ChainSelectionScreen` and `DeFiChainSelectionScreen`)
- This caused the Box to wrap its content height, so for small lists (DeFi chains) or search results with few items, the 60dp `BottomFadeEffect` overlay covered the chain name text labels
- Fix: always apply `Modifier.weight(1f)` to the Box so the grid always has a bounded, scrollable height, and the `BottomFadeEffect` always sits at the visible bottom
- Also add `contentPadding = PaddingValues(bottom = 60.dp)` to `LazyVerticalGrid` so the last row scrolls fully clear of the fade

## Issue
Closes #3911

## Test Plan
- [ ] Open Select Chains page — verify all chain names are fully visible
- [ ] Search for a chain (e.g. "ak") — verify name is visible below icon and not faded out
- [ ] Open DeFi → Select DeFi Chains — verify all chain names are visible in the default list
- [ ] Open Select Chains with Key Import vault — verify banner still appears below the grid
- [ ] Scroll to bottom of list — verify last row names are not hidden under the fade gradient
- [ ] Lint passes (`./gradlew lint`) ✅

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token selection list layout with enhanced bottom padding to ensure better scrollability and visibility of all token items.
  * Simplified and improved layout container behavior to reliably allocate space and maintain consistent layout regardless of additional content presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->