### PR TITLE
Fix keysign completion for hashless broadcasts

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -76,7 +76,7 @@ constructor(
     override suspend fun invoke(chain: Chain, tx: SignedTransactionResult) =
         when (chain) {
             ThorChain -> {
-                thorChainApi.broadcastTransaction(tx.rawTransaction)
+                thorChainApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
             }
 
             Bitcoin,
@@ -124,18 +124,18 @@ constructor(
             Akash,
             Chain.Qbtc -> {
                 val cosmosApi = cosmosApiFactory.createCosmosApi(chain)
-                cosmosApi.broadcastTransaction(tx.rawTransaction)
+                cosmosApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
             }
 
             MayaChain -> {
-                mayaChainApi.broadcastTransaction(tx.rawTransaction)
+                mayaChainApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
             }
 
             Polkadot ->
                 recoverIfAlreadyBroadcast(
                     tx = tx,
                     broadcast = {
-                        polkadotApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
+                        polkadotApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
                     },
                     verify = { hash ->
                         polkadotApi.getTxStatus(hash)?.data?.extrinsicHash?.isNotBlank() == true
@@ -143,7 +143,7 @@ constructor(
                 )
 
             Chain.Bittensor -> {
-                bittensorApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
+                bittensorApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
             }
 
             Sui ->
@@ -158,9 +158,7 @@ constructor(
             Ton ->
                 recoverIfAlreadyBroadcast(
                     tx = tx,
-                    broadcast = {
-                        tonApi.broadcastTransaction(tx.rawTransaction) ?: tx.transactionHash
-                    },
+                    broadcast = { tonApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx) },
                     verify = { hash -> tonApi.getTsStatus(hash).transactions.isNotEmpty() },
                 )
 
@@ -185,8 +183,9 @@ constructor(
                 recoverIfAlreadyBroadcast(
                     tx = tx,
                     broadcast = {
-                        cardanoApi.broadcastTransaction(chain.name, tx.rawTransaction)
-                            ?: tx.transactionHash
+                        cardanoApi
+                            .broadcastTransaction(chain.name, tx.rawTransaction)
+                            .orKnownHash(tx)
                     },
                     verify = { hash -> cardanoApi.getTxStatus(hash)?.txHash?.isNotBlank() == true },
                 )
@@ -215,4 +214,7 @@ constructor(
                 throw e
             }
         }
+
+    private fun String?.orKnownHash(tx: SignedTransactionResult): String? =
+        this ?: tx.transactionHash.takeIf { it.isNotBlank() }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -1,0 +1,108 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.BittensorApi
+import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.api.RippleApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.TonApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class BroadcastTxUseCaseTest {
+
+    @Test
+    fun `falls back to signed transaction hash when cosmos broadcast omits hash`() = runTest {
+        val cosmosApi = mockk<CosmosApi>()
+        val cosmosApiFactory = mockk<CosmosApiFactory>()
+        coEvery { cosmosApi.broadcastTransaction(RAW_TRANSACTION) } returns null
+        every { cosmosApiFactory.createCosmosApi(Chain.Kujira) } returns cosmosApi
+
+        val txHash =
+            createUseCase(cosmosApiFactory = cosmosApiFactory)(Chain.Kujira, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
+    @Test
+    fun `falls back to signed transaction hash when thorchain broadcast omits hash`() = runTest {
+        val thorChainApi = mockk<ThorChainApi>()
+        coEvery { thorChainApi.broadcastTransaction(RAW_TRANSACTION) } returns null
+
+        val txHash =
+            createUseCase(thorChainApi = thorChainApi)(Chain.ThorChain, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
+    @Test
+    fun `falls back to signed transaction hash when mayachain broadcast omits hash`() = runTest {
+        val mayaChainApi = mockk<MayaChainApi>()
+        coEvery { mayaChainApi.broadcastTransaction(RAW_TRANSACTION) } returns null
+
+        val txHash =
+            createUseCase(mayaChainApi = mayaChainApi)(Chain.MayaChain, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
+    @Test
+    fun `uses broadcast hash when cosmos broadcast returns hash`() = runTest {
+        val cosmosApi = mockk<CosmosApi>()
+        val cosmosApiFactory = mockk<CosmosApiFactory>()
+        coEvery { cosmosApi.broadcastTransaction(RAW_TRANSACTION) } returns BROADCAST_HASH
+        every { cosmosApiFactory.createCosmosApi(Chain.Kujira) } returns cosmosApi
+
+        val txHash =
+            createUseCase(cosmosApiFactory = cosmosApiFactory)(Chain.Kujira, signedTransaction())
+
+        assertEquals(BROADCAST_HASH, txHash)
+    }
+
+    private fun createUseCase(
+        thorChainApi: ThorChainApi = mockk(relaxed = true),
+        mayaChainApi: MayaChainApi = mockk(relaxed = true),
+        cosmosApiFactory: CosmosApiFactory = mockk(relaxed = true),
+    ) =
+        BroadcastTxUseCaseImpl(
+            thorChainApi = thorChainApi,
+            evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
+            blockChairApi = mockk<BlockChairApi>(relaxed = true),
+            mayaChainApi = mayaChainApi,
+            cosmosApiFactory = cosmosApiFactory,
+            solanaApi = mockk<SolanaApi>(relaxed = true),
+            polkadotApi = mockk<PolkadotApi>(relaxed = true),
+            bittensorApi = mockk<BittensorApi>(relaxed = true),
+            suiApi = mockk<SuiApi>(relaxed = true),
+            tonApi = mockk<TonApi>(relaxed = true),
+            rippleApi = mockk<RippleApi>(relaxed = true),
+            tronApi = mockk<TronApi>(relaxed = true),
+            cardanoApi = mockk<CardanoApi>(relaxed = true),
+        )
+
+    private fun signedTransaction() =
+        SignedTransactionResult(
+            rawTransaction = RAW_TRANSACTION,
+            transactionHash = KNOWN_TRANSACTION_HASH,
+        )
+
+    private companion object {
+        const val RAW_TRANSACTION = "signed-transaction"
+        const val KNOWN_TRANSACTION_HASH = "known-transaction-hash"
+        const val BROADCAST_HASH = "broadcast-hash"
+    }
+}


### PR DESCRIPTION
## Summary
- fall back to the signed transaction's deterministic hash when Cosmos, THORChain, or MayaChain broadcast returns null
- keep thrown broadcast errors surfaced instead of converting them to success
- add unit coverage for hashless and normal Cosmos/THORChain broadcast responses

## Why
Android could remain on the signing screen after a transaction landed if broadcast completed without returning a tx hash. KeysignViewModel only advances to KeysignFinished when BroadcastTxUseCase returns a non-null hash.

## Testing
- env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew :data:ktfmtCheck :data:lintDebug :data:testDebugUnitTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcasting reliability on ThorChain, Cosmos-based networks, and MayaChain by implementing fallback handling when blockchain APIs don't return transaction hashes.

* **Tests**
  * Added comprehensive test suite for transaction broadcasting functionality to validate proper hash resolution across multiple blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->