### PR TITLE
fix: surface sRUJI under DeFi tab only, hide from wallet token list (#4097)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -337,8 +337,8 @@ constructor(
             "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"
         private const val YTCY_CONTRACT =
             "thor1h0hr0rm3dawkedh44hlrmgvya6plsryehcr46yda2vj0wfwgq5xqrs86px"
-
-        // Denoms surfaced under the DeFi tab — must not be auto-discovered as wallet tokens.
-        internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji")
     }
 }
+
+// Denoms surfaced under the DeFi tab — must not be auto-discovered as wallet tokens.
+internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -96,6 +96,7 @@ constructor(
                 val balances = thorApi.getBalance(address)
                 val metaCache = mutableMapOf<String, DenomMetadata?>()
                 balances.mapNotNull {
+                    if (it.denom in DEFI_ONLY_THORCHAIN_DENOMS) return@mapNotNull null
                     val metadata =
                         metaCache.getOrPut(it.denom) { thorApi.getDenomMetaFromLCD(it.denom) }
 
@@ -336,5 +337,8 @@ constructor(
             "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"
         private const val YTCY_CONTRACT =
             "thor1h0hr0rm3dawkedh44hlrmgvya6plsryehcr46yda2vj0wfwgq5xqrs86px"
+
+        // Denoms surfaced under the DeFi tab — must not be auto-discovered as wallet tokens.
+        internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji")
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.TokenRepositoryImpl.Companion.DEFI_ONLY_THORCHAIN_DENOMS
 import com.vultisig.wallet.data.repositories.VaultRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -56,6 +58,8 @@ constructor(
 
             for (chain in chains) {
                 try {
+                    cleanupDeFiOnlyTokens(vault, chain)
+
                     tokenRepository
                         .getRefreshTokens(chain, vault)
                         .filter { disabledCoinIds.none { disabledId -> disabledId == it.id } }
@@ -71,6 +75,13 @@ constructor(
             }
         }
         return Result.success()
+    }
+
+    private suspend fun cleanupDeFiOnlyTokens(vault: Vault, chain: Chain) {
+        if (chain != Chain.ThorChain) return
+        vault.coins
+            .filter { it.chain == chain && it.contractAddress in DEFI_ONLY_THORCHAIN_DENOMS }
+            .forEach { vaultRepository.deleteTokenFromVault(vault.id, it) }
     }
 
     private suspend fun addRefreshTokenToVault(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -7,8 +7,8 @@ import androidx.work.WorkerParameters
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.DEFI_ONLY_THORCHAIN_DENOMS
 import com.vultisig.wallet.data.repositories.TokenRepository
-import com.vultisig.wallet.data.repositories.TokenRepositoryImpl.Companion.DEFI_ONLY_THORCHAIN_DENOMS
 import com.vultisig.wallet.data.repositories.VaultRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -59,7 +59,11 @@ constructor(
             for (chain in chains) {
                 try {
                     cleanupDeFiOnlyTokens(vault, chain)
+                } catch (e: Exception) {
+                    Timber.e(e)
+                }
 
+                try {
                     tokenRepository
                         .getRefreshTokens(chain, vault)
                         .filter { disabledCoinIds.none { disabledId -> disabledId == it.id } }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -1,0 +1,86 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.CoinGeckoApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.DenomMetadata
+import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
+import com.vultisig.wallet.data.api.swapAggregators.OneInchApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.OneInchToCoinsUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class TokenRepositoryImplTest {
+
+    @Test
+    fun `getTokensWithBalance for ThorChain skips x_staking-ruji denom`() = runTest {
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(
+                CosmosBalance(denom = "x/staking-ruji", amount = "100"),
+                CosmosBalance(denom = "x/ruji", amount = "200"),
+            )
+        coEvery { thorApi.getDenomMetaFromLCD(any()) } returns null
+
+        val coins = newRepository(thorApi).getTokensWithBalance(Chain.ThorChain, ADDRESS)
+
+        assertTrue(coins.none { it.contractAddress == "x/staking-ruji" })
+    }
+
+    @Test
+    fun `getTokensWithBalance for ThorChain keeps non-staking denoms`() = runTest {
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(
+                CosmosBalance(denom = "x/staking-ruji", amount = "100"),
+                CosmosBalance(denom = "x/ruji", amount = "200"),
+                CosmosBalance(denom = "tcy", amount = "300"),
+            )
+        coEvery { thorApi.getDenomMetaFromLCD(any()) } returns null
+
+        val coins = newRepository(thorApi).getTokensWithBalance(Chain.ThorChain, ADDRESS)
+
+        assertEquals(setOf("x/ruji", "tcy"), coins.map { it.contractAddress }.toSet())
+    }
+
+    @Test
+    fun `getTokensWithBalance for ThorChain skips x_staking-ruji even with metadata`() = runTest {
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(CosmosBalance(denom = "x/staking-ruji", amount = "100"))
+        coEvery { thorApi.getDenomMetaFromLCD("x/staking-ruji") } returns
+            DenomMetadata(
+                base = "x/staking-ruji",
+                symbol = "sRUJI",
+                display = null,
+                denomUnits = null,
+            )
+
+        val coins = newRepository(thorApi).getTokensWithBalance(Chain.ThorChain, ADDRESS)
+
+        assertTrue(coins.isEmpty())
+    }
+
+    private fun newRepository(thorApi: ThorChainApi): TokenRepositoryImpl =
+        TokenRepositoryImpl(
+            oneInchApi = mockk<OneInchApi>(relaxed = true),
+            evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
+            thorApi = thorApi,
+            coinGeckoApi = mockk<CoinGeckoApi>(relaxed = true),
+            currencyRepository = mockk<AppCurrencyRepository>(relaxed = true),
+            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            oneInchToCoins = mockk<OneInchToCoinsUseCase>(relaxed = true),
+        )
+
+    private companion object {
+        const val ADDRESS = "thor1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4097.

When a vault has staked RUJI, the THORChain bank balance returns an `x/staking-ruji` denom. `TokenRefreshWorker` auto-discovers it via `TokenRepository.getTokensWithBalance` and adds it to the vault as a wallet token (rendered as \"sRUJI\") — even though the staked position is already surfaced on the DeFi tab via `ThorchainDeFiBalanceService` → `RujiStakingService`. Cross-platform parity: iOS and Windows have mirrored issues.

## Changes

- `TokenRepository.kt` — add a `DEFI_ONLY_THORCHAIN_DENOMS` set (currently `\"x/staking-ruji\"`) and skip those denoms in `getTokensWithBalance` for ThorChain so `sRUJI` is not picked up on future refreshes.
- `TokenRefreshWorker.kt` — call `cleanupDeFiOnlyTokens(vault, chain)` before discovery on each ThorChain refresh; it removes any existing `x/staking-ruji` entries from the vault so users who already had sRUJI persisted no longer see it in the wallet.

The DeFi tab is unchanged — it continues to render the staked RUJI position (balance, value, stake/unstake) via the existing service.

## Test plan

- [x] `./gradlew :data:compileDebugKotlin` — passes
- [x] `./gradlew :data:testDebugUnitTest` — passes
- [x] `./gradlew :data:ktfmtFormat` — applied
- [ ] Manual: vault with active RUJI staking — verify sRUJI no longer appears under THORChain tokens; staked position still appears on DeFi tab with correct balance and value
- [ ] Manual: vault with no RUJI staking — verify no regression in THORChain token list
- [ ] Manual: vault that previously had sRUJI persisted — verify the entry is removed on next refresh

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented DeFi-only ThorChain denom ("x/staking-ruji") from creating wallet coins during balance discovery.
  * During token refresh, DeFi-only ThorChain tokens are cleaned from vaults to keep balances accurate; removal errors are logged without failing the refresh.

* **Tests**
  * Added unit tests verifying ThorChain discovery excludes the DeFi-only denom in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->