### PR TITLE
fix(tron): drop unwired Freeze card info icon (#4163)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
@@ -46,33 +46,25 @@ internal fun TronFreezePositionCard(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Header: logo + title + amount
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                UiIcon(drawableResId = R.drawable.tron, size = 42.dp)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            UiIcon(drawableResId = R.drawable.tron, size = 42.dp)
 
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        text = stringResource(R.string.tron_defi_tron_freeze),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                    )
-                    Text(
-                        text = if (isBalanceVisible) frozenTotalPrice else HIDE_BALANCE_CHARS,
-                        style = Theme.brockmann.headings.title1,
-                        color = Theme.v2.colors.text.primary,
-                    )
-                }
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = stringResource(R.string.tron_defi_tron_freeze),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                Text(
+                    text = if (isBalanceVisible) frozenTotalPrice else HIDE_BALANCE_CHARS,
+                    style = Theme.brockmann.headings.title1,
+                    color = Theme.v2.colors.text.primary,
+                )
             }
-
-            UiIcon(
-                drawableResId = R.drawable.circleinfo,
-                size = 20.dp,
-                modifier = Modifier.align(Alignment.TopEnd),
-                tint = Theme.v2.colors.text.tertiary,
-            )
         }
 
         HorizontalDivider(color = Theme.v2.colors.border.light, thickness = 1.dp)


### PR DESCRIPTION
## Summary
- Closes #4163.
- `TronFreezePositionCard` rendered a `circleinfo` icon with no `onClick` and no `contentDescription` — it looked tappable to sighted users, did nothing, and screen readers skipped it.
- iOS does **not** surface an info icon on its equivalent freeze card (`TronDashboardView.actionsCard`); the only Tron info sheet (`TronResourcesInfoSheet`) lives on the bandwidth/energy resources card, which Android already implements via `BandwidthEnergyBottomSheet` in `ResourceStateScreen.kt`.
- Per the issue's accepted alternative ("OR drop the icon if the info sheet is not in scope"), removing the icon brings Android to parity with iOS without inventing new copy.

## Changes
- `app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt` — remove the unwired `UiIcon(circleinfo)` and the now-unnecessary outer `Box` wrapper; collapse to a single `Row` for the header.

## Test plan
- [ ] Open TRON DeFi positions screen with frozen TRX → freeze card no longer shows a non-functional info icon in the top-right.
- [ ] Bandwidth/Energy info icon on the Resources card still works and opens `BandwidthEnergyBottomSheet`.
- [ ] TalkBack: card no longer announces a phantom unlabeled icon affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored the Tron freeze position card header layout for improved structure and removed the informational icon previously displayed at the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->