### PR TITLE
fix: show correct Cardano fee (180000 lovelace) instead of 0

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeSelection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeSelection.kt
@@ -1,0 +1,35 @@
+package com.vultisig.wallet.ui.models.send
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.ui.utils.UiText
+import java.math.BigInteger
+
+/**
+ * Picks the gas fee value passed to GasFeeToEstimatedFeeUseCase for a given chain.
+ *
+ * Cardano is special-cased: it uses a fixed fee from UtxoFeeService and never goes through the
+ * Bitcoin UTXO planner, so [planFee] is the sentinel `1`. Without this branch the generic UTXO path
+ * would overwrite the real fee with `1` and the UI would show ~0 ADA.
+ */
+internal fun selectGasFeeForFeeEstimation(
+    chain: Chain,
+    gasFee: TokenValue,
+    planFee: Long?,
+    evmGasSettings: GasSettings.Eth?,
+): TokenValue =
+    when {
+        chain == Chain.Cardano -> gasFee
+        chain.standard == TokenStandard.UTXO -> {
+            val plan =
+                planFee
+                    ?: throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_invalid_plan_fee)
+                    )
+            if (plan > 0) gasFee.copy(value = BigInteger.valueOf(plan)) else gasFee
+        }
+        evmGasSettings != null -> gasFee.copy(value = evmGasSettings.baseFee)
+        else -> gasFee
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -1353,6 +1353,7 @@ constructor(
                                 else BigInteger.valueOf(1),
                             gasFee =
                                 when {
+                                    chain == Chain.Cardano -> gasFee
                                     chain.standard == TokenStandard.UTXO -> {
                                         val plan =
                                             planFee.value
@@ -2680,6 +2681,7 @@ constructor(
                                     else BigInteger.valueOf(1),
                                 gasFee =
                                     when {
+                                        chain == Chain.Cardano -> gasFee
                                         chain.standard == TokenStandard.UTXO ->
                                             gasFee.copy(value = BigInteger.valueOf(planFee))
                                         evmGasSettings != null ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -1352,23 +1352,12 @@ constructor(
                                 if (evmGasSettings != null) evmGasSettings.gasLimit
                                 else BigInteger.valueOf(1),
                             gasFee =
-                                when {
-                                    chain == Chain.Cardano -> gasFee
-                                    chain.standard == TokenStandard.UTXO -> {
-                                        val plan =
-                                            planFee.value
-                                                ?: throw InvalidTransactionDataException(
-                                                    UiText.StringResource(
-                                                        R.string.send_error_invalid_plan_fee
-                                                    )
-                                                )
-                                        if (plan > 0) gasFee.copy(value = BigInteger.valueOf(plan))
-                                        else gasFee
-                                    }
-                                    evmGasSettings != null ->
-                                        gasFee.copy(value = evmGasSettings.baseFee)
-                                    else -> gasFee
-                                },
+                                selectGasFeeForFeeEstimation(
+                                    chain = chain,
+                                    gasFee = gasFee,
+                                    planFee = planFee.value,
+                                    evmGasSettings = evmGasSettings,
+                                ),
                             selectedToken = selectedToken,
                         )
                     )
@@ -2680,14 +2669,12 @@ constructor(
                                     if (evmGasSettings != null) evmGasSettings.gasLimit
                                     else BigInteger.valueOf(1),
                                 gasFee =
-                                    when {
-                                        chain == Chain.Cardano -> gasFee
-                                        chain.standard == TokenStandard.UTXO ->
-                                            gasFee.copy(value = BigInteger.valueOf(planFee))
-                                        evmGasSettings != null ->
-                                            gasFee.copy(value = evmGasSettings.baseFee)
-                                        else -> gasFee
-                                    },
+                                    selectGasFeeForFeeEstimation(
+                                        chain = chain,
+                                        gasFee = gasFee,
+                                        planFee = planFee,
+                                        evmGasSettings = evmGasSettings,
+                                    ),
                                 selectedToken = token,
                                 perUnit = true,
                             )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SelectGasFeeForFeeEstimationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SelectGasFeeForFeeEstimationTest.kt
@@ -1,0 +1,106 @@
+package com.vultisig.wallet.ui.models.send
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenValue
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class SelectGasFeeForFeeEstimationTest {
+
+    private val cardanoFee =
+        TokenValue(value = BigInteger.valueOf(180_000L), unit = "ADA", decimals = 6)
+
+    private val btcFee = TokenValue(value = BigInteger.valueOf(10L), unit = "BTC", decimals = 8)
+
+    private val ethFee = TokenValue(value = BigInteger.valueOf(1L), unit = "ETH", decimals = 18)
+
+    @Test
+    fun `cardano returns the original gas fee unchanged - regression for fee showing 0`() {
+        // planFee is the sentinel value 1 for Cardano because it skips the BTC UTXO planner.
+        // The Cardano branch must run BEFORE the generic UTXO branch, otherwise the real
+        // 180000 lovelace fee gets overwritten with 1 and the UI shows ~0 ADA.
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Cardano,
+                gasFee = cardanoFee,
+                planFee = 1L,
+                evmGasSettings = null,
+            )
+
+        assertEquals(cardanoFee, result)
+        assertEquals(BigInteger.valueOf(180_000L), result.value)
+    }
+
+    @Test
+    fun `bitcoin with positive plan fee uses the plan fee value`() {
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Bitcoin,
+                gasFee = btcFee,
+                planFee = 1234L,
+                evmGasSettings = null,
+            )
+
+        assertEquals(BigInteger.valueOf(1234L), result.value)
+        assertEquals(btcFee.unit, result.unit)
+    }
+
+    @Test
+    fun `bitcoin with non-positive plan fee falls back to the original gas fee`() {
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Bitcoin,
+                gasFee = btcFee,
+                planFee = 0L,
+                evmGasSettings = null,
+            )
+
+        assertEquals(btcFee, result)
+    }
+
+    @Test
+    fun `utxo chain with null plan fee throws InvalidTransactionDataException`() {
+        assertThrows<InvalidTransactionDataException> {
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Bitcoin,
+                gasFee = btcFee,
+                planFee = null,
+                evmGasSettings = null,
+            )
+        }
+    }
+
+    @Test
+    fun `ethereum uses the base fee from evm gas settings`() {
+        val baseFee = BigInteger.valueOf(42L)
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Ethereum,
+                gasFee = ethFee,
+                planFee = null,
+                evmGasSettings =
+                    GasSettings.Eth(
+                        baseFee = baseFee,
+                        priorityFee = BigInteger.valueOf(2L),
+                        gasLimit = BigInteger.valueOf(21_000L),
+                    ),
+            )
+
+        assertEquals(baseFee, result.value)
+    }
+
+    @Test
+    fun `non-utxo chain without evm settings returns the original gas fee`() {
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Solana,
+                gasFee = ethFee,
+                planFee = null,
+                evmGasSettings = null,
+            )
+
+        assertEquals(ethFee, result)
+    }
+}


