### PR TITLE
fix(thorchain): silence expected NotFound from per-denom metadata fetch (#4326)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -42,6 +42,7 @@ import com.vultisig.wallet.data.api.models.thorchain.ThorchainConstantsResponse
 import com.vultisig.wallet.data.api.models.thorchain.VaultRedemptionResponseJson
 import com.vultisig.wallet.data.chains.helpers.ThorChainAffiliateHelper
 import com.vultisig.wallet.data.common.Endpoints
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
@@ -57,6 +58,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.json.Json
@@ -500,6 +502,15 @@ constructor(
                     .get("$THORNODE_BASE/cosmos/bank/v1beta1/denoms_metadata/$encodedDenom")
                     .bodyOrThrow<MetadataResponse>()
             response.metadata
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: NetworkException) {
+            if (e.httpStatusCode == HttpStatusCode.NotFound.value) {
+                Timber.d("No denom metadata for %s (expected for non-standard denoms)", denom)
+            } else {
+                Timber.e(e, "Failed to fetch denom metadata for %s", denom)
+            }
+            null
         } catch (e: Exception) {
             Timber.e(e, "Failed to fetch denom metadata for %s", denom)
             null


### PR DESCRIPTION
## Summary
- `xrp-xrp` (and other non-standard denoms) consistently return HTTP 404 from `cosmos/bank/v1beta1/denoms_metadata/{denom}`, so every balance refresh produced a `Timber.e` stack trace even though the all-denoms fallback recovered cleanly.
- Demote 404 responses to `Timber.d` (no stack trace), keep `Timber.e` for unexpected errors (5xx, transport, parse), and rethrow `CancellationException` so coroutine cancellation isn't swallowed.

## Test plan
- [x] `./gradlew :data:compileDebugKotlin`
- [x] `./gradlew :data:ktfmtFormat`
- [ ] Open a vault with a THORChain address holding `xrp-xrp` and refresh balances — confirm no `Timber.e` stack trace, single `Timber.d` line per missing denom
- [ ] Confirm balances still resolve via the all-denoms fallback
- [ ] Confirm a real network failure (toggle airplane mode mid-refresh) still logs at `Timber.e`

Closes #4326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved denomination metadata fetching reliability with better error handling for network issues and non-standard denominations. The app now more gracefully handles connectivity problems and invalid denomination requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->