### PR TITLE
fix: time out mediator discovery when no host device is found

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.models.proto.v1.ReshareMessageProto
 import com.vultisig.wallet.data.models.proto.v1.SingleKeygenMessageProto
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DecompressQrUseCase
+import com.vultisig.wallet.ui.models.keygen.JoinKeygenError.DiscoveryTimeout
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenError.DuplicateVaultName
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenError.InvalidQr
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenError.UnknownError
@@ -42,7 +43,6 @@ import io.ktor.util.decodeBase64Bytes
 import java.net.Inet4Address
 import javax.inject.Inject
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Duration.Companion.seconds
@@ -52,7 +52,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
@@ -69,6 +71,9 @@ internal sealed class JoinKeygenError(val message: UiText) {
     data object WrongResharePrefix :
         JoinKeygenError(R.string.join_keysign_wrong_reshare.asUiText())
 
+    data object DiscoveryTimeout :
+        JoinKeygenError(R.string.join_key_gen_mediator_discovery_timeout.asUiText())
+
     data class UnknownError(val error: String) : JoinKeygenError(error.asUiText())
 }
 
@@ -78,6 +83,8 @@ internal data class JoinKeygenUiModel(
 )
 
 private class JoinKeygenException(val error: JoinKeygenError) : Exception()
+
+private val DISCOVERY_TIMEOUT = 30.seconds
 
 @HiltViewModel
 internal class JoinKeygenViewModel
@@ -282,19 +289,28 @@ constructor(
         }
     }
 