### PR DESCRIPTION
## Summary

- Cardano (ADA) transaction fee was displaying as **0** in the send form
- Root cause: `planFee` is set to sentinel value `1` for Cardano (it skips the Bitcoin UTXO planner), then both fee display paths overrode `gasFee.value` with `BigInteger.valueOf(1)` = 1 lovelace ≈ 0 ADA
- Fix: add `chain == Chain.Cardano -> gasFee` before the generic `UTXO` branch in both fee calculation paths so the actual 180,000 lovelace value from `UtxoFeeService` flows through

## Changes

| Location | Before | After |
|----------|--------|-------|
| `collectEstimatedFee()` UTXO fee branch | uses `planFee` (=1) for Cardano | passes `gasFee` (=180000) directly |
| Transaction confirmation fee branch | uses `planFee` (=1) for Cardano | passes `gasFee` (=180000) directly |

## Test Plan
- [ ] Send screen for Cardano shows **0.18 ADA** as the estimated fee
- [ ] Other UTXO chains (BTC, LTC, etc.) still use the transaction planner fee
- [ ] Cardano transaction confirmation shows correct fee

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified fee selection so estimated fees and final gas/fee use a consistent strategy across Cardano, UTXO chains (e.g., Bitcoin) and EVM chains; EVM uses network base fee when available.
  * Added validation to surface errors when required plan-fee data is missing for UTXO transactions.

* **Tests**
  * Added tests covering fee-selection behavior across chains to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->