### PR TITLE
fix(scan-qr): use SAF picker so Upload QR Code can reach Downloads

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -9,8 +9,7 @@ import android.graphics.BlurMaskFilter.Blur
 import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
@@ -170,7 +169,7 @@ private fun ScanQrScreen(
     DisposableEffect(Unit) { onDispose { executor.shutdownNow() } }
 
     val pickMedia =
-        rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
+        rememberLauncherForActivityResult(GetContent()) { uri ->
             isPickerLaunched = false
             coroutineScope.launch {
                 if (uri != null) {
@@ -216,7 +215,7 @@ private fun ScanQrScreen(
     val onUploadQr: () -> Unit = {
         if (!isPickerLaunched) {
             isPickerLaunched = true
-            pickMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageOnly))
+            pickMedia.launch("image/*")
         }
     }
 


### PR DESCRIPTION
## Summary

The **Upload QR Code** button on the Scan QR screen could not see QR images saved in the Downloads folder. The picker only listed photos already indexed by MediaStore (Camera, Screenshots, etc.), so files dropped into the emulator or downloaded via a browser were invisible until they were opened in the Files app, which forced a media scan.

This PR switches the launcher from the Android Photo Picker (`PickVisualMedia`) to the Storage Access Framework picker (`GetContent("image/*")`).

## Why this picker

`PickVisualMedia` only enumerates images that MediaStore has already discovered in the gallery buckets (Camera, Screenshots, Pictures…). Files that land in `Downloads/` are not part of those buckets and are not visible to the Photo Picker.

QR codes are almost always **received** as files (downloaded from a browser, AirDrop equivalents, dragged into an emulator) rather than **taken** as photos. The SAF picker (`GetContent`) is the correct choice for this flow because it:

- Exposes Downloads, Drive, Recent, and any other DocumentProvider out of the box.
- Requires no runtime permission and no manifest entries (same as the Photo Picker).
- Works on every supported API level without a fallback path.

## Changes

`app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt`
- Replaced `PickVisualMedia()` contract with `GetContent()`.
- Replaced `pickMedia.launch(PickVisualMediaRequest(PickVisualMedia.ImageOnly))` with `pickMedia.launch("image/*")`.
- Removed the now-unused `PickVisualMediaRequest` and `PickVisualMedia` imports.

The downstream pipeline is unchanged — the returned `Uri` is still fed into `InputImage.fromFilePath`, the same retry-with-white-border logic runs on failure, and `isPickerLaunched`/`onSuccess`/`onError` behave identically.

## Repro before the fix

1. Drag a QR `.png` into the emulator (lands in Downloads).
2. Open the app, deny camera, tap **Upload QR Code**.
3. Picker shows only Recent gallery images — the dragged file is missing.
4. Open Files → Downloads → tap the file (forces MediaStore scan).
5. Repeat step 2 — file now appears.

After the fix, step 4 is no longer required.

## Test plan

- [ ] Drag a QR PNG into the emulator's Downloads folder, tap **Upload QR Code**, navigate to Downloads, select the file → QR is decoded and the scan flow continues.
- [ ] Pick a QR image from the gallery (Recent / Camera) → still works.
- [ ] Pick a non-image file via the picker (it should be filtered by the `image/*` mime) → no crash.
- [ ] Pick an image that does not contain a QR → "No barcode found" banner appears (existing white-border retry path still runs).
- [ ] Cancel the picker without selecting → returns to Scan QR screen, `isPickerLaunched` is reset (button can be tapped again).
- [ ] Same flow with camera permission granted → camera scanning still works; bottom-bar Upload QR Code still launches the new picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the QR code scanner’s gallery picker to a more compatible content picker, improving reliability when selecting images from device storage. Scanning behavior and error handling are unchanged. This reduces upload issues and provides a smoother QR scanning experience across a wider range of devices and gallery apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->