### PR TITLE
perf(thorchain): single-pool LP lookup for Remove LP screen (#4338)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -58,6 +58,7 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
+import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
@@ -217,6 +218,7 @@ constructor(
     private val gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl,
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase,
     private val getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase,
+    private val getThorChainLpPositionUseCase: GetThorChainLpPositionUseCase,
 ) : ViewModel() {
 
     private val appCurrency =
@@ -663,15 +665,14 @@ constructor(
                 if (currentVaultId != null) {
                     resolvePairedAddress(Chain.ThorChain, currentVaultId, poolId)
                 } else null
-            val assetAddressesByPool = pairedAddress?.let { mapOf(poolId to it) } ?: emptyMap()
             val position =
                 withContext(Dispatchers.IO) {
-                        getThorChainLpPositionsUseCase(
-                            runeAddress = userAddress,
-                            assetAddressesByPool = assetAddressesByPool,
-                        )
-                    }
-                    .find { it.pool == poolId }
+                    getThorChainLpPositionUseCase(
+                        poolId = poolId,
+                        runeAddress = userAddress,
+                        assetAddress = pairedAddress,
+                    )
+                }
 
             if (position == null || position.units <= BigInteger.ZERO) {
                 _state.update {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -59,7 +59,6 @@ import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
-import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
 import com.vultisig.wallet.data.usecases.ValidateMayaTransactionHeightUseCase
@@ -217,7 +216,6 @@ constructor(
     private val tokenRepository: TokenRepository,
     private val gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl,
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase,
-    private val getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase,
     private val getThorChainLpPositionUseCase: GetThorChainLpPositionUseCase,
 ) : ViewModel() {
 
@@ -275,6 +273,7 @@ constructor(
     private val secureAssetNodeValue = MutableStateFlow<String?>(null)
     private var addressJob: Job? = null
     private var whitelistJob: Job? = null
+    private var loadLpJob: Job? = null
     private var depositTypeAction: String? = null
     private var bondAddress: String? = null
     private var lpPoolId: String? = null
@@ -647,83 +646,90 @@ constructor(
                 balance = R.string.share_balance_loading.asUiText(),
             )
         }
-        viewModelScope.safeLaunch {
-            val userAddress =
-                withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
-                    ?.address
-                    ?: run {
-                        _state.update {
-                            it.copy(
-                                errorText =
-                                    UiText.StringResource(R.string.dialog_default_error_body)
-                            )
+        loadLpJob?.cancel()
+        loadLpJob =
+            viewModelScope.safeLaunch {
+                val userAddress =
+                    withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
+                        ?.address
+                        ?: run {
+                            _state.update {
+                                it.copy(
+                                    errorText =
+                                        UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                            }
+                            return@safeLaunch
                         }
-                        return@safeLaunch
+                val currentVaultId = vaultId
+                val pairedAddress =
+                    if (currentVaultId != null) {
+                        resolvePairedAddress(Chain.ThorChain, currentVaultId, poolId)
+                    } else null
+                val position =
+                    withContext(Dispatchers.IO) {
+                        getThorChainLpPositionUseCase(
+                            poolId = poolId,
+                            runeAddress = userAddress,
+                            assetAddress = pairedAddress,
+                        )
                     }
-            val currentVaultId = vaultId
-            val pairedAddress =
-                if (currentVaultId != null) {
-                    resolvePairedAddress(Chain.ThorChain, currentVaultId, poolId)
-                } else null
-            val position =
-                withContext(Dispatchers.IO) {
-                    getThorChainLpPositionUseCase(
-                        poolId = poolId,
-                        runeAddress = userAddress,
-                        assetAddress = pairedAddress,
-                    )
+
+                if (position == null || position.units <= BigInteger.ZERO) {
+                    _state.update {
+                        it.copy(
+                            availableLpUnits = null,
+                            removeLpUnitsDivisor = BigInteger.ZERO,
+                            removeLpPoolDepth = BigInteger.ZERO,
+                            balance = UiText.Empty,
+                            errorText = UiText.StringResource(R.string.dialog_default_error_body),
+                        )
+                    }
+                    return@safeLaunch
                 }
 
-            if (position == null || position.units <= BigInteger.ZERO) {
+                // Use the pre-computed redeem value from the use case as `poolDepth` and the user's
+                // own
+                // units as `totalPoolUnits`. With selectedUnits = percent * userUnits, the
+                // calculator
+                // produces percent * runeRedeemValue, which is the symmetric RUNE half of
+                // withdrawal.
+                // Keep BigInteger end-to-end for whale positions whose units exceed Long.MAX_VALUE.
+                val userUnits = position.units
+                val runeRedeemBase = position.runeRedeemValue
+                val symbol = Coins.ThorChain.RUNE.ticker
+                val userUnitsLongOrNull =
+                    userUnits
+                        .takeIf { it.signum() > 0 && it.bitLength() < Long.SIZE_BITS }
+                        ?.toLong()
+                val userRune =
+                    userUnitsLongOrNull?.let { userUnitsLong ->
+                        RemoveLpCalculator.computeAmountDisplay(
+                            selectedUnits = userUnitsLong,
+                            poolDepth = runeRedeemBase,
+                            totalPoolUnits = userUnits,
+                            decimals = RemoveLpCalculator.RUNE_DECIMALS,
+                        )
+                    }
+                val balanceText =
+                    if (userRune != null) {
+                        UiText.FormattedText(
+                            R.string.remove_pool_amount_format,
+                            listOf(userRune, symbol),
+                        )
+                    } else UiText.Empty
                 _state.update {
                     it.copy(
-                        availableLpUnits = null,
-                        removeLpUnitsDivisor = BigInteger.ZERO,
-                        removeLpPoolDepth = BigInteger.ZERO,
-                        balance = UiText.Empty,
-                        errorText = UiText.StringResource(R.string.dialog_default_error_body),
+                        availableLpUnits = userUnits.toString(),
+                        removeLpUnitsDivisor = userUnits,
+                        removeLpPoolDepth = runeRedeemBase,
+                        removeLpDecimals = RemoveLpCalculator.RUNE_DECIMALS,
+                        removeLpTokenSymbol = symbol,
+                        balance = balanceText,
                     )
                 }
-                return@safeLaunch
+                setRemoveLpPercent(state.value.removeLpPercent)
             }
-
-            // Use the pre-computed redeem value from the use case as `poolDepth` and the user's own
-            // units as `totalPoolUnits`. With selectedUnits = percent * userUnits, the calculator
-            // produces percent * runeRedeemValue, which is the symmetric RUNE half of withdrawal.
-            // Keep BigInteger end-to-end for whale positions whose units exceed Long.MAX_VALUE.
-            val userUnits = position.units
-            val runeRedeemBase = position.runeRedeemValue
-            val symbol = Coins.ThorChain.RUNE.ticker
-            val userUnitsLongOrNull =
-                userUnits.takeIf { it.signum() > 0 && it.bitLength() < Long.SIZE_BITS }?.toLong()
-            val userRune =
-                userUnitsLongOrNull?.let { userUnitsLong ->
-                    RemoveLpCalculator.computeAmountDisplay(
-                        selectedUnits = userUnitsLong,
-                        poolDepth = runeRedeemBase,
-                        totalPoolUnits = userUnits,
-                        decimals = RemoveLpCalculator.RUNE_DECIMALS,
-                    )
-                }
-            val balanceText =
-                if (userRune != null) {
-                    UiText.FormattedText(
-                        R.string.remove_pool_amount_format,
-                        listOf(userRune, symbol),
-                    )
-                } else UiText.Empty
-            _state.update {
-                it.copy(
-                    availableLpUnits = userUnits.toString(),
-                    removeLpUnitsDivisor = userUnits,
-                    removeLpPoolDepth = runeRedeemBase,
-                    removeLpDecimals = RemoveLpCalculator.RUNE_DECIMALS,
-                    removeLpTokenSymbol = symbol,
-                    balance = balanceText,
-                )
-            }
-            setRemoveLpPercent(state.value.removeLpPercent)
-        }
     }
 
     fun selectBondAsset(asset: String) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -539,83 +539,86 @@ constructor(
                 balance = R.string.share_balance_loading.asUiText(),
             )
         }
-        viewModelScope.safeLaunch {
-            val userAddress =
-                withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
-                    ?.address
-                    ?: run {
-                        _state.update {
-                            it.copy(
-                                errorText =
-                                    UiText.StringResource(R.string.dialog_default_error_body)
-                            )
+        loadLpJob?.cancel()
+        loadLpJob =
+            viewModelScope.safeLaunch {
+                val userAddress =
+                    withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
+                        ?.address
+                        ?: run {
+                            _state.update {
+                                it.copy(
+                                    errorText =
+                                        UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                            }
+                            return@safeLaunch
                         }
-                        return@safeLaunch
+                val memberDetails =
+                    withContext(Dispatchers.IO) {
+                        mayachainBondRepository.getMemberDetails(userAddress)
                     }
-            val memberDetails =
-                withContext(Dispatchers.IO) {
-                    mayachainBondRepository.getMemberDetails(userAddress)
+                val userLpUnits =
+                    memberDetails.pools.find { it.pool == poolId }?.liquidityUnits
+                        ?: run {
+                            _state.update {
+                                it.copy(
+                                    availableLpUnits = null,
+                                    removeLpUnitsDivisor = BigInteger.ZERO,
+                                    removeLpPoolDepth = BigInteger.ZERO,
+                                    errorText =
+                                        UiText.StringResource(R.string.dialog_default_error_body),
+                                )
+                            }
+                            return@safeLaunch
+                        }
+                val poolStats =
+                    withContext(Dispatchers.IO) { mayachainBondRepository.getLpPoolStats() }
+                val pool =
+                    poolStats.find { it.asset == poolId }
+                        ?: run {
+                            _state.update {
+                                it.copy(
+                                    availableLpUnits = null,
+                                    removeLpUnitsDivisor = BigInteger.ZERO,
+                                    removeLpPoolDepth = BigInteger.ZERO,
+                                    errorText =
+                                        UiText.StringResource(R.string.dialog_default_error_body),
+                                )
+                            }
+                            return@safeLaunch
+                        }
+                val totalPoolUnits = pool.units.toBigIntegerOrNull() ?: BigInteger.ZERO
+                val cacaoDepth = pool.cacaoDepth.toBigIntegerOrNull() ?: BigInteger.ZERO
+                val userAvailableUnits = userLpUnits.toLongOrNull()
+                val userCacao =
+                    if (userAvailableUnits != null) {
+                        RemoveLpCalculator.computeAmountDisplay(
+                            selectedUnits = userAvailableUnits,
+                            poolDepth = cacaoDepth,
+                            totalPoolUnits = totalPoolUnits,
+                            decimals = RemoveLpCalculator.CACAO_DECIMALS,
+                        )
+                    } else null
+                val balanceText =
+                    if (userCacao != null) {
+                        UiText.FormattedText(
+                            R.string.remove_pool_amount_format,
+                            listOf(userCacao, "CACAO"),
+                        )
+                    } else UiText.Empty
+                _state.update {
+                    it.copy(
+                        availableLpUnits = userLpUnits,
+                        removeLpUnitsDivisor = totalPoolUnits,
+                        removeLpPoolDepth = cacaoDepth,
+                        removeLpDecimals = RemoveLpCalculator.CACAO_DECIMALS,
+                        removeLpTokenSymbol = "CACAO",
+                        balance = balanceText,
+                    )
                 }
-            val userLpUnits =
-                memberDetails.pools.find { it.pool == poolId }?.liquidityUnits
-                    ?: run {
-                        _state.update {
-                            it.copy(
-                                availableLpUnits = null,
-                                removeLpUnitsDivisor = BigInteger.ZERO,
-                                removeLpPoolDepth = BigInteger.ZERO,
-                                errorText =
-                                    UiText.StringResource(R.string.dialog_default_error_body),
-                            )
-                        }
-                        return@safeLaunch
-                    }
-            val poolStats = withContext(Dispatchers.IO) { mayachainBondRepository.getLpPoolStats() }
-            val pool =
-                poolStats.find { it.asset == poolId }
-                    ?: run {
-                        _state.update {
-                            it.copy(
-                                availableLpUnits = null,
-                                removeLpUnitsDivisor = BigInteger.ZERO,
-                                removeLpPoolDepth = BigInteger.ZERO,
-                                errorText =
-                                    UiText.StringResource(R.string.dialog_default_error_body),
-                            )
-                        }
-                        return@safeLaunch
-                    }
-            val totalPoolUnits = pool.units.toBigIntegerOrNull() ?: BigInteger.ZERO
-            val cacaoDepth = pool.cacaoDepth.toBigIntegerOrNull() ?: BigInteger.ZERO
-            val userAvailableUnits = userLpUnits.toLongOrNull()
-            val userCacao =
-                if (userAvailableUnits != null) {
-                    RemoveLpCalculator.computeAmountDisplay(
-                        selectedUnits = userAvailableUnits,
-                        poolDepth = cacaoDepth,
-                        totalPoolUnits = totalPoolUnits,
-                        decimals = RemoveLpCalculator.CACAO_DECIMALS,
-                    )
-                } else null
-            val balanceText =
-                if (userCacao != null) {
-                    UiText.FormattedText(
-                        R.string.remove_pool_amount_format,
-                        listOf(userCacao, "CACAO"),
-                    )
-                } else UiText.Empty
-            _state.update {
-                it.copy(
-                    availableLpUnits = userLpUnits,
-                    removeLpUnitsDivisor = totalPoolUnits,
-                    removeLpPoolDepth = cacaoDepth,
-                    removeLpDecimals = RemoveLpCalculator.CACAO_DECIMALS,
-                    removeLpTokenSymbol = "CACAO",
-                    balance = balanceText,
-                )
+                setRemoveLpPercent(state.value.removeLpPercent)
             }
-            setRemoveLpPercent(state.value.removeLpPercent)
-        }
     }
 
     private fun loadThorChainRemoveLpData() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -537,6 +537,7 @@ constructor(
                 removeLpPercent = 0f,
                 removeLpCacaoDisplay = "",
                 balance = R.string.share_balance_loading.asUiText(),
+                errorText = null,
             )
         }
         loadLpJob?.cancel()
@@ -647,6 +648,7 @@ constructor(
                 removeLpPercent = 0f,
                 removeLpCacaoDisplay = "",
                 balance = R.string.share_balance_loading.asUiText(),
+                errorText = null,
             )
         }
         loadLpJob?.cancel()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -871,6 +871,8 @@ constructor(
     }
 
     fun selectDepositOption(option: DepositOption) {
+        // Stop any in-flight Remove LP fetch so it can't write stale state into the new option.
+        loadLpJob?.cancel()
         viewModelScope.launch {
             resetTextFields()
             _state.update { it.copy(depositOption = option) }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -83,6 +83,9 @@ internal class DepositFormViewModelTest {
     private val getThorChainLpPositionsUseCase:
         com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase =
         mockk(relaxed = true)
+    private val getThorChainLpPositionUseCase:
+        com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase =
+        mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
@@ -120,6 +123,7 @@ internal class DepositFormViewModelTest {
             gasFeeToEstimate = gasFeeToEstimate,
             requestAddressBookEntry = requestAddressBookEntry,
             getThorChainLpPositionsUseCase = getThorChainLpPositionsUseCase,
+            getThorChainLpPositionUseCase = getThorChainLpPositionUseCase,
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -80,9 +80,6 @@ internal class DepositFormViewModelTest {
     private val tokenRepository: TokenRepository = mockk(relaxed = true)
     private val gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl = mockk(relaxed = true)
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase = mockk(relaxed = true)
-    private val getThorChainLpPositionsUseCase:
-        com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase =
-        mockk(relaxed = true)
     private val getThorChainLpPositionUseCase:
         com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase =
         mockk(relaxed = true)
@@ -122,7 +119,6 @@ internal class DepositFormViewModelTest {
             tokenRepository = tokenRepository,
             gasFeeToEstimate = gasFeeToEstimate,
             requestAddressBookEntry = requestAddressBookEntry,
-            getThorChainLpPositionsUseCase = getThorChainLpPositionsUseCase,
             getThorChainLpPositionUseCase = getThorChainLpPositionUseCase,
         )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -221,4 +221,10 @@ internal interface DataUsecasesModule {
     fun bindGetThorChainLpPositionsUseCase(
         impl: GetThorChainLpPositionsUseCaseImpl
     ): GetThorChainLpPositionsUseCase
+
+    @Binds
+    @Singleton
+    fun bindGetThorChainLpPositionUseCase(
+        impl: GetThorChainLpPositionUseCaseImpl
+    ): GetThorChainLpPositionUseCase
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCase.kt
@@ -1,10 +1,10 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainLiquidityProviderJson
 import com.vultisig.wallet.data.models.ThorChainLpPosition
 import com.vultisig.wallet.data.utils.NetworkException
 import java.io.IOException
-import java.math.BigInteger
 import javax.inject.Inject
 import timber.log.Timber
 
@@ -16,11 +16,16 @@ interface GetThorChainLpPositionUseCase {
      * issues at most two requests (rune-side, then asset-side fallback) instead of fanning out
      * across every available pool.
      *
+     * Returns `null` for any of the following — callers cannot distinguish them:
+     * - the user has no LP record on either side of the pool;
+     * - the rune-side and (optional) asset-side records both exist but report zero units;
+     * - thornode/midgard returned an unparseable amount field;
+     * - the request failed with a swallowed [IOException] or [NetworkException].
+     *
      * @param poolId the pool to query, e.g. `"BTC.BTC"`.
      * @param runeAddress the user's RUNE address — tried first.
      * @param assetAddress optional non-RUNE side address used as a fallback when an LP record is
-     *   keyed by the pool's asset side rather than RUNE.
-     * @return the position, or `null` if the user has no LP units in this pool.
+     *   keyed by the pool's asset side rather than RUNE. Blank addresses are ignored.
      */
     suspend operator fun invoke(
         poolId: String,
@@ -38,27 +43,41 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainLpPositionUseC
         runeAddress: String,
         assetAddress: String?,
     ): ThorChainLpPosition? {
+        val runeSide = fetchSide(poolId, runeAddress)
+        // A stale rune-side record with units == 0 must not shadow a real asset-side position.
         val lp =
-            try {
-                thorChainApi.getLiquidityProvider(poolId, runeAddress)
-                    ?: assetAddress?.let { thorChainApi.getLiquidityProvider(poolId, it) }
-            } catch (e: IOException) {
-                Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
-                null
-            } catch (e: NetworkException) {
-                Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
-                null
-            } ?: return null
+            runeSide?.takeIf { it.hasUnits() }
+                ?: assetAddress?.takeIf { it.isNotBlank() }?.let { fetchSide(poolId, it) }
+                ?: return null
 
-        val units = lp.units.toBigIntegerOrNull() ?: BigInteger.ZERO
+        val units = lp.units.toBigIntegerOrNull() ?: return null
         if (units.signum() == 0) return null
+        val runeRedeemValue = lp.runeRedeemValue.toBigIntegerOrNull() ?: return null
+        val assetRedeemValue = lp.assetRedeemValue.toBigIntegerOrNull() ?: return null
 
         return ThorChainLpPosition(
             pool = poolId,
             units = units,
-            runeRedeemValue = lp.runeRedeemValue.toBigIntegerOrNull() ?: BigInteger.ZERO,
-            assetRedeemValue = lp.assetRedeemValue.toBigIntegerOrNull() ?: BigInteger.ZERO,
+            runeRedeemValue = runeRedeemValue,
+            assetRedeemValue = assetRedeemValue,
             annualPercentageRate = null,
         )
     }
+
+    private suspend fun fetchSide(
+        poolId: String,
+        address: String,
+    ): ThorChainLiquidityProviderJson? =
+        try {
+            thorChainApi.getLiquidityProvider(poolId, address)
+        } catch (e: IOException) {
+            Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
+            null
+        } catch (e: NetworkException) {
+            Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
+            null
+        }
+
+    private fun ThorChainLiquidityProviderJson.hasUnits(): Boolean =
+        (units.toBigIntegerOrNull()?.signum() ?: 0) > 0
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCase.kt
@@ -1,0 +1,64 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.models.ThorChainLpPosition
+import com.vultisig.wallet.data.utils.NetworkException
+import java.io.IOException
+import java.math.BigInteger
+import javax.inject.Inject
+import timber.log.Timber
+
+interface GetThorChainLpPositionUseCase {
+    /**
+     * Fetches the user's THORChain LP position for a single pool.
+     *
+     * Use this when the caller already knows which pool to inspect (e.g. the Remove LP screen) — it
+     * issues at most two requests (rune-side, then asset-side fallback) instead of fanning out
+     * across every available pool.
+     *
+     * @param poolId the pool to query, e.g. `"BTC.BTC"`.
+     * @param runeAddress the user's RUNE address — tried first.
+     * @param assetAddress optional non-RUNE side address used as a fallback when an LP record is
+     *   keyed by the pool's asset side rather than RUNE.
+     * @return the position, or `null` if the user has no LP units in this pool.
+     */
+    suspend operator fun invoke(
+        poolId: String,
+        runeAddress: String,
+        assetAddress: String? = null,
+    ): ThorChainLpPosition?
+}
+
+internal class GetThorChainLpPositionUseCaseImpl
+@Inject
+constructor(private val thorChainApi: ThorChainApi) : GetThorChainLpPositionUseCase {
+
+    override suspend fun invoke(
+        poolId: String,
+        runeAddress: String,
+        assetAddress: String?,
+    ): ThorChainLpPosition? {
+        val lp =
+            try {
+                thorChainApi.getLiquidityProvider(poolId, runeAddress)
+                    ?: assetAddress?.let { thorChainApi.getLiquidityProvider(poolId, it) }
+            } catch (e: IOException) {
+                Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
+                null
+            } catch (e: NetworkException) {
+                Timber.w(e, "Failed to fetch LP position for pool %s", poolId)
+                null
+            } ?: return null
+
+        val units = lp.units.toBigIntegerOrNull() ?: BigInteger.ZERO
+        if (units.signum() == 0) return null
+
+        return ThorChainLpPosition(
+            pool = poolId,
+            units = units,
+            runeRedeemValue = lp.runeRedeemValue.toBigIntegerOrNull() ?: BigInteger.ZERO,
+            assetRedeemValue = lp.assetRedeemValue.toBigIntegerOrNull() ?: BigInteger.ZERO,
+            annualPercentageRate = null,
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainLiquidityProviderJson
+import com.vultisig.wallet.data.utils.NetworkException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GetThorChainLpPositionUseCaseTest {
+
+    private lateinit var api: ThorChainApi
+    private lateinit var useCase: GetThorChainLpPositionUseCaseImpl
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        useCase = GetThorChainLpPositionUseCaseImpl(api)
+    }
+
+    @Test
+    fun `returns position from rune-side lookup without touching pool stats`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns
+            lp(units = "1000", runeRedeem = "1500", assetRedeem = "2500")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertEquals(POOL, position?.pool)
+        assertEquals(BigInteger("1000"), position?.units)
+        assertEquals(BigInteger("1500"), position?.runeRedeemValue)
+        assertEquals(BigInteger("2500"), position?.assetRedeemValue)
+        assertNull(position?.annualPercentageRate)
+        coVerify(exactly = 0) { api.getPoolStats(any()) }
+        coVerify(exactly = 0) { api.getLiquidityProvider(neq(POOL), any()) }
+    }
+
+    @Test
+    fun `falls back to asset address when rune-side has no record`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns null
+        coEvery { api.getLiquidityProvider(POOL, ASSET_ADDR) } returns lp(units = "42")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
+
+        assertEquals(BigInteger("42"), position?.units)
+        coVerify { api.getLiquidityProvider(POOL, ASSET_ADDR) }
+    }
+
+    @Test
+    fun `returns null when no position exists for either side`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns null
+        coEvery { api.getLiquidityProvider(POOL, ASSET_ADDR) } returns null
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
+
+        assertNull(position)
+    }
+
+    @Test
+    fun `returns null when units are zero`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns lp(units = "0")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertNull(position)
+    }
+
+    @Test
+    fun `does not query asset address when not provided`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns null
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertNull(position)
+        coVerify(exactly = 1) { api.getLiquidityProvider(POOL, any()) }
+    }
+
+    @Test
+    fun `swallows network errors and returns null`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } throws
+            NetworkException(httpStatusCode = 500, message = "boom")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertNull(position)
+    }
+
+    @Test
+    fun `propagates unexpected exceptions`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } throws
+            IllegalStateException("unexpected")
+
+        assertFailsWith<IllegalStateException> { useCase(poolId = POOL, runeAddress = RUNE_ADDR) }
+    }
+
+    private fun lp(
+        units: String,
+        runeRedeem: String = "0",
+        assetRedeem: String = "0",
+    ): ThorChainLiquidityProviderJson =
+        ThorChainLiquidityProviderJson(
+            asset = "any",
+            units = units,
+            runeRedeemValue = runeRedeem,
+            assetRedeemValue = assetRedeem,
+        )
+
+    private companion object {
+        const val POOL = "BTC.BTC"
+        const val RUNE_ADDR = "thor1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        const val ASSET_ADDR = "bc1qxyz"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.utils.NetworkException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import java.io.IOException
 import java.math.BigInteger
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
@@ -26,20 +27,23 @@ internal class GetThorChainLpPositionUseCaseTest {
     }
 
     @Test
-    fun `returns position from rune-side lookup without touching pool stats`() = runTest {
-        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns
-            lp(units = "1000", runeRedeem = "1500", assetRedeem = "2500")
+    fun `returns position from rune-side lookup without touching pool stats or asset side`() =
+        runTest {
+            coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns
+                lp(units = "1000", runeRedeem = "1500", assetRedeem = "2500")
 
-        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+            val position =
+                useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
 
-        assertEquals(POOL, position?.pool)
-        assertEquals(BigInteger("1000"), position?.units)
-        assertEquals(BigInteger("1500"), position?.runeRedeemValue)
-        assertEquals(BigInteger("2500"), position?.assetRedeemValue)
-        assertNull(position?.annualPercentageRate)
-        coVerify(exactly = 0) { api.getPoolStats(any()) }
-        coVerify(exactly = 0) { api.getLiquidityProvider(neq(POOL), any()) }
-    }
+            assertEquals(POOL, position?.pool)
+            assertEquals(BigInteger("1000"), position?.units)
+            assertEquals(BigInteger("1500"), position?.runeRedeemValue)
+            assertEquals(BigInteger("2500"), position?.assetRedeemValue)
+            assertNull(position?.annualPercentageRate)
+            coVerify(exactly = 0) { api.getPoolStats(any()) }
+            coVerify(exactly = 1) { api.getLiquidityProvider(POOL, RUNE_ADDR) }
+            coVerify(exactly = 0) { api.getLiquidityProvider(POOL, ASSET_ADDR) }
+        }
 
     @Test
     fun `falls back to asset address when rune-side has no record`() = runTest {
@@ -48,8 +52,19 @@ internal class GetThorChainLpPositionUseCaseTest {
 
         val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
 
+        assertEquals(POOL, position?.pool)
         assertEquals(BigInteger("42"), position?.units)
         coVerify { api.getLiquidityProvider(POOL, ASSET_ADDR) }
+    }
+
+    @Test
+    fun `falls back to asset address when rune-side reports zero units`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns lp(units = "0")
+        coEvery { api.getLiquidityProvider(POOL, ASSET_ADDR) } returns lp(units = "99")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
+
+        assertEquals(BigInteger("99"), position?.units)
     }
 
     @Test
@@ -63,10 +78,11 @@ internal class GetThorChainLpPositionUseCaseTest {
     }
 
     @Test
-    fun `returns null when units are zero`() = runTest {
+    fun `returns null when units are zero on both sides`() = runTest {
         coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns lp(units = "0")
+        coEvery { api.getLiquidityProvider(POOL, ASSET_ADDR) } returns lp(units = "0")
 
-        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = ASSET_ADDR)
 
         assertNull(position)
     }
@@ -82,9 +98,38 @@ internal class GetThorChainLpPositionUseCaseTest {
     }
 
     @Test
+    fun `ignores blank asset address`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns null
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR, assetAddress = "  ")
+
+        assertNull(position)
+        coVerify(exactly = 1) { api.getLiquidityProvider(POOL, any()) }
+    }
+
+    @Test
+    fun `returns null on malformed redeem amounts`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } returns
+            lp(units = "1000", runeRedeem = "not-a-number", assetRedeem = "2500")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertNull(position)
+    }
+
+    @Test
     fun `swallows network errors and returns null`() = runTest {
         coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } throws
             NetworkException(httpStatusCode = 500, message = "boom")
+
+        val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
+
+        assertNull(position)
+    }
+
+    @Test
+    fun `swallows io errors and returns null`() = runTest {
+        coEvery { api.getLiquidityProvider(POOL, RUNE_ADDR) } throws IOException("network down")
 
         val position = useCase(poolId = POOL, runeAddress = RUNE_ADDR)
 


### PR DESCRIPTION
## Summary

- Closes #4338. Remove LP screen previously triggered an O(pool-count) fan-out — `GetThorChainLpPositionsUseCase` calls `getPoolStats()` and probes every available pool via per-pool Midgard requests, just to be filtered down to the one target pool by `.find { it.pool == poolId }`.
- Adds `GetThorChainLpPositionUseCase` (singular) that takes `poolId`, `runeAddress`, and optional `assetAddress`. It issues at most two requests (rune-side, then asset-side fallback) and skips `getPoolStats` entirely — the Remove LP flow doesn't read APR.
- `DepositFormViewModel.loadThorChainRemoveLpData()` switches to the new use case, dropping the post-filter. `GetThorChainLpPositionsUseCase` is unchanged and still drives `ThorchainDefiPositionsViewModel` (which legitimately needs the full list).

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*GetThorChainLpPositionUseCaseTest"` — 7 new tests covering rune-side success, asset-side fallback, no-position, zero-units, no fallback when asset address is null, network error swallowing, unexpected exception propagation
- [x] `./gradlew :data:testDebugUnitTest --tests "*GetThorChainLpPositionsUseCaseTest"` — pre-existing tests still pass
- [x] `./gradlew :app:testDebugUnitTest --tests "*DepositFormViewModelTest"` — passes with new dependency wired in
- [x] `./gradlew :data:compileDebugKotlin :app:compileDebugKotlin` — clean compile
- [ ] Manual: open Remove LP for a THORChain pool, verify position loads correctly and only the target pool is queried

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single LP-position lookup to directly retrieve a user's THORChain LP position for the current pool.

* **Refactor**
  * Cancels in-flight LP load operations when starting new requests or switching deposit options to prevent stale UI updates; populates remove-LP amounts and balances from the single-position result.

* **Tests**
  * Added unit tests covering single-position lookup, asset-side fallback, zero-unit handling, malformed data, and network/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->