### PR TITLE
fix(tx-complete): align title, back button, and padding across initiator/joined (#4343)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -197,7 +197,7 @@ private fun JoinKeysignScreen(
         content()
     } else {
         V2Scaffold(
-            onBackClick = onBack.takeIf { isKeySignFinished.not() && isError.not() },
+            onBackClick = onBack.takeIf { isError.not() },
             rightIcon = R.drawable.big_close.takeIf { isError },
             onRightIconClick = onBack.takeIf { isError },
             title =
@@ -206,6 +206,9 @@ private fun JoinKeysignScreen(
                         if (isKeySignFinished.not()) R.string.keysign
                         else R.string.transaction_complete_screen_title
                 ),
+            // TxDoneScaffold inside KeysignView already pads its content; skip the
+            // V2Scaffold default padding when finished so it matches the initiator.
+            applyDefaultPaddings = isKeySignFinished.not(),
             content = content,
         )
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -78,7 +78,7 @@ internal fun TxDoneScaffold(
         topBar = {
             if (showToolbar) {
                 V2Topbar(
-                    title = stringResource(R.string.tx_overview_screen_title),
+                    title = stringResource(R.string.transaction_complete_screen_title),
                     onBackClick = onBack,
                 )
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -881,7 +881,6 @@
     <string name="select_vault_type_fast_title">Schnelle Einrichtung mit nur einem Gerät</string>
     <string name="select_vault_type_fast_desc_1">Nur 1 Gerät erforderlich</string>
     <string name="scan_qr_code_modal_scan_the">Scannen Sie den QR auf Ihren anderen Geräten</string>
-    <string name="tx_overview_screen_title">Fertig</string>
     <string name="fast_vault_password_screen_warning">Passwort kann nicht zurückgesetzt oder wiederhergestellt werden</string>
     <string name="referral_top_bar_list">Empfehlung</string>
     <string name="onboarding_desc_page_1_part_3">Ihr neuer Tresor</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -879,7 +879,6 @@
     <string name="select_vault_type_fast_title">Configuración rápida en un solo dispositivo</string>
     <string name="select_vault_type_fast_desc_1">Solo se necesita un dispositivo</string>
     <string name="scan_qr_code_modal_scan_the">Escanea el QR en tus otros dispositivos</string>
-    <string name="tx_overview_screen_title">Listo</string>
     <string name="fast_vault_password_screen_warning">La contraseña no se puede restablecer ni recuperar.</string>
     <string name="referral_top_bar_list">Referido</string>
     <string name="onboarding_desc_page_1_part_3">Tu nuevo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -884,7 +884,6 @@
     <string name="select_vault_type_fast_title">Brzo postavljanje na 1 uređaju</string>
     <string name="select_vault_type_fast_desc_1">Potreban je samo 1 uređaj</string>
     <string name="scan_qr_code_modal_scan_the">Skenirajte QR na svojim drugim uređajima</string>
-    <string name="tx_overview_screen_title">Gotovo</string>
     <string name="fast_vault_password_screen_warning">Lozinka se ne može resetirati ili oporaviti</string>
     <string name="referral_top_bar_list">Preporuka</string>
     <string name="onboarding_desc_page_1_part_3">vaš novi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -879,7 +879,6 @@
     <string name="select_vault_type_fast_title">Configurazione rapida su un solo dispositivo</string>
     <string name="select_vault_type_fast_desc_1">È necessario un solo dispositivo</string>
     <string name="scan_qr_code_modal_scan_the">Scansiona il QR sui tuoi altri dispositivi</string>
-    <string name="tx_overview_screen_title">Fatto</string>
     <string name="fast_vault_password_screen_warning">La password non può essere reimpostata o recuperata</string>
     <string name="referral_top_bar_list">Referral</string>
     <string name="onboarding_desc_page_1_part_3">il tuo nuovo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -638,7 +638,6 @@
     <string name="security_scanner_transaction_scanning">스캔 중…</string>
     <string name="security_scanner_transaction_not_scanned">거래 스캔 미완료:</string>
 
-    <string name="tx_overview_screen_title">완료</string>
     <string name="tx_transaction_successful_screen_title">거래 성공</string>
     <string name="tx_overview_screen_tx_hash">거래 해시</string>
     <string name="tx_overview_screen_tx_from">보내는 주소</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -876,7 +876,6 @@
     <string name="select_vault_type_fast_title">Snelle installatie van 1 apparaat</string>
     <string name="select_vault_type_fast_desc_1">Slechts 1 apparaat nodig</string>
     <string name="scan_qr_code_modal_scan_the">Scan de QR op je andere apparaten</string>
-    <string name="tx_overview_screen_title">Klaar</string>
     <string name="fast_vault_password_screen_warning">Wachtwoord kan niet worden gereset of hersteld</string>
     <string name="referral_top_bar_list">Verwijzing</string>
     <string name="onboarding_desc_page_1_part_3">Je nieuwe</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -878,7 +878,6 @@
     <string name="select_vault_type_fast_title">Configuração rápida num único dispositivo</string>
     <string name="select_vault_type_fast_desc_1">Apenas 1 dispositivo necessário</string>
     <string name="scan_qr_code_modal_scan_the">Leia o QR nos seus outros dispositivos</string>
-    <string name="tx_overview_screen_title">Concluído</string>
     <string name="fast_vault_password_screen_warning">A palavra-passe não pode ser redefinida ou recuperada</string>
     <string name="referral_top_bar_list">Referência</string>
     <string name="onboarding_desc_page_1_part_3">O seu novo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -884,7 +884,6 @@
     <string name="select_vault_type_fast_title">Быстрая настройка на одном устройстве</string>
     <string name="select_vault_type_fast_desc_1">Требуется только одно устройство</string>
     <string name="scan_qr_code_modal_scan_the">Сканируйте QR на других устройствах</string>
-    <string name="tx_overview_screen_title">Готово</string>
     <string name="fast_vault_password_screen_warning">Пароль не может быть сброшен или восстановлен</string>
     <string name="referral_top_bar_list">Реферал</string>
     <string name="onboarding_desc_page_1_part_3">ваш новый</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1210,7 +1210,6 @@
     <string name="select_vault_type_fast_title">快速单设备设置</string>
     <string name="select_vault_type_fast_desc_1">仅需一台设备</string>
     <string name="scan_qr_code_modal_scan_the">在其他设备上扫描二维码</string>
-    <string name="tx_overview_screen_title">完成</string>
     <string name="fast_vault_password_screen_warning">密码无法重置或恢复</string>
     <string name="referral_top_bar_list">推荐</string>
     <string name="onboarding_desc_page_1_part_3">您的新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,7 +646,6 @@
     <string name="security_scanner_transaction_scanning">Scanning…</string>
     <string name="security_scanner_transaction_not_scanned">Transaction not scanned by</string>
 
-    <string name="tx_overview_screen_title">Done</string>
     <string name="tx_transaction_successful_screen_title">Transaction successful</string>
     <string name="tx_overview_screen_tx_hash">Transaction Hash</string>
     <string name="tx_overview_screen_tx_from">From</string>


### PR DESCRIPTION
## Summary

Fixes #4343 — the Transaction complete screen behaved differently between the initiator and the joined (paired) device:

1. **Initiator title** — `TxDoneScaffold` used `tx_overview_screen_title` ("Done") for the toolbar. Switched to `transaction_complete_screen_title` ("Transaction complete") to match the joined device. The orphan `tx_overview_screen_title` key is removed from all 10 locale files.
2. **Joined back button** — `JoinKeysignScreen` set `onBackClick = onBack.takeIf { isKeySignFinished.not() && isError.not() }`, hiding the back button on the complete screen. Dropped the `isKeySignFinished.not()` clause; the back button now appears as expected (the right-icon X handler is still gated on `isError`, so the X-only state for errors is preserved).
3. **Joined padding** — when finished, `KeysignView` renders `TxDoneScaffold` whose content already pads `16h / 8v`. The outer `V2Scaffold` was *also* applying its default `16h / 12v` padding, so the joined-device content was inset more than the initiator. Pass `applyDefaultPaddings = isKeySignFinished.not()` so the joined side matches the initiator while leaving the loading/verify/error states unchanged.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — clean build (only pre-existing warnings).
- [x] ktfmt applied.
- [x] No remaining references to `tx_overview_screen_title` (codebase + all 10 locale files).
- [ ] Manual: complete a transaction on initiator → toolbar reads "Transaction complete" (was "Done").
- [ ] Manual: complete a transaction on a joined/paired device → back button appears in the toolbar; tapping it navigates home; horizontal/vertical padding matches the initiator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Transaction completion screen title updated.
  * Back navigation behavior adjusted during keysign flows (enabled when no error).
  * Layout padding refined for completed transaction screens.

* **Localization**
  * New UI text for fast vault setup added.
  * QR code scanning prompts added across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->