### PR TITLE
fix: move Upload QR button into ErrorView on permission denied

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -65,7 +65,7 @@ internal fun ErrorView(
             }
 
             secondaryButtonUiModel?.let {
-                UiSpacer(12.dp)
+                UiSpacer(if (buttonUiModel != null) 12.dp else 30.dp)
                 VsButton(
                     variant = VsButtonVariant.CTA,
                     label = it.text,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -41,6 +41,7 @@ internal fun ErrorView(
     description: String? = null,
     errorState: ErrorState = ErrorState.WARNING,
     buttonUiModel: ErrorViewButtonUiModel?,
+    secondaryButtonUiModel: ErrorViewButtonUiModel? = null,
     onBack: (() -> Unit)? = null,
 ) {
     Box(modifier = modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
@@ -57,6 +58,16 @@ internal fun ErrorView(
                 UiSpacer(30.dp)
                 VsButton(
                     variant = VsButtonVariant.Secondary,
+                    label = it.text,
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = it.onClick,
+                )
+            }
+
+            secondaryButtonUiModel?.let {
+                UiSpacer(12.dp)
+                VsButton(
+                    variant = VsButtonVariant.CTA,
                     label = it.text,
                     modifier = Modifier.fillMaxWidth(),
                     onClick = it.onClick,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -104,7 +104,7 @@ internal fun ErrorWaves(
 
     val waveCircleColor = Theme.v2.colors.border.light
     Column(
-        modifier = modifier,
+        modifier = modifier.padding(bottom = 56.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -216,15 +216,18 @@ private fun ScanQrScreen(
 
     val isCameraGranted = cameraPermissionState.status.isGranted
 
+    val onUploadQr: () -> Unit = {
+        if (!isPickerLaunched) {
+            isPickerLaunched = true
+            pickMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageOnly))
+        }
+    }
+
     ScanQrLayout(
         uiModel = uiModel,
         onDismiss = onDismiss,
-        onUploadQr = {
-            if (!isPickerLaunched) {
-                isPickerLaunched = true
-                pickMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageOnly))
-            }
-        },
+        onUploadQr = onUploadQr,
+        showBottomBar = isCameraGranted,
         toggleMoreInfo = onMoreInfo,
     ) {
         if (isCameraGranted) {
@@ -263,6 +266,11 @@ private fun ScanQrScreen(
                                 )
                             },
                         ),
+                    secondaryButtonUiModel =
+                        ErrorViewButtonUiModel(
+                            text = stringResource(R.string.scan_qr_upload_qr_code),
+                            onClick = onUploadQr,
+                        ),
                 )
             }
         }
@@ -274,6 +282,7 @@ private fun ScanQrLayout(
     uiModel: ScanQrUiModel,
     onDismiss: () -> Unit,
     onUploadQr: () -> Unit,
+    showBottomBar: Boolean,
     toggleMoreInfo: () -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -292,7 +301,7 @@ private fun ScanQrLayout(
             }
     ) {
         Scaffold(
-            bottomBar = { ScanQrBottomBar(onUploadQr = onUploadQr) },
+            bottomBar = { if (showBottomBar) ScanQrBottomBar(onUploadQr = onUploadQr) },
             topBar = {
                 ScanQrTopBar(
                     onBackClick = onDismiss,
@@ -575,6 +584,7 @@ private fun ScanQrScreenPreview() {
         uiModel = ScanQrUiModel(isTipVisible = false),
         onDismiss = {},
         onUploadQr = {},
+        showBottomBar = true,
         toggleMoreInfo = {},
     ) {
         ScanViewport(isFrameHighlighted = false)


### PR DESCRIPTION
## Summary
- When camera permission is denied on the Scan QR screen, the "Upload QR Code" bottom bar button was obscured behind the full-screen `ErrorView`
- Now the bottom bar is hidden when permission is denied, and the upload action appears as a secondary CTA button inside the `ErrorView` itself
- Added optional `secondaryButtonUiModel` parameter to `ErrorView` for reuse across other screens
- Added bottom padding to `ErrorWaves` to prevent button overlap with wave circles

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/PU61hl3.png) | ![after](https://i.imgur.com/ZClgyeO.png) |

## Test plan
- [ ] Deny camera permission and verify the "Upload QR Code" button appears inside the error view below "Open Settings"
- [ ] Tap "Upload QR Code" from the error view and verify image picker opens correctly
- [ ] Tap "Open Settings" and verify it navigates to app settings
- [ ] Grant camera permission and verify the bottom bar "Upload QR Code" button still works normally
- [ ] Verify other screens using `ErrorView` are unaffected (keygen, keysign, peer discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>