### PR TITLE
fix: remove unreachable code and duplication in fee services

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.data.blockchain.sui
 
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.blockchain.FeeService
-import com.vultisig.wallet.data.blockchain.model.BasicFee
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
@@ -115,7 +114,6 @@ class SuiFeeService @Inject constructor(private val suiApi: SuiApi) : FeeService
         val estimatedFees = SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15)
 
         return GasFees(price = gasPrice, limit = estimatedFees, amount = estimatedFees)
-        return BasicFee(amount = estimatedFees)
     }
 
     internal companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/UtxoFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/UtxoFeeService.kt
@@ -12,8 +12,7 @@ import javax.inject.Inject
 class UtxoFeeService @Inject constructor(private val blockChairApi: BlockChairApi) : FeeService {
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
-        val amount = getDefaultGasFee(transaction.coin.chain)
-        return BasicFee(amount)
+        return calculateDefaultFees(transaction)
     }
 
     override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee {


### PR DESCRIPTION
## Summary
- Remove unreachable `return BasicFee(...)` after `return GasFees(...)` in `SuiFeeService.calculateDefaultFees`
- Remove unused `BasicFee` import from `SuiFeeService`
- Deduplicate `UtxoFeeService.calculateFees` by delegating to `calculateDefaultFees` instead of duplicating its body (matches the pattern used by `TonFeeService` and `CosmosFeeService`)

## Test plan
- [ ] Verify SUI fee estimation works correctly
- [ ] Verify UTXO fee estimation works correctly for BTC, Doge, Zcash, Cardano

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved fee calculation logic consistency and removed unused code references for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->