### PR TITLE
test: stabilize flaky QBTC token re-add test

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.DefaultDispatcher
 import com.vultisig.wallet.data.common.AppZipEntry
 import com.vultisig.wallet.data.common.fileContent
 import com.vultisig.wallet.data.common.fileName
@@ -38,7 +39,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -76,6 +77,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val snackBarFlow: SnackbarFlow,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val args = savedStateHandle.toRoute<Route.ImportVault>()
@@ -125,7 +127,7 @@ constructor(
     private suspend fun saveToDb(fileContent: String, password: String?): SaveResult =
         try {
             val vault =
-                withContext(Dispatchers.Default) { parseVaultFromString(fileContent, password) }
+                withContext(defaultDispatcher) { parseVaultFromString(fileContent, password) }
             insertVaultToDb(vault)
             SaveResult.Success
         } catch (e: DuplicateVaultException) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -41,8 +41,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-private const val VERIFY_TIMEOUT_MS = 1_000L
-
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class ImportFileViewModelTest {
 
@@ -98,6 +96,7 @@ internal class ImportFileViewModelTest {
                 vaultRepository = vaultRepository,
                 chainAccountAddressRepository = chainAccountAddressRepository,
                 snackBarFlow = snackbarFlow,
+                defaultDispatcher = testDispatcher,
             )
         vm.uiModel.value =
             ImportFileState(fileName = fileName, fileContent = fileContent, isZip = false)
@@ -166,11 +165,7 @@ internal class ImportFileViewModelTest {
         createViewModel(fileName = "share1of2-test.bak").decryptVaultData()
 
         val tokenSlot = slot<Coin>()
-        // saveToDb hops onto Dispatchers.Default to parse the vault, which escapes the
-        // test scheduler — poll until the verification succeeds instead of asserting eagerly.
-        coVerify(timeout = VERIFY_TIMEOUT_MS) {
-            vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot))
-        }
+        coVerify { vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot)) }
         assertEquals(Coins.Qbtc.QBTC.ticker, tokenSlot.captured.ticker)
         assertEquals("qbtc1address", tokenSlot.captured.address)
         assertEquals("qbtc-derived-pubkey", tokenSlot.captured.hexPublicKey)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+private const val VERIFY_TIMEOUT_MS = 1_000L
+
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class ImportFileViewModelTest {
 
@@ -164,7 +166,11 @@ internal class ImportFileViewModelTest {
         createViewModel(fileName = "share1of2-test.bak").decryptVaultData()
 
         val tokenSlot = slot<Coin>()
-        coVerify { vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot)) }
+        // saveToDb hops onto Dispatchers.Default to parse the vault, which escapes the
+        // test scheduler — poll until the verification succeeds instead of asserting eagerly.
+        coVerify(timeout = VERIFY_TIMEOUT_MS) {
+            vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot))
+        }
         assertEquals(Coins.Qbtc.QBTC.ticker, tokenSlot.captured.ticker)
         assertEquals("qbtc1address", tokenSlot.captured.address)
         assertEquals("qbtc-derived-pubkey", tokenSlot.captured.hexPublicKey)


### PR DESCRIPTION
## Summary

- Fix intermittent CI failure: `ImportFileViewModelTest > restoring an MLDSA-capable vault re-adds the QBTC token`
- The test verified `addTokenToVault` eagerly, but `ImportFileViewModel.saveToDb` wraps `parseVaultFromString` in `withContext(Dispatchers.Default)` — a real thread pool that is **not** controlled by `runTest`'s `UnconfinedTestDispatcher`. Under CI load this raced and the verification ran before the QBTC token was added, producing a bare `AssertionError` at the test method line.
- Switch to `coVerify(timeout = 1_000)` so mockk polls until the call lands. The same race exists in principle for the sibling tests, but they verify state set inside `insertVaultToDb` directly and have not flaked — leaving them alone.

## Failures observed

The same test failed in three recent merge_group runs and intermittently passed otherwise:

- https://github.com/vultisig/vultisig-android/actions/runs/24943166541/job/73040093200
- https://github.com/vultisig/vultisig-android/actions/runs/24944726015
- https://github.com/vultisig/vultisig-android/actions/runs/24945042369

```
ImportFileViewModelTest > restoring an MLDSA-capable vault re-adds the QBTC token() FAILED
    java.lang.AssertionError at ImportFileViewModelTest.kt:148
```

## Test plan

- [x] Ran the affected test 5 consecutive times locally with `--rerun-tasks` — all green
- [x] Full `:app:testDebugUnitTest` for the class passes
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for vault restoration scenarios with controlled coroutine scheduling to make asynchronous operations more deterministic.
* **Refactor**
  * Switched to an injected coroutine execution strategy to improve async behavior consistency during file import and restore operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->