### PR TITLE
fix: validate custom token address and metadata before search

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenStandard.EVM
 import com.vultisig.wallet.data.models.TokenStandard.SOL
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import java.math.BigDecimal
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
@@ -23,21 +24,47 @@ constructor(
     private val searchEvmToken: SearchEvmTokenUseCase,
     private val searchSolToken: SearchSolTokenUseCase,
     private val searchKujiToken: SearchKujiraTokenUseCase,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
 ) : SearchTokenUseCase {
     override suspend fun invoke(chainId: String, contractAddress: String): CoinAndFiatValue? {
         val chain = Chain.fromRaw(chainId)
+        val address = contractAddress.trim()
+        if (!isContractAddressValid(chain, address)) return null
+
         val searchedToken =
             when {
-                chain.standard == EVM -> searchEvmToken(chainId, contractAddress)
-                chain.standard == SOL -> searchSolToken(contractAddress)
-                chain == Chain.Kujira -> searchKujiToken(contractAddress)
-                else -> return null
+                chain.standard == EVM -> searchEvmToken(chainId, address)
+                chain.standard == SOL -> searchSolToken(address)
+                chain == Chain.Kujira -> searchKujiToken(address)
+                else -> null
             } ?: return null
 
-        val rawPrice = searchedToken.price
+        if (!searchedToken.coin.hasSaneMetadata()) return null
 
         val currency = appCurrencyRepository.currency.first()
-        val tokenFiatValue = FiatValue(rawPrice, currency.ticker)
+        val tokenFiatValue = FiatValue(searchedToken.price, currency.ticker)
         return CoinAndFiatValue(searchedToken.coin, tokenFiatValue)
+    }
+
+    private fun isContractAddressValid(chain: Chain, address: String): Boolean {
+        if (address.isEmpty()) return false
+        val candidate = canonicalize(chain, address)
+        return chainAccountAddressRepository.isValid(chain, candidate)
+    }
+
+    // Kujira factory denoms take the form `factory/<creator-address>/<sub-denom>`;
+    // the creator segment is what WalletCore can validate as bech32.
+    private fun canonicalize(chain: Chain, address: String): String =
+        if (chain == Chain.Kujira && address.startsWith(KUJIRA_FACTORY_PREFIX)) {
+            address.substringAfter('/').substringBefore('/')
+        } else {
+            address
+        }
+
+    private fun Coin.hasSaneMetadata(): Boolean = ticker.isNotBlank() && decimal in 0..MAX_DECIMALS
+
+    private companion object {
+        const val KUJIRA_FACTORY_PREFIX = "factory/"
+        const val MAX_DECIMALS = 30
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -26,40 +26,37 @@ constructor(
     private val searchKujiToken: SearchKujiraTokenUseCase,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
 ) : SearchTokenUseCase {
+
     override suspend fun invoke(chainId: String, contractAddress: String): CoinAndFiatValue? {
         val chain = Chain.fromRaw(chainId)
-        val address = contractAddress.trim()
-        if (!isContractAddressValid(chain, address)) return null
-
-        val searchedToken =
-            when {
-                chain.standard == EVM -> searchEvmToken(chainId, address)
-                chain.standard == SOL -> searchSolToken(address)
-                chain == Chain.Kujira -> searchKujiToken(address)
-                else -> null
-            } ?: return null
-
-        if (!searchedToken.coin.hasSaneMetadata()) return null
-
-        val currency = appCurrencyRepository.currency.first()
-        val tokenFiatValue = FiatValue(searchedToken.price, currency.ticker)
-        return CoinAndFiatValue(searchedToken.coin, tokenFiatValue)
+        return contractAddress
+            .trim()
+            .takeIf { it.isValidAddressOn(chain) }
+            ?.let { address -> dispatch(chain, chainId, address) }
+            ?.takeIf { it.coin.hasSaneMetadata() }
+            ?.withFiatValue()
     }
 
-    private fun isContractAddressValid(chain: Chain, address: String): Boolean {
-        if (address.isEmpty()) return false
-        val candidate = canonicalize(chain, address)
-        return chainAccountAddressRepository.isValid(chain, candidate)
-    }
-
-    // Kujira factory denoms take the form `factory/<creator-address>/<sub-denom>`;
-    // the creator segment is what WalletCore can validate as bech32.
-    private fun canonicalize(chain: Chain, address: String): String =
-        if (chain == Chain.Kujira && address.startsWith(KUJIRA_FACTORY_PREFIX)) {
-            address.substringAfter('/').substringBefore('/')
-        } else {
-            address
+    private suspend fun dispatch(chain: Chain, chainId: String, address: String): CoinAndPrice? =
+        when {
+            chain.standard == EVM -> searchEvmToken(chainId, address)
+            chain.standard == SOL -> searchSolToken(address)
+            chain == Chain.Kujira -> searchKujiToken(address)
+            else -> null
         }
+
+    private suspend fun CoinAndPrice.withFiatValue(): CoinAndFiatValue {
+        val currency = appCurrencyRepository.currency.first()
+        return CoinAndFiatValue(coin, FiatValue(price, currency.ticker))
+    }
+
+    private fun String.isValidAddressOn(chain: Chain): Boolean =
+        isNotEmpty() && chainAccountAddressRepository.isValid(chain, canonicalizedFor(chain))
+
+    private fun String.canonicalizedFor(chain: Chain): String =
+        if (chain == Chain.Kujira && startsWith(KUJIRA_FACTORY_PREFIX)) {
+            substringAfter('/').substringBefore('/')
+        } else this
 
     private fun Coin.hasSaneMetadata(): Boolean = ticker.isNotBlank() && decimal in 0..MAX_DECIMALS
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
@@ -15,146 +15,119 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class SearchTokenUseCaseImplTest {
 
-    private lateinit var appCurrencyRepository: AppCurrencyRepository
-    private lateinit var searchEvmToken: SearchEvmTokenUseCase
-    private lateinit var searchSolToken: SearchSolTokenUseCase
-    private lateinit var searchKujiToken: SearchKujiraTokenUseCase
-    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
-    private lateinit var useCase: SearchTokenUseCaseImpl
-
-    @BeforeEach
-    fun setUp() {
-        appCurrencyRepository = mockk()
-        searchEvmToken = mockk()
-        searchSolToken = mockk()
-        searchKujiToken = mockk()
-        chainAccountAddressRepository = mockk()
-
-        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
-
-        useCase =
-            SearchTokenUseCaseImpl(
-                appCurrencyRepository = appCurrencyRepository,
-                searchEvmToken = searchEvmToken,
-                searchSolToken = searchSolToken,
-                searchKujiToken = searchKujiToken,
-                chainAccountAddressRepository = chainAccountAddressRepository,
-            )
+    private val addressRepository: ChainAccountAddressRepository = mockk()
+    private val searchEvmToken: SearchEvmTokenUseCase = mockk()
+    private val searchSolToken: SearchSolTokenUseCase = mockk()
+    private val searchKujiToken: SearchKujiraTokenUseCase = mockk()
+    private val appCurrencyRepository: AppCurrencyRepository = mockk {
+        every { currency } returns flowOf(AppCurrency.USD)
     }
 
-    @Test
-    fun `blank address returns null without touching validator or searchers`() = runTest {
-        val result = useCase(Chain.Ethereum.id, "   ")
+    private val useCase =
+        SearchTokenUseCaseImpl(
+            appCurrencyRepository = appCurrencyRepository,
+            searchEvmToken = searchEvmToken,
+            searchSolToken = searchSolToken,
+            searchKujiToken = searchKujiToken,
+            chainAccountAddressRepository = addressRepository,
+        )
 
-        assertNull(result)
-        verify(exactly = 0) { chainAccountAddressRepository.isValid(any(), any()) }
+    @Test
+    fun `blank input returns null and calls nothing`() = runTest {
+        assertNull(useCase(Chain.Ethereum.id, "   "))
+
+        verify(exactly = 0) { addressRepository.isValid(any(), any()) }
         coVerify(exactly = 0) { searchEvmToken(any(), any()) }
         coVerify(exactly = 0) { searchSolToken(any()) }
         coVerify(exactly = 0) { searchKujiToken(any()) }
     }
 
     @Test
-    fun `empty address returns null without touching validator or searchers`() = runTest {
-        val result = useCase(Chain.Ethereum.id, "")
+    fun `empty input returns null and calls nothing`() = runTest {
+        assertNull(useCase(Chain.Ethereum.id, ""))
 
-        assertNull(result)
-        verify(exactly = 0) { chainAccountAddressRepository.isValid(any(), any()) }
-        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+        verify(exactly = 0) { addressRepository.isValid(any(), any()) }
     }
 
     @Test
     fun `invalid EVM address returns null and skips EVM searcher`() = runTest {
-        val address = "0xdead"
-        every { chainAccountAddressRepository.isValid(Chain.Ethereum, address) } returns false
+        stubValid(Chain.Ethereum, "0xdead", valid = false)
 
-        val result = useCase(Chain.Ethereum.id, address)
+        assertNull(useCase(Chain.Ethereum.id, "0xdead"))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchEvmToken(any(), any()) }
     }
 
     @Test
-    fun `solana-formatted address rejected when EVM chain selected`() = runTest {
+    fun `solana formatted address rejected when EVM chain selected`() = runTest {
         val solAddress = "So11111111111111111111111111111111111111112"
-        every { chainAccountAddressRepository.isValid(Chain.Ethereum, solAddress) } returns false
+        stubValid(Chain.Ethereum, solAddress, valid = false)
 
-        val result = useCase(Chain.Ethereum.id, solAddress)
+        assertNull(useCase(Chain.Ethereum.id, solAddress))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchEvmToken(any(), any()) }
     }
 
     @Test
-    fun `valid EVM address delegates to EVM searcher with trimmed address`() = runTest {
-        val padded = "  $EVM_ADDRESS  "
-        val price = BigDecimal("1.5")
-        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
-        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns
-            CoinAndPrice(sampleEvmCoin(EVM_ADDRESS), price)
+    fun `valid EVM address is trimmed and delegated to EVM searcher`() = runTest {
+        givenEvmResponse(evmCoin(), price = BigDecimal("1.5"))
 
-        val result = useCase(Chain.Ethereum.id, padded)
+        val result = useCase(Chain.Ethereum.id, "  $EVM_ADDRESS  ")
 
-        assertEquals(price, result?.fiatValue?.value)
+        assertEquals(BigDecimal("1.5"), result?.fiatValue?.value)
         assertEquals(AppCurrency.USD.ticker, result?.fiatValue?.currency)
         coVerify(exactly = 1) { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) }
     }
 
     @Test
-    fun `EVM searcher null result surfaces as null`() = runTest {
-        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
+    fun `EVM searcher returning null surfaces as null`() = runTest {
+        stubValid(Chain.Ethereum, EVM_ADDRESS, valid = true)
         coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns null
 
-        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Ethereum.id, EVM_ADDRESS))
     }
 
     @Test
     fun `invalid Solana address returns null and skips SOL searcher`() = runTest {
-        val address = "not-a-real-address"
-        every { chainAccountAddressRepository.isValid(Chain.Solana, address) } returns false
+        stubValid(Chain.Solana, "not-a-real-address", valid = false)
 
-        val result = useCase(Chain.Solana.id, address)
+        assertNull(useCase(Chain.Solana.id, "not-a-real-address"))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchSolToken(any()) }
     }
 
     @Test
-    fun `valid Solana address delegates to SOL searcher`() = runTest {
+    fun `valid Solana address delegated to SOL searcher`() = runTest {
         val address = "So11111111111111111111111111111111111111112"
-        val price = BigDecimal("20.0")
-        every { chainAccountAddressRepository.isValid(Chain.Solana, address) } returns true
-        coEvery { searchSolToken(address) } returns CoinAndPrice(sampleSolCoin(address), price)
+        stubValid(Chain.Solana, address, valid = true)
+        coEvery { searchSolToken(address) } returns
+            CoinAndPrice(solCoin(contract = address), BigDecimal("20.0"))
 
         val result = useCase(Chain.Solana.id, address)
 
-        assertEquals(price, result?.fiatValue?.value)
+        assertEquals(BigDecimal("20.0"), result?.fiatValue?.value)
         coVerify(exactly = 1) { searchSolToken(address) }
     }
 
     @Test
     fun `invalid Kujira address returns null and skips Kujira searcher`() = runTest {
-        val address = "0xnot-a-bech32"
-        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns false
+        stubValid(Chain.Kujira, "0xnot-a-bech32", valid = false)
 
-        val result = useCase(Chain.Kujira.id, address)
+        assertNull(useCase(Chain.Kujira.id, "0xnot-a-bech32"))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchKujiToken(any()) }
     }
 
     @Test
-    fun `valid Kujira bech32 address delegates to Kujira searcher`() = runTest {
+    fun `valid Kujira bech32 address delegated to Kujira searcher`() = runTest {
         val address = "kujira1xyzcontractaddress"
-        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns true
+        stubValid(Chain.Kujira, address, valid = true)
         coEvery { searchKujiToken(address) } returns
-            CoinAndPrice(sampleKujiCoin(address), BigDecimal.ZERO)
+            CoinAndPrice(kujiraCoin(contract = address), BigDecimal.ZERO)
 
         val result = useCase(Chain.Kujira.id, address)
 
@@ -166,67 +139,57 @@ internal class SearchTokenUseCaseImplTest {
     fun `Kujira factory denom validates against extracted creator address`() = runTest {
         val creator = "kujira1creator"
         val factoryAddress = "factory/$creator/uusdc"
-        every { chainAccountAddressRepository.isValid(Chain.Kujira, creator) } returns true
+        stubValid(Chain.Kujira, creator, valid = true)
         coEvery { searchKujiToken(factoryAddress) } returns
-            CoinAndPrice(sampleKujiCoin(factoryAddress), BigDecimal.ZERO)
+            CoinAndPrice(kujiraCoin(contract = factoryAddress), BigDecimal.ZERO)
 
         val result = useCase(Chain.Kujira.id, factoryAddress)
 
         assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
-        verify(exactly = 1) { chainAccountAddressRepository.isValid(Chain.Kujira, creator) }
+        verify(exactly = 1) { addressRepository.isValid(Chain.Kujira, creator) }
         coVerify(exactly = 1) { searchKujiToken(factoryAddress) }
     }
 
     @Test
     fun `Kujira factory denom with invalid creator returns null`() = runTest {
-        val factoryAddress = "factory/0xbadcreator/uusdc"
-        every { chainAccountAddressRepository.isValid(Chain.Kujira, "0xbadcreator") } returns false
+        stubValid(Chain.Kujira, "0xbadcreator", valid = false)
 
-        val result = useCase(Chain.Kujira.id, factoryAddress)
+        assertNull(useCase(Chain.Kujira.id, "factory/0xbadcreator/uusdc"))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchKujiToken(any()) }
     }
 
     @Test
-    fun `blank ticker in searcher response returns null`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(ticker = "   "))
+    fun `blank ticker in response returns null`() = runTest {
+        givenEvmResponse(evmCoin(ticker = "   "))
 
-        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Ethereum.id, EVM_ADDRESS))
     }
 
     @Test
-    fun `empty ticker in searcher response returns null`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(ticker = ""))
+    fun `empty ticker in response returns null`() = runTest {
+        givenEvmResponse(evmCoin(ticker = ""))
 
-        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Ethereum.id, EVM_ADDRESS))
     }
 
     @Test
-    fun `negative decimals in searcher response returns null`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = -1))
+    fun `negative decimals in response returns null`() = runTest {
+        givenEvmResponse(evmCoin(decimal = -1))
 
-        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Ethereum.id, EVM_ADDRESS))
     }
 
     @Test
