### PR TITLE
fix(evm): floor ERC-20 deposit gas at 200k for THORChain router calls

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -233,6 +233,11 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
 
         val DEFAULT_ARBITRUM_TRANSFER = "160000".toBigInteger()
         val DEFAULT_MANTLE_SWAP_LIMIT = "3000000000".toBigInteger()
+
+        // Floor for non-native ERC-20 deposits that go through a router contract
+        // (e.g. THORChain `depositWithExpiry`). Estimating against `transfer()` underestimates
+        // the real call, and a USDT deposit at 120k reverts with no reason string. See #4152.
+        val MIN_ERC20_DEPOSIT_GAS_LIMIT = "200000".toBigInteger()
     }
 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.MIN_ERC20_DEPOSIT_GAS_LIMIT
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
@@ -195,7 +196,15 @@ constructor(
 
                     val nonce = evmApi.getNonce(address)
 
-                    val gasLimitFee = gasLimit ?: max(defaultGasLimit, estimateGasLimit)
+                    val gasLimitFee =
+                        gasLimit
+                            ?: max(defaultGasLimit, estimateGasLimit).let { base ->
+                                if (isDeposit && !token.isNativeToken) {
+                                    max(base, MIN_ERC20_DEPOSIT_GAS_LIMIT)
+                                } else {
+                                    base
+                                }
+                            }
                     val fees =
                         if (isSwap) {
                             feeServiceComposite.calculateDefaultFees(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -112,6 +112,121 @@ internal class BlockChainSpecificRepositoryImplTest {
     }
 
     @Test
+    fun `ERC20 deposit gas limit is floored to safety minimum`() = runTest {
+        // Plain `transfer()` estimate (50000 * 1.5 = 75000) and the default
+        // 150k token-transfer limit are both below the router-deposit safety floor (200k).
+        // Confirms that a non-native deposit lands at the 200k floor so router calls
+        // like THORChain `depositWithExpiry` aren't sent under-gassed (issue #4152).
+        val destination = "0xrouter"
+        val coin =
+            evmCoin(chain = Chain.Ethereum, isNativeToken = false, contractAddress = "0xusdt")
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(erc20GasByRecipient = mapOf(destination to BigInteger("50000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22")))
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Ethereum,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger("300000"),
+                    memo = "+:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:thor1...",
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("200000"),
+            maxFeePerGas = BigInteger("111"),
+            priorityFee = BigInteger("22"),
+        )
+    }
+
+    @Test
+    fun `ERC20 deposit keeps higher estimate when above safety floor`() = runTest {
+        // Estimate (300000 * 1.5 = 450000) is above the 200k floor, so the floor must not
+        // clamp it down — we still want the higher estimated value.
+        val destination = "0xrouter"
+        val coin =
+            evmCoin(chain = Chain.Ethereum, isNativeToken = false, contractAddress = "0xusdt")
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(erc20GasByRecipient = mapOf(destination to BigInteger("300000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22")))
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Ethereum,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger("300000"),
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("450000"),
+            maxFeePerGas = BigInteger("111"),
+            priorityFee = BigInteger("22"),
+        )
+    }
+
+    @Test
+    fun `native ETH deposit is not affected by ERC20 deposit floor`() = runTest {
+        // The floor only applies to non-native tokens — native ETH deposits keep the
+        // exact estimate from `eth_estimateGas` since the call typically isn't a router
+        // contract interaction with the same gas profile.
+        val destination = "0xinbound"
+        val coin = evmCoin(chain = Chain.Ethereum, isNativeToken = true)
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(nativeGasByRecipient = mapOf(destination to BigInteger("80000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22")))
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Ethereum,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger.TEN,
+                    memo = "+:ETH.ETH:thor1...",
+                )
+
+        assertEthereumSpecific(
+            result = result,
+            gasLimit = BigInteger("80000"),
+            maxFeePerGas = BigInteger("111"),
+            priorityFee = BigInteger("22"),
+        )
+    }
+
+    @Test
     fun `zkSync estimation uses destination address in returned dto`() = runTest {
         val destination = "0xzkrecipient"
         val coin = evmCoin(chain = Chain.ZkSync, isNativeToken = true)


### PR DESCRIPTION
## Summary

- Adds a 200k gas-limit floor for non-native EVM deposits so THORChain router calls (`depositWithExpiry`) aren't sent under-gassed.
- Existing path estimates against `transfer()` and falls back to a 150k default — both underestimate USDT/USDC router deposits, which need ~120-140k. A 0.30 USDT LP add reverted on-chain with no reason string and consumed the full gas (#4152).
- Floor applies only when `isDeposit && !token.isNativeToken` on the standard EVM path. Native ETH, ZkSync, swaps (already at 600k), and explicit `gasLimit` overrides are untouched.

## Why a floor and not `eth_estimateGas`

This PR is the safety net — it stops users losing gas immediately. The proper fix (estimate against the populated `depositWithExpiry` calldata × 1.3) requires threading calldata earlier in the pipeline and is worth its own PR.

Closes #4152

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests BlockChainSpecificRepositoryImplTest` — all 9 tests green, including 3 new tests:
  - `ERC20 deposit gas limit is floored to safety minimum` — estimate (75k) and default (150k) below floor → result is 200k
  - `ERC20 deposit keeps higher estimate when above safety floor` — estimate (450k) above floor → result is 450k (floor doesn't clamp down)
  - `native ETH deposit is not affected by ERC20 deposit floor` — native token deposit with low estimate is unchanged
- [x] `./gradlew ktfmtFormat` — clean
- [ ] Manual: USDT THORChain LP add on a test vault confirms on-chain (deferred — verifying which UI path produces the failing tx; happy to follow up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas fee calculation for non-native (ERC‑20) token deposits to prevent failures from underestimated gas limits; native token transfers remain unaffected.
* **Tests**
  * Added coverage verifying ERC‑20 deposit gas is clamped to a safe minimum while larger estimates are preserved, and native deposits are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->