### PR TITLE
fix: add stable testTags to swap form controls (#4181)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -257,6 +258,8 @@ internal fun SwapScreen(
                                     fiatValue = state.srcFiatValue,
                                     onSelectNetworkClick = onSelectSrcNetworkClick,
                                     onSelectTokenClick = onSelectSrcToken,
+                                    chainTestTag = "SwapFormScreen.fromChain",
+                                    tokenTestTag = "SwapFormScreen.fromToken",
                                     shape =
                                         RoundedWithCutoutShape(
                                             cutoutPosition = CutoutPosition.Bottom,
@@ -286,7 +289,9 @@ internal fun SwapScreen(
                                                     keyboardType = KeyboardType.Number,
                                                     imeAction = ImeAction.Done,
                                                 ),
-                                            modifier = Modifier.fillMaxWidth(),
+                                            modifier =
+                                                Modifier.fillMaxWidth()
+                                                    .testTag("SwapFormScreen.fromAmount"),
                                         )
                                     },
                                 )
@@ -360,6 +365,8 @@ internal fun SwapScreen(
                                 fiatValue = state.estimatedDstFiatValue,
                                 onSelectNetworkClick = onSelectDstNetworkClick,
                                 onSelectTokenClick = onSelectDstToken,
+                                chainTestTag = "SwapFormScreen.toChain",
+                                tokenTestTag = "SwapFormScreen.toToken",
                                 shape =
                                     RoundedWithCutoutShape(
                                         cutoutPosition = CutoutPosition.Top,
@@ -620,7 +627,9 @@ internal fun SwapScreen(
                             onSwap()
                         },
                         modifier =
-                            Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 24.dp),
+                            Modifier.fillMaxWidth()
+                                .padding(vertical = 12.dp, horizontal = 24.dp)
+                                .testTag("SwapFormScreen.swapButton"),
                     )
                 }
             }
