### PR TITLE
fix: make SignMessageScreen Compose preview render

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/sign/SignMessageScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/sign/SignMessageScreen.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.screens.sign
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -47,62 +48,70 @@ internal fun SignMessageScreen(
     val route = navBackStackEntry?.destination?.route
 
     val useMainNavigator = route == SendDst.Send.route
-    val progressNav =
-        if (useMainNavigator) {
-            navController
-        } else {
-            sendNav
-        }
 
-    val progress: Float
-    val title: String
-
-    when (route) {
-        SendDst.Send.route -> {
-            progress = 0.25f
-            title = stringResource(R.string.sign_message_sign_screen_title)
+    val title =
+        when (route) {
+            SendDst.VerifyTransaction.staticRoute ->
+                stringResource(R.string.verify_transaction_screen_title)
+            else -> stringResource(R.string.sign_message_sign_screen_title)
         }
-        SendDst.VerifyTransaction.staticRoute -> {
-            progress = 0.5f
-            title = stringResource(R.string.verify_transaction_screen_title)
-        }
-        else -> {
-            progress = 0.0f
-            title = stringResource(R.string.sign_message_sign_screen_title)
-        }
-    }
 
     val qrAddress by viewModel.addressProvider.address.collectAsState()
     val qr = qrAddress.takeIf { it.isNotEmpty() }
 
+    SignMessageScreen(
+        title = title,
+        isKeysignFinished = isKeysignFinished,
+        rightIcon = qr?.let { R.drawable.qr_share },
+        onBackClick = { viewModel.navigateToHome(useMainNavigator) },
+        onRightIconClick = { keysignShareViewModel.shareQRCode(context) },
+    ) {
+        NavHost(
+            navController = sendNav,
+            startDestination = SendDst.Send.route,
+            enterTransition = slideInFromEndEnterTransition(),
+            exitTransition = slideOutToStartExitTransition(),
+            popEnterTransition = slideInFromStartEnterTransition(),
+            popExitTransition = slideOutToEndExitTransition(),
+        ) {
+            composable(route = SendDst.Send.route) { SignMessageFormScreen(vaultId = vaultId) }
+            composable(
+                route = SendDst.VerifyTransaction.staticRoute,
+                arguments = SendDst.transactionArgs,
+            ) {
+                VerifySignMessageScreen()
+            }
+        }
+    }
+}
+
+@Composable
+private fun SignMessageScreen(
+    title: String,
+    isKeysignFinished: Boolean,
+    @DrawableRes rightIcon: Int?,
+    onBackClick: () -> Unit,
+    onRightIconClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
     V2Scaffold(
         title = title,
-        onBackClick = { viewModel.navigateToHome(useMainNavigator) }.takeIf { !isKeysignFinished },
-        rightIcon = qr?.let { R.drawable.qr_share },
-        onRightIconClick = qr?.let { { keysignShareViewModel.shareQRCode(context) } },
-        content = {
-            NavHost(
-                navController = sendNav,
-                startDestination = SendDst.Send.route,
-                enterTransition = slideInFromEndEnterTransition(),
-                exitTransition = slideOutToStartExitTransition(),
-                popEnterTransition = slideInFromStartEnterTransition(),
-                popExitTransition = slideOutToEndExitTransition(),
-            ) {
-                composable(route = SendDst.Send.route) { SignMessageFormScreen(vaultId = vaultId) }
-                composable(
-                    route = SendDst.VerifyTransaction.staticRoute,
-                    arguments = SendDst.transactionArgs,
-                ) {
-                    VerifySignMessageScreen()
-                }
-            }
-        },
+        onBackClick = onBackClick.takeIf { !isKeysignFinished },
+        rightIcon = rightIcon,
+        onRightIconClick = onRightIconClick.takeIf { rightIcon != null },
+        content = content,
     )
 }
 
 @Preview
 @Composable
 private fun SignMessageScreenPreview() {
-    SignMessageScreen(navController = rememberNavController(), vaultId = "")
+    SignMessageScreen(
+        title = "Sign Message",
+        isKeysignFinished = false,
+        rightIcon = R.drawable.qr_share,
+        onBackClick = {},
+        onRightIconClick = {},
+        content = {},
+    )
 }


### PR DESCRIPTION
## Summary
- Split `SignMessageScreen` into a stateful wrapper (injects `SendViewModel` + `KeysignShareViewModel`, owns the nested `NavHost`) and a stateless private overload that takes plain parameters.
- `SignMessageScreenPreview` now calls the stateless overload with mock values, so Compose Preview renders it without a Hilt graph — fixes the "This preview uses a ViewModel…" exception.
- Dropped two pieces of dead code that showed up during the split: an unused `progressNav` local, and an unused `progress: Float` local.

## Test plan
- [ ] Open `SignMessageScreen.kt` in Android Studio and confirm the `@Preview` renders without throwing.
- [ ] Launch the app and walk the Sign Message flow end-to-end (Send → VerifyTransaction) to confirm titles, back button, and QR-share icon still behave the same.
- [ ] Verify `NavGraph.kt`'s `Route.SignMessage` destination still navigates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the sign message screen for clearer UI behavior: title selection simplified for fewer routes.
  * Navigation flow reorganized for more consistent transitions between signing and verification steps.
  * Back and right-action icons now behave more predictably (conditionally enabled/disabled), improving UX during key-signing.
  * Updated preview configuration to reflect the new screen composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->