### PR TITLE
feat: add prevent screenshots privacy setting

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -9,6 +9,7 @@ import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -27,6 +28,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -35,11 +37,13 @@ import com.google.android.play.core.install.model.AppUpdateType
 import com.vultisig.wallet.app.activity.components.AnimatedSplash
 import com.vultisig.wallet.app.activity.components.CheckDeeplink
 import com.vultisig.wallet.app.activity.components.MainActivityContent
+import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.services.VultisigFirebaseMessagingService
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 import com.vultisig.wallet.ui.theme.v2.V2.colors
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -48,6 +52,8 @@ class MainActivity : AppCompatActivity() {
     private val mainViewModel: MainViewModel by viewModels<MainViewModel>()
 
     @Inject lateinit var appUpdateManager: AppUpdateManager
+
+    @Inject lateinit var preventScreenshotsRepository: PreventScreenshotsRepository
 
     private val pushNotificationReceiver =
         object : BroadcastReceiver() {
@@ -84,6 +90,8 @@ class MainActivity : AppCompatActivity() {
             }
 
         enableEdgeToEdge(statusBarStyle = systemBarStyle, navigationBarStyle = systemBarStyle)
+
+        observePreventScreenshots()
 
         setContent {
             OnBoardingComposeTheme {
@@ -151,6 +159,23 @@ class MainActivity : AppCompatActivity() {
             unregisterReceiver(pushNotificationReceiver)
         } catch (e: IllegalArgumentException) {
             Timber.w(e, "Receiver was not registered")
+        }
+    }
+
+    private fun observePreventScreenshots() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                preventScreenshotsRepository.isEnabled.collect { isEnabled ->
+                    if (isEnabled) {
+                        window.setFlags(
+                            WindowManager.LayoutParams.FLAG_SECURE,
+                            WindowManager.LayoutParams.FLAG_SECURE,
+                        )
+                    } else {
+                        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -164,7 +164,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun observePreventScreenshots() {
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.CREATED) {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
                 preventScreenshotsRepository.isEnabled.collect { isEnabled ->
                     if (isEnabled) {
                         window.setFlags(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.models.settings.AppLanguage
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.AppLocaleRepository
+import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
 import com.vultisig.wallet.ui.models.settings.SettingsItem.AddressBook
 import com.vultisig.wallet.ui.models.settings.SettingsItem.CheckForUpdates
@@ -20,6 +21,7 @@ import com.vultisig.wallet.ui.models.settings.SettingsItem.Faq
 import com.vultisig.wallet.ui.models.settings.SettingsItem.Github
 import com.vultisig.wallet.ui.models.settings.SettingsItem.Language
 import com.vultisig.wallet.ui.models.settings.SettingsItem.Notifications
+import com.vultisig.wallet.ui.models.settings.SettingsItem.PreventScreenshots
 import com.vultisig.wallet.ui.models.settings.SettingsItem.PrivacyPolicy
 import com.vultisig.wallet.ui.models.settings.SettingsItem.ReferralCode
 import com.vultisig.wallet.ui.models.settings.SettingsItem.ShareTheApp
@@ -207,6 +209,15 @@ internal sealed class SettingsItem(val value: SettingsItemUiModel, val enabled: 
                 trailingIcon = R.drawable.ic_small_caret_right,
             )
         )
+
+    data class PreventScreenshots(val isEnabled: Boolean = false) :
+        SettingsItem(
+            SettingsItemUiModel(
+                title = UiText.StringResource(R.string.settings_screen_prevent_screenshots),
+                leadingIcon = R.drawable.security,
+                trailingSwitch = isEnabled,
+            )
+        )
 }
 
 internal data class SettingsItemUiModel(
@@ -234,6 +245,7 @@ constructor(
     private val appCurrencyRepository: AppCurrencyRepository,
     private val appLocaleRepository: AppLocaleRepository,
     private val referralRepository: ReferralCodeSettingsRepositoryContract,
+    private val preventScreenshotsRepository: PreventScreenshotsRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _uiEvents = Channel<SettingsUiEvent>()
@@ -257,6 +269,10 @@ constructor(
                                 AddressBook,
                                 ReferralCode,
                             ),
+                    ),
+                    SettingsGroupUiModel(
+                        title = UiText.StringResource(R.string.settings_screen_privacy),
+                        items = listOf(PreventScreenshots()),
                     ),
                     SettingsGroupUiModel(
                         title = UiText.StringResource(R.string.support),
@@ -320,6 +336,13 @@ constructor(
             }
 
             VultisigWebsite -> sendEvent(SettingsUiEvent.OpenLink(VsAuxiliaryLinks.VULT_WEBSITE))
+
+            is PreventScreenshots -> {
+                viewModelScope.launch {
+                    val newValue = !item.isEnabled
+                    preventScreenshotsRepository.setEnabled(newValue)
+                }
+            }
         }
     }
 
@@ -331,12 +354,34 @@ constructor(
         viewModelScope.launch {
             loadCurrency()
             loadAppLocale()
+            loadPreventScreenshots()
             loadWasReferralUsed()
         }
     }
 
     private fun loadWasReferralUsed() {
         viewModelScope.launch { hasUsedReferral = referralRepository.hasVisitReferralCode() }
+    }
+
+    private fun loadPreventScreenshots() {
+        viewModelScope.launch {
+            preventScreenshotsRepository.isEnabled.collect { isEnabled ->
+                state.update { current ->
+                    current.copy(
+                        items = current.items.map { group ->
+                            group.copy(
+                                items = group.items.map { item ->
+                                    when (item) {
+                                        is PreventScreenshots -> item.copy(isEnabled = isEnabled)
+                                        else -> item
+                                    }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        }
     }
 
     private fun loadAppLocale() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
@@ -368,16 +368,19 @@ constructor(
             preventScreenshotsRepository.isEnabled.collect { isEnabled ->
                 state.update { current ->
                     current.copy(
-                        items = current.items.map { group ->
-                            group.copy(
-                                items = group.items.map { item ->
-                                    when (item) {
-                                        is PreventScreenshots -> item.copy(isEnabled = isEnabled)
-                                        else -> item
-                                    }
-                                }
-                            )
-                        }
+                        items =
+                            current.items.map { group ->
+                                group.copy(
+                                    items =
+                                        group.items.map { item ->
+                                            when (item) {
+                                                is PreventScreenshots ->
+                                                    item.copy(isEnabled = isEnabled)
+                                                else -> item
+                                            }
+                                        }
+                                )
+                            }
                     )
                 }
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -249,6 +249,8 @@
     <string name="add_address_address_title">Adresse</string>
     <string name="add_address_type_hint">Geben Sie hier ein</string>
     <string name="join_keysign_invalid_qr">Ungültiger QR-Code-Inhalt</string>
+    <string name="settings_screen_privacy">Datenschutz</string>
+    <string name="settings_screen_prevent_screenshots">Screenshots verhindern</string>
     <string name="settings_screen_legal">Rechtliches</string>
     <string name="settings_screen_privacy_policy">Datenschutzrichtlinie</string>
     <string name="settings_screen_tos">Servicebedingungen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -249,6 +249,8 @@
     <string name="add_address_address_title">DIRECCIÓN</string>
     <string name="add_address_type_hint">Escribe aquí</string>
     <string name="join_keysign_invalid_qr">Contenido de código QR no válido</string>
+    <string name="settings_screen_privacy">Privacidad</string>
+    <string name="settings_screen_prevent_screenshots">Evitar capturas de pantalla</string>
     <string name="settings_screen_legal">Legal</string>
     <string name="settings_screen_privacy_policy">política de privacidad</string>
     <string name="settings_screen_tos">Condiciones de servicio</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -249,6 +249,8 @@
     <string name="add_address_address_title">Adresa</string>
     <string name="add_address_type_hint">Upišite ovdje</string>
     <string name="join_keysign_invalid_qr">Nevažeći sadržaj QR koda</string>
+    <string name="settings_screen_privacy">Privatnost</string>
+    <string name="settings_screen_prevent_screenshots">Spriječi snimke zaslona</string>
     <string name="settings_screen_legal">Pravno</string>
     <string name="settings_screen_privacy_policy">Politika privatnosti</string>
     <string name="settings_screen_tos">Uvjeti usluge</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -249,6 +249,8 @@
     <string name="add_address_address_title">Indirizzo</string>
     <string name="add_address_type_hint">Scrivi qui</string>
     <string name="join_keysign_invalid_qr">Contenuto del codice QR non valido</string>
+    <string name="settings_screen_privacy">Privacy</string>
+    <string name="settings_screen_prevent_screenshots">Impedisci screenshot</string>
     <string name="settings_screen_legal">Legal</string>
     <string name="settings_screen_privacy_policy">Informativa sulla privacy</string>
     <string name="settings_screen_tos">Termini di servizio</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -316,6 +316,8 @@
     <string name="add_address_address_title">주소</string>
     <string name="add_address_type_hint">여기에 입력하세요</string>
     <string name="join_keysign_invalid_qr">유효하지 않은 QR 코드 내용</string>
+    <string name="settings_screen_privacy">개인정보</string>
+    <string name="settings_screen_prevent_screenshots">스크린샷 방지</string>
     <string name="settings_screen_legal">법적 고지</string>
     <string name="settings_screen_privacy_policy">개인정보 처리방침</string>
     <string name="settings_screen_tos">서비스 이용약관</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -248,6 +248,8 @@
     <string name="add_address_address_title">Adres</string>
     <string name="add_address_type_hint">Typ hier</string>
     <string name="join_keysign_invalid_qr">Ongeldige QR-code-inhoud</string>
+    <string name="settings_screen_privacy">Privacy</string>
+    <string name="settings_screen_prevent_screenshots">Screenshots voorkomen</string>
     <string name="settings_screen_legal">Juridisch</string>
     <string name="settings_screen_privacy_policy">Privacybeleid</string>
     <string name="settings_screen_tos">Servicevoorwaarden</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -250,6 +250,8 @@
     <string name="add_address_address_title">Morada</string>
     <string name="add_address_type_hint">Digite aqui</string>
     <string name="join_keysign_invalid_qr">Conteúdo de código QR inválido</string>
+    <string name="settings_screen_privacy">Privacidade</string>
+    <string name="settings_screen_prevent_screenshots">Impedir capturas de tela</string>
     <string name="settings_screen_legal">Legal</string>
     <string name="settings_screen_privacy_policy">política de Privacidade</string>
     <string name="settings_screen_tos">Termos de Serviço</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -247,6 +247,8 @@
     <string name="add_address_address_title">Адрес</string>
     <string name="add_address_type_hint">Введите здесь</string>
     <string name="join_keysign_invalid_qr">Недействительное содержимое QR-кода</string>
+    <string name="settings_screen_privacy">Конфиденциальность</string>
+    <string name="settings_screen_prevent_screenshots">Запретить снимки экрана</string>
     <string name="settings_screen_legal">Юридический</string>
     <string name="settings_screen_privacy_policy">политика конфиденциальности</string>
     <string name="settings_screen_tos">Условия обслуживания</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -437,6 +437,8 @@
     <string name="join_keysign_invalid_qr">无效的二维码内容</string>
 
     <!-- Settings Screen -->
+    <string name="settings_screen_privacy">隐私</string>
+    <string name="settings_screen_prevent_screenshots">防止截图</string>
     <string name="settings_screen_legal">法律</string>
     <string name="settings_screen_privacy_policy">隐私政策</string>
     <string name="settings_screen_tos">服务条款</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,8 @@
     <string name="add_address_address_title">Address</string>
     <string name="add_address_type_hint">Type here</string>
     <string name="join_keysign_invalid_qr">Invalid QR code content</string>
+    <string name="settings_screen_privacy">Privacy</string>
+    <string name="settings_screen_prevent_screenshots">Prevent Screenshots</string>
     <string name="settings_screen_legal">Legal</string>
     <string name="settings_screen_privacy_policy">Privacy Policy</string>
     <string name="settings_screen_tos">Terms of Service</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PreventScreenshotsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PreventScreenshotsRepository.kt
@@ -1,0 +1,28 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import com.vultisig.wallet.data.sources.AppDataStore
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+interface PreventScreenshotsRepository {
+    val isEnabled: Flow<Boolean>
+
+    suspend fun setEnabled(enabled: Boolean)
+}
+
+internal class PreventScreenshotsRepositoryImpl
+@Inject
+constructor(private val dataStore: AppDataStore) : PreventScreenshotsRepository {
+
+    override val isEnabled: Flow<Boolean> =
+        dataStore.readData(KEY_PREVENT_SCREENSHOTS, false)
+
+    override suspend fun setEnabled(enabled: Boolean) {
+        dataStore.set(KEY_PREVENT_SCREENSHOTS, enabled)
+    }
+
+    private companion object {
+        val KEY_PREVENT_SCREENSHOTS = booleanPreferencesKey("prevent_screenshots")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PreventScreenshotsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PreventScreenshotsRepository.kt
@@ -15,8 +15,7 @@ internal class PreventScreenshotsRepositoryImpl
 @Inject
 constructor(private val dataStore: AppDataStore) : PreventScreenshotsRepository {
 
-    override val isEnabled: Flow<Boolean> =
-        dataStore.readData(KEY_PREVENT_SCREENSHOTS, false)
+    override val isEnabled: Flow<Boolean> = dataStore.readData(KEY_PREVENT_SCREENSHOTS, false)
 
     override suspend fun setEnabled(enabled: Boolean) {
         dataStore.set(KEY_PREVENT_SCREENSHOTS, enabled)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -243,6 +243,12 @@ internal interface RepositoriesModule {
     fun bindNotificationTokenRepository(
         impl: NotificationTokenRepositoryImpl
     ): NotificationTokenRepository
+
+    @Binds
+    @Singleton
+    fun bindPreventScreenshotsRepository(
+        impl: PreventScreenshotsRepositoryImpl
+    ): PreventScreenshotsRepository
 }
 
 @Qualifier @Retention(AnnotationRetention.BINARY) annotation class PrettyJson


### PR DESCRIPTION
## Summary
- Adds a **Prevent Screenshots** toggle under a new **Privacy** section in Settings
- When enabled, sets `FLAG_SECURE` on the activity window, blocking screenshots and screen recording app-wide
- Preference persisted via DataStore, observed lifecycle-aware from `onCreate` to avoid any unprotected window on cold start
- Translations added to all 10 locale files

Closes #4046

## Test plan
- [ ] Open Settings, verify new "Privacy" section with "Prevent Screenshots" toggle appears
- [ ] Toggle ON → attempt screenshot via Power+Volume Down or ADB `screencap` → should produce black/blank image
- [ ] Toggle OFF → screenshot works normally
- [ ] Kill and relaunch app with toggle ON → verify FLAG_SECURE persists across restart
- [ ] Verify no ANR or lag when toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Privacy section in Settings with a "Prevent Screenshots" toggle; when enabled the app blocks screenshots and screen recordings in real time and persists the preference across sessions.

* **Localization**
  * Added translations for the Privacy section and "Prevent Screenshots" control in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->