### PR TITLE
fix: recover from 'tx already known' broadcast errors on 7 non-EVM chains

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -48,6 +48,8 @@ import com.vultisig.wallet.data.models.Chain.Ton
 import com.vultisig.wallet.data.models.Chain.ZkSync
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 fun interface BroadcastTxUseCase {
     suspend operator fun invoke(chain: Chain, tx: SignedTransactionResult): String?
@@ -103,9 +105,14 @@ constructor(
                 evmApi.sendTransaction(tx.rawTransaction)
             }
 
-            Solana -> {
-                solanaApi.broadcastTransaction(tx.rawTransaction)
-            }
+            Solana ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = { solanaApi.broadcastTransaction(tx.rawTransaction) },
+                    verify = { hash ->
+                        solanaApi.checkStatus(hash)?.result?.value?.any { it != null } == true
+                    },
+                )
 
             GaiaChain,
             Kujira,
@@ -124,31 +131,88 @@ constructor(
                 mayaChainApi.broadcastTransaction(tx.rawTransaction)
             }
 
-            Polkadot -> {
-                polkadotApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
-            }
+            Polkadot ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = {
+                        polkadotApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
+                    },
+                    verify = { hash ->
+                        polkadotApi.getTxStatus(hash)?.data?.extrinsicHash?.isNotBlank() == true
+                    },
+                )
 
             Chain.Bittensor -> {
                 bittensorApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
             }
 
-            Sui -> {
-                suiApi.executeTransactionBlock(tx.rawTransaction, tx.signature ?: "")
-            }
+            Sui ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = {
+                        suiApi.executeTransactionBlock(tx.rawTransaction, tx.signature ?: "")
+                    },
+                    verify = { hash -> suiApi.checkStatus(hash)?.digest?.isNotBlank() == true },
+                )
 
-            Ton -> {
-                tonApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
-            }
+            Ton ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = {
+                        tonApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
+                    },
+                    verify = { hash -> tonApi.getTsStatus(hash).transactions.isNotEmpty() },
+                )
 
-            Ripple -> {
-                rippleApi.broadcastTransaction(tx.rawTransaction)
-            }
+            Ripple ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = { rippleApi.broadcastTransaction(tx.rawTransaction) },
+                    verify = { hash ->
+                        rippleApi.getTsStatus(hash)?.result?.hash?.isNotBlank() == true
+                    },
+                )
 
-            Chain.Tron -> {
-                tronApi.broadcastTransaction(tx.rawTransaction)
-            }
-            Chain.Cardano -> {
-                cardanoApi.broadcastTransaction(chain.name, tx.rawTransaction) ?: tx.transactionHash
+            Chain.Tron ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = { tronApi.broadcastTransaction(tx.rawTransaction) },
+                    verify = { hash ->
+                        tronApi.getTsStatus(chain, hash)?.txId?.isNotBlank() == true
+                    },
+                )
+            Chain.Cardano ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = {
+                        cardanoApi.broadcastTransaction(chain.name, tx.rawTransaction)
+                            ?: tx.transactionHash
+                    },
+                    verify = { hash -> cardanoApi.getTxStatus(hash)?.txHash?.isNotBlank() == true },
+                )
+        }
+
+    private suspend fun recoverIfAlreadyBroadcast(
+        tx: SignedTransactionResult,
+        broadcast: suspend () -> String?,
+        verify: suspend (String) -> Boolean,
+    ): String? =
+        try {
+            broadcast()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val hash = tx.transactionHash
+            val alreadyOnChain =
+                hash.isNotBlank() && runCatching { verify(hash) }.getOrDefault(false)
+            if (alreadyOnChain) {
+                Timber.d(
+                    "broadcast failed but tx %s is already on-chain; treating as success",
+                    hash,
+                )
+                hash
+            } else {
+                throw e
             }
         }
 }


### PR DESCRIPTION
Closes #4105

## Summary
- In MPC keysign every participating device broadcasts the signed tx independently. When a peer wins the RPC race, the slower device gets an "already known"/"duplicate"/"already in mempool" error — even though the tx is on-chain and funds moved.
- EVM, Cosmos, and Bittensor already handle this. Cardano, Solana, Tron, Sui, Ripple, Polkadot, and Ton did not, so keysign surfaced `KeysignState.Error()` despite success.
- Added `recoverIfAlreadyBroadcast` in `BroadcastTxUseCase`: on any broadcast exception it verifies `tx.transactionHash` via each chain's existing tx-status lookup and returns the hash if the tx is already on-chain. Otherwise the original exception is rethrown. `CancellationException` is rethrown unchanged.
- This replaces fragile per-chain string matching with deterministic on-chain hash verification and removes the false-positive risk noted in the issue (lookalike error strings from unrelated txs on the same account).

## Per-chain lookups used
| Chain | Lookup | "Found" signal |
|-------|--------|----------------|
| Cardano  | `CardanoApi.getTxStatus` | `txHash` non-blank |
| Solana   | `SolanaApi.checkStatus` | any non-null entry in `result.value` |
| Polkadot | `PolkadotApi.getTxStatus` | `data.extrinsicHash` non-blank |
| Tron     | `TronApi.getTsStatus` | `txId` non-blank |
| Sui      | `SuiApi.checkStatus` | `digest` non-blank |
| Ripple   | `RippleApi.getTsStatus` | `result.hash` non-blank |
| Ton      | `TonApi.getTsStatus` | `transactions` non-empty |

EVM/Cosmos/MayaChain/Thorchain/Bittensor paths are unchanged — the audit/consolidation of their existing string-matches is left as a follow-up per the issue.

## Test plan
- [ ] `./gradlew :data:compileDebugKotlin` (verified locally)
- [ ] `./gradlew :app:compileDebugKotlin` (verified locally)
- [ ] `./gradlew :data:ktfmtFormat` clean (verified locally)
- [ ] Keygen/keysign on Solana with 2 devices — slower device no longer surfaces `KeysignState.Error()` after the first peer wins
- [ ] Same check on Cardano, Tron, Sui, Ripple, Polkadot, Ton
- [ ] Regression: single-device broadcast still surfaces a real error when the tx never reaches the chain (hash lookup returns not-found → original exception rethrown)

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcasting reliability for Solana, Polkadot, Sui, Ton, Ripple, Tron, and Cardano. The app now better handles cases where transactions were already broadcast to the blockchain, preventing unnecessary errors and allowing successful completion when transactions are confirmed on-chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->