### PR TITLE
Tron: refresh DeFi screen and DeFi balance cache after keysign

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -600,6 +600,16 @@ constructor(
                 explorerLinkRepository.getSwapProgressLink(txHash, payload.swapPayload)
             runCatching { balanceRepository.invalidateBalance(payload.coin.address, payload.coin) }
                 .onFailure { Timber.e(it, "Failed to invalidate balance cache after broadcast") }
+            runCatching {
+                    balanceRepository.invalidateDeFiBalance(
+                        address = payload.coin.address,
+                        chain = chain,
+                        vaultId = vault.id,
+                    )
+                }
+                .onFailure {
+                    Timber.e(it, "Failed to invalidate DeFi balance cache after broadcast")
+                }
             saveTransactionHistory(txHash, chain)
             if (txStatusConfigurationProvider.supportTxStatus(chain)) {
                 startForegroundPolling(txHash, chain)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -26,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.models.ResourceUsage
 import com.vultisig.wallet.data.models.VaultId
@@ -71,7 +71,10 @@ internal fun TronDeFiPositionsScreen(
 ) {
     val state by viewModel.state.collectAsState()
 
-    LaunchedEffect(vaultId) { viewModel.setData(vaultId) }
+    LifecycleResumeEffect(vaultId) {
+        viewModel.setData(vaultId)
+        onPauseOrDispose {}
+    }
 
     TronDeFiPositionsScreenContent(
         state = state,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -168,16 +168,18 @@ constructor(
     }
 
     override suspend fun invalidateDeFiBalance(address: String, chain: Chain, vaultId: String) {
-        val key =
-            when (chain) {
-                ThorChain,
-                Ethereum -> address
-                MayaChain,
-                Chain.Tron -> "${chain.id}:$vaultId:$address"
-                else -> return
-            }
+        val key = deFiCacheKey(address, chain, vaultId) ?: return
         defiBalanceCache.remove(key)
     }
+
+    private fun deFiCacheKey(address: String, chain: Chain, vaultId: String): String? =
+        when (chain) {
+            ThorChain,
+            Ethereum -> address
+            MayaChain,
+            Chain.Tron -> "${chain.id}:$vaultId:$address"
+            else -> null
+        }
 
     override suspend fun getCachedTokenBalanceAndPrice(
         address: String,
@@ -377,58 +379,24 @@ constructor(
         coin: Coin,
         vaultId: String,
     ): List<DeFiBalance> {
-        return when (coin.chain) {
-            ThorChain -> {
-                val mutex = lockFor(address)
-                mutex.withLock {
-                    defiBalanceCache.get(address)
-                        ?: run {
-                            val remote =
-                                thorchainDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-                            defiBalanceCache.put(address, remote)
-                            remote
-                        }
-                }
+        val cacheKey =
+            deFiCacheKey(address, coin.chain, vaultId) ?: error("Not supported ${coin.chain}")
+        val service =
+            when (coin.chain) {
+                ThorChain -> thorchainDeFiBalanceService
+                Ethereum -> circleDeFiBalanceService
+                MayaChain -> mayaDeFiBalanceService
+                Chain.Tron -> tronDeFiBalanceService
+                else -> error("Not supported ${coin.chain}")
             }
-            Ethereum -> {
-                val mutex = lockFor(address)
-                mutex.withLock {
-                    defiBalanceCache.get(address)
-                        ?: run {
-                            val remote =
-                                circleDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-                            defiBalanceCache.put(address, remote)
-                            remote
-                        }
+        val mutex = lockFor(cacheKey)
+        return mutex.withLock {
+            defiBalanceCache.get(cacheKey)
+                ?: run {
+                    val remote = service.getRemoteDeFiBalance(address, vaultId)
+                    defiBalanceCache.put(cacheKey, remote)
+                    remote
                 }
-            }
-            MayaChain -> {
-                val cacheKey = "${Chain.MayaChain.id}:$vaultId:$address"
-                val mutex = lockFor(cacheKey)
-                mutex.withLock {
-                    defiBalanceCache.get(cacheKey)
-                        ?: run {
-                            val remote =
-                                mayaDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-                            defiBalanceCache.put(cacheKey, remote)
-                            remote
-                        }
-                }
-            }
-            Chain.Tron -> {
-                val cacheKey = "${Chain.Tron.id}:$vaultId:$address"
-                val mutex = lockFor(cacheKey)
-                mutex.withLock {
-                    defiBalanceCache.get(cacheKey)
-                        ?: run {
-                            val remote =
-                                tronDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-                            defiBalanceCache.put(cacheKey, remote)
-                            remote
-                        }
-                }
-            }
-            else -> error("Not supported")
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -169,7 +169,10 @@ constructor(
 
     override suspend fun invalidateDeFiBalance(address: String, chain: Chain, vaultId: String) {
         val key = deFiCacheKey(address, chain, vaultId) ?: return
-        defiBalanceCache.remove(key)
+        val mutex = lockFor(key)
+        mutex.withLock {
+            defiBalanceCache.remove(key)
+        }
     }
 
     private fun deFiCacheKey(address: String, chain: Chain, vaultId: String): String? =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -114,6 +114,8 @@ interface BalanceRepository {
     suspend fun getTcyAutoCompoundAmount(address: String): String?
 
     suspend fun invalidateBalance(address: String, coin: Coin)
+
+    suspend fun invalidateDeFiBalance(address: String, chain: Chain, vaultId: String)
 }
 
 internal class BalanceRepositoryImpl
@@ -163,6 +165,18 @@ constructor(
             address = address,
             ticker = coin.ticker,
         )
+    }
+
+    override suspend fun invalidateDeFiBalance(address: String, chain: Chain, vaultId: String) {
+        val key =
+            when (chain) {
+                ThorChain,
+                Ethereum -> address
+                MayaChain,
+                Chain.Tron -> "${chain.id}:$vaultId:$address"
+                else -> return
+            }
+        defiBalanceCache.remove(key)
     }
 
     override suspend fun getCachedTokenBalanceAndPrice(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -170,9 +170,7 @@ constructor(
     override suspend fun invalidateDeFiBalance(address: String, chain: Chain, vaultId: String) {
         val key = deFiCacheKey(address, chain, vaultId) ?: return
         val mutex = lockFor(key)
-        mutex.withLock {
-            defiBalanceCache.remove(key)
-        }
+        mutex.withLock { defiBalanceCache.remove(key) }
     }
 
     private fun deFiCacheKey(address: String, chain: Chain, vaultId: String): String? =


### PR DESCRIPTION
## Summary
- Fixes #4159. After a successful TRON `FREEZE_TRX` / `UNFREEZE_TRX` keysign, `TronDeFiPositionsScreen` displayed stale data (frozen balance, pending withdrawals) because `LaunchedEffect(vaultId)` did not re-fire on return and `KeysignViewModel` only invalidated the wallet token balance, not the DeFi balance cache.
- Switched the TRON DeFi screen to `LifecycleResumeEffect(vaultId)` so `viewModel.setData` runs every time the screen becomes resumed — this is the minimal change that reliably refetches account / resource state after a freeze/unfreeze completes.
- Added `BalanceRepository.invalidateDeFiBalance(address, chain, vaultId)` and invoke it in `KeysignViewModel.broadcastTransaction` alongside the existing wallet balance invalidation. The method removes the in-memory `defiBalanceCache` entry using the same key scheme as `getDeFiTokenValue` (ThorChain/Ethereum: `address`; MayaChain/Tron: `"$chainId:$vaultId:$address"`), covering the broader DeFi screens too.

## Test plan
- [ ] Build debug APK (`./gradlew assembleDebug`) and run unit tests.
- [ ] On a vault with TRX, freeze TRX → return to TRON DeFi screen → verify frozen balance updates and new pending withdrawal appears without needing to leave the tab.
- [ ] Unfreeze TRX → return → verify pending withdrawal entry moves / balance decreases.
- [ ] Smoke-test a non-DeFi send on another chain to ensure no regression in wallet balance refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Balance cache sync after broadcasts now also clears DeFi balances for the affected vault; errors during this step are logged and won’t interrupt saving transactions or status polling.

* **Refactor**
  * DeFi balance caching and retrieval unified for consistent cache keys, locking, and service selection.

* **UX**
  * DeFi positions screen refreshes reliably when you return to it via lifecycle-aware initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->