### PR TITLE
fix: use simulated safe gas budget for Sui signing (#3988)

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
@@ -31,6 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +115,9 @@ internal class CircleDeFiPositionsViewModelTest {
 
             assertEquals(SnackbarType.Success, type)
             coVerify(exactly = 1) { scaCircleAccountRepository.saveAccount(VAULT_ID, MSCA_ADDRESS) }
+            // onCreateAccount updates state after showing the snackbar on a non-test
+            // dispatcher, so wait for it to propagate instead of racing the ViewModel.
+            awaitAccountOpen(vm)
             assertTrue(vm.state.value.circleDefi.isAccountOpen)
         }
 
@@ -161,6 +165,12 @@ internal class CircleDeFiPositionsViewModelTest {
         // must use a real dispatcher.
         return withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(5.seconds) { captured.await() }
+        }
+    }
+
+    private suspend fun awaitAccountOpen(vm: CircleDeFiPositionsViewModel) {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5.seconds) { vm.state.first { it.circleDefi.isAccountOpen } }
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
 import com.vultisig.wallet.data.models.Chain
@@ -41,6 +42,7 @@ import javax.inject.Inject
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.datetime.Clock
@@ -469,30 +471,39 @@ constructor(
                 coroutineScope {
                     val gasPriceDeferred = async { suiApi.getReferenceGasPrice() }
                     val coinsDeferred = async { suiApi.getAllCoins(address) }
-                    val feesDeferred = async {
-                        feeServiceComposite.calculateFees(
-                            Transfer(
-                                coin = token,
-                                vault = VaultData("", ""),
-                                amount = tokenAmountValue ?: BigInteger.ZERO,
-                                to = dstAddress ?: address,
-                            )
-                        )
-                    }
-
-                    val safeGasBudget =
-                        when (val fees = feesDeferred.await()) {
-                            is GasFees -> fees.limit
-                            else ->
-                                error(
-                                    "Unsupported fee type ${fees::class.simpleName} for chain=$chain"
+                    val safeGasBudgetDeferred = async {
+                        try {
+                            val fees =
+                                feeServiceComposite.calculateFees(
+                                    Transfer(
+                                        coin = token,
+                                        vault = VaultData("", ""),
+                                        amount = tokenAmountValue ?: BigInteger.ZERO,
+                                        to = dstAddress ?: address,
+                                    )
                                 )
+                            when (fees) {
+                                is GasFees -> fees.limit
+                                else -> {
+                                    Timber.w(
+                                        "Unexpected fee type %s for SUI; using default gas budget",
+                                        fees::class.simpleName,
+                                    )
+                                    SUI_DEFAULT_GAS_BUDGET
+                                }
+                            }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Timber.w(e, "SUI fee estimation failed; using default gas budget")
+                            SUI_DEFAULT_GAS_BUDGET
                         }
+                    }
 
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Sui(
                             referenceGasPrice = gasPriceDeferred.await(),
-                            gasBudget = safeGasBudget,
+                            gasBudget = safeGasBudgetDeferred.await(),
                             coins = coinsDeferred.await(),
                         ),
                         utxos = emptyList(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -469,41 +469,49 @@ constructor(
 
             TokenStandard.SUI ->
                 coroutineScope {
-                    val gasPriceDeferred = async { suiApi.getReferenceGasPrice() }
                     val coinsDeferred = async { suiApi.getAllCoins(address) }
-                    val safeGasBudgetDeferred = async {
+                    val transfer =
+                        Transfer(
+                            coin = token,
+                            vault = VaultData("", ""),
+                            amount = tokenAmountValue ?: BigInteger.ZERO,
+                            to = dstAddress ?: address,
+                        )
+
+                    suspend fun paddedDefaultSuiFees(): GasFees {
+                        val price = suiApi.getReferenceGasPrice()
+                        val padded = SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15)
+                        return GasFees(price = price, limit = padded, amount = padded)
+                    }
+
+                    val suiFeesDeferred = async {
                         try {
-                            val fees =
-                                feeServiceComposite.calculateFees(
-                                    Transfer(
-                                        coin = token,
-                                        vault = VaultData("", ""),
-                                        amount = tokenAmountValue ?: BigInteger.ZERO,
-                                        to = dstAddress ?: address,
-                                    )
-                                )
-                            when (fees) {
-                                is GasFees -> fees.limit
+                            when (val fees = feeServiceComposite.calculateFees(transfer)) {
+                                is GasFees -> fees
                                 else -> {
                                     Timber.w(
-                                        "Unexpected fee type %s for SUI; using default gas budget",
+                                        "Unexpected fee type %s for SUI; using padded default gas budget",
                                         fees::class.simpleName,
                                     )
-                                    SUI_DEFAULT_GAS_BUDGET
+                                    paddedDefaultSuiFees()
                                 }
                             }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {
-                            Timber.w(e, "SUI fee estimation failed; using default gas budget")
-                            SUI_DEFAULT_GAS_BUDGET
+                            Timber.w(
+                                e,
+                                "SUI fee estimation failed; using padded default gas budget",
+                            )
+                            paddedDefaultSuiFees()
                         }
                     }
 
+                    val suiFees = suiFeesDeferred.await()
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Sui(
-                            referenceGasPrice = gasPriceDeferred.await(),
-                            gasBudget = safeGasBudgetDeferred.await(),
+                            referenceGasPrice = suiFees.price,
+                            gasBudget = suiFees.limit,
                             coins = coinsDeferred.await(),
                         ),
                         utxos = emptyList(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -25,7 +25,6 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
-import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
 import com.vultisig.wallet.data.models.Chain
@@ -470,11 +469,30 @@ constructor(
                 coroutineScope {
                     val gasPriceDeferred = async { suiApi.getReferenceGasPrice() }
                     val coinsDeferred = async { suiApi.getAllCoins(address) }
+                    val feesDeferred = async {
+                        feeServiceComposite.calculateFees(
+                            Transfer(
+                                coin = token,
+                                vault = VaultData("", ""),
+                                amount = tokenAmountValue ?: BigInteger.ZERO,
+                                to = dstAddress ?: address,
+                            )
+                        )
+                    }
+
+                    val safeGasBudget =
+                        when (val fees = feesDeferred.await()) {
+                            is GasFees -> fees.limit
+                            else ->
+                                error(
+                                    "Unsupported fee type ${fees::class.simpleName} for chain=$chain"
+                                )
+                        }
 
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Sui(
                             referenceGasPrice = gasPriceDeferred.await(),
-                            gasBudget = SUI_DEFAULT_GAS_BUDGET,
+                            gasBudget = safeGasBudget,
                             coins = coinsDeferred.await(),
                         ),
                         utxos = emptyList(),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -29,10 +29,13 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.utils.increaseByPercent
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -149,12 +152,13 @@ internal class BlockChainSpecificRepositoryImplTest {
     }
 
     @Test
-    fun `SUI specific uses GasFees limit from fee service`() = runTest {
+    fun `SUI specific uses GasFees limit and price from fee service`() = runTest {
         val simulatedBudget = BigInteger("4200000")
+        val simulatedPrice = BigInteger("750")
         val result =
             repository(
-                    suiApi = suiApi(referenceGasPrice = BigInteger("750")),
-                    suiFeeService = suiFeeService(limit = simulatedBudget),
+                    suiApi = suiApi(referenceGasPrice = BigInteger("1")),
+                    suiFeeService = suiFeeService(limit = simulatedBudget, price = simulatedPrice),
                 )
                 .getSpecific(
                     chain = Chain.Sui,
@@ -168,14 +172,15 @@ internal class BlockChainSpecificRepositoryImplTest {
 
         val specific = result.blockChainSpecific as BlockChainSpecific.Sui
         assertEquals(simulatedBudget, specific.gasBudget)
-        assertEquals(BigInteger("750"), specific.referenceGasPrice)
+        assertEquals(simulatedPrice, specific.referenceGasPrice)
     }
 
     @Test
-    fun `SUI specific falls back to default budget when fee service throws`() = runTest {
+    fun `SUI specific falls back to padded default budget when fee service throws`() = runTest {
+        val fallbackPrice = BigInteger("500")
         val result =
             repository(
-                    suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                    suiApi = suiApi(referenceGasPrice = fallbackPrice),
                     suiFeeService = failingFeeService(),
                 )
                 .getSpecific(
@@ -189,20 +194,23 @@ internal class BlockChainSpecificRepositoryImplTest {
                 )
 
         val specific = result.blockChainSpecific as BlockChainSpecific.Sui
-        assertEquals(SUI_DEFAULT_GAS_BUDGET, specific.gasBudget)
+        assertEquals(SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15), specific.gasBudget)
+        assertEquals(fallbackPrice, specific.referenceGasPrice)
     }
 
     @Test
     fun `SUI specific uses default fees when primary throws but default succeeds`() = runTest {
         val defaultBudget = BigInteger("3450000")
+        val defaultPrice = BigInteger("620")
         val result =
             repository(
-                    suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                    suiApi = suiApi(referenceGasPrice = BigInteger("1")),
                     suiFeeService =
                         suiFeeService(
                             limit = BigInteger.ZERO,
                             primaryThrows = true,
                             defaultLimit = defaultBudget,
+                            defaultPrice = defaultPrice,
                         ),
                 )
                 .getSpecific(
@@ -217,14 +225,16 @@ internal class BlockChainSpecificRepositoryImplTest {
 
         val specific = result.blockChainSpecific as BlockChainSpecific.Sui
         assertEquals(defaultBudget, specific.gasBudget)
+        assertEquals(defaultPrice, specific.referenceGasPrice)
     }
 
     @Test
-    fun `SUI specific falls back to default budget when fee service returns unexpected type`() =
+    fun `SUI specific falls back to padded default when fee service returns unexpected type`() =
         runTest {
+            val fallbackPrice = BigInteger("500")
             val result =
                 repository(
-                        suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                        suiApi = suiApi(referenceGasPrice = fallbackPrice),
                         suiFeeService = basicFeeService(),
                     )
                     .getSpecific(
@@ -238,8 +248,28 @@ internal class BlockChainSpecificRepositoryImplTest {
                     )
 
             val specific = result.blockChainSpecific as BlockChainSpecific.Sui
-            assertEquals(SUI_DEFAULT_GAS_BUDGET, specific.gasBudget)
+            assertEquals(SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15), specific.gasBudget)
+            assertEquals(fallbackPrice, specific.referenceGasPrice)
         }
+
+    @Test
+    fun `SUI specific rethrows CancellationException without falling back`() = runTest {
+        assertFailsWith<CancellationException> {
+            repository(
+                    suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                    suiFeeService = cancellingFeeService(),
+                )
+                .getSpecific(
+                    chain = Chain.Sui,
+                    address = SOURCE_ADDRESS,
+                    token = suiCoin(),
+                    gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+        }
+    }
 
     private fun suiApi(referenceGasPrice: BigInteger): SuiApi = mockk {
         coEvery { getReferenceGasPrice() } returns referenceGasPrice
@@ -248,17 +278,28 @@ internal class BlockChainSpecificRepositoryImplTest {
 
     private fun suiFeeService(
         limit: BigInteger,
+        price: BigInteger = BigInteger.ZERO,
+        defaultPrice: BigInteger = price,
         primaryThrows: Boolean = false,
         defaultLimit: BigInteger = BigInteger.ZERO,
     ): FeeService =
         object : FeeService {
             override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
                 if (primaryThrows) throw java.io.IOException("sui rpc down")
-                return GasFees(price = BigInteger.ZERO, limit = limit, amount = limit)
+                return GasFees(price = price, limit = limit, amount = limit)
             }
 
             override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
-                GasFees(price = BigInteger.ZERO, limit = defaultLimit, amount = defaultLimit)
+                GasFees(price = defaultPrice, limit = defaultLimit, amount = defaultLimit)
+        }
+
+    private fun cancellingFeeService(): FeeService =
+        object : FeeService {
+            override suspend fun calculateFees(transaction: BlockchainTransaction): Fee =
+                throw CancellationException("sui fee calculation cancelled")
+
+            override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
+                throw CancellationException("sui default fee calculation cancelled")
         }
 
     private fun failingFeeService(): FeeService =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -22,7 +22,9 @@ import com.vultisig.wallet.data.blockchain.model.BasicFee
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.Fee
+import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
@@ -146,9 +148,155 @@ internal class BlockChainSpecificRepositoryImplTest {
         )
     }
 
+    @Test
+    fun `SUI specific uses GasFees limit from fee service`() = runTest {
+        val simulatedBudget = BigInteger("4200000")
+        val result =
+            repository(
+                    suiApi = suiApi(referenceGasPrice = BigInteger("750")),
+                    suiFeeService = suiFeeService(limit = simulatedBudget),
+                )
+                .getSpecific(
+                    chain = Chain.Sui,
+                    address = SOURCE_ADDRESS,
+                    token = suiCoin(),
+                    gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+
+        val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+        assertEquals(simulatedBudget, specific.gasBudget)
+        assertEquals(BigInteger("750"), specific.referenceGasPrice)
+    }
+
+    @Test
+    fun `SUI specific falls back to default budget when fee service throws`() = runTest {
+        val result =
+            repository(
+                    suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                    suiFeeService = failingFeeService(),
+                )
+                .getSpecific(
+                    chain = Chain.Sui,
+                    address = SOURCE_ADDRESS,
+                    token = suiCoin(),
+                    gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+
+        val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+        assertEquals(SUI_DEFAULT_GAS_BUDGET, specific.gasBudget)
+    }
+
+    @Test
+    fun `SUI specific uses default fees when primary throws but default succeeds`() = runTest {
+        val defaultBudget = BigInteger("3450000")
+        val result =
+            repository(
+                    suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                    suiFeeService =
+                        suiFeeService(
+                            limit = BigInteger.ZERO,
+                            primaryThrows = true,
+                            defaultLimit = defaultBudget,
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Sui,
+                    address = SOURCE_ADDRESS,
+                    token = suiCoin(),
+                    gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+
+        val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+        assertEquals(defaultBudget, specific.gasBudget)
+    }
+
+    @Test
+    fun `SUI specific falls back to default budget when fee service returns unexpected type`() =
+        runTest {
+            val result =
+                repository(
+                        suiApi = suiApi(referenceGasPrice = BigInteger("500")),
+                        suiFeeService = basicFeeService(),
+                    )
+                    .getSpecific(
+                        chain = Chain.Sui,
+                        address = SOURCE_ADDRESS,
+                        token = suiCoin(),
+                        gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                    )
+
+            val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+            assertEquals(SUI_DEFAULT_GAS_BUDGET, specific.gasBudget)
+        }
+
+    private fun suiApi(referenceGasPrice: BigInteger): SuiApi = mockk {
+        coEvery { getReferenceGasPrice() } returns referenceGasPrice
+        coEvery { getAllCoins(any()) } returns emptyList()
+    }
+
+    private fun suiFeeService(
+        limit: BigInteger,
+        primaryThrows: Boolean = false,
+        defaultLimit: BigInteger = BigInteger.ZERO,
+    ): FeeService =
+        object : FeeService {
+            override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
+                if (primaryThrows) throw java.io.IOException("sui rpc down")
+                return GasFees(price = BigInteger.ZERO, limit = limit, amount = limit)
+            }
+
+            override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
+                GasFees(price = BigInteger.ZERO, limit = defaultLimit, amount = defaultLimit)
+        }
+
+    private fun failingFeeService(): FeeService =
+        object : FeeService {
+            override suspend fun calculateFees(transaction: BlockchainTransaction): Fee =
+                throw java.io.IOException("primary rpc down")
+
+            override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
+                throw java.io.IOException("default rpc down")
+        }
+
+    private fun basicFeeService(): FeeService =
+        object : FeeService {
+            override suspend fun calculateFees(transaction: BlockchainTransaction): Fee =
+                BasicFee(BigInteger.ZERO)
+
+            override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee =
+                BasicFee(BigInteger.ZERO)
+        }
+
+    private fun suiCoin() =
+        Coin(
+            chain = Chain.Sui,
+            ticker = "SUI",
+            logo = "",
+            address = SOURCE_ADDRESS,
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "sui",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
     private fun repository(
-        evmApi: EvmApi,
-        evmFeeService: FeeService,
+        evmApi: EvmApi = mockk<EvmApi>(relaxed = true),
+        evmFeeService: FeeService = NoOpFeeService,
+        suiApi: SuiApi = mockk<SuiApi>(relaxed = true),
+        suiFeeService: FeeService = NoOpFeeService,
     ): BlockChainSpecificRepositoryImpl {
         val evmApiFactory =
             object : EvmApiFactory {
@@ -165,7 +313,7 @@ internal class BlockChainSpecificRepositoryImplTest {
             dashApi = mockk<DashApi>(relaxed = true),
             polkadotApi = mockk<PolkadotApi>(relaxed = true),
             bittensorApi = mockk<BittensorApi>(relaxed = true),
-            suiApi = mockk<SuiApi>(relaxed = true),
+            suiApi = suiApi,
             tonApi = mockk<TonApi>(relaxed = true),
             rippleApi = mockk<RippleApi>(relaxed = true),
             tronApi = mockk<TronApi>(relaxed = true),
@@ -177,7 +325,7 @@ internal class BlockChainSpecificRepositoryImplTest {
                     polkadotFeeService = NoOpFeeService,
                     bittensorFeeService = NoOpFeeService,
                     rippleFeeService = NoOpFeeService,
-                    suiFeeService = NoOpFeeService,
+                    suiFeeService = suiFeeService,
                     tonFeeService = NoOpFeeService,
                     tronFeeService = NoOpFeeService,
                     solanaFeeService = NoOpFeeService,


### PR DESCRIPTION
## Summary

Closes #3988.

`BlockChainSpecificRepositoryImpl` hardcoded `gasBudget = SUI_DEFAULT_GAS_BUDGET` when building `BlockChainSpecific.Sui`, even though `SuiFeeService` already computes a safer budget via an on-chain dry-run (`computationCost + storageCost`, +15% margin, floored at `MIN_NETWORK_GAS_BUDGET = 2000`). Because this struct flows all the way into `SuiHelper.getPreSignedInputData(...).setGasBudget(...)`, the **on-chain** transaction was signed with the wrong budget — not a UI-only estimate mismatch.

## Changes

- `data/.../repositories/BlockChainSpecificRepository.kt` — the `TokenStandard.SUI` branch now calls `feeServiceComposite.calculateFees(Transfer(...))`, which routes to `SuiFeeService` and returns `GasFees(price, limit = finalSafeGasBudget, amount)`. `gasBudget` in `BlockChainSpecific.Sui` is set from `fees.limit`.
- Pattern matches the existing EVM branch (parallel `async` deferreds, `when (fees)` with an `error()` fallback for unsupported types).
- Removed the now-unused `SUI_DEFAULT_GAS_BUDGET` import.
- If the dry-run fails, `FeeServiceComposite` falls back to `SuiFeeService.calculateDefaultFees`, which still returns `GasFees` (with `SUI_DEFAULT_GAS_BUDGET * 1.15`) — safe for the runtime cast.

## Test plan

- [x] `./gradlew :data:compileDebugKotlin` — passes
- [x] `./gradlew :data:testDebugUnitTest --tests "*BlockChainSpecificRepositoryImplTest*"` — passes
- [x] `./gradlew ktfmtFormat` — applied
- [ ] Manual: send native SUI from a fragmented vault; verify the signed tx uses the simulated budget (not 3,000,000) and lands on-chain
- [ ] Manual: send a non-native SUI coin (Pay path); verify the gas coin selection + budget behave as before

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SUI transactions now use dynamic fee estimation with explicit fallbacks, clearer error handling, and logging to improve reliability and fee accuracy.
* **Tests**
  * Added comprehensive SUI tests for successful estimation, estimator failures, cancellation behavior, unexpected fee types, and default-fallbacks.
  * Improved a UI test to await account-open state to avoid race conditions when asserting success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->