### PR TITLE
fix: set THORChain streaming interval to 0 for Rapid Swaps

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepository.kt
@@ -266,7 +266,7 @@ constructor(
                     fromAsset = srcToken.swapAssetName(),
                     toAsset = dstToken.swapAssetName(),
                     amount = thorTokenValue.toString(),
-                    interval = "1",
+                    interval = "0",
                     referralCode = referralCode,
                     bpsDiscount = bpsDiscount,
                 )


### PR DESCRIPTION
## Summary
- Change THORChain `streaming_interval` from `1` to `0` in `SwapQuoteRepository.kt`
- `interval=0` lets THORChain decide optimally whether to stream or serve in a single block (Rapid Swaps), rather than forcing streaming
- MayaChain interval remains unchanged at `3`

## Issue
Closes #3702

## Test Plan
- [x] THORChain swap quote request includes `streaming_interval=0`
- [x] MayaChain swap quote request still uses `streaming_interval=3`
- [ ] Lint passes (`./gradlew lint`)
- [x] Debug build succeeds (`./gradlew assembleDebug`)

https://runescan.io/tx/56253d28606d288cd254381990d3c1f2856783f943a9476bcf7a0d3fb155af22

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted swap quote retrieval configuration to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->