-    fun `absurdly large decimals in searcher response returns null`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 256))
+    fun `absurdly large decimals in response returns null`() = runTest {
+        givenEvmResponse(evmCoin(decimal = 256))
 
-        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Ethereum.id, EVM_ADDRESS))
     }
 
     @Test
     fun `zero decimals accepted as valid metadata`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 0))
+        givenEvmResponse(evmCoin(decimal = 0))
 
         val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
 
@@ -236,7 +199,7 @@ internal class SearchTokenUseCaseImplTest {
 
     @Test
     fun `thirty decimals accepted as upper bound`() = runTest {
-        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 30))
+        givenEvmResponse(evmCoin(decimal = 30))
 
         val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
 
@@ -246,42 +209,51 @@ internal class SearchTokenUseCaseImplTest {
     @Test
     fun `blank Kujira ticker returns null after successful search`() = runTest {
         val address = "kujira1xyzcontractaddress"
-        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns true
+        stubValid(Chain.Kujira, address, valid = true)
         coEvery { searchKujiToken(address) } returns
-            CoinAndPrice(sampleKujiCoin(address).copy(ticker = ""), BigDecimal.ZERO)
+            CoinAndPrice(kujiraCoin(ticker = "", contract = address), BigDecimal.ZERO)
 
-        val result = useCase(Chain.Kujira.id, address)
-
-        assertNull(result)
+        assertNull(useCase(Chain.Kujira.id, address))
     }
 
     @Test
-    fun `unsupported chain returns null and skips all searchers`() = runTest {
-        val address = "bc1qanyaddress"
-        every { chainAccountAddressRepository.isValid(Chain.Bitcoin, address) } returns true
+    fun `unsupported chain returns null even for valid format`() = runTest {
+        stubValid(Chain.Bitcoin, "bc1qanyaddress", valid = true)
 
-        val result = useCase(Chain.Bitcoin.id, address)
+        assertNull(useCase(Chain.Bitcoin.id, "bc1qanyaddress"))
 
-        assertNull(result)
         coVerify(exactly = 0) { searchEvmToken(any(), any()) }
         coVerify(exactly = 0) { searchSolToken(any()) }
         coVerify(exactly = 0) { searchKujiToken(any()) }
     }
 
-    private fun sampleEvmCoin(address: String): Coin =
+    private fun stubValid(chain: Chain, address: String, valid: Boolean) {
+        every { addressRepository.isValid(chain, address) } returns valid
+    }
+
+    private fun givenEvmResponse(coin: Coin, price: BigDecimal = BigDecimal.ONE) {
+        stubValid(Chain.Ethereum, EVM_ADDRESS, valid = true)
+        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns CoinAndPrice(coin, price)
+    }
+
+    private fun evmCoin(
+        ticker: String = "USDC",
+        decimal: Int = 6,
+        contract: String = EVM_ADDRESS,
+    ): Coin =
         Coin(
             chain = Chain.Ethereum,
-            ticker = "USDC",
+            ticker = ticker,
             logo = "",
             address = "0x0",
-            decimal = 6,
+            decimal = decimal,
             hexPublicKey = "",
             priceProviderID = "usd-coin",
-            contractAddress = address,
+            contractAddress = contract,
             isNativeToken = false,
         )
 
-    private fun sampleSolCoin(address: String): Coin =
+    private fun solCoin(contract: String): Coin =
         Coin(
             chain = Chain.Solana,
             ticker = "WSOL",
@@ -290,28 +262,22 @@ internal class SearchTokenUseCaseImplTest {
             decimal = 9,
             hexPublicKey = "",
             priceProviderID = "solana",
-            contractAddress = address,
+            contractAddress = contract,
             isNativeToken = false,
         )
 
-    private fun sampleKujiCoin(address: String): Coin =
+    private fun kujiraCoin(ticker: String = "TOKEN", contract: String): Coin =
         Coin(
             chain = Chain.Kujira,
-            ticker = "TOKEN",
+            ticker = ticker,
             logo = "",
             address = "",
             decimal = 6,
             hexPublicKey = "",
             priceProviderID = "",
-            contractAddress = address,
+            contractAddress = contract,
             isNativeToken = false,
         )
-
-    private fun arrangeEvmResponse(coin: Coin) {
-        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
-        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns
-            CoinAndPrice(coin, BigDecimal.ONE)
-    }
 
     private companion object {
         const val EVM_ADDRESS = "0x1234567890123456789012345678901234567890"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
@@ -1,0 +1,319 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SearchTokenUseCaseImplTest {
+
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var searchEvmToken: SearchEvmTokenUseCase
+    private lateinit var searchSolToken: SearchSolTokenUseCase
+    private lateinit var searchKujiToken: SearchKujiraTokenUseCase
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var useCase: SearchTokenUseCaseImpl
+
+    @BeforeEach
+    fun setUp() {
+        appCurrencyRepository = mockk()
+        searchEvmToken = mockk()
+        searchSolToken = mockk()
+        searchKujiToken = mockk()
+        chainAccountAddressRepository = mockk()
+
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+
+        useCase =
+            SearchTokenUseCaseImpl(
+                appCurrencyRepository = appCurrencyRepository,
+                searchEvmToken = searchEvmToken,
+                searchSolToken = searchSolToken,
+                searchKujiToken = searchKujiToken,
+                chainAccountAddressRepository = chainAccountAddressRepository,
+            )
+    }
+
+    @Test
+    fun `blank address returns null without touching validator or searchers`() = runTest {
+        val result = useCase(Chain.Ethereum.id, "   ")
+
+        assertNull(result)
+        verify(exactly = 0) { chainAccountAddressRepository.isValid(any(), any()) }
+        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+        coVerify(exactly = 0) { searchSolToken(any()) }
+        coVerify(exactly = 0) { searchKujiToken(any()) }
+    }
+
+    @Test
+    fun `empty address returns null without touching validator or searchers`() = runTest {
+        val result = useCase(Chain.Ethereum.id, "")
+
+        assertNull(result)
+        verify(exactly = 0) { chainAccountAddressRepository.isValid(any(), any()) }
+        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+    }
+
+    @Test
+    fun `invalid EVM address returns null and skips EVM searcher`() = runTest {
+        val address = "0xdead"
+        every { chainAccountAddressRepository.isValid(Chain.Ethereum, address) } returns false
+
+        val result = useCase(Chain.Ethereum.id, address)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+    }
+
+    @Test
+    fun `solana-formatted address rejected when EVM chain selected`() = runTest {
+        val solAddress = "So11111111111111111111111111111111111111112"
+        every { chainAccountAddressRepository.isValid(Chain.Ethereum, solAddress) } returns false
+
+        val result = useCase(Chain.Ethereum.id, solAddress)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+    }
+
+    @Test
+    fun `valid EVM address delegates to EVM searcher with trimmed address`() = runTest {
+        val padded = "  $EVM_ADDRESS  "
+        val price = BigDecimal("1.5")
+        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
+        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns
+            CoinAndPrice(sampleEvmCoin(EVM_ADDRESS), price)
+
+        val result = useCase(Chain.Ethereum.id, padded)
+
+        assertEquals(price, result?.fiatValue?.value)
+        assertEquals(AppCurrency.USD.ticker, result?.fiatValue?.currency)
+        coVerify(exactly = 1) { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) }
+    }
+
+    @Test
+    fun `EVM searcher null result surfaces as null`() = runTest {
+        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
+        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns null
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `invalid Solana address returns null and skips SOL searcher`() = runTest {
+        val address = "not-a-real-address"
+        every { chainAccountAddressRepository.isValid(Chain.Solana, address) } returns false
+
+        val result = useCase(Chain.Solana.id, address)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchSolToken(any()) }
+    }
+
+    @Test
+    fun `valid Solana address delegates to SOL searcher`() = runTest {
+        val address = "So11111111111111111111111111111111111111112"
+        val price = BigDecimal("20.0")
+        every { chainAccountAddressRepository.isValid(Chain.Solana, address) } returns true
+        coEvery { searchSolToken(address) } returns CoinAndPrice(sampleSolCoin(address), price)
+
+        val result = useCase(Chain.Solana.id, address)
+
+        assertEquals(price, result?.fiatValue?.value)
+        coVerify(exactly = 1) { searchSolToken(address) }
+    }
+
+    @Test
+    fun `invalid Kujira address returns null and skips Kujira searcher`() = runTest {
+        val address = "0xnot-a-bech32"
+        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns false
+
+        val result = useCase(Chain.Kujira.id, address)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchKujiToken(any()) }
+    }
+
+    @Test
+    fun `valid Kujira bech32 address delegates to Kujira searcher`() = runTest {
+        val address = "kujira1xyzcontractaddress"
+        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns true
+        coEvery { searchKujiToken(address) } returns
+            CoinAndPrice(sampleKujiCoin(address), BigDecimal.ZERO)
+
+        val result = useCase(Chain.Kujira.id, address)
+
+        assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
+        coVerify(exactly = 1) { searchKujiToken(address) }
+    }
+
+    @Test
+    fun `Kujira factory denom validates against extracted creator address`() = runTest {
+        val creator = "kujira1creator"
+        val factoryAddress = "factory/$creator/uusdc"
+        every { chainAccountAddressRepository.isValid(Chain.Kujira, creator) } returns true
+        coEvery { searchKujiToken(factoryAddress) } returns
+            CoinAndPrice(sampleKujiCoin(factoryAddress), BigDecimal.ZERO)
+
+        val result = useCase(Chain.Kujira.id, factoryAddress)
+
+        assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
+        verify(exactly = 1) { chainAccountAddressRepository.isValid(Chain.Kujira, creator) }
+        coVerify(exactly = 1) { searchKujiToken(factoryAddress) }
+    }
+
+    @Test
+    fun `Kujira factory denom with invalid creator returns null`() = runTest {
+        val factoryAddress = "factory/0xbadcreator/uusdc"
+        every { chainAccountAddressRepository.isValid(Chain.Kujira, "0xbadcreator") } returns false
+
+        val result = useCase(Chain.Kujira.id, factoryAddress)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchKujiToken(any()) }
+    }
+
+    @Test
+    fun `blank ticker in searcher response returns null`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(ticker = "   "))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `empty ticker in searcher response returns null`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(ticker = ""))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `negative decimals in searcher response returns null`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = -1))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `absurdly large decimals in searcher response returns null`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 256))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `zero decimals accepted as valid metadata`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 0))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertEquals("USDC", result?.coin?.ticker)
+        assertEquals(0, result?.coin?.decimal)
+    }
+
+    @Test
+    fun `thirty decimals accepted as upper bound`() = runTest {
+        arrangeEvmResponse(sampleEvmCoin(EVM_ADDRESS).copy(decimal = 30))
+
+        val result = useCase(Chain.Ethereum.id, EVM_ADDRESS)
+
+        assertEquals(30, result?.coin?.decimal)
+    }
+
+    @Test
+    fun `blank Kujira ticker returns null after successful search`() = runTest {
+        val address = "kujira1xyzcontractaddress"
+        every { chainAccountAddressRepository.isValid(Chain.Kujira, address) } returns true
+        coEvery { searchKujiToken(address) } returns
+            CoinAndPrice(sampleKujiCoin(address).copy(ticker = ""), BigDecimal.ZERO)
+
+        val result = useCase(Chain.Kujira.id, address)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `unsupported chain returns null and skips all searchers`() = runTest {
+        val address = "bc1qanyaddress"
+        every { chainAccountAddressRepository.isValid(Chain.Bitcoin, address) } returns true
+
+        val result = useCase(Chain.Bitcoin.id, address)
+
+        assertNull(result)
+        coVerify(exactly = 0) { searchEvmToken(any(), any()) }
+        coVerify(exactly = 0) { searchSolToken(any()) }
+        coVerify(exactly = 0) { searchKujiToken(any()) }
+    }
+
+    private fun sampleEvmCoin(address: String): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "USDC",
+            logo = "",
+            address = "0x0",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = address,
+            isNativeToken = false,
+        )
+
+    private fun sampleSolCoin(address: String): Coin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "WSOL",
+            logo = "",
+            address = "",
+            decimal = 9,
+            hexPublicKey = "",
+            priceProviderID = "solana",
+            contractAddress = address,
+            isNativeToken = false,
+        )
+
+    private fun sampleKujiCoin(address: String): Coin =
+        Coin(
+            chain = Chain.Kujira,
+            ticker = "TOKEN",
+            logo = "",
+            address = "",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = address,
+            isNativeToken = false,
+        )
+
+    private fun arrangeEvmResponse(coin: Coin) {
+        every { chainAccountAddressRepository.isValid(Chain.Ethereum, EVM_ADDRESS) } returns true
+        coEvery { searchEvmToken(Chain.Ethereum.id, EVM_ADDRESS) } returns
+            CoinAndPrice(coin, BigDecimal.ONE)
+    }
+
+    private companion object {
+        const val EVM_ADDRESS = "0x1234567890123456789012345678901234567890"
+    }
+}


