### PR TITLE
fix: show password error when vault import decryption fails

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -95,11 +95,15 @@ constructor(
         val vaultFileContent = uiModel.value.fileContent
         if (!vaultFileContent.isNullOrBlank()) {
             viewModelScope.launch {
-                val result = saveToDb(vaultFileContent, key)
-                hidePasswordPromptDialog()
-                when (result) {
-                    SaveResult.Success -> showSuccessImport()
-                    SaveResult.Duplicate -> showDuplicateError()
+                when (saveToDb(vaultFileContent, key)) {
+                    SaveResult.Success -> {
+                        hidePasswordPromptDialog()
+                        showSuccessImport()
+                    }
+                    SaveResult.Duplicate -> {
+                        hidePasswordPromptDialog()
+                        showDuplicateError()
+                    }
                     SaveResult.Failed -> showErrorHint()
                 }
             }


### PR DESCRIPTION
## Summary

Closes #4100.

`ImportFileViewModel.decryptVaultData()` was hiding the password prompt unconditionally before branching on the save result. The `Failed` branch sets `passwordErrorHint` on state, but that field is only rendered inside `KeysignPasswordBottomSheet`, which is gated by `showPasswordPrompt`. By the time the error was set, the sheet was already gone, so the user saw silent failure on a wrong password.

## Change

Only hide the dialog on `Success` / `Duplicate`. On `Failed` leave it open so the inline `passwordError` renders.

```kotlin
when (saveToDb(vaultFileContent, key)) {
    SaveResult.Success -> { hidePasswordPromptDialog(); showSuccessImport() }
    SaveResult.Duplicate -> { hidePasswordPromptDialog(); showDuplicateError() }
    SaveResult.Failed -> showErrorHint()   // dialog stays open
}
```

## Screenshots

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/e219dd15-5c1e-4a23-a271-d92ba65152ac" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved control flow when importing vault files with optimized dialog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->