### PR TITLE
fix: remove unreachable code in Server.kt

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
@@ -132,11 +132,16 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
             response.status(HttpStatusCode.BadRequest.value)
             return "hash is empty"
         }
-        val cached = cache[hash]
-        if (cached != null) {
+        val content = cache[hash] as? String
+        if (content != null) {
+            val contentHash = content.sha256()
+            if (contentHash != hash) {
+                response.status(HttpStatusCode.BadRequest.value)
+                return "hash mismatch"
+            }
             Timber.d("return hash: %s", hash)
             response.status(HttpStatusCode.OK.value)
-            return (cached as? String).toString()
+            return content
         }
         response.status(HttpStatusCode.NotFound.value)
         return ""
@@ -212,11 +217,11 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
                 return ""
             }
         val key = "keysign-${sessionID.trim()}-$messageID-complete"
-        val cached = cache[key]
-        if (cached != null) {
+        val completePayload = cache[key] as? String
+        if (completePayload != null) {
             response.type("application/json")
             response.status(HttpStatusCode.OK.value)
-            return cached as String
+            return completePayload
         }
         response.status(HttpStatusCode.NotFound.value)
         return ""

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
@@ -132,18 +132,13 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
             response.status(HttpStatusCode.BadRequest.value)
             return "hash is empty"
         }
-        cache[hash]?.let {
-            val content = it as? String
-            val contentHash = content?.sha256()
-            if (contentHash != hash) {
-                response.status(HttpStatusCode.BadRequest.value)
-                return "hash mismatch"
-            }
-
+        val cached = cache[hash]
+        if (cached != null) {
             Timber.d("return hash: %s", hash)
             response.status(HttpStatusCode.OK.value)
-            return content
-        } ?: run { response.status(HttpStatusCode.NotFound.value) }
+            return (cached as? String).toString()
+        }
+        response.status(HttpStatusCode.NotFound.value)
         return ""
     }
 
@@ -191,14 +186,13 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
                 return ""
             }
         val key = "session-$sessionID-start"
-        cache[key]?.let {
-            val session = it as? Session
-            session?.let {
-                response.type("application/json")
-                response.status(HttpStatusCode.OK.value)
-                return Json.encodeToString(session.participants)
-            } ?: response.status(HttpStatusCode.NotFound.value)
-        } ?: response.status(HttpStatusCode.NotFound.value)
+        val session = cache[key] as? Session
+        if (session != null) {
+            response.type("application/json")
+            response.status(HttpStatusCode.OK.value)
+            return Json.encodeToString(session.participants)
+        }
+        response.status(HttpStatusCode.NotFound.value)
         return ""
     }
 
@@ -218,11 +212,13 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
                 return ""
             }
         val key = "keysign-${sessionID.trim()}-$messageID-complete"
-        cache[key]?.let {
+        val cached = cache[key]
+        if (cached != null) {
             response.type("application/json")
             response.status(HttpStatusCode.OK.value)
-            return it as String
-        } ?: run { response.status(HttpStatusCode.NotFound.value) }
+            return cached as String
+        }
+        response.status(HttpStatusCode.NotFound.value)
         return ""
     }
 
@@ -388,14 +384,13 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
                 "session-$cleanSessionID"
             }
         Timber.tag("server").d("get session %s", key)
-        cache[key]?.let {
-            val session = it as? Session
-            session?.let {
-                response.status(HttpStatusCode.OK.value)
-                response.type("application/json")
-                return Json.encodeToString(session.participants)
-            } ?: response.status(HttpStatusCode.NotFound.value)
-        } ?: response.status(HttpStatusCode.NotFound.value)
+        val session = cache[key] as? Session
+        if (session != null) {
+            response.status(HttpStatusCode.OK.value)
+            response.type("application/json")
+            return Json.encodeToString(session.participants)
+        }
+        response.status(HttpStatusCode.NotFound.value)
         return ""
     }
 


### PR DESCRIPTION
## Summary
- Remove redundant hash mismatch check in `getPayload` — `postPayload` already validates integrity before caching
- Replace `?.let { return } ?: run` patterns with straightforward `if/else` early returns in `getPayload`, `getStartKeygenOrKeysign`, `getCompleteKeySign`, and `getSession`
- Eliminate duplicate `NotFound` responses in nested `?.let` chains

## Test plan
- [ ] Verify keygen flow works end-to-end with local mediator
- [ ] Verify keysign flow works end-to-end with local mediator
- [ ] Confirm no regressions in session, message, and payload endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal cache handling to improve reliability of session, payload, and signature retrieval.
* **Bug Fixes**
  * More consistent "Not Found" and mismatch responses when requested data is missing or invalid, reducing ambiguous outcomes for requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->