### PR TITLE
refactor: derive TRON_STAKING_MEMO_REGEX from enum entries (#4162)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronStaking.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronStaking.kt
@@ -1,8 +1,5 @@
 package com.vultisig.wallet.data.blockchain.tron
 
-/** Matches exactly FREEZE:BANDWIDTH, FREEZE:ENERGY, UNFREEZE:BANDWIDTH, UNFREEZE:ENERGY */
-val TRON_STAKING_MEMO_REGEX = Regex("^(FREEZE|UNFREEZE):(BANDWIDTH|ENERGY)$")
-
 enum class TronResourceType {
     BANDWIDTH,
     ENERGY,
@@ -11,6 +8,12 @@ enum class TronResourceType {
 enum class TronStakingOperation(val memoPrefix: String) {
     FREEZE("FREEZE"),
     UNFREEZE("UNFREEZE"),
+}
+
+val TRON_STAKING_MEMO_REGEX: Regex = run {
+    val operations = TronStakingOperation.entries.joinToString("|") { Regex.escape(it.memoPrefix) }
+    val resources = TronResourceType.entries.joinToString("|") { Regex.escape(it.name) }
+    Regex("^($operations):($resources)$")
 }
 
 fun tronStakingMemo(operation: TronStakingOperation, resource: TronResourceType): String =


### PR DESCRIPTION
## Summary

- `TRON_STAKING_MEMO_REGEX` is now built at runtime from `TronStakingOperation.entries` (joined by `memoPrefix`) and `TronResourceType.entries` (joined by `name`), so the regex stays in sync with the enums automatically.
- Adding a new operation (e.g. `UNBOND`, `CLAIM`) or a new resource type only requires extending the enum — the regex follows.
- `Regex.escape` keeps the derived pattern safe if a future `memoPrefix` ever contains regex metachars.

Fixes #4162.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.blockchain.tron.TronStakingTest` — all 6 cases pass (matches all four valid combinations, rejects empty/case/anchor/extra-segment/unknown-token cases).
- [x] `./gradlew :data:ktfmtFormat`
- [x] `./gradlew :app:compileDebugKotlin` — confirms the only consumer (`SendFormViewModel.kt`, `TronHelper.kt`) still compiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized TRON staking validation to dynamically support staking operations, improving flexibility for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->