### PR TITLE
fix: render password prompt Compose previews

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ImportFileScreen.kt
@@ -42,6 +42,7 @@ import com.vultisig.wallet.ui.models.ImportFileState
 import com.vultisig.wallet.ui.models.ImportFileViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignPasswordUiModel
 import com.vultisig.wallet.ui.screens.keysign.KeysignPasswordBottomSheet
+import com.vultisig.wallet.ui.screens.keysign.KeysignPasswordSheetContent
 import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.ActivityResultContractsGetContentWithMimeTypes
@@ -238,5 +239,14 @@ private fun ImportFilePreview() {
 @Preview(showBackground = true)
 @Composable
 private fun ImportFilePasswordPromptPreview() {
-    ImportFileScreen(uiModel = ImportFileState(showPasswordPrompt = true))
+    KeysignPasswordSheetContent(
+        title = stringResource(R.string.keysign_password_enter_your_password),
+        subtitle = stringResource(R.string.import_file_screen_enter_password_sub),
+        confirmButtonLabel = stringResource(R.string.fast_vault_password_screen_next),
+        state = KeysignPasswordUiModel(isPasswordVisible = false, passwordError = null),
+        passwordFieldState = TextFieldState(),
+        onPasswordVisibilityToggle = {},
+        onContinueClick = {},
+        onBackClick = {},
+    )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPasswordScreen.kt
@@ -237,7 +237,8 @@ fun KeysignPasswordSheetContent(
 @Preview
 @Composable
 private fun KeysignPasswordScreenPreview() {
-    InputPasswordScreen(
+    KeysignPasswordSheetContent(
+        title = stringResource(R.string.keysign_password_enter_your_password),
         subtitle = "Enter your password to unlock your Server Share and start the upgrade",
         state = KeysignPasswordUiModel(passwordHint = UiText.DynamicString("Hint")),
         passwordFieldState = TextFieldState(),


### PR DESCRIPTION
## Summary
- `ImportFilePasswordPromptPreview` and `KeysignPasswordScreenPreview` were rendering blank because both flowed into `KeysignPasswordBottomSheet`/`V2BottomSheet`, and `ModalBottomSheet` draws in a separate platform window that Compose `@Preview` cannot display.
- Switched both previews to call `KeysignPasswordSheetContent` directly so the password prompt content renders in the preview.

## Test plan
- [ ] Open `ImportFileScreen.kt` in Android Studio and confirm `ImportFilePasswordPromptPreview` renders the password prompt content.
- [ ] Open `KeysignPasswordScreen.kt` and confirm `KeysignPasswordScreenPreview` renders the password prompt content.
- [ ] Run the app and verify the actual `KeysignPasswordBottomSheet` flows still display correctly (no runtime change expected — preview-only edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development preview screens to render the password sheet content directly with localized strings and default UI state.
  * These updates affect only preview rendering for developers and do not change runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->