### PR TITLE
ci: upload debug APK as workflow artifact

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -98,3 +98,12 @@ jobs:
           path: |
             app/build/reports/lint-results-debug.html
             app/build/intermediates/lint_intermediate_text_report/debug/lintReportDebug/lint-results-debug.txt
+
+      # Archive debug APK
+      - name: Archive debug APK
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Adds an `actions/upload-artifact@v4` step to publish the debug APK built by the Android CI workflow so it can be downloaded from the run's artifacts page.
- Fails the step (`if-no-files-found: error`) when no APK is produced, so path drift is caught early.

## Test plan
- [ ] CI run succeeds and the `app-debug-apk` artifact appears on the workflow run summary.
- [ ] Download the artifact and confirm it contains the expected `app-debug.apk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to automatically archive debug builds, improving the testing and build artifact management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->