### PR TITLE
fix: correct Modifier extensions and Timber logging misuse

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
@@ -165,13 +165,13 @@ private fun ServerBackupScreen(
 
 private val SectionShape = RoundedCornerShape(12.dp)
 
-@Composable
-private fun Modifier.sectionCard(): Modifier =
+private fun Modifier.sectionCard(): Modifier = composed {
     this.fillMaxWidth()
         .border(1.dp, Theme.v2.colors.border.light, SectionShape)
         .clip(SectionShape)
         .background(Theme.v2.colors.backgrounds.secondary)
         .padding(16.dp)
+}
 
 @Composable
 private fun ConfirmedRow(label: String, value: String, onEditClick: (() -> Unit)? = null) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -240,8 +241,7 @@ internal fun BondFormContent(
 private val cardShape = RoundedCornerShape(12.dp)
 private val inputShape = RoundedCornerShape(12.dp)
 
-@Composable
-private fun Modifier.vsClickableBackground() =
+private fun Modifier.vsClickableBackground() = composed {
     border(
             border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
             shape = RoundedCornerShape(12.dp),
@@ -250,6 +250,7 @@ private fun Modifier.vsClickableBackground() =
             color = Theme.v2.colors.backgrounds.secondary,
             shape = RoundedCornerShape(12.dp),
         )
+}
 
 private fun String.toDisplayAsset(): String =
     substringBefore("-").substringAfterLast("/").substringAfterLast(".")

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
@@ -1283,8 +1283,7 @@ internal fun FadingHorizontalDivider(modifier: Modifier = Modifier) {
     )
 }
 
-@Composable
-private fun Modifier.vsClickableBackground() =
+private fun Modifier.vsClickableBackground() = composed {
     border(
             border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
             shape = RoundedCornerShape(12.dp),
@@ -1293,6 +1292,7 @@ private fun Modifier.vsClickableBackground() =
             color = Theme.v2.colors.backgrounds.secondary,
             shape = RoundedCornerShape(12.dp),
         )
+}
 
 @Composable
 private fun FoldableSection(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -630,7 +630,7 @@ constructor(
         ) {
             TcyStakeResponse(address = address, amount = "0")
         } else if (!httpResponse.status.isSuccess()) {
-            Timber.e("FetchTcyStakedAmount", "${httpResponse.status}")
+            Timber.e("FetchTcyStakedAmount %s", "${httpResponse.status}")
             error("Error Fetching Tcy Staked: ")
         } else {
             httpResponse.bodyOrThrow<TcyStakeResponse>()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCase.kt
@@ -27,7 +27,7 @@ constructor(private val thorChainRepository: ThorChainRepository) :
                 "THORChain network id initialized with: ${ThorChainHelper.THORCHAIN_NETWORK_ID}"
             )
         } catch (e: Exception) {
-            Timber.e("Failed to fetch network chain id", e)
+            Timber.e(e, "Failed to fetch network chain id")
         }
     }
 }


### PR DESCRIPTION
## Summary

- Convert three `@Composable Modifier` extension functions to `Modifier.composed { }`:
  - `ServerBackupScreen.sectionCard`
  - `BondFormScreen.vsClickableBackground`
  - `SendFormScreen.vsClickableBackground`

  Marking a `Modifier` extension as `@Composable` forces every caller into a composable scope and is not the idiomatic way to read `CompositionLocal` state (`Theme.v2.colors.*`) inside a modifier. `Modifier.composed { }` is the correct primitive and avoids subtle recomposition surprises.

- `ThorChainApi.fetchTcyStakedAmount`: the error branch called `Timber.e("FetchTcyStakedAmount", "\${httpResponse.status}")`, passing the status as a stray second argument. Switched to a proper `%s` format specifier: `Timber.e("FetchTcyStakedAmount %s", "\${httpResponse.status}")`.

- `InitializeThorChainNetworkIdUseCase`: fixed argument order on the catch-block log. Timber's signature is `Timber.e(throwable, message, ...)`, so `Timber.e(e, "Failed to fetch network chain id")` now logs the exception as a real throwable (stack trace + all) instead of silently treating it as a format argument.

## Test plan

- [ ] App builds (`./gradlew assembleDebug`)
- [ ] Lint passes (`./gradlew lint`)
- [ ] Manually open Server Backup confirm screen — section cards still render with border + rounded corners
- [ ] Manually open Bond form + Send form — clickable background containers render unchanged
- [ ] Trigger a TCY stake fetch error path and verify the log contains the response status
- [ ] Force THORChain network-id init to fail and verify the log includes the thrown exception (stack trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal UI modifier composition for more maintainable and consistent styling; no visual or behavioral changes for users.
  * Standardized and clarified error logging in network and initialization flows to aid diagnostics without affecting end-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->