### PR TITLE
fix: disable back button on vault backup onboarding screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/onboarding/VaultBackupOnboardingViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/onboarding/VaultBackupOnboardingViewModel.kt
@@ -10,7 +10,6 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.Route.BackupVault.BackupPasswordType
-import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -26,8 +25,6 @@ internal data class VaultBackupOnboardingUiModel(
 
 sealed interface VaultBackupOnboardingEvent {
     object Next : VaultBackupOnboardingEvent
-
-    object Back : VaultBackupOnboardingEvent
 }
 
 data class VaultBackupOnboardingTip(val title: UiText, val description: UiText, val logo: Int)
@@ -72,7 +69,6 @@ constructor(savedStateHandle: SavedStateHandle, private val navigator: Navigator
 
     fun onEvent(event: VaultBackupOnboardingEvent) {
         when (event) {
-            VaultBackupOnboardingEvent.Back -> back()
             VaultBackupOnboardingEvent.Next -> next()
         }
     }
@@ -105,10 +101,6 @@ constructor(savedStateHandle: SavedStateHandle, private val navigator: Navigator
                 }
             }
         }
-    }
-
-    private fun back() {
-        viewModelScope.launch { navigator.back() }
     }
 
     companion object {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/onboarding/VaultBackupOnboardingScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/onboarding/VaultBackupOnboardingScreen.kt
@@ -52,7 +52,6 @@ internal fun VaultBackupOnboardingScreen(
     onEvent: (VaultBackupOnboardingEvent) -> Unit,
 ) {
     V3Scaffold(
-        onBackClick = { onEvent(VaultBackupOnboardingEvent.Back) },
         applyDefaultPaddings = false,
         content = {
             Column(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
## Summary
- After Fast Vault creation, `VaultBackupOnboardingScreen` had a scaffold back button that called `navigator.back()`, popping to the keygen connecting/peer-discovery screen and leaving users stuck
- The hardware back button was already blocked via `BlockBackClick()` — this PR closes the remaining gap by removing the scaffold back button (`onBackClick = null` on `V3Scaffold`)
- Removes the now-dead `VaultBackupOnboardingEvent.Back` event and `back()` handler from the ViewModel

## Issue
Closes #3909

## Test Plan
- [ ] Create a Fast Vault — complete keygen until the backup intro page appears
- [ ] Confirm there is **no back arrow** in the toolbar on the backup intro page
- [ ] Confirm the hardware back button is also blocked (already was via `BlockBackClick`)
- [ ] Confirm "Continue" / "Next" still navigates forward correctly
- [ ] Lint passes (`./gradlew lint`) ✅

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed back button navigation from the vault backup onboarding screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->