### PR TITLE
fix: send chain.raw not chain.name for FastVault keysign on imported vaults (#4109)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignRequestBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignRequestBuilder.kt
@@ -1,0 +1,36 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.api.models.signer.JoinKeysignRequestJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TssKeyType
+import com.vultisig.wallet.data.models.Vault
+
+/**
+ * Single source of truth for the FastVault `/sign` request shape. The chain field uses [Chain.raw]
+ * (wire string), not [Enum.name] (Kotlin case identifier) — server stores chain pubkeys keyed by
+ * `.raw` at import time and matches case-insensitively at sign time.
+ */
+internal object JoinKeysignRequestBuilder {
+
+    fun build(
+        vault: Vault,
+        chain: Chain?,
+        derivePath: String,
+        sessionId: String,
+        encryptionKeyHex: String,
+        messages: List<String>,
+        password: String,
+        tssKeysignType: TssKeyType,
+    ): JoinKeysignRequestJson =
+        JoinKeysignRequestJson(
+            publicKeyEcdsa = vault.pubKeyECDSA,
+            messages = messages,
+            sessionId = sessionId,
+            hexEncryptionKey = encryptionKeyHex,
+            derivePath = derivePath,
+            isEcdsa = tssKeysignType == TssKeyType.ECDSA,
+            password = password,
+            chain = chain?.raw ?: "",
+            mldsa = tssKeysignType == TssKeyType.MLDSA,
+        )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -617,13 +617,18 @@ constructor(
                     )
                 Timber.tag("KeysignFlowViewModel")
                     .d(
-                        "joinKeysign: chain=${request.chain}, isEcdsa=${request.isEcdsa}, tssKeysignType=$tssKeysignType, messages=${messagesToSign.map { it.take(16) }}"
+                        "joinKeysign: chain=%s, isEcdsa=%s, tssKeysignType=%s, messages=%s",
+                        request.chain,
+                        request.isEcdsa,
+                        tssKeysignType,
+                        messagesToSign.map { it.take(16) },
                     )
                 vultiSignerRepository.joinKeysign(request)
                 Timber.tag("KeysignFlowViewModel").d("joinKeysign: server notified successfully")
             }
         } catch (e: Exception) {
-            Timber.tag("KeysignFlowViewModel").e("startSession: ${e.stackTraceToString()}")
+            Timber.tag("KeysignFlowViewModel").e(e, "startSession failed")
+            moveToState(KeysignFlowState.Error((e.message ?: "Failed to start session").asUiText()))
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -22,7 +22,6 @@ import com.vultisig.wallet.data.api.RouterApi
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.ThorChainApi
-import com.vultisig.wallet.data.api.models.signer.JoinKeysignRequestJson
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
 import com.vultisig.wallet.data.common.Endpoints
 import com.vultisig.wallet.data.common.Endpoints.LOCAL_MEDIATOR_SERVER_URL
@@ -604,26 +603,23 @@ constructor(
                             moveToState(KeysignFlowState.Error("Vault is not set".asUiText()))
                             return
                         }
-                val chain = _keysignPayload?.coin?.chain?.raw ?: ""
-                val isEcdsa = tssKeysignType == TssKeyType.ECDSA
-                Timber.tag("KeysignFlowViewModel")
-                    .d(
-                        "joinKeysign: chain=$chain, isEcdsa=$isEcdsa, tssKeysignType=$tssKeysignType, messages=${messagesToSign.map { it.take(16) }}"
-                    )
-                vultiSignerRepository.joinKeysign(
-                    JoinKeysignRequestJson(
-                        publicKeyEcdsa = vault.pubKeyECDSA,
-                        messages = messagesToSign,
-                        sessionId = sessionID,
-                        hexEncryptionKey = _encryptionKeyHex,
+                val request =
+                    JoinKeysignRequestBuilder.build(
+                        vault = vault,
+                        chain = _keysignPayload?.coin?.chain,
                         derivePath =
                             (_keysignPayload?.coin?.coinType ?: CoinType.ETHEREUM).derivationPath(),
-                        isEcdsa = isEcdsa,
+                        sessionId = sessionID,
+                        encryptionKeyHex = _encryptionKeyHex,
+                        messages = messagesToSign,
                         password = password,
-                        chain = chain,
-                        mldsa = tssKeysignType == TssKeyType.MLDSA,
+                        tssKeysignType = tssKeysignType,
                     )
-                )
+                Timber.tag("KeysignFlowViewModel")
+                    .d(
+                        "joinKeysign: chain=${request.chain}, isEcdsa=${request.isEcdsa}, tssKeysignType=$tssKeysignType, messages=${messagesToSign.map { it.take(16) }}"
+                    )
+                vultiSignerRepository.joinKeysign(request)
                 Timber.tag("KeysignFlowViewModel").d("joinKeysign: server notified successfully")
             }
         } catch (e: Exception) {
@@ -652,17 +648,17 @@ constructor(
                                 return
                             }
                     vultiSignerRepository.joinKeysign(
-                        JoinKeysignRequestJson(
-                            publicKeyEcdsa = vault.pubKeyECDSA,
-                            messages = messagesToSign,
-                            sessionId = sessionID,
-                            hexEncryptionKey = _encryptionKeyHex,
+                        JoinKeysignRequestBuilder.build(
+                            vault = vault,
+                            chain = _keysignPayload?.coin?.chain,
                             derivePath =
                                 (_keysignPayload?.coin?.coinType ?: CoinType.ETHEREUM)
                                     .derivationPath(),
-                            isEcdsa = tssKeysignType == TssKeyType.ECDSA,
+                            sessionId = sessionID,
+                            encryptionKeyHex = _encryptionKeyHex,
+                            messages = messagesToSign,
                             password = password,
-                            chain = _keysignPayload?.coin?.chain?.name ?: "",
+                            tssKeysignType = tssKeysignType,
                         )
                     )
                 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignRequestBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignRequestBuilderTest.kt
@@ -1,0 +1,125 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.api.models.signer.JoinKeysignRequestJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.TssKeyType
+import com.vultisig.wallet.data.models.Vault
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class JoinKeysignRequestBuilderTest {
+
+    private val vault =
+        Vault(id = "v", name = "v", pubKeyECDSA = "04abcdef", localPartyID = "android-123")
+
+    private fun build(
+        chain: Chain?,
+        type: TssKeyType = TssKeyType.ECDSA,
+        derivePath: String = STUB_DERIVE_PATH,
+    ): JoinKeysignRequestJson =
+        JoinKeysignRequestBuilder.build(
+            vault = vault,
+            chain = chain,
+            derivePath = derivePath,
+            sessionId = "sess",
+            encryptionKeyHex = "key",
+            messages = listOf("msg"),
+            password = "pwd",
+            tssKeysignType = type,
+        )
+
+    @Test
+    fun `BscChain wire string is BSC, not BscChain`() {
+        assertEquals("BSC", build(Chain.BscChain).chain)
+    }
+
+    @Test
+    fun `BitcoinCash wire string is Bitcoin-Cash, not BitcoinCash`() {
+        assertEquals("Bitcoin-Cash", build(Chain.BitcoinCash).chain)
+    }
+
+    @Test
+    fun `GaiaChain wire string is Cosmos, not GaiaChain`() {
+        assertEquals("Cosmos", build(Chain.GaiaChain).chain)
+    }
+
+    @Test
+    fun `Ethereum wire string is Ethereum`() {
+        assertEquals("Ethereum", build(Chain.Ethereum).chain)
+    }
+
+    @Test
+    fun `Bitcoin wire string is Bitcoin`() {
+        assertEquals("Bitcoin", build(Chain.Bitcoin).chain)
+    }
+
+    @Test
+    fun `Solana wire string is Solana for EdDSA chain`() {
+        assertEquals("Solana", build(Chain.Solana, TssKeyType.EDDSA).chain)
+    }
+
+    @Test
+    fun `ThorChain wire string is THORChain capitalised`() {
+        assertEquals("THORChain", build(Chain.ThorChain).chain)
+    }
+
+    @Test
+    fun `ECDSA key type sets isEcdsa true and mldsa false`() {
+        val req = build(Chain.Ethereum, TssKeyType.ECDSA)
+        assertTrue(req.isEcdsa)
+        assertFalse(req.mldsa)
+    }
+
+    @Test
+    fun `EDDSA key type sets both isEcdsa and mldsa false`() {
+        val req = build(Chain.Solana, TssKeyType.EDDSA)
+        assertFalse(req.isEcdsa)
+        assertFalse(req.mldsa)
+    }
+
+    @Test
+    fun `MLDSA key type sets mldsa true and isEcdsa false`() {
+        val req = build(Chain.Qbtc, TssKeyType.MLDSA)
+        assertFalse(req.isEcdsa)
+        assertTrue(req.mldsa)
+    }
+
+    @Test
+    fun `request carries vault root pubKeyEcdsa as identifier for server lookup`() {
+        assertEquals("04abcdef", build(Chain.Ethereum).publicKeyEcdsa)
+    }
+
+    @Test
+    fun `null chain yields empty chain string`() {
+        assertEquals("", build(chain = null).chain)
+    }
+
+    @Test
+    fun `derivePath is passed through verbatim`() {
+        assertEquals(STUB_DERIVE_PATH, build(Chain.Ethereum).derivePath)
+    }
+
+    @Test
+    fun `KeyImport vault sign for BSC sends chain BSC matching what was registered at import`() {
+        val keyImportVault = vault.copy(libType = SigningLibType.KeyImport)
+        val req =
+            JoinKeysignRequestBuilder.build(
+                vault = keyImportVault,
+                chain = Chain.BscChain,
+                derivePath = STUB_DERIVE_PATH,
+                sessionId = "s",
+                encryptionKeyHex = "k",
+                messages = listOf("m"),
+                password = "p",
+                tssKeysignType = TssKeyType.ECDSA,
+            )
+        assertEquals("BSC", req.chain)
+    }
+
+    private companion object {
+        const val STUB_DERIVE_PATH = "m/44'/60'/0'/0/0"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/ChainWireFormatTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/ChainWireFormatTest.kt
@@ -1,0 +1,74 @@
+package com.vultisig.wallet.data.models
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [Chain.raw] values that travel on the wire to the FastVault server. Server stores chain
+ * pubkeys keyed by `.raw` at /vault/import time and looks them up via case-insensitive match at
+ * sign time. API request models MUST send `.raw`, not `.name` (the Kotlin enum case identifier).
+ */
+class ChainWireFormatTest {
+
+    @Test
+    fun `BscChain raw is BSC, name is BscChain`() {
+        assertEquals("BSC", Chain.BscChain.raw)
+        assertEquals("BscChain", Chain.BscChain.name)
+    }
+
+    @Test
+    fun `BitcoinCash raw is Bitcoin-Cash with hyphen`() {
+        assertEquals("Bitcoin-Cash", Chain.BitcoinCash.raw)
+        assertEquals("BitcoinCash", Chain.BitcoinCash.name)
+    }
+
+    @Test
+    fun `GaiaChain raw is Cosmos`() {
+        assertEquals("Cosmos", Chain.GaiaChain.raw)
+        assertEquals("GaiaChain", Chain.GaiaChain.name)
+    }
+
+    @Test
+    fun `ThorChain raw is THORChain capitalised`() {
+        assertEquals("THORChain", Chain.ThorChain.raw)
+        assertEquals("ThorChain", Chain.ThorChain.name)
+    }
+
+    @Test
+    fun `Ethereum raw equals Ethereum`() {
+        assertEquals("Ethereum", Chain.Ethereum.raw)
+    }
+
+    @Test
+    fun `Bitcoin raw equals Bitcoin`() {
+        assertEquals("Bitcoin", Chain.Bitcoin.raw)
+    }
+
+    @Test
+    fun `Solana raw equals Solana`() {
+        assertEquals("Solana", Chain.Solana.raw)
+    }
+
+    @Test
+    fun `Polygon raw equals Polygon`() {
+        assertEquals("Polygon", Chain.Polygon.raw)
+    }
+
+    @Test
+    fun `fromRaw round-trips for chains where name differs from raw`() {
+        assertEquals(Chain.ThorChain, Chain.fromRaw("thorchain"))
+        assertEquals(Chain.BscChain, Chain.fromRaw("bsc"))
+        assertEquals(Chain.GaiaChain, Chain.fromRaw("cosmos"))
+    }
+
+    @Test
+    fun `Android raw matches iOS chain name for chains with custom wire string`() {
+        assertEquals("BSC", Chain.BscChain.raw)
+        assertEquals("Bitcoin-Cash", Chain.BitcoinCash.raw)
+        assertEquals("Cosmos", Chain.GaiaChain.raw)
+        assertEquals("THORChain", Chain.ThorChain.raw)
+        assertEquals("MayaChain", Chain.MayaChain.raw)
+        assertEquals("CronosChain", Chain.CronosChain.raw)
+        assertEquals("TerraClassic", Chain.TerraClassic.raw)
+    }
+}


### PR DESCRIPTION
Closes #4109

## Problem
Imported seedphrase Fast Vaults fail to sign on BSC BitcoinCash and Cosmos. Server returns "public key for chain X not found in vault" and the local DKLS ceremony stalls.

At import time we register chains with the FastVault server using `chain.raw` (`BSC` `Cosmos` `Bitcoin-Cash`). At sign time `KeysignFlowViewModel` was sending `chain.name` (the Kotlin enum identifier `BscChain` `GaiaChain` `BitcoinCash`). Server lookup misses for these three chains.

The primary `startSession` path was fixed in #3573 along with the `mldsa` flag. The retry path in `startSessionWithRetry` was missed.

## Fix
Extract `JoinKeysignRequestBuilder` so both call sites build the request the same way. Builder always uses `chain.raw` and the right `mldsa` flag.

## Tests
`ChainWireFormatTest` pins `Chain.raw` per chain. `JoinKeysignRequestBuilderTest` pins the request shape.

## Test plan

Imported seedphrase Fast Vault on Android:
- [ ] Sign on BSC
- [ ] Sign on BitcoinCash
- [ ] Sign on Cosmos
- [ ] Sign on Ethereum
- [ ] Sign on Bitcoin
- [ ] Sign on Solana
- [ ] Sign on THORChain

Multi device co-sign on Android:
- [ ] Two Android devices. Sign on BSC
- [ ] Android plus iOS. Sign on Ethereum

Cross platform vault interop:
- [ ] Vault imported on iOS. Sign on Android
- [ ] Vault imported on extension. Sign on Android

Regression:
- [ ] Native Fast Vault sign on Ethereum and BSC
- [ ] DKLS co-sign vault sign on Ethereum
- [ ] GG20 vault sign on Ethereum
- [ ] QBTC sign on a QBTC vault
- [ ] Migrate GG20 to DKLS then sign

## TypeScript
Same symptom on Windows and the extension is a different bug (derivation group representative). vultisig/vultisig-windows#3779 had a fix that was closed without merging. Asked dev why and will follow up there.