### PR TITLE
fix: return null instead of hanging when transaction id is unknown

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -17,6 +17,7 @@ import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
 import com.vultisig.wallet.data.securityscanner.isChainSupported
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.mappers.TransactionToUiModelMapper
 import com.vultisig.wallet.ui.models.swap.ValuedToken
@@ -225,14 +226,15 @@ constructor(
     }
 
     private fun loadTransaction() {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch(
+            onError = {
+                Timber.e(it, "Failed to load transaction")
+                navigator.back()
+            }
+        ) {
             val tx =
                 transactionRepository.getTransaction(transactionId)
-                    ?: run {
-                        Timber.e("Transaction not found: %s", transactionId)
-                        navigator.back()
-                        return@launch
-                    }
+                    ?: error("Transaction not found: $transactionId")
             transaction = tx
             val transactionUiModel = mapTransactionToUiModel(tx)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -226,14 +226,14 @@ constructor(
 
     private fun loadTransaction() {
         viewModelScope.launch {
-            transaction =
-                runCatching { transactionRepository.getTransaction(transactionId) }
-                    .getOrElse {
-                        Timber.e(it, "Failed to load transaction")
+            val tx =
+                transactionRepository.getTransaction(transactionId)
+                    ?: run {
+                        Timber.e("Transaction not found: %s", transactionId)
                         navigator.back()
                         return@launch
                     }
-            val tx = transaction ?: return@launch
+            transaction = tx
             val transactionUiModel = mapTransactionToUiModel(tx)
 
             val allVaults = withContext(Dispatchers.IO) { vaultRepository.getAll() }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -521,10 +521,10 @@ constructor(
                         }
 
                         else -> {
-                            val transactionDetailsUiModel =
-                                mapTransactionToUiModel(
-                                    transactionRepository.getTransaction(transactionId)
-                                )
+                            val tx =
+                                transactionRepository.getTransaction(transactionId)
+                                    ?: error("Transaction not found: $transactionId")
+                            val transactionDetailsUiModel = mapTransactionToUiModel(tx)
                             transactionHistoryData.update {
                                 transactionHistoryDataMapper(transactionDetailsUiModel)
                             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignFlowViewModel.kt
@@ -476,7 +476,7 @@ constructor(
                     keysignPayload.swapPayload != null ||
                         txType == Route.Keysign.Keysign.TxType.Swap
 
-                viewModelScope.launch {
+                viewModelScope.safeLaunch {
                     val isDeposit =
                         when (val specific = keysignPayload.blockChainSpecific) {
                             is BlockChainSpecific.MayaChain -> specific.isDeposit
@@ -523,7 +523,10 @@ constructor(
                         else -> {
                             val tx =
                                 transactionRepository.getTransaction(transactionId)
-                                    ?: error("Transaction not found: $transactionId")
+                                    ?: run {
+                                        Timber.e("Transaction not found: %s", transactionId)
+                                        return@safeLaunch
+                                    }
                             val transactionDetailsUiModel = mapTransactionToUiModel(tx)
                             transactionHistoryData.update {
                                 transactionHistoryDataMapper(transactionDetailsUiModel)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import vultisig.keysign.v1.CustomMessagePayload
 
 @HiltViewModel
@@ -71,7 +72,10 @@ constructor(
     suspend fun loadTransaction(transactionId: TransactionId) {
         val transaction =
             transactionRepository.getTransaction(transactionId)
-                ?: error("Transaction not found: $transactionId")
+                ?: run {
+                    Timber.e("Transaction not found: %s", transactionId)
+                    throw IllegalStateException()
+                }
 
         val vault = vaultRepository.get(transaction.vaultId)!!
 
@@ -100,7 +104,12 @@ constructor(
     }
 
     suspend fun loadSignMessageTx(id: String) {
-        val dto = customMessagePayloadRepo.get(id) ?: error("Sign message payload not found: $id")
+        val dto =
+            customMessagePayloadRepo.get(id)
+                ?: run {
+                    Timber.e("Sign message payload not found: %s", id)
+                    throw IllegalStateException()
+                }
 
         val vault = vaultRepository.get(dto.vaultId)!!
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -69,7 +69,9 @@ constructor(
     private var saveShareQrBitmapJob: Job? = null
 
     suspend fun loadTransaction(transactionId: TransactionId) {
-        val transaction = transactionRepository.getTransaction(transactionId)
+        val transaction =
+            transactionRepository.getTransaction(transactionId)
+                ?: error("Transaction not found: $transactionId")
 
         val vault = vaultRepository.get(transaction.vaultId)!!
 
@@ -98,7 +100,7 @@ constructor(
     }
 
     suspend fun loadSignMessageTx(id: String) {
-        val dto = customMessagePayloadRepo.get(id)
+        val dto = customMessagePayloadRepo.get(id) ?: error("Sign message payload not found: $id")
 
         val vault = vaultRepository.get(dto.vaultId)!!
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
@@ -6,9 +6,13 @@ import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.data.repositories.CustomMessagePayloadRepo
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SendDst
+import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -38,6 +42,7 @@ constructor(
     private val vaultPasswordRepository: VaultPasswordRepository,
     private val launchKeysignUseCase: LaunchKeysignUseCase,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
+    private val navigator: Navigator<Destination>,
 ) : ViewModel() {
 
     val state = MutableStateFlow(VerifySignMessageUiModel())
@@ -47,13 +52,15 @@ constructor(
     private val vaultId: String = requireNotNull(savedStateHandle[SendDst.ARG_VAULT_ID])
 
     init {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch(
+            onError = {
+                Timber.e(it, "Failed to load sign message payload")
+                navigator.back()
+            }
+        ) {
             val payload =
                 customMessagePayloadRepo.get(transactionId)?.payload
-                    ?: run {
-                        Timber.e("Sign message payload not found: %s", transactionId)
-                        return@launch
-                    }
+                    ?: error("Sign message payload not found: $transactionId")
 
             state.update {
                 it.copy(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
@@ -16,6 +16,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 internal data class SignMessageTransactionUiModel(
     val method: String = "",
@@ -47,7 +48,12 @@ constructor(
 
     init {
         viewModelScope.launch {
-            val payload = customMessagePayloadRepo.get(transactionId).payload
+            val payload =
+                customMessagePayloadRepo.get(transactionId)?.payload
+                    ?: run {
+                        Timber.e("Sign message payload not found: %s", transactionId)
+                        return@launch
+                    }
 
             state.update {
                 it.copy(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModelTest.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.ui.models.sign
+
+import androidx.lifecycle.SavedStateHandle
+import com.vultisig.wallet.data.repositories.CustomMessagePayloadDto
+import com.vultisig.wallet.data.repositories.CustomMessagePayloadRepo
+import com.vultisig.wallet.data.repositories.VaultPasswordRepository
+import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.SendDst
+import com.vultisig.wallet.ui.navigation.back
+import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.CustomMessagePayload
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class VerifySignMessageViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+    private val customMessagePayloadRepo: CustomMessagePayloadRepo = mockk(relaxed = true)
+    private val vaultPasswordRepository: VaultPasswordRepository = mockk(relaxed = true)
+    private val launchKeysign: LaunchKeysignUseCase = mockk(relaxed = true)
+    private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        coEvery { isVaultHasFastSignById(any()) } returns false
+        coEvery { vaultPasswordRepository.getPassword(any()) } returns null
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `missing payload navigates back and leaves the sign message model empty`() = runTest {
+        coEvery { customMessagePayloadRepo.get(TX_ID) } returns null
+
+        val viewModel = createViewModel()
+
+        coVerify(exactly = 1) { navigator.back() }
+        assertEquals("", viewModel.state.value.model.method)
+        assertEquals("", viewModel.state.value.model.message)
+    }
+
+    @Test
+    fun `present payload populates method and message and does not navigate back`() = runTest {
+        val payload =
+            mockk<CustomMessagePayload>(relaxed = true) {
+                every { method } returns "personal_sign"
+                every { message } returns "hello"
+            }
+        coEvery { customMessagePayloadRepo.get(TX_ID) } returns
+            CustomMessagePayloadDto(id = TX_ID, vaultId = VAULT_ID, payload = payload)
+
+        val viewModel = createViewModel()
+
+        assertEquals("personal_sign", viewModel.state.value.model.method)
+        assertEquals("hello", viewModel.state.value.model.message)
+        coVerify(exactly = 0) { navigator.back() }
+    }
+
+    private fun createViewModel(): VerifySignMessageViewModel =
+        VerifySignMessageViewModel(
+            savedStateHandle =
+                SavedStateHandle(
+                    mapOf(SendDst.ARG_TRANSACTION_ID to TX_ID, SendDst.ARG_VAULT_ID to VAULT_ID)
+                ),
+            customMessagePayloadRepo = customMessagePayloadRepo,
+            vaultPasswordRepository = vaultPasswordRepository,
+            launchKeysignUseCase = launchKeysign,
+            isVaultHasFastSignById = isVaultHasFastSignById,
+            navigator = navigator,
+        )
+
+    private companion object {
+        const val TX_ID = "tx-1"
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CustomMessagePayloadRepo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CustomMessagePayloadRepo.kt
@@ -3,8 +3,6 @@ package com.vultisig.wallet.data.repositories
 import com.vultisig.wallet.data.models.VaultId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import vultisig.keysign.v1.CustomMessagePayload
 
@@ -17,17 +15,16 @@ data class CustomMessagePayloadDto(
 interface CustomMessagePayloadRepo {
     fun add(payload: CustomMessagePayloadDto)
 
-    suspend fun get(id: String): CustomMessagePayloadDto
+    suspend fun get(id: String): CustomMessagePayloadDto?
 }
 
 internal class CustomMessagePayloadRepoImpl @Inject constructor() : CustomMessagePayloadRepo {
-    private val _payloads = MutableStateFlow(mapOf<String, CustomMessagePayloadDto>())
+
+    private val payloads = MutableStateFlow(mapOf<String, CustomMessagePayloadDto>())
 
     override fun add(payload: CustomMessagePayloadDto) {
-        _payloads.update { it + (payload.id to payload) }
+        payloads.update { it + (payload.id to payload) }
     }
 
-    override suspend fun get(id: String): CustomMessagePayloadDto {
-        return _payloads.mapNotNull { it[id] }.first()
-    }
+    override suspend fun get(id: String): CustomMessagePayloadDto? = payloads.value[id]
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionRepository.kt
@@ -4,15 +4,13 @@ import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.models.TransactionId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 
 interface TransactionRepository {
 
     suspend fun addTransaction(transaction: Transaction)
 
-    suspend fun getTransaction(id: TransactionId): Transaction
+    suspend fun getTransaction(id: TransactionId): Transaction?
 }
 
 internal class TransactionRepositoryImpl @Inject constructor() : TransactionRepository {
@@ -23,6 +21,5 @@ internal class TransactionRepositoryImpl @Inject constructor() : TransactionRepo
         transactions.update { it + (transaction.id to transaction) }
     }
 
-    override suspend fun getTransaction(id: TransactionId): Transaction =
-        transactions.mapNotNull { it[id] }.first()
+    override suspend fun getTransaction(id: TransactionId): Transaction? = transactions.value[id]
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/CustomMessagePayloadRepoImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/CustomMessagePayloadRepoImplTest.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.data.repositories
+
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+internal class CustomMessagePayloadRepoImplTest {
+
+    private val repository = CustomMessagePayloadRepoImpl()
+
+    @Test
+    fun `get returns null when repository is empty`() = runTest {
+        assertNull(repository.get("missing"))
+    }
+
+    @Test
+    fun `get returns null when id is unknown`() = runTest {
+        repository.add(payload("known"))
+
+        assertNull(repository.get("missing"))
+    }
+
+    @Test
+    fun `get returns the stored payload`() = runTest {
+        val stored = payload("p-1")
+        repository.add(stored)
+
+        assertSame(stored, repository.get("p-1"))
+    }
+
+    @Test
+    fun `add overwrites the previous entry for the same id`() = runTest {
+        repository.add(payload("p-1"))
+        val replacement = payload("p-1")
+        repository.add(replacement)
+
+        assertSame(replacement, repository.get("p-1"))
+    }
+
+    @Test
+    fun `multiple payloads are addressable independently`() = runTest {
+        val first = payload("a")
+        val second = payload("b")
+        repository.add(first)
+        repository.add(second)
+
+        assertSame(first, repository.get("a"))
+        assertSame(second, repository.get("b"))
+    }
+
+    private fun payload(id: String): CustomMessagePayloadDto =
+        CustomMessagePayloadDto(id = id, vaultId = "vault-1", payload = mockk())
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TransactionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TransactionRepositoryImplTest.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.models.Transaction
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+internal class TransactionRepositoryImplTest {
+
+    private val repository = TransactionRepositoryImpl()
+
+    @Test
+    fun `getTransaction returns null when repository is empty`() = runTest {
+        assertNull(repository.getTransaction("missing"))
+    }
+
+    @Test
+    fun `getTransaction returns null when id is unknown`() = runTest {
+        repository.addTransaction(transaction("known"))
+
+        assertNull(repository.getTransaction("missing"))
+    }
+
+    @Test
+    fun `getTransaction returns the stored transaction`() = runTest {
+        val stored = transaction("tx-1")
+        repository.addTransaction(stored)
+
+        assertSame(stored, repository.getTransaction("tx-1"))
+    }
+
+    @Test
+    fun `addTransaction overwrites the previous entry for the same id`() = runTest {
+        repository.addTransaction(transaction("tx-1"))
+        val replacement = transaction("tx-1")
+        repository.addTransaction(replacement)
+
+        assertSame(replacement, repository.getTransaction("tx-1"))
+    }
+
+    @Test
+    fun `multiple transactions are addressable independently`() = runTest {
+        val first = transaction("a")
+        val second = transaction("b")
+        repository.addTransaction(first)
+        repository.addTransaction(second)
+
+        assertSame(first, repository.getTransaction("a"))
+        assertSame(second, repository.getTransaction("b"))
+    }
+
+    private fun transaction(id: String): Transaction =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+}


### PR DESCRIPTION
## Description

Fixes #4265

`TransactionRepositoryImpl.getTransaction(id)` was implemented as `transactions.mapNotNull { it[id] }.first()`. When the id was missing the only emission of the underlying `MutableStateFlow` was filtered out and `first()` suspended forever. `CustomMessagePayloadRepoImpl.get(id)` carried the same shape and the same hang. The interface signature claimed a non null return but the runtime behaviour was a deadlock.

Both repositories now resolve the lookup synchronously through `value[id]` and surface the truth at the type level by returning a nullable. Every caller (`VerifyTransactionViewModel`, `KeysignShareViewModel`, `VerifySignMessageViewModel`, `KeysignFlowViewModel`) is updated: paths that already had a recovery branch keep navigating back, paths that always trusted the lookup raise `error(...)` so a missing id becomes a visible exception instead of a silent hang.

Two new test classes (`TransactionRepositoryImplTest`, `CustomMessagePayloadRepoImplTest`) cover empty repository, missing id, present id, overwrite by id and independent storage, ten unit tests in total. The full app test suite stays green.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user navigation when transactions or message payloads are not found.
  * Enhanced null-safety validation to prevent application crashes from missing data references.
  * Strengthened data repository lookups with explicit null checks.

* **Tests**
  * Added comprehensive test coverage for transaction and message payload data retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->