### PR TITLE
fix: use shorthand memo prefixes for liquidity operations

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -110,11 +110,11 @@ internal interface DepositMemo {
     }
 
     data class AddLiquidity(val pool: String) : DepositMemo {
-        override fun toString(): String = "ADD:$pool"
+        override fun toString(): String = "+:$pool"
     }
 
     data class RemoveLiquidity(val pool: String, val basisPoints: Int) : DepositMemo {
-        override fun toString(): String = "WITHDRAW:$pool:$basisPoints"
+        override fun toString(): String = "-:$pool:$basisPoints"
     }
 
     data class WithdrawPool(val basisPoints: Int) : DepositMemo {

--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -110,11 +110,11 @@ internal interface DepositMemo {
     }
 
     data class AddLiquidity(val pool: String) : DepositMemo {
-        override fun toString(): String = "+:$pool"
+        override fun toString(): String = "ADD:$pool"
     }
 
     data class RemoveLiquidity(val pool: String, val basisPoints: Int) : DepositMemo {
-        override fun toString(): String = "-:$pool:$basisPoints"
+        override fun toString(): String = "WITHDRAW:$pool:$basisPoints"
     }
 
     data class WithdrawPool(val basisPoints: Int) : DepositMemo {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.data.blockchain.sui
 
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.blockchain.FeeService
-import com.vultisig.wallet.data.blockchain.model.BasicFee
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
@@ -115,7 +114,6 @@ class SuiFeeService @Inject constructor(private val suiApi: SuiApi) : FeeService
         val estimatedFees = SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15)
 
         return GasFees(price = gasPrice, limit = estimatedFees, amount = estimatedFees)
-        return BasicFee(amount = estimatedFees)
     }
 
     internal companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.blockchain.sui
 
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.blockchain.FeeService
+import com.vultisig.wallet.data.blockchain.model.BasicFee
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
@@ -114,6 +115,7 @@ class SuiFeeService @Inject constructor(private val suiApi: SuiApi) : FeeService
         val estimatedFees = SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15)
 
         return GasFees(price = gasPrice, limit = estimatedFees, amount = estimatedFees)
+        return BasicFee(amount = estimatedFees)
     }
 
     internal companion object {


### PR DESCRIPTION
## Summary
- Use `+` instead of `ADD` and `-` instead of `WITHDRAW` as memo prefixes for liquidity operations (`AddLiquidity` and `RemoveLiquidity`)
- Aligns Android memo format with iOS implementation for cross-platform consistency
- Shorter memos result in lower transaction fees
- Remove unreachable `BasicFee` return statement in `SuiFeeService.calculateDefaultFees`

## Coordination
This change brings Android in line with the iOS repo which already uses `+:$pool` and `-:$pool:$basisPoints` for liquidity memos. Both shorthand and longhand prefixes are valid per THORChain spec, but the shorter form saves bytes in the transaction memo, reducing fees.

## Test plan
- [ ] Verify add liquidity transactions produce memos starting with `+:`
- [ ] Verify remove liquidity transactions produce memos starting with `-:`
- [ ] Confirm transactions are accepted by THORChain with the shorthand prefixes
- [ ] Verify SUI fee estimation still works correctly after dead code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated liquidity operation memo formats for improved readability: AddLiquidity memos now display as "+:$pool" and RemoveLiquidity memos now display as "-:$pool:$basisPoints", making liquidity actions clearer in transaction memos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->