### PR TITLE
fix(a11y): expose ChooseDeviceCount Rive screen to TalkBack

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -59,10 +59,11 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                 val vmi = rememberViewModelInstance(file = riveFile)
                 var deviceIndex by remember { mutableIntStateOf(0) }
 
-                LaunchedEffect(Unit) {
+                LaunchedEffect(vmi) {
                     vmi.getNumberFlow("Index").collect { index ->
-                        deviceIndex = index.toInt().coerceIn(0, 3)
-                        onEvent(ChooseDeviceCountUiEvent.IndexChanged(index.toInt()))
+                        val clampedIndex = index.toInt().coerceIn(0, 3)
+                        deviceIndex = clampedIndex
+                        onEvent(ChooseDeviceCountUiEvent.IndexChanged(clampedIndex))
                     }
                 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -10,9 +10,17 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -49,19 +57,28 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                 VsCircularLoading(modifier = Modifier.fillMaxSize().wrapContentSize())
             } else {
                 val vmi = rememberViewModelInstance(file = riveFile)
+                var deviceCount by remember { mutableIntStateOf(1) }
 
                 LaunchedEffect(Unit) {
                     vmi.getNumberFlow("Index").collect { index ->
+                        deviceCount = (index.toInt() + 1).coerceIn(1, 4)
                         onEvent(ChooseDeviceCountUiEvent.IndexChanged(index.toInt()))
                     }
                 }
+
+                val a11yDescription =
+                    stringResource(R.string.choose_device_count_a11y_description, deviceCount)
 
                 Box(Modifier.fillMaxSize()) {
                     RiveAnimation(
                         file = riveFile,
                         viewModelInstance = vmi,
                         fit = Fit.Contain(alignment = RiveAlignment.TopCenter),
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier =
+                            Modifier.fillMaxWidth().semantics {
+                                contentDescription = a11yDescription
+                                liveRegion = LiveRegionMode.Polite
+                            },
                     )
                     Column(modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
                         Tip()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -57,17 +57,18 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                 VsCircularLoading(modifier = Modifier.fillMaxSize().wrapContentSize())
             } else {
                 val vmi = rememberViewModelInstance(file = riveFile)
-                var deviceCount by remember { mutableIntStateOf(1) }
+                var deviceIndex by remember { mutableIntStateOf(0) }
 
                 LaunchedEffect(Unit) {
                     vmi.getNumberFlow("Index").collect { index ->
-                        deviceCount = (index.toInt() + 1).coerceIn(1, 4)
+                        deviceIndex = index.toInt().coerceIn(0, 3)
                         onEvent(ChooseDeviceCountUiEvent.IndexChanged(index.toInt()))
                     }
                 }
 
+                val deviceCountLabel = if (deviceIndex == 3) "4+" else (deviceIndex + 1).toString()
                 val a11yDescription =
-                    stringResource(R.string.choose_device_count_a11y_description, deviceCount)
+                    stringResource(R.string.choose_device_count_a11y_description, deviceCountLabel)
 
                 Box(Modifier.fillMaxSize()) {
                     RiveAnimation(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1045,6 +1045,7 @@
     <string name="key_import_chains_no_results">Keine Blockchains entsprechen Ihrer Suche</string>
 
     <string name="key_import_device_count_get_started">Loslegen</string>
+    <string name="choose_device_count_a11y_description">Wie viele Geräte haben Sie? %1$d ausgewählt. Tippen, um eine andere Auswahl zu treffen.</string>
     <string name="vault_count_recommended">Empfohlen</string>
 
     <string name="welcome_tip">Tipp: Sie können einen Browser als Gerät verwenden</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1045,7 +1045,7 @@
     <string name="key_import_chains_no_results">Keine Blockchains entsprechen Ihrer Suche</string>
 
     <string name="key_import_device_count_get_started">Loslegen</string>
-    <string name="choose_device_count_a11y_description">Wie viele Geräte haben Sie? %1$d ausgewählt. Tippen, um eine andere Auswahl zu treffen.</string>
+    <string name="choose_device_count_a11y_description">Wie viele Geräte haben Sie? %1$s ausgewählt. Tippen, um eine andere Auswahl zu treffen.</string>
     <string name="vault_count_recommended">Empfohlen</string>
 
     <string name="welcome_tip">Tipp: Sie können einen Browser als Gerät verwenden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1043,7 +1043,7 @@
     <string name="key_import_chains_no_results">Ninguna cadena coincide con tu búsqueda</string>
 
     <string name="key_import_device_count_get_started">Comenzar</string>
-    <string name="choose_device_count_a11y_description">¿Cuántos dispositivos tienes? %1$d seleccionados. Toca para elegir otro.</string>
+    <string name="choose_device_count_a11y_description">¿Cuántos dispositivos tienes? Selección actual: %1$s. Toca para elegir otro.</string>
     <string name="vault_count_recommended">Recomendado</string>
 
     <string name="welcome_tip">Consejo: Puedes usar un navegador como dispositivo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1043,6 +1043,7 @@
     <string name="key_import_chains_no_results">Ninguna cadena coincide con tu búsqueda</string>
 
     <string name="key_import_device_count_get_started">Comenzar</string>
+    <string name="choose_device_count_a11y_description">¿Cuántos dispositivos tienes? %1$d seleccionados. Toca para elegir otro.</string>
     <string name="vault_count_recommended">Recomendado</string>
 
     <string name="welcome_tip">Consejo: Puedes usar un navegador como dispositivo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1052,6 +1052,7 @@
     <string name="key_import_chains_no_results">Nijedan lanac ne odgovara vašem pretraživanju</string>
 
     <string name="key_import_device_count_get_started">Započni</string>
+    <string name="choose_device_count_a11y_description">Koliko uređaja imate? %1$d odabrano. Dodirnite za drugi odabir.</string>
     <string name="vault_count_recommended">Preporučeno</string>
 
     <string name="welcome_tip">Savjet: Možete koristiti preglednik kao uređaj</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1052,7 +1052,7 @@
     <string name="key_import_chains_no_results">Nijedan lanac ne odgovara vašem pretraživanju</string>
 
     <string name="key_import_device_count_get_started">Započni</string>
-    <string name="choose_device_count_a11y_description">Koliko uređaja imate? %1$d odabrano. Dodirnite za drugi odabir.</string>
+    <string name="choose_device_count_a11y_description">Koliko uređaja imate? %1$s odabrano. Dodirnite za drugi odabir.</string>
     <string name="vault_count_recommended">Preporučeno</string>
 
     <string name="welcome_tip">Savjet: Možete koristiti preglednik kao uređaj</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1046,7 +1046,7 @@
     <string name="key_import_chains_no_results">Nessuna catena corrisponde alla tua ricerca</string>
 
     <string name="key_import_device_count_get_started">Inizia</string>
-    <string name="choose_device_count_a11y_description">Quanti dispositivi hai? %1$d selezionati. Tocca per sceglierne un altro.</string>
+    <string name="choose_device_count_a11y_description">Quanti dispositivi hai? Selezione attuale: %1$s. Tocca per sceglierne un altro.</string>
     <string name="vault_count_recommended">Consigliata</string>
 
     <string name="welcome_tip">Suggerimento: Puoi usare un browser come dispositivo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1046,6 +1046,7 @@
     <string name="key_import_chains_no_results">Nessuna catena corrisponde alla tua ricerca</string>
 
     <string name="key_import_device_count_get_started">Inizia</string>
+    <string name="choose_device_count_a11y_description">Quanti dispositivi hai? %1$d selezionati. Tocca per sceglierne un altro.</string>
     <string name="vault_count_recommended">Consigliata</string>
 
     <string name="welcome_tip">Suggerimento: Puoi usare un browser come dispositivo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1070,7 +1070,7 @@
     <string name="key_import_chains_get_started">시작하기</string>
     <string name="key_import_chains_no_results">검색에 일치하는 체인이 없습니다</string>
     <string name="key_import_device_count_get_started">시작하기</string>
-    <string name="choose_device_count_a11y_description">기기를 몇 대 가지고 계신가요? %1$d개 선택됨. 탭하여 다른 옵션을 선택하세요.</string>
+    <string name="choose_device_count_a11y_description">기기를 몇 대 가지고 계신가요? 현재 선택: %1$s. 탭하여 다른 옵션을 선택하세요.</string>
 
     <string name="review_vault_devices_title">볼트 기기 확인</string>
     <string name="review_vault_devices_description">추가한 기기가 올바른지 확인하세요:</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1070,6 +1070,7 @@
     <string name="key_import_chains_get_started">시작하기</string>
     <string name="key_import_chains_no_results">검색에 일치하는 체인이 없습니다</string>
     <string name="key_import_device_count_get_started">시작하기</string>
+    <string name="choose_device_count_a11y_description">기기를 몇 대 가지고 계신가요? %1$d개 선택됨. 탭하여 다른 옵션을 선택하세요.</string>
 
     <string name="review_vault_devices_title">볼트 기기 확인</string>
     <string name="review_vault_devices_description">추가한 기기가 올바른지 확인하세요:</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1040,6 +1040,7 @@
     <string name="key_import_chains_no_results">Geen ketens komen overeen met uw zoekopdracht</string>
 
     <string name="key_import_device_count_get_started">Aan de slag</string>
+    <string name="choose_device_count_a11y_description">Hoeveel apparaten hebt u? %1$d geselecteerd. Tik om een andere te kiezen.</string>
     <string name="vault_count_recommended">Aanbevolen</string>
 
     <string name="welcome_tip">Tip: U kunt een browser gebruiken als apparaat</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1040,7 +1040,7 @@
     <string name="key_import_chains_no_results">Geen ketens komen overeen met uw zoekopdracht</string>
 
     <string name="key_import_device_count_get_started">Aan de slag</string>
-    <string name="choose_device_count_a11y_description">Hoeveel apparaten hebt u? %1$d geselecteerd. Tik om een andere te kiezen.</string>
+    <string name="choose_device_count_a11y_description">Hoeveel apparaten hebt u? %1$s geselecteerd. Tik om een andere te kiezen.</string>
     <string name="vault_count_recommended">Aanbevolen</string>
 
     <string name="welcome_tip">Tip: U kunt een browser gebruiken als apparaat</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1044,7 +1044,7 @@
     <string name="key_import_chains_no_results">Nenhuma cadeia corresponde à sua pesquisa</string>
 
     <string name="key_import_device_count_get_started">Começar</string>
-    <string name="choose_device_count_a11y_description">Quantos dispositivos tem? %1$d selecionados. Toque para escolher outro.</string>
+    <string name="choose_device_count_a11y_description">Quantos dispositivos tem? Seleção atual: %1$s. Toque para escolher outro.</string>
     <string name="vault_count_recommended">Recomendada</string>
 
     <string name="welcome_tip">Dica: Pode usar um browser como dispositivo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1044,6 +1044,7 @@
     <string name="key_import_chains_no_results">Nenhuma cadeia corresponde à sua pesquisa</string>
 
     <string name="key_import_device_count_get_started">Começar</string>
+    <string name="choose_device_count_a11y_description">Quantos dispositivos tem? %1$d selecionados. Toque para escolher outro.</string>
     <string name="vault_count_recommended">Recomendada</string>
 
     <string name="welcome_tip">Dica: Pode usar um browser como dispositivo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1056,6 +1056,7 @@
     <string name="key_import_chains_no_results">Нет сетей, соответствующих запросу</string>
 
     <string name="key_import_device_count_get_started">Начать</string>
+    <string name="choose_device_count_a11y_description">Сколько у вас устройств? Выбрано %1$d. Нажмите, чтобы выбрать другое.</string>
     <string name="vault_count_recommended">Рекомендуется</string>
 
     <string name="welcome_tip">Совет: Вы можете использовать браузер как устройство</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1056,7 +1056,7 @@
     <string name="key_import_chains_no_results">Нет сетей, соответствующих запросу</string>
 
     <string name="key_import_device_count_get_started">Начать</string>
-    <string name="choose_device_count_a11y_description">Сколько у вас устройств? Выбрано %1$d. Нажмите, чтобы выбрать другое.</string>
+    <string name="choose_device_count_a11y_description">Сколько у вас устройств? Выбрано: %1$s. Нажмите, чтобы выбрать другое.</string>
     <string name="vault_count_recommended">Рекомендуется</string>
 
     <string name="welcome_tip">Совет: Вы можете использовать браузер как устройство</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1372,7 +1372,7 @@
     <string name="key_import_chains_no_results">没有与您的搜索匹配的链</string>
 
     <string name="key_import_device_count_get_started">开始</string>
-    <string name="choose_device_count_a11y_description">您有多少台设备？已选择 %1$d 台。点击以选择其他。</string>
+    <string name="choose_device_count_a11y_description">您有多少台设备？当前选择：%1$s。点击以选择其他。</string>
     <string name="vault_count_recommended">推荐</string>
 
     <string name="welcome_tip">提示：您可以将浏览器用作设备</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1372,6 +1372,7 @@
     <string name="key_import_chains_no_results">没有与您的搜索匹配的链</string>
 
     <string name="key_import_device_count_get_started">开始</string>
+    <string name="choose_device_count_a11y_description">您有多少台设备？已选择 %1$d 台。点击以选择其他。</string>
     <string name="vault_count_recommended">推荐</string>
 
     <string name="welcome_tip">提示：您可以将浏览器用作设备</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1110,11 +1110,11 @@
     <string name="key_import_chains_continue">Get started</string>
     <string name="key_import_chains_customize">Customize chains</string>
     <string name="key_import_chains_no_active_title">No Active Chains Found</string>
-    <string name="key_import_chains_no_active_desc">We couldn\'t find aniiy balances. Please select the chains you want to import manually.</string>
+    <string name="key_import_chains_no_active_desc">We couldn\'t find any balances. Please select the chains you want to import manually.</string>
     <string name="key_import_chains_get_started">Get started</string>
     <string name="key_import_chains_no_results">No chains match your search</string>
     <string name="key_import_device_count_get_started">Get started</string>
-    <string name="choose_device_count_a11y_description">How many devices do you have? %1$d selected. Tap to choose another.</string>
+    <string name="choose_device_count_a11y_description">How many devices do you have? %1$s selected. Tap to choose another.</string>
     <string name="key_import_error_title">Key Import Failed</string>
     <string name="key_import_error_description">Unable to import vault from seed phrase. Please check your seed phrase and try again.</string>
     <string name="key_import_error_no_mnemonic_description">No seed phrase found. Please re-enter your seed phrase and try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1110,10 +1110,11 @@
     <string name="key_import_chains_continue">Get started</string>
     <string name="key_import_chains_customize">Customize chains</string>
     <string name="key_import_chains_no_active_title">No Active Chains Found</string>
-    <string name="key_import_chains_no_active_desc">We couldn\'t find any balances. Please select the chains you want to import manually.</string>
+    <string name="key_import_chains_no_active_desc">We couldn\'t find aniiy balances. Please select the chains you want to import manually.</string>
     <string name="key_import_chains_get_started">Get started</string>
     <string name="key_import_chains_no_results">No chains match your search</string>
     <string name="key_import_device_count_get_started">Get started</string>
+    <string name="choose_device_count_a11y_description">How many devices do you have? %1$d selected. Tap to choose another.</string>
     <string name="key_import_error_title">Key Import Failed</string>
     <string name="key_import_error_description">Unable to import vault from seed phrase. Please check your seed phrase and try again.</string>
     <string name="key_import_error_no_mnemonic_description">No seed phrase found. Please re-enter your seed phrase and try again.</string>


### PR DESCRIPTION
## Summary

Closes #4182.

The Rive-based `ChooseDeviceCountScreen` shipped in v1.0.99 renders its title (\"How many devices do you have?\") and all explanatory copy inside the Rive canvas. Only the native `Tip:` and `Get started` button were exposed to Android accessibility services, so TalkBack users heard \"Get started\" without any context for what they were starting, and `uiautomator dump` returned no text nodes for the screen body.

## Approach

Took option 2 from the issue (semantic `contentDescription` on the Rive surface). Option 1 (native Compose text overlays) was infeasible without a redesign — the per-index text is baked into the Rive animation and would have to be replicated as native overlays alongside the existing Rive text, duplicating visuals.

- `ChooseDeviceCountScreen.kt`: track the selected count locally from the Rive `Index` flow and apply `Modifier.semantics { contentDescription = ...; liveRegion = LiveRegionMode.Polite }` on the `RiveAnimation`. TalkBack now announces the screen on entry and re-announces when the user taps a different device count.
- New string `choose_device_count_a11y_description` added to all 10 locales (en, de, es, hr, it, ko, nl, pt, ru, zh-rCN), placed next to existing device-count strings, using each locale's established term for \"device\" and \"selected\".

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin\` passes
- [ ] On a debug build, enable TalkBack → navigate to the device-count screen → verify the title + selection are announced
- [ ] Tap a different device option → verify the new selection is announced (live region)
- [ ] \`adb exec-out uiautomator dump\` now includes the description in the accessibility tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved accessibility on the device count selection screen: live-region announcements now update as the selection changes and use a clearer, localized label (e.g., "4+") for the maximum bucket.

* **Localization**
  * Added localized accessibility descriptions for device count selection in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, Simplified Chinese, and English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->