### PR TITLE
fix(deposit): populate fiat value on joiner verify screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -875,7 +875,14 @@ constructor(
                                 ValuedToken(
                                     token = payload.coin,
                                     value = mapTokenValueToDecimalUiString(tokenValue),
-                                    fiatValue = "",
+                                    fiatValue =
+                                        fiatValueToStringMapper(
+                                            convertTokenValueToFiat(
+                                                payload.coin,
+                                                tokenValue,
+                                                currency,
+                                            )
+                                        ),
                                 ),
                             srcAddress = payload.coin.address,
                             dstAddress = payload.toAddress,


### PR DESCRIPTION
## Summary

- The joiner builds its `DepositTransactionUiModel` inline in `JoinKeysignViewModel` and hardcoded `fiatValue = ""`, so on a multi-device THORChain LP / deposit the joiner saw the token amount with no fiat sub-line while the initiator (which goes through `DepositTransactionUiModelMapperImpl`) showed both.
- Replaces the empty string with `fiatValueToStringMapper(convertTokenValueToFiat(payload.coin, tokenValue, currency))` — the same pattern the swap branch in the same function already uses at line 988. All deps were already injected and `currency` was already in scope from line 486.

Closes #4330

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] `./gradlew ktfmtFormat` — clean
- [ ] Manual: 2-device vault, initiate THORChain LP / deposit on device A, join on device B, verify the fiat sub-line is present on B's verify screen and matches A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit transactions now display the token's fiat equivalent alongside the token amount.
  * Fiat values are correctly shown in the user's selected currency for deposit flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->