### PR TITLE
fix: restore SendFormScreen.amountField testTag (#4180)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/TokenAmountInput.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/TokenAmountInput.kt
@@ -36,6 +36,7 @@ internal fun TokenAmountInput(
     primaryLabel: String,
     secondaryText: String,
     modifier: Modifier = Modifier,
+    inputModifier: Modifier = Modifier,
     maxBalance: BigDecimal? = null,
     focusRequester: FocusRequester? = null,
     onLostFocus: (() -> Unit)? = null,
@@ -98,7 +99,8 @@ internal fun TokenAmountInput(
                                     }
                                 }
                             } else Modifier
-                        ),
+                        )
+                        .then(inputModifier),
                 decorator = { textField ->
                     if (primaryFieldState.text.isEmpty()) {
                         Text(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
@@ -176,10 +176,8 @@ internal fun FoldableAmountWidget(
                         focusManager.clearFocus()
                         onSend()
                     },
-                    modifier =
-                        Modifier.padding(horizontal = 54.dp)
-                            .align(Alignment.Center)
-                            .testTag("SendFormScreen.amountField"),
+                    modifier = Modifier.padding(horizontal = 54.dp).align(Alignment.Center),
+                    inputModifier = Modifier.testTag("SendFormScreen.amountField"),
                 )
 
                 if (!isCircleMode) {

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/send/SendFormScreenTestTagsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/send/SendFormScreenTestTagsTest.kt
@@ -1,0 +1,46 @@
+package com.vultisig.wallet.ui.screens.send
+
+import java.io.File
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+/**
+ * Guards the stable Compose `testTag` selectors that QA Maestro flows depend on. A silent removal
+ * during a refactor (see #4180) breaks every automated send flow, so this test fails the build the
+ * moment any of the four selectors disappears from the send form sources.
+ */
+class SendFormScreenTestTagsTest {
+
+    @Test
+    fun `SendFormScreen testTags are present in send form sources`() {
+        val sendFormSources =
+            listOf("src/main/java/com/vultisig/wallet/ui/screens/send").map(::File).flatMap { dir ->
+                require(dir.isDirectory) { "Expected source directory: ${dir.absolutePath}" }
+                dir.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+            }
+
+        val combined = sendFormSources.joinToString(separator = "\n") { it.readText() }
+
+        assertAll(
+            REQUIRED_TEST_TAGS.map { tag ->
+                {
+                    assert(combined.contains("\"$tag\"")) {
+                        "Expected testTag \"$tag\" to be present in app/src/main/java/com/vultisig/wallet/ui/screens/send/. " +
+                            "If this is intentional, update SendFormScreenTestTagsTest, otherwise restore the testTag — " +
+                            "QA Maestro flows depend on it (see issue #4180)."
+                    }
+                }
+            }
+        )
+    }
+
+    private companion object {
+        val REQUIRED_TEST_TAGS =
+            listOf(
+                "SendFormScreen.chainSelector",
+                "SendFormScreen.addressField",
+                "SendFormScreen.amountField",
+                "SendFormScreen.bondAddressField",
+            )
+    }
+}


### PR DESCRIPTION
## Summary

- Restores the stable Compose selector `SendFormScreen.amountField` so Maestro QA flows can tap the amount input again. PR #4007 / #4108 split refactor moved the testTag onto the outer `Column` wrapping `TokenAmountInput`; that node is not focusable, so `tapOn id:` was a silent no-op and every automated send flow stalled with amount `0`.
- Adds an `inputModifier` parameter to `TokenAmountInput` and routes the testTag onto the inner `BasicTextField`, matching the pre-refactor placement that QA depends on.
- Adds `SendFormScreenTestTagsTest`, a fast JVM unit test that scans `app/src/main/java/com/vultisig/wallet/ui/screens/send/` and fails the build if any of the four stable selectors (`chainSelector`, `addressField`, `amountField`, `bondAddressField`) disappears in a future refactor.

Fixes #4180.

## Test plan

- [x] `./gradlew :app:ktfmtCheck`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest --tests com.vultisig.wallet.ui.screens.send.SendFormScreenTestTagsTest`
- [ ] Run a Maestro send flow that uses `tapOn id: "SendFormScreen.amountField"` and confirm the amount input gains focus, the keyboard opens, and the entered text lands in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component parameter structure for improved flexibility.

* **Tests**
  * Added validation test to ensure UI test identifiers remain intact across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->