### PR TITLE
fix: emit empty list when vault id is unknown in getEnabledTokens

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.models.VaultId
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
@@ -64,13 +63,12 @@ internal class VaultRepositoryImpl
 constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRepository) :
     VaultRepository {
 
-    override fun getEnabledTokens(vaultId: String): Flow<List<Coin>> = flow {
-        emit(requireNotNull(get(vaultId)?.coins))
-    }
+    override fun getEnabledTokens(vaultId: String): Flow<List<Coin>> =
+        getAsFlow(vaultId).map { it?.coins.orEmpty() }
 
     override fun getEnabledChains(vaultId: String): Flow<Set<Chain>> =
-        getEnabledTokens(vaultId).map { enabledTokens ->
-            enabledTokens.asSequence().filter { it.isNativeToken }.map { it.chain }.toSet()
+        getEnabledTokens(vaultId).map { tokens ->
+            tokens.asSequence().filter { it.isNativeToken }.map { it.chain }.toSet()
         }
 
     override suspend fun getDisabledCoinIds(vaultId: VaultId) =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -1,0 +1,117 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.models.CoinEntity
+import com.vultisig.wallet.data.db.models.VaultEntity
+import com.vultisig.wallet.data.db.models.VaultWithKeySharesAndTokens
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SigningLibType
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class VaultRepositoryImplTest {
+
+    private val vaultDao: VaultDao = mockk()
+    private val tokenRepository: TokenRepository = mockk {
+        coEvery { getToken(any()) } returns null
+    }
+
+    private val repository = VaultRepositoryImpl(vaultDao, tokenRepository)
+
+    @Test
+    fun `getEnabledTokens emits empty list when vault is missing`() = runTest {
+        every { vaultDao.loadByIdAsFlow(MISSING_ID) } returns flowOf(null)
+
+        val tokens = repository.getEnabledTokens(MISSING_ID).first()
+
+        assertEquals(emptyList<Any>(), tokens)
+    }
+
+    @Test
+    fun `getEnabledTokens emits empty list when vault has no coins`() = runTest {
+        every { vaultDao.loadByIdAsFlow(VAULT_ID) } returns flowOf(vaultEntity())
+
+        val tokens = repository.getEnabledTokens(VAULT_ID).first()
+
+        assertEquals(emptyList<Any>(), tokens)
+    }
+
+    @Test
+    fun `getEnabledTokens emits coins from vault`() = runTest {
+        every { vaultDao.loadByIdAsFlow(VAULT_ID) } returns
+            flowOf(vaultEntity(coin("ETH", "Ethereum"), coin("BTC", "Bitcoin")))
+
+        val tokens = repository.getEnabledTokens(VAULT_ID).first()
+
+        assertEquals(listOf("ETH", "BTC"), tokens.map { it.ticker })
+    }
+
+    @Test
+    fun `getEnabledChains emits empty set when vault is missing`() = runTest {
+        every { vaultDao.loadByIdAsFlow(MISSING_ID) } returns flowOf(null)
+
+        val chains = repository.getEnabledChains(MISSING_ID).first()
+
+        assertEquals(emptySet<Chain>(), chains)
+    }
+
+    @Test
+    fun `getEnabledChains keeps only native token chains`() = runTest {
+        every { vaultDao.loadByIdAsFlow(VAULT_ID) } returns
+            flowOf(
+                vaultEntity(
+                    coin("ETH", "Ethereum"),
+                    coin("USDC", "Ethereum", contract = "0xUsdc"),
+                    coin("BTC", "Bitcoin"),
+                )
+            )
+
+        val chains = repository.getEnabledChains(VAULT_ID).first()
+
+        assertEquals(setOf(Chain.Ethereum, Chain.Bitcoin), chains)
+    }
+
+    private fun vaultEntity(vararg coins: CoinEntity) =
+        VaultWithKeySharesAndTokens(
+            vault =
+                VaultEntity(
+                    id = VAULT_ID,
+                    name = "Test",
+                    pubKeyEcdsa = "",
+                    pubKeyEddsa = "",
+                    hexChainCode = "",
+                    localPartyID = "",
+                    resharePrefix = "",
+                    libType = SigningLibType.DKLS,
+                ),
+            keyShares = emptyList(),
+            signers = emptyList(),
+            coins = coins.toList(),
+            chainPublicKeys = emptyList(),
+        )
+
+    private fun coin(ticker: String, chain: String, contract: String = ""): CoinEntity =
+        CoinEntity(
+            vaultId = VAULT_ID,
+            id = "$ticker-$chain",
+            chain = chain,
+            ticker = ticker,
+            address = "",
+            decimals = 18,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contract,
+            logo = "",
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+        const val MISSING_ID = "vault-missing"
+    }
+}


### PR DESCRIPTION
## Description

Fixes #4261

`VaultRepositoryImpl.getEnabledTokens(vaultId)` wrapped the lookup in `requireNotNull(get(vaultId)?.coins)` and threw `IllegalArgumentException` to the collector whenever the vault id did not resolve. The crash propagated to every caller of `getEnabledTokens` and `getEnabledChains` — Token Selection, Chain Selection and the token refresh worker among them.

The flow now sources its data from the existing reactive `getAsFlow(vaultId)` and maps a missing vault to an empty token list. `getEnabledChains` keeps the native token filter and inherits the same null safety.

Five unit tests cover the missing vault, vault with no coins and vault with mixed native and contract tokens for both methods.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to vault data handling for enhanced reliability and maintainability.

* **Tests**
  * Added comprehensive test coverage for vault repository functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->