### PR TITLE
fix: show loading state while validating biometric fast sign password

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsScreen.kt
@@ -163,7 +163,9 @@ private fun BiometricFastSignBottomSheetContent(
                     isVisible = uiModel.isPasswordVisible,
                     onVisibilityClick = onToggleVisibilityClick,
                 ),
-            hint = uiModel.passwordHint?.asString() ?: stringResource(R.string.import_file_screen_hint_password),
+            hint =
+                uiModel.passwordHint?.asString()
+                    ?: stringResource(R.string.import_file_screen_hint_password),
             footNote = errorMessage,
             innerState =
                 if (errorMessage != null) VsTextInputFieldInnerState.Error
@@ -194,7 +196,6 @@ private fun BiometricFastSignBottomSheetContent(
         }
     }
 }
-
 
 @Preview
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -20,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.VsCircularLoading
 import com.vultisig.wallet.ui.components.backup.BackupMethodBottomSheet
 import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
 import com.vultisig.wallet.ui.components.buttons.VsButton
@@ -109,7 +111,7 @@ private fun VaultSettingsScreen(
                     biometricTextFieldState,
                     onToggleVisibilityClick,
                     onSaveBiometricsClick,
-                    uiModel,
+                    uiModel.biometricsEnableUiModel,
                 )
             }
         }
@@ -122,33 +124,24 @@ private fun BiometricFastSignBottomSheet(
     biometricTextFieldState: TextFieldState,
     onToggleVisibilityClick: () -> Unit,
     onSaveBiometricsClick: () -> Unit,
-    uiModel: VaultSettingsState,
+    biometricsEnableUiModel: BiometricsEnableUiModel,
 ) {
     VsModalBottomSheet(onDismissRequest = onDismissBiometricsBottomSheet) {
         BiometricFastSignBottomSheetContent(
+            uiModel = biometricsEnableUiModel,
             passwordTextFieldState = biometricTextFieldState,
             onToggleVisibilityClick = onToggleVisibilityClick,
             onSaveClick = onSaveBiometricsClick,
-            hint =
-                uiModel.biometricsEnableUiModel.passwordHint?.asString()
-                    ?: stringResource(R.string.import_file_screen_hint_password),
-            errorMessage = uiModel.biometricsEnableUiModel.passwordErrorMessage?.asString(),
-            isSaveEnabled = uiModel.biometricsEnableUiModel.isSaveEnabled,
-            isPasswordVisible = uiModel.biometricsEnableUiModel.isPasswordVisible,
         )
     }
 }
 
