### PR TITLE
fix: move DocumentsContract.deleteDocument off main thread (#4070)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -276,12 +276,13 @@ constructor(
     }
 
     private suspend fun backupAllVaults(password: String, uri: Uri): Boolean {
-        val content = vaults.map { vault ->
-            val vaultBackupData =
-                createVaultBackup(mapVaultToProto(vault), password) ?: return false
-            val fileName = createVaultBackupFileName(vault)
-            AppZipEntry(fileName, vaultBackupData)
-        }
+        val content =
+            vaults.map { vault ->
+                val vaultBackupData =
+                    createVaultBackup(mapVaultToProto(vault), password) ?: return false
+                val fileName = createVaultBackupFileName(vault)
+                AppZipEntry(fileName, vaultBackupData)
+            }
 
         return context.saveContentToUri(uri, content)
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -2,13 +2,13 @@ package com.vultisig.wallet.ui.models
 
 import android.content.Context
 import android.net.Uri
-import android.provider.DocumentsContract
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.common.deleteDocument
 import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.models.Vault
@@ -243,7 +243,7 @@ constructor(
                     }
                 completeBackupVault(isSuccess)
             } else {
-                DocumentsContract.deleteDocument(context.contentResolver, uri)
+                context.deleteDocument(uri)
 
                 state.update {
                     it.copy(
@@ -276,13 +276,12 @@ constructor(
     }
 
     private suspend fun backupAllVaults(password: String, uri: Uri): Boolean {
-        val content =
-            vaults.map { vault ->
-                val vaultBackupData =
-                    createVaultBackup(mapVaultToProto(vault), password) ?: return false
-                val fileName = createVaultBackupFileName(vault)
-                AppZipEntry(fileName, vaultBackupData)
-            }
+        val content = vaults.map { vault ->
+            val vaultBackupData =
+                createVaultBackup(mapVaultToProto(vault), password) ?: return false
+            val fileName = createVaultBackupFileName(vault)
+            AppZipEntry(fileName, vaultBackupData)
+        }
 
         return context.saveContentToUri(uri, content)
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
@@ -2,12 +2,12 @@ package com.vultisig.wallet.ui.models.keygen
 
 import android.content.Context
 import android.net.Uri
-import android.provider.DocumentsContract
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.common.deleteDocument
 import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.models.TssAction
@@ -139,7 +139,7 @@ constructor(
                 val isSuccess = backupCurrentVault(password, uri)
                 completeBackupVault(isSuccess)
             } else {
-                DocumentsContract.deleteDocument(context.contentResolver, uri)
+                context.deleteDocument(uri)
                 showError(
                     UiText.FormattedText(
                         R.string.vault_settings_error_extension_backup_file,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.provider.OpenableColumns.DISPLAY_NAME
 import androidx.annotation.RequiresApi
@@ -211,6 +212,10 @@ suspend fun Uri.isValidZipFile(context: Context) = doFileOperation {
     } catch (_: Exception) {
         false
     }
+}
+
+suspend fun Context.deleteDocument(uri: Uri) = doFileOperation {
+    DocumentsContract.deleteDocument(contentResolver, uri)
 }
 
 private suspend fun <T> doFileOperation(block: suspend CoroutineScope.() -> T) =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
@@ -214,8 +214,13 @@ suspend fun Uri.isValidZipFile(context: Context) = doFileOperation {
     }
 }
 
-suspend fun Context.deleteDocument(uri: Uri) = doFileOperation {
-    DocumentsContract.deleteDocument(contentResolver, uri)
+suspend fun Context.deleteDocument(uri: Uri): Boolean = doFileOperation {
+    try {
+        DocumentsContract.deleteDocument(contentResolver, uri)
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to delete document: %s", uri)
+        false
+    }
 }
 
 private suspend fun <T> doFileOperation(block: suspend CoroutineScope.() -> T) =


### PR DESCRIPTION
## Summary
- Extracted `Context.deleteDocument(uri)` helper in `FileHelper.kt` that dispatches to `Dispatchers.IO` via `doFileOperation`, consistent with all other file operations in that file
- Replaced direct `DocumentsContract.deleteDocument()` calls in `BackupPasswordViewModel` and `BackupVaultViewModel` with the new helper, preventing ANR from Binder IPC on the main thread

Closes #4070

## Test plan
- [ ] Trigger backup flow with an invalid file extension to hit the `deleteDocument` path
- [ ] Verify the file is deleted and error message is shown without ANR
- [ ] Verify normal backup flow (valid extension) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated document deletion logic into a shared helper function with improved error handling and logging, reducing code duplication across backup-related features. No changes to user-facing functionality—backup file deletion behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->