### PR TITLE
fix: time-out cached THORChain network id read

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorChainRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorChainRepository.kt
@@ -4,10 +4,20 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.sources.AppDataStore
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
 
 interface ThorChainRepository {
 
+    /**
+     * Returns the cached THORChain network id, or `null` if the cache is empty **or** the read
+     * exceeds [CACHE_READ_TIMEOUT]. A slow DataStore read must not block app startup, so callers
+     * should treat `null` as a cache miss and fall back to [fetchNetworkChainId].
+     */
     suspend fun getCachedNetworkChainId(): String?
 
     suspend fun fetchNetworkChainId(): String
@@ -19,7 +29,19 @@ constructor(private val thorChainApi: ThorChainApi, private val dataStore: AppDa
     ThorChainRepository {
 
     override suspend fun getCachedNetworkChainId(): String? =
-        dataStore.readData(prefKeyThorChainNetworkId).first()
+        try {
+            withTimeout(CACHE_READ_TIMEOUT) {
+                dataStore.readData(prefKeyThorChainNetworkId).first()
+            }
+        } catch (_: TimeoutCancellationException) {
+            Timber.w(
+                "Cached THORChain network id read timed out after %ds; falling back to live fetch",
+                CACHE_READ_TIMEOUT.inWholeSeconds,
+            )
+            null
+        } catch (e: CancellationException) {
+            throw e
+        }
 
     override suspend fun fetchNetworkChainId(): String =
         thorChainApi.getNetworkChainId().also { dataStore.set(prefKeyThorChainNetworkId, it) }
@@ -29,3 +51,5 @@ constructor(private val thorChainApi: ThorChainApi, private val dataStore: AppDa
             stringPreferencesKey("pref_key_thor_chain_network_id")
     }
 }
+
+private val CACHE_READ_TIMEOUT = 3.seconds

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorChainRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorChainRepositoryImplTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.preferencesOf
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.sources.AppDataStore
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class ThorChainRepositoryImplTest {
+
+    private val api: ThorChainApi = mockk(relaxed = true)
+
+    @Test
+    fun `getCachedNetworkChainId returns cached value when DataStore responds fast`() = runTest {
+        val repo = ThorChainRepositoryImpl(api, FakeDataStore(cached = "thorchain-mainnet"))
+
+        assertEquals("thorchain-mainnet", repo.getCachedNetworkChainId())
+    }
+
+    @Test
+    fun `getCachedNetworkChainId returns null when cache is empty`() = runTest {
+        val repo = ThorChainRepositoryImpl(api, FakeDataStore(cached = null))
+
+        assertNull(repo.getCachedNetworkChainId())
+    }
+
+    @Test
+    fun `getCachedNetworkChainId returns null when read exceeds timeout`() = runTest {
+        val repo = ThorChainRepositoryImpl(api, FakeDataStore(hangForever = true))
+
+        val result = async(start = CoroutineStart.UNDISPATCHED) { repo.getCachedNetworkChainId() }
+        advanceTimeBy(4.seconds)
+        advanceUntilIdle()
+
+        assertNull(result.await())
+    }
+
+    @Test
+    fun `fetchNetworkChainId writes result to DataStore`() = runTest {
+        val store = FakeDataStore()
+        coEvery { api.getNetworkChainId() } returns "thorchain-stagenet"
+        val repo = ThorChainRepositoryImpl(api, store)
+
+        assertEquals("thorchain-stagenet", repo.fetchNetworkChainId())
+        assertEquals("thorchain-stagenet", store.lastWritten)
+    }
+
+    private class FakeDataStore(
+        private val cached: String? = null,
+        private val hangForever: Boolean = false,
+    ) : AppDataStore {
+
+        var lastWritten: String? = null
+            private set
+
+        override suspend fun editData(
+            transform: suspend (MutablePreferences) -> Unit
+        ): Preferences = preferencesOf()
+
+        override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =
+            flowOf(defaultValue)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> readData(key: Preferences.Key<T>): Flow<T?> =
+            if (hangForever) flow { CompletableDeferred<Unit>().await() } else flowOf(cached as T?)
+
+        override suspend fun <T> set(key: Preferences.Key<T>, value: T) {
+            lastWritten = value as? String
+        }
+    }
+}


### PR DESCRIPTION
`ThorChainRepositoryImpl.getCachedNetworkChainId()` reads from `AppDataStore` with no upper bound. The underlying preferences file is shared with 15+ other repositories and `TokenRefreshWorker`, so a writer holding the internal mutex — or a slow first-access on a cold device — blocks the read. Called during app startup from `InitializeThorChainNetworkIdUseCase`, a stall there leaves `THORCHAIN_NETWORK_ID` at its hard-coded default with no live fetch ever triggered.

Wrap the read in `withTimeout(3.seconds)`, log and return `null` on timeout. The caller already treats `null` as a cache miss and falls back to `fetchNetworkChainId()`, so behaviour under timeout is the same as an empty cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application responsiveness by adding a timeout mechanism for cache operations, ensuring the app doesn't hang when retrieving cached network data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->