@@ -711,6 +720,8 @@ private fun TokenInput(
     shape: Shape,
     focused: Boolean,
     modifier: Modifier = Modifier,
+    chainTestTag: String? = null,
+    tokenTestTag: String? = null,
     @SuppressLint("ComposableLambdaParameterNaming") onDragStart: (Offset) -> Unit = {},
     onDrag: (Offset) -> Unit = {},
     onDragEnd: () -> Unit = {},
@@ -740,16 +751,21 @@ private fun TokenInput(
             val selectedChain = selectedToken?.model?.address?.chain
 
             if (selectedChain != null) {
-                ChainSelector(
-                    title = title,
-                    chain = selectedChain,
-                    onClick = onSelectNetworkClick,
-                    onDragStart = onDragStart,
-                    onDragCancel = onDragCancel,
-                    onDragEnd = onDragEnd,
-                    onDrag = onDrag,
-                    onLongPressStarted = onLongPressStarted,
-                )
+                Box(
+                    modifier =
+                        if (chainTestTag != null) Modifier.testTag(chainTestTag) else Modifier
+                ) {
+                    ChainSelector(
+                        title = title,
+                        chain = selectedChain,
+                        onClick = onSelectNetworkClick,
+                        onDragStart = onDragStart,
+                        onDragCancel = onDragCancel,
+                        onDragEnd = onDragEnd,
+                        onDrag = onDrag,
+                        onLongPressStarted = onLongPressStarted,
+                    )
+                }
             }
 
             Text(
@@ -765,7 +781,9 @@ private fun TokenInput(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            TokenChip(selectedToken = selectedToken, onSelectTokenClick = onSelectTokenClick)
+            Box(modifier = if (tokenTestTag != null) Modifier.testTag(tokenTestTag) else Modifier) {
+                TokenChip(selectedToken = selectedToken, onSelectTokenClick = onSelectTokenClick)
+            }
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/swap/SwapFormScreenTestTagsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/swap/SwapFormScreenTestTagsTest.kt
@@ -1,0 +1,51 @@
+package com.vultisig.wallet.ui.screens.swap
+
+import java.io.File
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+/**
+ * Guards the stable Compose `testTag` selectors that QA Maestro flows depend on for the swap
+ * surface. A silent removal during a refactor (see #4181) breaks every cross-chain swap flow, so
+ * this test fails the build the moment any of the selectors disappears.
+ */
+class SwapFormScreenTestTagsTest {
+
+    @Test
+    fun `SwapFormScreen testTags are present in swap screen sources`() {
+        val swapSources =
+            File("src/main/java/com/vultisig/wallet/ui/screens/swap")
+                .also {
+                    require(it.isDirectory) { "Expected source directory: ${it.absolutePath}" }
+                }
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .toList()
+
+        val combined = swapSources.joinToString(separator = "\n") { it.readText() }
+
+        assertAll(
+            REQUIRED_TEST_TAGS.map { tag ->
+                {
+                    assert(combined.contains("\"$tag\"")) {
+                        "Expected testTag \"$tag\" to be present in app/src/main/java/com/vultisig/wallet/ui/screens/swap/. " +
+                            "If this is intentional, update SwapFormScreenTestTagsTest, otherwise restore the testTag — " +
+                            "QA Maestro flows depend on it (see issue #4181)."
+                    }
+                }
+            }
+        )
+    }
+
+    private companion object {
+        val REQUIRED_TEST_TAGS =
+            listOf(
+                "SwapFormScreen.fromChain",
+                "SwapFormScreen.fromToken",
+                "SwapFormScreen.fromAmount",
+                "SwapFormScreen.toChain",
+                "SwapFormScreen.toToken",
+                "SwapFormScreen.swapButton",
+            )
+    }
+}


### PR DESCRIPTION
## Summary

The v1.0.99 swap redesign (PR #4015) split the combined chain+token pill into separate controls without exposing stable Compose selectors. Maestro's cross-chain flows land on the wrong target and silent-fail (Run 3 of the v1.0.99 QA pass logged 14 cross-chain failures).

This PR addresses the **automation stability** ask from #4181: it adds the six selectors QA expects, mirroring the `SendFormScreen.*` naming convention.

| testTag | Control |
|---|---|
| `SwapFormScreen.fromChain` | Source chain dropdown |
| `SwapFormScreen.fromToken` | Source token pill |
| `SwapFormScreen.fromAmount` | Source amount input (BasicTextField, focusable) |
| `SwapFormScreen.toChain` | Destination chain dropdown |
| `SwapFormScreen.toToken` | Destination token pill |
| `SwapFormScreen.swapButton` | Bottom CTA |

Closes #4181 (automation-stability portion). The release-notes/CHANGELOG ask is left for the docs team.

## Implementation notes

- `TokenInput` now takes optional `chainTestTag` / `tokenTestTag` params applied to `Box` wrappers around `ChainSelector` / `TokenChip` — same pattern as `SendFormAssetSection.kt:78`.
- `fromAmount` is on `VsBasicTextField`'s `modifier`, which is forwarded directly onto the inner `BasicTextField` — same fix as #4180 (avoid putting the tag on a non-focusable wrapper).
- `swapButton` is on `VsButton`'s outer `modifier`, which the component applies to its clickable `Row`.
- Adds `SwapFormScreenTestTagsTest` — a JVM unit test that scans `app/src/main/java/com/vultisig/wallet/ui/screens/swap/` and fails the build if any of the six selectors disappears in a future refactor (mirrors the regression guard added in #4277).

## Test plan

- [x] `./gradlew :app:ktfmtFormat`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest --tests com.vultisig.wallet.ui.screens.swap.SwapFormScreenTestTagsTest`
- [ ] Run a Maestro cross-chain swap flow (e.g. `87-swap-eth-to-btc.yaml`) using the new selectors and confirm the from-chain dropdown opens, source token can be picked, amount entry receives focus, and the Swap CTA is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated verification ensuring required UI test selectors are present in the swap screen.

* **Chores**
  * Enhanced swap form testing infrastructure with specific test tag implementation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->