### PR TITLE
refactor(keysign): unify deposit UI-model construction via shared mapper

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.common.normalizeMessageFormat
 import com.vultisig.wallet.data.mappers.KeysignMessageFromProtoMapper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.SigningLibType
@@ -66,10 +67,10 @@ import com.vultisig.wallet.data.usecases.resolveprovider.SwapSelectionContext
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
-import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.keygen.MediatorServiceDiscoveryListener
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionHistoryDataMapper
+import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.SendTransactionHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
@@ -189,6 +190,7 @@ constructor(
     private val mapTransactionHistoryData: SendTransactionHistoryDataMapper,
     private val mapSwapTransactionToHistoryData: SwapTransactionToHistoryDataMapper,
     private val mapDepositTransactionHistoryData: DepositTransactionHistoryDataMapper,
+    private val mapDepositTransactionToUiModel: DepositTransactionToUiModelMapper,
     private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val tokenRepository: TokenRepository,
@@ -888,27 +890,21 @@ constructor(
                             )
                         )
 
-                    val depositTransactionUiModel =
-                        DepositTransactionUiModel(
-                            token =
-                                ValuedToken(
-                                    token = payload.coin,
-                                    value = mapTokenValueToDecimalUiString(tokenValue),
-                                    fiatValue =
-                                        fiatValueToStringMapper(
-                                            convertTokenValueToFiat(
-                                                payload.coin,
-                                                tokenValue,
-                                                currency,
-                                            )
-                                        ),
-                                ),
+                    val depositTransaction =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = payload.coin,
                             srcAddress = payload.coin.address,
                             dstAddress = payload.toAddress,
-                            networkFeeTokenValue = totalGasAndFee.formattedTokenValue,
-                            networkFeeFiatValue = totalGasAndFee.formattedFiatValue,
                             memo = payload.memo ?: "",
+                            srcTokenValue = tokenValue,
+                            estimatedFees = estimatedTokenFees,
+                            estimateFeesFiat = totalGasAndFee.formattedFiatValue,
+                            blockChainSpecific = payload.blockChainSpecific,
                         )
+                    val depositTransactionUiModel =
+                        mapDepositTransactionToUiModel(depositTransaction)
                     transactionTypeUiModel =
                         TransactionTypeUiModel.Deposit(depositTransactionUiModel)
                     transactionHistoryData =


### PR DESCRIPTION
## Summary

- Replaces the inline `DepositTransactionUiModel(...)` build in `JoinKeysignViewModel`'s deposit branch with a `DepositTransaction` + `DepositTransactionToUiModelMapper` call — the same path the initiator (`VerifyDepositViewModel`) uses.
- Removes the drift risk that caused #4330 / #4344: any future field added to `DepositTransactionUiModel` (or change to how its fields are computed) is now applied in one place, not two.

Closes #4357.

## Equivalence check

| Field | Inline (before) | Mapper (after) |
|---|---|---|
| `token.value` | `mapTokenValueToDecimalUiString(tokenValue)` | `mapTokenValueToDecimalUiString(srcTokenValue)` — identical |
| `token.fiatValue` | `fiatValueToStringMapper(convertTokenValueToFiat(coin, tokenValue, currency))` | same call inside the mapper |
| `networkFeeFiatValue` | `totalGasAndFee.formattedFiatValue` | mapper passes through `estimateFeesFiat` (= `totalGasAndFee.formattedFiatValue`) |
| `networkFeeTokenValue` | `totalGasAndFee.formattedTokenValue` | `mapTokenValueToStringWithUnit(estimatedFees)` — same `TokenValueToStringWithUnitMapper` on the same `TokenValue` (`gasLimit = 1` is identity inside `gasFeeToEstimatedFee`) |
| `srcAddress`, `dstAddress`, `memo` | direct assignment | direct assignment via `DepositTransaction` |

## Test plan

- [x] `:app:compileDebugKotlin --rerun-tasks` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `ktfmt` clean
- [ ] **Manual smoke:** 2-device THORChain LP / deposit — verify screen on the joiner matches the initiator (token value, fiat sub-line, network fee, memo)
- [ ] **Manual smoke:** 2-device MayaChain deposit — same verification
- [ ] **Manual smoke:** ETH securedAsset `SECURE+:` deposit — same verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deposit-related UI (deposit screen, transaction history, and verification) now uses a unified domain-to-UI mapping so deposit details, fees, and fiat estimates display more consistently and reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->