### PR TITLE
fix: select Sui gas coin by gasBudget, not referenceGasPrice (#3989)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -7,8 +7,10 @@ import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.tss.getSignature
+import java.math.BigInteger
 import timber.log.Timber
 import tss.KeysignResponse
+import vultisig.keysign.v1.SuiCoin
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.Base64
 import wallet.core.jni.CoinType
@@ -57,12 +59,7 @@ object SuiHelper {
                                     .build()
                             }
                 }
-        val gascoin =
-            coins
-                .filter {
-                    it.coinType == suiContractAddress && it.balance.toBigInteger() >= gasBudget
-                }
-                .minByOrNull { it.balance.toBigInteger() }
+        val gascoin = selectSuiGasCoin(coins, gasBudget)
 
         val input =
             if (nonSuiObjectRef.isNotEmpty()) {
@@ -125,6 +122,11 @@ object SuiHelper {
 
         return Base64.encode(tx)
     }
+
+    internal fun selectSuiGasCoin(coins: List<SuiCoin>, gasBudget: BigInteger): SuiCoin? =
+        coins
+            .filter { it.coinType == suiContractAddress && it.balance.toBigInteger() >= gasBudget }
+            .minByOrNull { it.balance.toBigInteger() }
 
     fun getSignedTransaction(
         vaultHexPubKey: String,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -60,8 +60,7 @@ object SuiHelper {
         val gascoin =
             coins
                 .filter {
-                    it.coinType == suiContractAddress &&
-                        it.balance.toBigInteger() > referenceGasPrice
+                    it.coinType == suiContractAddress && it.balance.toBigInteger() >= gasBudget
                 }
                 .minByOrNull { it.balance.toBigInteger() }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
@@ -1,0 +1,164 @@
+package com.vultisig.wallet.data.crypto
+
+import java.math.BigInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SuiCoin
+
+/**
+ * Covers [SuiHelper.selectSuiGasCoin] with exact `suix_getAllCoins` RPC response payloads to
+ * protect the #3989 fix (filter by `balance >= gasBudget`, not `balance > referenceGasPrice`).
+ */
+class SuiHelperTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Real-shape suix_getAllCoins response. Three SUI coins of different balances and one
+    // non-SUI coin, so we can exercise eligibility + min-selection + non-SUI exclusion.
+    private val getAllCoinsResponse =
+        """
+        {
+          "jsonrpc": "2.0",
+          "result": {
+            "data": [
+              {
+                "coinType": "0x2::sui::SUI",
+                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "version": "100",
+                "digest": "DGstCoinOneXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "balance": "600",
+                "previousTransaction": "PrevTx1"
+              },
+              {
+                "coinType": "0x2::sui::SUI",
+                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "version": "101",
+                "digest": "DGstCoinTwoXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "balance": "3000000",
+                "previousTransaction": "PrevTx2"
+              },
+              {
+                "coinType": "0x2::sui::SUI",
+                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                "version": "102",
+                "digest": "DGstCoinThreeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "balance": "10000000000",
+                "previousTransaction": "PrevTx3"
+              },
+              {
+                "coinType": "0xabc::usdc::USDC",
+                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000099",
+                "version": "200",
+                "digest": "DGstUsdcXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "balance": "999999999999",
+                "previousTransaction": "PrevTx99"
+              }
+            ],
+            "nextCursor": null,
+            "hasNextPage": false
+          },
+          "id": 1
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun `selectSuiGasCoin picks smallest SUI coin that covers gasBudget`() {
+        val coins = parseCoins(getAllCoinsResponse)
+        val gasBudget = "3000000".toBigInteger()
+
+        val selected = SuiHelper.selectSuiGasCoin(coins, gasBudget)
+
+        // balance=600 is too small (the old bug had it pass because 600 > refGasPrice=500);
+        // 3000000 meets the budget exactly and is the smallest eligible coin.
+        assertEquals(
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+            selected?.coinObjectId,
+        )
+        assertEquals("3000000", selected?.balance)
+    }
+
+    @Test
+    fun `selectSuiGasCoin rejects coin that beats referenceGasPrice but not gasBudget`() {
+        // Regression for #3989: balance=600 > referenceGasPrice=500 but < gasBudget=3000000.
+        // The pre-fix code would have returned this coin; the post-fix code must skip it
+        // and fall through to the next eligible coin (or null if none exists).
+        val coins =
+            parseCoins(getAllCoinsResponse).filter {
+                it.balance.toBigInteger() < 1_000_000.toBigInteger()
+            }
+        val gasBudget = "3000000".toBigInteger()
+
+        val selected = SuiHelper.selectSuiGasCoin(coins, gasBudget)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectSuiGasCoin returns null when no SUI coin can cover gasBudget`() {
+        val coins = parseCoins(getAllCoinsResponse)
+        val gasBudget = "100000000000".toBigInteger() // 100 SUI, larger than any balance
+
+        val selected = SuiHelper.selectSuiGasCoin(coins, gasBudget)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectSuiGasCoin ignores non-SUI coins even when balance exceeds gasBudget`() {
+        // The USDC coin has a huge balance but is not 0x2::sui::SUI and must not be picked.
+        val nonSuiOnly = parseCoins(getAllCoinsResponse).filter { it.coinType != "0x2::sui::SUI" }
+        val gasBudget = "3000000".toBigInteger()
+
+        val selected = SuiHelper.selectSuiGasCoin(nonSuiOnly, gasBudget)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectSuiGasCoin picks largest when only the top balance is eligible`() {
+        val coins = parseCoins(getAllCoinsResponse)
+        val gasBudget = "5000000".toBigInteger() // only the 10 SUI coin qualifies
+
+        val selected = SuiHelper.selectSuiGasCoin(coins, gasBudget)
+
+        assertEquals(
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            selected?.coinObjectId,
+        )
+    }
+
+    @Test
+    fun `selectSuiGasCoin accepts coin whose balance equals gasBudget exactly`() {
+        val coins = parseCoins(getAllCoinsResponse)
+        val gasBudget = BigInteger("3000000")
+
+        val selected = SuiHelper.selectSuiGasCoin(coins, gasBudget)
+
+        assertEquals("3000000", selected?.balance)
+    }
+
+    /** Mirrors the parsing in `SuiApiImpl.getAllCoins` so tests consume the real RPC shape. */
+    private fun parseCoins(rpcResponse: String): List<SuiCoin> =
+        json
+            .parseToJsonElement(rpcResponse)
+            .jsonObject["result"]!!
+            .jsonObject["data"]!!
+            .jsonArray
+            .map {
+                SuiCoin(
+                    coinType = it.jsonObject["coinType"]!!.jsonPrimitive.content,
+                    coinObjectId = it.jsonObject["coinObjectId"]!!.jsonPrimitive.content,
+                    version = it.jsonObject["version"]!!.jsonPrimitive.content,
+                    digest = it.jsonObject["digest"]!!.jsonPrimitive.content,
+                    balance = it.jsonObject["balance"]!!.jsonPrimitive.content,
+                    previousTransaction =
+                        it.jsonObject["previousTransaction"]?.jsonPrimitive?.content ?: "",
+                )
+            }
+}


### PR DESCRIPTION
## Summary

Closes #3989.

https://suiscan.xyz/mainnet/tx/4VHCWwUuKefH3DFCGRtBf6LsPoSx4kJMXLvdpcTnf46s

`SuiHelper.getPreSignedInputData` filtered gas-coin candidates with `balance > referenceGasPrice`. The `referenceGasPrice` is a per-unit gas price (typically ~1000 MIST), **far smaller** than the actual `gasBudget` required to fund the transaction (millions of MIST). A coin passing that check could still be insufficient — the transaction would be signed with an underfunded gas coin and fail on-chain.

## Changes

- `data/.../crypto/SuiHelper.kt` — change the gas-coin filter predicate from `balance > referenceGasPrice` to `balance >= gasBudget`, so only coins that can actually cover the budget are eligible.

## Test plan

- [x] `./gradlew :data:compileDebugKotlin` — passes
- [x] `./gradlew ktfmtFormat` — applied
- [ ] Manual: send a non-native SUI coin (Pay path) from a vault with multiple SUI gas coins — verify a coin with `balance >= gasBudget` is picked and the tx lands on-chain
- [ ] Manual: confirm behavior when no SUI coin meets the threshold (should surface an error cleanly — follow-up with #3990 for the `.first { }` crash)

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sui gas-coin selection: coins now must meet the actual gas budget (balance >= gasBudget) and the smallest eligible SUI coin is preferred, reducing failed or suboptimal fee choices.
* **Tests**
  * Added unit tests covering various coin-selection scenarios to ensure reliable fee selection and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->