### PR TITLE
fix: prevent splash screen from hanging on slow DB

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -28,6 +28,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +44,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 internal data class ForegroundNotificationState(
@@ -93,16 +95,14 @@ constructor(
         VSSnackbarState(duration = 1.seconds, coroutineScope = CoroutineScope(Dispatchers.Default))
 
     init {
-        viewModelScope.launch {
-            if (vaultRepository.hasVaults()) _startDestination.value = Route.Home()
-            else _startDestination.value = Route.AddVault
-
+        viewModelScope.safeLaunch {
+            _startDestination.value = resolveStartDestination()
             _isLoading.value = false
 
             snackbarFlow.collectMessage { (message, type) -> snakeBarHostState.show(message, type) }
         }
 
-        viewModelScope.launch { initializeThorChainNetworkId() }
+        viewModelScope.safeLaunch { initializeThorChainNetworkId() }
 
         networkUtils
             .observeConnectivityAsFlow()
@@ -207,4 +207,25 @@ constructor(
                 _startUpdateEvent.tryEmit(Unit)
         }
     }
+
+    private suspend fun resolveStartDestination(): Any =
+        if (hasAnyVault()) Route.Home() else Route.AddVault
+
+    private suspend fun hasAnyVault(): Boolean =
+        try {
+            withTimeoutOrNull(SPLASH_VAULT_QUERY_TIMEOUT) { vaultRepository.hasVaults() }
+                ?: false.also {
+                    Timber.w(
+                        "hasVaults() timed out after %ds; assuming no vaults",
+                        SPLASH_VAULT_QUERY_TIMEOUT.inWholeSeconds,
+                    )
+                }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Timber.e(e, "hasVaults() failed; assuming no vaults")
+            false
+        }
 }
+
+private val SPLASH_VAULT_QUERY_TIMEOUT = 5.seconds

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
@@ -172,11 +171,11 @@ constructor(
     }
 
     fun openUri(uri: Uri) {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch {
             _navigationReady.await()
             val deepLinkHelper = DeepLinkHelper(uri)
             if (deepLinkHelper.isSendDeeplink()) {
-                if (vaultRepository.hasVaults()) {
+                if (hasAnyVault()) {
                     navigator.route(
                         Route.VaultList(
                             openType =

--- a/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
@@ -1,0 +1,141 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.app.activity
+
+import android.content.Context
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.GetDirectionByQrCodeUseCase
+import com.vultisig.wallet.data.usecases.GetKeysignTransactionSummaryUseCase
+import com.vultisig.wallet.data.usecases.InitializeThorChainNetworkIdUseCase
+import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.NetworkUtils
+import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MainViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private val context: Context = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+    private val snackbarFlow: SnackbarFlow = mockk(relaxed = true)
+    private val vaultRepository: VaultRepository = mockk(relaxed = true)
+    private val appUpdateManager: AppUpdateManager = mockk(relaxed = true)
+    private val initializeThorChainNetworkId: InitializeThorChainNetworkIdUseCase =
+        mockk(relaxed = true)
+    private val getDirectionByQrCodeUseCase: GetDirectionByQrCodeUseCase = mockk(relaxed = true)
+    private val getKeysignTransactionSummary: GetKeysignTransactionSummaryUseCase =
+        mockk(relaxed = true)
+    private val mapTokenValueToStringWithUnit: TokenValueToStringWithUnitMapper =
+        mockk(relaxed = true)
+    private val networkUtils: NetworkUtils = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { networkUtils.observeConnectivityAsFlow() } returns emptyFlow()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() =
+        MainViewModel(
+            context = context,
+            navigator = navigator,
+            snackbarFlow = snackbarFlow,
+            vaultRepository = vaultRepository,
+            appUpdateManager = appUpdateManager,
+            initializeThorChainNetworkId = initializeThorChainNetworkId,
+            getDirectionByQrCodeUseCase = getDirectionByQrCodeUseCase,
+            getKeysignTransactionSummary = getKeysignTransactionSummary,
+            mapTokenValueToStringWithUnit = mapTokenValueToStringWithUnit,
+            networkUtils = networkUtils,
+        )
+
+    @Test
+    fun `hasVaults returns true - startDestination is Home and isLoading clears`() =
+        runTest(dispatcher) {
+            coEvery { vaultRepository.hasVaults() } returns true
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.startDestination.value is Route.Home)
+            assertFalse(vm.isLoading.value)
+        }
+
+    @Test
+    fun `hasVaults returns false - startDestination is AddVault and isLoading clears`() =
+        runTest(dispatcher) {
+            coEvery { vaultRepository.hasVaults() } returns false
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(Route.AddVault, vm.startDestination.value)
+            assertFalse(vm.isLoading.value)
+        }
+
+    @Test
+    fun `hasVaults suspends past timeout - falls back to AddVault and isLoading clears`() =
+        runTest(dispatcher) {
+            val neverCompletes = CompletableDeferred<Boolean>()
+            coEvery { vaultRepository.hasVaults() } coAnswers { neverCompletes.await() }
+
+            val vm = createViewModel()
+            advanceTimeBy(6.seconds)
+            advanceUntilIdle()
+
+            assertEquals(Route.AddVault, vm.startDestination.value)
+            assertFalse(vm.isLoading.value)
+        }
+
+    @Test
+    fun `hasVaults throws - falls back to AddVault and isLoading clears`() =
+        runTest(dispatcher) {
+            coEvery { vaultRepository.hasVaults() } throws IllegalStateException("db closed")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(Route.AddVault, vm.startDestination.value)
+            assertFalse(vm.isLoading.value)
+        }
+
+    @Test
+    fun `isLoading starts true before init coroutine runs`() =
+        runTest(dispatcher) {
+            coEvery { vaultRepository.hasVaults() } returns true
+
+            val vm = createViewModel()
+            // no advance — init coroutine has not executed yet
+
+            assertTrue(vm.isLoading.value)
+        }
+}


### PR DESCRIPTION
Devs are reporting the splash screen hanging on cold-start for 20+ seconds, sometimes resolving after force-closing and reopening a few times. Release builds strip Timber so there's no app-side signal, but from ADB logs the process is alive and the main thread is responsive — the only thing holding the splash is `MainViewModel`'s init coroutine waiting on `vaultRepository.hasVaults()`, which transitively opens the Room DB and can stall for any number of reasons (contended storage, keystore daemon, etc.).

Wrap that call in `withTimeout(5.seconds)` and treat timeout/exception as "no vaults" so the splash always dismisses into `Route.AddVault` instead of hanging. Route the init block and the `openUri` deeplink entry through `safeLaunch` so a thrown exception can no longer leave `_isLoading = true` forever.