### PR TITLE
fix: make DeFi positions screen scrollable (#3239)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
@@ -39,7 +41,10 @@ fun BaseDeFiPositionsScreenContent(
 ) {
     V2Scaffold(onBackClick = onBackClick) {
         Column(
-            modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
+            modifier =
+                Modifier.fillMaxSize()
+                    .background(Theme.v2.colors.backgrounds.primary)
+                    .verticalScroll(rememberScrollState()),
             horizontalAlignment = CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {


### PR DESCRIPTION
## Summary
- Adds vertical scroll to `BaseDeFiPositionsScreen` so content is accessible on smaller devices where the Circle USDC amount and buttons don't fit on screen

Fixes #3239

## Test plan
- [ ] Open Circle DeFi positions screen on a small screen device/emulator
- [ ] Verify the USDC amount and action buttons are visible by scrolling
- [ ] Confirm no regression on larger screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeFi positions screen layout by enabling vertical scrolling, allowing users to view all content without content being cut off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->