### PR TITLE
fix(tron-defi): two-tone Bandwidth/Energy counter with space-padded slash

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/AutoSizingText.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/AutoSizingText.kt
@@ -2,11 +2,10 @@ package com.vultisig.wallet.ui.components.buttons
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.TextUnit
@@ -20,7 +19,21 @@ internal fun AutoSizingText(
     modifier: Modifier = Modifier,
     minFontSize: TextUnit = 1.sp,
 ) {
+    AutoSizingText(
+        text = AnnotatedString(text),
+        style = style.copy(color = color),
+        modifier = modifier,
+        minFontSize = minFontSize,
+    )
+}
 
+@Composable
+internal fun AutoSizingText(
+    text: AnnotatedString,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    minFontSize: TextUnit = 1.sp,
+) {
     SubcomposeLayout(modifier = modifier) { constraints ->
         val maxWidth = constraints.maxWidth.toFloat()
 
@@ -31,7 +44,7 @@ internal fun AutoSizingText(
         // First, try to measure at original font size
         val originalMeasurable =
             subcompose("originalText") {
-                Text(text = text, style = style, color = color, maxLines = 1, softWrap = false)
+                Text(text = text, style = style, maxLines = 1, softWrap = false)
             }
 
         val originalPlaceables =
@@ -59,13 +72,7 @@ internal fun AutoSizingText(
 
             val measurable =
                 subcompose("text_$iteration") {
-                    Text(
-                        text = text,
-                        style = testStyle,
-                        color = color,
-                        maxLines = 1,
-                        softWrap = false,
-                    )
+                    Text(text = text, style = testStyle, maxLines = 1, softWrap = false)
                 }
 
             val placeables =
@@ -84,7 +91,7 @@ internal fun AutoSizingText(
 
         val finalMeasurable =
             subcompose("finalText") {
-                Text(text = text, style = bestStyle, color = color, maxLines = 1, softWrap = false)
+                Text(text = text, style = bestStyle, maxLines = 1, softWrap = false)
             }
 
         val placeables =

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ResourceStateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ResourceStateScreen.kt
@@ -43,7 +43,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -175,9 +178,16 @@ fun ResourceCard(
 
                 Column(modifier = Modifier.fillMaxWidth()) {
                     AutoSizingText(
-                        text = "${state.available}/${state.total}",
+                        text =
+                            buildAnnotatedString {
+                                withStyle(SpanStyle(color = colors.text.secondary)) {
+                                    append(state.available.toString())
+                                }
+                                withStyle(SpanStyle(color = colors.text.tertiary)) {
+                                    append(" / ${state.total}")
+                                }
+                            },
                         style = Theme.brockmann.supplementary.caption,
-                        color = colors.text.secondary,
                     )
                     Spacer(modifier = Modifier.height(7.dp))
                     AnimatedProgressBar(


### PR DESCRIPTION
## Summary

- `ResourceStateScreen.kt:178` rendered the Bandwidth / Energy counter as a single-tone, no-space `${available}/${total}` string. Figma ([node 59573:167415](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=59573-167415)) wants it two-tone with a space-padded slash: `1500 / 2000`, where `1500` is `text.secondary` (#C9D6E8) and `" / 2000"` is `text.tertiary` (#8295AE).
- Switched the call to a two-tone `AnnotatedString`. `AutoSizingText` gained an `AnnotatedString` overload; the existing `String(text, color)` overload now delegates to it so there's a single implementation.
- Affects both Bandwidth and Energy cards (they share `ResourceCard`).

Closes #4384.

Refs: split from #4362.

## Test plan

- [x] `:app:compileDebugKotlin --rerun-tasks` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `ktfmt` clean
- [ ] **Manual visual review on device:** open a vault with TRX → Tron chain → DeFi tab → "Staked"; confirm Bandwidth and Energy counters render `available / total` two-tone matching Figma

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Text component now supports rich/annotated text input and consolidates color into style for more flexible styling.

* **Style**
  * Resource displays updated to color individual value segments differently for clearer visual distinction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->