### PR TITLE
Fix dest address for EVM fee estimation

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -137,6 +137,7 @@ constructor(
 
             TokenStandard.EVM -> {
                 val evmApi = evmApiFactory.createEvmApi(chain)
+                val recipientAddress = dstAddress ?: address
                 if (chain == Chain.ZkSync) {
                     val memoDataHex =
                         "0xffffffff".toByteArray().joinToString(separator = "") { byte ->
@@ -149,7 +150,7 @@ constructor(
                     val feeEstimate =
                         evmApi.zkEstimateFee(
                             srcAddress = token.address,
-                            dstAddress = address,
+                            dstAddress = recipientAddress,
                             data = data,
                         )
 
@@ -174,7 +175,7 @@ constructor(
                         if (token.isNativeToken)
                             evmApi.estimateGasForEthTransaction(
                                 senderAddress = token.address,
-                                recipientAddress = address,
+                                recipientAddress = recipientAddress,
                                 value = tokenAmountValue ?: BigInteger.ZERO,
                                 memo = memo,
                             )
@@ -182,7 +183,7 @@ constructor(
                             evmApi
                                 .estimateGasForERC20Transfer(
                                     senderAddress = token.address,
-                                    recipientAddress = address,
+                                    recipientAddress = recipientAddress,
                                     contractAddress = token.contractAddress,
                                     value = tokenAmountValue ?: BigInteger.ZERO,
                                 )
@@ -212,7 +213,7 @@ constructor(
                                     coin = token,
                                     vault = VaultData("", ""),
                                     amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    to = address,
+                                    to = recipientAddress,
                                     memo = memo,
                                 )
                             )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -1,0 +1,281 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.BittensorApi
+import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.DashApi
+import com.vultisig.wallet.data.api.EvmApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.api.RippleApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.TonApi
+import com.vultisig.wallet.data.api.models.ZkGasFee
+import com.vultisig.wallet.data.blockchain.FeeService
+import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.model.BasicFee
+import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
+import com.vultisig.wallet.data.blockchain.model.Eip1559
+import com.vultisig.wallet.data.blockchain.model.Fee
+import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class BlockChainSpecificRepositoryImplTest {
+
+    @Test
+    fun `native EVM estimation uses destination address in returned dto`() = runTest {
+        val destination = "0xdestination"
+        val coin = evmCoin(chain = Chain.Ethereum, isNativeToken = true)
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(nativeGasByRecipient = mapOf(destination to BigInteger("40000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22")))
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Ethereum,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger.TEN,
+                    memo = "memo",
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("40000"),
+            maxFeePerGas = BigInteger("111"),
+            priorityFee = BigInteger("22"),
+        )
+    }
+
+    @Test
+    fun `ERC20 estimation uses destination address in returned dto`() = runTest {
+        val destination = "0xrecipient"
+        val coin =
+            evmCoin(chain = Chain.Ethereum, isNativeToken = false, contractAddress = "0xcontract")
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(erc20GasByRecipient = mapOf(destination to BigInteger("200000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22")))
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Ethereum,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger("42"),
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("300000"),
+            maxFeePerGas = BigInteger("111"),
+            priorityFee = BigInteger("22"),
+        )
+    }
+
+    @Test
+    fun `zkSync estimation uses destination address in returned dto`() = runTest {
+        val destination = "0xzkrecipient"
+        val coin = evmCoin(chain = Chain.ZkSync, isNativeToken = true)
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(
+                            zkFeesByRecipient =
+                                mapOf(
+                                    destination to
+                                        ZkGasFee(
+                                            gasLimit = BigInteger("25000"),
+                                            gasPerPubdataLimit = BigInteger.ONE,
+                                            maxFeePerGas = BigInteger("77"),
+                                            maxPriorityFeePerGas = BigInteger("33"),
+                                        )
+                                )
+                        ),
+                    evmFeeService = NoOpFeeService,
+                )
+                .getSpecific(
+                    chain = Chain.ZkSync,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                    dstAddress = destination,
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("25000"),
+            maxFeePerGas = BigInteger("77"),
+            priorityFee = BigInteger("33"),
+        )
+    }
+
+    private fun repository(
+        evmApi: EvmApi,
+        evmFeeService: FeeService,
+    ): BlockChainSpecificRepositoryImpl {
+        val evmApiFactory =
+            object : EvmApiFactory {
+                override fun createEvmApi(chain: Chain): EvmApi = evmApi
+            }
+
+        return BlockChainSpecificRepositoryImpl(
+            thorChainApi = mockk<ThorChainApi>(relaxed = true),
+            mayaChainApi = mockk<MayaChainApi>(relaxed = true),
+            evmApiFactory = evmApiFactory,
+            solanaApi = mockk<SolanaApi>(relaxed = true),
+            cosmosApiFactory = mockk<CosmosApiFactory>(relaxed = true),
+            blockChairApi = mockk<BlockChairApi>(relaxed = true),
+            dashApi = mockk<DashApi>(relaxed = true),
+            polkadotApi = mockk<PolkadotApi>(relaxed = true),
+            bittensorApi = mockk<BittensorApi>(relaxed = true),
+            suiApi = mockk<SuiApi>(relaxed = true),
+            tonApi = mockk<TonApi>(relaxed = true),
+            rippleApi = mockk<RippleApi>(relaxed = true),
+            tronApi = mockk<TronApi>(relaxed = true),
+            cardanoApi = mockk<CardanoApi>(relaxed = true),
+            feeServiceComposite =
+                FeeServiceComposite(
+                    ethereumFeeService = evmFeeService,
+                    zkFeeService = NoOpFeeService,
+                    polkadotFeeService = NoOpFeeService,
+                    bittensorFeeService = NoOpFeeService,
+                    rippleFeeService = NoOpFeeService,
+                    suiFeeService = NoOpFeeService,
+                    tonFeeService = NoOpFeeService,
+                    tronFeeService = NoOpFeeService,
+                    solanaFeeService = NoOpFeeService,
+                    thorchainFeeService = NoOpFeeService,
+                    cosmosFeeService = NoOpFeeService,
+                    utxoFeeService = NoOpFeeService,
+                ),
+        )
+    }
+
+    private fun evmApi(
+        nativeGasByRecipient: Map<String, BigInteger> = emptyMap(),
+        erc20GasByRecipient: Map<String, BigInteger> = emptyMap(),
+        zkFeesByRecipient: Map<String, ZkGasFee> = emptyMap(),
+    ): EvmApi = mockk {
+        coEvery { getNonce(any()) } returns NONCE
+
+        coEvery { estimateGasForEthTransaction(any(), any(), any(), any()) } answers
+            {
+                val recipient = invocation.args[1] as String
+                nativeGasByRecipient[recipient] ?: BigInteger("1000")
+            }
+
+        coEvery { estimateGasForERC20Transfer(any(), any(), any(), any()) } answers
+            {
+                val recipient = invocation.args[2] as String
+                erc20GasByRecipient[recipient] ?: BigInteger("50000")
+            }
+
+        coEvery { zkEstimateFee(any(), any(), any()) } answers
+            {
+                val recipient = invocation.args[1] as String
+                zkFeesByRecipient[recipient]
+                    ?: ZkGasFee(
+                        gasLimit = BigInteger("999"),
+                        gasPerPubdataLimit = BigInteger.ONE,
+                        maxFeePerGas = BigInteger("5"),
+                        maxPriorityFeePerGas = BigInteger.ONE,
+                    )
+            }
+    }
+
+    private fun evmFeeService(
+        feesByRecipient: Map<String, Pair<BigInteger, BigInteger>>
+    ): FeeService = mockk {
+        coEvery { calculateFees(any()) } answers
+            {
+                val transfer = invocation.args.first() as Transfer
+                val (maxFee, priorityFee) =
+                    feesByRecipient[transfer.to] ?: (BigInteger("999") to BigInteger("888"))
+                Eip1559(
+                    limit = BigInteger.ONE,
+                    networkPrice = BigInteger.ZERO,
+                    maxFeePerGas = maxFee,
+                    maxPriorityFeePerGas = priorityFee,
+                    amount = maxFee,
+                )
+            }
+
+        coEvery { calculateDefaultFees(any()) } returns BasicFee(BigInteger.ZERO)
+    }
+
+    private fun assertEthereumSpecific(
+        result: BlockChainSpecificAndUtxo,
+        gasLimit: BigInteger,
+        maxFeePerGas: BigInteger,
+        priorityFee: BigInteger,
+    ) {
+        val specific = result.blockChainSpecific as BlockChainSpecific.Ethereum
+        assertEquals(gasLimit, specific.gasLimit)
+        assertEquals(maxFeePerGas, specific.maxFeePerGasWei)
+        assertEquals(priorityFee, specific.priorityFeeWei)
+        assertEquals(NONCE, specific.nonce)
+    }
+
+    private fun evmCoin(chain: Chain, isNativeToken: Boolean, contractAddress: String = "") =
+        Coin(
+            chain = chain,
+            ticker = "ETH",
+            logo = "",
+            address = SOURCE_ADDRESS,
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "eth",
+            contractAddress = contractAddress,
+            isNativeToken = isNativeToken,
+        )
+
+    private companion object {
+        val NONCE: BigInteger = BigInteger("7")
+        const val SOURCE_ADDRESS = "0xsource"
+    }
+}
+
+private object NoOpFeeService : FeeService {
+    override suspend fun calculateFees(transaction: BlockchainTransaction): Fee =
+        BasicFee(BigInteger.ZERO)
+
+    override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
+        BasicFee(BigInteger.ZERO)
+}


### PR DESCRIPTION
## Summary

Fix EVM destination-address handling in `BlockChainSpecificRepository` so send flows estimate gas and build fee inputs against the actual recipient instead of the sender address.

## Problem

The send form passes both the source address and the destination address into `getSpecific()`, but the EVM branch was still using `address` in recipient-facing fields:

- `zkEstimateFee(... dstAddress = address, ...)`
- `estimateGasForEthTransaction(... recipientAddress = address, ...)`
- `estimateGasForERC20Transfer(... recipientAddress = address, ...)`
- `Transfer(to = address, ...)` passed into `feeServiceComposite.calculateFees(...)`

That caused self-transfer style estimation for native EVM sends, ERC20 sends, and zkSync sends.

## Fix

- Derive `recipientAddress` once in the EVM branch as `dstAddress ?: address`
- Use `recipientAddress` for:
  - zkSync fee estimation
  - native EVM gas estimation
  - ERC20 transfer gas estimation
  - fee calculation `Transfer.to`

## Tests

Added tests covering:

- native EVM gas estimation uses the destination address
- ERC20 gas estimation uses the destination address
- zkSync fee estimation uses the destination address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved fee estimation for EVM token transfers and zkSync transactions to correctly use the destination address when provided, ensuring accurate gas fees and transaction costs are calculated for cross-destination token transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->