### PR TITLE
fix: route to EnterVaultInfoScreen on "Use a different email" (#3910)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
@@ -90,7 +90,7 @@ constructor(
     fun changeEmail() {
         viewModelScope.launch {
             navigator.route(
-                route = Route.EnterVaultInfo(count = 1),
+                route = Route.EnterVaultInfo(count = 1, tssAction = args.tssAction),
                 opts =
                     NavigationOptions(popUpToRoute = Route.EnterVaultInfo::class, inclusive = true),
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/ChooseDeviceCountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/ChooseDeviceCountViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.ui.models.v3.onboarding.ChooseDeviceCountViewModel.Companion.Tips
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -80,20 +79,7 @@ constructor(savedStateHandle: SavedStateHandle, private val navigator: Navigator
     private fun next() {
         viewModelScope.launch {
             val count = _uiState.value.deviceCount
-            if (args.tssAction == TssAction.KeyImport) {
-                val vaultType =
-                    if (count == 1) Route.VaultInfo.VaultType.Fast
-                    else Route.VaultInfo.VaultType.Secure
-                navigator.route(
-                    Route.VaultInfo.Name(
-                        vaultType = vaultType,
-                        tssAction = TssAction.KeyImport,
-                        deviceCount = count,
-                    )
-                )
-            } else {
-                navigator.route(Route.SetupVaultInfo(count = count))
-            }
+            navigator.route(Route.SetupVaultInfo(count = count, tssAction = args.tssAction))
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GenerateUniqueName
@@ -140,8 +139,9 @@ constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val deviceCount: Int =
-        savedStateHandle.toRoute<Route.EnterVaultInfo>().count.coerceIn(1, 4)
+    private val vaultInfoArgs = savedStateHandle.toRoute<Route.EnterVaultInfo>()
+    private val deviceCount: Int = vaultInfoArgs.count.coerceIn(1, 4)
+    private val tssAction = vaultInfoArgs.tssAction
     val isSecureVault = deviceCount != 1
 
     private val passwordDelegate = PasswordViewModelDelegate()
@@ -464,7 +464,7 @@ constructor(
             if (isSecureVault) {
                 navigator.route(
                     Route.Keygen.PeerDiscovery(
-                        action = TssAction.KEYGEN,
+                        action = tssAction,
                         vaultName = name,
                         deviceCount = deviceCount,
                     )
@@ -472,7 +472,7 @@ constructor(
             } else {
                 navigator.route(
                     Route.Keygen.PeerDiscovery(
-                        action = TssAction.KEYGEN,
+                        action = tssAction,
                         vaultName = name,
                         email = email,
                         password = password,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/SetupVaultInfoViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/SetupVaultInfoViewModel.kt
@@ -42,7 +42,9 @@ internal class SetupVaultInfoViewModel
 @Inject
 constructor(private val navigator: Navigator<Destination>, savedStateHandle: SavedStateHandle) :
     ViewModel() {
-    private val deviceCount = savedStateHandle.toRoute<Route.SetupVaultInfo>().count
+    private val args = savedStateHandle.toRoute<Route.SetupVaultInfo>()
+    private val deviceCount = args.count
+    private val tssAction = args.tssAction
     private val _uiState = MutableStateFlow(SetupVaultInfoUiState())
     val uiState = _uiState.asStateFlow()
 
@@ -99,7 +101,9 @@ constructor(private val navigator: Navigator<Destination>, savedStateHandle: Sav
     }
 
     private fun next() {
-        viewModelScope.launch { navigator.route(Route.EnterVaultInfo(count = deviceCount)) }
+        viewModelScope.launch {
+            navigator.route(Route.EnterVaultInfo(count = deviceCount, tssAction = tssAction))
+        }
     }
 
     private fun back() {

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -485,9 +485,11 @@ internal sealed class Route {
 
     @Serializable data class ChainDashboard(val route: ChainDashboardRoute)
 
-    @Serializable data class EnterVaultInfo(val count: Int)
+    @Serializable
+    data class EnterVaultInfo(val count: Int, val tssAction: TssAction = TssAction.KEYGEN)
 
-    @Serializable data class SetupVaultInfo(val count: Int)
+    @Serializable
+    data class SetupVaultInfo(val count: Int, val tssAction: TssAction = TssAction.KEYGEN)
 
     @Serializable data class ChooseVaultCount(val tssAction: TssAction = TssAction.KEYGEN)
 


### PR DESCRIPTION
## Summary
- When tapping **"Use a different email"** on `FastVaultVerificationScreen`, the app was routing to `Route.VaultInfo.Email` (old fast vault email screen), skipping the password step. Now routes to `Route.EnterVaultInfo` (new flow).
- `ChooseDeviceCountViewModel` was routing `KeyImport` to `Route.VaultInfo.Name` (old onboarding). Now routes to `Route.SetupVaultInfo` so `KeyImport` goes through the new flow consistently.
- Added `tssAction` to `Route.SetupVaultInfo` and `Route.EnterVaultInfo` (defaulting to `KEYGEN` for backward compatibility) so the action threads correctly through the whole flow to `Keygen.PeerDiscovery`.

## Changes
| File | Change |
|------|--------|
| `Navigation.kt` | Add `tssAction` param to `SetupVaultInfo` and `EnterVaultInfo` routes |
| `ChooseDeviceCountViewModel` | Route `KeyImport` to `SetupVaultInfo` instead of old `VaultInfo.Name` |
| `SetupVaultInfoViewModel` | Read and forward `tssAction` to `EnterVaultInfo` |
| `EnterVaultInfoViewModel` | Read `tssAction` from route args; pass to `PeerDiscovery` instead of hardcoded `KEYGEN` |
| `FastVaultVerificationViewModel` | Pass `args.tssAction` when navigating to `EnterVaultInfo` on email change |

## Issue
Closes #3910

## Test Plan
- [ ] **KeyImport flow**: Start a Key Import, pick device count → confirm `SetupVaultInfoScreen` is shown (new flow), proceed through Name/Password steps → confirm keygen starts with `KeyImport` action
- [ ] **Fast Vault normal flow**: Create a Fast Vault end-to-end → confirm password hint page appears
- [ ] **"Use a different email"**: On `FastVaultVerificationScreen`, tap "Use a different email" → confirm `EnterVaultInfoScreen` is shown with the correct action preserved
- [ ] **Existing KEYGEN flows unaffected**: Create a new vault via the normal flow → confirm behavior unchanged
- [ ] Lint passes (`./gradlew lint`) ✅
- [ ] Debug build compiles (`./gradlew compileDebugKotlin`) ✅

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined onboarding and vault setup navigation so selected device count and action persist across steps, improving continuity when advancing between screens.
  * Simplified email-change flow during vault verification to ensure users are routed to the consolidated vault info entry screen.
* **Behavior**
  * A default action is applied when not explicitly chosen, reducing friction for common flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->