### PR TITLE
fix: render join-device keysign progress full-screen (#4157)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -95,6 +95,17 @@ internal sealed class KeysignState {
     data class KeysignFinished(val transactionStatus: TransactionStatus) : KeysignState()
 
     data class Error(val errorMessage: UiText) : KeysignState()
+
+    val isInProgress: Boolean
+        get() =
+            when (this) {
+                CreatingInstance,
+                KeysignECDSA,
+                KeysignEdDSA,
+                KeysignMLDSA -> true
+                is KeysignFinished,
+                is Error -> false
+            }
 }
 
 internal val KeysignState.progress: Float

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -46,10 +46,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
         viewModel.enableNavigationToHome()
     }
     val state by viewModel.currentState.collectAsState()
-    val isKeysignInProgress =
-        state == Keysign &&
-            keysignState !is KeysignState.KeysignFinished &&
-            keysignState !is KeysignState.Error
+    val isKeysignInProgress = state == Keysign && keysignState.isInProgress
     JoinKeysignScreen(
         isKeySignFinished = keysignState is KeysignState.KeysignFinished,
         onBack = viewModel::navigateToHome,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -46,10 +46,15 @@ internal fun JoinKeysignView(navController: NavHostController) {
         viewModel.enableNavigationToHome()
     }
     val state by viewModel.currentState.collectAsState()
+    val isKeysignInProgress =
+        state == Keysign &&
+            keysignState !is KeysignState.KeysignFinished &&
+            keysignState !is KeysignState.Error
     JoinKeysignScreen(
         isKeySignFinished = keysignState is KeysignState.KeysignFinished,
         onBack = viewModel::navigateToHome,
         isError = state is Error,
+        fullScreen = isKeysignInProgress,
     ) {
         when (state) {
             DiscoveringSessionID,
@@ -141,6 +146,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     onAddToAddressBook = keysignViewModel::navigateToAddressBook,
                     showSaveToAddressBook =
                         keysignViewModel.showSaveToAddressBook.collectAsState().value,
+                    hasBackClick = false,
                 )
             }
 
@@ -185,22 +191,27 @@ internal fun JoinKeysignView(navController: NavHostController) {
 private fun JoinKeysignScreen(
     isKeySignFinished: Boolean,
     isError: Boolean,
+    fullScreen: Boolean = false,
     onBack: () -> Unit = {},
     content: @Composable () -> Unit = {},
 ) {
     BackHandler(onBack = onBack)
-    V2Scaffold(
-        onBackClick = onBack.takeIf { isKeySignFinished.not() && isError.not() },
-        rightIcon = R.drawable.big_close.takeIf { isError },
-        onRightIconClick = onBack.takeIf { isError },
-        title =
-            stringResource(
-                id =
-                    if (isKeySignFinished.not()) R.string.keysign
-                    else R.string.transaction_complete_screen_title
-            ),
-        content = content,
-    )
+    if (fullScreen) {
+        content()
+    } else {
+        V2Scaffold(
+            onBackClick = onBack.takeIf { isKeySignFinished.not() && isError.not() },
+            rightIcon = R.drawable.big_close.takeIf { isError },
+            onRightIconClick = onBack.takeIf { isError },
+            title =
+                stringResource(
+                    id =
+                        if (isKeySignFinished.not()) R.string.keysign
+                        else R.string.transaction_complete_screen_title
+                ),
+            content = content,
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -45,6 +45,7 @@ internal fun KeysignView(
     progressLink: String?,
     transactionTypeUiModel: TransactionTypeUiModel?,
     showToolbar: Boolean = false,
+    hasBackClick: Boolean,
     showSaveToAddressBook: Boolean,
 ) {
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -101,7 +102,7 @@ internal fun KeysignView(
                 KeysignErrorScreen(
                     errorMessage = state.errorMessage,
                     tryAgain = onBack,
-                    onBack = onBack,
+                    onBack = onBack.takeIf { hasBackClick },
                 )
             }
 
@@ -165,5 +166,6 @@ private fun KeysignPreview() {
         onComplete = {},
         onAddToAddressBook = {},
         showSaveToAddressBook = true,
+        hasBackClick = true,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
@@ -109,5 +109,6 @@ private fun Keysign(
         onBack = viewModel::navigateToHome,
         onAddToAddressBook = keysignViewModel::navigateToAddressBook,
         showSaveToAddressBook = keysignViewModel.showSaveToAddressBook.collectAsState().value,
+        hasBackClick = true,
     )
 }


### PR DESCRIPTION
## Summary
- Drop the `V2Scaffold` wrapper on the join device while keysign is in progress so the Rive animation takes the full viewport (matches fastvault behavior). Closes #4157.
- Scaffold still wraps the `KeysignFinished` and `KeysignState.Error` branches (title + back / close button), and every non-Keysign outer state (DiscoveringSessionID, WaitingForKeysignStart, DiscoverService, JoinKeysign verify screens, outer Error).
- Also threads a `hasBackClick` flag into `KeysignView` so the keysign error screen on the join device can suppress its own back button (bundled because the compile path goes through the same call site).

## Implementation
- `JoinKeysignView.kt`: compute `isKeysignInProgress = state == Keysign && keysignState !is KeysignFinished && keysignState !is Error` and pass it as `fullScreen` to `JoinKeysignScreen`.
- `JoinKeysignScreen`: new `fullScreen: Boolean = false` param — when true, render `content()` directly; `BackHandler` stays outside the conditional so the system back button keeps working during the animation.
- `Keysign.kt` / `KeysignScreen.kt`: `KeysignView` gains a `hasBackClick` parameter that gates the error screen's back button.

## Test plan
- [ ] Secure vault pair-sign Send: on join device, verify Rive progress is full-screen (no top bar, no back button).
- [ ] Secure vault pair-sign Swap and Deposit: same check.
- [ ] After successful keysign, confirm the transaction-complete screen on the join device still shows scaffold with "Transaction Complete" title.
- [ ] If keysign errors, confirm the error screen on the join device renders inside scaffold.
- [ ] Fastvault keysign: confirm no regression (was already full-screen on host flow).
- [ ] DiscoveringSessionID / WaitingForKeysignStart / DiscoverService screens still show the "Keysign" scaffold title and back button.
- [ ] Outer error (wrong vault share etc.) still shows scaffold with close (X) icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The signing interface now switches to a true fullscreen mode during active multi-party signing, removing surrounding scaffolding and toolbar for a focused experience.
  * Back-button behavior is now context-aware across the signing flow and error screens, enabling or disabling navigation appropriately to prevent accidental interruptions and clarify retry/back actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->