### PR TITLE
fix(tx-done): keep status visible after expanding Transaction Details

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -407,6 +407,8 @@ private fun SendTxDonePreview() {
                 networkFeeTokenValue = "0.0024 ETH",
                 networkFeeFiatValue = "$6.15",
             ),
+        isTransactionDetailVisible = false,
+        onTransactionDetailVisibleChange = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -53,6 +56,7 @@ internal fun KeysignView(
             is KeysignState.KeysignFinished -> {
                 when (transactionTypeUiModel) {
                     is TransactionTypeUiModel.Swap -> {
+                        var isTransactionDetailVisible by remember { mutableStateOf(false) }
                         SwapTransactionOverviewScreen(
                             showToolbar = showToolbar,
                             transactionHash = txHash,
@@ -64,10 +68,13 @@ internal fun KeysignView(
                             progressLink = progressLink,
                             onBack = onBack,
                             transactionTypeUiModel = transactionTypeUiModel.swapTransactionUiModel,
+                            isTransactionDetailVisible = isTransactionDetailVisible,
+                            onTransactionDetailVisibleChange = { isTransactionDetailVisible = it },
                         )
                     }
                     is TransactionTypeUiModel.Deposit,
                     is TransactionTypeUiModel.Send -> {
+                        var isTransactionDetailVisible by remember { mutableStateOf(false) }
                         SendTxOverviewScreen(
                             transactionHash = txHash,
                             transactionLink = transactionLink,
@@ -78,6 +85,8 @@ internal fun KeysignView(
                             showToolbar = showToolbar,
                             onAddToAddressBook = onAddToAddressBook,
                             showSaveToAddressBook = showSaveToAddressBook,
+                            isTransactionDetailVisible = isTransactionDetailVisible,
+                            onTransactionDetailVisibleChange = { isTransactionDetailVisible = it },
                         )
                     }
                     else -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -55,14 +55,17 @@ internal fun SendTxOverviewScreen(
     onBack: () -> Unit = {},
     onAddToAddressBook: () -> Unit,
     tx: UiTransactionInfo,
+    isTransactionDetailVisible: Boolean,
+    onTransactionDetailVisibleChange: (Boolean) -> Unit,
 ) {
-
     TxDoneScaffold(
         transactionHash = transactionHash,
         transactionLink = transactionLink,
         transactionStatus = transactionStatus,
         showToolbar = showToolbar,
         onBack = onBack,
+        isTransactionDetailVisible = isTransactionDetailVisible,
+        onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
         bottomBarContent = {
             VsButton(
                 label = stringResource(R.string.transaction_done_title),
@@ -88,6 +91,10 @@ internal fun SendTxOverviewScreen(
         },
         detailContent = {
             Column {
+                TransactionStatusRow(transactionStatus)
+
+                VerifyCardDivider(size = 1.dp)
+
                 VerifyCardDetails(
                     title = stringResource(R.string.tx_overview_screen_tx_from),
                     subtitle = tx.fromLabel ?: tx.from,
@@ -259,7 +266,18 @@ internal fun TxDetails(
 
 @Preview
 @Composable
-private fun PreviewSendTxOverviewScreen() {
+private fun PreviewSendTxOverviewScreenCollapsed() {
+    PreviewSendTxOverviewScreen(isTransactionDetailVisible = false)
+}
+
+@Preview
+@Composable
+private fun PreviewSendTxOverviewScreenExpanded() {
+    PreviewSendTxOverviewScreen(isTransactionDetailVisible = true)
+}
+
+@Composable
+private fun PreviewSendTxOverviewScreen(isTransactionDetailVisible: Boolean) {
     SendTxOverviewScreen(
         transactionHash = "",
         transactionLink = "",
@@ -279,6 +297,8 @@ private fun PreviewSendTxOverviewScreen() {
                 .toUiTransactionInfo(),
         showSaveToAddressBook = true,
         transactionStatus = TransactionStatus.Broadcasted,
+        isTransactionDetailVisible = isTransactionDetailVisible,
+        onTransactionDetailVisibleChange = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -54,6 +54,8 @@ internal fun SwapTransactionOverviewScreen(
     progressLink: String?,
     onBack: () -> Unit = {},
     transactionTypeUiModel: SwapTransactionUiModel,
+    isTransactionDetailVisible: Boolean,
+    onTransactionDetailVisibleChange: (Boolean) -> Unit,
 ) {
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -65,6 +67,8 @@ internal fun SwapTransactionOverviewScreen(
         transactionLink = transactionLink,
         transactionStatus = transactionStatus,
         onBack = onBack,
+        isTransactionDetailVisible = isTransactionDetailVisible,
+        onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
         tokenContent = {
             Box {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -116,6 +120,11 @@ internal fun SwapTransactionOverviewScreen(
                         copiedApprovalTx = null
                     }
                 }
+
+                TransactionStatusRow(transactionStatus)
+
+                VerifyCardDivider(size = 1.dp)
+
                 if (approveTransactionHash.isNotEmpty()) {
                     TxDetails(
                         title = stringResource(R.string.swap_transaction_overview_approval_tx_hash),
@@ -213,7 +222,18 @@ internal fun Details(
 
 @Preview
 @Composable
-private fun SwapTransactionOverviewScreenPreview() {
+private fun SwapTransactionOverviewScreenPreviewCollapsed() {
+    PreviewSwapTransactionOverviewScreen(isTransactionDetailVisible = false)
+}
+
+@Preview
+@Composable
+private fun SwapTransactionOverviewScreenPreviewExpanded() {
+    PreviewSwapTransactionOverviewScreen(isTransactionDetailVisible = true)
+}
+
+@Composable
+private fun PreviewSwapTransactionOverviewScreen(isTransactionDetailVisible: Boolean) {
     SwapTransactionOverviewScreen(
         transactionHash = "abx123abx123abx123abx123abx123abx123abx123abx123abx123",
         approveTransactionHash = "321xba",
@@ -223,5 +243,7 @@ private fun SwapTransactionOverviewScreenPreview() {
         progressLink = "",
         transactionTypeUiModel = SwapTransactionUiModel(),
         transactionStatus = TransactionStatus.Broadcasted,
+        isTransactionDetailVisible = isTransactionDetailVisible,
+        onTransactionDetailVisibleChange = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -24,11 +24,8 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -61,6 +58,8 @@ internal fun TxDoneScaffold(
     transactionHash: String,
     transactionLink: String,
     transactionStatus: TransactionStatus,
+    isTransactionDetailVisible: Boolean,
+    onTransactionDetailVisibleChange: (Boolean) -> Unit,
     onBack: () -> Unit = {},
     tokenContent: @Composable () -> Unit,
     detailContent: @Composable () -> Unit,
@@ -95,6 +94,8 @@ internal fun TxDoneScaffold(
                 snackbarHostState = snackbarHostState,
                 context = context,
                 detailContent = detailContent,
+                isTransactionDetailVisible = isTransactionDetailVisible,
+                onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
             )
         },
         bottomBar = { bottomBarContent() },
@@ -112,9 +113,9 @@ private fun SuccessTransaction(
     snackbarHostState: SnackbarHostState,
     context: Context,
     detailContent: @Composable (() -> Unit),
+    isTransactionDetailVisible: Boolean,
+    onTransactionDetailVisibleChange: (Boolean) -> Unit,
 ) {
-
-    var isTransactionDetailVisible by remember { mutableStateOf(false) }
 
     Column(
         modifier =
@@ -205,7 +206,7 @@ private fun SuccessTransaction(
                 Details(
                     title = stringResource(R.string.tx_done_transaction_details),
                     modifier =
-                        Modifier.clickable(onClick = { isTransactionDetailVisible = true })
+                        Modifier.clickable(onClick = { onTransactionDetailVisibleChange(true) })
                             .padding(vertical = 12.dp),
                     titleColor = Theme.v2.colors.text.secondary,
                     content = {
@@ -229,6 +230,31 @@ private fun TransactionPending(modifier: Modifier = Modifier) {
     RiveAnimation(animation = R.raw.riv_transaction_pending, modifier = modifier.fillMaxWidth())
 }
 
+@Composable
+internal fun TransactionStatusRow(status: TransactionStatus, modifier: Modifier = Modifier) {
+    val (label, color) =
+        when (status) {
+            TransactionStatus.Confirmed ->
+                stringResource(R.string.transaction_status_confirmed_label) to
+                    Theme.v2.colors.alerts.success
+
+            is TransactionStatus.Failed ->
+                stringResource(R.string.transaction_status_failed_label) to
+                    Theme.v2.colors.alerts.error
+
+            TransactionStatus.Broadcasted,
+            TransactionStatus.Pending ->
+                stringResource(R.string.transaction_status_in_progress_label) to
+                    Theme.v2.colors.text.secondary
+        }
+    Details(
+        title = stringResource(R.string.transaction_history_detail_status),
+        modifier = modifier.padding(vertical = 12.dp),
+    ) {
+        Text(text = label, style = Theme.brockmann.body.s.medium, color = color)
+    }
+}
+
 @Preview
 @Composable
 private fun SuccessTransactionPreview() {
@@ -249,8 +275,14 @@ private fun SuccessTransactionPreview() {
             snackbarHostState = remember { SnackbarHostState() },
             transactionStatus = TransactionStatus.Failed(UiText.Empty),
             context = LocalContext.current,
+            isTransactionDetailVisible = true,
+            onTransactionDetailVisibleChange = {},
             detailContent = {
                 Column {
+                    TransactionStatusRow(TransactionStatus.Failed(UiText.Empty))
+
+                    VerifyCardDivider(size = 1.dp)
+
                     TextDetails(
                         title = stringResource(R.string.tx_overview_screen_tx_from),
                         subtitle = "tx.from",


### PR DESCRIPTION
## Summary

- On the Transaction Complete screen, expanding the "Transaction Details" section hid the entire success/pending/failed hero block, so the user lost sight of the transaction status while looking at the details (#4332).
- Render the status as the first row inside each consumer's `detailContent` (Send/Deposit and Swap), reusing existing string keys (`transaction_status_confirmed_label`, `transaction_status_failed_label`, `transaction_status_in_progress_label`) that already exist in all 10 locales — no string changes.
- While here: hoist `isTransactionDetailVisible` out of `TxDoneScaffold` (now stateless) up through `SendTxOverviewScreen` and `SwapTransactionOverviewScreen` (also stateless) to their parent `KeysignView`, which owns the state via `remember { mutableStateOf(false) }`. Each overview screen now exposes both a collapsed and an expanded `@Preview` so Android Studio renders both layouts.

Closes #4332

## Screenshot
<img width="590" height="1280"  src="https://github.com/user-attachments/assets/04cee1ab-482e-4008-8ccf-e4da76bb96ae" />


## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] `./gradlew ktfmtFormat` — clean
- [ ] Manual: complete a Send/Deposit/Swap, tap "Transaction Details ›", verify Status row is the first row of the expanded panel and reflects Success / Error / In progress…
- [ ] Manual: confirm `PreviewSendTxOverviewScreenExpanded` and `SwapTransactionOverviewScreenPreviewExpanded` render the expanded layout in Android Studio's preview pane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction status label added to the top of Send and Swap detail panels for clearer success/failure indication.
  * Expanded/collapsed previews available to demonstrate collapsed and expanded transaction details.

* **Refactor**
  * Transaction-detail visibility moved to shared external state so overview screens consistently control expand/collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->