### PR TITLE
fix: avoid Sui crash when gas coin missing from suiObjectRefs (#3990)

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
@@ -31,6 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +115,9 @@ internal class CircleDeFiPositionsViewModelTest {
 
             assertEquals(SnackbarType.Success, type)
             coVerify(exactly = 1) { scaCircleAccountRepository.saveAccount(VAULT_ID, MSCA_ADDRESS) }
+            // onCreateAccount updates state after showing the snackbar on a non-test
+            // dispatcher, so wait for it to propagate instead of racing the ViewModel.
+            awaitAccountOpen(vm)
             assertTrue(vm.state.value.circleDefi.isAccountOpen)
         }
 
@@ -161,6 +165,12 @@ internal class CircleDeFiPositionsViewModelTest {
         // must use a real dispatcher.
         return withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(5.seconds) { captured.await() }
+        }
+    }
+
+    private suspend fun awaitAccountOpen(vm: CircleDeFiPositionsViewModel) {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5.seconds) { vm.state.first { it.circleDefi.isAccountOpen } }
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -71,7 +71,9 @@ object SuiHelper {
                         .setPay(
                             Sui.Pay.newBuilder()
                                 .setGas(
-                                    suiObjectRefs.first { it.objectId == gascoin?.coinObjectId }
+                                    suiObjectRefs.firstOrNull {
+                                        it.objectId == gascoin?.coinObjectId
+                                    } ?: error("No suitable SUI gas coin available for transaction")
                                 )
                                 .addAllInputCoins(nonSuiObjectRef)
                                 .addAllRecipients(listOf(toAddress.description()))

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -70,11 +70,7 @@ object SuiHelper {
                     Sui.SigningInput.newBuilder()
                         .setPay(
                             Sui.Pay.newBuilder()
-                                .setGas(
-                                    suiObjectRefs.firstOrNull {
-                                        it.objectId == gascoin?.coinObjectId
-                                    } ?: error("No suitable SUI gas coin available for transaction")
-                                )
+                                .setGas(selectSuiGasObjectRef(suiObjectRefs, gascoin?.coinObjectId))
                                 .addAllInputCoins(nonSuiObjectRef)
                                 .addAllRecipients(listOf(toAddress.description()))
                                 .addAllAmounts(listOf(keysignPayload.toAmount.toLong()))
@@ -128,6 +124,13 @@ object SuiHelper {
 
         return Base64.encode(tx)
     }
+
+    internal fun selectSuiGasObjectRef(
+        suiObjectRefs: List<Sui.ObjectRef>,
+        gasCoinObjectId: String?,
+    ): Sui.ObjectRef =
+        suiObjectRefs.firstOrNull { it.objectId == gasCoinObjectId }
+            ?: error("No suitable SUI gas coin available for transaction")
 
     fun getSignedTransaction(
         vaultHexPubKey: String,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.data.crypto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import wallet.core.jni.proto.Sui
+
+class SuiHelperTest {
+
+    @Test
+    fun `selectSuiGasObjectRef returns matching ref when present`() {
+        val target = objectRef("obj-2", version = 20)
+        val refs =
+            listOf(objectRef("obj-1", version = 10), target, objectRef("obj-3", version = 30))
+
+        val result = SuiHelper.selectSuiGasObjectRef(refs, "obj-2")
+
+        assertEquals(target, result)
+    }
+
+    @Test
+    fun `selectSuiGasObjectRef returns first match when duplicate objectIds exist`() {
+        val first = objectRef("obj-dup", version = 1)
+        val second = objectRef("obj-dup", version = 2)
+        val refs = listOf(first, second)
+
+        val result = SuiHelper.selectSuiGasObjectRef(refs, "obj-dup")
+
+        assertEquals(first, result)
+    }
+
+    @Test
+    fun `selectSuiGasObjectRef throws when objectId is missing from refs`() {
+        val refs = listOf(objectRef("obj-1"), objectRef("obj-2"))
+
+        val error =
+            assertThrows(IllegalStateException::class.java) {
+                SuiHelper.selectSuiGasObjectRef(refs, "missing-id")
+            }
+
+        assertEquals("No suitable SUI gas coin available for transaction", error.message)
+    }
+
+    @Test
+    fun `selectSuiGasObjectRef throws when gasCoinObjectId is null`() {
+        val refs = listOf(objectRef("obj-1"), objectRef("obj-2"))
+
+        assertThrows(IllegalStateException::class.java) {
+            SuiHelper.selectSuiGasObjectRef(refs, null)
+        }
+    }
+
+    @Test
+    fun `selectSuiGasObjectRef throws when refs list is empty`() {
+        assertThrows(IllegalStateException::class.java) {
+            SuiHelper.selectSuiGasObjectRef(emptyList(), "obj-1")
+        }
+    }
+
+    private fun objectRef(
+        id: String,
+        version: Long = 1,
+        digest: String = "digest-$id",
+    ): Sui.ObjectRef =
+        Sui.ObjectRef.newBuilder()
+            .setObjectId(id)
+            .setVersion(version)
+            .setObjectDigest(digest)
+            .build()
+}


### PR DESCRIPTION
## Summary

Closes #3990.

https://suiscan.xyz/mainnet/tx/FtPWUhVegotLUQQYX9cUDgHeEDzzzqbBdM7TUjmrpt8R

`SuiHelper.getPreSignedInputData` used `.first { it.objectId == gascoin?.coinObjectId }` to fetch the chosen gas coin reference. This throws `NoSuchElementException` (uncaught) when:
- `gascoin` is `null` — no SUI coin met the gas-coin filter
- The selected `coinObjectId` is missing from `suiObjectRefs` — RPC inconsistency or coin fragmentation

Either case crashes the app while sending SUI.

## Changes

- `data/.../crypto/SuiHelper.kt` — switch the lookup to `firstOrNull`, fall through to `error(\"No suitable SUI gas coin available for transaction\")` so the failure is surfaced through the normal keysign error path instead of an uncaught exception.

## Test plan

- [x] `./gradlew :data:compileDebugKotlin` — passes
- [x] `./gradlew ktfmtFormat` — applied
- [ ] Manual: attempt to send a non-native SUI coin from a vault with no qualifying SUI gas coin — verify a clean error surfaces instead of a crash
- [ ] Manual: send a non-native SUI coin in the normal case — verify behavior is unchanged

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SUI gas-coin selection for transactions; when no suitable gas coin is available, a clear runtime error message is provided to reduce unexpected failures.

* **Tests**
  * Added unit tests to validate gas-coin selection behavior and consistent error reporting.
  * Enhanced UI test timing to wait for state updates, reducing flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->