### PR TITLE
fix: gracefully handle Rive SDK init failure on unsupported ABIs

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -7,6 +7,9 @@ import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
+internal var isRiveInitialized: Boolean = false
+    private set
+
 internal open class VsBaseApplication : Application() {
     override fun onCreate() {
         super.onCreate()
@@ -17,7 +20,12 @@ internal open class VsBaseApplication : Application() {
             Timber.plant(Timber.DebugTree())
         }
 
-        Rive.init(this)
+        try {
+            Rive.init(this)
+            isRiveInitialized = true
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.app
 
 import android.app.Application
+import android.content.Context
+import androidx.annotation.VisibleForTesting
 import app.rive.runtime.kotlin.core.Rive
 import com.vultisig.wallet.BuildConfig
 import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
@@ -9,6 +11,20 @@ import timber.log.Timber
 
 internal var isRiveInitialized: Boolean = false
     private set
+
+@VisibleForTesting
+internal fun resetRiveInitialized() {
+    isRiveInitialized = false
+}
+
+internal fun initializeRive(context: Context) {
+    try {
+        Rive.init(context)
+        isRiveInitialized = true
+    } catch (e: Throwable) {
+        Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
+    }
+}
 
 internal open class VsBaseApplication : Application() {
     override fun onCreate() {
@@ -20,12 +36,7 @@ internal open class VsBaseApplication : Application() {
             Timber.plant(Timber.DebugTree())
         }
 
-        try {
-            Rive.init(this)
-            isRiveInitialized = true
-        } catch (e: Throwable) {
-            Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
-        }
+        initializeRive(this)
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -23,7 +23,7 @@ internal open class VsBaseApplication : Application() {
         try {
             Rive.init(this)
             isRiveInitialized = true
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
@@ -22,6 +22,7 @@ import app.rive.rememberRiveFile
 import app.rive.rememberRiveWorkerOrNull
 import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.core.Alignment
+import com.vultisig.wallet.app.isRiveInitialized
 
 @Composable
 fun RiveAnimation(
@@ -33,8 +34,7 @@ fun RiveAnimation(
     autoPlay: Boolean = true,
     onInit: (RiveAnimationView) -> Unit = {},
 ) {
-    if (LocalInspectionMode.current) {
-        // rive doesn't work in preview
+    if (LocalInspectionMode.current || !isRiveInitialized) {
         Spacer(modifier)
     } else {
         key(animation) {
@@ -66,8 +66,7 @@ fun RiveAnimation(
     viewModelInstance: ViewModelInstance? = null,
     fit: Fit = Fit.Contain(),
 ) {
-    if (LocalInspectionMode.current) {
-        // rive doesn't work in preview
+    if (LocalInspectionMode.current || !isRiveInitialized) {
         Spacer(modifier)
     } else {
         Rive(
@@ -83,6 +82,10 @@ fun RiveAnimation(
 
 @Composable
 fun rememberRiveResourceFile(@RawRes resId: Int): State<RiveFile?> {
+    if (!isRiveInitialized) {
+        return remember { derivedStateOf { null } }
+    }
+
     val riveWorker = rememberRiveWorkerOrNull()
 
     val riveFileResult =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -83,7 +84,7 @@ fun RiveAnimation(
 @Composable
 fun rememberRiveResourceFile(@RawRes resId: Int): State<RiveFile?> {
     if (!isRiveInitialized) {
-        return remember { derivedStateOf { null } }
+        return remember { mutableStateOf(null) }
     }
 
     val riveWorker = rememberRiveWorkerOrNull()

--- a/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
@@ -1,0 +1,62 @@
+package com.vultisig.wallet.app
+
+import android.content.Context
+import app.rive.runtime.kotlin.core.Rive
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RiveInitializationTest {
+
+    private val context: Context = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        resetRiveInitialized()
+        mockkObject(Rive)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(Rive)
+        resetRiveInitialized()
+    }
+
+    @Test
+    fun `isRiveInitialized is false by default`() {
+        assertFalse(isRiveInitialized)
+    }
+
+    @Test
+    fun `isRiveInitialized is true after successful Rive init`() {
+        every { Rive.init(any(), any()) } returns Unit
+
+        initializeRive(context)
+
+        assertTrue(isRiveInitialized)
+    }
+
+    @Test
+    fun `isRiveInitialized stays false when Rive init throws UnsatisfiedLinkError`() {
+        every { Rive.init(any(), any()) } throws UnsatisfiedLinkError("missing native lib")
+
+        initializeRive(context)
+
+        assertFalse(isRiveInitialized)
+    }
+
+    @Test
+    fun `isRiveInitialized stays false when Rive init throws RuntimeException`() {
+        every { Rive.init(any(), any()) } throws RuntimeException("init failed")
+
+        initializeRive(context)
+
+        assertFalse(isRiveInitialized)
+    }
+}


### PR DESCRIPTION
## Summary
- Wraps `Rive.init()` in a try-catch in `VsBaseApplication.onCreate` so the app no longer crashes on startup when the Rive native library (`libandroid.so`) is missing for the device ABI (e.g., `armeabi-v7a`)
- Adds an `isRiveInitialized` flag checked by all `RiveAnimation` composables — when Rive is unavailable, animations degrade to empty spacers instead of crashing
- Fixes fatal crash reported on Samsung Galaxy J7 Prime (Android 8.1, 32-bit ARM)

Closes #4068

## Test plan
- [ ] Verify app launches normally on arm64-v8a devices (Rive animations work as before)
- [ ] Verify app launches on armeabi-v7a device/emulator without crashing (animations simply don't render)
- [ ] Verify screens that use Rive animations (onboarding, keygen, keysign) are still functional without animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the app's animation system so initialization failures no longer crash the app; animations are gracefully disabled on failure.
  * UI components now render a lightweight placeholder when animations are unavailable, preventing background loading and improving startup stability.

* **Tests**
  * Added tests validating animation initialization behavior and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->