### PR TITLE
fix: Plugin Store badge inner shadow and rename (#3361)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -227,7 +230,28 @@ private fun DeviceCountDescription(
             Row(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth().padding(vertical = 14.dp),
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .drawWithContent {
+                            drawContent()
+                            // top inset shadow: 0 -1px 0.5px 0 #0F1C3E
+                            drawLine(
+                                color = Color(0xFF0F1C3E),
+                                start = Offset(0f, 0f),
+                                end = Offset(size.width, 0f),
+                                strokeWidth = 1.dp.toPx(),
+                                blendMode = BlendMode.SrcOver,
+                            )
+                            // bottom inset highlight: 0 1px 1px 0 rgba(255,255,255,0.10)
+                            drawLine(
+                                color = Color(0x1AFFFFFF),
+                                start = Offset(0f, size.height),
+                                end = Offset(size.width, size.height),
+                                strokeWidth = 1.dp.toPx(),
+                                blendMode = BlendMode.SrcOver,
+                            )
+                        }
+                        .padding(vertical = 14.dp),
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.appstore_style_icon),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -978,7 +978,7 @@
     <string name="welcome_fast_and_easy">Schnell &amp; einfach</string>
     <string name="welcome_fast_and_easy_desc">Signieren Sie mit nur 1 Gerät. Unser sicherer Server signiert mit Ihnen für Multisig-Sicherheit. Plugin-kompatibel.</string>
     <string name="welcome_fast_and_easy_highlight">nur 1 Gerät.</string>
-    <string name="welcome_plugin_compatible">Plugin Marketplace kompatibel</string>
+    <string name="welcome_plugin_compatible">Plugin Store kompatibel</string>
     <string name="welcome_tip">Tipp: Sie können einen Browser als Gerät verwenden</string>
     <string name="welcome_only_your_devices">Nur Ihre Geräte</string>
     <string name="welcome_only_your_devices_desc">Nur Ihre Geräte sind autorisierte Unterzeichner. Das Signieren von Transaktionen erfordert 2 Geräte. Vollständige Selbstverwahrung auf Knopfdruck.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -976,7 +976,7 @@
     <string name="welcome_fast_and_easy">Rápido &amp; fácil</string>
     <string name="welcome_fast_and_easy_desc">Firma con solo 1 dispositivo. Nuestro servidor seguro firma contigo para seguridad multisig. Compatible con plugins.</string>
     <string name="welcome_fast_and_easy_highlight">solo 1 dispositivo.</string>
-    <string name="welcome_plugin_compatible">Compatible con Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Compatible con Plugin Store</string>
     <string name="welcome_tip">Consejo: Puedes usar un navegador como dispositivo</string>
     <string name="welcome_only_your_devices">Solo tus dispositivos</string>
     <string name="welcome_only_your_devices_desc">Solo tus dispositivos son firmantes autorizados. Firmar transacciones requiere 2 dispositivos. Autocustodia total al alcance de tu mano.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -980,7 +980,7 @@
     <string name="welcome_fast_and_easy">Brzo &amp; jednostavno</string>
     <string name="welcome_fast_and_easy_desc">Potpisujte s samo 1 uređajem. Naš sigurni poslužitelj potpisuje s vama za multisig sigurnost. Kompatibilno s dodacima.</string>
     <string name="welcome_fast_and_easy_highlight">samo 1 uređajem.</string>
-    <string name="welcome_plugin_compatible">Kompatibilno s Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Kompatibilno s Plugin Store</string>
     <string name="welcome_tip">Savjet: Možete koristiti preglednik kao uređaj</string>
     <string name="welcome_only_your_devices">Samo vaši uređaji</string>
     <string name="welcome_only_your_devices_desc">Samo vaši uređaji su ovlašteni potpisnici. Potpisivanje transakcija zahtijeva 2 uređaja. Potpuna samopohrana na dohvat ruke.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -979,7 +979,7 @@
     <string name="welcome_fast_and_easy">Veloce &amp; facile</string>
     <string name="welcome_fast_and_easy_desc">Firma con solo 1 dispositivo. Il nostro server sicuro firma con te per la sicurezza multisig. Compatibile con i plugin.</string>
     <string name="welcome_fast_and_easy_highlight">solo 1 dispositivo.</string>
-    <string name="welcome_plugin_compatible">Compatibile con Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Compatibile con Plugin Store</string>
     <string name="welcome_tip">Suggerimento: Puoi usare un browser come dispositivo</string>
     <string name="welcome_only_your_devices">Solo i tuoi dispositivi</string>
     <string name="welcome_only_your_devices_desc">Solo i tuoi dispositivi sono firmatari autorizzati. Firmare le transazioni richiede 2 dispositivi. Custodia autonoma completa a portata di mano.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1034,7 +1034,7 @@
     <string name="welcome_fast_and_easy">빠르고 간편</string>
     <string name="welcome_fast_and_easy_desc">기기 1대로만 서명. 보안 서버가 멀티시그 보안을 위해 함께 서명합니다. 플러그인 호환.</string>
     <string name="welcome_fast_and_easy_highlight">기기 1대로만.</string>
-    <string name="welcome_plugin_compatible">플러그인 마켓플레이스 호환</string>
+    <string name="welcome_plugin_compatible">플러그인 스토어 호환</string>
     <string name="welcome_tip">팁: 브라우저를 기기로 사용할 수 있습니다</string>
     <string name="welcome_only_your_devices">내 기기만 사용</string>
     <string name="welcome_only_your_devices_desc">내 기기만이 승인된 서명자입니다. 거래 서명에 기기 2대가 필요합니다. 완전한 자기 수탁.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -973,7 +973,7 @@
     <string name="welcome_fast_and_easy">Snel &amp; eenvoudig</string>
     <string name="welcome_fast_and_easy_desc">Onderteken met slechts 1 apparaat. Onze beveiligde server ondertekent met u voor multisig-beveiliging. Plugin-compatibel.</string>
     <string name="welcome_fast_and_easy_highlight">slechts 1 apparaat.</string>
-    <string name="welcome_plugin_compatible">Compatibel met Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Compatibel met Plugin Store</string>
     <string name="welcome_tip">Tip: U kunt een browser gebruiken als apparaat</string>
     <string name="welcome_only_your_devices">Alleen uw apparaten</string>
     <string name="welcome_only_your_devices_desc">Alleen uw apparaten zijn bevoegde ondertekenaars. Transacties ondertekenen vereist 2 apparaten. Volledige zelfbeheer binnen handbereik.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -977,7 +977,7 @@
     <string name="welcome_fast_and_easy">Rápido &amp; fácil</string>
     <string name="welcome_fast_and_easy_desc">Assine com apenas 1 dispositivo. O nosso servidor seguro assina consigo para segurança multisig. Compatível com plugins.</string>
     <string name="welcome_fast_and_easy_highlight">apenas 1 dispositivo.</string>
-    <string name="welcome_plugin_compatible">Compatível com Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Compatível com Plugin Store</string>
     <string name="welcome_tip">Dica: Pode usar um browser como dispositivo</string>
     <string name="welcome_only_your_devices">Apenas os seus dispositivos</string>
     <string name="welcome_only_your_devices_desc">Apenas os seus dispositivos são signatários autorizados. Assinar transações requer 2 dispositivos. Custódia própria completa ao seu alcance.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -979,7 +979,7 @@
     <string name="welcome_fast_and_easy">Быстро &amp; просто</string>
     <string name="welcome_fast_and_easy_desc">Подписывайте всего с 1 устройством. Наш защищённый сервер подписывает вместе с вами для мультисиг-безопасности. Совместим с плагинами.</string>
     <string name="welcome_fast_and_easy_highlight">всего с 1 устройством.</string>
-    <string name="welcome_plugin_compatible">Совместимо с Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">Совместимо с Plugin Store</string>
     <string name="welcome_tip">Совет: Вы можете использовать браузер как устройство</string>
     <string name="welcome_only_your_devices">Только ваши устройства</string>
     <string name="welcome_only_your_devices_desc">Только ваши устройства являются авторизованными подписантами. Для подписания транзакций требуется 2 устройства. Полное самостоятельное хранение в ваших руках.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1310,7 +1310,7 @@
     <string name="welcome_fast_and_easy">快速 &amp; 简便</string>
     <string name="welcome_fast_and_easy_desc">仅用1台设备签署。我们的安全服务器与您共同签署以实现多签安全。兼容插件。</string>
     <string name="welcome_fast_and_easy_highlight">仅用1台设备签署。</string>
-    <string name="welcome_plugin_compatible">兼容 Plugin Marketplace</string>
+    <string name="welcome_plugin_compatible">兼容 Plugin Store</string>
     <string name="welcome_tip">提示：您可以将浏览器用作设备</string>
     <string name="welcome_only_your_devices">仅您的设备</string>
     <string name="welcome_only_your_devices_desc">只有您的设备是授权签署方。签署交易需要2台设备。完全自我托管触手可及。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1055,7 +1055,7 @@
     <string name="welcome_fast_and_easy">Fast &amp; easy</string>
     <string name="welcome_fast_and_easy_desc">Sign with only 1 device. Our secure server signs with you for multisig security. Plugin compatible.</string>
     <string name="welcome_fast_and_easy_highlight">only 1 device.</string>
-    <string name="welcome_plugin_compatible">Plugin Marketplace compatible</string>
+    <string name="welcome_plugin_compatible">Plugin Store compatible</string>
     <string name="welcome_tip">Tip: You can use a browser as a device</string>
     <string name="welcome_only_your_devices">Only your devices</string>
     <string name="welcome_only_your_devices_desc">Only your devices are authorized signers. Signing transactions takes 2 devices. Full self-custody at your fingertips.</string>


### PR DESCRIPTION
## Summary

- Adds inset box shadow to the Plugin Store badge `Row` on `ChooseDeviceCountScreen` matching the Figma spec (`0 -1px 0.5px 0 #0F1C3E inset, 0 1px 1px 0 rgba(255,255,255,0.10) inset`)
- Renames "Plugin Marketplace compatible" → "Plugin Store compatible" across all 10 locale string files

Fixes #3361

## Test plan
- [ ] Launch onboarding flow and verify the Plugin Store badge renders with the correct top dark shadow and bottom white highlight
- [ ] Verify label reads "Plugin Store compatible" on device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced badge component with improved visual definition through added inset shadow and highlight effects.

* **Localization**
  * Updated onboarding text to reference "Plugin Store" across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->