### PR TITLE
feat(tron): show Bandwidth/Energy on pending withdrawal rows

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.models.TronAccountJson
 import com.vultisig.wallet.data.api.models.TronAccountResourceJson
 import com.vultisig.wallet.data.api.models.calculateResourceStats
+import com.vultisig.wallet.data.blockchain.tron.TronResourceType
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.VaultId
@@ -84,7 +85,12 @@ internal sealed interface TronDeFiUiState {
     ) : TronDeFiUiState
 }
 
-@Immutable data class TronPendingWithdrawalUiModel(val amountTrx: String, val expiryEpochMs: Long)
+@Immutable
+data class TronPendingWithdrawalUiModel(
+    val amountTrx: String,
+    val expiryEpochMs: Long,
+    val resourceType: TronResourceType?,
+)
 
 internal enum class TronAction(val defiType: DeFiNavActions) {
     FREEZE(DeFiNavActions.FREEZE_TRX),
@@ -203,9 +209,17 @@ constructor(
                 TronPendingWithdrawalUiModel(
                     amountTrx = amountSun.sunToTrx().toPlainString(),
                     expiryEpochMs = expireTimeMs,
+                    resourceType = entry.type.toTronResourceType(),
                 )
             }
             .sortedWith(compareBy { it.expiryEpochMs })
+
+    private fun String?.toTronResourceType(): TronResourceType? =
+        when (this) {
+            "BANDWIDTH" -> TronResourceType.BANDWIDTH
+            "ENERGY" -> TronResourceType.ENERGY
+            else -> null
+        }
 
     private suspend fun findTrxCoin(vaultId: VaultId) =
         vaultRepository.get(vaultId)?.coins?.find { it.chain == Chain.Tron && it.isNativeToken }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -28,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.models.ResourceUsage
+import com.vultisig.wallet.data.blockchain.tron.TronResourceType
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.clickOnce
@@ -291,18 +292,24 @@ private fun TronPendingWithdrawalRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
                 text = if (isBalanceVisible) "${withdrawal.amountTrx} TRX" else HIDE_BALANCE_CHARS,
                 style = Theme.brockmann.body.m.medium,
                 color = Theme.v2.colors.text.primary,
             )
-            if (!isClaimable) {
-                Text(
-                    text = timeRemainingText,
-                    style = Theme.brockmann.body.s.medium,
-                    color = Theme.v2.colors.text.secondary,
-                )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                withdrawal.resourceType?.let { TronResourceTypeBadge(it) }
+                if (!isClaimable) {
+                    Text(
+                        text = timeRemainingText,
+                        style = Theme.brockmann.body.s.medium,
+                        color = Theme.v2.colors.text.secondary,
+                    )
+                }
             }
         }
 
@@ -320,6 +327,40 @@ private fun TronPendingWithdrawalRow(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun TronResourceTypeBadge(resourceType: TronResourceType) {
+    val labelRes =
+        when (resourceType) {
+            TronResourceType.BANDWIDTH -> R.string.tron_resource_bandwidth
+            TronResourceType.ENERGY -> R.string.tron_resource_energy
+        }
+    val iconRes =
+        when (resourceType) {
+            TronResourceType.BANDWIDTH -> R.drawable.bandwidth
+            TronResourceType.ENERGY -> R.drawable.energy
+        }
+    val iconTint =
+        when (resourceType) {
+            TronResourceType.BANDWIDTH -> Theme.v2.colors.alerts.success
+            TronResourceType.ENERGY -> Theme.v2.colors.alerts.warning
+        }
+    Row(
+        modifier =
+            Modifier.clip(RoundedCornerShape(6.dp))
+                .background(Theme.v2.colors.backgrounds.surface2)
+                .padding(horizontal = 8.dp, vertical = 3.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        UiIcon(drawableResId = iconRes, size = 12.dp, tint = iconTint)
+        Text(
+            text = stringResource(labelRes),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.secondary,
+        )
     }
 }
 
@@ -379,10 +420,12 @@ private fun TronDeFiPositionsScreenPreview() {
                                 TronPendingWithdrawalUiModel(
                                     amountTrx = "50.000000",
                                     expiryEpochMs = System.currentTimeMillis() - 1_000L,
+                                    resourceType = TronResourceType.BANDWIDTH,
                                 ),
                                 TronPendingWithdrawalUiModel(
                                     amountTrx = "30.000000",
                                     expiryEpochMs = System.currentTimeMillis() + TWO_DAYS_MS,
+                                    resourceType = TronResourceType.ENERGY,
                                 ),
                             ),
                     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -298,17 +298,19 @@ private fun TronPendingWithdrawalRow(
                 style = Theme.brockmann.body.m.medium,
                 color = Theme.v2.colors.text.primary,
             )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                withdrawal.resourceType?.let { TronResourceTypeBadge(it) }
-                if (!isClaimable) {
-                    Text(
-                        text = timeRemainingText,
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.secondary,
-                    )
+            if (withdrawal.resourceType != null || !isClaimable) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    withdrawal.resourceType?.let { TronResourceTypeBadge(it) }
+                    if (!isClaimable) {
+                        Text(
+                            text = timeRemainingText,
+                            style = Theme.brockmann.body.s.medium,
+                            color = Theme.v2.colors.text.secondary,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #4161.

Now that freezing is split by resource (Bandwidth / Energy), the pending withdrawal list shows which resource each entry is unfreezing. Previously `mapPendingWithdrawals` (`TronDeFiPositionsViewModel.kt:200`) dropped `TronUnfrozenV2Json.type`, so a user who unfroze both kinds couldn't tell which row in `TronPendingWithdrawalsCard` corresponded to which resource.

- `TronUnfrozenV2Json.type` (`BANDWIDTH` | `ENERGY`) is parsed into `TronResourceType?` and surfaced through `TronPendingWithdrawalUiModel.resourceType`.
- `TronPendingWithdrawalsCard` renders a small icon + label badge on each row using the existing `bandwidth`/`energy` drawables and `tron_resource_*` strings (added in #4142). Bandwidth uses the success-green tint, Energy uses the warning-amber tint, matching `TronResourceTypeTab`.
- Unknown / null types render no badge (defensive — should not occur in practice).

No new strings, drawables, or locale changes — all assets reused from the prior split-by-resource freeze work.

### Before
<img width="590" height="1280" src="https://github.com/user-attachments/assets/065bcf22-a8d0-41ac-80f3-55d93048d6f3" />



### After
<img width="590" height="1280" src="https://github.com/user-attachments/assets/0b2667fa-00fb-4d3e-8567-4994e64efac1" />



## Layout

The badge sits below the amount on the same row as the countdown, so it does not compete with the amount or the "Ready to claim" badge for horizontal space:

```
50.000000 TRX                    [Ready to claim]
[bandwidth] · 2 days, 5 hrs
```

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Existing `SendFormViewModelTronStakingTest` still passes
- [ ] Visual: open TRON DeFi positions screen with pending unfreezes for both Bandwidth and Energy and verify the correct badge appears on each row
- [ ] Visual: row with a claimable withdrawal still shows "Ready to claim" badge correctly (no overflow / clipping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TRON pending withdrawals now include an optional resource-type badge (icon + localized label) for Bandwidth or Energy when available.
  * Pending withdrawal row layout updated for clearer organization: amount column resized, resource badge shown when present, and countdown displayed only when the withdrawal is not yet claimable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->