### PR TITLE
fix: skip THORChain network id fetch on startup when no vaults exist

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCase.kt
@@ -2,30 +2,42 @@ package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.repositories.ThorChainRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 
 interface InitializeThorChainNetworkIdUseCase : suspend () -> Unit
 
 internal class InitializeThorChainNetworkIdUseCaseImpl
 @Inject
-constructor(private val thorChainRepository: ThorChainRepository) :
-    InitializeThorChainNetworkIdUseCase {
+constructor(
+    private val thorChainRepository: ThorChainRepository,
+    private val vaultRepository: VaultRepository,
+) : InitializeThorChainNetworkIdUseCase {
 
     override suspend fun invoke() {
+        if (!vaultRepository.hasVaults()) {
+            Timber.d("Skipping THORChain network id init: no vaults")
+            return
+        }
+
         Timber.d("Initializing THORChain network id")
 
         val cachedNetworkChainId = thorChainRepository.getCachedNetworkChainId()
         if (!cachedNetworkChainId.isNullOrBlank()) {
             ThorChainHelper.THORCHAIN_NETWORK_ID = cachedNetworkChainId
-            Timber.d("THORChain network id initialized from cache with: $cachedNetworkChainId")
+            Timber.d("THORChain network id initialized from cache with: %s", cachedNetworkChainId)
         }
 
         try {
             ThorChainHelper.THORCHAIN_NETWORK_ID = thorChainRepository.fetchNetworkChainId()
             Timber.d(
-                "THORChain network id initialized with: ${ThorChainHelper.THORCHAIN_NETWORK_ID}"
+                "THORChain network id initialized with: %s",
+                ThorChainHelper.THORCHAIN_NETWORK_ID,
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "Failed to fetch network chain id")
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/InitializeThorChainNetworkIdUseCaseImplTest.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.crypto.ThorChainHelper
+import com.vultisig.wallet.data.repositories.ThorChainRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InitializeThorChainNetworkIdUseCaseImplTest {
+
+    private val thorChainRepository: ThorChainRepository = mockk(relaxed = true)
+    private val vaultRepository: VaultRepository = mockk(relaxed = true)
+
+    private lateinit var useCase: InitializeThorChainNetworkIdUseCaseImpl
+
+    private var originalNetworkId: String = ThorChainHelper.THORCHAIN_NETWORK_ID
+
+    @BeforeEach
+    fun setUp() {
+        originalNetworkId = ThorChainHelper.THORCHAIN_NETWORK_ID
+        useCase = InitializeThorChainNetworkIdUseCaseImpl(thorChainRepository, vaultRepository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ThorChainHelper.THORCHAIN_NETWORK_ID = originalNetworkId
+    }
+
+    @Test
+    fun `skips fetch and cache when no vaults exist`() = runTest {
+        ThorChainHelper.THORCHAIN_NETWORK_ID = "default-id"
+        coEvery { vaultRepository.hasVaults() } returns false
+
+        useCase()
+
+        coVerify(exactly = 0) { thorChainRepository.getCachedNetworkChainId() }
+        coVerify(exactly = 0) { thorChainRepository.fetchNetworkChainId() }
+        assertEquals("default-id", ThorChainHelper.THORCHAIN_NETWORK_ID)
+    }
+
+    @Test
+    fun `applies cached value then fetches when vaults exist`() = runTest {
+        coEvery { vaultRepository.hasVaults() } returns true
+        coEvery { thorChainRepository.getCachedNetworkChainId() } returns "thorchain-cached"
+        coEvery { thorChainRepository.fetchNetworkChainId() } returns "thorchain-fresh"
+
+        useCase()
+
+        coVerify(exactly = 1) { thorChainRepository.getCachedNetworkChainId() }
+        coVerify(exactly = 1) { thorChainRepository.fetchNetworkChainId() }
+        assertEquals("thorchain-fresh", ThorChainHelper.THORCHAIN_NETWORK_ID)
+    }
+
+    @Test
+    fun `keeps cached value when fetch fails`() = runTest {
+        coEvery { vaultRepository.hasVaults() } returns true
+        coEvery { thorChainRepository.getCachedNetworkChainId() } returns "thorchain-cached"
+        coEvery { thorChainRepository.fetchNetworkChainId() } throws RuntimeException("boom")
+
+        useCase()
+
+        assertEquals("thorchain-cached", ThorChainHelper.THORCHAIN_NETWORK_ID)
+    }
+}


### PR DESCRIPTION
## Summary

- On a fresh install (no vault imported yet), `MainViewModel.init` was unconditionally calling `InitializeThorChainNetworkIdUseCase`, which fired `GET https://gateway.liquify.com/chain/thorchain_rpc/status` before the user had opted into the wallet.
- Gate the use case on `vaultRepository.hasVaults()` so the cache read and network fetch are both skipped when no vaults exist. The default `THORCHAIN_NETWORK_ID = "thorchain-1"` covers any pre-vault code path; once a vault exists, the next launch initializes normally.
- Rethrow `CancellationException` in the existing fetch catch block (project coding principle).
- Gating inside the use case keeps the call site behavior intact for any future caller.

Closes #4316

## Test plan

- [x] `./gradlew :data:ktfmtFormat`
- [x] `./gradlew :data:testDebugUnitTest` — new `InitializeThorChainNetworkIdUseCaseImplTest` (no-vault skip / cache+fetch / fetch-failure-keeps-cache) all pass
- [x] `./gradlew :app:testDebugUnitTest --tests MainViewModelTest` — existing tests still pass
- [x] `./gradlew :data:assembleDebug`
- [ ] Manual: fresh install → confirm no `GET .../thorchain_rpc/status` request on launch
- [ ] Manual: install with existing vault → confirm THORChain network id still initializes on launch

Co-Authored-By: aminsato <Amin.saradar@yahoo.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery during THORChain network identification operations. The system now handles fetch failures more gracefully while preserving cached network data. Operation cancellations are properly managed.

* **Tests**
  * Added comprehensive test coverage for THORChain network initialization, validating behavior across vault detection, successful initialization, and network error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->