### PR TITLE
fix: surface dust-threshold error with a specific message (#4167)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -487,6 +487,8 @@ constructor(
                 UiText.StringResource(R.string.swap_error_small_insufficient_funds)
             is SwapException.RateLimitExceeded ->
                 UiText.StringResource(R.string.swap_error_rate_limit)
+            is SwapException.AmountBelowDustThreshold ->
+                UiText.StringResource(R.string.swap_error_amount_below_dust_threshold)
         }
 
     companion object {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -338,6 +338,7 @@
     <string name="form_token_selection_asset">Vermögenswert</string>
     <string name="insufficient_native_token">Nicht genügend %1$s für Gasgebühren</string>
     <string name="swap_error_amount_too_low">Swap-Betrag zu niedrig</string>
+    <string name="swap_error_amount_below_dust_threshold">Der Betrag liegt unter dem Dust-Schwellenwert. Bitte erhöhen Sie den Betrag und versuchen Sie es erneut.</string>
     <string name="swap_error_insufficient_balance_and_fees">Unzureichendes %1$s-Guthaben für den Swap und Gasgebühren. Laden Sie %1$s auf oder reduzieren Sie den Swap-Betrag</string>
     <string name="swap_error_insufficient_source_token">Unzureichendes %1$s-Guthaben zum Tauschen</string>
     <string name="swap_error_insufficient_gas_fees">Nicht genügend %1$s für Gasgebühren. Bitte füllen Sie die Wallet auf.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -338,6 +338,7 @@
     <string name="form_token_selection_asset">Activo</string>
     <string name="insufficient_native_token">No hay suficiente %1$s para las comisiones de gas</string>
     <string name="swap_error_amount_too_low">El monto de intercambio es demasiado bajo</string>
+    <string name="swap_error_amount_below_dust_threshold">El monto es inferior al umbral de polvo. Aumenta el monto e inténtalo de nuevo.</string>
     <string name="swap_error_insufficient_balance_and_fees">Saldo de %1$s insuficiente para el intercambio y las comisiones de gas. Recargue %1$s o reduzca el monto del intercambio</string>
     <string name="swap_error_insufficient_source_token">Saldo de %1$s insuficiente para intercambiar</string>
     <string name="swap_error_insufficient_gas_fees">No hay suficiente %1$s para cubrir las comisiones de gas. Por favor, cargue la billetera.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -338,6 +338,7 @@
     <string name="form_token_selection_asset">Sredstvo</string>
     <string name="insufficient_native_token">Nedovoljno %1$s za naknade za gas</string>
     <string name="swap_error_amount_too_low">Iznos zamjene je prenizak</string>
+    <string name="swap_error_amount_below_dust_threshold">Iznos je manji od praga za prašinu. Povećajte iznos i pokušajte ponovno.</string>
     <string name="swap_error_insufficient_balance_and_fees">Nedovoljno %1$s salda za zamjenu i naknade za gas. Dopunite %1$s ili smanjite iznos zamjene</string>
     <string name="swap_error_insufficient_source_token">Nedovoljno %1$s salda za zamjenu</string>
     <string name="swap_error_insufficient_gas_fees">Nema dovoljno %1$s za pokrivanje naknada za gas. Molimo uplatite novčanik.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -338,6 +338,7 @@
     <string name="form_token_selection_asset">Risorsa</string>
     <string name="insufficient_native_token">%1$s insufficienti per le commissioni del gas</string>
     <string name="swap_error_amount_too_low">Importo dello swap troppo basso</string>
+    <string name="swap_error_amount_below_dust_threshold">L\'importo è inferiore alla soglia di dust. Aumenta l\'importo e riprova.</string>
     <string name="swap_error_insufficient_balance_and_fees">Saldo %1$s insufficiente per lo swap e le commissioni del gas. Ricarica %1$s o riduci l\'importo dello swap</string>
     <string name="swap_error_insufficient_source_token">Saldo %1$s insufficiente per lo scambio</string>
     <string name="swap_error_insufficient_gas_fees">Non c\'è abbastanza %1$s per coprire le commissioni del gas. Si prega di finanziare il portafoglio.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -433,6 +433,7 @@
     <string name="form_token_selection_asset">자산</string>
     <string name="insufficient_native_token">가스 수수료를 충당할 %1$s이(가) 부족합니다</string>
     <string name="swap_error_amount_too_low">스왑 금액이 너무 적습니다</string>
+    <string name="swap_error_amount_below_dust_threshold">금액이 더스트 한도보다 낮습니다. 금액을 늘린 후 다시 시도하세요.</string>
     <string name="swap_error_insufficient_balance_and_fees">스왑과 가스 수수료를 위한 %1$s 잔액이 부족합니다. %1$s을(를) 충전하거나 스왑 금액을 줄여주세요</string>
     <string name="swap_error_insufficient_source_token">스왑할 %1$s 잔액이 부족합니다</string>
     <string name="swap_error_insufficient_gas_fees">가스 수수료를 충당할 %1$s이(가) 부족합니다. 지갑에 자금을 충전해 주세요.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -337,6 +337,7 @@
     <string name="form_token_selection_asset">Bezit</string>
     <string name="insufficient_native_token">Onvoldoende %1$s voor gaskosten</string>
     <string name="swap_error_amount_too_low">Swapbedrag te laag</string>
+    <string name="swap_error_amount_below_dust_threshold">Het bedrag is lager dan de dust-drempel. Verhoog het bedrag en probeer het opnieuw.</string>
     <string name="swap_error_insufficient_balance_and_fees">Onvoldoende %1$s saldo voor de swap en gaskosten. Vul %1$s aan of verlaag het swapbedrag</string>
     <string name="swap_error_insufficient_source_token">Onvoldoende %1$s saldo om te ruilen</string>
     <string name="swap_error_insufficient_gas_fees">Er is niet genoeg %1$s om de gaskosten te dekken. Vul de wallet aan.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -338,6 +338,7 @@
     <string name="form_token_selection_asset">Ativo</string>
     <string name="insufficient_native_token">%1$s insuficiente para taxas de gás</string>
     <string name="swap_error_amount_too_low">Valor de swap muito baixo</string>
+    <string name="swap_error_amount_below_dust_threshold">O valor é inferior ao limite de poeira. Aumente o valor e tente novamente.</string>
     <string name="swap_error_insufficient_balance_and_fees">Saldo de %1$s insuficiente para o swap e taxas de gás. Recarregue %1$s ou reduza o valor do swap</string>
     <string name="swap_error_insufficient_source_token">Saldo de %1$s insuficiente para trocar</string>
     <string name="swap_error_insufficient_gas_fees">Não há %1$s suficiente para cobrir as taxas de gás. Por favor, financie a carteira.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -337,6 +337,7 @@
     <string name="form_token_selection_asset">Актив</string>
     <string name="insufficient_native_token">Недостаточно %1$s для комиссии за газ</string>
     <string name="swap_error_amount_too_low">Сумма обмена слишком мала</string>
+    <string name="swap_error_amount_below_dust_threshold">Сумма меньше пылевого порога. Увеличьте сумму и попробуйте снова.</string>
     <string name="swap_error_insufficient_balance_and_fees">Недостаточный баланс %1$s для обмена и комиссии за газ. Пополните %1$s или уменьшите сумму обмена</string>
     <string name="swap_error_insufficient_source_token">Недостаточный баланс %1$s для обмена</string>
     <string name="swap_error_insufficient_gas_fees">Недостаточно %1$s для оплаты комиссии за газ. Пожалуйста, пополните кошелек.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -632,6 +632,7 @@
 
     <!-- Swap Errors -->
     <string name="swap_error_amount_too_low">交换金额太低</string>
+    <string name="swap_error_amount_below_dust_threshold">金额低于粉尘阈值。请增加金额后重试。</string>
     <string name="swap_error_insufficient_balance_and_fees">%1$s 余额不足以支付交换和 Gas 费用。请充值 %1$s 或减少交换金额</string>
     <string name="swap_error_insufficient_source_token">%1$s 余额不足以进行交换</string>
     <string name="swap_error_insufficient_gas_fees">没有足够的 %1$s 来支付 Gas 费用。请为钱包充值。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,6 +442,7 @@
     <string name="form_token_selection_asset">Asset</string>
     <string name="insufficient_native_token">Not enough %1$s to cover gas fees</string>
     <string name="swap_error_amount_too_low">Swap Amount too low</string>
+    <string name="swap_error_amount_below_dust_threshold">Amount is less than the dust threshold. Please increase the amount and try again.</string>
     <string name="swap_error_insufficient_balance_and_fees">Insufficient %1$s balance for the swap and gas fees. Top up %1$s or reduce swap amount</string>
     <string name="swap_error_insufficient_source_token">Insufficient %1$s balance to swap</string>
     <string name="swap_error_insufficient_gas_fees">Not enough %1$s to cover gas fees. Please fund the wallet.</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -25,6 +25,8 @@ sealed class SwapException(message: String) : Exception(message) {
 
     class RateLimitExceeded(message: String) : SwapException(message)
 
+    class AmountBelowDustThreshold(message: String) : SwapException(message)
+
     companion object {
         fun handleSwapException(error: String): SwapException {
             with(error.lowercase()) {
@@ -40,8 +42,7 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("insufficient funds") -> InsufficientFunds(error)
                     contains("no available quotes for the requested") ->
                         SwapRouteNotAvailable(error)
-                    contains("amount less than dust threshold: invalid request") ->
-                        SmallSwapAmount(error)
+                    contains("amount less than dust threshold") -> AmountBelowDustThreshold(error)
                     contains("amount less than min swap amount") -> SmallSwapAmount(error)
                     contains("pool does not exist") -> SwapRouteNotAvailable(error)
                     contains("trading is halted") -> SwapRouteNotAvailable(error)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
@@ -87,6 +87,18 @@ class HandleSwapExceptionTest {
     }
 
     @Test
+    fun `dust threshold error maps to AmountBelowDustThreshold`() {
+        val result = SwapException.handleSwapException("amount less than dust threshold")
+        assertInstanceOf(SwapException.AmountBelowDustThreshold::class.java, result)
+    }
+
+    @Test
+    fun `dust threshold error is case insensitive`() {
+        val result = SwapException.handleSwapException("Amount Less Than Dust Threshold")
+        assertInstanceOf(SwapException.AmountBelowDustThreshold::class.java, result)
+    }
+
+    @Test
     fun `network error maps to NetworkConnection`() {
         val result = SwapException.handleSwapException("Unable to resolve host api.example.com")
         assertInstanceOf(SwapException.NetworkConnection::class.java, result)


### PR DESCRIPTION
## Summary

Fixes #4167.

- THORChain returns `amount less than dust threshold` (no suffix) for sub-dust swaps, so the existing `"amount less than dust threshold: invalid request"` substring match never fired and the user saw the generic `"Swap quote failed. Please try again or adjust the amount."` toast.
- Add a dedicated `SwapException.AmountBelowDustThreshold` case, match the bare `"amount less than dust threshold"` substring (case-insensitive), and map it to a new localized string so the user gets an actionable message.
- New string `swap_error_amount_below_dust_threshold` added to all 10 locale files.

## Design choice: new `AmountBelowDustThreshold` class vs. reusing `SmallSwapAmount`

I chose to add a dedicated sealed case rather than reuse the existing `SmallSwapAmount`. Reasons:

1. **The issue explicitly asks for it** — ticket #4167 names `SwapException.AmountBelowDustThreshold` as the target.
2. **`SmallSwapAmount`'s mapper is amount-parsing-specific.** At `SwapQuoteManager.kt:452-485` it tries to parse `recommended_min_amount_in: <n>` or a bare number to render a formatted `"Minimum X TOKEN"` toast. The THORChain dust error carries no such number, so it would fall into the `else` branch and display the raw English API text via `UiText.DynamicString` — non-localized and not user-friendly.
3. **Semantically distinct.** `SmallSwapAmount` = below a provider's economic minimum (quote-dependent). `AmountBelowDustThreshold` = below a protocol-level UTXO floor (THORChain-specific). Separating them keeps the error surface clearer and future-proof.
4. **One extra sealed case is cheap** — 12 → 13, no structural complexity added.

## Test plan

- [x] Unit tests added in `HandleSwapExceptionTest` for the new exception branch (exact match + case-insensitive).
- [x] `./gradlew :data:test` passes.
- [x] `./gradlew assembleDebug` succeeds.
- [x] `./gradlew lint` passes.
- [ ] Manual: on the Swap screen, set `From: BTC`, `To: THOR.RUNE`, enter `0.000003 BTC` (300 sats) and confirm the toast shows the dust-threshold message, not the generic fallback.
- [ ] Manual: verify other swap error paths (network error, route-not-available, high price impact) still show their existing messages unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap flow now shows a specific error when the entered amount is below the dust threshold.

* **Localization**
  * Added localized versions of the new dust-threshold error message in 10+ languages.

* **Tests**
  * Added unit tests to verify correct handling and display of dust-threshold swap errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->