-@Preview
 @Composable
 private fun BiometricFastSignBottomSheetContent(
-    passwordTextFieldState: TextFieldState = rememberTextFieldState(),
-    onToggleVisibilityClick: () -> Unit = {},
-    onSaveClick: () -> Unit = {},
-    hint: String? = null,
-    errorMessage: String? = null,
-    isSaveEnabled: Boolean = true,
-    isPasswordVisible: Boolean = true,
+    uiModel: BiometricsEnableUiModel,
+    passwordTextFieldState: TextFieldState,
+    onToggleVisibilityClick: () -> Unit,
+    onSaveClick: () -> Unit,
 ) {
     Column(
         Modifier.padding(16.dp).verticalScroll(rememberScrollState()),
@@ -162,14 +155,15 @@ private fun BiometricFastSignBottomSheetContent(
 
         FadingHorizontalDivider(modifier = Modifier.padding(vertical = 24.dp))
 
+        val errorMessage = uiModel.passwordErrorMessage?.asString()
         VsTextInputField(
             textFieldState = passwordTextFieldState,
             type =
                 VsTextInputFieldType.Password(
-                    isVisible = isPasswordVisible,
+                    isVisible = uiModel.isPasswordVisible,
                     onVisibilityClick = onToggleVisibilityClick,
                 ),
-            hint = hint,
+            hint = uiModel.passwordHint?.asString() ?: stringResource(R.string.import_file_screen_hint_password),
             footNote = errorMessage,
             innerState =
                 if (errorMessage != null) VsTextInputFieldInnerState.Error
@@ -179,10 +173,36 @@ private fun BiometricFastSignBottomSheetContent(
         UiSpacer(14.dp)
 
         VsButton(
-            state = if (isSaveEnabled) VsButtonState.Enabled else VsButtonState.Disabled,
-            label = stringResource(R.string.add_vault_save),
+            state =
+                when {
+                    uiModel.isLoading -> VsButtonState.Disabled
+                    uiModel.isSaveEnabled -> VsButtonState.Enabled
+                    else -> VsButtonState.Disabled
+                },
             onClick = onSaveClick,
             modifier = Modifier.fillMaxWidth(),
-        )
+        ) {
+            if (uiModel.isLoading) {
+                VsCircularLoading(modifier = Modifier.size(20.dp))
+            } else {
+                Text(
+                    text = stringResource(R.string.add_vault_save),
+                    style = Theme.brockmann.button.semibold.medium,
+                    color = Theme.v2.colors.text.button.primary,
+                )
+            }
+        }
     }
+}
+
+
+@Preview
+@Composable
+private fun BiometricFastSignBottomSheetContentPreview() {
+    BiometricFastSignBottomSheetContent(
+        uiModel = BiometricsEnableUiModel(),
+        passwordTextFieldState = rememberTextFieldState(),
+        onToggleVisibilityClick = {},
+        onSaveClick = {},
+    )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -557,9 +557,7 @@ constructor(
     private fun setBiometricLoading(isLoading: Boolean) {
         uiModel.update {
             it.copy(
-                biometricsEnableUiModel = it.biometricsEnableUiModel.copy(
-                    isLoading = isLoading,
-                )
+                biometricsEnableUiModel = it.biometricsEnableUiModel.copy(isLoading = isLoading)
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -47,6 +47,7 @@ internal data class BiometricsEnableUiModel(
     val isPasswordVisible: Boolean = false,
     val passwordErrorMessage: UiText? = null,
     val passwordHint: UiText? = null,
+    val isLoading: Boolean = false,
 )
 
 internal data class VaultSettingsState(
@@ -515,12 +516,14 @@ constructor(
     fun onSaveEnableBiometricFastSign() =
         viewModelScope.launch {
             val vault = vaultRepository.get(vaultId) ?: error("No vault with id $vaultId exists")
+            setBiometricLoading(isLoading = true)
             val isPasswordValid =
                 vultiSignerRepository.isPasswordValid(
                     publicKeyEcdsa = vault.pubKeyECDSA,
                     password = passwordTextFieldState.text.toString(),
                 )
 
+            setBiometricLoading(isLoading = false)
             if (!isPasswordValid) {
                 val hint = getPasswordHint()
                 passwordTextFieldState.clearText()
@@ -550,6 +553,16 @@ constructor(
                 showSnackbarMessage()
             }
         }
+
+    private fun setBiometricLoading(isLoading: Boolean) {
+        uiModel.update {
+            it.copy(
+                biometricsEnableUiModel = it.biometricsEnableUiModel.copy(
+                    isLoading = isLoading,
+                )
+            )
+        }
+    }
 
     private fun hideBiometricFastVaultBottomSheet() {
         uiModel.update { it.copy(isBiometricFastSignBottomSheetVisible = false) }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.VultiSignerRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.settings.SettingsItemUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -514,43 +515,46 @@ constructor(
         }
 
     fun onSaveEnableBiometricFastSign() =
-        viewModelScope.launch {
+        viewModelScope.safeLaunch {
             val vault = vaultRepository.get(vaultId) ?: error("No vault with id $vaultId exists")
             setBiometricLoading(isLoading = true)
-            val isPasswordValid =
-                vultiSignerRepository.isPasswordValid(
-                    publicKeyEcdsa = vault.pubKeyECDSA,
-                    password = passwordTextFieldState.text.toString(),
-                )
-
-            setBiometricLoading(isLoading = false)
-            if (!isPasswordValid) {
-                val hint = getPasswordHint()
-                passwordTextFieldState.clearText()
-                uiModel.update {
-                    it.copy(
-                        biometricsEnableUiModel =
-                            it.biometricsEnableUiModel.copy(
-                                passwordErrorMessage =
-                                    UiText.StringResource(
-                                        R.string.keysign_password_incorrect_password
-                                    ),
-                                passwordHint = hint,
-                                isSaveEnabled = false,
-                            )
+            try {
+                val isPasswordValid =
+                    vultiSignerRepository.isPasswordValid(
+                        publicKeyEcdsa = vault.pubKeyECDSA,
+                        password = passwordTextFieldState.text.toString(),
                     )
+
+                if (!isPasswordValid) {
+                    val hint = getPasswordHint()
+                    passwordTextFieldState.clearText()
+                    uiModel.update {
+                        it.copy(
+                            biometricsEnableUiModel =
+                                it.biometricsEnableUiModel.copy(
+                                    passwordErrorMessage =
+                                        UiText.StringResource(
+                                            R.string.keysign_password_incorrect_password
+                                        ),
+                                    passwordHint = hint,
+                                    isSaveEnabled = false,
+                                )
+                        )
+                    }
+                    return@safeLaunch
                 }
-                return@launch
-            }
-            if (!isBiometricFastSignEnabled) {
-                vaultPasswordRepository.savePassword(
-                    vaultId = vaultId,
-                    password = passwordTextFieldState.text.toString(),
-                )
-                isBiometricFastSignEnabled = true
-                passwordTextFieldState.clearText()
-                hideBiometricFastVaultBottomSheet()
-                showSnackbarMessage()
+                if (!isBiometricFastSignEnabled) {
+                    vaultPasswordRepository.savePassword(
+                        vaultId = vaultId,
+                        password = passwordTextFieldState.text.toString(),
+                    )
+                    isBiometricFastSignEnabled = true
+                    passwordTextFieldState.clearText()
+                    hideBiometricFastVaultBottomSheet()
+                    showSnackbarMessage()
+                }
+            } finally {
+                setBiometricLoading(isLoading = false)
             }
         }
 


### PR DESCRIPTION
## Summary
- Drive a loading indicator on the Save button in the Biometric Fast Sign bottom sheet from a new `isLoading` field on `BiometricsEnableUiModel`, flipped around the `vultiSignerRepository.isPasswordValid` call.
- Disable the button while the validation call is in flight so it can't be re-submitted.
- Refactor `BiometricFastSignBottomSheet` to take `BiometricsEnableUiModel` directly instead of the whole `VaultSettingsState`.

## Why
Before this change the password-validation network call ran with no visual feedback — users saw a noticeable delay between tapping **Save** and the incorrect-password error appearing, which felt like a frozen UI. The spinner makes the pending state obvious and preserves the existing error flow once the call resolves.

Fixes #3250

## Test plan
- [ ] Open a vault's settings → **Biometric Fast Signing**
- [ ] Enter an **incorrect** password and tap **Save** → spinner appears on the button immediately, then the error message is shown once the server responds
- [ ] Enter the **correct** password and tap **Save** → spinner appears, biometric fast signing is enabled, snackbar confirmation is shown, bottom sheet closes
- [ ] While the spinner is visible, confirm the button is not tappable (no double-submit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Save button during biometric fast-sign setup is disabled while validating and shows a loading spinner for clearer feedback.

* **New Features**
  * Password hint, error messages, and save-button state are now derived and presented consistently within the biometric setup UI.

* **Refactor**
  * Biometric setup component simplified to accept a focused UI model for clearer behavior and previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->