### PR TITLE
fix: redesign Share QR Code share-bitmap to match Figma (#4130)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -562,7 +562,7 @@ private fun ShareQrPreview(info: QrShareInfo) {
                         Color.Transparent,
                         null,
                     )
-            val logo = BitmapFactory.decodeResource(context.resources, R.drawable.ic_share_qr_logo)
+            val logo = BitmapFactory.decodeResource(context.resources, R.drawable.logo)
             entry.makeQrCodeBitmapShareFormat().invoke(context, qr, bgColor.toArgb(), logo, info)
         }
     Box(

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -110,6 +110,7 @@ class PreviewActivity : ComponentActivity() {
                     "import_seedphrase" -> ImportSeedphrasePreview()
                     "defi_account_list" -> DeFiAccountListPreview()
                     "share_qr_keysign" -> ShareQrKeysignPreview()
+                    "share_qr_keysign_swap" -> ShareQrKeysignSwapPreview()
                     "share_qr_keygen" -> ShareQrKeygenPreview()
                     else -> SwapConfirmPreview()
                 }
@@ -522,6 +523,25 @@ private fun ShareQrKeysignPreview() {
                         QrShareField("Vault", "Honeypot Vault DKLS"),
                         QrShareField("Amount", "100 USDC", usdcIcon),
                         QrShareField("To", "0xe3F83...6CE1e8b2"),
+                    ),
+            )
+    )
+}
+
+@Composable
+private fun ShareQrKeysignSwapPreview() {
+    val context = LocalContext.current
+    val srcIcon = remember { BitmapFactory.decodeResource(context.resources, R.drawable.usdc) }
+    val dstIcon = remember { BitmapFactory.decodeResource(context.resources, R.drawable.bitcoin) }
+    ShareQrPreview(
+        info =
+            QrShareInfo(
+                title = "Join Keysign Swap",
+                fields =
+                    listOf(
+                        QrShareField("Vault", "Honeypot Vault DKLS"),
+                        QrShareField("From", "100 USDC", srcIcon),
+                        QrShareField("To", "0.0012 BTC", dstIcon),
                     ),
             )
     )

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -1,25 +1,39 @@
 package com.vultisig.wallet.debug
 
+import android.graphics.BitmapFactory
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
+import com.vultisig.wallet.data.usecases.GenerateQrBitmap
+import com.vultisig.wallet.data.usecases.MakeQrCodeBitmapShareFormat
+import com.vultisig.wallet.data.usecases.QrShareField
+import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
@@ -54,7 +68,20 @@ import com.vultisig.wallet.ui.screens.v2.home.components.TransactionTypeButton
 import com.vultisig.wallet.ui.screens.v2.home.pager.banner.UpgradeBanner
 import com.vultisig.wallet.ui.screens.v2.home.pager.container.HomePagePagerContainer
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
+import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ShareQrPreviewEntryPoint {
+    fun generateQrBitmap(): GenerateQrBitmap
+
+    fun makeQrCodeBitmapShareFormat(): MakeQrCodeBitmapShareFormat
+}
 
 class PreviewActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -82,6 +109,8 @@ class PreviewActivity : ComponentActivity() {
                     "swap_error" -> SwapErrorPreview()
                     "import_seedphrase" -> ImportSeedphrasePreview()
                     "defi_account_list" -> DeFiAccountListPreview()
+                    "share_qr_keysign" -> ShareQrKeysignPreview()
+                    "share_qr_keygen" -> ShareQrKeygenPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -479,3 +508,71 @@ private fun deFiAccount(
         fiatAmount = fiat,
         assetsSize = assets,
     )
+
+@Composable
+private fun ShareQrKeysignPreview() {
+    val context = LocalContext.current
+    val usdcIcon = remember { BitmapFactory.decodeResource(context.resources, R.drawable.usdc) }
+    ShareQrPreview(
+        info =
+            QrShareInfo(
+                title = "Join Keysign",
+                fields =
+                    listOf(
+                        QrShareField("Vault", "Honeypot Vault DKLS"),
+                        QrShareField("Amount", "100 USDC", usdcIcon),
+                        QrShareField("To", "0xe3F83...6CE1e8b2"),
+                    ),
+            )
+    )
+}
+
+@Composable
+private fun ShareQrKeygenPreview() {
+    ShareQrPreview(
+        info =
+            QrShareInfo(
+                title = "Join Keygen",
+                fields =
+                    listOf(
+                        QrShareField("Vault", "Honeypot Vault DKLS"),
+                        QrShareField("Type", "Fast Vault"),
+                    ),
+            )
+    )
+}
+
+@Composable
+private fun ShareQrPreview(info: QrShareInfo) {
+    val context = LocalContext.current
+    val bgColor = Theme.v2.colors.backgrounds.primary
+    val bitmap =
+        remember(info) {
+            val entry =
+                EntryPointAccessors.fromApplication(
+                    context.applicationContext,
+                    ShareQrPreviewEntryPoint::class.java,
+                )
+            val qr =
+                entry
+                    .generateQrBitmap()
+                    .invoke(
+                        "vultisig://preview/${info.title.replace(" ", "_")}",
+                        Color.White,
+                        Color.Transparent,
+                        null,
+                    )
+            val logo = BitmapFactory.decodeResource(context.resources, R.drawable.ic_share_qr_logo)
+            entry.makeQrCodeBitmapShareFormat().invoke(context, qr, bgColor.toArgb(), logo, info)
+        }
+    Box(
+        modifier = Modifier.fillMaxSize().background(bgColor).padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/models/CoinLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/CoinLogo.kt
@@ -143,3 +143,8 @@ internal fun getCoinLogo(logoName: String): ImageModel {
         else -> logoName
     }
 }
+
+// Returns a drawable resource id for the coin's logo. Falls back to the chain's native logo when
+// the coin's `logo` string is not in the predefined mapping (e.g. for arbitrary ERC20s where
+// `logo` would otherwise be a URL).
+internal fun Coin.tokenLogoRes(): Int = (getCoinLogo(logo) as? Int) ?: chain.logo

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/CreateQrCodeSharingBitmapUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/CreateQrCodeSharingBitmapUseCase.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.data.usecases
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.toArgb
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.theme.v2.V2.colors
@@ -11,28 +10,24 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 fun interface CreateQrCodeSharingBitmapUseCase {
-    operator fun invoke(qr: Bitmap, @StringRes title: Int, @StringRes description: Int?): Bitmap
+    operator fun invoke(qr: Bitmap, info: QrShareInfo): Bitmap
 }
 
 internal class CreateQrCodeSharingBitmapUseCaseImpl
 @Inject
 constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val makeQrCodeBitmapShareFormat: MakeQrCodeBitmapShareFormat,
 ) : CreateQrCodeSharingBitmapUseCase {
-    override fun invoke(qr: Bitmap, title: Int, description: Int?): Bitmap {
-        val titleString = context.getString(title)
-        val descriptionString = description?.let { context.getString(it) }
-
-        val logo = BitmapFactory.decodeResource(context.resources, R.drawable.ic_share_qr_logo)
+    override fun invoke(qr: Bitmap, info: QrShareInfo): Bitmap {
+        val logo = BitmapFactory.decodeResource(context.resources, R.drawable.logo)
 
         return makeQrCodeBitmapShareFormat(
             context,
             qr,
             colors.backgrounds.primary.toArgb(),
             logo,
-            titleString,
-            descriptionString,
+            info,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/CreateQrCodeSharingBitmapUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/CreateQrCodeSharingBitmapUseCase.kt
@@ -19,15 +19,12 @@ constructor(
     @param:ApplicationContext private val context: Context,
     private val makeQrCodeBitmapShareFormat: MakeQrCodeBitmapShareFormat,
 ) : CreateQrCodeSharingBitmapUseCase {
-    override fun invoke(qr: Bitmap, info: QrShareInfo): Bitmap {
-        val logo = BitmapFactory.decodeResource(context.resources, R.drawable.logo)
 
-        return makeQrCodeBitmapShareFormat(
-            context,
-            qr,
-            colors.backgrounds.primary.toArgb(),
-            logo,
-            info,
-        )
+    // R.drawable.logo never changes; decode once and reuse across shares.
+    private val logo: Bitmap by lazy {
+        BitmapFactory.decodeResource(context.resources, R.drawable.logo)
     }
+
+    override fun invoke(qr: Bitmap, info: QrShareInfo): Bitmap =
+        makeQrCodeBitmapShareFormat(context, qr, colors.backgrounds.primary.toArgb(), logo, info)
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.lifecycle.SavedStateHandle
@@ -32,7 +33,9 @@ import com.vultisig.wallet.data.models.TransactionHistoryData
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.isSecureVault
+import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.proto.v1.KeysignMessageProto
@@ -118,6 +121,8 @@ data class KeysignFlowUiState(
     val isLoading: Boolean = false,
     val enableNotification: Boolean = false,
     val resendCooldownSeconds: Int = 0,
+    @param:DrawableRes val srcTokenLogoRes: Int? = null,
+    @param:DrawableRes val dstTokenLogoRes: Int? = null,
 )
 
 @HiltViewModel
@@ -307,12 +312,20 @@ constructor(
                     }
                 }
 
+            val srcLogoModel =
+                keysignPayload?.coin?.let { (getCoinLogo(it.logo) as? Int) ?: it.chain.logo }
+            val dstLogoModel =
+                keysignPayload?.swapPayload?.dstToken?.let {
+                    (getCoinLogo(it.logo) as? Int) ?: it.chain.logo
+                }
             uiState.update {
                 it.copy(
                     vault = vault,
                     isSwap = shareViewModel.keysignPayload?.swapPayload != null,
                     toAddress = keysignPayload?.toAddress ?: "",
                     enableNotification = vault.isSecureVault(),
+                    srcTokenLogoRes = srcLogoModel,
+                    dstTokenLogoRes = dstLogoModel,
                 )
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -33,12 +33,11 @@ import com.vultisig.wallet.data.models.TransactionHistoryData
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.isSecureVault
-import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.proto.v1.KeysignMessageProto
+import com.vultisig.wallet.data.models.tokenLogoRes
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
@@ -312,12 +311,8 @@ constructor(
                     }
                 }
 
-            val srcLogoModel =
-                keysignPayload?.coin?.let { (getCoinLogo(it.logo) as? Int) ?: it.chain.logo }
-            val dstLogoModel =
-                keysignPayload?.swapPayload?.dstToken?.let {
-                    (getCoinLogo(it.logo) as? Int) ?: it.chain.logo
-                }
+            val srcLogoModel = keysignPayload?.coin?.tokenLogoRes()
+            val dstLogoModel = keysignPayload?.swapPayload?.dstToken?.tokenLogoRes()
             uiState.update {
                 it.copy(
                     vault = vault,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -35,6 +35,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import vultisig.keysign.v1.CustomMessagePayload
@@ -224,10 +225,20 @@ constructor(
         saveShareQrBitmapJob =
             viewModelScope.launch {
                 val bitmap = qrBitmap ?: return@launch
+                // Allocation happens on IO; if cancellation races with the render, `withContext`'s
+                // prompt-cancellation guarantee discards the returned bitmap before we can recycle
+                // it. Recycle in-place and return null so the native memory is released instead of
+                // waiting for GC.
                 val rendered =
                     withContext(Dispatchers.IO) {
-                        makeQrCodeBitmapShareFormat(context, bitmap, color, logo, info)
-                    }
+                        val bmp = makeQrCodeBitmapShareFormat(context, bitmap, color, logo, info)
+                        if (!isActive) {
+                            bmp.recycle()
+                            null
+                        } else {
+                            bmp
+                        }
+                    } ?: return@launch
                 val previous = shareQrBitmap.value
                 shareQrBitmap.value = rendered
                 if (previous != null && previous !== rendered) previous.recycle()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -33,6 +33,7 @@ import com.vultisig.wallet.ui.utils.shareFileName
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -64,6 +65,7 @@ constructor(
     val qrBitmapPainter = MutableStateFlow<BitmapPainter?>(null)
     private var qrBitmap: Bitmap? = null
     private val shareQrBitmap = MutableStateFlow<Bitmap?>(null)
+    private var saveShareQrBitmapJob: Job? = null
 
     suspend fun loadTransaction(transactionId: TransactionId) {
         val transaction = transactionRepository.getTransaction(transactionId)
@@ -214,13 +216,21 @@ constructor(
         activity.share(qrBitmap, shareFileName(requireNotNull(vault), ShareType.SEND))
     }
 
-    internal fun saveShareQrBitmap(context: Context, color: Int, info: QrShareInfo, logo: Bitmap) =
-        viewModelScope.launch {
-            val bitmap = qrBitmap ?: return@launch
-            val qrBitmap =
-                withContext(Dispatchers.IO) {
-                    makeQrCodeBitmapShareFormat(context, bitmap, color, logo, info)
-                }
-            shareQrBitmap.value = qrBitmap
-        }
+    internal fun saveShareQrBitmap(context: Context, color: Int, info: QrShareInfo, logo: Bitmap) {
+        // Cancel any in-flight render so rapid `qrShareInfo` updates (painter then icons) can't
+        // race and let a stale bitmap overwrite a fresher one. The previous rendered bitmap is
+        // recycled on replacement to avoid leaks when icons/amounts change repeatedly.
+        saveShareQrBitmapJob?.cancel()
+        saveShareQrBitmapJob =
+            viewModelScope.launch {
+                val bitmap = qrBitmap ?: return@launch
+                val rendered =
+                    withContext(Dispatchers.IO) {
+                        makeQrCodeBitmapShareFormat(context, bitmap, color, logo, info)
+                    }
+                val previous = shareQrBitmap.value
+                shareQrBitmap.value = rendered
+                if (previous != null && previous !== rendered) previous.recycle()
+            }
+    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.MakeQrCodeBitmapShareFormat
+import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.utils.ShareType
 import com.vultisig.wallet.ui.utils.share
@@ -213,18 +214,12 @@ constructor(
         activity.share(qrBitmap, shareFileName(requireNotNull(vault), ShareType.SEND))
     }
 
-    internal fun saveShareQrBitmap(
-        context: Context,
-        color: Int,
-        title: String,
-        description: String,
-        logo: Bitmap,
-    ) =
+    internal fun saveShareQrBitmap(context: Context, color: Int, info: QrShareInfo, logo: Bitmap) =
         viewModelScope.launch {
             val bitmap = qrBitmap ?: return@launch
             val qrBitmap =
                 withContext(Dispatchers.IO) {
-                    makeQrCodeBitmapShareFormat(context, bitmap, color, logo, title, description)
+                    makeQrCodeBitmapShareFormat(context, bitmap, color, logo, info)
                 }
             shareQrBitmap.value = qrBitmap
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -207,8 +207,15 @@ constructor(
     fun shareQr(activity: Context) {
         val qr = qrBitmap.value ?: return
 
+        // Mirror loadData()'s fast/secure predicate: active-vault migrate (signers > 2) goes
+        // through peer discovery even when email+password are present, so the share card must
+        // not advertise "Fast Vault" for it.
+        val isFastVault =
+            !email.isNullOrBlank() &&
+                !password.isNullOrBlank() &&
+                !(args?.action == TssAction.Migrate && signers.size > 2)
         val typeRes =
-            if (email != null) R.string.qr_share_type_fast_vault
+            if (isFastVault) R.string.qr_share_type_fast_vault
             else R.string.qr_share_type_secure_vault
         val info =
             QrShareInfo(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.core.graphics.scale
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -208,15 +207,6 @@ constructor(
     fun shareQr(activity: Context) {
         val qr = qrBitmap.value ?: return
 
-        val scaleModifier = 4
-
-        val scaledQr =
-            qr.scale(
-                width = qr.width * scaleModifier,
-                height = qr.height * scaleModifier,
-                filter = false,
-            )
-
         val typeRes =
             if (email != null) R.string.qr_share_type_fast_vault
             else R.string.qr_share_type_secure_vault
@@ -236,7 +226,7 @@ constructor(
                     ),
             )
 
-        val shareBitmap = createQrCodeSharingBitmap(scaledQr, info)
+        val shareBitmap = createQrCodeSharingBitmap(qr, info)
 
         activity.share(shareBitmap, shareFileName(vaultName, vaultName.sha256(), ShareType.KEYGEN))
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -48,6 +48,8 @@ import com.vultisig.wallet.data.usecases.ExtractMasterKeysUseCase
 import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.GenerateServerPartyId
 import com.vultisig.wallet.data.usecases.GenerateServiceName
+import com.vultisig.wallet.data.usecases.QrShareField
+import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -61,6 +63,7 @@ import com.vultisig.wallet.ui.utils.NetworkUtils
 import com.vultisig.wallet.ui.utils.ShareType
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.forCanvasMinify
 import com.vultisig.wallet.ui.utils.share
 import com.vultisig.wallet.ui.utils.shareFileName
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -214,12 +217,26 @@ constructor(
                 filter = false,
             )
 
-        val shareBitmap =
-            createQrCodeSharingBitmap(
-                scaledQr,
-                R.string.qr_title_join_keygen,
-                R.string.qr_title_join_keygen_description,
+        val typeRes =
+            if (email != null) R.string.qr_share_type_fast_vault
+            else R.string.qr_share_type_secure_vault
+        val info =
+            QrShareInfo(
+                title = context.getString(R.string.qr_title_join_keygen),
+                fields =
+                    listOf(
+                        QrShareField(
+                            context.getString(R.string.qr_share_label_vault),
+                            vaultName.forCanvasMinify(),
+                        ),
+                        QrShareField(
+                            context.getString(R.string.qr_share_label_type),
+                            context.getString(typeRes),
+                        ),
+                    ),
             )
+
+        val shareBitmap = createQrCodeSharingBitmap(scaledQr, info)
 
         activity.share(shareBitmap, shareFileName(vaultName, vaultName.sha256(), ShareType.KEYGEN))
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
@@ -73,13 +73,16 @@ internal fun KeysignPeerDiscovery(
         remember(uiModel.srcTokenLogoRes) {
             uiModel.srcTokenLogoRes?.let { BitmapFactory.decodeResource(context.resources, it) }
         }
+    DisposableEffect(srcIconBitmap) { onDispose { srcIconBitmap?.recycle() } }
     val dstIconBitmap =
         remember(uiModel.dstTokenLogoRes) {
             uiModel.dstTokenLogoRes?.let { BitmapFactory.decodeResource(context.resources, it) }
         }
+    DisposableEffect(dstIconBitmap) { onDispose { dstIconBitmap?.recycle() } }
     val vultisigLogoBitmap = remember {
         BitmapFactory.decodeResource(context.resources, R.drawable.logo)
     }
+    DisposableEffect(vultisigLogoBitmap) { onDispose { vultisigLogoBitmap.recycle() } }
     val qrShareInfo =
         QrShareInfo(
             title = qrShareTitle,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
@@ -19,6 +20,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.app.activity.MainActivity
 import com.vultisig.wallet.data.common.Utils
+import com.vultisig.wallet.data.usecases.QrShareField
+import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.models.keysign.KeysignFlowState
 import com.vultisig.wallet.ui.models.keysign.KeysignFlowViewModel
@@ -62,21 +65,38 @@ internal fun KeysignPeerDiscovery(
     val qrShareBackground = Theme.v2.colors.backgrounds.primary
 
     val vault = uiModel.vault
-    val qrShareDescription =
-        if (isSwap)
-            stringResource(
-                R.string.qr_title_join_keysign_swap_description,
-                vault.name.forCanvasMinify(),
-                uiModel.amount.forCanvasMinify(),
-                uiModel.toAmount.forCanvasMinify(),
-            )
-        else
-            stringResource(
-                R.string.qr_title_join_keysign_description,
-                vault.name.forCanvasMinify(),
-                uiModel.amount.forCanvasMinify(),
-                uiModel.toAddress.forCanvasMinify(),
-            )
+    val labelVault = stringResource(R.string.qr_share_label_vault)
+    val labelAmount = stringResource(R.string.qr_share_label_amount)
+    val labelTo = stringResource(R.string.qr_share_label_to)
+    val labelFrom = stringResource(R.string.qr_share_label_from)
+    val srcIconBitmap =
+        remember(uiModel.srcTokenLogoRes) {
+            uiModel.srcTokenLogoRes?.let { BitmapFactory.decodeResource(context.resources, it) }
+        }
+    val dstIconBitmap =
+        remember(uiModel.dstTokenLogoRes) {
+            uiModel.dstTokenLogoRes?.let { BitmapFactory.decodeResource(context.resources, it) }
+        }
+    val vultisigLogoBitmap = remember {
+        BitmapFactory.decodeResource(context.resources, R.drawable.logo)
+    }
+    val qrShareInfo =
+        QrShareInfo(
+            title = qrShareTitle,
+            fields =
+                if (isSwap)
+                    listOf(
+                        QrShareField(labelVault, vault.name.forCanvasMinify()),
+                        QrShareField(labelFrom, uiModel.amount.forCanvasMinify(), srcIconBitmap),
+                        QrShareField(labelTo, uiModel.toAmount.forCanvasMinify(), dstIconBitmap),
+                    )
+                else
+                    listOf(
+                        QrShareField(labelVault, vault.name.forCanvasMinify()),
+                        QrShareField(labelAmount, uiModel.amount.forCanvasMinify(), srcIconBitmap),
+                        QrShareField(labelTo, uiModel.toAddress.forCanvasMinify()),
+                    ),
+        )
 
     LaunchedEffect(key1 = viewModel.participants) {
         viewModel.participants.collect { newList ->
@@ -108,13 +128,12 @@ internal fun KeysignPeerDiscovery(
 
     DisposableEffect(Unit) { onDispose { viewModel.stopParticipantDiscovery() } }
 
-    LaunchedEffect(uiModel.qrBitmapPainter) {
+    LaunchedEffect(uiModel.qrBitmapPainter, qrShareInfo) {
         sharedViewModel.saveShareQrBitmap(
             context,
             qrShareBackground.toArgb(),
-            qrShareTitle,
-            qrShareDescription,
-            BitmapFactory.decodeResource(context.resources, R.drawable.ic_share_qr_logo),
+            qrShareInfo,
+            vultisigLogoBitmap,
         )
     }
     val isLookingForVultiServer =

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -296,7 +296,7 @@
     <string name="qr_title_join_keysign_swap_description">Tresor: %1$s\n Von: %2$s\n An: %3$s</string>
     <string name="qr_share_label_vault">Tresor</string>
     <string name="qr_share_label_amount">Menge</string>
-    <string name="qr_share_label_to">An</string>
+    <string name="qr_share_label_to">Zu</string>
     <string name="qr_share_label_from">Von</string>
     <string name="qr_share_label_type">Typ</string>
     <string name="qr_share_type_fast_vault">Schneller Tresor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -294,6 +294,13 @@
     <string name="qr_title_join_keygen_description">Mit Geräten scannen, um der \nVault-Generation beizutreten</string>
     <string name="qr_title_join_keysign_description">Tresor: %1$s\nVon: %2$s\n Bis: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Tresor: %1$s\n Von: %2$s\n An: %3$s</string>
+    <string name="qr_share_label_vault">Tresor</string>
+    <string name="qr_share_label_amount">Menge</string>
+    <string name="qr_share_label_to">An</string>
+    <string name="qr_share_label_from">Von</string>
+    <string name="qr_share_label_type">Typ</string>
+    <string name="qr_share_type_fast_vault">Schneller Tresor</string>
+    <string name="qr_share_type_secure_vault">Sicherer Tresor</string>
     <string name="error_folder_must_have_at_least_one_vault">Für den Ordner ist mindestens ein ausgewählter Tresor erforderlich</string>
     <string name="import_file_password_hint_text">Hinweis: %s</string>
     <string name="scan_qr_upload_qr_code">QR-Code hochladen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -294,6 +294,13 @@
     <string name="qr_title_join_keygen_description">Escanear con dispositivos para unirse a la\n generación de bóveda</string>
     <string name="qr_title_join_keysign_description">Bóveda: %1$s\nCantidad: %2$s\n Para: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Bóveda: %1$s\n Desde: %2$s\n Hasta: %3$s</string>
+    <string name="qr_share_label_vault">Bóveda</string>
+    <string name="qr_share_label_amount">Cantidad</string>
+    <string name="qr_share_label_to">Para</string>
+    <string name="qr_share_label_from">Desde</string>
+    <string name="qr_share_label_type">Tipo</string>
+    <string name="qr_share_type_fast_vault">Bóveda rápida</string>
+    <string name="qr_share_type_secure_vault">Bóveda segura</string>
     <string name="error_folder_must_have_at_least_one_vault">La carpeta necesita al menos una bóveda seleccionada</string>
     <string name="import_file_password_hint_text">Pista: %s</string>
     <string name="scan_qr_upload_qr_code">Subir código QR</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -294,6 +294,13 @@
     <string name="qr_title_join_keygen_description">Skenirajte s uređajima da biste se pridružili \n generacija trezora</string>
     <string name="qr_title_join_keysign_description">Trezor: %1$s\nIznos: %2$s\n Za: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Trezor: %1$s\nOd: %2$s\n Do: %3$s</string>
+    <string name="qr_share_label_vault">Trezor</string>
+    <string name="qr_share_label_amount">Iznos</string>
+    <string name="qr_share_label_to">Za</string>
+    <string name="qr_share_label_from">Od</string>
+    <string name="qr_share_label_type">Vrsta</string>
+    <string name="qr_share_type_fast_vault">Brzi trezor</string>
+    <string name="qr_share_type_secure_vault">Sigurni trezor</string>
     <string name="error_folder_must_have_at_least_one_vault">Za mapu je potreban barem jedan odabrani trezor</string>
     <string name="import_file_password_hint_text">Savjet: %s</string>
     <string name="scan_qr_upload_qr_code">Učitaj QR kod</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -294,6 +294,13 @@
     <string name="qr_title_join_keygen_description">Esegui la scansione con i dispositivi per partecipare alla\n generazione del vault</string>
     <string name="qr_title_join_keysign_description">Cassaforte: %1$s\n Importo: %2$s\n A: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Cassaforte: %1$s\n Da: %2$s\n A: %3$s</string>
+    <string name="qr_share_label_vault">Cassaforte</string>
+    <string name="qr_share_label_amount">Importo</string>
+    <string name="qr_share_label_to">A</string>
+    <string name="qr_share_label_from">Da</string>
+    <string name="qr_share_label_type">Tipo</string>
+    <string name="qr_share_type_fast_vault">Cassaforte rapida</string>
+    <string name="qr_share_type_secure_vault">Cassaforte sicura</string>
     <string name="error_folder_must_have_at_least_one_vault">La cartella necessita di almeno un vault selezionato</string>
     <string name="import_file_password_hint_text">Suggerimento: %s</string>
     <string name="scan_qr_upload_qr_code">Carica codice QR</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -383,6 +383,13 @@
     <string name="qr_title_join_keygen_description">기기로 스캔하여\n볼트 생성에 참여하세요</string>
     <string name="qr_title_join_keysign_description">볼트: %1$s\n금액: %2$s\n 수신: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">볼트: %1$s\n보내기: %2$s\n 받기: %3$s</string>
+    <string name="qr_share_label_vault">볼트</string>
+    <string name="qr_share_label_amount">금액</string>
+    <string name="qr_share_label_to">수신</string>
+    <string name="qr_share_label_from">보내기</string>
+    <string name="qr_share_label_type">유형</string>
+    <string name="qr_share_type_fast_vault">빠른 볼트</string>
+    <string name="qr_share_type_secure_vault">보안 볼트</string>
     <string name="error_folder_must_have_at_least_one_vault">폴더에는 최소 하나의 볼트가 선택되어야 합니다</string>
     <string name="import_file_password_hint_text">힌트: %s</string>
     <string name="scan_qr_upload_qr_code">QR 코드 업로드</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -385,8 +385,8 @@
     <string name="qr_title_join_keysign_swap_description">볼트: %1$s\n보내기: %2$s\n 받기: %3$s</string>
     <string name="qr_share_label_vault">볼트</string>
     <string name="qr_share_label_amount">금액</string>
-    <string name="qr_share_label_to">수신</string>
-    <string name="qr_share_label_from">보내기</string>
+    <string name="qr_share_label_to">받는</string>
+    <string name="qr_share_label_from">보내는</string>
     <string name="qr_share_label_type">유형</string>
     <string name="qr_share_type_fast_vault">빠른 볼트</string>
     <string name="qr_share_type_secure_vault">보안 볼트</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -293,6 +293,13 @@
     <string name="qr_title_join_keygen_description">Scannen met apparaten om deel te nemen\n aan de kluisgeneratie</string>
     <string name="qr_title_join_keysign_description">Kluis: %1$s\nBedrag: %2$s\nAan: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Kluis: %1$s\nVan: %2$s\nAan: %3$s</string>
+    <string name="qr_share_label_vault">Kluis</string>
+    <string name="qr_share_label_amount">Bedrag</string>
+    <string name="qr_share_label_to">Aan</string>
+    <string name="qr_share_label_from">Van</string>
+    <string name="qr_share_label_type">Type</string>
+    <string name="qr_share_type_fast_vault">Snelle kluis</string>
+    <string name="qr_share_type_secure_vault">Beveiligde kluis</string>
     <string name="error_folder_must_have_at_least_one_vault">Map heeft minimaal één geselecteerde kluis nodig</string>
     <string name="import_file_password_hint_text">Hint: %s</string>
     <string name="scan_qr_upload_qr_code">QR-code uploaden</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -294,6 +294,13 @@
     <string name="qr_title_join_keygen_description">Digitalize com dispositivos para participar na geração do cofre</string>
     <string name="qr_title_join_keysign_description">Cofre: %1$s\nValor: %2$s\n Para: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Cofre: %1$s De: %2$s\n Para: %3$s</string>
+    <string name="qr_share_label_vault">Cofre</string>
+    <string name="qr_share_label_amount">Montante</string>
+    <string name="qr_share_label_to">Para</string>
+    <string name="qr_share_label_from">De</string>
+    <string name="qr_share_label_type">Tipo</string>
+    <string name="qr_share_type_fast_vault">Cofre rápido</string>
+    <string name="qr_share_type_secure_vault">Cofre seguro</string>
     <string name="error_folder_must_have_at_least_one_vault">A pasta necessita de pelo menos um cofre selecionado</string>
     <string name="import_file_password_hint_text">Dica: %s</string>
     <string name="scan_qr_upload_qr_code">Enviar código QR</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -293,6 +293,13 @@
     <string name="qr_title_join_keygen_description">Сканируйте с помощью устройств, чтобы\n присоединиться к созданию хранилища</string>
     <string name="qr_title_join_keysign_description">Хранилище: %1$s\nСумма: %2$s\n Кому: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Хранилище: %1$s\nОт: %2$s\nКуда: %3$s</string>
+    <string name="qr_share_label_vault">Хранилище</string>
+    <string name="qr_share_label_amount">Сумма</string>
+    <string name="qr_share_label_to">Кому</string>
+    <string name="qr_share_label_from">От</string>
+    <string name="qr_share_label_type">Тип</string>
+    <string name="qr_share_type_fast_vault">Быстрое хранилище</string>
+    <string name="qr_share_type_secure_vault">Защищённое хранилище</string>
     <string name="error_folder_must_have_at_least_one_vault">Папке необходимо выбрать хотя бы одно хранилище</string>
     <string name="import_file_password_hint_text">Подсказка: %s</string>
     <string name="scan_qr_upload_qr_code">Загрузить QR-код</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -543,6 +543,13 @@
     <string name="qr_title_join_keygen_description">扫描设备以加入\n保险库生成</string>
     <string name="qr_title_join_keysign_description">保险库：%1$s\n金额：%2$s\n至：%3$s</string>
     <string name="qr_title_join_keysign_swap_description">保险库：%1$s\n从：%2$s\n至：%3$s</string>
+    <string name="qr_share_label_vault">保险库</string>
+    <string name="qr_share_label_amount">金额</string>
+    <string name="qr_share_label_to">至</string>
+    <string name="qr_share_label_from">从</string>
+    <string name="qr_share_label_type">类型</string>
+    <string name="qr_share_type_fast_vault">快速保险库</string>
+    <string name="qr_share_type_secure_vault">安全保险库</string>
 
     <!-- Error Folder -->
     <string name="error_folder_must_have_at_least_one_vault">文件夹需要至少一个选定的保险库</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,13 @@
     <string name="qr_title_join_keygen_description">Scan with devices to join the\nvault generation</string>
     <string name="qr_title_join_keysign_description">Vault: %1$s\nAmount: %2$s\n To: %3$s</string>
     <string name="qr_title_join_keysign_swap_description">Vault: %1$s\nFrom: %2$s\n To: %3$s</string>
+    <string name="qr_share_label_vault">Vault</string>
+    <string name="qr_share_label_amount">Amount</string>
+    <string name="qr_share_label_to">To</string>
+    <string name="qr_share_label_from">From</string>
+    <string name="qr_share_label_type">Type</string>
+    <string name="qr_share_type_fast_vault">Fast Vault</string>
+    <string name="qr_share_type_secure_vault">Secure Vault</string>
     <string name="error_folder_must_have_at_least_one_vault">Folder needs at least one selected vault</string>
     <string name="share_vault_qr_uid" translatable="false">UID: %1$s</string>
     <string name="share_vault_qr_address" translatable="false">vultisig.com</string>

--- a/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
@@ -75,4 +75,68 @@ internal class CoinLogoTest {
         val res = coin(logo = "eth", chain = Chain.Ethereum).tokenLogoRes()
         assertEquals(R.drawable.ethereum, res)
     }
+
+    // Multi-alias entries are easy to break by typo — any alias that silently falls through to the
+    // chain logo would be a regression. Pin each known alias to its drawable so renames get caught.
+    @Test
+    fun `tokenLogoRes resolves solana aliases`() {
+        assertEquals(R.drawable.solana, coin(logo = "sol").tokenLogoRes())
+        assertEquals(R.drawable.solana, coin(logo = "solana").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves polygon aliases`() {
+        assertEquals(R.drawable.polygon, coin(logo = "pol").tokenLogoRes())
+        assertEquals(R.drawable.polygon, coin(logo = "matic").tokenLogoRes())
+        assertEquals(R.drawable.polygon, coin(logo = "polygon").tokenLogoRes())
+        assertEquals(R.drawable.polygon, coin(logo = "eth_polygon").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves zksync aliases`() {
+        assertEquals(R.drawable.zksync, coin(logo = "zksync").tokenLogoRes())
+        assertEquals(R.drawable.zksync, coin(logo = "zsync-era").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves wif aliases`() {
+        assertEquals(R.drawable.wif, coin(logo = "wif").tokenLogoRes())
+        assertEquals(R.drawable.wif, coin(logo = "dogwifhat-wif-logo").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves raydium aliases`() {
+        assertEquals(R.drawable.ray, coin(logo = "ray").tokenLogoRes())
+        assertEquals(R.drawable.ray, coin(logo = "raydium-ray-seeklogo-2").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves astro aliases`() {
+        assertEquals(R.drawable.astro, coin(logo = "astro").tokenLogoRes())
+        assertEquals(R.drawable.astro, coin(logo = "terra-astroport").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves levana aliases`() {
+        assertEquals(R.drawable.lvn, coin(logo = "lvn").tokenLogoRes())
+        assertEquals(R.drawable.lvn, coin(logo = "levana").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves fuzion aliases`() {
+        assertEquals(R.drawable.fuzion, coin(logo = "fuzion").tokenLogoRes())
+        assertEquals(R.drawable.fuzion, coin(logo = "fuzn").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves vulti aliases`() {
+        assertEquals(R.drawable.vulti, coin(logo = "vult").tokenLogoRes())
+        assertEquals(R.drawable.vulti, coin(logo = "vulti").tokenLogoRes())
+    }
+
+    @Test
+    fun `tokenLogoRes resolves hyperliquid aliases`() {
+        assertEquals(R.drawable.hyperliquid, coin(logo = "hype").tokenLogoRes())
+        assertEquals(R.drawable.hyperliquid, coin(logo = "whype").tokenLogoRes())
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
@@ -1,0 +1,78 @@
+package com.vultisig.wallet.data.models
+
+import com.vultisig.wallet.R
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class CoinLogoTest {
+
+    private fun coin(logo: String, chain: Chain = Chain.Arbitrum): Coin =
+        Coin(
+            chain = chain,
+            ticker = "TEST",
+            logo = logo,
+            address = "",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `tokenLogoRes returns the predefined drawable when the coin logo is in the mapping`() {
+        // "usdc" is mapped to R.drawable.usdc in getCoinLogo
+        val res = coin(logo = "usdc").tokenLogoRes()
+        assertEquals(R.drawable.usdc, res)
+    }
+
+    @Test
+    fun `tokenLogoRes mapping is case-insensitive`() {
+        // getCoinLogo lowercases the input — uppercase "USDC" should still resolve to
+        // R.drawable.usdc
+        val res = coin(logo = "USDC").tokenLogoRes()
+        assertEquals(R.drawable.usdc, res)
+    }
+
+    @Test
+    fun `tokenLogoRes falls back to chain logo when coin logo is unknown`() {
+        // A URL-style logo (typical for arbitrary ERC20s) is not in the mapping
+        val res =
+            coin(logo = "https://example.com/some-token.png", chain = Chain.Arbitrum).tokenLogoRes()
+        assertEquals(Chain.Arbitrum.logo, res)
+    }
+
+    @Test
+    fun `tokenLogoRes falls back to chain logo when coin logo is empty`() {
+        val res = coin(logo = "", chain = Chain.Ethereum).tokenLogoRes()
+        assertEquals(Chain.Ethereum.logo, res)
+    }
+
+    @Test
+    fun `tokenLogoRes always returns a non-zero drawable id`() {
+        // Sanity check: every supported chain must produce a usable resource id, even when the
+        // coin's logo string is junk.
+        Chain.entries.forEach { chain ->
+            val res = coin(logo = "definitely-not-a-real-logo", chain = chain).tokenLogoRes()
+            assertTrue(res != 0, "Expected non-zero drawable id for chain $chain, got 0")
+        }
+    }
+
+    @Test
+    fun `tokenLogoRes for known token does not equal chain logo when they differ`() {
+        // USDC on Ethereum: token logo (usdc) should differ from chain logo (ethereum)
+        val res = coin(logo = "usdc", chain = Chain.Ethereum).tokenLogoRes()
+        assertEquals(R.drawable.usdc, res)
+        assertNotEquals(Chain.Ethereum.logo, res)
+    }
+
+    @Test
+    fun `tokenLogoRes for native chain token resolves via getCoinLogo not fallback`() {
+        // ETH's logo string is "eth" which getCoinLogo maps to R.drawable.ethereum — same drawable
+        // as Chain.Ethereum.logo, but the path through getCoinLogo is what's exercised here.
+        val res = coin(logo = "eth", chain = Chain.Ethereum).tokenLogoRes()
+        assertEquals(R.drawable.ethereum, res)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
@@ -7,6 +7,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.os.Build
 import android.text.TextPaint
 import android.text.TextUtils
 import androidx.core.content.res.ResourcesCompat
@@ -67,15 +68,28 @@ private fun ellipsizeToWidth(text: String, paint: Paint, maxWidth: Float): Strin
 
 // Resolve the app's Brockmann Medium font from this shared data-module use case. The font lives
 // in the app module's resources, so it is not reachable via R.font here — name lookup is the only
-// option available across modules.
+// option available across modules. `getIdentifier` is the reason for the @SuppressLint.
 @SuppressLint("DiscouragedApi")
 private fun loadBrockmannMedium(context: Context): Typeface {
     val id = context.resources.getIdentifier("brockmann_medium", "font", context.packageName)
-    return id.takeIf { it != 0 }?.let { ResourcesCompat.getFont(context, it) }
-        ?: Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+    val resolved = id.takeIf { it != 0 }?.let { ResourcesCompat.getFont(context, it) }
+    if (resolved != null) return resolved
+    // Brockmann Medium is weight 500; fall back to a matching weight so the share bitmap does not
+    // render noticeably heavier than Figma when the font resource is unavailable.
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        Typeface.create(Typeface.DEFAULT, 500, false)
+    } else {
+        Typeface.DEFAULT
+    }
 }
 
 internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCodeBitmapShareFormat {
+
+    @Volatile private var cachedTypeface: Typeface? = null
+
+    private fun titleTypeface(context: Context): Typeface =
+        cachedTypeface ?: loadBrockmannMedium(context).also { cachedTypeface = it }
+
     override fun invoke(
         context: Context,
         qrCodeBitmap: Bitmap,
@@ -175,7 +189,7 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
         canvas.drawRoundRect(metaCardRect, cardCorner, cardCorner, cardFillPaint)
         canvas.drawRoundRect(metaCardRect, cardCorner, cardCorner, borderPaint)
 
-        val titleTypeface = loadBrockmannMedium(context)
+        val titleTypeface = titleTypeface(context)
         val titlePaint =
             Paint().apply {
                 isAntiAlias = true
@@ -228,7 +242,10 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
             val iconReservation = if (iconPx > 0) iconPx + valueIconToTextGap else 0f
             val ellipsizedLabel = ellipsizeToWidth(field.label, labelPaint, metaContentWidth * 0.5f)
             val labelMeasured = labelPaint.measureText(ellipsizedLabel)
-            val valueMaxWidth = metaContentWidth - labelMeasured - iconReservation
+            // Guard against negatives on narrow cards with wide localized labels + an icon;
+            // otherwise `ellipsizeToWidth` returns "" and the value silently disappears.
+            val valueMaxWidth =
+                (metaContentWidth - labelMeasured - iconReservation).coerceAtLeast(0f)
             val ellipsizedValue = ellipsizeToWidth(field.value, valuePaint, valueMaxWidth)
             canvas.drawText(ellipsizedLabel, metaContentLeft, textBaselineY, labelPaint)
             val valueTextWidth = valuePaint.measureText(ellipsizedValue)
@@ -238,6 +255,7 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
                 val iconLeft = metaContentRight - valueTextWidth - valueIconToTextGap - iconPx
                 val iconTop = rowsCursorY + (fieldLineHeight - iconPx) / 2f
                 canvas.drawBitmap(scaledIcon, iconLeft, iconTop, null)
+                if (scaledIcon !== icon) scaledIcon.recycle()
             }
             canvas.drawText(ellipsizedValue, metaContentRight, textBaselineY, valuePaint)
             rowsCursorY += fieldLineHeight
@@ -259,6 +277,7 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
         val scaledLogo = logo.scale(scaledLogoSize, scaledLogoSize)
         val logoLeft = (finalWidth - scaledLogoSize) / 2f
         canvas.drawBitmap(scaledLogo, logoLeft, signatureTop, null)
+        if (scaledLogo !== logo) scaledLogo.recycle()
 
         val signatureTextPaint =
             Paint().apply {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
@@ -7,6 +7,8 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.text.TextPaint
+import android.text.TextUtils
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
@@ -51,6 +53,13 @@ data class QrShareInfo(val title: String, val fields: List<QrShareField>)
 interface MakeQrCodeBitmapShareFormat : (Context, Bitmap, Int, Bitmap, QrShareInfo) -> Bitmap
 
 private fun Float.dp(context: Context): Float = this * context.resources.displayMetrics.density
+
+private fun ellipsizeToWidth(text: String, paint: Paint, maxWidth: Float): String {
+    if (maxWidth <= 0f) return ""
+    if (paint.measureText(text) <= maxWidth) return text
+    val textPaint = if (paint is TextPaint) paint else TextPaint(paint)
+    return TextUtils.ellipsize(text, textPaint, maxWidth, TextUtils.TruncateAt.END).toString()
+}
 
 // Resolve the app's Brockmann Medium font from this shared data-module use case. The font lives
 // in the app module's resources, so it is not reachable via R.font here — name lookup is the only
@@ -198,8 +207,11 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
         val metaContentLeft = cardLeft + metaPadding
         val metaContentRight = cardRight - metaPadding
 
+        val metaContentWidth = metaContentRight - metaContentLeft
+
         val titleBaselineY = metaCardTop + metaPadding + titleLineHeight * 0.75f
-        canvas.drawText(info.title, metaContentLeft, titleBaselineY, titlePaint)
+        val ellipsizedTitle = ellipsizeToWidth(info.title, titlePaint, metaContentWidth)
+        canvas.drawText(ellipsizedTitle, metaContentLeft, titleBaselineY, titlePaint)
 
         val valueIconSize = VALUE_ICON_SIZE_DP.dp(context)
         val valueIconToTextGap = VALUE_ICON_TO_TEXT_GAP_DP.dp(context)
@@ -207,17 +219,23 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
         var rowsCursorY = metaCardTop + metaPadding + titleLineHeight + titleToFieldsGap
         info.fields.forEachIndexed { index, field ->
             val textBaselineY = rowsCursorY + fieldLineHeight * 0.75f
-            canvas.drawText(field.label, metaContentLeft, textBaselineY, labelPaint)
-            val valueTextWidth = valuePaint.measureText(field.value)
+            val iconPx =
+                if (field.valueIcon != null) valueIconSize.roundToInt().coerceAtLeast(1) else 0
+            val iconReservation = if (iconPx > 0) iconPx + valueIconToTextGap else 0f
+            val ellipsizedLabel = ellipsizeToWidth(field.label, labelPaint, metaContentWidth * 0.5f)
+            val labelMeasured = labelPaint.measureText(ellipsizedLabel)
+            val valueMaxWidth = metaContentWidth - labelMeasured - iconReservation
+            val ellipsizedValue = ellipsizeToWidth(field.value, valuePaint, valueMaxWidth)
+            canvas.drawText(ellipsizedLabel, metaContentLeft, textBaselineY, labelPaint)
+            val valueTextWidth = valuePaint.measureText(ellipsizedValue)
             val icon = field.valueIcon
             if (icon != null) {
-                val iconPx = valueIconSize.roundToInt().coerceAtLeast(1)
                 val scaledIcon = icon.scale(iconPx, iconPx)
                 val iconLeft = metaContentRight - valueTextWidth - valueIconToTextGap - iconPx
                 val iconTop = rowsCursorY + (fieldLineHeight - iconPx) / 2f
                 canvas.drawBitmap(scaledIcon, iconLeft, iconTop, null)
             }
-            canvas.drawText(field.value, metaContentRight, textBaselineY, valuePaint)
+            canvas.drawText(ellipsizedValue, metaContentRight, textBaselineY, valuePaint)
             rowsCursorY += fieldLineHeight
             if (index < info.fields.lastIndex) {
                 rowsCursorY += fieldRowGap

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
@@ -48,7 +48,11 @@ private const val TEXT_TERTIARY_COLOR = 0xFF8295AE.toInt()
 
 data class QrShareField(val label: String, val value: String, val valueIcon: Bitmap? = null)
 
-data class QrShareInfo(val title: String, val fields: List<QrShareField>)
+data class QrShareInfo(val title: String, val fields: List<QrShareField>) {
+    init {
+        require(fields.isNotEmpty()) { "QrShareInfo.fields must not be empty" }
+    }
+}
 
 interface MakeQrCodeBitmapShareFormat : (Context, Bitmap, Int, Bitmap, QrShareInfo) -> Bitmap
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/MakeQrCodeBitmapShareFormat.kt
@@ -1,27 +1,65 @@
 package com.vultisig.wallet.data.usecases
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
-private const val SHARE_QR_CODE_REGULAR_PADDING_WIDTH_SCALE = 0.1f
-private const val SHARE_QR_CODE_REGULAR_TEXT_SIZE_WIDTH_SCALE = 0.06f
-private const val SHARE_QR_CODE_LOGO_SCALE_SCALE = 0.4f
-private const val VULTISIG_ADDRESS = "vultisig.com"
-
-interface MakeQrCodeBitmapShareFormat : (Context, Bitmap, Int, Bitmap, String, String?) -> Bitmap
-
 private const val QR_CODE_MIN_SIZE_DP = 200
 private const val QR_CODE_MAX_SIZE_DP = 400
 
-fun Int.dpToPx(context: Context): Int {
-    return (this * context.resources.displayMetrics.density).roundToInt()
+private const val OUTER_PADDING_DP = 30f
+private const val CARD_CORNER_RADIUS_DP = 24f
+private const val CARD_BORDER_WIDTH_DP = 1f
+private const val QR_CARD_INNER_PADDING_DP = 4f
+private const val BETWEEN_CARDS_GAP_DP = 18f
+
+private const val META_CARD_PADDING_DP = 20f
+private const val META_TITLE_TO_FIELDS_GAP_DP = 28f
+private const val META_FIELD_ROW_GAP_DP = 14f
+private const val META_DIVIDER_HEIGHT_DP = 1f
+private const val META_TITLE_LINE_HEIGHT_DP = 20f
+private const val META_FIELD_LINE_HEIGHT_DP = 16f
+private const val META_TITLE_FONT_SIZE_DP = 14f
+private const val META_FIELD_FONT_SIZE_DP = 12f
+
+private const val SIGNATURE_TOP_GAP_DP = 22f
+private const val SIGNATURE_ICON_SIZE_DP = 33f
+private const val SIGNATURE_ICON_TO_TEXT_GAP_DP = 10f
+private const val SIGNATURE_TEXT_SIZE_DP = 12f
+
+private const val VALUE_ICON_SIZE_DP = 16f
+private const val VALUE_ICON_TO_TEXT_GAP_DP = 4f
+
+private const val CARD_BACKGROUND_COLOR = 0xFF061B3A.toInt()
+private const val BORDER_COLOR = 0xFF11284A.toInt()
+private const val TEXT_PRIMARY_COLOR = 0xFFF0F4FC.toInt()
+private const val TEXT_TERTIARY_COLOR = 0xFF8295AE.toInt()
+
+data class QrShareField(val label: String, val value: String, val valueIcon: Bitmap? = null)
+
+data class QrShareInfo(val title: String, val fields: List<QrShareField>)
+
+interface MakeQrCodeBitmapShareFormat : (Context, Bitmap, Int, Bitmap, QrShareInfo) -> Bitmap
+
+private fun Float.dp(context: Context): Float = this * context.resources.displayMetrics.density
+
+// Resolve the app's Brockmann Medium font from this shared data-module use case. The font lives
+// in the app module's resources, so it is not reachable via R.font here — name lookup is the only
+// option available across modules.
+@SuppressLint("DiscouragedApi")
+private fun loadBrockmannMedium(context: Context): Typeface {
+    val id = context.resources.getIdentifier("brockmann_medium", "font", context.packageName)
+    return id.takeIf { it != 0 }?.let { ResourcesCompat.getFont(context, it) }
+        ?: Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
 }
 
 internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCodeBitmapShareFormat {
@@ -30,90 +68,187 @@ internal class MakeQrCodeBitmapShareFormatImpl @Inject constructor() : MakeQrCod
         qrCodeBitmap: Bitmap,
         color: Int,
         logo: Bitmap,
-        title: String,
-        description: String?,
+        info: QrShareInfo,
     ): Bitmap {
-        // Ensure QR code rendering is independent of screen pixel density.
-        // By using DP for sizing, the QR code maintains a consistent physical
-        // size across devices with varying densities.
-        // This prevents issues where the QR code appears too small on high-density
-        // screens or too large on low-density screens, which could otherwise lead
-        // to scanning difficulties with ML or QR code libraries.
+        val density = context.resources.displayMetrics.density
 
-        val minQrCodePx = QR_CODE_MIN_SIZE_DP.dpToPx(context)
-        val maxQrCodePx = QR_CODE_MAX_SIZE_DP.dpToPx(context)
-
+        val minQrPx = (QR_CODE_MIN_SIZE_DP * density).roundToInt()
+        val maxQrPx = (QR_CODE_MAX_SIZE_DP * density).roundToInt()
         val qrBitmap =
             when {
-                qrCodeBitmap.width < minQrCodePx -> {
-                    qrCodeBitmap.scale(minQrCodePx, minQrCodePx, false)
-                }
-                qrCodeBitmap.width > maxQrCodePx -> {
-                    qrCodeBitmap.scale(maxQrCodePx, maxQrCodePx, false)
-                }
-                else -> {
-                    qrCodeBitmap
-                }
+                qrCodeBitmap.width < minQrPx -> qrCodeBitmap.scale(minQrPx, minQrPx, false)
+                qrCodeBitmap.width > maxQrPx -> qrCodeBitmap.scale(maxQrPx, maxQrPx, false)
+                else -> qrCodeBitmap
             }
 
-        val width = qrBitmap.width
-        val height = qrBitmap.height
-        val config = qrBitmap.config
-        val padding = (width * SHARE_QR_CODE_REGULAR_PADDING_WIDTH_SCALE).toInt()
-        val textSize = width * SHARE_QR_CODE_REGULAR_TEXT_SIZE_WIDTH_SCALE
-        val logoWidth = (width * SHARE_QR_CODE_LOGO_SCALE_SCALE).toInt()
-        val descLines = description?.split("\n")
-        val scaledLogo = logo.scale(logoWidth, logoWidth)
-        val textColor = Color.WHITE
+        val outerPadding = OUTER_PADDING_DP.dp(context)
+        val cardCorner = CARD_CORNER_RADIUS_DP.dp(context)
+        val borderWidth = CARD_BORDER_WIDTH_DP.dp(context)
+        val qrCardInnerPadding = QR_CARD_INNER_PADDING_DP.dp(context)
+        val betweenCardsGap = BETWEEN_CARDS_GAP_DP.dp(context)
+        val metaPadding = META_CARD_PADDING_DP.dp(context)
+        val titleToFieldsGap = META_TITLE_TO_FIELDS_GAP_DP.dp(context)
+        val fieldRowGap = META_FIELD_ROW_GAP_DP.dp(context)
+        val dividerHeight = META_DIVIDER_HEIGHT_DP.dp(context)
+        val titleLineHeight = META_TITLE_LINE_HEIGHT_DP.dp(context)
+        val fieldLineHeight = META_FIELD_LINE_HEIGHT_DP.dp(context)
+        val titleFontSize = META_TITLE_FONT_SIZE_DP.dp(context)
+        val fieldFontSize = META_FIELD_FONT_SIZE_DP.dp(context)
+        val signatureTopGap = SIGNATURE_TOP_GAP_DP.dp(context)
+        val signatureIconSize = SIGNATURE_ICON_SIZE_DP.dp(context)
+        val signatureIconToTextGap = SIGNATURE_ICON_TO_TEXT_GAP_DP.dp(context)
+        val signatureTextSize = SIGNATURE_TEXT_SIZE_DP.dp(context)
 
-        var finalHeight = height + 2 * padding
-        finalHeight += (textSize * 2).toInt()
-        if (!description.isNullOrBlank()) {
-            val descNumberLines = descLines?.size ?: 0
-            finalHeight += (textSize * 3 / 2 * descNumberLines).toInt()
-        }
-        finalHeight += logoWidth + padding
-        finalHeight += (textSize * 2).toInt()
+        val cardOuterWidth = qrBitmap.width.toFloat() + 2 * qrCardInnerPadding
 
-        val finalWidth = width + 2 * padding
-        val bitmap = createBitmap(finalWidth, finalHeight, config ?: Bitmap.Config.ARGB_8888)
+        val rowsCount = info.fields.size
+        val dividersCount = (rowsCount - 1).coerceAtLeast(0)
+        val metaRowsBlockHeight =
+            rowsCount * fieldLineHeight +
+                dividersCount * dividerHeight +
+                (rowsCount + dividersCount - 1).coerceAtLeast(0) * fieldRowGap
+        val metaCardHeight =
+            metaPadding * 2 + titleLineHeight + titleToFieldsGap + metaRowsBlockHeight
 
+        val signatureBlockHeight = signatureIconSize + signatureIconToTextGap + signatureTextSize
+
+        val finalWidth = (cardOuterWidth + outerPadding * 2).roundToInt()
+        val finalHeight =
+            (outerPadding +
+                    cardOuterWidth +
+                    betweenCardsGap +
+                    metaCardHeight +
+                    signatureTopGap +
+                    signatureBlockHeight +
+                    outerPadding)
+                .roundToInt()
+
+        val bitmap =
+            createBitmap(finalWidth, finalHeight, qrBitmap.config ?: Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         canvas.drawColor(color)
-        canvas.drawBitmap(qrBitmap, padding.toFloat(), padding.toFloat(), null)
 
-        val paint =
+        val borderPaint =
             Paint().apply {
-                this.textSize = textSize
-                this.color = textColor
-                this.textAlign = Paint.Align.CENTER
-                this.isAntiAlias = true
+                isAntiAlias = true
+                style = Paint.Style.STROKE
+                strokeWidth = borderWidth
+                this.color = BORDER_COLOR
+            }
+        val cardFillPaint =
+            Paint().apply {
+                isAntiAlias = true
+                style = Paint.Style.FILL
+                this.color = CARD_BACKGROUND_COLOR
             }
 
-        canvas.drawText(title, finalWidth / 2f, padding + height + textSize * 3 / 2, paint)
+        val cardLeft = outerPadding
+        val cardRight = cardLeft + cardOuterWidth
 
-        descLines?.forEachIndexed { index, line ->
-            canvas.drawText(
-                line,
-                finalWidth / 2f,
-                padding + height + textSize * 3 + textSize / 2 + index * textSize * 3 / 2,
-                paint,
-            )
-        }
-
+        val qrCardTop = outerPadding
+        val qrCardBottom = qrCardTop + cardOuterWidth
+        val qrCardRect = RectF(cardLeft, qrCardTop, cardRight, qrCardBottom)
+        canvas.drawRoundRect(qrCardRect, cardCorner, cardCorner, borderPaint)
         canvas.drawBitmap(
-            scaledLogo,
-            (finalWidth - logoWidth) / 2f,
-            finalHeight - padding - 2 * textSize - logoWidth,
+            qrBitmap,
+            cardLeft + qrCardInnerPadding,
+            qrCardTop + qrCardInnerPadding,
             null,
         )
 
-        canvas.drawText(
-            VULTISIG_ADDRESS,
-            finalWidth / 2f,
-            finalHeight - padding - textSize / 2,
-            paint,
-        )
+        val metaCardTop = qrCardBottom + betweenCardsGap
+        val metaCardBottom = metaCardTop + metaCardHeight
+        val metaCardRect = RectF(cardLeft, metaCardTop, cardRight, metaCardBottom)
+        canvas.drawRoundRect(metaCardRect, cardCorner, cardCorner, cardFillPaint)
+        canvas.drawRoundRect(metaCardRect, cardCorner, cardCorner, borderPaint)
+
+        val titleTypeface = loadBrockmannMedium(context)
+        val titlePaint =
+            Paint().apply {
+                isAntiAlias = true
+                this.color = TEXT_PRIMARY_COLOR
+                textSize = titleFontSize
+                typeface = titleTypeface
+                textAlign = Paint.Align.LEFT
+            }
+
+        val labelPaint =
+            Paint().apply {
+                isAntiAlias = true
+                this.color = TEXT_TERTIARY_COLOR
+                textSize = fieldFontSize
+                typeface = titleTypeface
+                textAlign = Paint.Align.LEFT
+            }
+        val valuePaint =
+            Paint().apply {
+                isAntiAlias = true
+                this.color = TEXT_PRIMARY_COLOR
+                textSize = fieldFontSize
+                typeface = titleTypeface
+                textAlign = Paint.Align.RIGHT
+            }
+        val dividerPaint =
+            Paint().apply {
+                isAntiAlias = false
+                this.color = BORDER_COLOR
+                strokeWidth = dividerHeight
+            }
+
+        val metaContentLeft = cardLeft + metaPadding
+        val metaContentRight = cardRight - metaPadding
+
+        val titleBaselineY = metaCardTop + metaPadding + titleLineHeight * 0.75f
+        canvas.drawText(info.title, metaContentLeft, titleBaselineY, titlePaint)
+
+        val valueIconSize = VALUE_ICON_SIZE_DP.dp(context)
+        val valueIconToTextGap = VALUE_ICON_TO_TEXT_GAP_DP.dp(context)
+
+        var rowsCursorY = metaCardTop + metaPadding + titleLineHeight + titleToFieldsGap
+        info.fields.forEachIndexed { index, field ->
+            val textBaselineY = rowsCursorY + fieldLineHeight * 0.75f
+            canvas.drawText(field.label, metaContentLeft, textBaselineY, labelPaint)
+            val valueTextWidth = valuePaint.measureText(field.value)
+            val icon = field.valueIcon
+            if (icon != null) {
+                val iconPx = valueIconSize.roundToInt().coerceAtLeast(1)
+                val scaledIcon = icon.scale(iconPx, iconPx)
+                val iconLeft = metaContentRight - valueTextWidth - valueIconToTextGap - iconPx
+                val iconTop = rowsCursorY + (fieldLineHeight - iconPx) / 2f
+                canvas.drawBitmap(scaledIcon, iconLeft, iconTop, null)
+            }
+            canvas.drawText(field.value, metaContentRight, textBaselineY, valuePaint)
+            rowsCursorY += fieldLineHeight
+            if (index < info.fields.lastIndex) {
+                rowsCursorY += fieldRowGap
+                canvas.drawLine(
+                    metaContentLeft,
+                    rowsCursorY + dividerHeight / 2f,
+                    metaContentRight,
+                    rowsCursorY + dividerHeight / 2f,
+                    dividerPaint,
+                )
+                rowsCursorY += dividerHeight + fieldRowGap
+            }
+        }
+
+        val signatureTop = metaCardBottom + signatureTopGap
+        val scaledLogoSize = signatureIconSize.roundToInt().coerceAtLeast(1)
+        val scaledLogo = logo.scale(scaledLogoSize, scaledLogoSize)
+        val logoLeft = (finalWidth - scaledLogoSize) / 2f
+        canvas.drawBitmap(scaledLogo, logoLeft, signatureTop, null)
+
+        val signatureTextPaint =
+            Paint().apply {
+                isAntiAlias = true
+                this.color = TEXT_PRIMARY_COLOR
+                textSize = signatureTextSize
+                typeface = titleTypeface
+                textAlign = Paint.Align.CENTER
+            }
+        val signatureTextBaseline =
+            signatureTop + signatureIconSize + signatureIconToTextGap + signatureTextSize * 0.9f
+        canvas.drawText("Vultisig", finalWidth / 2f, signatureTextBaseline, signatureTextPaint)
 
         return bitmap
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
@@ -78,6 +78,7 @@ internal class QrShareInfoTest {
             )
 
         assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.usecases
 
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 
 /**
@@ -93,6 +94,6 @@ internal class QrShareInfoTest {
     @Test
     fun `QrShareField default valueIcon is null`() {
         val field = QrShareField("Vault", "My Vault")
-        assertEquals(null, field.valueIcon)
+        assertNull(field.valueIcon)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
@@ -1,7 +1,5 @@
 package com.vultisig.wallet.data.usecases
 
-import android.graphics.Bitmap
-import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -13,6 +11,12 @@ import org.junit.jupiter.api.Test
  * structural equality drifts (e.g. someone replaces it with reference equality, or omits a field
  * from `equals`/`hashCode`), the share image will silently stop refreshing when amounts, addresses
  * or token icons change. These tests pin the contract.
+ *
+ * Tests here intentionally avoid `valueIcon` since it is an `android.graphics.Bitmap` and this
+ * source set is JVM-only (no Robolectric or mockable-android-jar). The Bitmap branch of equality is
+ * covered by Kotlin's generated data class `equals`, which delegates to each property's `equals`;
+ * `Bitmap` uses default reference equality, so structural drift would show up as a hashCode/equals
+ * miss on the other fields too.
  */
 internal class QrShareInfoTest {
 
@@ -29,27 +33,6 @@ internal class QrShareInfoTest {
     fun `QrShareField differing only by value is not equal`() {
         val a = QrShareField("Amount", "100 USDC")
         val b = QrShareField("Amount", "200 USDC")
-
-        assertNotEquals(a, b)
-    }
-
-    @Test
-    fun `QrShareField differing only by valueIcon reference is not equal`() {
-        val icon1 = mockk<Bitmap>()
-        val icon2 = mockk<Bitmap>()
-
-        val a = QrShareField("Amount", "100 USDC", icon1)
-        val b = QrShareField("Amount", "100 USDC", icon2)
-
-        // Bitmap uses reference equality, so two different mocks are not equal — this is what
-        // makes the LaunchedEffect re-fire when the decoded token-icon Bitmap arrives.
-        assertNotEquals(a, b)
-    }
-
-    @Test
-    fun `QrShareField with null icon vs non-null icon is not equal`() {
-        val a = QrShareField("Amount", "100 USDC", valueIcon = null)
-        val b = QrShareField("Amount", "100 USDC", valueIcon = mockk<Bitmap>())
 
         assertNotEquals(a, b)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/QrShareInfoTest.kt
@@ -1,0 +1,114 @@
+package com.vultisig.wallet.data.usecases
+
+import android.graphics.Bitmap
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Equality contract for [QrShareInfo] / [QrShareField].
+ *
+ * The Compose `LaunchedEffect` that regenerates the share bitmap is keyed on `QrShareInfo`. If
+ * structural equality drifts (e.g. someone replaces it with reference equality, or omits a field
+ * from `equals`/`hashCode`), the share image will silently stop refreshing when amounts, addresses
+ * or token icons change. These tests pin the contract.
+ */
+internal class QrShareInfoTest {
+
+    @Test
+    fun `QrShareField with same primitive fields is structurally equal`() {
+        val a = QrShareField("Vault", "My Vault")
+        val b = QrShareField("Vault", "My Vault")
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `QrShareField differing only by value is not equal`() {
+        val a = QrShareField("Amount", "100 USDC")
+        val b = QrShareField("Amount", "200 USDC")
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareField differing only by valueIcon reference is not equal`() {
+        val icon1 = mockk<Bitmap>()
+        val icon2 = mockk<Bitmap>()
+
+        val a = QrShareField("Amount", "100 USDC", icon1)
+        val b = QrShareField("Amount", "100 USDC", icon2)
+
+        // Bitmap uses reference equality, so two different mocks are not equal — this is what
+        // makes the LaunchedEffect re-fire when the decoded token-icon Bitmap arrives.
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareField with null icon vs non-null icon is not equal`() {
+        val a = QrShareField("Amount", "100 USDC", valueIcon = null)
+        val b = QrShareField("Amount", "100 USDC", valueIcon = mockk<Bitmap>())
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareInfo equality cascades through fields list`() {
+        val a =
+            QrShareInfo(
+                title = "Join Keysign",
+                fields =
+                    listOf(
+                        QrShareField("Vault", "My Vault"),
+                        QrShareField("Amount", "100 USDC"),
+                        QrShareField("To", "0xabc...def"),
+                    ),
+            )
+        val b =
+            QrShareInfo(
+                title = "Join Keysign",
+                fields =
+                    listOf(
+                        QrShareField("Vault", "My Vault"),
+                        QrShareField("Amount", "100 USDC"),
+                        QrShareField("To", "0xabc...def"),
+                    ),
+            )
+
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareInfo with different field order is not equal`() {
+        val a =
+            QrShareInfo(
+                title = "Join Keysign",
+                fields =
+                    listOf(QrShareField("Vault", "My Vault"), QrShareField("Amount", "100 USDC")),
+            )
+        val b =
+            QrShareInfo(
+                title = "Join Keysign",
+                fields =
+                    listOf(QrShareField("Amount", "100 USDC"), QrShareField("Vault", "My Vault")),
+            )
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareInfo with different titles is not equal`() {
+        val a = QrShareInfo("Join Keysign", listOf(QrShareField("Vault", "My Vault")))
+        val b = QrShareInfo("Join Keygen", listOf(QrShareField("Vault", "My Vault")))
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `QrShareField default valueIcon is null`() {
+        val field = QrShareField("Vault", "My Vault")
+        assertEquals(null, field.valueIcon)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4130.

The exported **Join Keysign** and **Join Keygen** share images now match the current Figma:

- Rounded **QR card** with 1 dp border (`#11284A`) and 24 dp corner radius
- Separate **metadata card** (surface-1 fill `#061B3A`) containing:
  - Title (`Join Keysign` / `Join Keysign Swap` / `Join Keygen`) in Brockmann Medium 14 sp
  - Label/value rows separated by 1 dp dividers
    - **Keysign**: Vault / Amount / To
    - **Keysign swap**: Vault / From / To (both From and To rows render the source/destination token icons)
    - **Keygen**: Vault / Type (Fast Vault or Secure Vault)
- **Vultisig signature** at the bottom: rounded-square logo (`R.drawable.logo`) + Vultisig wordmark
- Source token icon (e.g. USDC `$` mark) rendered before the value in Amount/From/To rows; falls back to the chain logo when the token's logo string isn't in `getCoinLogo`

## Implementation notes

- `MakeQrCodeBitmapShareFormat` interface changed from `(title: String, description: String?)` to structured `QrShareInfo(title, fields: List<QrShareField>)` so call sites can pass real key/value pairs and per-row icons instead of newline-delimited strings.
- New labels (`qr_share_label_vault/amount/to/from/type`) and type strings (`qr_share_type_fast_vault/secure_vault`) added to all 10 locales using each locale's existing terminology (e.g. `Хранилище` for Vault in Russian, `保险库` in zh-rCN).
- Brockmann Medium loaded via `Resources.getIdentifier` (suppressed `DiscouragedApi` lint, justified by cross-module access — the font lives in the app module's resources, the renderer in `data`).
- `BitmapFactory.decodeResource` calls in `KeysignPeerDiscovery` are wrapped in `remember(...)` so they don't re-decode on every recomposition.
- `LaunchedEffect(saveShareQrBitmap)` now keys on `qrShareInfo` as well as `qrBitmapPainter`, so the share image regenerates when amount / address / token icon changes — not only when the QR painter changes.
- Added `share_qr_keysign` and `share_qr_keygen` previews in `PreviewActivity` (debug only) for visual iteration via ADB.

## Test plan

- [ ] Send → Keysign peer discovery → tap Share QR → exported image matches Figma (QR card, metadata card, signature, USDC token icon visible in Amount row)
- [ ] Swap → Keysign peer discovery → exported image shows Vault / From / To with both token icons
- [ ] Sign Message → Keysign peer discovery → exported image still works (no Amount row regression)
- [ ] Keygen (Fast Vault flow) → peer discovery → Share QR → metadata card shows Vault / Type = Fast Vault
- [ ] Keygen (Active / Secure Vault flow) → metadata card shows Vault / Type = Secure Vault
- [ ] Switch device language to each of de/es/hr/it/ko/nl/pt/ru/zh-rCN — labels translate correctly
- [ ] Existing `KeygenPeerDiscoveryViewModelTest` unit test still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced QR share card with structured fields, improved layout and app-branded logo
  * Token icons shown inline; richer metadata for swap and keysign sharing
  * New debug preview screens to view/share QR visuals

* **Refactor**
  * QR sharing APIs consolidated to accept a structured share-info object

* **Localization**
  * Added QR-sharing translations for multiple languages

* **Tests**
  * Added unit tests for QR share models and token-logo resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->