-    private suspend fun discoverMediator(serviceName: String): String = suspendCoroutine { cont ->
-        discoveryListener =
-            MediatorServiceDiscoveryListener(
-                nsdManager = nsdManager,
-                serviceName = serviceName,
-                onServerAddressDiscovered = { serverUrl ->
-                    nsdManager.stopServiceDiscovery(discoveryListener)
+    private suspend fun discoverMediator(serviceName: String): String =
+        withTimeoutOrNull(DISCOVERY_TIMEOUT) {
+            suspendCancellableCoroutine { cont ->
+                val listener =
+                    MediatorServiceDiscoveryListener(
+                        nsdManager = nsdManager,
+                        serviceName = serviceName,
+                        onServerAddressDiscovered = { serverUrl ->
+                            stopDiscoveryQuietly()
+                            if (cont.isActive) cont.resume(serverUrl)
+                        },
+                    )
+                discoveryListener = listener
+                cont.invokeOnCancellation { stopDiscoveryQuietly() }
+                nsdManager.discoverServices("_http._tcp.", NsdManager.PROTOCOL_DNS_SD, listener)
+            }
+        } ?: error(DiscoveryTimeout)
 
-                    cont.resume(serverUrl)
-                },
-            )
-
-        nsdManager.discoverServices("_http._tcp.", NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+    private fun stopDiscoveryQuietly() {
+        val listener = discoveryListener ?: return
+        discoveryListener = null
+        runCatching { nsdManager.stopServiceDiscovery(listener) }
     }
 
     private suspend fun waitForKeygenToStart(session: Session) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -698,6 +698,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Geben Sie Ihr Passwort ein, um Ihre Serverfreigabe freizugeben und das Upgrade zu starten.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Vault mit doppeltem Namen vorhanden</string>
     <string name="join_key_gen_unknown_tssaction">Unbekannte TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Das andere Gerät konnte im Netzwerk nicht gefunden werden</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Warte auf die Verbindung anderer Geräte</string>
     <string name="join_key_gen_your_vault_will_start_generating">Ihr Tresor wird generiert, sobald Sie die Einrichtung auf Ihrem Hauptgerät abgeschlossen haben.</string>
     <string name="join_key_sign_wrong_signing_library_type">Falscher Signaturbibliothekstyp</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -696,6 +696,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Ingrese su contraseña para desbloquear su servidor compartido e iniciar la actualización.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Existe una bóveda con nombre duplicado</string>
     <string name="join_key_gen_unknown_tssaction">TssAction desconocido</string>
+    <string name="join_key_gen_mediator_discovery_timeout">No se pudo encontrar el otro dispositivo en la red</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Esperando a que se unan otros dispositivos</string>
     <string name="join_key_gen_your_vault_will_start_generating">Tu bóveda empezará a generarse en cuanto la configures en tu dispositivo principal</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo de biblioteca de firma incorrecto</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -700,6 +700,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Unesite svoju lozinku za otključavanje dijeljenog poslužitelja i početak nadogradnje</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Trezor s dupliciranim nazivom postoji</string>
     <string name="join_key_gen_unknown_tssaction">Nepoznata TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Drugi uređaj nije pronađen na mreži</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Čekanje da se drugi uređaji pridruže</string>
     <string name="join_key_gen_your_vault_will_start_generating">Vaš trezor će početi generirati od trenutka kada završite s postavljanjem trezora na glavnom uređaju</string>
     <string name="join_key_sign_wrong_signing_library_type">Pogrešna vrsta biblioteke za potpisivanje</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -696,6 +696,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Inserisci la tua password per sbloccare la tua condivisione server e avviare l\'aggiornamento</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Esiste un Vault con nome duplicato</string>
     <string name="join_key_gen_unknown_tssaction">TssAction sconosciuta</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Impossibile trovare l\'altro dispositivo sulla rete</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">In attesa che altri dispositivi si uniscano</string>
     <string name="join_key_gen_your_vault_will_start_generating">Il vault inizierà a generare dati dal momento in cui finalizzi la configurazione del vault sul tuo dispositivo principale</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo di libreria di firma errato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -854,6 +854,7 @@
     <string name="import_file_supported_file_types_dat_bak_vult"><![CDATA[지원 파일 형식: .dat & .bak & .vult]]></string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">동일한 이름의 볼트가 존재합니다</string>
     <string name="join_key_gen_unknown_tssaction">알 수 없는 TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">네트워크에서 다른 기기를 찾을 수 없습니다</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">다른 기기의 참여를 기다리는 중</string>
     <string name="join_key_gen_your_vault_will_start_generating">메인 기기에서 볼트 설정을 완료하는 즉시 볼트 생성이 시작됩니다</string>
     <string name="join_key_sign_wrong_signing_library_type">잘못된 서명 라이브러리 유형</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -693,6 +693,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Voer uw wachtwoord in om uw servershare te ontgrendelen en de upgrade te starten</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Er bestaat een kluis met een dubbele naam</string>
     <string name="join_key_gen_unknown_tssaction">Onbekende TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Kan het andere apparaat niet vinden op het netwerk</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Wachten op andere apparaten om toe te treden</string>
     <string name="join_key_gen_your_vault_will_start_generating">Je kluis wordt gegenereerd vanaf het moment dat je de kluis op je hoofdapparaat hebt ingesteld</string>
     <string name="join_key_sign_wrong_signing_library_type">Verkeerd type ondertekeningsbibliotheek</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -695,6 +695,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Introduza a sua palavra-passe para desbloquear a sua Partilha de Servidor e iniciar a atualização.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Existe um cofre com nome duplicado</string>
     <string name="join_key_gen_unknown_tssaction">Ação Tss desconhecida</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Não foi possível encontrar o outro dispositivo na rede</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Aguarda a entrada de outros dispositivos</string>
     <string name="join_key_gen_your_vault_will_start_generating">O seu cofre começará a ser gerado a partir do momento em que finalizar a configuração do cofre no seu dispositivo principal.</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo de biblioteca de assinatura incorreto.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -699,6 +699,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Введите пароль, чтобы разблокировать общий сервер и начать обновление.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Существует хранилище с дублирующимся именем</string>
     <string name="join_key_gen_unknown_tssaction">Неизвестное действие TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Не удалось найти другое устройство в сети</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Ожидание подключения других устройств</string>
     <string name="join_key_gen_your_vault_will_start_generating">Генерация вашего хранилища начнётся с момента завершения настройки хранилища на основном устройстве</string>
     <string name="join_key_sign_wrong_signing_library_type">Неверный тип библиотеки подписи</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -863,6 +863,7 @@
     <!-- Keygen & Keysign -->
     <string name="join_key_gen_vault_with_duplicate_name_exists">存在重复名称的保险库</string>
     <string name="join_key_gen_unknown_tssaction">未知的 TSS 操作</string>
+    <string name="join_key_gen_mediator_discovery_timeout">无法在您的网络中找到其他设备</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">等待其他设备加入</string>
     <string name="join_key_gen_your_vault_will_start_generating">您的保险库将在您在主设备上完成设置后开始生成</string>
     <string name="join_key_sign_wrong_signing_library_type">错误的签名库类型</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -873,6 +873,7 @@
     <string name="import_file_supported_file_types_dat_bak_vult"><![CDATA[Supported file types: .dat & .bak & .vult]]></string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Vault with duplicate name exists</string>
     <string name="join_key_gen_unknown_tssaction">Unknown TssAction</string>
+    <string name="join_key_gen_mediator_discovery_timeout">Could not find the other device on your network</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Waiting for other devices to join</string>
     <string name="join_key_gen_your_vault_will_start_generating">Your vault will start generating from the moment you finalize setting up your vault on your main device</string>
     <string name="join_key_sign_wrong_signing_library_type">Wrong signing library type</string>


### PR DESCRIPTION
## Description

The join-keygen flow kicked off NSD service discovery inside a `suspendCoroutine` with no timeout and no cancellation path. If the host device never advertised (wrong Wi-Fi, firewall, or never launched) the user was stuck on a silent loading screen until they navigated away.

Switched to `suspendCancellableCoroutine` wrapped in `withTimeoutOrNull`. Discovery now stops cleanly on cancellation or a 30s timeout, and surfaces a translated error telling the user the other device could not be found on their network.

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works