### PR TITLE
fix: attach external referral to all THORChain-routed swaps

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -868,6 +868,13 @@ constructor(
                                     )
                                 }
                             }
+                        } else {
+                            uiState.update {
+                                it.copy(
+                                    referralBpsDiscount = null,
+                                    referralBpsDiscountFiatValue = null,
+                                )
+                            }
                         }
 
                         val vultResult =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -847,26 +847,26 @@ constructor(
 
                         val referral =
                             referralCode.value
-                                ?: vaultId
-                                    ?.takeIf { srcToken.chain.id == Chain.ThorChain.id }
-                                    ?.let { referralRepository.getExternalReferralBy(it) }
+                                ?: vaultId?.let { referralRepository.getExternalReferralBy(it) }
 
-                        referral?.let { code ->
-                            val tierType = vultBPSDiscount?.getTierType()
-                            val result =
-                                swapDiscountChecker.checkReferralBpsDiscount(
-                                    tierType,
-                                    srcToken,
-                                    tokenValue,
-                                    code,
-                                )
-                            result.referralCode?.let { rc -> referralCode.update { rc } }
-                            uiState.update {
-                                it.copy(
-                                    referralBpsDiscount = result.referralBpsDiscount,
-                                    referralBpsDiscountFiatValue =
-                                        result.referralBpsDiscountFiatValue,
-                                )
+                        if (provider == SwapProvider.THORCHAIN) {
+                            referral?.let { code ->
+                                val tierType = vultBPSDiscount?.getTierType()
+                                val result =
+                                    swapDiscountChecker.checkReferralBpsDiscount(
+                                        tierType,
+                                        srcToken,
+                                        tokenValue,
+                                        code,
+                                    )
+                                result.referralCode?.let { rc -> referralCode.update { rc } }
+                                uiState.update {
+                                    it.copy(
+                                        referralBpsDiscount = result.referralBpsDiscount,
+                                        referralBpsDiscountFiatValue =
+                                            result.referralBpsDiscountFiatValue,
+                                    )
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Summary
- External referral lookup was gated on the **source token's chain** being THORChain. Any swap starting from BASE/ETH/BTC/etc silently dropped the user's saved referral and wrote `va:<bps>` instead of `<userCode>/va:<user>/<affiliate>` to the THORChain memo.
- iOS (`Endpoint.swift`) and the vultisig-sdk (`packages/core/chain/swap/native/api/affiliate.ts`) both gate on the **swap provider** (`THORChain` vs `MAYA`), not the source chain. This change aligns Android with them.
- Also moves the UI "referral discount" display behind `provider == SwapProvider.THORCHAIN` so it isn't shown on KYBER / LIFI / 1INCH routes where the nested-affiliate split isn't applied.

## On-chain evidence
User tx: [`E94BB12D5DB9EA7B23599EC060177D8708E090CEC6B1D5B3879B6A2A1A2A86C3`](https://thorchain.net/tx/E94BB12D5DB9EA7B23599EC060177D8708E090CEC6B1D5B3879B6A2A1A2A86C3) (BASE.ETH → RUNE).

User has `TEX` saved as Friend Referral Code on the active vault (confirmed via screenshot). Memo on chain:
```
=:r:thor1cups30hy0e54l8mrwux7707r7quk2syzhlk7w5:0/1/0:va:25
```
Expected with referral + Platinum tier (25 bps discount):
```
=:r:thor1cups30hy0e54l8mrwux7707r7quk2syzhlk7w5:0/1/0:TEX/va:10/10
```

## Changes
| File | Change |
|------|--------|
| `app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt` | Drop the `srcToken.chain.id == Chain.ThorChain.id` `takeIf` on the external-referral lookup; gate the UI discount update on `provider == SwapProvider.THORCHAIN`. |

## Edge cases considered
- **Non-THOR providers (KYBER / LIFI / 1INCH)** — `referral` is only consumed inside the `when (provider) { THORCHAIN, MAYA -> ... }` quote branches. Other providers don't receive it. No leak.
- **MayaChain** — `MayaChainApi.getSwapQuotes` accepts `referralCode` but silently discards it (unchanged behavior). Fix doesn't regress Maya; if Maya is wired up for nested affiliates later, it will work automatically for all source chains.
- **UI discount display** — previously only shown for THORChain-sourced swaps; now gated on the THORCHAIN *provider* instead. Still hides for non-native routes.
- **`referralCode` StateFlow caching** — only written by the discount-check branch, which remains gated, so cache semantics are unchanged.
- **Vault scoping** — `getExternalReferralBy(vaultId)` still honors per-vault storage.
- **Ultimate tier (≥50 bps)** — intentionally-clean referral behavior in `ThorChainApi.kt` is unchanged (separately confirmed as intended).

## Test plan
- [x] `./gradlew ktfmtFormatMain` — no diff
- [x] `./gradlew :app:compileDebugKotlin` — build successful
- [ ] Manual: BASE/ETH → RUNE swap from a vault with a saved friend referral, verify memo contains `<code>/va:10/<affiliateBps>`
- [ ] Manual: KYBER or LIFI quote with a saved friend referral, verify UI no longer displays a referral discount

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Referral discount calculations are now applied exclusively to THORChain swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->