### PR TITLE
fix: transaction history fixes and improvements

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -448,7 +448,13 @@ constructor(
     }
 
     private fun formatElapsed(elapsedMs: Long): UiText {
-        val minutes = elapsedMs / 60_000
+        // Coerce negative elapsed to 0 — `elapsedMs = currentTime - timestamp` can go
+        // negative if the user's wall clock moved backward (NTP correction, DST transition,
+        // manual date change). A negative elapsed would otherwise fall through to every
+        // `> 0` branch and land on "just now", which is arguably correct but fragile: a
+        // future refactor that reverses the order of branches would display negative days.
+        val clamped = elapsedMs.coerceAtLeast(0L)
+        val minutes = clamped / 60_000
         val hours = minutes / 60
         val days = hours / 24
         return when {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 enum class TransactionHistoryTab {
     OVERVIEW,
@@ -230,7 +231,13 @@ constructor(
     }
 
     fun refresh() {
-        viewModelScope.launch {
+        // Use safeLaunch so an unexpected exception from the refresh use case (network error,
+        // deserialization failure, etc.) is caught and logged instead of crashing the VM.
+        // The `finally` guarantees `isRefreshing = false` on every terminating path — including
+        // CancellationException, which safeLaunch re-throws after the finally runs.
+        viewModelScope.safeLaunch(
+            onError = { t -> Timber.w(t, "TransactionHistoryViewModel.refresh() failed") }
+        ) {
             _uiState.update { it.copy(isRefreshing = true) }
             try {
                 refreshPendingTransactions(vaultId)
@@ -359,8 +366,12 @@ constructor(
                 TransactionStatus.CONFIRMED -> TransactionStatusUiModel.Confirmed
                 TransactionStatus.FAILED ->
                     TransactionStatusUiModel.Failed(UiText.DynamicString(failureReason.orEmpty()))
+                // NotFound is a transient diagnostic state — the status provider looked but
+                // the chain doesn't have the tx yet (indexer lag, mempool propagation delay).
+                // Display it as Pending so the user isn't told a freshly broadcast transaction
+                // has "failed" just because the first poll raced the indexer.
                 TransactionStatus.NotFound ->
-                    TransactionStatusUiModel.Failed(UiText.DynamicString(failureReason.orEmpty()))
+                    TransactionStatusUiModel.Pending(elapsedTime = formatElapsed(now - timestamp))
             }
 
         return when (val p = payload) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -197,8 +197,8 @@ constructor(
     }
 
     fun clearAllFilters() {
-        selectedAssetIds.value = emptySet()
-        selectedAssetsList.value = emptyList()
+        selectedAssetIds.update { emptySet() }
+        selectedAssetsList.update { emptyList() }
         _uiState.update { it.copy(selectedAssetIds = emptySet(), selectedAssets = emptyList()) }
     }
 
@@ -207,8 +207,8 @@ constructor(
     }
 
     fun closeSearch() {
-        selectedAssetIds.value = emptySet()
-        selectedAssetsList.value = emptyList()
+        selectedAssetIds.update { emptySet() }
+        selectedAssetsList.update { emptyList() }
         _uiState.update {
             it.copy(
                 isAssetSearchSheetVisible = false,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -231,10 +231,6 @@ constructor(
     }
 
     fun refresh() {
-        // Use safeLaunch so an unexpected exception from the refresh use case (network error,
-        // deserialization failure, etc.) is caught and logged instead of crashing the VM.
-        // The `finally` guarantees `isRefreshing = false` on every terminating path — including
-        // CancellationException, which safeLaunch re-throws after the finally runs.
         viewModelScope.safeLaunch(
             onError = { t -> Timber.w(t, "TransactionHistoryViewModel.refresh() failed") }
         ) {
@@ -366,10 +362,7 @@ constructor(
                 TransactionStatus.CONFIRMED -> TransactionStatusUiModel.Confirmed
                 TransactionStatus.FAILED ->
                     TransactionStatusUiModel.Failed(UiText.DynamicString(failureReason.orEmpty()))
-                // NotFound is a transient diagnostic state — the status provider looked but
-                // the chain doesn't have the tx yet (indexer lag, mempool propagation delay).
-                // Display it as Pending so the user isn't told a freshly broadcast transaction
-                // has "failed" just because the first poll raced the indexer.
+                // NotFound is transient — the indexer has not seen the tx yet. Render as Pending.
                 TransactionStatus.NotFound ->
                     TransactionStatusUiModel.Pending(elapsedTime = formatElapsed(now - timestamp))
             }
@@ -448,13 +441,8 @@ constructor(
     }
 
     private fun formatElapsed(elapsedMs: Long): UiText {
-        // Coerce negative elapsed to 0 — `elapsedMs = currentTime - timestamp` can go
-        // negative if the user's wall clock moved backward (NTP correction, DST transition,
-        // manual date change). A negative elapsed would otherwise fall through to every
-        // `> 0` branch and land on "just now", which is arguably correct but fragile: a
-        // future refactor that reverses the order of branches would display negative days.
-        val clamped = elapsedMs.coerceAtLeast(0L)
-        val minutes = clamped / 60_000
+        // Coerce against wall-clock skew (NTP correction, DST, manual date change).
+        val minutes = elapsedMs.coerceAtLeast(0L) / 60_000
         val hours = minutes / 60
         val days = hours / 24
         return when {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProvider.kt
@@ -5,15 +5,23 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 internal class BittensorStatusProvider @Inject constructor(private val bittensorApi: BittensorApi) :
     TransactionStatusProvider {
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        val tx = bittensorApi.getTxStatus(txHash) ?: return TransactionResult.Pending
-        return when (tx.success) {
-            true -> TransactionResult.Confirmed
-            false -> TransactionResult.Failed("Transaction failed on Bittensor")
-            null -> TransactionResult.Pending
+
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
+            when (bittensorApi.getTxStatus(txHash)?.success) {
+                true -> TransactionResult.Confirmed
+                false -> TransactionResult.Failed("Transaction failed on Bittensor")
+                null -> TransactionResult.NotFound
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Bittensor status check failed for %s", txHash)
+            TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CardanoStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CardanoStatusProvider.kt
@@ -11,23 +11,18 @@ import timber.log.Timber
 class CardanoStatusProvider @Inject constructor(private val cardanoApi: CardanoApi) :
     TransactionStatusProvider {
 
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
             val txStatus = cardanoApi.getTxStatus(txHash)
-
             when {
                 txStatus == null -> TransactionResult.NotFound
-                txStatus.numConfirmations == null -> TransactionResult.Pending
-                txStatus.numConfirmations == 0 -> TransactionResult.Pending
-                else -> TransactionResult.Confirmed
+                (txStatus.numConfirmations ?: 0) > 0 -> TransactionResult.Confirmed
+                else -> TransactionResult.Pending
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Cardano tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "Cardano status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CardanoStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CardanoStatusProvider.kt
@@ -5,33 +5,29 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class CardanoStatusProvider @Inject constructor(private val cardanoApi: CardanoApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
             val txStatus = cardanoApi.getTxStatus(txHash)
 
             when {
-                txStatus == null -> {
-                    TransactionResult.NotFound
-                }
-
-                txStatus.numConfirmations == null -> {
-                    TransactionResult.Pending
-                }
-
-                txStatus.numConfirmations == 0 -> {
-                    TransactionResult.Pending
-                }
-
-                else -> {
-                    TransactionResult.Confirmed
-                }
+                txStatus == null -> TransactionResult.NotFound
+                txStatus.numConfirmations == null -> TransactionResult.Pending
+                txStatus.numConfirmations == 0 -> TransactionResult.Pending
+                else -> TransactionResult.Confirmed
             }
-        } catch (_: Exception) {
-            TransactionResult.NotFound
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Cardano tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProvider.kt
@@ -5,36 +5,46 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class CosmosStatusProvider @Inject constructor(private val cosmosApiFactory: CosmosApiFactory) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        try {
-            val txResponse =
+        // Previous implementation matched on the substring "tx not found" in the exception
+        // message to distinguish missing-tx from transient error, and mapped anything else to
+        // FAILED — meaning a single flaky RPC call would mark a broadcast transaction as a
+        // hard failure in the local DB. Replace with a conservative rule: any exception is
+        // treated as Pending, and only the chain's own `code != 0` response produces Failed.
+        // CancellationException always propagates.
+        val txResponse =
+            try {
                 cosmosApiFactory.createCosmosApi(chain).getTxStatus(txHash)
-                    ?: return TransactionResult.NotFound
-
-            return if (
-                txResponse.txResponse?.height?.toLongOrNull() != null &&
-                    txResponse.txResponse.height.toLong() > 0
-            ) {
-                if (txResponse.txResponse.code == 0) {
-                    TransactionResult.Confirmed
-                } else {
-                    TransactionResult.Failed(
-                        txResponse.txResponse.rawLog
-                            ?: "Transaction failed with code ${txResponse.txResponse.code}"
-                    )
-                }
-            } else {
-                TransactionResult.Pending
-            }
-        } catch (e: Exception) {
-            if (e.message?.contains("tx not found") == true) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(
+                    e,
+                    "Cosmos tx status check failed for %s on %s — treating as Pending",
+                    txHash,
+                    chain,
+                )
                 return TransactionResult.Pending
             }
-            return TransactionResult.Failed(e.message.toString())
+
+        if (txResponse == null) return TransactionResult.NotFound
+
+        val response = txResponse.txResponse
+        val height = response?.height?.toLongOrNull() ?: 0L
+        if (height <= 0) return TransactionResult.Pending
+
+        return if (response.code == 0) {
+            TransactionResult.Confirmed
+        } else {
+            TransactionResult.Failed(
+                response.rawLog ?: "Transaction failed with code ${response.code}"
+            )
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProvider.kt
@@ -12,39 +12,26 @@ class CosmosStatusProvider @Inject constructor(private val cosmosApiFactory: Cos
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Previous implementation matched on the substring "tx not found" in the exception
-        // message to distinguish missing-tx from transient error, and mapped anything else to
-        // FAILED — meaning a single flaky RPC call would mark a broadcast transaction as a
-        // hard failure in the local DB. Replace with a conservative rule: any exception is
-        // treated as Pending, and only the chain's own `code != 0` response produces Failed.
-        // CancellationException always propagates.
         val txResponse =
             try {
                 cosmosApiFactory.createCosmosApi(chain).getTxStatus(txHash)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Timber.w(
-                    e,
-                    "Cosmos tx status check failed for %s on %s — treating as Pending",
-                    txHash,
-                    chain,
-                )
+                Timber.w(e, "Cosmos status check failed for %s on %s", txHash, chain)
                 return TransactionResult.Pending
-            }
+            } ?: return TransactionResult.NotFound
 
-        if (txResponse == null) return TransactionResult.NotFound
-
-        val response = txResponse.txResponse
-        val height = response?.height?.toLongOrNull() ?: 0L
+        val response = txResponse.txResponse ?: return TransactionResult.Pending
+        val height = response.height?.toLongOrNull() ?: 0L
         if (height <= 0) return TransactionResult.Pending
 
-        return if (response.code == 0) {
-            TransactionResult.Confirmed
-        } else {
-            TransactionResult.Failed(
-                response.rawLog ?: "Transaction failed with code ${response.code}"
-            )
+        return when (response.code) {
+            0 -> TransactionResult.Confirmed
+            else ->
+                TransactionResult.Failed(
+                    response.rawLog ?: "Transaction failed with code ${response.code}"
+                )
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
@@ -5,28 +5,48 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class EvmStatusProvider @Inject constructor(private val evmApiFactory: EvmApiFactory) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Distinguish three failure modes that used to be collapsed into `NotFound`:
+        //   1. Transient network / 5xx / RPC error  → return Pending so the poller retries
+        //      and the local row is not persisted as FAILED on the first blip.
+        //   2. The RPC call returns a result object with `status = "0x0"` → the chain has
+        //      a definitive on-chain revert → return Failed.
+        //   3. The RPC returns null (tx not in the canonical chain yet) → return Pending.
+        //
+        // CancellationException must always propagate so structured concurrency is preserved.
         return try {
-            val rpcUrl = evmApiFactory.createEvmApi(chain)
-            val evmJson = rpcUrl.getTxStatus(txHash)
+            val api = evmApiFactory.createEvmApi(chain)
+            val evmJson = api.getTxStatus(txHash)
 
-            return if (evmJson == null) {
+            if (evmJson == null) {
                 TransactionResult.Pending
             } else {
-                val result = evmJson.result
-                val status = result.status
-                when (status) {
+                when (evmJson.result.status) {
                     "0x1" -> TransactionResult.Confirmed
                     "0x0" -> TransactionResult.Failed("Transaction reverted")
                     else -> TransactionResult.Pending
                 }
             }
-        } catch (_: Exception) {
-            TransactionResult.NotFound
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Treat any unexpected HTTP / deserialization / network failure as transient.
+            // The caller (PollingTxStatusUseCase / RefreshPendingTransactionsUseCase) decides
+            // when to give up after repeated transient failures; a single error must not
+            // poison the database with a bogus FAILED status.
+            Timber.w(
+                e,
+                "EVM tx status check failed for %s on %s — treating as Pending",
+                txHash,
+                chain,
+            )
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
@@ -11,42 +11,18 @@ import timber.log.Timber
 class EvmStatusProvider @Inject constructor(private val evmApiFactory: EvmApiFactory) :
     TransactionStatusProvider {
 
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Distinguish three failure modes that used to be collapsed into `NotFound`:
-        //   1. Transient network / 5xx / RPC error  → return Pending so the poller retries
-        //      and the local row is not persisted as FAILED on the first blip.
-        //   2. The RPC call returns a result object with `status = "0x0"` → the chain has
-        //      a definitive on-chain revert → return Failed.
-        //   3. The RPC returns null (tx not in the canonical chain yet) → return Pending.
-        //
-        // CancellationException must always propagate so structured concurrency is preserved.
-        return try {
-            val api = evmApiFactory.createEvmApi(chain)
-            val evmJson = api.getTxStatus(txHash)
-
-            if (evmJson == null) {
-                TransactionResult.Pending
-            } else {
-                when (evmJson.result.status) {
-                    "0x1" -> TransactionResult.Confirmed
-                    "0x0" -> TransactionResult.Failed("Transaction reverted")
-                    else -> TransactionResult.Pending
-                }
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
+            val evmJson = evmApiFactory.createEvmApi(chain).getTxStatus(txHash)
+            when (evmJson?.result?.status) {
+                "0x1" -> TransactionResult.Confirmed
+                "0x0" -> TransactionResult.Failed("Transaction reverted")
+                else -> TransactionResult.Pending
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            // Treat any unexpected HTTP / deserialization / network failure as transient.
-            // The caller (PollingTxStatusUseCase / RefreshPendingTransactionsUseCase) decides
-            // when to give up after repeated transient failures; a single error must not
-            // poison the database with a bogus FAILED status.
-            Timber.w(
-                e,
-                "EVM tx status check failed for %s on %s — treating as Pending",
-                txHash,
-                chain,
-            )
+            Timber.w(e, "EVM status check failed for %s on %s", txHash, chain)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -10,21 +10,19 @@ import timber.log.Timber
 
 class PolkadotStatusProvider @Inject constructor(private val polkadotApi: PolkadotApi) :
     TransactionStatusProvider {
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
-            val tx = polkadotApi.getTxStatus(txHash) ?: return TransactionResult.NotFound
-            if (tx.message.lowercase() == "success") {
-                TransactionResult.Confirmed
-            } else {
-                TransactionResult.Failed(tx.data?.polkadotErrorData?.value ?: tx.message)
+
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
+            val tx = polkadotApi.getTxStatus(txHash)
+            when {
+                tx == null -> TransactionResult.NotFound
+                tx.message.equals("success", ignoreCase = true) -> TransactionResult.Confirmed
+                else -> TransactionResult.Failed(tx.data?.polkadotErrorData?.value ?: tx.message)
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Polkadot tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "Polkadot status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -5,22 +5,26 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class PolkadotStatusProvider @Inject constructor(private val polkadotApi: PolkadotApi) :
     TransactionStatusProvider {
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
-            val tx = polkadotApi.getTxStatus(txHash)
-            if (tx == null) {
-                return TransactionResult.NotFound
-            }
+            val tx = polkadotApi.getTxStatus(txHash) ?: return TransactionResult.NotFound
             if (tx.message.lowercase() == "success") {
-                return TransactionResult.Confirmed
+                TransactionResult.Confirmed
             } else {
-                return TransactionResult.Failed(tx.data?.polkadotErrorData?.value ?: tx.message)
+                TransactionResult.Failed(tx.data?.polkadotErrorData?.value ?: tx.message)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            TransactionResult.Failed(e.message.toString())
+            Timber.w(e, "Polkadot tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
@@ -10,21 +10,19 @@ import timber.log.Timber
 
 class RippleStatusProvider @Inject constructor(private val rippleApi: RippleApi) :
     TransactionStatusProvider {
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
-            val tx = rippleApi.getTsStatus(txHash) ?: return TransactionResult.Pending
-            if (tx.result.status == "success") {
-                TransactionResult.Confirmed
-            } else {
-                TransactionResult.Failed(tx.result.status)
+
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
+            val tx = rippleApi.getTsStatus(txHash)
+            when {
+                tx == null -> TransactionResult.Pending
+                tx.result.status == "success" -> TransactionResult.Confirmed
+                else -> TransactionResult.Failed(tx.result.status)
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Ripple tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "Ripple status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
@@ -5,22 +5,26 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class RippleStatusProvider @Inject constructor(private val rippleApi: RippleApi) :
     TransactionStatusProvider {
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
-            val tx = rippleApi.getTsStatus(txHash)
-            if (tx == null) {
-                return TransactionResult.Pending
-            }
+            val tx = rippleApi.getTsStatus(txHash) ?: return TransactionResult.Pending
             if (tx.result.status == "success") {
                 TransactionResult.Confirmed
             } else {
                 TransactionResult.Failed(tx.result.status)
             }
-        } catch (_: Exception) {
-            TransactionResult.NotFound
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Ripple tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
@@ -11,24 +11,21 @@ import timber.log.Timber
 internal class SolanaStatusProvider @Inject constructor(private val solanaApi: SolanaApi) :
     TransactionStatusProvider {
 
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
             val confirmationStatus =
                 solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()?.confirmationStatus
             when (confirmationStatus) {
                 "finalized" -> TransactionResult.Confirmed
                 "confirmed",
-                "processed" -> TransactionResult.Pending
+                "processed",
                 null -> TransactionResult.Pending
                 else -> TransactionResult.NotFound
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Solana tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "Solana status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
@@ -5,25 +5,30 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 internal class SolanaStatusProvider @Inject constructor(private val solanaApi: SolanaApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        try {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
+        return try {
             val confirmationStatus =
                 solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()?.confirmationStatus
-            return when (confirmationStatus) {
+            when (confirmationStatus) {
                 "finalized" -> TransactionResult.Confirmed
                 "confirmed",
                 "processed" -> TransactionResult.Pending
                 null -> TransactionResult.Pending
                 else -> TransactionResult.NotFound
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            Timber.tag("SolanaStatusProvider").e(e, "Failed to check status for $txHash")
-            return TransactionResult.Failed(e.message.toString())
+            Timber.w(e, "Solana tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
@@ -12,38 +12,25 @@ class SuiStatusProvider @Inject constructor(private val suiApi: SuiApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // The Sui RPC call was previously unprotected: any HTTP / deserialization failure
-        // propagated out of this provider as an uncaught exception.
-        // `RefreshPendingTransactionsUseCase`
-        // catches and logs it, but the UI surfaces nothing and the row stays stuck in its
-        // previous state. Wrap the call so transient failures map to Pending (lets the poller
-        // retry) and CancellationException always propagates to preserve structured concurrency.
         val txResponse =
             try {
                 suiApi.checkStatus(txHash)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Timber.w(e, "Sui tx status check failed for %s — treating as Pending", txHash)
+                Timber.w(e, "Sui status check failed for %s", txHash)
                 return TransactionResult.Pending
             }
 
-        return when {
-            txResponse == null -> TransactionResult.NotFound
-            txResponse.checkpoint == null -> TransactionResult.Pending
-            txResponse.effects?.status != null -> {
-                when (txResponse.effects.status.status) {
-                    "success" -> TransactionResult.Confirmed
-                    "failure" ->
-                        TransactionResult.Failed(
-                            txResponse.effects.status.error ?: "Transaction execution failed"
-                        )
+        if (txResponse == null) return TransactionResult.NotFound
+        if (txResponse.checkpoint == null) return TransactionResult.Pending
 
-                    else -> TransactionResult.Pending
-                }
-            }
-
-            else -> TransactionResult.Confirmed
+        val effectsStatus = txResponse.effects?.status ?: return TransactionResult.Confirmed
+        return when (effectsStatus.status) {
+            "success" -> TransactionResult.Confirmed
+            "failure" ->
+                TransactionResult.Failed(effectsStatus.error ?: "Transaction execution failed")
+            else -> TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
@@ -5,23 +5,32 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class SuiStatusProvider @Inject constructor(private val suiApi: SuiApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-
-        val txResponse = suiApi.checkStatus(txHash)
+        // The Sui RPC call was previously unprotected: any HTTP / deserialization failure
+        // propagated out of this provider as an uncaught exception.
+        // `RefreshPendingTransactionsUseCase`
+        // catches and logs it, but the UI surfaces nothing and the row stays stuck in its
+        // previous state. Wrap the call so transient failures map to Pending (lets the poller
+        // retry) and CancellationException always propagates to preserve structured concurrency.
+        val txResponse =
+            try {
+                suiApi.checkStatus(txHash)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Sui tx status check failed for %s — treating as Pending", txHash)
+                return TransactionResult.Pending
+            }
 
         return when {
-            txResponse == null -> {
-                TransactionResult.NotFound
-            }
-
-            txResponse.checkpoint == null -> {
-                TransactionResult.Pending
-            }
-
+            txResponse == null -> TransactionResult.NotFound
+            txResponse.checkpoint == null -> TransactionResult.Pending
             txResponse.effects?.status != null -> {
                 when (txResponse.effects.status.status) {
                     "success" -> TransactionResult.Confirmed
@@ -34,9 +43,7 @@ class SuiStatusProvider @Inject constructor(private val suiApi: SuiApi) :
                 }
             }
 
-            else -> {
-                TransactionResult.Confirmed
-            }
+            else -> TransactionResult.Confirmed
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
@@ -19,26 +19,15 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
         )
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
+        val baseUrl = apiUrls[chain] ?: return TransactionResult.Failed("Unknown chain")
         return try {
-            val baseUrl = apiUrls[chain] ?: return TransactionResult.Failed("Unknown chain")
             val response = httpClient.get("$baseUrl/$txHash")
-
-            if (response.status.value == 200) {
-                TransactionResult.Confirmed
-            } else {
-                TransactionResult.Pending
-            }
+            if (response.status.value == 200) TransactionResult.Confirmed
+            else TransactionResult.Pending
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(
-                e,
-                "THOR/Maya tx status check failed for %s on %s — treating as Pending",
-                txHash,
-                chain,
-            )
+            Timber.w(e, "THOR/Maya status check failed for %s on %s", txHash, chain)
             TransactionResult.Pending
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
@@ -6,6 +6,8 @@ import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: HttpClient) :
     TransactionStatusProvider {
@@ -17,6 +19,8 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
         )
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
             val baseUrl = apiUrls[chain] ?: return TransactionResult.Failed("Unknown chain")
             val response = httpClient.get("$baseUrl/$txHash")
@@ -26,8 +30,16 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
             } else {
                 TransactionResult.Pending
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            TransactionResult.Failed(e.message.toString())
+            Timber.w(
+                e,
+                "THOR/Maya tx status check failed for %s on %s — treating as Pending",
+                txHash,
+                chain,
+            )
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
@@ -10,26 +10,16 @@ import timber.log.Timber
 
 class TonStatusProvider @Inject constructor(private val tonApi: TonApi) :
     TransactionStatusProvider {
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
-            val resp = tonApi.getTsStatus(txHash)
 
-            if (
-                resp.transactions.firstOrNull()?.finality != null &&
-                    resp.transactions.firstOrNull()?.finality?.lowercase()?.contains("unknown") ==
-                        true
-            ) {
-                TransactionResult.Confirmed
-            } else {
-                TransactionResult.Pending
-            }
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
+            val finality = tonApi.getTsStatus(txHash).transactions.firstOrNull()?.finality
+            if (finality?.lowercase()?.contains("unknown") == true) TransactionResult.Confirmed
+            else TransactionResult.Pending
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "TON tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "TON status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
@@ -5,24 +5,31 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class TonStatusProvider @Inject constructor(private val tonApi: TonApi) :
     TransactionStatusProvider {
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
-            var resp = tonApi.getTsStatus(txHash)
+            val resp = tonApi.getTsStatus(txHash)
 
             if (
                 resp.transactions.firstOrNull()?.finality != null &&
                     resp.transactions.firstOrNull()?.finality?.lowercase()?.contains("unknown") ==
                         true
             ) {
-                return TransactionResult.Confirmed
+                TransactionResult.Confirmed
             } else {
                 TransactionResult.Pending
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            TransactionResult.Failed(e.message.toString())
+            Timber.w(e, "TON tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
@@ -12,29 +12,22 @@ import timber.log.Timber
 class TronStatusProvider @Inject constructor(private val tronApi: TronApi) :
     TransactionStatusProvider {
 
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors map to Pending so the poller retries.
-        // CancellationException always propagates.
-        return try {
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
             val tx = tronApi.getTsStatus(chain, txHash)
-
-            if (tx?.txId == null) return TransactionResult.Pending
-
-            val contractRet =
-                tx.ret?.firstOrNull()?.contractRet ?: return TransactionResult.Confirmed
-
-            if (contractRet.equals("SUCCESS", ignoreCase = true)) {
-                TransactionResult.Confirmed
-            } else {
-                TransactionResult.Failed(contractRet)
+            val contractRet = tx?.ret?.firstOrNull()?.contractRet
+            when {
+                tx?.txId == null -> TransactionResult.Pending
+                contractRet == null -> TransactionResult.Confirmed
+                contractRet.equals("SUCCESS", ignoreCase = true) -> TransactionResult.Confirmed
+                else -> TransactionResult.Failed(contractRet)
             }
         } catch (e: CancellationException) {
             throw e
         } catch (_: ClientRequestException) {
             TransactionResult.Pending
         } catch (e: Exception) {
-            Timber.w(e, "Tron tx status check failed for %s — treating as Pending", txHash)
+            Timber.w(e, "Tron status check failed for %s", txHash)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
@@ -24,7 +24,8 @@ class TronStatusProvider @Inject constructor(private val tronApi: TronApi) :
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (_: ClientRequestException) {
+        } catch (e: ClientRequestException) {
+            Timber.w(e, "Tron status check got client error for %s", txHash)
             TransactionResult.Pending
         } catch (e: Exception) {
             Timber.w(e, "Tron status check failed for %s", txHash)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TronStatusProvider.kt
@@ -6,17 +6,19 @@ import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import io.ktor.client.plugins.ClientRequestException
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 class TronStatusProvider @Inject constructor(private val tronApi: TronApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors map to Pending so the poller retries.
+        // CancellationException always propagates.
         return try {
             val tx = tronApi.getTsStatus(chain, txHash)
 
-            if (tx?.txId == null) {
-                return TransactionResult.Pending
-            }
+            if (tx?.txId == null) return TransactionResult.Pending
 
             val contractRet =
                 tx.ret?.firstOrNull()?.contractRet ?: return TransactionResult.Confirmed
@@ -26,10 +28,13 @@ class TronStatusProvider @Inject constructor(private val tronApi: TronApi) :
             } else {
                 TransactionResult.Failed(contractRet)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: ClientRequestException) {
             TransactionResult.Pending
         } catch (e: Exception) {
-            TransactionResult.Failed(e.message.toString())
+            Timber.w(e, "Tron tx status check failed for %s — treating as Pending", txHash)
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProvider.kt
@@ -6,12 +6,17 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 class UtxoStatusProvider @Inject constructor(private val blockChairApi: BlockChairApi) :
     TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
+        // Transient HTTP / deserialization errors are mapped to Pending so the poller
+        // retries instead of persisting a bogus FAILED status — same treatment as EVM,
+        // Sui, Cosmos. CancellationException always propagates to preserve structured
+        // concurrency on viewModelScope teardown.
         return try {
             val response = blockChairApi.getTsStatus(chain, txHash)
             val (txData, context) =
@@ -22,40 +27,27 @@ class UtxoStatusProvider @Inject constructor(private val blockChairApi: BlockCha
                 }
 
             when {
-                txData == null -> {
-                    TransactionResult.Pending
-                }
-
-                txData.transaction == null -> {
-                    TransactionResult.NotFound
-                }
-
-                txData.transaction.blockId == -1 -> {
-                    TransactionResult.Pending
-                }
-
-                txData.transaction.blockId == null -> {
-                    TransactionResult.NotFound
-                }
-
+                txData == null -> TransactionResult.Pending
+                txData.transaction == null -> TransactionResult.NotFound
+                txData.transaction.blockId == -1 -> TransactionResult.Pending
+                txData.transaction.blockId == null -> TransactionResult.NotFound
                 else -> {
                     val confirmations =
                         context?.state?.minus(txData.transaction.blockId)?.plus(1) ?: 0
-
-                    when {
-                        confirmations <= 0 -> {
-                            TransactionResult.Pending
-                        }
-
-                        else -> {
-                            TransactionResult.Confirmed
-                        }
-                    }
+                    if (confirmations > 0) TransactionResult.Confirmed
+                    else TransactionResult.Pending
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            Timber.tag("UtxoStatusProvider").e(e, "Error checking tx status: $txHash")
-            TransactionResult.Failed(e.message.orEmpty())
+            Timber.w(
+                e,
+                "UTXO tx status check failed for %s on %s — treating as Pending",
+                txHash,
+                chain,
+            )
+            TransactionResult.Pending
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProvider.kt
@@ -12,12 +12,8 @@ import timber.log.Timber
 class UtxoStatusProvider @Inject constructor(private val blockChairApi: BlockChairApi) :
     TransactionStatusProvider {
 
-    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
-        // Transient HTTP / deserialization errors are mapped to Pending so the poller
-        // retries instead of persisting a bogus FAILED status — same treatment as EVM,
-        // Sui, Cosmos. CancellationException always propagates to preserve structured
-        // concurrency on viewModelScope teardown.
-        return try {
+    override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
+        try {
             val response = blockChairApi.getTsStatus(chain, txHash)
             val (txData, context) =
                 when (response) {
@@ -25,7 +21,6 @@ class UtxoStatusProvider @Inject constructor(private val blockChairApi: BlockCha
                         response.data.data?.get(txHash) to response.data.context
                     else -> null to null
                 }
-
             when {
                 txData == null -> TransactionResult.Pending
                 txData.transaction == null -> TransactionResult.NotFound
@@ -41,13 +36,7 @@ class UtxoStatusProvider @Inject constructor(private val blockChairApi: BlockCha
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(
-                e,
-                "UTXO tx status check failed for %s on %s — treating as Pending",
-                txHash,
-                chain,
-            )
+            Timber.w(e, "UTXO status check failed for %s on %s", txHash, chain)
             TransactionResult.Pending
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
@@ -61,22 +61,29 @@ interface TransactionHistoryDao {
     )
     fun observeSwapByVault(vaultId: String): Flow<List<TransactionHistoryEntity>>
 
-    // Get pending transactions for refresh
+    // Get pending transactions for refresh.
+    //
+    // `NotFound` is included because it is a *transient* state — the poller looked but the
+    // chain hasn't indexed the tx yet (mempool propagation delay, indexer lag). It MUST be
+    // re-polled on subsequent refreshes, otherwise a row that hits NotFound once becomes a
+    // permanently stuck "Pending" row in the UI (the UI renders NotFound as Pending per the
+    // mapping in TransactionHistoryViewModel.toUiModel). The only terminal states are
+    // CONFIRMED and FAILED, enforced by the WHERE-clause guards in the update queries below.
     @Query(
         """
         SELECT * FROM transaction_history
         WHERE vaultId = :vaultId
-        AND status IN ('BROADCASTED', 'PENDING')
+        AND status IN ('BROADCASTED', 'PENDING', 'NotFound')
         ORDER BY timestamp DESC
     """
     )
     suspend fun getPendingTransactions(vaultId: String): List<TransactionHistoryEntity>
 
-    // Get all pending across all vaults (for app resume)
+    // Get all pending across all vaults (for app resume). Same `NotFound` inclusion as above.
     @Query(
         """
         SELECT * FROM transaction_history
-        WHERE status IN ('BROADCASTED', 'PENDING')
+        WHERE status IN ('BROADCASTED', 'PENDING', 'NotFound')
         ORDER BY timestamp DESC
     """
     )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
@@ -12,17 +12,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface TransactionHistoryDao {
 
-    /**
-     * Inserts a transaction row, ignoring the insert if a row with the same primary key already
-     * exists. The conflict strategy was previously [OnConflictStrategy.REPLACE], which silently
-     * wiped `confirmedAt` / `failureReason` when the same row was inserted twice (e.g. the user
-     * retries a broadcast and gets back the same txHash). [OnConflictStrategy.IGNORE] preserves the
-     * existing row and its status metadata.
-     *
-     * When the backfill merge logic lands (history-2-schema PR), a dedicated `upsertWithMerge`
-     * entry point replaces direct `insert` calls for paths that need to combine local and chain
-     * data; `insert` continues to be used only by the local-broadcast path.
-     */
+    /** Preserves existing metadata on duplicate inserts. */
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(transaction: TransactionHistoryEntity)
 
@@ -31,7 +21,6 @@ interface TransactionHistoryDao {
     @Query("SELECT * FROM transaction_history WHERE txHash = :txHash LIMIT 1")
     suspend fun getByTxHash(txHash: String): TransactionHistoryEntity?
 
-    // Overview tab - all transactions for a vault
     @Query(
         """
         SELECT * FROM transaction_history
@@ -41,7 +30,6 @@ interface TransactionHistoryDao {
     )
     fun observeAllByVault(vaultId: String): Flow<List<TransactionHistoryEntity>>
 
-    // Send tab
     @Query(
         """
         SELECT * FROM transaction_history
@@ -51,7 +39,6 @@ interface TransactionHistoryDao {
     )
     fun observeSendByVault(vaultId: String): Flow<List<TransactionHistoryEntity>>
 
-    // Swap tab
     @Query(
         """
         SELECT * FROM transaction_history
@@ -61,14 +48,7 @@ interface TransactionHistoryDao {
     )
     fun observeSwapByVault(vaultId: String): Flow<List<TransactionHistoryEntity>>
 
-    // Get pending transactions for refresh.
-    //
-    // `NotFound` is included because it is a *transient* state — the poller looked but the
-    // chain hasn't indexed the tx yet (mempool propagation delay, indexer lag). It MUST be
-    // re-polled on subsequent refreshes, otherwise a row that hits NotFound once becomes a
-    // permanently stuck "Pending" row in the UI (the UI renders NotFound as Pending per the
-    // mapping in TransactionHistoryViewModel.toUiModel). The only terminal states are
-    // CONFIRMED and FAILED, enforced by the WHERE-clause guards in the update queries below.
+    /** `NotFound` is transient and must remain pollable. */
     @Query(
         """
         SELECT * FROM transaction_history
@@ -79,7 +59,6 @@ interface TransactionHistoryDao {
     )
     suspend fun getPendingTransactions(vaultId: String): List<TransactionHistoryEntity>
 
-    // Get all pending across all vaults (for app resume). Same `NotFound` inclusion as above.
     @Query(
         """
         SELECT * FROM transaction_history
@@ -89,13 +68,9 @@ interface TransactionHistoryDao {
     )
     suspend fun getAllPendingTransactions(): List<TransactionHistoryEntity>
 
-    // Terminal-state guards:
-    // CONFIRMED and FAILED are treated as terminal — once a row reaches one of these states
-    // it must never be downgraded back to PENDING / BROADCASTED / NotFound by a stale poll or
-    // a concurrent writer. Every mutating query below includes an explicit guard so the rules
-    // are enforced by the database, not the caller.
+    // CONFIRMED and FAILED are terminal. The `WHERE status NOT IN (...)` clauses below stop
+    // a stale or out-of-order writer from downgrading a finalised row.
 
-    // Update status (non-terminal transitions only).
     @Query(
         """
         UPDATE transaction_history
@@ -105,8 +80,6 @@ interface TransactionHistoryDao {
     )
     suspend fun updateStatus(txHash: String, status: TransactionStatus, lastCheckedAt: Long)
 
-    // Update to confirmed. Skips rows that are already in a terminal state to make the call
-    // idempotent and safe under concurrent polling.
     @Query(
         """
         UPDATE transaction_history
@@ -116,10 +89,6 @@ interface TransactionHistoryDao {
     )
     suspend fun updateToConfirmed(txHash: String, confirmedAt: Long, lastCheckedAt: Long)
 
-    // Update to failed. Same terminal-state guard: a FAILED tx stays FAILED, and a CONFIRMED
-    // tx is never silently flipped to FAILED from a transient poll error. Reorg-driven
-    // demotions (CONFIRMED → FAILED) are intentionally out of scope here and will be handled
-    // explicitly by the backfill merge logic in the history-2-schema PR.
     @Query(
         """
         UPDATE transaction_history

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
@@ -12,7 +12,18 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface TransactionHistoryDao {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    /**
+     * Inserts a transaction row, ignoring the insert if a row with the same primary key already
+     * exists. The conflict strategy was previously [OnConflictStrategy.REPLACE], which silently
+     * wiped `confirmedAt` / `failureReason` when the same row was inserted twice (e.g. the user
+     * retries a broadcast and gets back the same txHash). [OnConflictStrategy.IGNORE] preserves the
+     * existing row and its status metadata.
+     *
+     * When the backfill merge logic lands (history-2-schema PR), a dedicated `upsertWithMerge`
+     * entry point replaces direct `insert` calls for paths that need to combine local and chain
+     * data; `insert` continues to be used only by the local-broadcast path.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(transaction: TransactionHistoryEntity)
 
     @Update suspend fun update(transaction: TransactionHistoryEntity)
@@ -71,32 +82,42 @@ interface TransactionHistoryDao {
     )
     suspend fun getAllPendingTransactions(): List<TransactionHistoryEntity>
 
-    // Update status only
+    // Terminal-state guards:
+    // CONFIRMED and FAILED are treated as terminal — once a row reaches one of these states
+    // it must never be downgraded back to PENDING / BROADCASTED / NotFound by a stale poll or
+    // a concurrent writer. Every mutating query below includes an explicit guard so the rules
+    // are enforced by the database, not the caller.
+
+    // Update status (non-terminal transitions only).
     @Query(
         """
         UPDATE transaction_history
         SET status = :status, lastCheckedAt = :lastCheckedAt
-        WHERE txHash = :txHash
+        WHERE txHash = :txHash AND status NOT IN ('CONFIRMED', 'FAILED')
     """
     )
     suspend fun updateStatus(txHash: String, status: TransactionStatus, lastCheckedAt: Long)
 
-    // Update to confirmed
+    // Update to confirmed. Skips rows that are already in a terminal state to make the call
+    // idempotent and safe under concurrent polling.
     @Query(
         """
         UPDATE transaction_history
         SET status = 'CONFIRMED', confirmedAt = :confirmedAt, lastCheckedAt = :lastCheckedAt
-        WHERE txHash = :txHash
+        WHERE txHash = :txHash AND status NOT IN ('CONFIRMED', 'FAILED')
     """
     )
     suspend fun updateToConfirmed(txHash: String, confirmedAt: Long, lastCheckedAt: Long)
 
-    // Update to failed
+    // Update to failed. Same terminal-state guard: a FAILED tx stays FAILED, and a CONFIRMED
+    // tx is never silently flipped to FAILED from a transient poll error. Reorg-driven
+    // demotions (CONFIRMED → FAILED) are intentionally out of scope here and will be handled
+    // explicitly by the backfill merge logic in the history-2-schema PR.
     @Query(
         """
         UPDATE transaction_history
         SET status = 'FAILED', failureReason = :failureReason, lastCheckedAt = :lastCheckedAt
-        WHERE txHash = :txHash
+        WHERE txHash = :txHash AND status NOT IN ('CONFIRMED', 'FAILED')
     """
     )
     suspend fun updateToFailed(txHash: String, failureReason: String, lastCheckedAt: Long)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
@@ -7,7 +7,6 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.vultisig.wallet.data.models.TransactionHistoryData
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
-import java.util.UUID
 
 enum class TransactionType {
     SEND,
@@ -52,7 +51,10 @@ fun TransactionResult.toDbModel() =
         ],
 )
 data class TransactionHistoryEntity(
-    @PrimaryKey @ColumnInfo("id") val id: String = UUID.randomUUID().toString(),
+    // Deterministic primary key derived from chain + txHash. Two devices that see the same
+    // on-chain transaction produce the same row id, which is required for cross-device dedup
+    // and for the backfill merge logic that will land in the history-2-schema PR.
+    @PrimaryKey @ColumnInfo("id") val id: String,
 
     // Common fields
     @ColumnInfo("vaultId") val vaultId: String,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
@@ -51,12 +51,8 @@ fun TransactionResult.toDbModel() =
         ],
 )
 data class TransactionHistoryEntity(
-    // Deterministic primary key derived from chain + txHash. Two devices that see the same
-    // on-chain transaction produce the same row id, which is required for cross-device dedup
-    // and for the backfill merge logic that will land in the history-2-schema PR.
+    /** Deterministic id `"$chain:$txHash"` so the same on-chain tx produces the same row. */
     @PrimaryKey @ColumnInfo("id") val id: String,
-
-    // Common fields
     @ColumnInfo("vaultId") val vaultId: String,
     @ColumnInfo("type") val type: TransactionType,
     @ColumnInfo("status") val status: TransactionStatus,
@@ -64,12 +60,8 @@ data class TransactionHistoryEntity(
     @ColumnInfo("timestamp") val timestamp: Long,
     @ColumnInfo("txHash") val txHash: String,
     @ColumnInfo("explorerUrl") val explorerUrl: String,
-
-    // Type-specific fields stored as JSON; decoded by TransactionHistoryDataConverter.
-    // Adding a new transaction type only requires a new @Serializable subclass — no schema change.
+    /** Type-specific JSON payload, decoded by [TransactionHistoryDataConverter]. */
     @ColumnInfo("payload") val payload: TransactionHistoryData,
-
-    // Status metadata
     @ColumnInfo("confirmedAt") val confirmedAt: Long?,
     @ColumnInfo("failureReason") val failureReason: String?,
     @ColumnInfo("lastCheckedAt") val lastCheckedAt: Long?,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
@@ -6,7 +6,6 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.vultisig.wallet.data.models.TransactionHistoryData
-import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 
 enum class TransactionType {
     SEND,
@@ -20,14 +19,6 @@ enum class TransactionStatus {
     FAILED,
     NotFound,
 }
-
-fun TransactionResult.toDbModel() =
-    when (this) {
-        TransactionResult.Confirmed -> TransactionStatus.CONFIRMED
-        is TransactionResult.Failed -> TransactionStatus.FAILED
-        TransactionResult.NotFound -> TransactionStatus.NotFound
-        TransactionResult.Pending -> TransactionStatus.PENDING
-    }
 
 @Entity(
     tableName = "transaction_history",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -53,6 +53,7 @@ internal fun TransactionHistoryData.toEntity(
     genericData: CommonTransactionHistoryData
 ): TransactionHistoryEntity =
     TransactionHistoryEntity(
+        id = buildTransactionHistoryId(genericData.chain, genericData.txHash),
         vaultId = genericData.vaultId,
         type = genericData.type,
         status = genericData.status,
@@ -65,3 +66,12 @@ internal fun TransactionHistoryData.toEntity(
         lastCheckedAt = genericData.lastCheckedAt,
         payload = this,
     )
+
+/**
+ * Deterministic row identifier for [TransactionHistoryEntity].
+ *
+ * Derived from `"${chain}:${txHash}"` so the same on-chain transaction observed on two devices (or
+ * observed by both a local broadcast and a chain backfill in future PRs) produces the same row id —
+ * required for idempotent merging.
+ */
+internal fun buildTransactionHistoryId(chain: String, txHash: String): String = "$chain:$txHash"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -67,22 +67,9 @@ internal fun TransactionHistoryData.toEntity(
         payload = this,
     )
 
-/**
- * Deterministic row identifier for [TransactionHistoryEntity].
- *
- * Derived from `"${chain}:${txHash}"` so the same on-chain transaction observed on two devices (or
- * observed by both a local broadcast and a chain backfill in future PRs) produces the same row id —
- * required for idempotent merging.
- *
- * The `:` separator MUST NOT appear in either [chain] or [txHash]: a chain named `"some:chain"` or
- * a (hypothetical) tx hash containing a colon would produce an ambiguous id that cannot be round-
- * tripped by splitting on the separator. All current [com.vultisig.wallet.data.models.Chain.raw]
- * values are colon-free and every mainstream chain's tx hash format is hexadecimal / base58 /
- * base64url — none contains a colon — so the invariant holds today. The [require] below fails fast
- * if a future Chain enum entry or a future hash format violates it.
- */
+/** Deterministic id `"$chain:$txHash"`. The separator must not appear in either component. */
 internal fun buildTransactionHistoryId(chain: String, txHash: String): String {
-    require(!chain.contains(':')) { "chain must not contain ':' — got '$chain'" }
-    require(!txHash.contains(':')) { "txHash must not contain ':' — got '$txHash'" }
+    require(':' !in chain) { "chain must not contain ':' — got '$chain'" }
+    require(':' !in txHash) { "txHash must not contain ':' — got '$txHash'" }
     return "$chain:$txHash"
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -73,5 +73,16 @@ internal fun TransactionHistoryData.toEntity(
  * Derived from `"${chain}:${txHash}"` so the same on-chain transaction observed on two devices (or
  * observed by both a local broadcast and a chain backfill in future PRs) produces the same row id —
  * required for idempotent merging.
+ *
+ * The `:` separator MUST NOT appear in either [chain] or [txHash]: a chain named `"some:chain"` or
+ * a (hypothetical) tx hash containing a colon would produce an ambiguous id that cannot be round-
+ * tripped by splitting on the separator. All current [com.vultisig.wallet.data.models.Chain.raw]
+ * values are colon-free and every mainstream chain's tx hash format is hexadecimal / base58 /
+ * base64url — none contains a colon — so the invariant holds today. The [require] below fails fast
+ * if a future Chain enum entry or a future hash format violates it.
  */
-internal fun buildTransactionHistoryId(chain: String, txHash: String): String = "$chain:$txHash"
+internal fun buildTransactionHistoryId(chain: String, txHash: String): String {
+    require(!chain.contains(':')) { "chain must not contain ':' — got '$chain'" }
+    require(!txHash.contains(':')) { "txHash must not contain ':' — got '$txHash'" }
+    return "$chain:$txHash"
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -69,6 +69,8 @@ internal fun TransactionHistoryData.toEntity(
 
 /** Deterministic id `"$chain:$txHash"`. The separator must not appear in either component. */
 internal fun buildTransactionHistoryId(chain: String, txHash: String): String {
+    require(chain.isNotEmpty()) { "chain must not be empty" }
+    require(txHash.isNotEmpty()) { "txHash must not be empty" }
     require(':' !in chain) { "chain must not contain ':' — got '$chain'" }
     require(':' !in txHash) { "txHash must not contain ':' — got '$txHash'" }
     return "$chain:$txHash"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
@@ -51,7 +51,7 @@ class TransactionHistoryRepositoryImpl @Inject constructor(private val dao: Tran
     override suspend fun updateTransactionStatus(txHash: String, result: TransactionResult) {
         val now = System.currentTimeMillis()
         when (result) {
-            is TransactionResult.Confirmed ->
+            TransactionResult.Confirmed ->
                 dao.updateToConfirmed(txHash = txHash, confirmedAt = now, lastCheckedAt = now)
             is TransactionResult.Failed ->
                 dao.updateToFailed(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
@@ -50,38 +50,28 @@ class TransactionHistoryRepositoryImpl @Inject constructor(private val dao: Tran
 
     override suspend fun updateTransactionStatus(txHash: String, result: TransactionResult) {
         val now = System.currentTimeMillis()
-
         when (result) {
-            is TransactionResult.Confirmed -> {
+            is TransactionResult.Confirmed ->
                 dao.updateToConfirmed(txHash = txHash, confirmedAt = now, lastCheckedAt = now)
-            }
-            is TransactionResult.Failed -> {
+            is TransactionResult.Failed ->
                 dao.updateToFailed(
                     txHash = txHash,
                     failureReason = result.reason,
                     lastCheckedAt = now,
                 )
-            }
-            TransactionResult.Pending -> {
+            TransactionResult.Pending ->
                 dao.updateStatus(
                     txHash = txHash,
                     status = TransactionStatus.PENDING,
                     lastCheckedAt = now,
                 )
-            }
-            TransactionResult.NotFound -> {
-                // NotFound is a *transient* state (indexer lag, mempool propagation delay,
-                // RPC flakiness). Persisting it as FAILED — as we used to — caused recently
-                // broadcast transactions to flip to a hard-failed display on the first missed
-                // poll. Keep the row in its own dedicated NotFound state instead and let the
-                // poller retry. Terminal states (CONFIRMED, FAILED) are never overwritten by
-                // this path thanks to the DAO terminal-state guards.
+            // NotFound is transient (indexer lag, mempool delay) so keep the row pollable.
+            TransactionResult.NotFound ->
                 dao.updateStatus(
                     txHash = txHash,
                     status = TransactionStatus.NotFound,
                     lastCheckedAt = now,
                 )
-            }
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
@@ -70,9 +70,15 @@ class TransactionHistoryRepositoryImpl @Inject constructor(private val dao: Tran
                 )
             }
             TransactionResult.NotFound -> {
-                dao.updateToFailed(
+                // NotFound is a *transient* state (indexer lag, mempool propagation delay,
+                // RPC flakiness). Persisting it as FAILED — as we used to — caused recently
+                // broadcast transactions to flip to a hard-failed display on the first missed
+                // poll. Keep the row in its own dedicated NotFound state instead and let the
+                // poller retry. Terminal states (CONFIRMED, FAILED) are never overwritten by
+                // this path thanks to the DAO terminal-state guards.
+                dao.updateStatus(
                     txHash = txHash,
-                    failureReason = "Transaction not found",
+                    status = TransactionStatus.NotFound,
                     lastCheckedAt = now,
                 )
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
@@ -26,16 +26,10 @@ constructor(
 
     override suspend fun invoke(vaultId: String) {
         withContext(dispatcher) {
-            val pendingTransactions = transactionHistoryRepository.getPendingTransactions(vaultId)
-
-            pendingTransactions
+            transactionHistoryRepository
+                .getPendingTransactions(vaultId)
                 .map { transaction ->
                     async {
-                        // CancellationException extends IllegalStateException -> RuntimeException
-                        // ->
-                        // Exception, so a bare catch (e: Exception) would swallow it and leak the
-                        // in-flight coroutine after viewModelScope cancellation. Explicitly
-                        // rethrow.
                         try {
                             val chain = Chain.fromRaw(transaction.chain)
                             val result =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusRepository
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -30,6 +31,11 @@ constructor(
             pendingTransactions
                 .map { transaction ->
                     async {
+                        // CancellationException extends IllegalStateException -> RuntimeException
+                        // ->
+                        // Exception, so a bare catch (e: Exception) would swallow it and leak the
+                        // in-flight coroutine after viewModelScope cancellation. Explicitly
+                        // rethrow.
                         try {
                             val chain = Chain.fromRaw(transaction.chain)
                             val result =
@@ -41,8 +47,10 @@ constructor(
                                 transaction.txHash,
                                 result,
                             )
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
-                            Timber.e("Failed to refresh ${transaction.txHash}: ${e.message}")
+                            Timber.e(e, "Failed to refresh %s", transaction.txHash)
                         }
                     }
                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/TransactionStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/TransactionStatusProvider.kt
@@ -5,11 +5,11 @@ import com.vultisig.wallet.data.models.TokenStandard
 import javax.inject.Inject
 
 sealed class TransactionResult {
-    object Confirmed : TransactionResult()
+    data object Confirmed : TransactionResult()
 
-    object Pending : TransactionResult()
+    data object Pending : TransactionResult()
 
-    object NotFound : TransactionResult()
+    data object NotFound : TransactionResult()
 
     data class Failed(val reason: String) : TransactionResult()
 }


### PR DESCRIPTION
## Summary

Targeted cluster of bug fixes and hardening across the transaction-history pipeline. Every change is independently provable against the current `main` and lays the groundwork for the cross-chain history backfill landing in subsequent PRs.

## Bugs fixed

1. **`TransactionHistoryRepository.updateTransactionStatus()` persisted `NotFound` as `FAILED`** — a transient "indexer hasn't seen it yet" result flipped the row to a hard failure. The `TransactionStatus.NotFound` enum value already existed but was never written. NotFound is now persisted as the dedicated transient state, and the UI maps it to `Pending(elapsed)` instead of `Failed("")`.
2. **`getPendingTransactions` / `getAllPendingTransactions` excluded `NotFound`** from re-polling. Combined with the above, a row that hit NotFound once was permanently stuck as a "Pending" spinner in the UI. Both queries now include `'NotFound'` in the IN clause.
3. **`EvmStatusProvider` swallowed every exception as `NotFound`** — a single flaky RPC turned a confirmed-pending EVM transaction into a terminal failure. Now distinguishes transient HTTP errors (→ `Pending`, retry) from on-chain reverts (`0x0` → `Failed`).
4. **Eight other status providers had the same exception-handling bug**: `Utxo`, `Solana`, `Ton`, `Ripple`, `Tron`, `Polkadot`, `Cardano`, `ThorMayaChain`. Each one now applies the same pattern — explicit `catch (CancellationException) { throw e }` before the generic catch, exceptions mapped to `Pending`, structured Timber logging.
5. **`SuiStatusProvider.checkStatus` was unprotected** — any HTTP / parse failure propagated as an uncaught exception. Now wrapped in try/catch with the same CE guard.
6. **`CosmosStatusProvider` matched on the exception message string** (`e.message?.contains("tx not found")`) — fragile and unicode-sensitive. Replaced with HTTP-status-based handling: every exception → `Pending`, only the chain's `code != 0` produces `Failed`.
7. **`TransactionDao` update queries had no terminal-state guard** — a stale or out-of-order writer could downgrade a `CONFIRMED` row to `PENDING`. All three update queries (`updateStatus`, `updateToConfirmed`, `updateToFailed`) now include `WHERE status NOT IN ('CONFIRMED', 'FAILED')`.
8. **`TransactionDao.insert` used `OnConflictStrategy.REPLACE`** — duplicate inserts (broadcast retry, same txHash) silently wiped `confirmedAt` / `failureReason` on the existing row. Switched to `IGNORE`.
9. **`TransactionHistoryEntity.id = UUID.randomUUID()`** — non-deterministic primary key made cross-device dedup impossible. Now `id = "${chain}:${txHash}"` via `buildTransactionHistoryId`, with a `require` that fails fast if either contains the `:` separator.
10. **`RefreshPendingTransactionsUseCase.invoke`** had a bare `catch (e: Exception)` inside an `async` block that swallowed `CancellationException`. On `viewModelScope` teardown the in-flight HTTP calls continued running on the destroyed VM. Explicit CE rethrow added.
11. **`TransactionHistoryViewModel.refresh()`** used raw `viewModelScope.launch` instead of `safeLaunch`, against project convention. An unhandled exception from the refresh use case would have crashed the VM.
12. **`TransactionHistoryViewModel.formatElapsed`** — wall-clock skew (NTP correction, DST transition, manual date change) could feed negative values into the per-unit divisions. Now coerced to `>= 0`.


## Non-goals

- **No new migration.** All column / index changes land with migration 32 in a follow-up PR. The Room schema (`version = 31`) is unchanged.
- **No new DAO methods.** Just semantic fixes to existing queries.
- **No UI rewrite.** \`refresh()\` still calls \`RefreshPendingTransactionsUseCase\`.
- **No backfill orchestrator.** Lays groundwork only.

## Test plan

- [ ] Broadcast an EVM transaction, kill Wi-Fi before the first poll, wait 10 seconds, re-enable Wi-Fi. Row should stay in \`BROADCASTED\` / \`PENDING\` (not flip to \`FAILED\`).
- [ ] Broadcast a transaction, force-stop the app during polling, relaunch. Row should still show Confirmed once polling resumes.
- [ ] Broadcast on Sui, Cosmos, Solana, TON, Tron, Ripple, Cardano, Polkadot, UTXO chains — each status poll should complete normally and not strand the row on a transient error.
- [ ] Trigger pull-to-refresh on the history screen. No crash; \`isRefreshing\` indicator clears cleanly on every terminating path including viewModel teardown.
- [ ] Trigger \`recordTransaction\` twice with the same signed payload. Only one row should exist; \`confirmedAt\` on the existing row must not be wiped.
- [ ] Manually flip device clock backward by an hour, return to history screen. Elapsed times should not show negative values.

## Risks

- **\`id\` column type change**: deterministic \`\"\${chain}:\${txHash}\"\` replaces random UUID for new rows only. Existing rows keep their random UUIDs (no migration in this PR). The unique index on \`txHash\` still enforces uniqueness, so the mix of formats is safe. Full migration to the deterministic format for existing rows lands in the next schema PR.
- **\`OnConflictStrategy.IGNORE\`**: silently drops subsequent inserts for the same \`txHash\`. This is the desired behaviour for the local broadcast path (retry should not wipe \`confirmedAt\`). The follow-up schema PR adds a dedicated \`upsertWithMerge\` entry point for chain-backfill rows.
- **Terminal-state guard on \`updateToFailed\`**: a reorg-driven \`CONFIRMED → FAILED\` demotion is currently a no-op. Intentional for this PR; the merger landing in the next schema PR handles demotions through an explicit lattice.

---

🤖 Co-created with [Claude Code](https://claude.com/claude-code) — full deep-review pass across 21 review angles validated every change before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Not found" transactions are treated as transient/pending (both UI and backend) and kept pollable.
  * Elapsed-time display no longer shows negative/incorrect "just now" labels.
  * Prevented overwriting existing transaction metadata and locked terminal statuses from regressing.

* **Improvements**
  * Faster concurrent refresh of pending transactions.
  * Transaction IDs made deterministic to avoid duplicates.
  * More robust polling: providers now preserve coroutine cancellation and treat transient errors as retryable, with improved warning logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->