### PR TITLE
feat: show vault name in fast vault password reminder dialog (#4040)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderDialog.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderDialog.kt
@@ -1,17 +1,25 @@
 package com.vultisig.wallet.ui.screens.home
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -19,13 +27,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.inputs.VsTextInputField
 import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldInnerState
 import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldType
-import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
 
 @Composable
@@ -59,30 +69,48 @@ private fun FastVaultPasswordReminderDialog(
             Modifier.background(Theme.v2.colors.backgrounds.primary)
                 .fillMaxWidth()
                 .padding(all = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        UiSpacer(size = 18.dp)
+
+        UiIcon(
+            drawableResId = R.drawable.focus_lock,
+            size = 32.dp,
+            tint = Theme.v2.colors.primary.accent4,
+        )
+
+        UiSpacer(size = 20.dp)
+
         Text(
-            text = stringResource(R.string.verify_your_server_share_password),
+            text = stringResource(R.string.fast_vault_password_reminder_title),
             textAlign = TextAlign.Center,
             style = Theme.brockmann.headings.title3,
             color = Theme.v2.colors.text.primary,
-            modifier = Modifier.padding(all = 10.dp),
         )
 
-        FadingHorizontalDivider()
+        UiSpacer(size = 12.dp)
+
+        Text(
+            text = state.vaultName,
+            textAlign = TextAlign.Center,
+            style = Theme.brockmann.headings.title2,
+            color = Theme.v2.colors.text.primary,
+        )
+
+        UiSpacer(size = 20.dp)
 
         Text(
             text = stringResource(R.string.periodically_ask_verify_password),
             textAlign = TextAlign.Center,
             style = Theme.brockmann.supplementary.caption,
             color = Theme.v2.colors.text.tertiary,
-            modifier = Modifier,
         )
+
+        UiSpacer(size = 10.dp)
 
         VsTextInputField(
             textFieldState = passwordFieldState,
-            hint = stringResource(R.string.keysign_password_title),
+            hint = stringResource(R.string.backup_password_screen_enter_password),
             type =
                 VsTextInputFieldType.Password(
                     isVisible = state.isPasswordVisible,
@@ -96,8 +124,55 @@ private fun FastVaultPasswordReminderDialog(
             footNote = state.error?.asString(),
         )
 
+        if (state.passwordHint != null) {
+            UiSpacer(size = 10.dp)
+
+            var isHintVisible by remember { mutableStateOf(false) }
+
+            val caretRotationDegree by animateFloatAsState(if (isHintVisible) -90f else 90f)
+
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .clickable(onClick = { isHintVisible = !isHintVisible })
+                        .wrapContentWidth(align = Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text =
+                        if (isHintVisible) stringResource(R.string.keysign_password_hide_hint)
+                        else stringResource(R.string.keysign_password_show_hint),
+                    color = Theme.v2.colors.text.secondary,
+                    style = Theme.brockmann.supplementary.footnote,
+                )
+
+                UiSpacer(size = 4.dp)
+
+                UiIcon(
+                    drawableResId = R.drawable.ic_small_caret_right,
+                    modifier = Modifier.rotate(degrees = caretRotationDegree),
+                    size = 12.dp,
+                    tint = Theme.v2.colors.text.secondary,
+                )
+            }
+
+            AnimatedVisibility(visible = isHintVisible) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    UiSpacer(size = 8.dp)
+                    Text(
+                        text = state.passwordHint.asString(),
+                        color = Theme.v2.colors.text.secondary,
+                        style = Theme.brockmann.supplementary.footnote,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+
+        UiSpacer(size = 10.dp)
+
         VsButton(
-            label = stringResource(R.string.verify_transaction_screen_title),
+            label = stringResource(R.string.fast_vault_password_reminder_done_button),
             onClick = onVerifyClick,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -106,9 +181,24 @@ private fun FastVaultPasswordReminderDialog(
 
 @Composable
 @Preview
-private fun FastVaultPasswordReminderDialogPreview() {
+private fun FastVaultPasswordReminderDialogPreview1() {
     FastVaultPasswordReminderDialog(
-        state = FastVaultPasswordReminderUiModel(),
+        state =
+            FastVaultPasswordReminderUiModel(
+                vaultName = "Main Vault",
+                passwordHint = UiText.DynamicString("Hint: favorite color"),
+            ),
+        passwordFieldState = TextFieldState(),
+        onVerifyClick = {},
+        onPasswordVisibilityClick = {},
+    )
+}
+
+@Composable
+@Preview
+private fun FastVaultPasswordReminderDialogPreview2() {
+    FastVaultPasswordReminderDialog(
+        state = FastVaultPasswordReminderUiModel(vaultName = "Main Vault"),
         passwordFieldState = TextFieldState(),
         onVerifyClick = {},
         onPasswordVisibilityClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
+import timber.log.Timber
 
 internal data class FastVaultPasswordReminderUiModel(
     val vaultName: String = "",
@@ -55,7 +56,12 @@ constructor(
 
     init {
         viewModelScope.launch {
-            val vault = vaultRepository.get(vaultId) ?: return@launch
+            val vault =
+                vaultRepository.get(vaultId)
+                    ?: run {
+                        Timber.e("Vault not found for id: %s", vaultId)
+                        return@launch
+                    }
             val hint = vaultDataStoreRepository.readFastSignHint(vaultId).first()
             val passwordHint =
                 if (hint.isNotEmpty())
@@ -80,7 +86,12 @@ constructor(
         val password = passwordFieldState.text.toString()
 
         viewModelScope.launch {
-            val vault = vaultRepository.get(vaultId) ?: return@launch
+            val vault =
+                vaultRepository.get(vaultId)
+                    ?: run {
+                        Timber.e("Vault not found for id: %s", vaultId)
+                        return@launch
+                    }
 
             when (val result = vultiSignerRepository.checkPassword(vault.pubKeyECDSA, password)) {
                 is PasswordCheckResult.Valid -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.repositories.PasswordCheckResult
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.VultiSignerRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
@@ -18,6 +19,7 @@ import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
@@ -25,7 +27,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 
 internal data class FastVaultPasswordReminderUiModel(
+    val vaultName: String = "",
     val isPasswordVisible: Boolean = false,
+    val passwordHint: UiText? = null,
     val error: UiText? = null,
 )
 
@@ -38,6 +42,7 @@ constructor(
     private val vultiSignerRepository: VultiSignerRepository,
     private val vaultMetadataRepo: VaultMetadataRepo,
     private val vaultRepository: VaultRepository,
+    private val vaultDataStoreRepository: VaultDataStoreRepository,
 ) : ViewModel() {
 
     private val args = savedStateHandle.toRoute<Route.FastVaultPasswordReminder>()
@@ -47,6 +52,18 @@ constructor(
     val passwordFieldState = TextFieldState()
 
     val state = MutableStateFlow(FastVaultPasswordReminderUiModel())
+
+    init {
+        viewModelScope.launch {
+            val vault = vaultRepository.get(vaultId) ?: return@launch
+            val hint = vaultDataStoreRepository.readFastSignHint(vaultId).first()
+            val passwordHint =
+                if (hint.isNotEmpty())
+                    UiText.FormattedText(R.string.import_file_password_hint_text, listOf(hint))
+                else null
+            state.update { it.copy(vaultName = vault.name, passwordHint = passwordHint) }
+        }
+    }
 
     fun back() {
         viewModelScope.launch {
@@ -65,9 +82,7 @@ constructor(
         viewModelScope.launch {
             val vault = vaultRepository.get(vaultId) ?: return@launch
 
-            val result = vultiSignerRepository.checkPassword(vault.pubKeyECDSA, password)
-
-            when (result) {
+            when (val result = vultiSignerRepository.checkPassword(vault.pubKeyECDSA, password)) {
                 is PasswordCheckResult.Valid -> {
                     back()
                 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -409,8 +409,9 @@
     <string name="send_shares_currency_hint">Anteile eingeben</string>
     <string name="send_error_max_shares">Betrag darf den Kontostand nicht überschreiten</string>
     <string name="deposit_form_shares_title">Anteile (Guthaben: %1$s)</string>
-    <string name="verify_your_server_share_password">Überprüfen Sie Ihr Server-Freigabekennwort</string>
-    <string name="periodically_ask_verify_password">Wir werden Sie regelmäßig bitten, Ihr Fast Sign-Passwort zu bestätigen, damit Sie es immer im Gedächtnis behalten.</string>
+    <string name="fast_vault_password_reminder_title">Überprüfen Sie Ihr Passwort für:</string>
+    <string name="fast_vault_password_reminder_done_button">Fertig</string>
+    <string name="periodically_ask_verify_password">Wir bitten regelmäßig um eine Bestätigung, damit Sie Ihr Passwort nicht vergessen.</string>
 
     <string name="security_scanner_medium_risk_title">Mittleres Sicherheitsrisiko</string>
     <string name="security_scanner_high_risk_title">Hohes Sicherheitsrisiko</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -409,8 +409,9 @@
     <string name="send_shares_currency_hint">Introduce acciones</string>
     <string name="send_error_max_shares">La cantidad no debe exceder el saldo</string>
     <string name="deposit_form_shares_title">Acciones (Saldo: %1$s)</string>
-    <string name="verify_your_server_share_password">Verifique su contraseña compartida del servidor</string>
-    <string name="periodically_ask_verify_password">Periódicamente te pediremos que verifiques tu contraseña de inicio de sesión rápido para que siempre la recuerdes.</string>
+    <string name="fast_vault_password_reminder_title">Verifica tu contraseña para:</string>
+    <string name="fast_vault_password_reminder_done_button">Hecho</string>
+    <string name="periodically_ask_verify_password">Periódicamente te pedimos una verificación para que no olvides tu contraseña.</string>
 
     <string name="security_scanner_medium_risk_title">Riesgo de seguridad medio</string>
     <string name="security_scanner_high_risk_title">Alto riesgo de seguridad</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -410,8 +410,9 @@
     <string name="send_shares_currency_hint">Unesite udjele</string>
     <string name="send_error_max_shares">Iznos ne smije premašiti stanje</string>
     <string name="deposit_form_shares_title">Udjeli (Stanje: %1$s)</string>
-    <string name="verify_your_server_share_password">Potvrdite lozinku za dijeljenje poslužitelja</string>
-    <string name="periodically_ask_verify_password">Povremeno ćemo vas tražiti da potvrdite svoju lozinku za brzo prijavljivanje kako biste je uvijek zapamtili</string>
+    <string name="fast_vault_password_reminder_title">Potvrdite svoju lozinku za:</string>
+    <string name="fast_vault_password_reminder_done_button">Gotovo</string>
+    <string name="periodically_ask_verify_password">Povremeno tražimo potvrdu kako ne biste zaboravili svoju lozinku.</string>
 
     <string name="security_scanner_medium_risk_title">Srednji sigurnosni rizik</string>
     <string name="security_scanner_high_risk_title">Visoki sigurnosni rizik</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -409,8 +409,9 @@
     <string name="send_shares_currency_hint">Inserisci quote</string>
     <string name="send_error_max_shares">L\'importo non deve superare il saldo</string>
     <string name="deposit_form_shares_title">Quote (Saldo: %1$s)</string>
-    <string name="verify_your_server_share_password">Verifica la password di condivisione del server</string>
-    <string name="periodically_ask_verify_password">Ti chiederemo periodicamente di verificare la tua password di accesso rapido in modo che tu possa sempre ricordarla</string>
+    <string name="fast_vault_password_reminder_title">Verifica la tua password per:</string>
+    <string name="fast_vault_password_reminder_done_button">Fatto</string>
+    <string name="periodically_ask_verify_password">Ti chiediamo periodicamente una verifica affinché tu non dimentichi la tua password.</string>
 
     <string name="security_scanner_medium_risk_title">Rischio di sicurezza medio</string>
     <string name="security_scanner_high_risk_title">Rischio di sicurezza elevato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -604,8 +604,9 @@
     <string name="keygen_email_error">이메일이 올바르지 않습니다. 확인해 주세요</string>
     <string name="scan_qr_screen_title">QR 코드 스캔</string>
     <string name="verify_transaction_function_inputs_title">함수 입력값</string>
-    <string name="verify_your_server_share_password">서버 공유 비밀번호 확인</string>
-    <string name="periodically_ask_verify_password">비밀번호를 항상 기억할 수 있도록 주기적으로 빠른 서명 비밀번호 확인을 요청합니다</string>
+    <string name="fast_vault_password_reminder_title">비밀번호를 확인하세요:</string>
+    <string name="fast_vault_password_reminder_done_button">완료</string>
+    <string name="periodically_ask_verify_password">비밀번호를 잊지 않도록 주기적으로 확인을 요청합니다.</string>
 
     <string name="security_scanner_medium_risk_title">중간 보안 위험</string>
     <string name="security_scanner_high_risk_title">높은 보안 위험</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -408,8 +408,9 @@
     <string name="send_shares_currency_hint">Voer aandelen in</string>
     <string name="send_error_max_shares">Bedrag mag het saldo niet overschrijden</string>
     <string name="deposit_form_shares_title">Aandelen (Saldo: %1$s)</string>
-    <string name="verify_your_server_share_password">Controleer uw serversharewachtwoord</string>
-    <string name="periodically_ask_verify_password">We zullen u regelmatig vragen om uw snel-aanmeldingswachtwoord te verifiëren, zodat u het altijd kunt onthouden</string>
+    <string name="fast_vault_password_reminder_title">Verifieer uw wachtwoord voor:</string>
+    <string name="fast_vault_password_reminder_done_button">Klaar</string>
+    <string name="periodically_ask_verify_password">We vragen regelmatig om verificatie zodat u uw wachtwoord niet vergeet.</string>
     <string name="security_scanner_medium_risk_title">Gemiddeld beveiligingsrisico</string>
     <string name="security_scanner_high_risk_title">Hoog beveiligingsrisico</string>
     <string name="security_scanner_critical_risk_title">Kritiek beveiligingsrisico</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -409,8 +409,9 @@
     <string name="send_shares_currency_hint">Insira cotas</string>
     <string name="send_error_max_shares">O valor não deve exceder o saldo</string>
     <string name="deposit_form_shares_title">Cotas (Saldo: %1$s)</string>
-    <string name="verify_your_server_share_password">Verifique a palavra-passe da sua partilha de servidor</string>
-    <string name="periodically_ask_verify_password">Pediremos periodicamente que verifique a sua palavra-passe de login rápido para que se lembre sempre dela</string>
+    <string name="fast_vault_password_reminder_title">Verifique a sua palavra-passe para:</string>
+    <string name="fast_vault_password_reminder_done_button">Concluído</string>
+    <string name="periodically_ask_verify_password">Pedimos periodicamente uma verificação para que não esqueça a sua palavra-passe.</string>
     <string name="security_scanner_medium_risk_title">Risco de segurança médio</string>
     <string name="security_scanner_high_risk_title">Risco de segurança alto</string>
     <string name="security_scanner_critical_risk_title">Risco de segurança crítico</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -410,8 +410,9 @@
     <string name="send_shares_currency_hint">Введите доли</string>
     <string name="send_error_max_shares">Сумма не должна превышать баланс</string>
     <string name="deposit_form_shares_title">Доли (Баланс: %1$s)</string>
-    <string name="verify_your_server_share_password">Подтвердите свой пароль для общего доступа к серверу</string>
-    <string name="periodically_ask_verify_password">Мы будем периодически просить вас подтвердить ваш пароль для быстрой регистрации, чтобы вы всегда его помнили.</string>
+    <string name="fast_vault_password_reminder_title">Подтвердите пароль для:</string>
+    <string name="fast_vault_password_reminder_done_button">Готово</string>
+    <string name="periodically_ask_verify_password">Мы периодически просим подтвердить пароль, чтобы вы его не забыли.</string>
     <string name="security_scanner_medium_risk_title">Средний риск безопасности</string>
     <string name="security_scanner_high_risk_title">Высокий риск безопасности</string>
     <string name="security_scanner_critical_risk_title">Критический риск безопасности</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -683,9 +683,10 @@
     <!-- Verify Transaction -->
     <string name="verify_transaction_function_inputs_title">功能输入</string>
 
-    <!-- Verify Server Share Password -->
-    <string name="verify_your_server_share_password">验证您的服务器份额密码</string>
-    <string name="periodically_ask_verify_password">我们会定期要求您验证快速签名密码，以便您始终记住它</string>
+    <!-- Fast Vault Password Reminder -->
+    <string name="fast_vault_password_reminder_title">验证您的密码：</string>
+    <string name="fast_vault_password_reminder_done_button">完成</string>
+    <string name="periodically_ask_verify_password">我们会定期要求您进行验证，以免忘记密码。</string>
 
     <!-- Security Scanner -->
     <string name="security_scanner_medium_risk_title">中等安全风险</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -612,8 +612,9 @@
     <string name="keygen_email_error">Incorrect email, please check</string>
     <string name="scan_qr_screen_title">Scan QR Code</string>
     <string name="verify_transaction_function_inputs_title">Function Inputs</string>
-    <string name="verify_your_server_share_password">Verify your Server Share Password</string>
-    <string name="periodically_ask_verify_password">We will periodically ask you to verify your fast sign password so you will always remember it</string>
+    <string name="fast_vault_password_reminder_title">Verify your password for:</string>
+    <string name="fast_vault_password_reminder_done_button">Done</string>
+    <string name="periodically_ask_verify_password">We periodically ask for a verification so you don\'t forget your password.</string>
 
     <string name="security_scanner_medium_risk_title">Medium Security Risk</string>
     <string name="security_scanner_high_risk_title">High Security Risk</string>


### PR DESCRIPTION
## Summary
- Updates the fast vault password verification popup to display the vault name being verified, matching the latest Figma design.
- Replaces the divider + old title/button copy with the new layout (lock icon, title, vault name, caption, input, done button).
- Adds an expandable password hint reading the stored fast sign hint from `VaultDataStoreRepository`.

Closes #4040

## Figma
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=73240-80663

## Test plan
- [ ] Open a fast vault and trigger the password reminder popup; confirm the vault name is shown.
- [ ] If the vault has a password hint stored, confirm the "Show hint" toggle expands it and "Hide hint" collapses it.
- [ ] If no hint is stored, confirm the hint section is hidden.
- [ ] Verify the popup renders correctly on both preview states (with and without hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show vault name in the password reminder dialog
  * Add optional password hint section with expandable/collapsible visibility and animation
  * Add "Done" action button for completing the reminder

* **Style**
  * Improve dialog spacing, layout and visual hierarchy
  * Add focus-lock and caret indicators with animated rotation

* **Localization**
  * Update reminder strings across supported languages (new title/button and revised periodic prompt)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->