### PR TITLE
fix: handle already-joined vault on QR scan instead of hanging

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
@@ -79,7 +79,10 @@ internal sealed class JoinKeygenError(val message: UiText) {
 internal data class JoinKeygenUiModel(
     val isSuccess: Boolean = false,
     val error: JoinKeygenError? = null,
+    val alreadyJoined: AlreadyJoinedVault? = null,
 )
+
+internal data class AlreadyJoinedVault(val vaultId: VaultId, val vaultName: String)
 
 private class JoinKeygenException(val error: JoinKeygenError) : Exception()
 
@@ -128,17 +131,22 @@ constructor(
 
                             // hexChainCode uniquely identifies the vault across devices.
                             // If a vault with the same chain code is already on this device,
-                            // skip the join and open it instead of running keygen + failing
-                            // on duplicate save.
+                            // skip the join and surface a clear "already on device" message
+                            // instead of running keygen + failing on duplicate save.
                             val alreadyJoinedVault = existingVaults.find {
                                 it.hexChainCode == message.hexChainCode &&
                                     it.hexChainCode.isNotBlank()
                             }
                             if (alreadyJoinedVault != null) {
-                                navigator.route(
-                                    route = Route.Home(openVaultId = alreadyJoinedVault.id),
-                                    opts = NavigationOptions(clearBackStack = true),
-                                )
+                                state.update {
+                                    it.copy(
+                                        alreadyJoined =
+                                            AlreadyJoinedVault(
+                                                vaultId = alreadyJoinedVault.id,
+                                                vaultName = alreadyJoinedVault.name,
+                                            )
+                                    )
+                                }
                                 return@launch
                             }
 
@@ -297,6 +305,16 @@ constructor(
 
     fun navigateBack() {
         viewModelScope.launch { navigator.navigate(Destination.Back) }
+    }
+
+    fun openExistingVault() {
+        val vaultId = state.value.alreadyJoined?.vaultId ?: return
+        viewModelScope.launch {
+            navigator.route(
+                route = Route.Home(openVaultId = vaultId),
+                opts = NavigationOptions(clearBackStack = true),
+            )
+        }
     }
 
     private fun assertNoVaultNameDuplicates(existingVaults: List<Vault>, name: String) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
@@ -68,7 +68,8 @@ internal sealed class JoinKeygenError(val message: UiText) {
 
     data object UnknownTss : JoinKeygenError(R.string.join_key_gen_unknown_tssaction.asUiText())
 
-    data object WrongResharePrefix : JoinKeygenError(R.string.join_keysign_wrong_reshare.asUiText())
+    data object WrongResharePrefix :
+        JoinKeygenError(R.string.join_keysign_wrong_reshare.asUiText())
 
     data object DiscoveryTimeout :
         JoinKeygenError(R.string.join_key_gen_mediator_discovery_timeout.asUiText())
@@ -133,10 +134,11 @@ constructor(
                             // If a vault with the same chain code is already on this device,
                             // skip the join and surface a clear "already on device" message
                             // instead of running keygen + failing on duplicate save.
-                            val alreadyJoinedVault = existingVaults.find {
-                                it.hexChainCode == message.hexChainCode &&
-                                    it.hexChainCode.isNotBlank()
-                            }
+                            val alreadyJoinedVault =
+                                existingVaults.find {
+                                    it.hexChainCode == message.hexChainCode &&
+                                        it.hexChainCode.isNotBlank()
+                                }
                             if (alreadyJoinedVault != null) {
                                 state.update {
                                     it.copy(
@@ -182,9 +184,8 @@ constructor(
                                     protoBuf.decodeFromByteArray<ReshareMessageProto>(bytes)
                                 )
 
-                            val existingVault = existingVaults.find {
-                                it.pubKeyECDSA == message.pubKeyECDSA
-                            }
+                            val existingVault =
+                                existingVaults.find { it.pubKeyECDSA == message.pubKeyECDSA }
 
                             if (
                                 existingVault != null &&

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/JoinKeygenViewModel.kt
@@ -68,8 +68,7 @@ internal sealed class JoinKeygenError(val message: UiText) {
 
     data object UnknownTss : JoinKeygenError(R.string.join_key_gen_unknown_tssaction.asUiText())
 
-    data object WrongResharePrefix :
-        JoinKeygenError(R.string.join_keysign_wrong_reshare.asUiText())
+    data object WrongResharePrefix : JoinKeygenError(R.string.join_keysign_wrong_reshare.asUiText())
 
     data object DiscoveryTimeout :
         JoinKeygenError(R.string.join_key_gen_mediator_discovery_timeout.asUiText())
@@ -127,6 +126,22 @@ constructor(
                                     protoBuf.decodeFromByteArray<KeygenMessageProto>(bytes)
                                 )
 
+                            // hexChainCode uniquely identifies the vault across devices.
+                            // If a vault with the same chain code is already on this device,
+                            // skip the join and open it instead of running keygen + failing
+                            // on duplicate save.
+                            val alreadyJoinedVault = existingVaults.find {
+                                it.hexChainCode == message.hexChainCode &&
+                                    it.hexChainCode.isNotBlank()
+                            }
+                            if (alreadyJoinedVault != null) {
+                                navigator.route(
+                                    route = Route.Home(openVaultId = alreadyJoinedVault.id),
+                                    opts = NavigationOptions(clearBackStack = true),
+                                )
+                                return@launch
+                            }
+
                             assertNoVaultNameDuplicates(existingVaults, message.vaultName)
 
                             val serverUrl =
@@ -159,8 +174,9 @@ constructor(
                                     protoBuf.decodeFromByteArray<ReshareMessageProto>(bytes)
                                 )
 
-                            val existingVault =
-                                existingVaults.find { it.pubKeyECDSA == message.pubKeyECDSA }
+                            val existingVault = existingVaults.find {
+                                it.pubKeyECDSA == message.pubKeyECDSA
+                            }
 
                             if (
                                 existingVault != null &&

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
@@ -687,7 +687,25 @@ constructor(
         } else {
             val shouldOverrideVault = isReshareMode || action == TssAction.Migrate
 
-            saveVault(vault, shouldOverrideVault)
+            try {
+                saveVault(vault, shouldOverrideVault)
+            } catch (e: DuplicateVaultException) {
+                // Defence in depth: if the join-time hexChainCode check missed (e.g. the QR
+                // carried an empty chain code), the duplicate is detected here by pubKeyECDSA.
+                // Treat it as already-joined and route to the existing vault instead of leaving
+                // the success screen stuck on a spinner.
+                val existingVault = vaultRepository.getByEcdsa(vault.pubKeyECDSA) ?: throw e
+                Timber.w(
+                    "saveVault: vault already exists, opening existing one (id=%s)",
+                    existingVault.id,
+                )
+                stopService()
+                navigator.route(
+                    route = Route.Home(openVaultId = existingVault.id),
+                    opts = NavigationOptions(clearBackStack = true),
+                )
+                return
+            }
 
             vaultDataStoreRepository.setBackupStatus(vaultId = vaultId, false)
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -34,17 +34,33 @@ internal fun JoinKeygenScreen(model: JoinKeygenViewModel = hiltViewModel()) {
 
     val state by model.state.collectAsState()
     val error = state.error
-    if (error == null) {
-        JoinKeygenScreen(state = state)
-    } else {
-        ErrorView(
-            title = error.message.asString(),
-            buttonUiModel =
-                ErrorViewButtonUiModel(
-                    text = stringResource(R.string.scan_qr_code_error_button),
-                    onClick = model::navigateBack,
-                ),
-        )
+    val alreadyJoined = state.alreadyJoined
+    when {
+        alreadyJoined != null ->
+            ErrorView(
+                title =
+                    stringResource(
+                        R.string.join_key_gen_vault_already_on_device,
+                        alreadyJoined.vaultName,
+                    ),
+                buttonUiModel =
+                    ErrorViewButtonUiModel(
+                        text = stringResource(R.string.join_key_gen_open_existing_vault),
+                        onClick = model::openExistingVault,
+                    ),
+            )
+
+        error != null ->
+            ErrorView(
+                title = error.message.asString(),
+                buttonUiModel =
+                    ErrorViewButtonUiModel(
+                        text = stringResource(R.string.scan_qr_code_error_button),
+                        onClick = model::navigateBack,
+                    ),
+            )
+
+        else -> JoinKeygenScreen(state = state)
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -723,6 +723,8 @@
     <string name="keysign_password_enter_your_password">Passwort eingeben.</string>
     <string name="migration_password_enter_your_password_to_unlock">Geben Sie Ihr Passwort ein, um Ihre Serverfreigabe freizugeben und das Upgrade zu starten.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Vault mit doppeltem Namen vorhanden</string>
+    <string name="join_key_gen_vault_already_on_device">Tresor \"%1$s\" ist bereits auf diesem Gerät</string>
+    <string name="join_key_gen_open_existing_vault">Tresor öffnen</string>
     <string name="join_key_gen_unknown_tssaction">Unbekannte TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">Das andere Gerät konnte im Netzwerk nicht gefunden werden</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Warte auf die Verbindung anderer Geräte</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -721,6 +721,8 @@
     <string name="keysign_password_enter_your_password">Ingrese su contraseña.</string>
     <string name="migration_password_enter_your_password_to_unlock">Ingrese su contraseña para desbloquear su servidor compartido e iniciar la actualización.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Existe una bóveda con nombre duplicado</string>
+    <string name="join_key_gen_vault_already_on_device">La bóveda \"%1$s\" ya está en este dispositivo</string>
+    <string name="join_key_gen_open_existing_vault">Abrir bóveda</string>
     <string name="join_key_gen_unknown_tssaction">TssAction desconocido</string>
     <string name="join_key_gen_mediator_discovery_timeout">No se pudo encontrar el otro dispositivo en la red</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Esperando a que se unan otros dispositivos</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -725,6 +725,8 @@
     <string name="keysign_password_enter_your_password">Unesite svoju lozinku</string>
     <string name="migration_password_enter_your_password_to_unlock">Unesite svoju lozinku za otključavanje dijeljenog poslužitelja i početak nadogradnje</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Trezor s dupliciranim nazivom postoji</string>
+    <string name="join_key_gen_vault_already_on_device">Trezor \"%1$s\" već se nalazi na ovom uređaju</string>
+    <string name="join_key_gen_open_existing_vault">Otvori trezor</string>
     <string name="join_key_gen_unknown_tssaction">Nepoznata TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">Drugi uređaj nije pronađen na mreži</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Čekanje da se drugi uređaji pridruže</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -721,6 +721,8 @@
     <string name="keysign_password_enter_your_password">Inserisci la tua password</string>
     <string name="migration_password_enter_your_password_to_unlock">Inserisci la tua password per sbloccare la tua condivisione server e avviare l\'aggiornamento</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Esiste un Vault con nome duplicato</string>
+    <string name="join_key_gen_vault_already_on_device">Il Vault \"%1$s\" è già su questo dispositivo</string>
+    <string name="join_key_gen_open_existing_vault">Apri Vault</string>
     <string name="join_key_gen_unknown_tssaction">TssAction sconosciuta</string>
     <string name="join_key_gen_mediator_discovery_timeout">Impossibile trovare l\'altro dispositivo sulla rete</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">In attesa che altri dispositivi si uniscano</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -878,6 +878,8 @@
     <string name="import_file_import_your_vault_share">볼트 공유 가져오기</string>
     <string name="import_file_supported_file_types_dat_bak_vult"><![CDATA[지원 파일 형식: .dat & .bak & .vult]]></string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">동일한 이름의 볼트가 존재합니다</string>
+    <string name="join_key_gen_vault_already_on_device">볼트 \"%1$s\"이(가) 이미 이 기기에 있습니다</string>
+    <string name="join_key_gen_open_existing_vault">볼트 열기</string>
     <string name="join_key_gen_unknown_tssaction">알 수 없는 TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">네트워크에서 다른 기기를 찾을 수 없습니다</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">다른 기기의 참여를 기다리는 중</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -718,6 +718,8 @@
     <string name="keysign_password_enter_your_password">Voer uw wachtwoord in</string>
     <string name="migration_password_enter_your_password_to_unlock">Voer uw wachtwoord in om uw servershare te ontgrendelen en de upgrade te starten</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Er bestaat een kluis met een dubbele naam</string>
+    <string name="join_key_gen_vault_already_on_device">Kluis \"%1$s\" staat al op dit apparaat</string>
+    <string name="join_key_gen_open_existing_vault">Kluis openen</string>
     <string name="join_key_gen_unknown_tssaction">Onbekende TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">Kan het andere apparaat niet vinden op het netwerk</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Wachten op andere apparaten om toe te treden</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -720,6 +720,8 @@
     <string name="keysign_password_enter_your_password">Introduza a sua senha</string>
     <string name="migration_password_enter_your_password_to_unlock">Introduza a sua palavra-passe para desbloquear a sua Partilha de Servidor e iniciar a atualização.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Existe um cofre com nome duplicado</string>
+    <string name="join_key_gen_vault_already_on_device">O cofre \"%1$s\" já está neste dispositivo</string>
+    <string name="join_key_gen_open_existing_vault">Abrir cofre</string>
     <string name="join_key_gen_unknown_tssaction">Ação Tss desconhecida</string>
     <string name="join_key_gen_mediator_discovery_timeout">Não foi possível encontrar o outro dispositivo na rede</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Aguarda a entrada de outros dispositivos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -724,6 +724,8 @@
     <string name="keysign_password_enter_your_password">Введите пароль</string>
     <string name="migration_password_enter_your_password_to_unlock">Введите пароль, чтобы разблокировать общий сервер и начать обновление.</string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Существует хранилище с дублирующимся именем</string>
+    <string name="join_key_gen_vault_already_on_device">Хранилище \"%1$s\" уже находится на этом устройстве</string>
+    <string name="join_key_gen_open_existing_vault">Открыть хранилище</string>
     <string name="join_key_gen_unknown_tssaction">Неизвестное действие TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">Не удалось найти другое устройство в сети</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Ожидание подключения других устройств</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -884,6 +884,8 @@
 
     <!-- Keygen & Keysign -->
     <string name="join_key_gen_vault_with_duplicate_name_exists">存在重复名称的保险库</string>
+    <string name="join_key_gen_vault_already_on_device">保险库 \"%1$s\" 已在此设备上</string>
+    <string name="join_key_gen_open_existing_vault">打开保险库</string>
     <string name="join_key_gen_unknown_tssaction">未知的 TSS 操作</string>
     <string name="join_key_gen_mediator_discovery_timeout">无法在您的网络中找到其他设备</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">等待其他设备加入</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,6 +896,8 @@
     <string name="import_file_import_your_vault_share">Import your vault share</string>
     <string name="import_file_supported_file_types_dat_bak_vult"><![CDATA[Supported file types: .dat & .bak & .vult]]></string>
     <string name="join_key_gen_vault_with_duplicate_name_exists">Vault with duplicate name exists</string>
+    <string name="join_key_gen_vault_already_on_device">Vault \"%1$s\" is already on this device</string>
+    <string name="join_key_gen_open_existing_vault">Open vault</string>
     <string name="join_key_gen_unknown_tssaction">Unknown TssAction</string>
     <string name="join_key_gen_mediator_discovery_timeout">Could not find the other device on your network</string>
     <string name="join_key_gen_waiting_for_other_devices_to_join">Waiting for other devices to join</string>


### PR DESCRIPTION
## Summary

Fixes #4282 — joining a QR for an existing seed-phrase vault on a device that already has it threw `DuplicateVaultException` after keygen completed, leaving the *Vault created successfully* screen stuck on an infinite spinner.

- **Primary fix** — `JoinKeygenViewModel` (KEYGEN/KeyImport branch) now compares the QR's `hexChainCode` against existing vaults before doing anything. If a match is found, it skips mediator discovery + keygen entirely and routes to `Route.Home(openVaultId = existingVault.id)`. The non-blank guard prevents matching legacy vaults that have an empty stored chain code.
- **Defence in depth** — `KeygenViewModel.saveVault()` now catches `DuplicateVaultException` on the non-override path (only `KEYGEN`/`KeyImport` can hit it; reshare/migrate use `upsert`). On catch it looks up the existing vault by `pubKeyECDSA`, stops the mediator service, and routes to Home — so the success screen never hangs even if the early `hexChainCode` check ever misses (e.g. the QR carries an empty chain code, or another flow saved the vault concurrently).
[Screen_recording_20260426_050958.webm](https://github.com/user-attachments/assets/24d7646d-5709-41f4-8b0e-4818fc32e854)

## Why two layers

The early `hexChainCode` check is the user-friendly path: skip the whole join when we already know the vault is here. The save-side catch protects the cases the early check can miss — initiating-device flows, blank/legacy chain codes, races against another save — so we never regress to the original infinite spinner.

## Test plan

- [ ] Device A has Vault X (seed-phrase). Device B has the same Vault X stored. Start join keygen flow on B with A's QR — B should land on Home with Vault X selected, no spinner hang, no error toast.
- [ ] Normal first-time join on a clean device still completes keygen and reaches the backup flow.
- [ ] Reshare / Migrate flows are unaffected (still upsert; never throw `DuplicateVaultException`).
- [ ] Verify on emulator with two debug builds (forward port 18080 + socat per README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate vault creation when rejoining or importing; users are automatically redirected to their existing vault instead of creating duplicates.

* **New Features**
  * UI now detects when a vault is already on the device, showing a localized message with the vault name and a primary action to open the existing vault (navigates to Home and clears back stack).

* **Localization**
  * Added localized strings for the new "already on device" message and "open existing vault" action across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->