### PR TITLE
test: cover UTXO swap gasFee per-byte rate regression (#4165)

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
@@ -1,0 +1,221 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.model.BasicFee
+import com.vultisig.wallet.data.chains.helpers.UtxoHelper
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.ui.models.send.SendSrc
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wallet.core.jni.proto.Bitcoin
+import wallet.core.jni.proto.Common.SigningError
+
+internal class SwapGasCalculatorTest {
+
+    private lateinit var feeServiceComposite: FeeServiceComposite
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var tokenRepository: TokenRepository
+    private lateinit var blockChainSpecificRepository: BlockChainSpecificRepository
+    private lateinit var gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase
+
+    private lateinit var calculator: SwapGasCalculator
+
+    @BeforeEach
+    fun setUp() {
+        feeServiceComposite = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        tokenRepository = mockk(relaxed = true)
+        blockChainSpecificRepository = mockk(relaxed = true)
+        gasFeeToEstimatedFee = mockk(relaxed = true)
+
+        mockkObject(UtxoHelper.Companion)
+
+        calculator =
+            SwapGasCalculator(
+                feeServiceComposite = feeServiceComposite,
+                vaultRepository = vaultRepository,
+                tokenRepository = tokenRepository,
+                blockChainSpecificRepository = blockChainSpecificRepository,
+                gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(UtxoHelper.Companion)
+    }
+
+    /**
+     * Regression test for #4164: `GasCalculationResult.gasFee` MUST remain the per-byte rate so
+     * WalletCore's `setByteFee(...)` receives sats/byte (not total sats) at signing. The plan's
+     * total fee goes to `estimated` for display only.
+     */
+    @Test
+    fun `utxo swap keeps gasFee as per-byte rate and routes plan fee only into estimated`() =
+        runTest {
+            val byteFeeRate = BigInteger("15") // sats/byte
+            val planTotalFee = 4200L // total sats for the built tx
+            val sendSrc = dogeSendSrc()
+            val nativeDoge = sendSrc.account.token
+
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault()
+            coEvery { feeServiceComposite.calculateFees(any()) } returns BasicFee(byteFeeRate)
+            coEvery { tokenRepository.getNativeToken(Chain.Dogecoin.id) } returns nativeDoge
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    blockChainSpecific = BlockChainSpecific.UTXO(byteFee = byteFeeRate, true),
+                    utxos = emptyList(),
+                )
+
+            val utxoHelper = mockk<UtxoHelper>()
+            every { UtxoHelper.getHelper(any(), any()) } returns utxoHelper
+            every { utxoHelper.getBitcoinTransactionPlan(any()) } returns
+                Bitcoin.TransactionPlan.newBuilder()
+                    .setFee(planTotalFee)
+                    .setError(SigningError.OK)
+                    .build()
+
+            val capturedParams = slot<GasFeeParams>()
+            val estimatedTotal =
+                EstimatedGasFee(
+                    formattedTokenValue = "$planTotalFee DOGE",
+                    formattedFiatValue = "$0.00",
+                    tokenValue =
+                        TokenValue(value = BigInteger.valueOf(planTotalFee), token = nativeDoge),
+                    fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+                )
+            coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns estimatedTotal
+
+            val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+
+            requireNotNull(result)
+            // (1) gasFee stays as per-byte sats/byte — what UtxoHelper.setByteFee(...) expects.
+            assertEquals(byteFeeRate, result.gasFee.value)
+            // (2) The total fee from the plan is what goes into the estimate (for display /
+            // balance check).
+            assertEquals(BigInteger.valueOf(planTotalFee), capturedParams.captured.gasFee.value)
+            assertEquals(estimatedTotal, result.estimated)
+        }
+
+    /**
+     * `getBitcoinTransactionPlan` returning `null` (plan.error != OK) must short-circuit the whole
+     * calculation — otherwise callers see a stale zero estimate while signing would fail later.
+     */
+    @Test
+    fun `utxo swap returns null when bitcoin plan fails`() = runTest {
+        val sendSrc = dogeSendSrc()
+        val nativeDoge = sendSrc.account.token
+
+        coEvery { vaultRepository.get(VAULT_ID) } returns vault()
+        coEvery { feeServiceComposite.calculateFees(any()) } returns BasicFee(BigInteger("10"))
+        coEvery { tokenRepository.getNativeToken(Chain.Dogecoin.id) } returns nativeDoge
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                blockChainSpecific = BlockChainSpecific.UTXO(BigInteger("10"), true),
+                utxos = emptyList(),
+            )
+
+        val utxoHelper = mockk<UtxoHelper>()
+        every { UtxoHelper.getHelper(any(), any()) } returns utxoHelper
+        every { utxoHelper.getBitcoinTransactionPlan(any()) } returns
+            Bitcoin.TransactionPlan.newBuilder()
+                .setFee(0L)
+                .setError(SigningError.Error_not_enough_utxos)
+                .build()
+
+        val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+
+        assertEquals(null, result)
+    }
+
+    companion object {
+        private const val VAULT_ID = "test-vault-id"
+
+        private val DOGE_COIN =
+            Coin(
+                chain = Chain.Dogecoin,
+                ticker = "DOGE",
+                logo = "doge",
+                address = "DOGEaddr",
+                decimal = 8,
+                hexPublicKey = "hex",
+                priceProviderID = "dogecoin",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+
+        private fun vault() =
+            Vault(
+                id = VAULT_ID,
+                name = "test-vault",
+                pubKeyECDSA = "02" + "00".repeat(32),
+                hexChainCode = "11".repeat(32),
+                localPartyID = "local-party",
+            )
+
+        private fun dogeSendSrc(): SendSrc {
+            val account =
+                Account(
+                    token = DOGE_COIN,
+                    tokenValue = TokenValue(BigInteger("500000000"), DOGE_COIN),
+                    fiatValue = null,
+                    price = null,
+                )
+            val address =
+                Address(
+                    chain = Chain.Dogecoin,
+                    address = DOGE_COIN.address,
+                    accounts = listOf(account),
+                )
+            return SendSrc(address, account)
+        }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
@@ -22,19 +22,24 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.ui.models.send.SendSrc
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
+import io.mockk.verify
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import wallet.core.jni.proto.Bitcoin
 import wallet.core.jni.proto.Common.SigningError
 
@@ -74,79 +79,81 @@ internal class SwapGasCalculatorTest {
     }
 
     /**
-     * Regression test for #4164: `GasCalculationResult.gasFee` MUST remain the per-byte rate so
-     * WalletCore's `setByteFee(...)` receives sats/byte (not total sats) at signing. The plan's
-     * total fee goes to `estimated` for display only.
+     * Regression test for #4164: for every UTXO chain that goes through the WalletCore plan path
+     * (i.e. all UTXO chains except Cardano), `GasCalculationResult.gasFee` MUST remain the per-byte
+     * rate so `UtxoHelper.setByteFee(...)` receives sats/byte (not total sats) at signing. The
+     * plan's total fee is routed into `estimated` for display / balance checks only.
      */
-    @Test
-    fun `utxo swap keeps gasFee as per-byte rate and routes plan fee only into estimated`() =
-        runTest {
-            val byteFeeRate = BigInteger("15") // sats/byte
-            val planTotalFee = 4200L // total sats for the built tx
-            val sendSrc = dogeSendSrc()
-            val nativeDoge = sendSrc.account.token
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(
+        value = Chain::class,
+        names = ["Bitcoin", "BitcoinCash", "Litecoin", "Dogecoin", "Dash", "Zcash"],
+    )
+    fun `utxo swap keeps gasFee as per-byte rate and routes plan fee only into estimated`(
+        chain: Chain
+    ) = runTest {
+        val byteFeeRate = BigInteger("15") // sats/byte
+        val planTotalFee = 4200L // total sats for the built tx
+        val sendSrc = utxoSendSrc(chain)
+        val nativeCoin = sendSrc.account.token
 
-            coEvery { vaultRepository.get(VAULT_ID) } returns vault()
-            coEvery { feeServiceComposite.calculateFees(any()) } returns BasicFee(byteFeeRate)
-            coEvery { tokenRepository.getNativeToken(Chain.Dogecoin.id) } returns nativeDoge
-            coEvery {
-                blockChainSpecificRepository.getSpecific(
-                    chain = any(),
-                    address = any(),
-                    token = any(),
-                    gasFee = any(),
-                    isSwap = any(),
-                    isMaxAmountEnabled = any(),
-                    isDeposit = any(),
-                )
-            } returns
-                BlockChainSpecificAndUtxo(
-                    blockChainSpecific = BlockChainSpecific.UTXO(byteFee = byteFeeRate, true),
-                    utxos = emptyList(),
-                )
+        stubCommon(chain, nativeCoin, BasicFee(byteFeeRate))
 
-            val utxoHelper = mockk<UtxoHelper>()
-            every { UtxoHelper.getHelper(any(), any()) } returns utxoHelper
-            every { utxoHelper.getBitcoinTransactionPlan(any()) } returns
-                Bitcoin.TransactionPlan.newBuilder()
-                    .setFee(planTotalFee)
-                    .setError(SigningError.OK)
-                    .build()
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                blockChainSpecific = BlockChainSpecific.UTXO(byteFee = byteFeeRate, true),
+                utxos = emptyList(),
+            )
 
-            val capturedParams = slot<GasFeeParams>()
-            val estimatedTotal =
-                EstimatedGasFee(
-                    formattedTokenValue = "$planTotalFee DOGE",
-                    formattedFiatValue = "$0.00",
-                    tokenValue =
-                        TokenValue(value = BigInteger.valueOf(planTotalFee), token = nativeDoge),
-                    fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
-                )
-            coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns estimatedTotal
+        val utxoHelper = mockk<UtxoHelper>()
+        every { UtxoHelper.getHelper(any(), any()) } returns utxoHelper
+        every { utxoHelper.getBitcoinTransactionPlan(any()) } returns
+            Bitcoin.TransactionPlan.newBuilder()
+                .setFee(planTotalFee)
+                .setError(SigningError.OK)
+                .build()
 
-            val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+        val capturedParams = slot<GasFeeParams>()
+        val estimatedTotal = estimatedFee(nativeCoin, BigInteger.valueOf(planTotalFee))
+        coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns estimatedTotal
 
-            requireNotNull(result)
-            // (1) gasFee stays as per-byte sats/byte — what UtxoHelper.setByteFee(...) expects.
-            assertEquals(byteFeeRate, result.gasFee.value)
-            // (2) The total fee from the plan is what goes into the estimate (for display /
-            // balance check).
-            assertEquals(BigInteger.valueOf(planTotalFee), capturedParams.captured.gasFee.value)
-            assertEquals(estimatedTotal, result.estimated)
-        }
+        val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+
+        requireNotNull(result)
+        // (1) gasFee stays as per-byte sats/byte — what UtxoHelper.setByteFee(...) expects.
+        assertEquals(byteFeeRate, result.gasFee.value)
+        // (2) The total fee from the plan is what goes into the estimate (for display /
+        // balance check).
+        assertEquals(BigInteger.valueOf(planTotalFee), capturedParams.captured.gasFee.value)
+        assertEquals(estimatedTotal, result.estimated)
+    }
 
     /**
      * `getBitcoinTransactionPlan` returning `null` (plan.error != OK) must short-circuit the whole
-     * calculation — otherwise callers see a stale zero estimate while signing would fail later.
+     * calculation for every UTXO chain that uses the plan path — otherwise callers see a stale zero
+     * estimate while signing would fail later.
      */
-    @Test
-    fun `utxo swap returns null when bitcoin plan fails`() = runTest {
-        val sendSrc = dogeSendSrc()
-        val nativeDoge = sendSrc.account.token
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(
+        value = Chain::class,
+        names = ["Bitcoin", "BitcoinCash", "Litecoin", "Dogecoin", "Dash", "Zcash"],
+    )
+    fun `utxo swap returns null when bitcoin plan fails`(chain: Chain) = runTest {
+        val sendSrc = utxoSendSrc(chain)
+        val nativeCoin = sendSrc.account.token
 
-        coEvery { vaultRepository.get(VAULT_ID) } returns vault()
-        coEvery { feeServiceComposite.calculateFees(any()) } returns BasicFee(BigInteger("10"))
-        coEvery { tokenRepository.getNativeToken(Chain.Dogecoin.id) } returns nativeDoge
+        stubCommon(chain, nativeCoin, BasicFee(BigInteger("10")))
+
         coEvery {
             blockChainSpecificRepository.getSpecific(
                 chain = any(),
@@ -173,24 +180,90 @@ internal class SwapGasCalculatorTest {
 
         val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
 
-        assertEquals(null, result)
+        assertNull(result)
+    }
+
+    /**
+     * Cardano is marked as the UTXO standard but is explicitly excluded from the WalletCore Bitcoin
+     * plan path. The fee service's value must flow through untouched and the UTXO helper must not
+     * be invoked.
+     */
+    @Test
+    fun `cardano swap bypasses bitcoin plan path and uses fee service value directly`() = runTest {
+        val feeAmount = BigInteger("170000") // lovelace
+        val sendSrc = utxoSendSrc(Chain.Cardano)
+        val nativeCoin = sendSrc.account.token
+
+        stubCommon(Chain.Cardano, nativeCoin, BasicFee(feeAmount))
+
+        val capturedParams = slot<GasFeeParams>()
+        val estimated = estimatedFee(nativeCoin, feeAmount)
+        coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns estimated
+
+        val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+
+        requireNotNull(result)
+        assertEquals(feeAmount, result.gasFee.value)
+        assertEquals(feeAmount, capturedParams.captured.gasFee.value)
+        assertEquals(estimated, result.estimated)
+        verify(exactly = 0) { UtxoHelper.getHelper(any(), any()) }
+        coVerify(exactly = 0) {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        }
+    }
+
+    /**
+     * Negative scenario: non-UTXO chains (e.g. Ethereum) must never enter the Bitcoin plan path.
+     * The fee service's value is the estimate directly and `UtxoHelper` must not be touched.
+     */
+    @Test
+    fun `non-utxo swap skips bitcoin plan path entirely`() = runTest {
+        val feeAmount = BigInteger("210000000000000") // wei
+        val sendSrc = ethSendSrc()
+        val nativeCoin = sendSrc.account.token
+
+        stubCommon(Chain.Ethereum, nativeCoin, BasicFee(feeAmount))
+
+        val capturedParams = slot<GasFeeParams>()
+        val estimated = estimatedFee(nativeCoin, feeAmount)
+        coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns estimated
+
+        val result = calculator.calculateGasFee(sendSrc, VAULT_ID)
+
+        requireNotNull(result)
+        assertEquals(feeAmount, result.gasFee.value)
+        assertEquals(feeAmount, capturedParams.captured.gasFee.value)
+        assertEquals(estimated, result.estimated)
+        verify(exactly = 0) { UtxoHelper.getHelper(any(), any()) }
+        coVerify(exactly = 0) {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        }
+    }
+
+    private fun stubCommon(chain: Chain, nativeCoin: Coin, fee: BasicFee) {
+        coEvery { vaultRepository.get(VAULT_ID) } returns vault()
+        coEvery { feeServiceComposite.calculateFees(any()) } returns fee
+        coEvery { tokenRepository.getNativeToken(chain.id) } returns nativeCoin
     }
 
     companion object {
         private const val VAULT_ID = "test-vault-id"
-
-        private val DOGE_COIN =
-            Coin(
-                chain = Chain.Dogecoin,
-                ticker = "DOGE",
-                logo = "doge",
-                address = "DOGEaddr",
-                decimal = 8,
-                hexPublicKey = "hex",
-                priceProviderID = "dogecoin",
-                contractAddress = "",
-                isNativeToken = true,
-            )
 
         private fun vault() =
             Vault(
@@ -201,21 +274,55 @@ internal class SwapGasCalculatorTest {
                 localPartyID = "local-party",
             )
 
-        private fun dogeSendSrc(): SendSrc {
+        private fun nativeCoinFor(chain: Chain): Coin {
+            val ticker =
+                when (chain) {
+                    Chain.Bitcoin -> "BTC"
+                    Chain.BitcoinCash -> "BCH"
+                    Chain.Litecoin -> "LTC"
+                    Chain.Dogecoin -> "DOGE"
+                    Chain.Dash -> "DASH"
+                    Chain.Zcash -> "ZEC"
+                    Chain.Cardano -> "ADA"
+                    Chain.Ethereum -> "ETH"
+                    else -> chain.raw
+                }
+            return Coin(
+                chain = chain,
+                ticker = ticker,
+                logo = ticker.lowercase(),
+                address = "${ticker}addr",
+                decimal = if (chain == Chain.Ethereum) 18 else 8,
+                hexPublicKey = "hex",
+                priceProviderID = ticker.lowercase(),
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        }
+
+        private fun utxoSendSrc(chain: Chain): SendSrc = buildSendSrc(nativeCoinFor(chain))
+
+        private fun ethSendSrc(): SendSrc = buildSendSrc(nativeCoinFor(Chain.Ethereum))
+
+        private fun buildSendSrc(coin: Coin): SendSrc {
             val account =
                 Account(
-                    token = DOGE_COIN,
-                    tokenValue = TokenValue(BigInteger("500000000"), DOGE_COIN),
+                    token = coin,
+                    tokenValue = TokenValue(BigInteger("500000000"), coin),
                     fiatValue = null,
                     price = null,
                 )
             val address =
-                Address(
-                    chain = Chain.Dogecoin,
-                    address = DOGE_COIN.address,
-                    accounts = listOf(account),
-                )
+                Address(chain = coin.chain, address = coin.address, accounts = listOf(account))
             return SendSrc(address, account)
         }
+
+        private fun estimatedFee(token: Coin, value: BigInteger): EstimatedGasFee =
+            EstimatedGasFee(
+                formattedTokenValue = "$value ${token.ticker}",
+                formattedFiatValue = "$0.00",
+                tokenValue = TokenValue(value = value, token = token),
+                fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+            )
     }
 }


### PR DESCRIPTION
## Summary
Adds `SwapGasCalculatorTest` to lock in the UTXO swap gas-fee fix from #4164 / #4165.

Addresses review feedback from @rkokhatskyi on #4165:
> https://github.com/vultisig/vultisig-android/pull/4165#pullrequestreview-4161470178
> "can you please attach other UTXO chains tx samples as well? Also cover this by tests, essential to have"



https://blockchair.com/tron/transaction/c2c36c2bcc1a75847fbd50d302b24191105f57146c66573bbcdd860ede38f370


https://blockchair.com/dash/transaction/902c956a0c91a5dab21053fba3f553694f9142dc5342de4abbd154adbc5c7d50

## What's covered
- `gasFee` stays as the per-byte sats/byte rate (what `UtxoHelper.setByteFee(...)` expects) while the plan's total fee is routed into `estimated` for display/balance checks only.
- `calculateGasFee` short-circuits to `null` when the Bitcoin plan fails (e.g. `Error_not_enough_utxos`), preventing a stale zero estimate.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapGasCalculatorTest"` passes
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for swap gas fee calculations covering multiple UTXO chains (BTC, BCH, LTC, DOGE, DASH, ZEC).
  * Verifies per-byte gas rate is preserved and total plan fee is routed to the estimated result.
  * Adds short‑circuit tests when UTXO transaction planning fails (returns null/no estimate).
  * Confirms non‑UTXO chains (Cardano, Ethereum) bypass UTXO planning and use fee service output directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->