### PR TITLE
fix(bittensor): handle 404 from taostats proxy (#4292)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -13,6 +13,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlinx.serialization.json.add
@@ -171,11 +172,9 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
 
     override suspend fun getTxStatus(txHash: String): TaostatsExtrinsicData? {
         val hash = if (txHash.startsWith("0x")) txHash else "0x$txHash"
-        val response =
-            httpClient
-                .get("${TAOSTATS_PROXY_URL}/extrinsic/v1?hash=$hash")
-                .body<TaostatsExtrinsicResponse>()
-        return response.data?.firstOrNull()
+        val response = httpClient.get("${TAOSTATS_PROXY_URL}/extrinsic/v1?hash=$hash")
+        if (response.status == HttpStatusCode.NotFound) return null
+        return response.body<TaostatsExtrinsicResponse>().data?.firstOrNull()
     }
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProvider.kt
@@ -16,7 +16,7 @@ internal class BittensorStatusProvider @Inject constructor(private val bittensor
             when (bittensorApi.getTxStatus(txHash)?.success) {
                 true -> TransactionResult.Confirmed
                 false -> TransactionResult.Failed("Transaction failed on Bittensor")
-                null -> TransactionResult.NotFound
+                null -> TransactionResult.Pending
             }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class BittensorApiTest {
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
@@ -1,0 +1,72 @@
+package com.vultisig.wallet.data.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class BittensorApiTest {
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    @Test
+    fun `getTxStatus returns null on 404 without throwing`() = runBlocking {
+        val api =
+            bittensorApi(MockEngine { respond(content = "", status = HttpStatusCode.NotFound) })
+
+        assertNull(api.getTxStatus("0xabc"))
+    }
+
+    @Test
+    fun `getTxStatus returns parsed extrinsic on 200`() = runBlocking {
+        val api =
+            bittensorApi(
+                MockEngine {
+                    respond(
+                        content = """{"data":[{"success":true,"block_number":42}]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val result = api.getTxStatus("0xabc")
+
+        assertEquals(true, result?.success)
+        assertEquals(42, result?.blockNumber)
+    }
+
+    @Test
+    fun `getTxStatus returns null when 200 response has empty data array`() = runBlocking {
+        val api =
+            bittensorApi(
+                MockEngine {
+                    respond(
+                        content = """{"data":[]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        assertNull(api.getTxStatus("0xabc"))
+    }
+
+    private fun bittensorApi(engine: MockEngine): BittensorApi =
+        BittensorApiImp(
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            }
+        )
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/BittensorStatusProviderTest.kt
@@ -1,0 +1,53 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.BittensorApi
+import com.vultisig.wallet.data.api.TaostatsExtrinsicData
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class BittensorStatusProviderTest {
+
+    private val bittensorApi = mockk<BittensorApi>()
+    private val provider = BittensorStatusProvider(bittensorApi)
+
+    @Test
+    fun `success true returns Confirmed`() = runTest {
+        coEvery { bittensorApi.getTxStatus(any()) } returns TaostatsExtrinsicData(success = true)
+
+        val result = provider.checkStatus("hash", Chain.Bittensor)
+
+        assertEquals(TransactionResult.Confirmed, result)
+    }
+
+    @Test
+    fun `success false returns Failed`() = runTest {
+        coEvery { bittensorApi.getTxStatus(any()) } returns TaostatsExtrinsicData(success = false)
+
+        val result = provider.checkStatus("hash", Chain.Bittensor)
+
+        assertEquals(TransactionResult.Failed("Transaction failed on Bittensor"), result)
+    }
+
+    @Test
+    fun `null result returns Pending so polling keeps running until tx is indexed`() = runTest {
+        coEvery { bittensorApi.getTxStatus(any()) } returns null
+
+        val result = provider.checkStatus("hash", Chain.Bittensor)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `api exception returns Pending`() = runTest {
+        coEvery { bittensorApi.getTxStatus(any()) } throws RuntimeException("network error")
+
+        val result = provider.checkStatus("hash", Chain.Bittensor)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+}


### PR DESCRIPTION
## Summary
- Treat HTTP 404 from the taostats extrinsic endpoint as "not yet indexed" and return `null` cleanly, instead of attempting to deserialize the empty body and throwing `NoTransformationFoundException` on every poll.
- Map a `null` result in `BittensorStatusProvider` to `Pending` so polling continues until the extrinsic is indexed. `PollingTxStatusUseCase` already emits its own `NotFound` after the polling timeout; mapping the intermediate "not yet indexed" state to `NotFound` here would have terminated polling early (consumers in `TransactionStatusService` and `KeysignViewModel` treat `NotFound` as terminal).

Closes #4292

## Test plan
- [x] New `BittensorApiTest` covers: 404 → `null` (no exception), 200 with extrinsic data, 200 with empty `data` array.
- [x] New `BittensorStatusProviderTest` covers: `success=true → Confirmed`, `success=false → Failed`, `null → Pending`, exception → `Pending`.
- [x] `./gradlew :data:testDebugUnitTest` passes.
- [ ] Manual: submit a Bittensor tx and verify polling no longer logs `NoTransformationFoundException` warnings while waiting for taostats indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction status requests now treat missing/404 responses as absent data and map unknown/absent statuses to Pending to avoid false NotFound reporting.

* **Tests**
  * Added unit tests covering API responses (404, empty, populated) and status-provider mapping (confirmed, failed, pending, error) to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->