### PR TITLE
fix: include chainPublicKeys and pubKeyMLDSA in MapVaultToProto

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.mappers
 
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.proto.v1.ChainPublicKeyProto
 import com.vultisig.wallet.data.models.proto.v1.KeyShareProto
 import com.vultisig.wallet.data.models.proto.v1.VaultProto
 import com.vultisig.wallet.data.models.proto.v1.toProto
@@ -25,5 +26,14 @@ internal class MapVaultToProtoImpl @Inject constructor() : MapVaultToProto {
                 from.keyshares.map { KeyShareProto(publicKey = it.pubKey, keyshare = it.keyShare) },
             createdAt = Timestamp(Clock.System.now().epochSeconds),
             libType = from.libType.toProto(),
+            chainPublicKeys =
+                from.chainPublicKeys.map {
+                    ChainPublicKeyProto(
+                        publicKey = it.publicKey,
+                        chain = it.chain,
+                        isEddsa = it.isEddsa,
+                    )
+                },
+            publicKeyMldsa44 = from.pubKeyMLDSA,
         )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -193,6 +193,9 @@ constructor(
         vaultDataStoreRepository.setBackupStatus(adjustedVault.id, true)
         discoverToken(adjustedVault.id, null)
 
+        // MLDSA capability is sticky across hide/restore. Hiding QBTC from the chain list
+        // doesn't strip the key from the backup, so a restored vault always re-adds the QBTC
+        // token — the user may still hold funds there.
         if (adjustedVault.pubKeyMLDSA.isNotBlank()) {
             val qbtcToken = Coins.Qbtc.QBTC
             val (address, pubKey) =

--- a/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
@@ -1,0 +1,128 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.mappers.utils.MapHexToPlainString
+import com.vultisig.wallet.data.models.ChainPublicKey
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.proto.v1.VaultContainerProto
+import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCaseImpl
+import com.vultisig.wallet.data.usecases.VaultBackupEncryption
+import io.mockk.mockk
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.assertNotNull
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalEncodingApi::class)
+internal class MapVaultToProtoImplTest {
+
+    private val mapper = MapVaultToProtoImpl()
+    private val protoBuf = ProtoBuf
+
+    @Test
+    fun `proto carries every chainPublicKey entry`() {
+        val proto =
+            mapper(
+                vault(
+                    chainPublicKeys =
+                        listOf(
+                            ChainPublicKey(
+                                chain = "Ethereum",
+                                publicKey = "ethPub",
+                                isEddsa = false,
+                            ),
+                            ChainPublicKey(chain = "Solana", publicKey = "solPub", isEddsa = true),
+                        )
+                )
+            )
+
+        assertEquals(2, proto.chainPublicKeys.size)
+        val ethereum = assertNotNull(proto.chainPublicKeys[0])
+        assertEquals("Ethereum", ethereum.chain)
+        assertEquals("ethPub", ethereum.publicKey)
+        assertEquals(false, ethereum.isEddsa)
+        val solana = assertNotNull(proto.chainPublicKeys[1])
+        assertEquals("Solana", solana.chain)
+        assertEquals("solPub", solana.publicKey)
+        assertEquals(true, solana.isEddsa)
+    }
+
+    @Test
+    fun `proto carries the MLDSA public key`() {
+        val proto = mapper(vault(pubKeyMLDSA = "mldsaPub"))
+
+        assertEquals("mldsaPub", proto.publicKeyMldsa44)
+    }
+
+    @Test
+    fun `proto leaves chainPublicKeys empty when source has none`() {
+        val proto = mapper(vault(chainPublicKeys = emptyList()))
+
+        assertTrue(proto.chainPublicKeys.isEmpty())
+        assertEquals("", proto.publicKeyMldsa44)
+    }
+
+    @Test
+    fun `KeyImport vault round-trips through export and parse without losing fields`() {
+        val source =
+            vault(
+                libType = SigningLibType.KeyImport,
+                pubKeyMLDSA = "mldsaPub",
+                chainPublicKeys =
+                    listOf(
+                        ChainPublicKey(chain = "Ethereum", publicKey = "ethPub", isEddsa = false),
+                        ChainPublicKey(chain = "Solana", publicKey = "solPub", isEddsa = true),
+                    ),
+            )
+
+        val restored = roundTrip(source)
+
+        assertEquals(SigningLibType.KeyImport, restored.libType)
+        assertEquals("mldsaPub", restored.pubKeyMLDSA)
+        assertEquals(2, restored.chainPublicKeys.size)
+        assertEquals(source.chainPublicKeys.toSet(), restored.chainPublicKeys.toSet())
+    }
+
+    private fun roundTrip(source: Vault): Vault {
+        val proto = mapper(source)
+        val vaultBytes = protoBuf.encodeToByteArray(proto)
+        val container = VaultContainerProto(vault = Base64.encode(vaultBytes), isEncrypted = false)
+        val containerBytes = protoBuf.encodeToByteArray(container)
+        val parser =
+            ParseVaultFromStringUseCaseImpl(
+                vaultFromOldJsonMapper = mockk(),
+                mapHexToPlainString = mockk<MapHexToPlainString>(),
+                encryption = mockk<VaultBackupEncryption>(),
+                protoBuf = protoBuf,
+                json = Json,
+            )
+        return parser(Base64.encode(containerBytes), null)
+    }
+
+    private fun vault(
+        chainPublicKeys: List<ChainPublicKey> = emptyList(),
+        pubKeyMLDSA: String = "",
+        libType: SigningLibType = SigningLibType.DKLS,
+    ): Vault =
+        Vault(
+            id = "vault-id",
+            name = "Test",
+            pubKeyECDSA = "ecdsa",
+            pubKeyEDDSA = "eddsa",
+            hexChainCode = "chainCode",
+            localPartyID = "party",
+            signers = listOf("party"),
+            resharePrefix = "",
+            libType = libType,
+            chainPublicKeys = chainPublicKeys,
+            pubKeyMLDSA = pubKeyMLDSA,
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
@@ -45,6 +45,7 @@ internal class MapVaultToProtoImplTest {
             )
 
         assertEquals(2, proto.chainPublicKeys.size)
+        // Generated proto element type is nullable; assertNotNull lifts it for direct access.
         val ethereum = assertNotNull(proto.chainPublicKeys[0])
         assertEquals("Ethereum", ethereum.chain)
         assertEquals("ethPub", ethereum.publicKey)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.fileContent
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -140,6 +142,48 @@ internal class ImportFileViewModelTest {
         val savedVaultSlot = slot<Vault>()
         coVerify { saveVault(capture(savedVaultSlot), false) }
         assertEquals(SigningLibType.DKLS, savedVaultSlot.captured.libType)
+    }
+
+    @Test
+    fun `restoring an MLDSA-capable vault re-adds the QBTC token`() = runTest {
+        val vault =
+            Vault(
+                id = "test-vault-id",
+                name = "Test Vault",
+                libType = SigningLibType.KeyImport,
+                pubKeyMLDSA = "mldsa-pubkey",
+            )
+        coEvery { parseVaultFromString(any(), any()) } returns vault
+        coEvery { saveVault(any(), false) } returns Unit
+        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } returns Unit
+        every { discoverToken(any(), any()) } returns Unit
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } returns
+            Pair("qbtc1address", "qbtc-derived-pubkey")
+        coEvery { vaultRepository.addTokenToVault(any(), any()) } returns Unit
+
+        createViewModel(fileName = "share1of2-test.bak").decryptVaultData()
+
+        val tokenSlot = slot<Coin>()
+        coVerify { vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot)) }
+        assertEquals(Coins.Qbtc.QBTC.ticker, tokenSlot.captured.ticker)
+        assertEquals("qbtc1address", tokenSlot.captured.address)
+        assertEquals("qbtc-derived-pubkey", tokenSlot.captured.hexPublicKey)
+    }
+
+    @Test
+    fun `restoring a vault without MLDSA leaves QBTC alone`() = runTest {
+        val vault =
+            Vault(
+                id = "test-vault-id",
+                name = "Test Vault",
+                libType = SigningLibType.DKLS,
+                pubKeyMLDSA = "",
+            )
+        coEvery { parseVaultFromString(any(), any()) } returns vault
+
+        createViewModel(fileName = "share1of2-test.bak").decryptVaultData()
+
+        coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
     }
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/proto/v1/Aliases.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/proto/v1/Aliases.kt
@@ -30,6 +30,8 @@ typealias VaultContainerProto = vultisig.vault.v1.VaultContainer
 
 typealias KeyShareProto = Vault.KeyShare
 
+typealias ChainPublicKeyProto = Vault.ChainPublicKey
+
 fun LibType.toSigningLibType() =
     when (this) {
         LibType.LIB_TYPE_GG20 -> SigningLibType.GG20


### PR DESCRIPTION
## Description

Restoring a KeyImport vault from a `.vult` backup now keeps the user's original chain selection visible in the chain list, and re-adds the QBTC token when the vault carries MLDSA capability. Hiding a chain in the UI is not the same as removing it from the backup, so the restored vault should still surface every chain the user originally enabled.

Six unit tests cover the change. `MapVaultToProtoImplTest` exercises the proto export and a full export/parse round-trip for a KeyImport vault carrying `chainPublicKeys` and `pubKeyMLDSA`. `ImportFileViewModelTest` covers the import contract: a restored vault with `pubKeyMLDSA` set re-adds QBTC; a vault without it leaves QBTC alone.

## Which feature is affected?

- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for vault data mapping, including chain public key preservation and MLDSA44 key support validation.
  * Added tests to verify proper QBTC token re-addition during vault restoration based on MLDSA capability status.

* **Bug Fixes**
  * Improved vault serialization to properly preserve all chain public keys and MLDSA44 cryptographic key data during import and restoration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->