### PR TITLE
refactor: rename isDefi to hasDeFiPositionsScreen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -397,7 +397,6 @@ constructor(
     }
 
     private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
-
         loadDeFiBalancesJob?.cancel()
         loadDeFiBalancesJob =
             viewModelScope.launch {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -69,607 +69,586 @@ import timber.log.Timber
 
 @Immutable
 internal data class VaultAccountsUiModel(
-    val vaultName: String = "",
-    val isFastVault: Boolean = false,
-    val showBackupWarning: Boolean = false,
-    val showMonthlyBackupReminder: Boolean = false,
-    val showNotificationIntroSheet: Boolean = false,
-    val showNotificationVaultSheet: Boolean = false,
-    val notificationIntroVaults: List<VaultIntroItem> = emptyList(),
-    val showMigration: Boolean = false,
-    val isRefreshing: Boolean = false,
-    val totalFiatValue: String? = null,
-    val totalDeFiValue: String? = null,
-    val isBalanceValueVisible: Boolean = true,
-    val accounts: List<AccountUiModel> = emptyList(),
-    val defiAccounts: List<AccountUiModel> = emptyList(),
-    val searchTextFieldState: TextFieldState = TextFieldState(),
-    val isBannerVisible: Boolean = true,
-    val cryptoConnectionType: CryptoConnectionType = CryptoConnectionType.Wallet,
-    val scanQrUiModel: ScanQrUiModel = ScanQrUiModel(),
-    val isChainSelectionEnabled: Boolean = true,
+  val vaultName: String = "",
+  val isFastVault: Boolean = false,
+  val showBackupWarning: Boolean = false,
+  val showMonthlyBackupReminder: Boolean = false,
+  val showNotificationIntroSheet: Boolean = false,
+  val showNotificationVaultSheet: Boolean = false,
+  val notificationIntroVaults: List<VaultIntroItem> = emptyList(),
+  val showMigration: Boolean = false,
+  val isRefreshing: Boolean = false,
+  val totalFiatValue: String? = null,
+  val totalDeFiValue: String? = null,
+  val isBalanceValueVisible: Boolean = true,
+  val accounts: List<AccountUiModel> = emptyList(),
+  val defiAccounts: List<AccountUiModel> = emptyList(),
+  val searchTextFieldState: TextFieldState = TextFieldState(),
+  val isBannerVisible: Boolean = true,
+  val cryptoConnectionType: CryptoConnectionType = CryptoConnectionType.Wallet,
+  val scanQrUiModel: ScanQrUiModel = ScanQrUiModel(),
+  val isChainSelectionEnabled: Boolean = true,
 ) {
-    val isSwapEnabled = accounts.any { it.model.chain.isSwapSupported }
-    val noChainFound: Boolean
-        get() = searchTextFieldState.text.isNotEmpty() && accounts.isEmpty()
+  val isSwapEnabled = accounts.any { it.model.chain.isSwapSupported }
+  val noChainFound: Boolean
+    get() = searchTextFieldState.text.isNotEmpty() && accounts.isEmpty()
 
-    val getAccounts: List<AccountUiModel>
-        get() =
-            if (cryptoConnectionType == CryptoConnectionType.Wallet) {
-                accounts
-            } else {
-                defiAccounts
-            }
+  val getAccounts: List<AccountUiModel>
+    get() =
+      if (cryptoConnectionType == CryptoConnectionType.Wallet) {
+        accounts
+      } else {
+        defiAccounts
+      }
 }
 
 @Immutable
 internal data class AccountUiModel(
-    val model: Address,
-    val chainName: String,
-    @param:DrawableRes val logo: Int,
-    val address: String,
-    val nativeTokenAmount: String?,
-    val fiatAmount: String?,
-    val assetsSize: Int = 0,
-    val nativeTokenTicker: String = "",
-    val isDeFiProvider: Boolean = false,
+  val model: Address,
+  val chainName: String,
+  @param:DrawableRes val logo: Int,
+  val address: String,
+  val nativeTokenAmount: String?,
+  val fiatAmount: String?,
+  val assetsSize: Int = 0,
+  val nativeTokenTicker: String = "",
+  val isDeFiProvider: Boolean = false,
 )
 
 @HiltViewModel
 internal class VaultAccountsViewModel
 @Inject
 constructor(
-    @param:ApplicationContext private val context: Context,
-    savedStateHandle: SavedStateHandle,
-    private val navigator: Navigator<Destination>,
-    private val requestResultRepository: RequestResultRepository,
-    private val addressToUiModelMapper: AddressToUiModelMapper,
-    private val fiatValueToStringMapper: FiatValueToStringMapper,
-    private val vaultRepository: VaultRepository,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
-    private val accountsRepository: AccountsRepository,
-    private val balanceVisibilityRepository: BalanceVisibilityRepository,
-    private val vaultMetadataRepo: VaultMetadataRepo,
-    private val isGlobalBackupReminderRequired: IsGlobalBackupReminderRequiredUseCase,
-    private val setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase,
-    private val lastOpenedVaultRepository: LastOpenedVaultRepository,
-    private val enableTokenUseCase: EnableTokenUseCase,
-    private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
-    private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
-    private val tiersNFTRepository: TiersNFTRepository,
-    private val remoteNFTService: TierRemoteNFTService,
-    private val pushNotificationManager: PushNotificationManager,
-    private val snackbarFlow: SnackbarFlow,
+  @param:ApplicationContext private val context: Context,
+  savedStateHandle: SavedStateHandle,
+  private val navigator: Navigator<Destination>,
+  private val requestResultRepository: RequestResultRepository,
+  private val addressToUiModelMapper: AddressToUiModelMapper,
+  private val fiatValueToStringMapper: FiatValueToStringMapper,
+  private val vaultRepository: VaultRepository,
+  private val vaultDataStoreRepository: VaultDataStoreRepository,
+  private val accountsRepository: AccountsRepository,
+  private val balanceVisibilityRepository: BalanceVisibilityRepository,
+  private val vaultMetadataRepo: VaultMetadataRepo,
+  private val isGlobalBackupReminderRequired: IsGlobalBackupReminderRequiredUseCase,
+  private val setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase,
+  private val lastOpenedVaultRepository: LastOpenedVaultRepository,
+  private val enableTokenUseCase: EnableTokenUseCase,
+  private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
+  private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
+  private val tiersNFTRepository: TiersNFTRepository,
+  private val remoteNFTService: TierRemoteNFTService,
+  private val pushNotificationManager: PushNotificationManager,
+  private val snackbarFlow: SnackbarFlow,
 ) : ViewModel() {
 
-    private var requestedVaultId: String? = savedStateHandle.toRoute<Route.Home>().openVaultId
-    private var vaultId: String? = null
+  private var requestedVaultId: String? = savedStateHandle.toRoute<Route.Home>().openVaultId
+  private var vaultId: String? = null
 
-    val uiState = MutableStateFlow(VaultAccountsUiModel())
+  val uiState = MutableStateFlow(VaultAccountsUiModel())
 
-    private var loadVaultNameJob: Job? = null
-    private var loadAccountsJob: Job? = null
-    private var loadDeFiBalancesJob: Job? = null
+  private var loadVaultNameJob: Job? = null
+  private var loadAccountsJob: Job? = null
+  private var loadDeFiBalancesJob: Job? = null
 
-    private val _requestNotificationPermission = Channel<Unit>(Channel.BUFFERED)
-    val requestNotificationPermission = _requestNotificationPermission.receiveAsFlow()
+  private val _requestNotificationPermission = Channel<Unit>(Channel.BUFFERED)
+  val requestNotificationPermission = _requestNotificationPermission.receiveAsFlow()
 
-    init {
-        collectCryptoConnectionType()
-        collectLastOpenedVault()
+  init {
+    collectCryptoConnectionType()
+    collectLastOpenedVault()
+  }
+
+  private fun collectCryptoConnectionType() {
+    cryptoConnectionTypeRepository.activeCryptoConnectionFlow
+      .onEach { connectionType ->
+        uiState.update { state -> state.copy(cryptoConnectionType = connectionType) }
+      }
+      .launchIn(viewModelScope)
+  }
+
+  private suspend fun updateLastOpenedVault() {
+    val requestedVaultId = requestedVaultId
+    if (requestedVaultId != null) {
+      lastOpenedVaultRepository.setLastOpenedVaultId(requestedVaultId)
+      this@VaultAccountsViewModel.requestedVaultId = null
     }
+  }
 
-    private fun collectCryptoConnectionType() {
-        cryptoConnectionTypeRepository.activeCryptoConnectionFlow
-            .onEach { connectionType ->
-                uiState.update { state -> state.copy(cryptoConnectionType = connectionType) }
-            }
-            .launchIn(viewModelScope)
-    }
-
-    private suspend fun updateLastOpenedVault() {
-        val requestedVaultId = requestedVaultId
-        if (requestedVaultId != null) {
-            lastOpenedVaultRepository.setLastOpenedVaultId(requestedVaultId)
-            this@VaultAccountsViewModel.requestedVaultId = null
+  private fun collectLastOpenedVault() {
+    viewModelScope.launch {
+      updateLastOpenedVault()
+      lastOpenedVaultRepository.lastOpenedVaultId
+        .map { lastOpenedVaultId ->
+          lastOpenedVaultId?.let { vaultRepository.get(it) }
+            ?: vaultRepository.getAll().firstOrNull()
+        }
+        .collect { vault ->
+          if (vault != null) {
+            loadData(vault.id)
+          }
         }
     }
+  }
 
-    private fun collectLastOpenedVault() {
-        viewModelScope.launch {
-            updateLastOpenedVault()
-            lastOpenedVaultRepository.lastOpenedVaultId
-                .map { lastOpenedVaultId ->
-                    lastOpenedVaultId?.let { vaultRepository.get(it) }
-                        ?: vaultRepository.getAll().firstOrNull()
-                }
-                .collect { vault ->
-                    if (vault != null) {
-                        loadData(vault.id)
-                    }
-                }
+  private fun loadData(vaultId: VaultId) {
+    val vaultChanged = this.vaultId != null && this.vaultId != vaultId
+
+    this.vaultId = vaultId
+    loadVaultNameAndShowBackup(vaultId)
+    loadAccounts(vaultId)
+    loadBalanceVisibility(vaultId)
+    showGlobalBackupReminder()
+    showVerifyFastVaultPasswordReminderIfRequired(vaultId)
+    enableVultTokenIfNeeded(vaultId)
+    loadDeFiBalances(vaultId, vaultChanged)
+    checkNotificationPrompt(vaultId)
+  }
+
+  private fun enableVultTokenIfNeeded(vaultId: VaultId) {
+    viewModelScope.launch {
+      try {
+        val vault = vaultRepository.get(vaultId) ?: return@launch
+
+        // Check if vault has Ethereum chain enabled
+        val hasEthereum = vault.coins.any { it.chain == Chain.Ethereum }
+        if (!hasEthereum) {
+          Timber.d("Ethereum chain not enabled, skipping VULT token auto-enable")
+          return@launch
         }
-    }
 
-    private fun loadData(vaultId: VaultId) {
-        val vaultChanged = this.vaultId != null && this.vaultId != vaultId
+        // Check if VULT token is already enabled
+        val vultCoin = vault.coins.find { it.id == Coins.Ethereum.VULT.id }
 
-        this.vaultId = vaultId
-        loadVaultNameAndShowBackup(vaultId)
-        loadAccounts(vaultId)
-        loadBalanceVisibility(vaultId)
-        showGlobalBackupReminder()
-        showVerifyFastVaultPasswordReminderIfRequired(vaultId)
-        enableVultTokenIfNeeded(vaultId)
-        loadDeFiBalances(vaultId, vaultChanged)
-        checkNotificationPrompt(vaultId)
-    }
-
-    private fun enableVultTokenIfNeeded(vaultId: VaultId) {
-        viewModelScope.launch {
-            try {
-                val vault = vaultRepository.get(vaultId) ?: return@launch
-
-                // Check if vault has Ethereum chain enabled
-                val hasEthereum = vault.coins.any { it.chain == Chain.Ethereum }
-                if (!hasEthereum) {
-                    Timber.d("Ethereum chain not enabled, skipping VULT token auto-enable")
-                    return@launch
-                }
-
-                // Check if VULT token is already enabled
-                val vultCoin = vault.coins.find { it.id == Coins.Ethereum.VULT.id }
-
-                if (vultCoin == null) {
-                    // Enable VULT token in background
-                    Timber.d("VULT token not enabled, enabling it now for vault: $vaultId")
-                    withContext(Dispatchers.IO) { enableTokenUseCase(vaultId, Coins.Ethereum.VULT) }
-                    Timber.d("VULT token enabled successfully")
-                }
-
-                // fetch NFT
-                val ethAddress = vault.coins.find { it.id == Coins.Ethereum.ETH.id }?.address
-                if (ethAddress != null) {
-                    withContext(Dispatchers.IO) {
-                        val balance = remoteNFTService.checkNFTBalance(ethAddress)
-                        tiersNFTRepository.saveTierNFT(vaultId, balance)
-                    }
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to auto-enable VULT token")
-            }
+        if (vultCoin == null) {
+          // Enable VULT token in background
+          Timber.d("VULT token not enabled, enabling it now for vault: $vaultId")
+          withContext(Dispatchers.IO) { enableTokenUseCase(vaultId, Coins.Ethereum.VULT) }
+          Timber.d("VULT token enabled successfully")
         }
-    }
 
-    private fun showGlobalBackupReminder() {
-        viewModelScope.launch {
-            val showReminder = isGlobalBackupReminderRequired()
-            uiState.update { it.copy(showMonthlyBackupReminder = showReminder) }
+        // fetch NFT
+        val ethAddress = vault.coins.find { it.id == Coins.Ethereum.ETH.id }?.address
+        if (ethAddress != null) {
+          withContext(Dispatchers.IO) {
+            val balance = remoteNFTService.checkNFTBalance(ethAddress)
+            tiersNFTRepository.saveTierNFT(vaultId, balance)
+          }
         }
+      } catch (e: Exception) {
+        Timber.e(e, "Failed to auto-enable VULT token")
+      }
     }
+  }
 
-    private fun showVerifyFastVaultPasswordReminderIfRequired(vaultId: VaultId) {
-        viewModelScope.launch {
-            val vault = vaultRepository.get(vaultId) ?: return@launch
-            if (
-                vault.isFastVault() &&
-                    vaultMetadataRepo.isFastVaultPasswordReminderRequired(vaultId)
-            ) {
-                navigator.route(Route.FastVaultPasswordReminder(vaultId))
-            }
-        }
+  private fun showGlobalBackupReminder() {
+    viewModelScope.launch {
+      val showReminder = isGlobalBackupReminderRequired()
+      uiState.update { it.copy(showMonthlyBackupReminder = showReminder) }
     }
+  }
 
-    private fun loadBalanceVisibility(vaultId: String) {
-        viewModelScope.launch {
-            val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
-            uiState.update { it.copy(isBalanceValueVisible = isBalanceVisible) }
-        }
+  private fun showVerifyFastVaultPasswordReminderIfRequired(vaultId: VaultId) {
+    viewModelScope.launch {
+      val vault = vaultRepository.get(vaultId) ?: return@launch
+      if (vault.isFastVault() && vaultMetadataRepo.isFastVaultPasswordReminderRequired(vaultId)) {
+        navigator.route(Route.FastVaultPasswordReminder(vaultId))
+      }
     }
+  }
 
-    fun refreshData() {
-        val vaultId = vaultId ?: return
-        updateRefreshing(true)
-        loadAccounts(vaultId, true)
+  private fun loadBalanceVisibility(vaultId: String) {
+    viewModelScope.launch {
+      val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
+      uiState.update { it.copy(isBalanceValueVisible = isBalanceVisible) }
     }
+  }
 
-    fun send() {
-        val vaultId = vaultId ?: return
-        viewModelScope.launch { navigator.route(Route.Send(vaultId = vaultId)) }
+  fun refreshData() {
+    val vaultId = vaultId ?: return
+    updateRefreshing(true)
+    loadAccounts(vaultId, true)
+  }
+
+  fun send() {
+    val vaultId = vaultId ?: return
+    viewModelScope.launch { navigator.route(Route.Send(vaultId = vaultId)) }
+  }
+
+  fun swap() {
+    val vaultId = vaultId ?: return
+    viewModelScope.launch { navigator.route(Route.Swap(vaultId = vaultId)) }
+  }
+
+  fun buy() {
+    val vaultId = vaultId ?: return
+    viewModelScope.launch {
+      navigator.route(Route.OnRamp(vaultId = vaultId, chainId = Chain.ThorChain.raw))
     }
+  }
 
-    fun swap() {
-        val vaultId = vaultId ?: return
-        viewModelScope.launch { navigator.route(Route.Swap(vaultId = vaultId)) }
-    }
+  fun receive() {
+    val vaultId = vaultId ?: return
+    viewModelScope.launch { navigator.route(Route.Receive(vaultId = vaultId)) }
+  }
 
-    fun buy() {
-        val vaultId = vaultId ?: return
-        viewModelScope.launch {
-            navigator.route(Route.OnRamp(vaultId = vaultId, chainId = Chain.ThorChain.raw))
-        }
-    }
+  fun openCamera() {
+    viewModelScope.launch { navigator.route(Route.ScanQr(vaultId = vaultId)) }
+  }
 
-    fun receive() {
-        val vaultId = vaultId ?: return
-        viewModelScope.launch { navigator.route(Route.Receive(vaultId = vaultId)) }
-    }
+  fun openAccount(account: AccountUiModel) {
+    val vaultId = vaultId ?: return
+    val chainId = account.model.chain.id
 
-    fun openCamera() {
-        viewModelScope.launch { navigator.route(Route.ScanQr(vaultId = vaultId)) }
-    }
-
-    fun openAccount(account: AccountUiModel) {
-        val vaultId = vaultId ?: return
-        val chainId = account.model.chain.id
-
-        viewModelScope.launch {
-            when (uiState.value.cryptoConnectionType) {
-                CryptoConnectionType.Wallet -> {
-                    navigator.route(
-                        Route.ChainDashboard(
-                            route = ChainDashboardRoute.Wallet(vaultId = vaultId, chainId = chainId)
-                        )
-                    )
-                }
-                CryptoConnectionType.Defi -> {
-                    when {
-                        account.chainName.equals(Chain.Ethereum.toDefi.raw, true) ->
-                            navigator.route(
-                                Route.ChainDashboard(
-                                    route = ChainDashboardRoute.PositionCircle(vaultId = vaultId)
-                                )
-                            )
-                        account.chainName.equals(Chain.MayaChain.raw, true) ->
-                            navigator.route(
-                                Route.ChainDashboard(
-                                    route = ChainDashboardRoute.PositionMaya(vaultId = vaultId)
-                                )
-                            )
-                        account.chainName.equals(Chain.Tron.raw, true) ->
-                            navigator.route(
-                                Route.ChainDashboard(
-                                    route = ChainDashboardRoute.PositionTron(vaultId = vaultId)
-                                )
-                            )
-                        else ->
-                            navigator.route(
-                                Route.ChainDashboard(
-                                    route = ChainDashboardRoute.PositionTokens(vaultId = vaultId)
-                                )
-                            )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun loadVaultNameAndShowBackup(vaultId: String) {
-        loadVaultNameJob?.cancel()
-        loadVaultNameJob =
-            viewModelScope.launch {
-                val vault = vaultRepository.get(vaultId) ?: return@launch
-                uiState.update {
-                    it.copy(
-                        vaultName = vault.name,
-                        isFastVault = vault.isFastVault(),
-                        // KeyImport vaults have a fixed set of chains chosen during import,
-                        // so chain selection is disabled on the home screen
-                        isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
-                    )
-                }
-                val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
-                uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
-                val showMigration = vault.libType == SigningLibType.GG20
-                uiState.update { it.copy(showMigration = showMigration) }
-            }
-    }
-
-    private fun loadAccounts(vaultId: String, isRefresh: Boolean = false) {
-        loadAccountsJob?.cancel()
-        loadAccountsJob =
-            viewModelScope.launch {
-                combine(
-                        accountsRepository
-                            .loadAddresses(vaultId, isRefresh)
-                            .map { it.sortByAccountsTotalFiatValue() }
-                            .catch {
-                                updateRefreshing(false)
-                                Timber.e(it)
-                            },
-                        uiState.value.searchTextFieldState.textAsFlow(),
-                        uiState.map { it.cryptoConnectionType }.distinctUntilChanged(),
-                    ) { accounts, searchQuery, cryptoConnectionType ->
-                        accounts
-                            .filter {
-                                when (cryptoConnectionType) {
-                                    CryptoConnectionType.Wallet -> true
-                                    CryptoConnectionType.Defi ->
-                                        cryptoConnectionTypeRepository.isDefi(it.chain)
-                                }
-                            }
-                            .updateUiStateFromList(searchQuery = searchQuery.toString())
-                    }
-                    .launchIn(this)
-            }
-    }
-
-    private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
-        loadDeFiBalancesJob?.cancel()
-        loadDeFiBalancesJob =
-            viewModelScope.launch {
-                combine(
-                        accountsRepository
-                            .loadDeFiAddresses(vaultId, isRefresh)
-                            .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
-                            .catch { error ->
-                                updateRefreshing(false)
-                                Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
-                            },
-                        uiState.value.searchTextFieldState.textAsFlow(),
-                        defaultDeFiChainsRepository.getDefaultChains(vaultId),
-                    ) { accounts, searchQuery, selectedDeFiChains ->
-                        Timber.d(
-                            "DeFi Accounts Loaded for vault $vaultId: ${accounts.size} accounts, selected chains: ${selectedDeFiChains.map { it.raw }}"
-                        )
-
-                        val filteredAccounts =
-                            accounts.filter { address ->
-                                val isSelected = selectedDeFiChains.contains(address.chain)
-                                Timber.d("Chain ${address.chain.raw} is selected: $isSelected")
-                                isSelected
-                            }
-
-                        Timber.d("Filtered DeFi accounts: ${filteredAccounts.size} accounts")
-
-                        filteredAccounts.updateUiStateFromList(
-                            searchQuery = searchQuery.toString(),
-                            isDefi = true,
-                        )
-                    }
-                    .launchIn(this)
-            }
-    }
-
-    private fun List<Address>.sortByAccountsTotalFiatValue() =
-        sortedWith(
-            compareBy(
-                { it.accounts.calculateAccountsTotalFiatValue()?.value?.unaryMinus() },
-                { it.chain.raw },
+    viewModelScope.launch {
+      when (uiState.value.cryptoConnectionType) {
+        CryptoConnectionType.Wallet -> {
+          navigator.route(
+            Route.ChainDashboard(
+              route = ChainDashboardRoute.Wallet(vaultId = vaultId, chainId = chainId)
             )
+          )
+        }
+        CryptoConnectionType.Defi -> {
+          when {
+            account.chainName.equals(Chain.Ethereum.toDefi.raw, true) ->
+              navigator.route(
+                Route.ChainDashboard(route = ChainDashboardRoute.PositionCircle(vaultId = vaultId))
+              )
+            account.chainName.equals(Chain.MayaChain.raw, true) ->
+              navigator.route(
+                Route.ChainDashboard(route = ChainDashboardRoute.PositionMaya(vaultId = vaultId))
+              )
+            account.chainName.equals(Chain.Tron.raw, true) ->
+              navigator.route(
+                Route.ChainDashboard(route = ChainDashboardRoute.PositionTron(vaultId = vaultId))
+              )
+            else ->
+              navigator.route(
+                Route.ChainDashboard(route = ChainDashboardRoute.PositionTokens(vaultId = vaultId))
+              )
+          }
+        }
+      }
+    }
+  }
+
+  private fun loadVaultNameAndShowBackup(vaultId: String) {
+    loadVaultNameJob?.cancel()
+    loadVaultNameJob = viewModelScope.launch {
+      val vault = vaultRepository.get(vaultId) ?: return@launch
+      uiState.update {
+        it.copy(
+          vaultName = vault.name,
+          isFastVault = vault.isFastVault(),
+          // KeyImport vaults have a fixed set of chains chosen during import,
+          // so chain selection is disabled on the home screen
+          isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
         )
+      }
+      val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
+      uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
+      val showMigration = vault.libType == SigningLibType.GG20
+      uiState.update { it.copy(showMigration = showMigration) }
+    }
+  }
 
-    private suspend fun List<Address>.updateUiStateFromList(
-        searchQuery: String,
-        isDefi: Boolean = false,
-    ) {
-        val totalFiatValue =
-            this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
-        val accountsUiModel = this.map { addressToUiModelMapper(it) }
-
-        if (!isDefi) {
-            uiState.update {
-                it.copy(
-                    totalFiatValue = totalFiatValue,
-                    accounts = accountsUiModel.filteredAccounts(searchQuery),
-                )
+  private fun loadAccounts(vaultId: String, isRefresh: Boolean = false) {
+    loadAccountsJob?.cancel()
+    loadAccountsJob = viewModelScope.launch {
+      combine(
+          accountsRepository
+            .loadAddresses(vaultId, isRefresh)
+            .map { it.sortByAccountsTotalFiatValue() }
+            .catch {
+              updateRefreshing(false)
+              Timber.e(it)
+            },
+          uiState.value.searchTextFieldState.textAsFlow(),
+          uiState.map { it.cryptoConnectionType }.distinctUntilChanged(),
+        ) { accounts, searchQuery, cryptoConnectionType ->
+          accounts
+            .filter {
+              when (cryptoConnectionType) {
+                CryptoConnectionType.Wallet -> true
+                CryptoConnectionType.Defi ->
+                  cryptoConnectionTypeRepository.hasDeFiPositionsScreen(it.chain)
+              }
             }
+            .updateUiStateFromList(searchQuery = searchQuery.toString())
+        }
+        .launchIn(this)
+    }
+  }
+
+  private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
+    loadDeFiBalancesJob?.cancel()
+    loadDeFiBalancesJob = viewModelScope.launch {
+      combine(
+          accountsRepository
+            .loadDeFiAddresses(vaultId, isRefresh)
+            .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
+            .catch { error ->
+              updateRefreshing(false)
+              Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
+            },
+          uiState.value.searchTextFieldState.textAsFlow(),
+          defaultDeFiChainsRepository.getDefaultChains(vaultId),
+        ) { accounts, searchQuery, selectedDeFiChains ->
+          Timber.d(
+            "DeFi Accounts Loaded for vault $vaultId: ${accounts.size} accounts, selected chains: ${selectedDeFiChains.map { it.raw }}"
+          )
+
+          val filteredAccounts = accounts.filter { address ->
+            val isSelected = selectedDeFiChains.contains(address.chain)
+            Timber.d("Chain ${address.chain.raw} is selected: $isSelected")
+            isSelected
+          }
+
+          Timber.d("Filtered DeFi accounts: ${filteredAccounts.size} accounts")
+
+          filteredAccounts.updateUiStateFromList(
+            searchQuery = searchQuery.toString(),
+            isDefi = true,
+          )
+        }
+        .launchIn(this)
+    }
+  }
+
+  private fun List<Address>.sortByAccountsTotalFiatValue() =
+    sortedWith(
+      compareBy(
+        { it.accounts.calculateAccountsTotalFiatValue()?.value?.unaryMinus() },
+        { it.chain.raw },
+      )
+    )
+
+  private suspend fun List<Address>.updateUiStateFromList(
+    searchQuery: String,
+    isDefi: Boolean = false,
+  ) {
+    val totalFiatValue =
+      this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
+    val accountsUiModel = this.map { addressToUiModelMapper(it) }
+
+    if (!isDefi) {
+      uiState.update {
+        it.copy(
+          totalFiatValue = totalFiatValue,
+          accounts = accountsUiModel.filteredAccounts(searchQuery),
+        )
+      }
+    } else {
+      uiState.update {
+        it.copy(
+          totalDeFiValue = totalFiatValue,
+          defiAccounts = accountsUiModel.filteredAccounts(searchQuery),
+        )
+      }
+    }
+    updateRefreshing(false)
+
+    Timber.d("Update updateUiStateFromList: %s", "$this")
+  }
+
+  private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {
+    if (searchQuery.isBlank()) return this
+    val query = searchQuery.trim()
+    return filter { account ->
+      listOf(account.chainName, account.nativeTokenTicker).any { field ->
+        field.contains(other = query, ignoreCase = true)
+      }
+    }
+  }
+
+  private fun updateRefreshing(isRefreshing: Boolean) {
+    Timber.d("UpdateRefresh $isRefreshing")
+    uiState.update { it.copy(isRefreshing = isRefreshing) }
+  }
+
+  fun toggleBalanceVisibility() {
+    val vaultId =
+      vaultId
+        ?: run {
+          Timber.w("toggleBalanceVisibility: vaultId is null, skipping")
+          return
+        }
+    val isBalanceValueVisible = !uiState.value.isBalanceValueVisible
+    viewModelScope.launch {
+      uiState.update { it.copy(isBalanceValueVisible = isBalanceValueVisible) }
+      balanceVisibilityRepository.setVisibility(vaultId, isBalanceValueVisible)
+    }
+  }
+
+  fun backupVault() {
+    val vaultId =
+      vaultId
+        ?: run {
+          Timber.w("backupVault: vaultId is null, skipping")
+          return
+        }
+    viewModelScope.launch {
+      dismissBackupReminder()
+      navigator.route(Route.BackupPasswordRequest(vaultId))
+    }
+  }
+
+  fun migrate() {
+    val vaultId = vaultId ?: return
+    viewModelScope.launch { navigator.route(Route.Migration.Onboarding(vaultId)) }
+  }
+
+  fun dismissBackupReminder() {
+    uiState.update { it.copy(showMonthlyBackupReminder = false) }
+  }
+
+  fun doNotRemindBackup() = viewModelScope.launch {
+    setNeverShowGlobalBackupReminder()
+    dismissBackupReminder()
+  }
+
+  fun openHistory() {
+    vaultId?.let { vaultId ->
+      viewModelScope.launch { navigator.route(Route.TransactionHistory(vaultId = vaultId)) }
+    }
+  }
+
+  fun openSettings() {
+    vaultId?.let { vaultId ->
+      viewModelScope.launch {
+        Timber.d("openSettings($vaultId)")
+        navigator.route(Route.Settings(vaultId = vaultId))
+      }
+    }
+  }
+
+  fun openAddChainAccount() {
+    vaultId?.let { vaultId ->
+      viewModelScope.launch {
+        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
+          navigator.route(Route.AddDeFiChainAccount(vaultId = vaultId))
         } else {
-            uiState.update {
-                it.copy(
-                    totalDeFiValue = totalFiatValue,
-                    defiAccounts = accountsUiModel.filteredAccounts(searchQuery),
-                )
-            }
+          navigator.route(Route.AddChainAccount(vaultId = vaultId))
         }
-        updateRefreshing(false)
+        requestResultRepository.request<Unit>(REFRESH_CHAIN_DATA)
 
-        Timber.d("Update updateUiStateFromList: %s", "$this")
+        loadData(vaultId)
+      }
     }
+  }
 
-    private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {
-        if (searchQuery.isBlank()) return this
-        val query = searchQuery.trim()
-        return filter { account ->
-            listOf(account.chainName, account.nativeTokenTicker).any { field ->
-                field.contains(other = query, ignoreCase = true)
-            }
-        }
+  fun openVaultList() {
+    vaultId?.let {
+      viewModelScope.launch {
+        navigator.route(Route.VaultList(openType = Route.VaultList.OpenType.Home(it)))
+      }
     }
+  }
 
-    private fun updateRefreshing(isRefreshing: Boolean) {
-        Timber.d("UpdateRefresh $isRefreshing")
-        uiState.update { it.copy(isRefreshing = isRefreshing) }
+  fun tempRemoveBanner() {
+    uiState.update { it.copy(isBannerVisible = false) }
+  }
+
+  fun setCryptoConnectionType(type: CryptoConnectionType) {
+    cryptoConnectionTypeRepository.setActiveCryptoConnection(type)
+    uiState.update { it.copy(cryptoConnectionType = type) }
+
+    val vaultId = vaultId ?: return
+
+    if (type == CryptoConnectionType.Defi) {
+      loadDeFiBalances(vaultId, true)
     }
+  }
 
-    fun toggleBalanceVisibility() {
-        val vaultId =
-            vaultId
-                ?: run {
-                    Timber.w("toggleBalanceVisibility: vaultId is null, skipping")
-                    return
-                }
-        val isBalanceValueVisible = !uiState.value.isBalanceValueVisible
-        viewModelScope.launch {
-            uiState.update { it.copy(isBalanceValueVisible = isBalanceValueVisible) }
-            balanceVisibilityRepository.setVisibility(vaultId, isBalanceValueVisible)
-        }
+  private fun checkNotificationPrompt(vaultId: String) {
+    viewModelScope.launch {
+      val currentVault = vaultRepository.get(vaultId) ?: return@launch
+      if (!currentVault.isSecureVault()) return@launch
+      if (
+        pushNotificationManager.isVaultOptedIn(vaultId) ||
+          pushNotificationManager.hasPromptedVault(vaultId)
+      )
+        return@launch
+
+      val eligibleVaults = vaultRepository.getAll().filter { it.isSecureVault() }
+      val introVaults = eligibleVaults.map { vault ->
+        VaultIntroItem(
+          vaultId = vault.id,
+          vaultName = vault.name,
+          isEnabled = pushNotificationManager.isVaultOptedIn(vault.id),
+          isFastVault = vault.isFastVault(),
+        )
+      }
+      uiState.update {
+        it.copy(showNotificationIntroSheet = true, notificationIntroVaults = introVaults)
+      }
     }
+  }
 
-    fun backupVault() {
-        val vaultId =
-            vaultId
-                ?: run {
-                    Timber.w("backupVault: vaultId is null, skipping")
-                    return
-                }
-        viewModelScope.launch {
-            dismissBackupReminder()
-            navigator.route(Route.BackupPasswordRequest(vaultId))
-        }
+  fun onNotificationEnable() {
+    viewModelScope.launch {
+      // Mark as prompted now so we don't re-prompt even if permission is denied
+      uiState.value.notificationIntroVaults.forEach { vault ->
+        pushNotificationManager.markVaultPrompted(vault.vaultId)
+      }
+      uiState.update { it.copy(showNotificationIntroSheet = false) }
+      _requestNotificationPermission.send(Unit)
     }
+  }
 
-    fun migrate() {
-        val vaultId = vaultId ?: return
-        viewModelScope.launch { navigator.route(Route.Migration.Onboarding(vaultId)) }
+  fun onNotificationPermissionResult(granted: Boolean) {
+    if (granted) {
+      uiState.update { it.copy(showNotificationVaultSheet = true) }
     }
+  }
 
-    fun dismissBackupReminder() {
-        uiState.update { it.copy(showMonthlyBackupReminder = false) }
+  fun onNotificationNotNow() {
+    viewModelScope.launch {
+      uiState.value.notificationIntroVaults.forEach { vault ->
+        pushNotificationManager.markVaultPrompted(vault.vaultId)
+      }
+      uiState.update { it.copy(showNotificationIntroSheet = false) }
     }
+  }
 
-    fun doNotRemindBackup() =
-        viewModelScope.launch {
-            setNeverShowGlobalBackupReminder()
-            dismissBackupReminder()
-        }
-
-    fun openHistory() {
-        vaultId?.let { vaultId ->
-            viewModelScope.launch { navigator.route(Route.TransactionHistory(vaultId = vaultId)) }
-        }
+  fun onNotificationVaultToggle(vaultId: String, enabled: Boolean) {
+    uiState.update { state ->
+      state.copy(
+        notificationIntroVaults =
+          state.notificationIntroVaults.map { vault ->
+            if (vault.vaultId == vaultId) vault.copy(isEnabled = enabled) else vault
+          }
+      )
     }
+  }
 
-    fun openSettings() {
-        vaultId?.let { vaultId ->
-            viewModelScope.launch {
-                Timber.d("openSettings($vaultId)")
-                navigator.route(Route.Settings(vaultId = vaultId))
-            }
-        }
+  fun onNotificationVaultSheetDismiss() {
+    uiState.update { it.copy(showNotificationVaultSheet = false) }
+  }
+
+  fun onNotificationVaultSheetDone() {
+    val vaultsToOptIn = uiState.value.notificationIntroVaults
+    uiState.update { it.copy(showNotificationVaultSheet = false) }
+    viewModelScope.safeLaunch(
+      onError = { e ->
+        Timber.w(e, "Failed to opt in vaults for notifications")
+        snackbarFlow.showMessage(pushNotificationErrorMessage(e, context), SnackbarType.Error)
+      }
+    ) {
+      pushNotificationManager.setVaultsOptIn(vaultsToOptIn.map { it.vaultId to it.isEnabled })
     }
+  }
 
-    fun openAddChainAccount() {
-        vaultId?.let { vaultId ->
-            viewModelScope.launch {
-                if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
-                    navigator.route(Route.AddDeFiChainAccount(vaultId = vaultId))
-                } else {
-                    navigator.route(Route.AddChainAccount(vaultId = vaultId))
-                }
-                requestResultRepository.request<Unit>(REFRESH_CHAIN_DATA)
-
-                loadData(vaultId)
-            }
-        }
+  fun onEnableAll(enabled: Boolean) {
+    uiState.update { state ->
+      state.copy(
+        notificationIntroVaults = state.notificationIntroVaults.map { it.copy(isEnabled = enabled) }
+      )
     }
+  }
 
-    fun openVaultList() {
-        vaultId?.let {
-            viewModelScope.launch {
-                navigator.route(Route.VaultList(openType = Route.VaultList.OpenType.Home(it)))
-            }
-        }
-    }
-
-    fun tempRemoveBanner() {
-        uiState.update { it.copy(isBannerVisible = false) }
-    }
-
-    fun setCryptoConnectionType(type: CryptoConnectionType) {
-        cryptoConnectionTypeRepository.setActiveCryptoConnection(type)
-        uiState.update { it.copy(cryptoConnectionType = type) }
-
-        val vaultId = vaultId ?: return
-
-        if (type == CryptoConnectionType.Defi) {
-            loadDeFiBalances(vaultId, true)
-        }
-    }
-
-    private fun checkNotificationPrompt(vaultId: String) {
-        viewModelScope.launch {
-            val currentVault = vaultRepository.get(vaultId) ?: return@launch
-            if (!currentVault.isSecureVault()) return@launch
-            if (
-                pushNotificationManager.isVaultOptedIn(vaultId) ||
-                    pushNotificationManager.hasPromptedVault(vaultId)
-            )
-                return@launch
-
-            val eligibleVaults = vaultRepository.getAll().filter { it.isSecureVault() }
-            val introVaults =
-                eligibleVaults.map { vault ->
-                    VaultIntroItem(
-                        vaultId = vault.id,
-                        vaultName = vault.name,
-                        isEnabled = pushNotificationManager.isVaultOptedIn(vault.id),
-                        isFastVault = vault.isFastVault(),
-                    )
-                }
-            uiState.update {
-                it.copy(showNotificationIntroSheet = true, notificationIntroVaults = introVaults)
-            }
-        }
-    }
-
-    fun onNotificationEnable() {
-        viewModelScope.launch {
-            // Mark as prompted now so we don't re-prompt even if permission is denied
-            uiState.value.notificationIntroVaults.forEach { vault ->
-                pushNotificationManager.markVaultPrompted(vault.vaultId)
-            }
-            uiState.update { it.copy(showNotificationIntroSheet = false) }
-            _requestNotificationPermission.send(Unit)
-        }
-    }
-
-    fun onNotificationPermissionResult(granted: Boolean) {
-        if (granted) {
-            uiState.update { it.copy(showNotificationVaultSheet = true) }
-        }
-    }
-
-    fun onNotificationNotNow() {
-        viewModelScope.launch {
-            uiState.value.notificationIntroVaults.forEach { vault ->
-                pushNotificationManager.markVaultPrompted(vault.vaultId)
-            }
-            uiState.update { it.copy(showNotificationIntroSheet = false) }
-        }
-    }
-
-    fun onNotificationVaultToggle(vaultId: String, enabled: Boolean) {
-        uiState.update { state ->
-            state.copy(
-                notificationIntroVaults =
-                    state.notificationIntroVaults.map { vault ->
-                        if (vault.vaultId == vaultId) vault.copy(isEnabled = enabled) else vault
-                    }
-            )
-        }
-    }
-
-    fun onNotificationVaultSheetDismiss() {
-        uiState.update { it.copy(showNotificationVaultSheet = false) }
-    }
-
-    fun onNotificationVaultSheetDone() {
-        val vaultsToOptIn = uiState.value.notificationIntroVaults
-        uiState.update { it.copy(showNotificationVaultSheet = false) }
-        viewModelScope.safeLaunch(
-            onError = { e ->
-                Timber.w(e, "Failed to opt in vaults for notifications")
-                snackbarFlow.showMessage(
-                    pushNotificationErrorMessage(e, context),
-                    SnackbarType.Error,
-                )
-            }
-        ) {
-            pushNotificationManager.setVaultsOptIn(vaultsToOptIn.map { it.vaultId to it.isEnabled })
-        }
-    }
-
-    fun onEnableAll(enabled: Boolean) {
-        uiState.update { state ->
-            state.copy(
-                notificationIntroVaults =
-                    state.notificationIntroVaults.map { it.copy(isEnabled = enabled) }
-            )
-        }
-    }
-
-    companion object {
-        internal const val REFRESH_CHAIN_DATA = "refresh_chain_data"
-    }
+  companion object {
+    internal const val REFRESH_CHAIN_DATA = "refresh_chain_data"
+  }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -69,586 +69,610 @@ import timber.log.Timber
 
 @Immutable
 internal data class VaultAccountsUiModel(
-  val vaultName: String = "",
-  val isFastVault: Boolean = false,
-  val showBackupWarning: Boolean = false,
-  val showMonthlyBackupReminder: Boolean = false,
-  val showNotificationIntroSheet: Boolean = false,
-  val showNotificationVaultSheet: Boolean = false,
-  val notificationIntroVaults: List<VaultIntroItem> = emptyList(),
-  val showMigration: Boolean = false,
-  val isRefreshing: Boolean = false,
-  val totalFiatValue: String? = null,
-  val totalDeFiValue: String? = null,
-  val isBalanceValueVisible: Boolean = true,
-  val accounts: List<AccountUiModel> = emptyList(),
-  val defiAccounts: List<AccountUiModel> = emptyList(),
-  val searchTextFieldState: TextFieldState = TextFieldState(),
-  val isBannerVisible: Boolean = true,
-  val cryptoConnectionType: CryptoConnectionType = CryptoConnectionType.Wallet,
-  val scanQrUiModel: ScanQrUiModel = ScanQrUiModel(),
-  val isChainSelectionEnabled: Boolean = true,
+    val vaultName: String = "",
+    val isFastVault: Boolean = false,
+    val showBackupWarning: Boolean = false,
+    val showMonthlyBackupReminder: Boolean = false,
+    val showNotificationIntroSheet: Boolean = false,
+    val showNotificationVaultSheet: Boolean = false,
+    val notificationIntroVaults: List<VaultIntroItem> = emptyList(),
+    val showMigration: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val totalFiatValue: String? = null,
+    val totalDeFiValue: String? = null,
+    val isBalanceValueVisible: Boolean = true,
+    val accounts: List<AccountUiModel> = emptyList(),
+    val defiAccounts: List<AccountUiModel> = emptyList(),
+    val searchTextFieldState: TextFieldState = TextFieldState(),
+    val isBannerVisible: Boolean = true,
+    val cryptoConnectionType: CryptoConnectionType = CryptoConnectionType.Wallet,
+    val scanQrUiModel: ScanQrUiModel = ScanQrUiModel(),
+    val isChainSelectionEnabled: Boolean = true,
 ) {
-  val isSwapEnabled = accounts.any { it.model.chain.isSwapSupported }
-  val noChainFound: Boolean
-    get() = searchTextFieldState.text.isNotEmpty() && accounts.isEmpty()
+    val isSwapEnabled = accounts.any { it.model.chain.isSwapSupported }
+    val noChainFound: Boolean
+        get() = searchTextFieldState.text.isNotEmpty() && accounts.isEmpty()
 
-  val getAccounts: List<AccountUiModel>
-    get() =
-      if (cryptoConnectionType == CryptoConnectionType.Wallet) {
-        accounts
-      } else {
-        defiAccounts
-      }
+    val getAccounts: List<AccountUiModel>
+        get() =
+            if (cryptoConnectionType == CryptoConnectionType.Wallet) {
+                accounts
+            } else {
+                defiAccounts
+            }
 }
 
 @Immutable
 internal data class AccountUiModel(
-  val model: Address,
-  val chainName: String,
-  @param:DrawableRes val logo: Int,
-  val address: String,
-  val nativeTokenAmount: String?,
-  val fiatAmount: String?,
-  val assetsSize: Int = 0,
-  val nativeTokenTicker: String = "",
-  val isDeFiProvider: Boolean = false,
+    val model: Address,
+    val chainName: String,
+    @param:DrawableRes val logo: Int,
+    val address: String,
+    val nativeTokenAmount: String?,
+    val fiatAmount: String?,
+    val assetsSize: Int = 0,
+    val nativeTokenTicker: String = "",
+    val isDeFiProvider: Boolean = false,
 )
 
 @HiltViewModel
 internal class VaultAccountsViewModel
 @Inject
 constructor(
-  @param:ApplicationContext private val context: Context,
-  savedStateHandle: SavedStateHandle,
-  private val navigator: Navigator<Destination>,
-  private val requestResultRepository: RequestResultRepository,
-  private val addressToUiModelMapper: AddressToUiModelMapper,
-  private val fiatValueToStringMapper: FiatValueToStringMapper,
-  private val vaultRepository: VaultRepository,
-  private val vaultDataStoreRepository: VaultDataStoreRepository,
-  private val accountsRepository: AccountsRepository,
-  private val balanceVisibilityRepository: BalanceVisibilityRepository,
-  private val vaultMetadataRepo: VaultMetadataRepo,
-  private val isGlobalBackupReminderRequired: IsGlobalBackupReminderRequiredUseCase,
-  private val setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase,
-  private val lastOpenedVaultRepository: LastOpenedVaultRepository,
-  private val enableTokenUseCase: EnableTokenUseCase,
-  private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
-  private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
-  private val tiersNFTRepository: TiersNFTRepository,
-  private val remoteNFTService: TierRemoteNFTService,
-  private val pushNotificationManager: PushNotificationManager,
-  private val snackbarFlow: SnackbarFlow,
+    @param:ApplicationContext private val context: Context,
+    savedStateHandle: SavedStateHandle,
+    private val navigator: Navigator<Destination>,
+    private val requestResultRepository: RequestResultRepository,
+    private val addressToUiModelMapper: AddressToUiModelMapper,
+    private val fiatValueToStringMapper: FiatValueToStringMapper,
+    private val vaultRepository: VaultRepository,
+    private val vaultDataStoreRepository: VaultDataStoreRepository,
+    private val accountsRepository: AccountsRepository,
+    private val balanceVisibilityRepository: BalanceVisibilityRepository,
+    private val vaultMetadataRepo: VaultMetadataRepo,
+    private val isGlobalBackupReminderRequired: IsGlobalBackupReminderRequiredUseCase,
+    private val setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase,
+    private val lastOpenedVaultRepository: LastOpenedVaultRepository,
+    private val enableTokenUseCase: EnableTokenUseCase,
+    private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
+    private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
+    private val tiersNFTRepository: TiersNFTRepository,
+    private val remoteNFTService: TierRemoteNFTService,
+    private val pushNotificationManager: PushNotificationManager,
+    private val snackbarFlow: SnackbarFlow,
 ) : ViewModel() {
 
-  private var requestedVaultId: String? = savedStateHandle.toRoute<Route.Home>().openVaultId
-  private var vaultId: String? = null
+    private var requestedVaultId: String? = savedStateHandle.toRoute<Route.Home>().openVaultId
+    private var vaultId: String? = null
 
-  val uiState = MutableStateFlow(VaultAccountsUiModel())
+    val uiState = MutableStateFlow(VaultAccountsUiModel())
 
-  private var loadVaultNameJob: Job? = null
-  private var loadAccountsJob: Job? = null
-  private var loadDeFiBalancesJob: Job? = null
+    private var loadVaultNameJob: Job? = null
+    private var loadAccountsJob: Job? = null
+    private var loadDeFiBalancesJob: Job? = null
 
-  private val _requestNotificationPermission = Channel<Unit>(Channel.BUFFERED)
-  val requestNotificationPermission = _requestNotificationPermission.receiveAsFlow()
+    private val _requestNotificationPermission = Channel<Unit>(Channel.BUFFERED)
+    val requestNotificationPermission = _requestNotificationPermission.receiveAsFlow()
 
-  init {
-    collectCryptoConnectionType()
-    collectLastOpenedVault()
-  }
-
-  private fun collectCryptoConnectionType() {
-    cryptoConnectionTypeRepository.activeCryptoConnectionFlow
-      .onEach { connectionType ->
-        uiState.update { state -> state.copy(cryptoConnectionType = connectionType) }
-      }
-      .launchIn(viewModelScope)
-  }
-
-  private suspend fun updateLastOpenedVault() {
-    val requestedVaultId = requestedVaultId
-    if (requestedVaultId != null) {
-      lastOpenedVaultRepository.setLastOpenedVaultId(requestedVaultId)
-      this@VaultAccountsViewModel.requestedVaultId = null
+    init {
+        collectCryptoConnectionType()
+        collectLastOpenedVault()
     }
-  }
 
-  private fun collectLastOpenedVault() {
-    viewModelScope.launch {
-      updateLastOpenedVault()
-      lastOpenedVaultRepository.lastOpenedVaultId
-        .map { lastOpenedVaultId ->
-          lastOpenedVaultId?.let { vaultRepository.get(it) }
-            ?: vaultRepository.getAll().firstOrNull()
-        }
-        .collect { vault ->
-          if (vault != null) {
-            loadData(vault.id)
-          }
-        }
-    }
-  }
-
-  private fun loadData(vaultId: VaultId) {
-    val vaultChanged = this.vaultId != null && this.vaultId != vaultId
-
-    this.vaultId = vaultId
-    loadVaultNameAndShowBackup(vaultId)
-    loadAccounts(vaultId)
-    loadBalanceVisibility(vaultId)
-    showGlobalBackupReminder()
-    showVerifyFastVaultPasswordReminderIfRequired(vaultId)
-    enableVultTokenIfNeeded(vaultId)
-    loadDeFiBalances(vaultId, vaultChanged)
-    checkNotificationPrompt(vaultId)
-  }
-
-  private fun enableVultTokenIfNeeded(vaultId: VaultId) {
-    viewModelScope.launch {
-      try {
-        val vault = vaultRepository.get(vaultId) ?: return@launch
-
-        // Check if vault has Ethereum chain enabled
-        val hasEthereum = vault.coins.any { it.chain == Chain.Ethereum }
-        if (!hasEthereum) {
-          Timber.d("Ethereum chain not enabled, skipping VULT token auto-enable")
-          return@launch
-        }
-
-        // Check if VULT token is already enabled
-        val vultCoin = vault.coins.find { it.id == Coins.Ethereum.VULT.id }
-
-        if (vultCoin == null) {
-          // Enable VULT token in background
-          Timber.d("VULT token not enabled, enabling it now for vault: $vaultId")
-          withContext(Dispatchers.IO) { enableTokenUseCase(vaultId, Coins.Ethereum.VULT) }
-          Timber.d("VULT token enabled successfully")
-        }
-
-        // fetch NFT
-        val ethAddress = vault.coins.find { it.id == Coins.Ethereum.ETH.id }?.address
-        if (ethAddress != null) {
-          withContext(Dispatchers.IO) {
-            val balance = remoteNFTService.checkNFTBalance(ethAddress)
-            tiersNFTRepository.saveTierNFT(vaultId, balance)
-          }
-        }
-      } catch (e: Exception) {
-        Timber.e(e, "Failed to auto-enable VULT token")
-      }
-    }
-  }
-
-  private fun showGlobalBackupReminder() {
-    viewModelScope.launch {
-      val showReminder = isGlobalBackupReminderRequired()
-      uiState.update { it.copy(showMonthlyBackupReminder = showReminder) }
-    }
-  }
-
-  private fun showVerifyFastVaultPasswordReminderIfRequired(vaultId: VaultId) {
-    viewModelScope.launch {
-      val vault = vaultRepository.get(vaultId) ?: return@launch
-      if (vault.isFastVault() && vaultMetadataRepo.isFastVaultPasswordReminderRequired(vaultId)) {
-        navigator.route(Route.FastVaultPasswordReminder(vaultId))
-      }
-    }
-  }
-
-  private fun loadBalanceVisibility(vaultId: String) {
-    viewModelScope.launch {
-      val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
-      uiState.update { it.copy(isBalanceValueVisible = isBalanceVisible) }
-    }
-  }
-
-  fun refreshData() {
-    val vaultId = vaultId ?: return
-    updateRefreshing(true)
-    loadAccounts(vaultId, true)
-  }
-
-  fun send() {
-    val vaultId = vaultId ?: return
-    viewModelScope.launch { navigator.route(Route.Send(vaultId = vaultId)) }
-  }
-
-  fun swap() {
-    val vaultId = vaultId ?: return
-    viewModelScope.launch { navigator.route(Route.Swap(vaultId = vaultId)) }
-  }
-
-  fun buy() {
-    val vaultId = vaultId ?: return
-    viewModelScope.launch {
-      navigator.route(Route.OnRamp(vaultId = vaultId, chainId = Chain.ThorChain.raw))
-    }
-  }
-
-  fun receive() {
-    val vaultId = vaultId ?: return
-    viewModelScope.launch { navigator.route(Route.Receive(vaultId = vaultId)) }
-  }
-
-  fun openCamera() {
-    viewModelScope.launch { navigator.route(Route.ScanQr(vaultId = vaultId)) }
-  }
-
-  fun openAccount(account: AccountUiModel) {
-    val vaultId = vaultId ?: return
-    val chainId = account.model.chain.id
-
-    viewModelScope.launch {
-      when (uiState.value.cryptoConnectionType) {
-        CryptoConnectionType.Wallet -> {
-          navigator.route(
-            Route.ChainDashboard(
-              route = ChainDashboardRoute.Wallet(vaultId = vaultId, chainId = chainId)
-            )
-          )
-        }
-        CryptoConnectionType.Defi -> {
-          when {
-            account.chainName.equals(Chain.Ethereum.toDefi.raw, true) ->
-              navigator.route(
-                Route.ChainDashboard(route = ChainDashboardRoute.PositionCircle(vaultId = vaultId))
-              )
-            account.chainName.equals(Chain.MayaChain.raw, true) ->
-              navigator.route(
-                Route.ChainDashboard(route = ChainDashboardRoute.PositionMaya(vaultId = vaultId))
-              )
-            account.chainName.equals(Chain.Tron.raw, true) ->
-              navigator.route(
-                Route.ChainDashboard(route = ChainDashboardRoute.PositionTron(vaultId = vaultId))
-              )
-            else ->
-              navigator.route(
-                Route.ChainDashboard(route = ChainDashboardRoute.PositionTokens(vaultId = vaultId))
-              )
-          }
-        }
-      }
-    }
-  }
-
-  private fun loadVaultNameAndShowBackup(vaultId: String) {
-    loadVaultNameJob?.cancel()
-    loadVaultNameJob = viewModelScope.launch {
-      val vault = vaultRepository.get(vaultId) ?: return@launch
-      uiState.update {
-        it.copy(
-          vaultName = vault.name,
-          isFastVault = vault.isFastVault(),
-          // KeyImport vaults have a fixed set of chains chosen during import,
-          // so chain selection is disabled on the home screen
-          isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
-        )
-      }
-      val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
-      uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
-      val showMigration = vault.libType == SigningLibType.GG20
-      uiState.update { it.copy(showMigration = showMigration) }
-    }
-  }
-
-  private fun loadAccounts(vaultId: String, isRefresh: Boolean = false) {
-    loadAccountsJob?.cancel()
-    loadAccountsJob = viewModelScope.launch {
-      combine(
-          accountsRepository
-            .loadAddresses(vaultId, isRefresh)
-            .map { it.sortByAccountsTotalFiatValue() }
-            .catch {
-              updateRefreshing(false)
-              Timber.e(it)
-            },
-          uiState.value.searchTextFieldState.textAsFlow(),
-          uiState.map { it.cryptoConnectionType }.distinctUntilChanged(),
-        ) { accounts, searchQuery, cryptoConnectionType ->
-          accounts
-            .filter {
-              when (cryptoConnectionType) {
-                CryptoConnectionType.Wallet -> true
-                CryptoConnectionType.Defi ->
-                  cryptoConnectionTypeRepository.hasDeFiPositionsScreen(it.chain)
-              }
+    private fun collectCryptoConnectionType() {
+        cryptoConnectionTypeRepository.activeCryptoConnectionFlow
+            .onEach { connectionType ->
+                uiState.update { state -> state.copy(cryptoConnectionType = connectionType) }
             }
-            .updateUiStateFromList(searchQuery = searchQuery.toString())
-        }
-        .launchIn(this)
+            .launchIn(viewModelScope)
     }
-  }
 
-  private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
-    loadDeFiBalancesJob?.cancel()
-    loadDeFiBalancesJob = viewModelScope.launch {
-      combine(
-          accountsRepository
-            .loadDeFiAddresses(vaultId, isRefresh)
-            .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
-            .catch { error ->
-              updateRefreshing(false)
-              Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
-            },
-          uiState.value.searchTextFieldState.textAsFlow(),
-          defaultDeFiChainsRepository.getDefaultChains(vaultId),
-        ) { accounts, searchQuery, selectedDeFiChains ->
-          Timber.d(
-            "DeFi Accounts Loaded for vault $vaultId: ${accounts.size} accounts, selected chains: ${selectedDeFiChains.map { it.raw }}"
-          )
-
-          val filteredAccounts = accounts.filter { address ->
-            val isSelected = selectedDeFiChains.contains(address.chain)
-            Timber.d("Chain ${address.chain.raw} is selected: $isSelected")
-            isSelected
-          }
-
-          Timber.d("Filtered DeFi accounts: ${filteredAccounts.size} accounts")
-
-          filteredAccounts.updateUiStateFromList(
-            searchQuery = searchQuery.toString(),
-            isDefi = true,
-          )
+    private suspend fun updateLastOpenedVault() {
+        val requestedVaultId = requestedVaultId
+        if (requestedVaultId != null) {
+            lastOpenedVaultRepository.setLastOpenedVaultId(requestedVaultId)
+            this@VaultAccountsViewModel.requestedVaultId = null
         }
-        .launchIn(this)
     }
-  }
 
-  private fun List<Address>.sortByAccountsTotalFiatValue() =
-    sortedWith(
-      compareBy(
-        { it.accounts.calculateAccountsTotalFiatValue()?.value?.unaryMinus() },
-        { it.chain.raw },
-      )
-    )
+    private fun collectLastOpenedVault() {
+        viewModelScope.launch {
+            updateLastOpenedVault()
+            lastOpenedVaultRepository.lastOpenedVaultId
+                .map { lastOpenedVaultId ->
+                    lastOpenedVaultId?.let { vaultRepository.get(it) }
+                        ?: vaultRepository.getAll().firstOrNull()
+                }
+                .collect { vault ->
+                    if (vault != null) {
+                        loadData(vault.id)
+                    }
+                }
+        }
+    }
 
-  private suspend fun List<Address>.updateUiStateFromList(
-    searchQuery: String,
-    isDefi: Boolean = false,
-  ) {
-    val totalFiatValue =
-      this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
-    val accountsUiModel = this.map { addressToUiModelMapper(it) }
+    private fun loadData(vaultId: VaultId) {
+        val vaultChanged = this.vaultId != null && this.vaultId != vaultId
 
-    if (!isDefi) {
-      uiState.update {
-        it.copy(
-          totalFiatValue = totalFiatValue,
-          accounts = accountsUiModel.filteredAccounts(searchQuery),
+        this.vaultId = vaultId
+        loadVaultNameAndShowBackup(vaultId)
+        loadAccounts(vaultId)
+        loadBalanceVisibility(vaultId)
+        showGlobalBackupReminder()
+        showVerifyFastVaultPasswordReminderIfRequired(vaultId)
+        enableVultTokenIfNeeded(vaultId)
+        loadDeFiBalances(vaultId, vaultChanged)
+        checkNotificationPrompt(vaultId)
+    }
+
+    private fun enableVultTokenIfNeeded(vaultId: VaultId) {
+        viewModelScope.launch {
+            try {
+                val vault = vaultRepository.get(vaultId) ?: return@launch
+
+                // Check if vault has Ethereum chain enabled
+                val hasEthereum = vault.coins.any { it.chain == Chain.Ethereum }
+                if (!hasEthereum) {
+                    Timber.d("Ethereum chain not enabled, skipping VULT token auto-enable")
+                    return@launch
+                }
+
+                // Check if VULT token is already enabled
+                val vultCoin = vault.coins.find { it.id == Coins.Ethereum.VULT.id }
+
+                if (vultCoin == null) {
+                    // Enable VULT token in background
+                    Timber.d("VULT token not enabled, enabling it now for vault: $vaultId")
+                    withContext(Dispatchers.IO) { enableTokenUseCase(vaultId, Coins.Ethereum.VULT) }
+                    Timber.d("VULT token enabled successfully")
+                }
+
+                // fetch NFT
+                val ethAddress = vault.coins.find { it.id == Coins.Ethereum.ETH.id }?.address
+                if (ethAddress != null) {
+                    withContext(Dispatchers.IO) {
+                        val balance = remoteNFTService.checkNFTBalance(ethAddress)
+                        tiersNFTRepository.saveTierNFT(vaultId, balance)
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to auto-enable VULT token")
+            }
+        }
+    }
+
+    private fun showGlobalBackupReminder() {
+        viewModelScope.launch {
+            val showReminder = isGlobalBackupReminderRequired()
+            uiState.update { it.copy(showMonthlyBackupReminder = showReminder) }
+        }
+    }
+
+    private fun showVerifyFastVaultPasswordReminderIfRequired(vaultId: VaultId) {
+        viewModelScope.launch {
+            val vault = vaultRepository.get(vaultId) ?: return@launch
+            if (
+                vault.isFastVault() &&
+                    vaultMetadataRepo.isFastVaultPasswordReminderRequired(vaultId)
+            ) {
+                navigator.route(Route.FastVaultPasswordReminder(vaultId))
+            }
+        }
+    }
+
+    private fun loadBalanceVisibility(vaultId: String) {
+        viewModelScope.launch {
+            val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
+            uiState.update { it.copy(isBalanceValueVisible = isBalanceVisible) }
+        }
+    }
+
+    fun refreshData() {
+        val vaultId = vaultId ?: return
+        updateRefreshing(true)
+        loadAccounts(vaultId, true)
+    }
+
+    fun send() {
+        val vaultId = vaultId ?: return
+        viewModelScope.launch { navigator.route(Route.Send(vaultId = vaultId)) }
+    }
+
+    fun swap() {
+        val vaultId = vaultId ?: return
+        viewModelScope.launch { navigator.route(Route.Swap(vaultId = vaultId)) }
+    }
+
+    fun buy() {
+        val vaultId = vaultId ?: return
+        viewModelScope.launch {
+            navigator.route(Route.OnRamp(vaultId = vaultId, chainId = Chain.ThorChain.raw))
+        }
+    }
+
+    fun receive() {
+        val vaultId = vaultId ?: return
+        viewModelScope.launch { navigator.route(Route.Receive(vaultId = vaultId)) }
+    }
+
+    fun openCamera() {
+        viewModelScope.launch { navigator.route(Route.ScanQr(vaultId = vaultId)) }
+    }
+
+    fun openAccount(account: AccountUiModel) {
+        val vaultId = vaultId ?: return
+        val chainId = account.model.chain.id
+
+        viewModelScope.launch {
+            when (uiState.value.cryptoConnectionType) {
+                CryptoConnectionType.Wallet -> {
+                    navigator.route(
+                        Route.ChainDashboard(
+                            route = ChainDashboardRoute.Wallet(vaultId = vaultId, chainId = chainId)
+                        )
+                    )
+                }
+                CryptoConnectionType.Defi -> {
+                    when {
+                        account.chainName.equals(Chain.Ethereum.toDefi.raw, true) ->
+                            navigator.route(
+                                Route.ChainDashboard(
+                                    route = ChainDashboardRoute.PositionCircle(vaultId = vaultId)
+                                )
+                            )
+                        account.chainName.equals(Chain.MayaChain.raw, true) ->
+                            navigator.route(
+                                Route.ChainDashboard(
+                                    route = ChainDashboardRoute.PositionMaya(vaultId = vaultId)
+                                )
+                            )
+                        account.chainName.equals(Chain.Tron.raw, true) ->
+                            navigator.route(
+                                Route.ChainDashboard(
+                                    route = ChainDashboardRoute.PositionTron(vaultId = vaultId)
+                                )
+                            )
+                        else ->
+                            navigator.route(
+                                Route.ChainDashboard(
+                                    route = ChainDashboardRoute.PositionTokens(vaultId = vaultId)
+                                )
+                            )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadVaultNameAndShowBackup(vaultId: String) {
+        loadVaultNameJob?.cancel()
+        loadVaultNameJob =
+            viewModelScope.launch {
+                val vault = vaultRepository.get(vaultId) ?: return@launch
+                uiState.update {
+                    it.copy(
+                        vaultName = vault.name,
+                        isFastVault = vault.isFastVault(),
+                        // KeyImport vaults have a fixed set of chains chosen during import,
+                        // so chain selection is disabled on the home screen
+                        isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
+                    )
+                }
+                val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
+                uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
+                val showMigration = vault.libType == SigningLibType.GG20
+                uiState.update { it.copy(showMigration = showMigration) }
+            }
+    }
+
+    private fun loadAccounts(vaultId: String, isRefresh: Boolean = false) {
+        loadAccountsJob?.cancel()
+        loadAccountsJob =
+            viewModelScope.launch {
+                combine(
+                        accountsRepository
+                            .loadAddresses(vaultId, isRefresh)
+                            .map { it.sortByAccountsTotalFiatValue() }
+                            .catch {
+                                updateRefreshing(false)
+                                Timber.e(it)
+                            },
+                        uiState.value.searchTextFieldState.textAsFlow(),
+                        uiState.map { it.cryptoConnectionType }.distinctUntilChanged(),
+                    ) { accounts, searchQuery, cryptoConnectionType ->
+                        accounts
+                            .filter {
+                                when (cryptoConnectionType) {
+                                    CryptoConnectionType.Wallet -> true
+                                    CryptoConnectionType.Defi ->
+                                        cryptoConnectionTypeRepository.hasDeFiPositionsScreen(
+                                            it.chain
+                                        )
+                                }
+                            }
+                            .updateUiStateFromList(searchQuery = searchQuery.toString())
+                    }
+                    .launchIn(this)
+            }
+    }
+
+    private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
+
+        loadDeFiBalancesJob?.cancel()
+        loadDeFiBalancesJob =
+            viewModelScope.launch {
+                combine(
+                        accountsRepository
+                            .loadDeFiAddresses(vaultId, isRefresh)
+                            .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
+                            .catch { error ->
+                                updateRefreshing(false)
+                                Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
+                            },
+                        uiState.value.searchTextFieldState.textAsFlow(),
+                        defaultDeFiChainsRepository.getDefaultChains(vaultId),
+                    ) { accounts, searchQuery, selectedDeFiChains ->
+                        Timber.d(
+                            "DeFi Accounts Loaded for vault $vaultId: ${accounts.size} accounts, selected chains: ${selectedDeFiChains.map { it.raw }}"
+                        )
+
+                        val filteredAccounts =
+                            accounts.filter { address ->
+                                val isSelected = selectedDeFiChains.contains(address.chain)
+                                Timber.d("Chain ${address.chain.raw} is selected: $isSelected")
+                                isSelected
+                            }
+
+                        Timber.d("Filtered DeFi accounts: ${filteredAccounts.size} accounts")
+
+                        filteredAccounts.updateUiStateFromList(
+                            searchQuery = searchQuery.toString(),
+                            isDefi = true,
+                        )
+                    }
+                    .launchIn(this)
+            }
+    }
+
+    private fun List<Address>.sortByAccountsTotalFiatValue() =
+        sortedWith(
+            compareBy(
+                { it.accounts.calculateAccountsTotalFiatValue()?.value?.unaryMinus() },
+                { it.chain.raw },
+            )
         )
-      }
-    } else {
-      uiState.update {
-        it.copy(
-          totalDeFiValue = totalFiatValue,
-          defiAccounts = accountsUiModel.filteredAccounts(searchQuery),
-        )
-      }
-    }
-    updateRefreshing(false)
 
-    Timber.d("Update updateUiStateFromList: %s", "$this")
-  }
-
-  private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {
-    if (searchQuery.isBlank()) return this
-    val query = searchQuery.trim()
-    return filter { account ->
-      listOf(account.chainName, account.nativeTokenTicker).any { field ->
-        field.contains(other = query, ignoreCase = true)
-      }
-    }
-  }
-
-  private fun updateRefreshing(isRefreshing: Boolean) {
-    Timber.d("UpdateRefresh $isRefreshing")
-    uiState.update { it.copy(isRefreshing = isRefreshing) }
-  }
-
-  fun toggleBalanceVisibility() {
-    val vaultId =
-      vaultId
-        ?: run {
-          Timber.w("toggleBalanceVisibility: vaultId is null, skipping")
-          return
-        }
-    val isBalanceValueVisible = !uiState.value.isBalanceValueVisible
-    viewModelScope.launch {
-      uiState.update { it.copy(isBalanceValueVisible = isBalanceValueVisible) }
-      balanceVisibilityRepository.setVisibility(vaultId, isBalanceValueVisible)
-    }
-  }
-
-  fun backupVault() {
-    val vaultId =
-      vaultId
-        ?: run {
-          Timber.w("backupVault: vaultId is null, skipping")
-          return
-        }
-    viewModelScope.launch {
-      dismissBackupReminder()
-      navigator.route(Route.BackupPasswordRequest(vaultId))
-    }
-  }
-
-  fun migrate() {
-    val vaultId = vaultId ?: return
-    viewModelScope.launch { navigator.route(Route.Migration.Onboarding(vaultId)) }
-  }
-
-  fun dismissBackupReminder() {
-    uiState.update { it.copy(showMonthlyBackupReminder = false) }
-  }
-
-  fun doNotRemindBackup() = viewModelScope.launch {
-    setNeverShowGlobalBackupReminder()
-    dismissBackupReminder()
-  }
-
-  fun openHistory() {
-    vaultId?.let { vaultId ->
-      viewModelScope.launch { navigator.route(Route.TransactionHistory(vaultId = vaultId)) }
-    }
-  }
-
-  fun openSettings() {
-    vaultId?.let { vaultId ->
-      viewModelScope.launch {
-        Timber.d("openSettings($vaultId)")
-        navigator.route(Route.Settings(vaultId = vaultId))
-      }
-    }
-  }
-
-  fun openAddChainAccount() {
-    vaultId?.let { vaultId ->
-      viewModelScope.launch {
-        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
-          navigator.route(Route.AddDeFiChainAccount(vaultId = vaultId))
-        } else {
-          navigator.route(Route.AddChainAccount(vaultId = vaultId))
-        }
-        requestResultRepository.request<Unit>(REFRESH_CHAIN_DATA)
-
-        loadData(vaultId)
-      }
-    }
-  }
-
-  fun openVaultList() {
-    vaultId?.let {
-      viewModelScope.launch {
-        navigator.route(Route.VaultList(openType = Route.VaultList.OpenType.Home(it)))
-      }
-    }
-  }
-
-  fun tempRemoveBanner() {
-    uiState.update { it.copy(isBannerVisible = false) }
-  }
-
-  fun setCryptoConnectionType(type: CryptoConnectionType) {
-    cryptoConnectionTypeRepository.setActiveCryptoConnection(type)
-    uiState.update { it.copy(cryptoConnectionType = type) }
-
-    val vaultId = vaultId ?: return
-
-    if (type == CryptoConnectionType.Defi) {
-      loadDeFiBalances(vaultId, true)
-    }
-  }
-
-  private fun checkNotificationPrompt(vaultId: String) {
-    viewModelScope.launch {
-      val currentVault = vaultRepository.get(vaultId) ?: return@launch
-      if (!currentVault.isSecureVault()) return@launch
-      if (
-        pushNotificationManager.isVaultOptedIn(vaultId) ||
-          pushNotificationManager.hasPromptedVault(vaultId)
-      )
-        return@launch
-
-      val eligibleVaults = vaultRepository.getAll().filter { it.isSecureVault() }
-      val introVaults = eligibleVaults.map { vault ->
-        VaultIntroItem(
-          vaultId = vault.id,
-          vaultName = vault.name,
-          isEnabled = pushNotificationManager.isVaultOptedIn(vault.id),
-          isFastVault = vault.isFastVault(),
-        )
-      }
-      uiState.update {
-        it.copy(showNotificationIntroSheet = true, notificationIntroVaults = introVaults)
-      }
-    }
-  }
-
-  fun onNotificationEnable() {
-    viewModelScope.launch {
-      // Mark as prompted now so we don't re-prompt even if permission is denied
-      uiState.value.notificationIntroVaults.forEach { vault ->
-        pushNotificationManager.markVaultPrompted(vault.vaultId)
-      }
-      uiState.update { it.copy(showNotificationIntroSheet = false) }
-      _requestNotificationPermission.send(Unit)
-    }
-  }
-
-  fun onNotificationPermissionResult(granted: Boolean) {
-    if (granted) {
-      uiState.update { it.copy(showNotificationVaultSheet = true) }
-    }
-  }
-
-  fun onNotificationNotNow() {
-    viewModelScope.launch {
-      uiState.value.notificationIntroVaults.forEach { vault ->
-        pushNotificationManager.markVaultPrompted(vault.vaultId)
-      }
-      uiState.update { it.copy(showNotificationIntroSheet = false) }
-    }
-  }
-
-  fun onNotificationVaultToggle(vaultId: String, enabled: Boolean) {
-    uiState.update { state ->
-      state.copy(
-        notificationIntroVaults =
-          state.notificationIntroVaults.map { vault ->
-            if (vault.vaultId == vaultId) vault.copy(isEnabled = enabled) else vault
-          }
-      )
-    }
-  }
-
-  fun onNotificationVaultSheetDismiss() {
-    uiState.update { it.copy(showNotificationVaultSheet = false) }
-  }
-
-  fun onNotificationVaultSheetDone() {
-    val vaultsToOptIn = uiState.value.notificationIntroVaults
-    uiState.update { it.copy(showNotificationVaultSheet = false) }
-    viewModelScope.safeLaunch(
-      onError = { e ->
-        Timber.w(e, "Failed to opt in vaults for notifications")
-        snackbarFlow.showMessage(pushNotificationErrorMessage(e, context), SnackbarType.Error)
-      }
+    private suspend fun List<Address>.updateUiStateFromList(
+        searchQuery: String,
+        isDefi: Boolean = false,
     ) {
-      pushNotificationManager.setVaultsOptIn(vaultsToOptIn.map { it.vaultId to it.isEnabled })
-    }
-  }
+        val totalFiatValue =
+            this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
+        val accountsUiModel = this.map { addressToUiModelMapper(it) }
 
-  fun onEnableAll(enabled: Boolean) {
-    uiState.update { state ->
-      state.copy(
-        notificationIntroVaults = state.notificationIntroVaults.map { it.copy(isEnabled = enabled) }
-      )
-    }
-  }
+        if (!isDefi) {
+            uiState.update {
+                it.copy(
+                    totalFiatValue = totalFiatValue,
+                    accounts = accountsUiModel.filteredAccounts(searchQuery),
+                )
+            }
+        } else {
+            uiState.update {
+                it.copy(
+                    totalDeFiValue = totalFiatValue,
+                    defiAccounts = accountsUiModel.filteredAccounts(searchQuery),
+                )
+            }
+        }
+        updateRefreshing(false)
 
-  companion object {
-    internal const val REFRESH_CHAIN_DATA = "refresh_chain_data"
-  }
+        Timber.d("Update updateUiStateFromList: %s", "$this")
+    }
+
+    private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {
+        if (searchQuery.isBlank()) return this
+        val query = searchQuery.trim()
+        return filter { account ->
+            listOf(account.chainName, account.nativeTokenTicker).any { field ->
+                field.contains(other = query, ignoreCase = true)
+            }
+        }
+    }
+
+    private fun updateRefreshing(isRefreshing: Boolean) {
+        Timber.d("UpdateRefresh $isRefreshing")
+        uiState.update { it.copy(isRefreshing = isRefreshing) }
+    }
+
+    fun toggleBalanceVisibility() {
+        val vaultId =
+            vaultId
+                ?: run {
+                    Timber.w("toggleBalanceVisibility: vaultId is null, skipping")
+                    return
+                }
+        val isBalanceValueVisible = !uiState.value.isBalanceValueVisible
+        viewModelScope.launch {
+            uiState.update { it.copy(isBalanceValueVisible = isBalanceValueVisible) }
+            balanceVisibilityRepository.setVisibility(vaultId, isBalanceValueVisible)
+        }
+    }
+
+    fun backupVault() {
+        val vaultId =
+            vaultId
+                ?: run {
+                    Timber.w("backupVault: vaultId is null, skipping")
+                    return
+                }
+        viewModelScope.launch {
+            dismissBackupReminder()
+            navigator.route(Route.BackupPasswordRequest(vaultId))
+        }
+    }
+
+    fun migrate() {
+        val vaultId = vaultId ?: return
+        viewModelScope.launch { navigator.route(Route.Migration.Onboarding(vaultId)) }
+    }
+
+    fun dismissBackupReminder() {
+        uiState.update { it.copy(showMonthlyBackupReminder = false) }
+    }
+
+    fun doNotRemindBackup() =
+        viewModelScope.launch {
+            setNeverShowGlobalBackupReminder()
+            dismissBackupReminder()
+        }
+
+    fun openHistory() {
+        vaultId?.let { vaultId ->
+            viewModelScope.launch { navigator.route(Route.TransactionHistory(vaultId = vaultId)) }
+        }
+    }
+
+    fun openSettings() {
+        vaultId?.let { vaultId ->
+            viewModelScope.launch {
+                Timber.d("openSettings($vaultId)")
+                navigator.route(Route.Settings(vaultId = vaultId))
+            }
+        }
+    }
+
+    fun openAddChainAccount() {
+        vaultId?.let { vaultId ->
+            viewModelScope.launch {
+                if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
+                    navigator.route(Route.AddDeFiChainAccount(vaultId = vaultId))
+                } else {
+                    navigator.route(Route.AddChainAccount(vaultId = vaultId))
+                }
+                requestResultRepository.request<Unit>(REFRESH_CHAIN_DATA)
+
+                loadData(vaultId)
+            }
+        }
+    }
+
+    fun openVaultList() {
+        vaultId?.let {
+            viewModelScope.launch {
+                navigator.route(Route.VaultList(openType = Route.VaultList.OpenType.Home(it)))
+            }
+        }
+    }
+
+    fun tempRemoveBanner() {
+        uiState.update { it.copy(isBannerVisible = false) }
+    }
+
+    fun setCryptoConnectionType(type: CryptoConnectionType) {
+        cryptoConnectionTypeRepository.setActiveCryptoConnection(type)
+        uiState.update { it.copy(cryptoConnectionType = type) }
+
+        val vaultId = vaultId ?: return
+
+        if (type == CryptoConnectionType.Defi) {
+            loadDeFiBalances(vaultId, true)
+        }
+    }
+
+    private fun checkNotificationPrompt(vaultId: String) {
+        viewModelScope.launch {
+            val currentVault = vaultRepository.get(vaultId) ?: return@launch
+            if (!currentVault.isSecureVault()) return@launch
+            if (
+                pushNotificationManager.isVaultOptedIn(vaultId) ||
+                    pushNotificationManager.hasPromptedVault(vaultId)
+            )
+                return@launch
+
+            val eligibleVaults = vaultRepository.getAll().filter { it.isSecureVault() }
+            val introVaults =
+                eligibleVaults.map { vault ->
+                    VaultIntroItem(
+                        vaultId = vault.id,
+                        vaultName = vault.name,
+                        isEnabled = pushNotificationManager.isVaultOptedIn(vault.id),
+                        isFastVault = vault.isFastVault(),
+                    )
+                }
+            uiState.update {
+                it.copy(showNotificationIntroSheet = true, notificationIntroVaults = introVaults)
+            }
+        }
+    }
+
+    fun onNotificationEnable() {
+        viewModelScope.launch {
+            // Mark as prompted now so we don't re-prompt even if permission is denied
+            uiState.value.notificationIntroVaults.forEach { vault ->
+                pushNotificationManager.markVaultPrompted(vault.vaultId)
+            }
+            uiState.update { it.copy(showNotificationIntroSheet = false) }
+            _requestNotificationPermission.send(Unit)
+        }
+    }
+
+    fun onNotificationPermissionResult(granted: Boolean) {
+        if (granted) {
+            uiState.update { it.copy(showNotificationVaultSheet = true) }
+        }
+    }
+
+    fun onNotificationNotNow() {
+        viewModelScope.launch {
+            uiState.value.notificationIntroVaults.forEach { vault ->
+                pushNotificationManager.markVaultPrompted(vault.vaultId)
+            }
+            uiState.update { it.copy(showNotificationIntroSheet = false) }
+        }
+    }
+
+    fun onNotificationVaultToggle(vaultId: String, enabled: Boolean) {
+        uiState.update { state ->
+            state.copy(
+                notificationIntroVaults =
+                    state.notificationIntroVaults.map { vault ->
+                        if (vault.vaultId == vaultId) vault.copy(isEnabled = enabled) else vault
+                    }
+            )
+        }
+    }
+
+    fun onNotificationVaultSheetDismiss() {
+        uiState.update { it.copy(showNotificationVaultSheet = false) }
+    }
+
+    fun onNotificationVaultSheetDone() {
+        val vaultsToOptIn = uiState.value.notificationIntroVaults
+        uiState.update { it.copy(showNotificationVaultSheet = false) }
+        viewModelScope.safeLaunch(
+            onError = { e ->
+                Timber.w(e, "Failed to opt in vaults for notifications")
+                snackbarFlow.showMessage(
+                    pushNotificationErrorMessage(e, context),
+                    SnackbarType.Error,
+                )
+            }
+        ) {
+            pushNotificationManager.setVaultsOptIn(vaultsToOptIn.map { it.vaultId to it.isEnabled })
+        }
+    }
+
+    fun onEnableAll(enabled: Boolean) {
+        uiState.update { state ->
+            state.copy(
+                notificationIntroVaults =
+                    state.notificationIntroVaults.map { it.copy(isEnabled = enabled) }
+            )
+        }
+    }
+
+    companion object {
+        internal const val REFRESH_CHAIN_DATA = "refresh_chain_data"
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
@@ -8,29 +8,29 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 interface CryptoConnectionTypeRepository {
-  val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType>
+    val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType>
 
-  fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType)
+    fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType)
 
-  fun hasDeFiPositionsScreen(chain: Chain): Boolean
+    fun hasDeFiPositionsScreen(chain: Chain): Boolean
 }
 
 internal class CryptoConnectionTypeRepositoryImpl @Inject constructor() :
-  CryptoConnectionTypeRepository {
-  private val connection = MutableStateFlow(CryptoConnectionType.Wallet)
+    CryptoConnectionTypeRepository {
+    private val connection = MutableStateFlow(CryptoConnectionType.Wallet)
 
-  override val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType> =
-    connection.asStateFlow()
+    override val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType> =
+        connection.asStateFlow()
 
-  override fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType) {
-    connection.value = cryptoConnectionType
-  }
-
-  override fun hasDeFiPositionsScreen(chain: Chain) =
-    when (chain) {
-      Chain.ThorChain,
-      Chain.MayaChain,
-      Chain.Tron -> true
-      else -> false
+    override fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType) {
+        connection.value = cryptoConnectionType
     }
+
+    override fun hasDeFiPositionsScreen(chain: Chain) =
+        when (chain) {
+            Chain.ThorChain,
+            Chain.MayaChain,
+            Chain.Tron -> true
+            else -> false
+        }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
@@ -8,29 +8,29 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 interface CryptoConnectionTypeRepository {
-    val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType>
+  val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType>
 
-    fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType)
+  fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType)
 
-    fun isDefi(chain: Chain): Boolean
+  fun hasDeFiPositionsScreen(chain: Chain): Boolean
 }
 
 internal class CryptoConnectionTypeRepositoryImpl @Inject constructor() :
-    CryptoConnectionTypeRepository {
-    private val connection = MutableStateFlow(CryptoConnectionType.Wallet)
+  CryptoConnectionTypeRepository {
+  private val connection = MutableStateFlow(CryptoConnectionType.Wallet)
 
-    override val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType> =
-        connection.asStateFlow()
+  override val activeCryptoConnectionFlow: StateFlow<CryptoConnectionType> =
+    connection.asStateFlow()
 
-    override fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType) {
-        connection.value = cryptoConnectionType
+  override fun setActiveCryptoConnection(cryptoConnectionType: CryptoConnectionType) {
+    connection.value = cryptoConnectionType
+  }
+
+  override fun hasDeFiPositionsScreen(chain: Chain) =
+    when (chain) {
+      Chain.ThorChain,
+      Chain.MayaChain,
+      Chain.Tron -> true
+      else -> false
     }
-
-    override fun isDefi(chain: Chain) =
-        when (chain) {
-            Chain.ThorChain,
-            Chain.MayaChain,
-            Chain.Tron -> true
-            else -> false
-        }
 }


### PR DESCRIPTION
Fixes #4052

## Summary
- Renames `isDefi()` to `hasDeFiPositionsScreen()` in `CryptoConnectionTypeRepository` interface and implementation
- Updates the call site in `VaultAccountsViewModel`
- The new name better describes the method's purpose: checking whether a chain has a DeFi positions screen, not whether the chain "is DeFi"

## Test plan
- [ ] Verify DeFi tab filtering still works correctly for supported chains (THORChain, MayaChain, Dydx, Tron)
- [ ] Verify wallet tab is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)