### PR TITLE
Fix unsafe cast in Mediator getMessage

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mediator/Server.kt
@@ -299,14 +299,10 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
         val keyPrefix =
             messageID?.let { "${sessionID.trim()}-${participantKey.trim()}-$it-" }
                 ?: run { "${sessionID.trim()}-${participantKey.trim()}-" }
-        cache
-            .filterKeys { it.startsWith(keyPrefix) }
-            .let {
-                val messages = it.values.toList().map { it as Message }
-                response.status(HttpStatusCode.OK.value)
-                response.type("application/json")
-                return Json.encodeToString(messages)
-            }
+        val messages = filterMessagesByPrefix(cache, keyPrefix)
+        response.status(HttpStatusCode.OK.value)
+        response.type("application/json")
+        return Json.encodeToString(messages)
     }
 
     private fun postMessage(request: Request, response: Response): String {
@@ -443,3 +439,9 @@ class Server(private val nsdManager: NsdManager) : NsdManager.RegistrationListen
         Timber.tag("Server").d("Service unregistered: %s", serviceInfo?.serviceName)
     }
 }
+
+/**
+ * Type-safe prefix filter — the cache stores [Message], [Session] and raw-body entries together.
+ */
+internal fun filterMessagesByPrefix(cache: Map<String, Any>, prefix: String): List<Message> =
+    cache.filterKeys { it.startsWith(prefix) }.values.filterIsInstance<Message>()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mediator/ServerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mediator/ServerTest.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.data.mediator
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class ServerTest {
+
+    @Test
+    fun `filterMessagesByPrefix returns empty when cache is empty`() {
+        assertTrue(filterMessagesByPrefix(emptyMap(), "sid-bob-").isEmpty())
+    }
+
+    @Test
+    fun `filterMessagesByPrefix returns empty when no key matches`() {
+        val cache = mapOf<String, Any>("sid-carol-h1" to message("h1"))
+
+        assertTrue(filterMessagesByPrefix(cache, "sid-bob-").isEmpty())
+    }
+
+    @Test
+    fun `filterMessagesByPrefix returns every matching message`() {
+        val m1 = message("h1")
+        val m2 = message("h2")
+        val cache =
+            mapOf<String, Any>(
+                "sid-bob-h1" to m1,
+                "sid-bob-h2" to m2,
+                "sid-carol-h3" to message("h3"),
+            )
+
+        assertEquals(setOf(m1, m2), filterMessagesByPrefix(cache, "sid-bob-").toSet())
+    }
+
+    @Test
+    fun `filterMessagesByPrefix skips non-Message entries that share the prefix`() {
+        val m = message("h1")
+        val cache =
+            mapOf(
+                "sid-bob-h1" to m,
+                "sid-bob-session" to Session("sid", mutableListOf("bob")),
+                "sid-bob-raw" to "arbitrary body",
+            )
+
+        assertEquals(listOf(m), filterMessagesByPrefix(cache, "sid-bob-"))
+    }
+
+    private fun message(hash: String): Message =
+        Message(
+            sessionID = "sid",
+            from = "alice",
+            to = listOf("bob"),
+            body = "body-$hash",
+            hash = hash,
+            sequenceNo = 0,
+        )
+}


### PR DESCRIPTION
## Description

Fixes an unchecked cast in `Server.getMessage` (the mediator HTTP handler).

---

The cache is a `ConcurrentHashMap<String, Any>` holding three value types under different key shapes. 

`Message` entries, `Session` entries, and raw request-body strings. `getMessage` filtered the cache by prefix and cast every matching value to `Message` which throws `ClassCastException` any time a non-Message entry happens to share the prefix.

Replaced the cast with `filterIsInstance<Message>()` via a new internal helper `filterMessagesByPrefix`


## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal message handling code to enhance safety and maintainability through refined implementation patterns and better type handling.

* **Tests**
  * Added comprehensive test coverage for message filtering functionality with multiple scenarios including empty states, prefix matching validation, and data integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->