### PR DESCRIPTION
## Description

Fixes #4253
Fixes #4254

Adding a custom token forwarded the raw input to the EVM RPC, the Solana token index or the Kujira REST endpoint with no format check. A Solana address pasted on Ethereum still fired a network call. When the searcher returned, the `Coin` was trusted as is so a record with a blank symbol or a broken decimal could land on the vault.

`SearchTokenUseCase` now trims the input and runs it through `ChainAccountAddressRepository.isValid` before dispatching to the chain specific searcher. Kujira `factory/<creator>/<denom>` inputs are reduced to the creator segment before validation so the existing path keeps working. After the searcher returns, the `Coin` is rejected if the ticker is blank or the decimal sits outside a sensible bound and the caller receives null.

Twenty unit tests cover valid and invalid paths per chain, trimming, empty input, factory denom handling and every metadata edge case.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

n/a

## Additional context

`ChainAccountAddressRepository.isValid` is the same WalletCore backed validator the Send flow runs when a destination address is pasted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token search validation by implementing stricter address format checks and metadata filtering.
  * Enhanced handling of multi-chain token lookups with proper address normalization across blockchain networks.
  * Fixed token data reliability by filtering out entries with invalid or missing required metadata fields.

* **Tests**
  * Added comprehensive test coverage for token search functionality across multiple blockchain networks and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->