### PR TITLE
fix(notifications): dismiss foreground keysign banner when joining via QR

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -150,8 +150,13 @@ constructor(
 
     fun onForegroundBannerTapped() {
         val qrCodeData = _foregroundNotification.value?.qrCodeData ?: return
-        _foregroundNotification.value = null
+        clearForegroundNotification()
         onPushNotificationReceived(qrCodeData)
+    }
+
+    fun clearForegroundNotification() {
+        foregroundPushJob?.cancel()
+        _foregroundNotification.value = null
     }
 
     fun onPushNotificationReceived(qrCodeData: String) {

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.app.activity.ForegroundNotificationState
@@ -40,6 +41,7 @@ import com.vultisig.wallet.ui.components.banners.OfflineBanner
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
+import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SetupNavGraph
 import com.vultisig.wallet.ui.navigation.route
 import com.vultisig.wallet.ui.screens.home.VaultAccountsScreen
@@ -75,6 +77,18 @@ internal fun MainActivityContent(
                 }
 
                 launch { mainViewModel.route.collect { navController.route(it) } }
+
+                launch {
+                    navController.currentBackStackEntryFlow.collect { entry ->
+                        val destination = entry.destination
+                        if (
+                            destination.hasRoute<Route.Keysign.Join>() ||
+                                destination.hasRoute<Route.Keygen.Join>()
+                        ) {
+                            mainViewModel.clearForegroundNotification()
+                        }
+                    }
+                }
 
                 mainViewModel.onNavigationReady()
                 onNavigationReady()

--- a/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
@@ -14,13 +14,13 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.NetworkUtils
 import com.vultisig.wallet.ui.utils.SnackbarFlow
-import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -154,10 +154,10 @@ internal class MainViewModelTest {
             vm.onForegroundPushReceived("vultisig://qr-payload")
             advanceUntilIdle()
 
-            vm.foregroundNotification.value.shouldNotBeNull()
+            assertNotNull(vm.foregroundNotification.value)
 
             vm.clearForegroundNotification()
 
-            vm.foregroundNotification.value.shouldBeNull()
+            assertNull(vm.foregroundNotification.value)
         }
 }

--- a/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
@@ -14,13 +14,13 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.NetworkUtils
 import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -154,10 +154,10 @@ internal class MainViewModelTest {
             vm.onForegroundPushReceived("vultisig://qr-payload")
             advanceUntilIdle()
 
-            assertNotNull(vm.foregroundNotification.value)
+            vm.foregroundNotification.value.shouldNotBeNull()
 
             vm.clearForegroundNotification()
 
-            assertNull(vm.foregroundNotification.value)
+            vm.foregroundNotification.value.shouldBeNull()
         }
 }

--- a/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
@@ -19,6 +19,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -137,5 +139,25 @@ internal class MainViewModelTest {
             // no advance — init coroutine has not executed yet
 
             assertTrue(vm.isLoading.value)
+        }
+
+    @Test
+    fun `clearForegroundNotification clears banner state`() =
+        runTest(dispatcher) {
+            coEvery { vaultRepository.hasVaults() } returns true
+            coEvery { vaultRepository.getByEcdsa(any()) } returns null
+            coEvery { getKeysignTransactionSummary.invoke(any()) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.onForegroundPushReceived("vultisig://qr-payload")
+            advanceUntilIdle()
+
+            assertNotNull(vm.foregroundNotification.value)
+
+            vm.clearForegroundNotification()
+
+            assertNull(vm.foregroundNotification.value)
         }
 }


### PR DESCRIPTION
## Summary
- The in-app foreground keysign banner was only cleared by tapping it (`MainViewModel.onForegroundBannerTapped`). Joining the same keysign via QR scan (or any path that bypasses the banner tap) left the banner pinned on top of `JoinKeysign` / `JoinKeygen`.
- Added `MainViewModel.clearForegroundNotification()` and observe `navController.currentBackStackEntryFlow` in `MainActivityContent`. When the destination becomes `Route.Keysign.Join` or `Route.Keygen.Join`, the banner is dismissed regardless of how the user got there.
- Banner dismissal is now a function of navigation, not just user-tap. `onForegroundBannerTapped` is unchanged in behaviour and routes through the same helper for DRY.
- Unit test added to `MainViewModelTest`.

Closes #4361

## Test plan
- [ ] Foreground app on a vault, trigger keysign from another device, banner appears.
- [ ] Without tapping the banner, scan the keysign QR — banner is dismissed when JoinKeysign appears.
- [ ] Tapping the banner still routes to JoinKeysign and dismisses the banner (existing behaviour preserved).
- [ ] Same flow for keygen QR (Route.Keygen.Join).
- [ ] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.app.activity.MainViewModelTest"` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Foreground notifications are now reliably cleared: pending notification tasks are cancelled when tapping banners or when navigating to specific join screens.

* **Tests**
  * Added a unit test confirming foreground notification state is cleared as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->