### PR TITLE
fix: surface decryption failure of keygen setup message

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -333,7 +333,7 @@ class DKLSKeygen(
                             encryption.decrypt(
                                 Base64.decode(it),
                                 Numeric.hexStringToByteArray(encryptionKeyHex),
-                            )!!
+                            ) ?: error("fail to decrypt keygen setup message")
                         }
                         .let { Base64.decode(it) }
             }
@@ -536,7 +536,7 @@ class DKLSKeygen(
                             encryption.decrypt(
                                 Base64.decode(it),
                                 Numeric.hexStringToByteArray(encryptionKeyHex),
-                            )!!
+                            ) ?: error("fail to decrypt reshare setup message")
                         }
                         .let { Base64.decode(it) }
             }


### PR DESCRIPTION
## Description

The keygen flow fetched an encrypted setup message and force-unwrapped the decryption result with `!!`. When decryption returned `null` (bad key or corrupted payload) the keygen coroutine died with a bare `NullPointerException` with no actionable context.

Replaced `!!` with `?: error("fail to decrypt ...")`, matching the existing failure-path convention already used throughout this file. Applied to both the keygen and reshare flows where the same pattern existed.

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during key generation, key import, and reshare operations by providing clearer error messages when decryption fails, replacing generic assertions with explicit failure handling to better inform users of issues during these critical processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->