### PR TITLE
fix(ui): align vault delete screen copy with Figma (#4295)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/delete/ConfirmDeleteScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/components/delete/ConfirmDeleteScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -62,7 +63,7 @@ private fun ConfirmDeleteScreen(
     onBackClick: () -> Unit,
 ) {
     V2Scaffold(
-        title = stringResource(R.string.vault_settings_delete_title),
+        title = stringResource(R.string.confirm_delete_delete_vault),
         onBackClick = onBackClick,
         bottomBar = {
             VsButton(
@@ -210,7 +211,7 @@ private fun DeleteVaultBanner() {
         UiSpacer(size = 14.dp)
 
         Text(
-            text = stringResource(R.string.vault_settings_delete_title),
+            text = stringResource(R.string.confirm_delete_delete_vault),
             style = Theme.brockmann.headings.title2,
             color = colors.alerts.error,
         )
@@ -221,6 +222,8 @@ private fun DeleteVaultBanner() {
             text = stringResource(R.string.confirm_delete_permanent_delete_message),
             style = Theme.brockmann.supplementary.footnote,
             color = colors.text.tertiary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
     }
 }
@@ -229,7 +232,12 @@ private fun DeleteVaultBanner() {
 @Composable
 private fun ConfirmDeleteScreenPreview() {
     ConfirmDeleteScreen(
-        cautions = listOf(com.vultisig.wallet.R.string.confirm_delete_delete_vault),
+        cautions =
+            listOf(
+                R.string.vault_settings_delete_vault_caution1,
+                R.string.vault_settings_delete_vault_caution2,
+                R.string.vault_settings_delete_vault_caution3,
+            ),
         checkedCautionIndexes = listOf(0, 1),
         isDeleteButtonActive = false,
         vaultDeleteUiModel =

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -126,8 +126,8 @@
     <string name="keysign_screen_signing_with_mldsa">MIT MLDSA-SCHLÜSSEL UNTERSCHREIBEN…</string>
     <string name="vault_settings_delete_vault_caution1">Mir ist bewusst, dass der Tresor dauerhaft gelöscht wird</string>
     <string name="vault_settings_delete_vault_caution2">Mir ist bewusst, dass ich Geld verlieren kann</string>
-    <string name="vault_settings_delete_vault_caution3">Ich habe eine Sicherung des Tresors erstellt</string>
-    <string name="confirm_delete_permanent_delete_message">Sie löschen Ihren Tresor dauerhaft</string>
+    <string name="vault_settings_delete_vault_caution3">Ich habe eine Sicherung des Tresors für eine spätere Wiederherstellung erstellt</string>
+    <string name="confirm_delete_permanent_delete_message">Sie löschen Ihren Tresorteil dauerhaft aus dieser App</string>
     <string name="confirm_delete_delete_vault">Tresor löschen</string>
     <string name="rename_vault_screen_vault_name">Tresorname</string>
     <string name="faq_settings_q1">Was ist Vultisig?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -157,8 +157,8 @@
     <string name="successfully_scanned_barcode">Código de barras escaneado con éxito: %1$s</string>
     <string name="vault_settings_delete_vault_caution1">Soy consciente de que la bóveda será eliminada permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Soy consciente de que puedo perder fondos.</string>
-    <string name="vault_settings_delete_vault_caution3">He hecho una copia de seguridad de la bóveda</string>
-    <string name="confirm_delete_permanent_delete_message">Estás eliminando permanentemente tu bóveda</string>
+    <string name="vault_settings_delete_vault_caution3">He hecho una copia de seguridad de la bóveda para restaurarla más tarde</string>
+    <string name="confirm_delete_permanent_delete_message">Estás eliminando permanentemente tu parte de la bóveda de esta aplicación</string>
     <string name="confirm_delete_delete_vault">Eliminar Bóveda</string>
     <string name="rename_vault_screen_vault_name">Nombre de la Bóveda</string>
     <string name="faq_settings_q1">¿Qué es Vultisig?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -121,8 +121,8 @@
     <string name="keysign_screen_preparing_vault">PRIPREMA SEFA…</string>
     <string name="vault_settings_delete_vault_caution1">Ovaj sef će biti trajno uklonjen</string>
     <string name="vault_settings_delete_vault_caution2">Svjestan sam da mogu izgubiti sredstva</string>
-    <string name="vault_settings_delete_vault_caution3">Napravio sam sigurnosnu kopiju spremišta</string>
-    <string name="confirm_delete_permanent_delete_message">Trajno brišete svoje spremište</string>
+    <string name="vault_settings_delete_vault_caution3">Napravio sam sigurnosnu kopiju spremišta za kasniju obnovu</string>
+    <string name="confirm_delete_permanent_delete_message">Trajno brišete svoj udio spremišta iz ove aplikacije</string>
     <string name="confirm_delete_delete_vault">Izbriši sef</string>
     <string name="rename_vault_screen_vault_name">Ime sefa</string>
     <string name="faq_settings_q2">Koje su prednosti korištenja Vultisiga?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -121,8 +121,8 @@
     <string name="keysign_screen_preparing_vault">PREPARANDO LA CASSAFORTE…</string>
     <string name="vault_settings_delete_vault_caution1">Sono consapevole che il caveau sarà eliminato permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Sono consapevole che posso perdere fondi</string>
-    <string name="vault_settings_delete_vault_caution3">Ho fatto un backup del caveau</string>
-    <string name="confirm_delete_permanent_delete_message">Stai eliminando definitivamente il tuo caveau</string>
+    <string name="vault_settings_delete_vault_caution3">Ho fatto un backup del caveau per ripristinarlo in seguito</string>
+    <string name="confirm_delete_permanent_delete_message">Stai eliminando definitivamente la tua parte del caveau da questa app</string>
     <string name="confirm_delete_delete_vault">Elimina Cassaforte</string>
     <string name="rename_vault_screen_vault_name">Nome Cassaforte</string>
     <string name="faq_settings_q2">Quali sono i vantaggi dell\'utilizzo di Vultisig?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -239,14 +239,14 @@
     <string name="successfully_scanned_barcode">바코드 스캔 성공: %1$s</string>
     <string name="vault_settings_delete_vault_caution1">볼트가 영구적으로 삭제된다는 것을 알고 있습니다</string>
     <string name="vault_settings_delete_vault_caution2">자금을 잃을 수 있다는 것을 알고 있습니다</string>
-    <string name="vault_settings_delete_vault_caution3">볼트 백업을 완료했습니다</string>
+    <string name="vault_settings_delete_vault_caution3">나중에 복원할 수 있도록 볼트 백업을 완료했습니다</string>
     <string name="vault_settings_delete_vault_name">볼트 이름:</string>
     <string name="vault_settings_delete_vault_value">볼트 가치:</string>
     <string name="vault_settings_delete_vault_id">기기 ID:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">ECDSA 키:</string>
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA 키:</string>
 
-    <string name="confirm_delete_permanent_delete_message">볼트를 영구적으로 삭제합니다</string>
+    <string name="confirm_delete_permanent_delete_message">이 앱에서 볼트 공유를 영구적으로 삭제합니다</string>
     <string name="confirm_delete_delete_vault">볼트 삭제</string>
     <string name="vault_accounts_account_assets">%1$s 자산</string>
     <string name="s_of_s_vault">%1$s-of-%2$s 볼트 설정</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -158,13 +158,13 @@
     <string name="successfully_scanned_barcode">Barcode succesvol gescand: %1$s</string>
     <string name="vault_settings_delete_vault_caution1">Ik ben me ervan bewust dat de kluis permanent zal worden verwijderd</string>
     <string name="vault_settings_delete_vault_caution2">Ik ben me ervan bewust dat ik geld kan verliezen</string>
-    <string name="vault_settings_delete_vault_caution3">Ik heb een kluisback-up gemaakt</string>
+    <string name="vault_settings_delete_vault_caution3">Ik heb een kluisback-up gemaakt om later te kunnen herstellen</string>
     <string name="vault_settings_delete_vault_name">Kluisnaam:</string>
     <string name="vault_settings_delete_vault_value">Kluiswaarde:</string>
     <string name="vault_settings_delete_vault_id">Apparaat-ID:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">ECDSA-sleutel:</string>
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA-sleutel:</string>
-    <string name="confirm_delete_permanent_delete_message">U verwijdert uw kluis permanent</string>
+    <string name="confirm_delete_permanent_delete_message">U verwijdert uw kluisgedeelte permanent uit deze app</string>
     <string name="confirm_delete_delete_vault">Kluis verwijderen</string>
     <string name="vault_accounts_account_assets">%1$s activa</string>
     <string name="s_of_s_vault">%1$s van %2$s kluis</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -129,8 +129,8 @@
     <string name="keysign_screen_signing_with_mldsa">ASSINANDO USANDO CHAVE MLDSA…</string>
     <string name="vault_settings_delete_vault_caution1">Estou ciente de que o cofre será excluído permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Estou ciente de que posso perder fundos</string>
-    <string name="vault_settings_delete_vault_caution3">Fiz um backup do cofre</string>
-    <string name="confirm_delete_permanent_delete_message">Você está excluindo permanentemente seu cofre</string>
+    <string name="vault_settings_delete_vault_caution3">Fiz um backup do cofre para restaurá-lo mais tarde</string>
+    <string name="confirm_delete_permanent_delete_message">Você está excluindo permanentemente sua parte do cofre deste aplicativo</string>
     <string name="confirm_delete_delete_vault">Deletar Cofre</string>
     <string name="rename_vault_screen_vault_name">Nome do Cofre</string>
     <string name="faq_settings_q1">O que é a Vultisig?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -158,13 +158,13 @@
     <string name="successfully_scanned_barcode">Штрихкод успешно отсканирован: %1$s</string>
     <string name="vault_settings_delete_vault_caution1">Я понимаю, что хранилище будет удалено навсегда</string>
     <string name="vault_settings_delete_vault_caution2">Я понимаю, что могу потерять средства</string>
-    <string name="vault_settings_delete_vault_caution3">Я сделал резервную копию хранилища</string>
+    <string name="vault_settings_delete_vault_caution3">Я сделал резервную копию хранилища для последующего восстановления</string>
     <string name="vault_settings_delete_vault_name">Имя хранилища:</string>
     <string name="vault_settings_delete_vault_value">Стоимость хранилища:</string>
     <string name="vault_settings_delete_vault_id">Идентификатор устройства:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">Ключ ECDSA:</string>
     <string name="vault_settings_delete_vault_eddsa_key">Ключ EdDSA:</string>
-    <string name="confirm_delete_permanent_delete_message">Вы навсегда удаляете своё хранилище</string>
+    <string name="confirm_delete_permanent_delete_message">Вы навсегда удаляете свою долю хранилища из этого приложения</string>
     <string name="confirm_delete_delete_vault">Удалить хранилище</string>
     <string name="vault_accounts_account_assets">%1$s активы</string>
     <string name="s_of_s_vault">%1$s из %2$s хранилища</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -289,7 +289,7 @@
     <!-- Vault Settings Delete -->
     <string name="vault_settings_delete_vault_caution1">我知道保险库将被永久删除</string>
     <string name="vault_settings_delete_vault_caution2">我知道我可能会失去资金</string>
-    <string name="vault_settings_delete_vault_caution3">我已经备份了保险库</string>
+    <string name="vault_settings_delete_vault_caution3">我已经备份了保险库以便日后恢复</string>
     <string name="vault_settings_delete_vault_name">保险库名称：</string>
     <string name="vault_settings_delete_vault_value">保险库价值：</string>
     <string name="vault_settings_delete_vault_id">设备 ID：</string>
@@ -297,7 +297,7 @@
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA 密钥：</string>
 
     <!-- Confirm Delete -->
-    <string name="confirm_delete_permanent_delete_message">您正在永久删除您的保险库</string>
+    <string name="confirm_delete_permanent_delete_message">您正在从此应用永久删除您的保险库份额</string>
     <string name="confirm_delete_delete_vault">删除保险库</string>
 
     <!-- Vault Accounts -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,14 +240,14 @@
     <string name="successfully_scanned_barcode">Successfully scanned barcode: %1$s</string>
     <string name="vault_settings_delete_vault_caution1">I am aware that the vault will be deleted permanently</string>
     <string name="vault_settings_delete_vault_caution2">I am aware that I can lose funds</string>
-    <string name="vault_settings_delete_vault_caution3">I have made a vault backup</string>
+    <string name="vault_settings_delete_vault_caution3">I have made a vault backup to restore later</string>
     <string name="vault_settings_delete_vault_name">Vault Name:</string>
     <string name="vault_settings_delete_vault_value">Vault Value:</string>
     <string name="vault_settings_delete_vault_id">Device ID:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">ECDSA Key:</string>
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA Key:</string>
 
-    <string name="confirm_delete_permanent_delete_message">You are permanently deleting your vault</string>
+    <string name="confirm_delete_permanent_delete_message">You are permanently deleting your vault share from this app</string>
     <string name="confirm_delete_delete_vault">Delete Vault</string>
     <string name="vault_accounts_account_assets">%1$s Assets</string>
     <string name="s_of_s_vault">%1$s-of-%2$s Vault Setup</string>
@@ -428,7 +428,7 @@
     <string name="eth_gas_settings_gas_limit_title">Gas Limit</string>
     <string name="vault_details_screen_vault_part">Vault Share</string>
     <string name="vault_details_screen_vault_type">Vault Type</string>
-    <string name="vault_settings_delete_vault_part">Vault Share:</string>
+    <string name="vault_settings_delete_vault_part">Vault Part:</string>
     <string name="vault_password_hint_too_long">Hint is too long</string>
     <string name="vault_details_screen_vault_part_desc">Share %1$s of %2$s</string>
     <string name="do_not_remind_me_again">Don\'t remind me again</string>


### PR DESCRIPTION
## Summary
- Verified the vault deletion screen copy against the Figma redesign ([node 38220:69211](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=38220-69211)) and updated the strings/composables that were out of date.
- Subtitle now reads "You are permanently deleting your vault share from this app" (was: "You are permanently deleting your vault") to make it clear that only this device's vault share is removed.
- Third caution checkbox now reads "I have made a vault backup to restore later" (was missing the "to restore later" qualifier).
- English label `vault_settings_delete_vault_part` changed from "Vault Share:" to "Vault Part:" to match Figma's terminology. Other locales already use their own established term ("Tresorteil", "Доля хранилища", etc.) consistent with the existing `vault_part_n_of_t` value, so no change there.
- The screen toolbar title and the red banner heading now use the existing `confirm_delete_delete_vault` ("Delete Vault") string so they match the Figma 1:1. The shared `vault_settings_delete_title` ("Delete") is still used by the vault settings menu list item, so out-of-scope screens are untouched.
- The two substantive copy changes (subtitle + caution3) are localized across all 9 supported locales (de, es, hr, it, ko, nl, pt, ru, zh-rCN).

Closes #4295

## Test plan
- [ ] Open the vault settings → tap Delete; verify the toolbar reads "Delete Vault"
- [ ] Verify the red banner heading reads "Delete Vault" and the subtitle reads "You are permanently deleting your vault share from this app"
- [ ] Verify the three caution rows read exactly: "I am aware that the vault will be deleted permanently", "I am aware that I can lose funds", "I have made a vault backup to restore later"
- [ ] Verify the detail card labels read: Vault Name, Vault Value, Vault Part / Device ID, ECDSA Key / EdDSA Key
- [ ] Verify the primary button reads "Delete Vault"
- [ ] Spot-check at least one non-English locale (e.g. `de` or `ru`) for the updated subtitle and caution3 strings

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified vault deletion confirmation messaging across all supported languages to accurately communicate that only your vault portion is being permanently deleted from the app, not your entire vault.
  * Enhanced backup caution messages to explicitly clarify the backup is intended for later restoration.
  * Updated deletion interface label from "Vault Share" to "Vault Part" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->