### PR TITLE
fix: UTXO swap byteFee unit mismatch causing Error_not_enough_utxos (#4164)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculator.kt
@@ -68,7 +68,8 @@ constructor(
 
         val nativeCoin = withContext(Dispatchers.IO) { tokenRepository.getNativeToken(chain.id) }
 
-        var gasFee = TokenValue(value = fee.amount, token = nativeCoin)
+        val gasFee = TokenValue(value = fee.amount, token = nativeCoin)
+        var estimatedTotalFee = gasFee
 
         if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
             val specific =
@@ -93,14 +94,14 @@ constructor(
                     ),
                     memo = null,
                 )
-            gasFee = gasFee.copy(value = (plan ?: return null).fee.toBigInteger())
+            estimatedTotalFee = gasFee.copy(value = (plan ?: return null).fee.toBigInteger())
         }
 
         val estimated =
             gasFeeToEstimatedFee(
                 GasFeeParams(
                     gasLimit = BigInteger.valueOf(1),
-                    gasFee = gasFee,
+                    gasFee = estimatedTotalFee,
                     selectedToken = selectedToken,
                     perUnit = true,
                 )


### PR DESCRIPTION
Fixes #4164

https://blockchair.com/dogecoin/transaction/a4707de26787a940a1f54866debf99fe203660fc56279df3031577ec555a603e

## Summary
- `SwapGasCalculator.calculateGasFee` was reassigning `gasFee` to `plan.fee` (total sats) for UTXO chains. That value propagated into `BlockChainSpecific.UTXO.byteFee` and was handed to WalletCore's signing input as a per-byte rate, inflating the mining fee quote and triggering `Error_not_enough_utxos` at keysign.
- Keep `gasFee` as the per-byte rate (used by `UtxoHelper.setByteFee(...)` for signing). Introduce a local `estimatedTotalFee` that carries `plan.fee` only into `gasFeeToEstimatedFee` for display and the balance-check path.
- Matches the iOS contract documented in `BlockChainSpecific.swift`: *"For UTXO, gas represents the byteFee (sats/byte rate), not the total fee."*

## Test plan
- [ ] Swap DOGE → RUNE on THORChain from a vault with sufficient balance; keysign proceeds without `Error_not_enough_utxos`.
- [ ] Swap BTC → RUNE on THORChain; keysign proceeds successfully.
- [ ] Displayed network fee on the swap screen still matches the planned total fee (not the per-byte rate).
- [ ] Regular BTC send (non-swap) still works and displays the correct fee.
- [ ] Balance-check rejects swaps that would actually exceed balance + fee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate gas fee estimation for swap transactions on UTXO-based chains (non-Cardano). The fee reported to users is now stable while the transaction estimation process computes a separate, clearer estimated total fee so displayed estimates better reflect actual expected costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->