### PR TITLE
fix: scale fiat balances by the selected currency precision

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -64,9 +64,9 @@ import com.vultisig.wallet.data.models.TokenBalanceAndPrice
 import com.vultisig.wallet.data.models.TokenBalanceWrapped
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.utils.SimpleCache
+import com.vultisig.wallet.data.utils.scaledFor
 import java.math.BigDecimal
 import java.math.BigInteger
-import java.math.RoundingMode
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -197,7 +197,7 @@ constructor(
         val fiatValue =
             if (tokenValue != null) {
                 FiatValue(
-                    tokenValue.decimal.multiply(priceValue).setScale(2, RoundingMode.DOWN),
+                    tokenValue.decimal.multiply(priceValue).scaledFor(currency),
                     currency.ticker,
                 )
             } else {
@@ -206,7 +206,7 @@ constructor(
 
         return TokenBalanceAndPrice(
             tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
-            price = FiatValue(priceValue.setScale(2, RoundingMode.DOWN), currency.ticker),
+            price = FiatValue(priceValue.scaledFor(currency), currency.ticker),
         )
     }
 
@@ -242,7 +242,7 @@ constructor(
             val fiatValue =
                 if (price != null) {
                     FiatValue(
-                        value = tokenValue.decimal.multiply(price).setScale(2, RoundingMode.DOWN),
+                        value = tokenValue.decimal.multiply(price).scaledFor(currency),
                         currency = currency.ticker,
                     )
                 } else {
@@ -253,7 +253,7 @@ constructor(
                 tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
                 price =
                     if (price != null) {
-                        FiatValue(price.setScale(2, RoundingMode.DOWN), currency.ticker)
+                        FiatValue(price.scaledFor(currency), currency.ticker)
                     } else {
                         null
                     },
@@ -283,7 +283,7 @@ constructor(
             val fiatValue =
                 if (price != null) {
                     FiatValue(
-                        tokenValue.decimal.multiply(price).setScale(2, RoundingMode.DOWN),
+                        tokenValue.decimal.multiply(price).scaledFor(currency),
                         currency.ticker,
                     )
                 } else {
@@ -310,18 +310,11 @@ constructor(
                             tokenValue = balance,
                             fiatValue =
                                 FiatValue(
-                                    value =
-                                        balance.decimal
-                                            .multiply(price)
-                                            .setScale(2, RoundingMode.DOWN),
+                                    value = balance.decimal.multiply(price).scaledFor(currency),
                                     currency = currency.ticker,
                                 ),
                         ),
-                    price =
-                        FiatValue(
-                            value = price.setScale(2, RoundingMode.DOWN),
-                            currency = currency.ticker,
-                        ),
+                    price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
                 )
             }
         }
@@ -352,18 +345,14 @@ constructor(
 
         val fiatValue =
             FiatValue(
-                value = tokenValue.decimal.multiply(price).setScale(2, RoundingMode.DOWN),
+                value = tokenValue.decimal.multiply(price).scaledFor(currency),
                 currency = currency.ticker,
             )
 
         emit(
             TokenBalanceAndPrice(
                 tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
-                price =
-                    FiatValue(
-                        value = price.setScale(2, RoundingMode.DOWN),
-                        currency = currency.ticker,
-                    ),
+                price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
             )
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScaling.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScaling.kt
@@ -1,0 +1,17 @@
+package com.vultisig.wallet.data.utils
+
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.Currency
+
+internal val AppCurrency.fractionDigits: Int
+    get() =
+        runCatching { Currency.getInstance(ticker).defaultFractionDigits }
+            .getOrDefault(DEFAULT_FRACTION_DIGITS)
+            .coerceAtLeast(0)
+
+internal fun BigDecimal.scaledFor(currency: AppCurrency): BigDecimal =
+    setScale(currency.fractionDigits, RoundingMode.DOWN)
+
+private const val DEFAULT_FRACTION_DIGITS = 2

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScalingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScalingTest.kt
@@ -1,0 +1,45 @@
+package com.vultisig.wallet.data.utils
+
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class AppCurrencyScalingTest {
+
+    @Test
+    fun `JPY trims fiat to whole units`() {
+        assertEquals(BigDecimal("1234"), BigDecimal("1234.567").scaledFor(AppCurrency.JPY))
+        assertEquals(0, AppCurrency.JPY.fractionDigits)
+    }
+
+    @Test
+    fun `USD keeps two fraction digits`() {
+        assertEquals(BigDecimal("1234.56"), BigDecimal("1234.567").scaledFor(AppCurrency.USD))
+        assertEquals(2, AppCurrency.USD.fractionDigits)
+    }
+
+    @Test
+    fun `EUR keeps two fraction digits`() {
+        assertEquals(BigDecimal("0.99"), BigDecimal("0.999").scaledFor(AppCurrency.EUR))
+    }
+
+    @Test
+    fun `RUB keeps two fraction digits`() {
+        assertEquals(BigDecimal("12.34"), BigDecimal("12.349").scaledFor(AppCurrency.RUB))
+    }
+
+    @Test
+    fun `rounding mode is DOWN`() {
+        assertEquals(BigDecimal("1.99"), BigDecimal("1.999").scaledFor(AppCurrency.USD))
+        assertEquals(BigDecimal("0.00"), BigDecimal("0.005").scaledFor(AppCurrency.USD))
+    }
+
+    @Test
+    fun `every supported currency reports a non-negative scale`() {
+        AppCurrency.entries.forEach { currency ->
+            val digits = currency.fractionDigits
+            assert(digits >= 0) { "${currency.ticker} reported $digits" }
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScalingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/AppCurrencyScalingTest.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.utils
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class AppCurrencyScalingTest {
@@ -39,7 +40,7 @@ internal class AppCurrencyScalingTest {
     fun `every supported currency reports a non-negative scale`() {
         AppCurrency.entries.forEach { currency ->
             val digits = currency.fractionDigits
-            assert(digits >= 0) { "${currency.ticker} reported $digits" }
+            assertTrue(digits >= 0) { "${currency.ticker} reported $digits" }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #4273

`BalanceRepositoryImpl` hardcoded `setScale(2, RoundingMode.DOWN)` at every fiat construction site, so users on Japanese Yen saw `¥1,234.00` for every balance, price and aggregated value. The trailing decimals are wrong for any zero fraction currency and obscured the precision of every JPY screen.

A small `AppCurrency.fractionDigits` helper now reads `defaultFractionDigits` from `java.util.Currency` (with a defensive fallback of two for unknown tickers), and a `BigDecimal.scaledFor(currency)` extension wraps the rounding. Every fiat scale call in `BalanceRepositoryImpl` was rewritten to go through it. JPY shows `¥1,234`, USD/EUR/GBP/RUB and the rest keep two digits.

Six unit tests in `AppCurrencyScalingTest` cover JPY, USD, EUR, RUB, the rounding mode and a sanity check across every supported currency.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated balance and price calculations to apply currency-specific decimal precision instead of using a fixed decimal value.

* **Tests**
  * Added comprehensive tests for currency scaling behavior across all supported currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->