### PR TITLE
fix(swap): show specific error when balance can't cover gas on percentage tap

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -713,12 +713,13 @@ constructor(
 
         if (maxUsableTokenAmount <= BigInteger.ZERO) {
             srcAmountState.setTextAndPlaceCursorAtEnd("0")
-            showError(
-                UiText.FormattedText(
-                    R.string.swap_error_insufficient_balance_and_fees,
-                    listOf(srcToken.ticker),
-                )
-            )
+            val errorRes =
+                if (srcToken.isNativeToken) {
+                    R.string.swap_error_insufficient_balance_and_fees
+                } else {
+                    R.string.swap_error_insufficient_source_token
+                }
+            showError(UiText.FormattedText(errorRes, listOf(srcToken.ticker)))
             return
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -713,6 +713,12 @@ constructor(
 
         if (maxUsableTokenAmount <= BigInteger.ZERO) {
             srcAmountState.setTextAndPlaceCursorAtEnd("0")
+            showError(
+                UiText.FormattedText(
+                    R.string.swap_error_insufficient_balance_and_fees,
+                    listOf(srcToken.ticker),
+                )
+            )
             return
         }
 


### PR DESCRIPTION
## Summary
- When the user taps **25% / 50% / 75% / MAX** on a native source token (e.g. ETH) whose balance is below the estimated network fee, the input field was silently set to `0` and the form surfaced only the generic **"Invalid amount"** error — leaving the user no way to know that gas was the cause.
- `selectSrcPercentage` now also calls `showError(...)` with the existing `swap_error_insufficient_balance_and_fees` string, so the message clearly tells the user to top up their native token or reduce the swap amount.
- The manually-typed-amount path was already covered by `SwapValidator.validateBalanceForSwap`, which uses the same string — so behavior is consistent across both entry methods.

## Repro
1. Vault with very low native balance (e.g. **0.00057564 ETH**) on Ethereum.
2. Open Swap, source = ETH.
3. Tap **MAX** (or any percentage). Estimated network fee (~$3.51) exceeds the entire ETH balance.

**Before:** field flips to `0`, tooltip just says "Invalid amount".
**After:** tooltip explains "Insufficient ETH balance for the swap and gas fees. Top up ETH or reduce swap amount".

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/FjKWdjo.png) | ![after](https://i.imgur.com/gX18yKp.png) |

## Test plan
- [ ] On a vault with native balance < estimated gas (Ethereum), tap each of 25% / 50% / 75% / MAX and confirm the new error tooltip appears.
- [ ] On a vault with sufficient ETH, confirm the percentage chips still set a positive amount and no error is shown.
- [ ] Manually type an amount that exceeds `balance - gas`; confirm the existing `swap_error_insufficient_balance_and_fees` error fires (regression check on `SwapValidator`).
- [ ] Repeat with a non-native source (ERC-20) — gas check should be skipped on the percentage path; existing native-gas validation still gates submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap form will now immediately reset the input amount to "0" and show a clear, context-aware error when no usable tokens are available—displaying a message that distinguishes insufficient balance including fees for native tokens versus insufficient source-token balance for non‑native tokens, preventing silent failures and improving clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->