### PR TITLE
fix: GG20 keysign swallows CancellationException

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -63,6 +63,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import java.math.BigInteger
 import java.util.Base64
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -379,7 +380,7 @@ constructor(
                 currentState.value = KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
             }
             isNavigateToHome = true
-        } catch (e: kotlinx.coroutines.CancellationException) {
+        } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Timber.e(e)
@@ -432,6 +433,9 @@ constructor(
             isNavigateToHome = true
 
             pullTssMessagesJob?.cancel()
+        } catch (e: CancellationException) {
+            pullTssMessagesJob?.cancel()
+            throw e
         } catch (e: Exception) {
             Timber.e(e)
             currentState.value = KeysignState.Error(e.message or R.string.unknown_error)
@@ -509,6 +513,9 @@ constructor(
             pullTssMessagesJob?.cancel()
 
             delay(1.seconds)
+        } catch (e: CancellationException) {
+            pullTssMessagesJob?.cancel()
+            throw e
         } catch (e: Exception) {
             pullTssMessagesJob?.cancel()
             Timber.tag("KeysignViewModel")


### PR DESCRIPTION
Closes #4018

## What was wrong

`signAndBroadcast` and `signMessageWithRetry` in `KeysignViewModel` caught `Exception` without rethrowing `CancellationException`. The DKLS/KeyImport path (`startKeysignCore`) already had the correct guard but GG20 never got it.

When a coroutine cancellation happened mid sign (user navigating away or a TSS child job getting cancelled) the GG20 path would catch the CE and display it as a signing error instead of letting structured concurrency do its thing.

## What changed

Added `catch (e: CancellationException) { throw e }` before the generic `catch (e: Exception)` in both `signAndBroadcast` and `signMessageWithRetry`. Also replaced the fully qualified `kotlinx.coroutines.CancellationException` in all three catch sites (including the pre-existing one in `startKeysignCore`) with an import for readability.

## Test plan

- [ ] GG20 keysign completes normally (no regression)
- [ ] Navigate away mid GG20 keysign. App should not show a spurious error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling and cancellation mechanisms for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->