### PR TITLE
fix: hide Unlock Tier button when tier is already active

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
@@ -302,13 +302,15 @@ private fun TierCard(
                         }
                     }
 
-                    UiSpacer(size = 16.dp)
+                    if (!isActive) {
+                        UiSpacer(size = 16.dp)
 
-                    VsButton(
-                        label = stringResource(R.string.vault_tier_unlock),
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onClickUnlock,
-                    )
+                        VsButton(
+                            label = stringResource(R.string.vault_tier_unlock),
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = onClickUnlock,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Hides the "Unlock Tier" button when the tier card is expanded and the tier is already active
- Users who hold sufficient VULT tokens will no longer see a confusing action button on their active tier

## Test plan
- [ ] Navigate to vault settings → Discounts
- [ ] With an active tier: expand the tier card → confirm no "Unlock Tier" button appears, only the ✓ Active indicator
- [ ] With an inactive tier: expand the tier card → confirm "Unlock Tier" button still appears
- [ ] `./gradlew assembleDebug` succeeds

Closes #3674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unlock button visibility on discount tiers to only display when a tier is not yet unlocked, preventing the button from appearing on already-active tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->