### PR TITLE
fix: hide address from chain rows on DeFi tab (#4010)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -14,11 +14,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
 import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
+import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultBackupState
@@ -42,6 +46,7 @@ import com.vultisig.wallet.ui.screens.transaction.SendTxOverviewScreen
 import com.vultisig.wallet.ui.screens.transaction.TransactionHistoryEmptyState
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfo
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfoType
+import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.CameraButton
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionType
 import com.vultisig.wallet.ui.screens.v2.home.components.TransactionTypeButton
@@ -74,6 +79,7 @@ class PreviewActivity : ComponentActivity() {
                     "solana_display" -> SolanaDisplayPreview()
                     "swap_error_before" -> SwapErrorBeforePreview()
                     "swap_error" -> SwapErrorPreview()
+                    "defi_account_list" -> DeFiAccountListPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -374,3 +380,86 @@ private fun SwapErrorPreview() {
         srcAmountTextFieldState = TextFieldState("1000"),
     )
 }
+
+@Composable
+private fun DeFiAccountListPreview() {
+    val accounts =
+        listOf(
+            deFiAccount(
+                chain = Chain.ThorChain,
+                chainName = "THORChain",
+                address = "thor1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v",
+                fiat = "$32,201.15",
+                native = "32,020.12 RUNE",
+            ),
+            deFiAccount(
+                chain = Chain.Ethereum,
+                chainName = "Ethereum",
+                address = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+                fiat = "$7,400.00",
+                assets = 4,
+            ),
+            deFiAccount(
+                chain = Chain.MayaChain,
+                chainName = "Maya",
+                address = "maya1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v",
+                fiat = "$1,240.50",
+                assets = 3,
+            ),
+            deFiAccount(
+                chain = Chain.Solana,
+                chainName = "Solana",
+                address = "8FE27ioQh3T7o22QsYVT5Re8NnHFqmFNbdqwiF3ywuZQ",
+                fiat = "$990.00",
+                assets = 3,
+            ),
+            deFiAccount(
+                chain = Chain.Tron,
+                chainName = "Tron",
+                address = "TXYZopq123abc456def789ghi012jkl345mno678",
+                fiat = "$865.75",
+                native = "10,829.10 TRX",
+            ),
+        )
+
+    androidx.compose.foundation.layout.Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.primary)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+    ) {
+        androidx.compose.foundation.layout.Column(
+            modifier =
+                Modifier.background(
+                    color = com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.secondary,
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                )
+        ) {
+            AccountList(
+                onAccountClick = {},
+                snackbarState = rememberVsSnackbarState(),
+                accounts = accounts,
+                isBalanceVisible = true,
+                showAddress = false,
+            )
+        }
+    }
+}
+
+private fun deFiAccount(
+    chain: Chain,
+    chainName: String,
+    address: String,
+    fiat: String,
+    native: String? = null,
+    assets: Int = 0,
+): AccountUiModel =
+    AccountUiModel(
+        model = Address(chain = chain, address = address, accounts = emptyList()),
+        chainName = chainName,
+        logo = chain.logo,
+        address = address,
+        nativeTokenAmount = native,
+        fiatAmount = fiat,
+        assetsSize = assets,
+    )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -323,6 +323,7 @@ internal fun VaultAccountsScreen(
                                         snackbarState = snackbarState,
                                         isBalanceVisible = state.isBalanceValueVisible,
                                         accounts = state.getAccounts,
+                                        showAddress = isWallet,
                                     )
                                 }
                             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
@@ -38,6 +38,7 @@ internal fun AccountItem(
     account: AccountUiModel,
     isBalanceVisible: Boolean,
     onCopy: (String) -> Unit,
+    showAddress: Boolean = true,
     onClick: () -> Unit = {},
 ) {
     Row(
@@ -54,7 +55,7 @@ internal fun AccountItem(
 
         Column(
             modifier = Modifier.fillMaxHeight(),
-            verticalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = if (showAddress) Arrangement.SpaceBetween else Arrangement.Center,
             horizontalAlignment = Alignment.Start,
         ) {
             Text(
@@ -65,11 +66,13 @@ internal fun AccountItem(
                 overflow = TextOverflow.Ellipsis,
             )
 
-            CopiableAddress(
-                address = account.address,
-                modifier = Modifier.padding(top = 2.dp),
-                onAddressCopied = onCopy,
-            )
+            if (showAddress) {
+                CopiableAddress(
+                    address = account.address,
+                    modifier = Modifier.padding(top = 2.dp),
+                    onAddressCopied = onCopy,
+                )
+            }
         }
 
         UiSpacer(weight = 1f)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountList.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountList.kt
@@ -19,6 +19,7 @@ internal fun AccountList(
     snackbarState: VSSnackbarState,
     accounts: List<AccountUiModel>,
     isBalanceVisible: Boolean,
+    showAddress: Boolean = true,
 ) {
     val context = LocalContext.current
 
@@ -30,6 +31,7 @@ internal fun AccountList(
                         modifier = Modifier.Companion.padding(horizontal = 16.dp, vertical = 12.dp),
                         account = account,
                         isBalanceVisible = isBalanceVisible,
+                        showAddress = showAddress,
                         onClick = { onAccountClick(account) },
                         onCopy = {
                             snackbarState.show(


### PR DESCRIPTION
## Summary

Closes #4010.

The home page's chain list shares one component (`AccountItem` / `AccountList`) between the Wallet and DeFi tabs and always renders the chain address under the chain name. The Figma DeFi design ([node 50776:152189](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=50776-152189)) shows only the chain name, fiat balance, and positions/native amount — no address.

Add a `showAddress` flag (defaulting to `true` so Wallet behavior is unchanged) and wire it from `VaultAccountsScreen` so the DeFi tab passes `false`. When the address is hidden, the chain name is centered vertically to match the Figma layout.

## Changes

- `AccountItem.kt` — add `showAddress: Boolean = true`; skip `CopiableAddress` when `false` and switch the inner column to `Arrangement.Center` so the chain name is vertically centered.
- `AccountList.kt` — forward the `showAddress` flag down.
- `VaultAccountsScreen.kt` — pass `showAddress = isWallet` so DeFi hides addresses while Wallet keeps them.
- `PreviewActivity.kt` — add a `defi_account_list` case rendering `AccountList` with mock chain accounts and `showAddress = false`, used for local ADB screencap verification.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — passes
- [x] `./gradlew ktfmtFormat` — applied
- [x] PreviewActivity render verified on Pixel 8a emulator against Figma [node 50776:152189](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=50776-152189)
- [ ] Manual: Wallet tab still shows the chain addresses under each chain name
- [ ] Manual: DeFi tab no longer shows addresses; chain name vertically centered
- [ ] Manual: Tap-to-open behavior unchanged on both tabs

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable address visibility in account lists; addresses can now be optionally hidden from account displays based on context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->