### PR TITLE
refactor(send): split SendFormViewModel into Address/Amount managers

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -114,7 +114,9 @@ internal class AddressManager(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.d(e, "Failed to resolve address %s on %s", addressStr, chain)
+            // Resolver failures are non-fatal (the user can retry), but log at warning so a
+            // genuine bug in the resolver surface — RPC, parsing, etc. — isn't silently buried.
+            Timber.w(e, "Failed to resolve address %s on %s", addressStr, chain)
             _resolvedDstAddress.value = null
             _dstAddressLabel.value = null
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 internal class AddressManager(
     private val scope: CoroutineScope,
@@ -112,7 +113,8 @@ internal class AddressManager(
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Timber.d(e, "Failed to resolve address %s on %s", addressStr, chain)
             _resolvedDstAddress.value = null
             _dstAddressLabel.value = null
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -1,0 +1,120 @@
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.ui.utils.asAddressInput
+import com.vultisig.wallet.ui.utils.textAsFlow
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.launch
+
+internal class AddressManager(
+    private val scope: CoroutineScope,
+    private val addressFieldState: TextFieldState,
+    private val selectedToken: StateFlow<Coin?>,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val addressParserRepository: AddressParserRepository,
+) {
+    private val _resolvedDstAddress = MutableStateFlow<String?>(null)
+    val resolvedDstAddress: StateFlow<String?> = _resolvedDstAddress.asStateFlow()
+
+    private val _dstAddressLabel = MutableStateFlow<String?>(null)
+    val dstAddressLabel: StateFlow<String?> = _dstAddressLabel.asStateFlow()
+
+    private val _isDstAddressComplete = MutableStateFlow(false)
+    val isDstAddressComplete: StateFlow<Boolean> = _isDstAddressComplete.asStateFlow()
+
+    private val _onAddressValidated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val onAddressValidated: SharedFlow<Unit> = _onAddressValidated.asSharedFlow()
+
+    fun start() {
+        scope.launch { collectIsComplete() }
+        scope.launch { collectResolvedAddress() }
+    }
+
+    fun setOutputAddress(address: String) {
+        addressFieldState.setTextAndPlaceCursorAtEnd(address)
+    }
+
+    private suspend fun collectIsComplete() {
+        addressFieldState.textAsFlow().collect { text ->
+            _isDstAddressComplete.value = text.toString().isNotBlank()
+        }
+    }
+
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+    private suspend fun collectResolvedAddress() {
+        addressFieldState
+            .textAsFlow()
+            .debounce(300)
+            .combine(selectedToken.filterNotNull()) { address, token ->
+                address.asAddressInput() to token
+            }
+            .mapLatest { (addressStr, token) -> handleAddressInput(addressStr, token) }
+            .collect()
+    }
+
+    private suspend fun handleAddressInput(addressStr: String, token: Coin) {
+        val chain = token.chain
+        when {
+            chainAccountAddressRepository.isValid(chain, addressStr) -> {
+                // Only clear ENS label if the user typed a new raw address,
+                // not when we programmatically set the field to the resolved address.
+                if (addressStr != _resolvedDstAddress.value) {
+                    _dstAddressLabel.value = null
+                }
+                _resolvedDstAddress.value = addressStr
+                _onAddressValidated.tryEmit(Unit)
+            }
+            addressStr.isNotEmpty() -> {
+                // Clear stale resolved address while async resolution is in-flight
+                _resolvedDstAddress.value = null
+                _dstAddressLabel.value = null
+                tryResolveName(addressStr, token)
+            }
+            else -> {
+                _resolvedDstAddress.value = null
+                _dstAddressLabel.value = null
+            }
+        }
+    }
+
+    private suspend fun tryResolveName(addressStr: String, token: Coin) {
+        val chain = token.chain
+        try {
+            val resolved = addressParserRepository.resolveName(addressStr, chain)
+            // Ignore stale result if user changed input while resolving
+            if (addressFieldState.text.asAddressInput() != addressStr) return
+            if (chainAccountAddressRepository.isValid(chain, resolved)) {
+                _dstAddressLabel.value = addressStr
+                _resolvedDstAddress.value = resolved
+                addressFieldState.setTextAndPlaceCursorAtEnd(resolved)
+                _onAddressValidated.tryEmit(Unit)
+            } else {
+                _resolvedDstAddress.value = null
+                _dstAddressLabel.value = null
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            _resolvedDstAddress.value = null
+            _dstAddressLabel.value = null
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -102,7 +102,7 @@ internal class AmountManager(
 
     private suspend fun handleTokenInput(token: Coin, tokenString: String) {
         val tokenDecimal = tokenString.toBigDecimalOrNull()
-        _isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
+        _isMaxAmount.value = tokenDecimal?.compareTo(maxAmount) == 0 && maxAmount > BigDecimal.ZERO
 
         val fiatValue =
             convertValue(tokenString, token) { value, price, t ->
@@ -112,7 +112,16 @@ internal class AmountManager(
                         .setScale(t.decimal, RoundingMode.DOWN)
                         .stripTrailingZeros()
                 }
-                ?.takeIf { it.isNotEmpty() } ?: return
+                ?.takeIf { it.isNotEmpty() }
+
+        if (fiatValue == null) {
+            // Token side became blank/invalid — clear the mirrored fiat field so the
+            // form does not show a stale converted value alongside an empty input.
+            lastTokenValueUserInput = tokenString
+            lastFiatValueUserInput = ""
+            fiatAmountFieldState.setTextAndPlaceCursorAtEnd("")
+            return
+        }
 
         lastTokenValueUserInput = tokenString
         lastFiatValueUserInput = fiatValue
@@ -124,10 +133,19 @@ internal class AmountManager(
             convertValue(fiatString, token) { value, price, t ->
                     value.divide(price, t.decimal, RoundingMode.DOWN)
                 }
-                ?.takeIf { it.isNotEmpty() } ?: return
+                ?.takeIf { it.isNotEmpty() }
+
+        if (tokenValue == null) {
+            // Fiat side became blank/invalid — clear the mirrored token field.
+            lastFiatValueUserInput = fiatString
+            lastTokenValueUserInput = ""
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("")
+            _isMaxAmount.value = false
+            return
+        }
 
         val tokenDecimal = tokenValue.toBigDecimalOrNull()
-        _isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
+        _isMaxAmount.value = tokenDecimal?.compareTo(maxAmount) == 0 && maxAmount > BigDecimal.ZERO
 
         lastTokenValueUserInput = tokenValue
         lastFiatValueUserInput = fiatString
@@ -151,7 +169,7 @@ internal class AmountManager(
                 return null
             }
 
-        if (price == BigDecimal.ZERO) {
+        if (price.signum() == 0) {
             Timber.w("convertValue: price is ZERO for token %s, skipping", token.ticker)
             return null
         }
@@ -160,18 +178,21 @@ internal class AmountManager(
     }
 
     private suspend fun collectReaping() {
-        combine(
-                selectedToken.filterNotNull(),
-                tokenAmountFieldState.textAsFlow(),
-                gasFee.filterNotNull(),
-            ) { token, tokenAmount, gas ->
+        combine(selectedToken, tokenAmountFieldState.textAsFlow(), gasFee) { token, tokenAmount, gas
+                ->
+                // Don't filterNotNull on token/gas — when they clear (e.g. mid fee recalculation)
+                // we need the combine to still emit so we can drop any stale reaping warning.
                 _reapingError.value =
-                    chainValidationService.checkIsReapable(
-                        accountProvider(),
-                        token,
-                        tokenAmount.toString(),
-                        gas,
-                    )
+                    if (token == null || gas == null) {
+                        null
+                    } else {
+                        chainValidationService.checkIsReapable(
+                            accountProvider(),
+                            token,
+                            tokenAmount.toString(),
+                            gas,
+                        )
+                    }
             }
             .collect()
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -1,0 +1,168 @@
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.utils.TextFieldUtils
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.textAsFlow
+import java.math.BigDecimal
+import java.math.RoundingMode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+internal class AmountManager(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val fiatAmountFieldState: TextFieldState,
+    private val selectedToken: StateFlow<Coin?>,
+    private val gasFee: StateFlow<TokenValue?>,
+    private val accountProvider: () -> Account?,
+    private val appCurrency: StateFlow<AppCurrency>,
+    private val chainValidationService: ChainValidationService,
+    private val tokenPriceRepository: TokenPriceRepository,
+) {
+    private var lastTokenValueUserInput = ""
+    private var lastFiatValueUserInput = ""
+    private var maxAmount: BigDecimal = BigDecimal.ZERO
+
+    private val _isMaxAmount = MutableStateFlow(false)
+    val isMaxAmount: StateFlow<Boolean> = _isMaxAmount.asStateFlow()
+
+    private val _reapingError = MutableStateFlow<UiText?>(null)
+    val reapingError: StateFlow<UiText?> = _reapingError.asStateFlow()
+
+    /** Snapshot of the last value the user picked as "max" — read at submit time. */
+    val currentMaxAmount: BigDecimal
+        get() = maxAmount
+
+    fun start() {
+        scope.launch { collectConversion() }
+        scope.launch { collectReaping() }
+    }
+
+    /** Capture the value the user just picked as max, so the conversion flow can recognize it. */
+    fun markMax(amount: BigDecimal) {
+        maxAmount = amount
+        _isMaxAmount.value = amount > BigDecimal.ZERO
+    }
+
+    /** Reset the bidirectional cache so a fresh token selection re-triggers conversion. */
+    fun resetUserInputCache() {
+        lastTokenValueUserInput = ""
+    }
+
+    fun validateTokenAmount(value: String): UiText? {
+        if (value.length > TextFieldUtils.AMOUNT_MAX_LENGTH) {
+            return UiText.StringResource(R.string.send_from_invalid_amount)
+        }
+        val decimal = value.toBigDecimalOrNull()
+        if (decimal == null || decimal <= BigDecimal.ZERO) {
+            return UiText.StringResource(R.string.send_error_no_amount)
+        }
+        return null
+    }
+
+    private suspend fun collectConversion() {
+        combine(
+                selectedToken.filterNotNull(),
+                tokenAmountFieldState.textAsFlow(),
+                fiatAmountFieldState.textAsFlow(),
+            ) { token, tokenField, fiatField ->
+                val tokenString = tokenField.toString()
+                val fiatString = fiatField.toString()
+                when {
+                    lastTokenValueUserInput != tokenString -> handleTokenInput(token, tokenString)
+                    lastFiatValueUserInput != fiatString -> handleFiatInput(token, fiatString)
+                }
+            }
+            .collect()
+    }
+
+    private suspend fun handleTokenInput(token: Coin, tokenString: String) {
+        val tokenDecimal = tokenString.toBigDecimalOrNull()
+        _isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
+
+        val fiatValue =
+            convertValue(tokenString, token) { value, price, t ->
+                    // Fiat output: bound to the token's decimal precision
+                    value
+                        .multiply(price)
+                        .setScale(t.decimal, RoundingMode.DOWN)
+                        .stripTrailingZeros()
+                }
+                ?.takeIf { it.isNotEmpty() } ?: return
+
+        lastTokenValueUserInput = tokenString
+        lastFiatValueUserInput = fiatValue
+        fiatAmountFieldState.setTextAndPlaceCursorAtEnd(fiatValue)
+    }
+
+    private suspend fun handleFiatInput(token: Coin, fiatString: String) {
+        val tokenValue =
+            convertValue(fiatString, token) { value, price, t ->
+                    value.divide(price, t.decimal, RoundingMode.DOWN)
+                }
+                ?.takeIf { it.isNotEmpty() } ?: return
+
+        val tokenDecimal = tokenValue.toBigDecimalOrNull()
+        _isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
+
+        lastTokenValueUserInput = tokenValue
+        lastFiatValueUserInput = fiatString
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd(tokenValue)
+    }
+
+    private suspend fun convertValue(
+        value: String,
+        token: Coin,
+        transform: (value: BigDecimal, price: BigDecimal, token: Coin) -> BigDecimal,
+    ): String? {
+        val decimalValue = value.toBigDecimalOrNull() ?: return ""
+
+        val price =
+            try {
+                tokenPriceRepository.getPrice(token, appCurrency.value).first()
+            } catch (e: Exception) {
+                Timber.d("Failed to get price for token %s", token)
+                return null
+            }
+
+        if (price == BigDecimal.ZERO) {
+            Timber.w("convertValue: price is ZERO for token %s, skipping", token.ticker)
+            return null
+        }
+
+        return transform(decimalValue, price, token).toPlainString()
+    }
+
+    private suspend fun collectReaping() {
+        combine(
+                selectedToken.filterNotNull(),
+                tokenAmountFieldState.textAsFlow(),
+                gasFee.filterNotNull(),
+            ) { token, tokenAmount, gas ->
+                _reapingError.value =
+                    chainValidationService.checkIsReapable(
+                        accountProvider(),
+                        token,
+                        tokenAmount.toString(),
+                        gas,
+                    )
+            }
+            .collect()
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.textAsFlow
 import java.math.BigDecimal
 import java.math.RoundingMode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -60,9 +61,16 @@ internal class AmountManager(
         _isMaxAmount.value = amount > BigDecimal.ZERO
     }
 
-    /** Reset the bidirectional cache so a fresh token selection re-triggers conversion. */
+    /**
+     * Reset the bidirectional cache and the max snapshot. Called when the selected token changes —
+     * keeping the prior token's max value would let `isMax` flip on a coincidental amount match
+     * after the switch.
+     */
     fun resetUserInputCache() {
         lastTokenValueUserInput = ""
+        lastFiatValueUserInput = ""
+        maxAmount = BigDecimal.ZERO
+        _isMaxAmount.value = false
     }
 
     fun validateTokenAmount(value: String): UiText? {
@@ -136,8 +144,10 @@ internal class AmountManager(
         val price =
             try {
                 tokenPriceRepository.getPrice(token, appCurrency.value).first()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                Timber.d("Failed to get price for token %s", token)
+                Timber.w(e, "Failed to get price for token %s", token)
                 return null
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -1306,7 +1306,7 @@ constructor(
                     tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
 
                 val srcAddress = selectedToken.address
-                val isMaxAmount = tokenAmount == amountManager.currentMaxAmount
+                val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
 
                 if (chain == Chain.Tron) {
                     val isTronStakingOp =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -2888,11 +2888,6 @@ constructor(
         }
     }
 
-    private fun validateDstAddress(dstAddress: String): UiText? {
-        if (dstAddress.isBlank()) return UiText.StringResource(R.string.send_error_no_address)
-        return null
-    }
-
     fun enableAdvanceGasUi() {
         advanceGasUiRepository.showIcon()
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -72,7 +72,6 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
-import com.vultisig.wallet.data.utils.TextFieldUtils
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.mappers.AccountToTokenBalanceUiModelMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
@@ -103,9 +102,7 @@ import java.math.RoundingMode
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.uuid.Uuid
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -123,7 +120,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -324,17 +320,10 @@ constructor(
     private val planBtc = MutableStateFlow<Bitcoin.TransactionPlan?>(null)
 
     private val gasFee = MutableStateFlow<TokenValue?>(null)
-    private val resolvedDstAddress = MutableStateFlow<String?>(null)
-    private val dstAddressLabel = MutableStateFlow<String?>(null)
 
     private var gasSettings = MutableStateFlow<GasSettings?>(null)
 
     private val specific = MutableStateFlow<BlockChainSpecificAndUtxo?>(null)
-    private var maxAmount = BigDecimal.ZERO
-    private val isMaxAmount = MutableStateFlow(false)
-
-    private var lastTokenValueUserInput = ""
-    private var lastFiatValueUserInput = ""
 
     private val isSwitchingAccounts = MutableStateFlow(false)
 
@@ -344,6 +333,28 @@ constructor(
 
     private fun isTronStakingType(): Boolean =
         defiType == DeFiNavActions.FREEZE_TRX || defiType == DeFiNavActions.UNFREEZE_TRX
+
+    private val addressManager =
+        AddressManager(
+            scope = viewModelScope,
+            addressFieldState = addressFieldState,
+            selectedToken = selectedToken,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = addressParserRepository,
+        )
+
+    private val amountManager =
+        AmountManager(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            fiatAmountFieldState = fiatAmountFieldState,
+            selectedToken = selectedToken,
+            gasFee = gasFee,
+            accountProvider = { selectedAccount },
+            appCurrency = appCurrency,
+            chainValidationService = chainValidationService,
+            tokenPriceRepository = tokenPriceRepository,
+        )
 
     init {
         loadData(
@@ -358,70 +369,33 @@ constructor(
         )
         loadSelectedCurrency()
         collectSelectedAccount()
-        collectAmountChanges()
         calculateGasFees()
         calculateGasTokenBalance()
         collectEstimatedFee()
         collectPlanFee()
         calculateSpecific()
         collectAdvanceGasUi()
-        collectAmountChecks()
         loadVaultName()
         loadGasSettings()
-        collectDstAddress()
-        collectAddress()
         collectMaxAmount()
+        addressManager.start()
+        amountManager.start()
+        observeManagers()
     }
 
-    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-    private fun collectAddress() {
+    private fun observeManagers() {
         viewModelScope.launch {
-            addressFieldState
-                .textAsFlow()
-                .debounce(300)
-                .combine(selectedToken.filterNotNull()) { address, token ->
-                    address.asAddressInput() to token
-                }
-                .mapLatest { (addressStr, token) ->
-                    if (chainAccountAddressRepository.isValid(token.chain, addressStr)) {
-                        // Only clear ENS label if the user typed a new raw address,
-                        // not when we programmatically set the field to the resolved address.
-                        if (addressStr != resolvedDstAddress.value) {
-                            dstAddressLabel.value = null
-                        }
-                        resolvedDstAddress.value = addressStr
-                        expandSection(SendSections.Amount)
-                    } else if (addressStr.isNotEmpty()) {
-                        // Clear stale resolved address while async resolution is in-flight
-                        resolvedDstAddress.value = null
-                        dstAddressLabel.value = null
-                        try {
-                            val resolved =
-                                addressParserRepository.resolveName(addressStr, token.chain)
-                            // Ignore stale result if user changed input while resolving
-                            if (addressFieldState.text.asAddressInput() != addressStr)
-                                return@mapLatest
-                            if (chainAccountAddressRepository.isValid(token.chain, resolved)) {
-                                dstAddressLabel.value = addressStr
-                                resolvedDstAddress.value = resolved
-                                addressFieldState.setTextAndPlaceCursorAtEnd(resolved)
-                                expandSection(SendSections.Amount)
-                            } else {
-                                resolvedDstAddress.value = null
-                                dstAddressLabel.value = null
-                            }
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (_: Exception) {
-                            resolvedDstAddress.value = null
-                            dstAddressLabel.value = null
-                        }
-                    } else {
-                        resolvedDstAddress.value = null
-                        dstAddressLabel.value = null
-                    }
-                }
-                .collect()
+            addressManager.isDstAddressComplete.collect { isComplete ->
+                uiState.update { it.copy(isDstAddressComplete = isComplete) }
+            }
+        }
+        viewModelScope.launch {
+            addressManager.onAddressValidated.collect { expandSection(SendSections.Amount) }
+        }
+        viewModelScope.launch {
+            amountManager.reapingError.collect { error ->
+                uiState.update { it.copy(reapingError = error) }
+            }
         }
     }
 
@@ -606,20 +580,8 @@ constructor(
         }
     }
 
-    private fun collectDstAddress() {
-        viewModelScope.launch {
-            addressFieldState
-                .textAsFlow()
-                .map { it.toString() }
-                .collect { dstAddress ->
-                    val isDstAddressComplete = dstAddress.isNotBlank()
-                    uiState.update { it.copy(isDstAddressComplete = isDstAddressComplete) }
-                }
-        }
-    }
-
     fun validateTokenAmount() {
-        val errorText = validateTokenAmount(tokenAmountFieldState.text.toString())
+        val errorText = amountManager.validateTokenAmount(tokenAmountFieldState.text.toString())
         uiState.update { it.copy(tokenAmountError = errorText) }
     }
 
@@ -806,7 +768,7 @@ constructor(
     }
 
     fun setOutputAddress(address: String) {
-        addressFieldState.setTextAndPlaceCursorAtEnd(address)
+        addressManager.setOutputAddress(address)
     }
 
     fun setProviderAddress(address: String) {
@@ -951,8 +913,7 @@ constructor(
                     } finally {
                         uiState.update { it.copy(isAmountSelectionLoading = false) }
                     }
-                maxAmount = amount
-                isMaxAmount.value = true
+                amountManager.markMax(amount)
                 tokenAmountFieldState.setTextAndPlaceCursorAtEnd(amount.toPlainString())
             }
     }
@@ -1313,11 +1274,11 @@ constructor(
                             UiText.StringResource(R.string.failed_to_resolve_address)
                         )
                     }
-                // Use the label from collectAddress() if available (ENS/thorname was already
-                // resolved
-                // and the field was rewritten to the resolved address). Fall back to rawInput for
-                // cases where the user typed an ENS name and taps send before debounce completes.
-                val labelCandidate = dstAddressLabel.value ?: rawInput
+                // Use the label from AddressManager if available (ENS/thorname was already
+                // resolved and the field was rewritten to the resolved address). Fall back to
+                // rawInput for cases where the user typed an ENS name and taps send before the
+                // debounce completes.
+                val labelCandidate = addressManager.dstAddressLabel.value ?: rawInput
                 val dstLabel =
                     labelCandidate.takeIf {
                         it.isNotBlank() &&
@@ -1345,7 +1306,7 @@ constructor(
                     tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
 
                 val srcAddress = selectedToken.address
-                val isMaxAmount = tokenAmount == maxAmount
+                val isMaxAmount = tokenAmount == amountManager.currentMaxAmount
 
                 if (chain == Chain.Tron) {
                     val isTronStakingOp =
@@ -2347,7 +2308,7 @@ constructor(
     private fun selectToken(token: Coin) {
         Timber.d("selectToken(token = $token)")
 
-        lastTokenValueUserInput = ""
+        amountManager.resetUserInputCache()
         selectedToken.value = token
     }
 
@@ -2666,7 +2627,7 @@ constructor(
                                             vaultHexPublicKey = vault.getPubKeyByChain(chain),
                                         ),
                                     amount = tokenAmountInt,
-                                    to = resolvedDstAddress.value ?: dst,
+                                    to = addressManager.resolvedDstAddress.value ?: dst,
                                     memo = memo,
                                     isMax = false,
                                 )
@@ -2750,7 +2711,7 @@ constructor(
 
     private fun collectMaxAmount() {
         viewModelScope.launch {
-            isMaxAmount.collect { isMax ->
+            amountManager.isMaxAmount.collect { isMax ->
                 val chain = selectedAccount?.token?.chain ?: return@collect
                 // Only require to re-trigger utxo chains, due to no change output utxo and
                 // therefore
@@ -2927,118 +2888,8 @@ constructor(
         }
     }
 
-    private fun collectAmountChanges() {
-        viewModelScope.launch {
-            combine(
-                    selectedToken.filterNotNull(),
-                    tokenAmountFieldState.textAsFlow(),
-                    fiatAmountFieldState.textAsFlow(),
-                ) { selectedToken, tokenFieldValue, fiatFieldValue ->
-                    val tokenString = tokenFieldValue.toString()
-                    val fiatString = fiatFieldValue.toString()
-                    if (lastTokenValueUserInput != tokenString) {
-                        val tokenDecimal = tokenString.toBigDecimalOrNull()
-                        isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
-
-                        val fiatValue =
-                            convertValue(tokenString, selectedToken) { value, price, token ->
-                                    // this is the fiat value , we should not keep too much decimal
-                                    // places
-                                    value
-                                        .multiply(price)
-                                        .setScale(selectedToken.decimal, RoundingMode.DOWN)
-                                        .stripTrailingZeros()
-                                }
-                                ?.takeIf { it.isNotEmpty() } ?: return@combine
-
-                        lastTokenValueUserInput = tokenString
-                        lastFiatValueUserInput = fiatValue
-
-                        fiatAmountFieldState.setTextAndPlaceCursorAtEnd(fiatValue)
-                    } else if (lastFiatValueUserInput != fiatString) {
-                        val tokenValue =
-                            convertValue(fiatString, selectedToken) { value, price, token ->
-                                    value.divide(price, token.decimal, RoundingMode.DOWN)
-                                }
-                                ?.takeIf { it.isNotEmpty() } ?: return@combine
-
-                        val tokenDecimal = tokenValue.toBigDecimalOrNull()
-                        isMaxAmount.value = tokenDecimal == maxAmount && maxAmount > BigDecimal.ZERO
-
-                        lastTokenValueUserInput = tokenValue
-                        lastFiatValueUserInput = fiatString
-
-                        tokenAmountFieldState.setTextAndPlaceCursorAtEnd(tokenValue)
-                    }
-                }
-                .collect()
-        }
-    }
-
-    private fun collectAmountChecks() {
-        viewModelScope.launch {
-            combine(
-                    selectedToken.filterNotNull(),
-                    tokenAmountFieldState.textAsFlow(),
-                    gasFee.filterNotNull(),
-                ) { selectedToken, tokenAmount, gasFee ->
-                    val reapingError =
-                        chainValidationService.checkIsReapable(
-                            selectedAccount,
-                            selectedToken,
-                            tokenAmount.toString(),
-                            gasFee,
-                        )
-                    uiState.update { it.copy(reapingError = reapingError) }
-                }
-                .collect()
-        }
-    }
-
-    private suspend fun convertValue(
-        value: String,
-        token: Coin?,
-        transform: (value: BigDecimal, price: BigDecimal, token: Coin) -> BigDecimal,
-    ): String? {
-        val decimalValue = value.toBigDecimalOrNull()
-
-        return if (decimalValue != null) {
-            val selectedToken = token ?: return null
-
-            val price =
-                try {
-                    tokenPriceRepository.getPrice(selectedToken, appCurrency.value).first()
-                } catch (e: Exception) {
-                    Timber.d("Failed to get price for token $selectedToken")
-                    return null
-                }
-
-            if (price == BigDecimal.ZERO) {
-                Timber.w(
-                    "convertValue: price is ZERO for token %s, skipping conversion",
-                    selectedToken.ticker,
-                )
-                return null
-            }
-
-            transform(decimalValue, price, selectedToken).toPlainString()
-        } else {
-            ""
-        }
-    }
-
     private fun validateDstAddress(dstAddress: String): UiText? {
         if (dstAddress.isBlank()) return UiText.StringResource(R.string.send_error_no_address)
-        return null
-    }
-
-    private fun validateTokenAmount(tokenAmount: String): UiText? {
-        if (tokenAmount.length > TextFieldUtils.AMOUNT_MAX_LENGTH)
-            return UiText.StringResource(R.string.send_from_invalid_amount)
-        val tokenAmountBigDecimal = tokenAmount.toBigDecimalOrNull()
-        if (tokenAmountBigDecimal == null || tokenAmountBigDecimal <= BigDecimal.ZERO) {
-            return UiText.StringResource(R.string.send_error_no_amount)
-        }
         return null
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
@@ -9,14 +9,16 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -62,17 +64,17 @@ internal class AddressManagerTest {
             manager.start()
             advanceUntilIdle()
 
-            assertFalse(manager.isDstAddressComplete.value)
+            manager.isDstAddressComplete.value.shouldBeFalse()
 
             addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
             Snapshot.sendApplyNotifications()
             advanceUntilIdle()
-            assertTrue(manager.isDstAddressComplete.value)
+            manager.isDstAddressComplete.value.shouldBeTrue()
 
             addressFieldState.setTextAndPlaceCursorAtEnd("   ")
             Snapshot.sendApplyNotifications()
             advanceUntilIdle()
-            assertFalse(manager.isDstAddressComplete.value)
+            manager.isDstAddressComplete.value.shouldBeFalse()
         }
 
     @Test
@@ -82,7 +84,7 @@ internal class AddressManagerTest {
 
             manager.setOutputAddress("0xdeadbeef")
 
-            assertEquals("0xdeadbeef", addressFieldState.text.toString())
+            addressFieldState.text.toString() shouldBe "0xdeadbeef"
         }
 
     @Test
@@ -100,9 +102,9 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertEquals("0xabc", manager.resolvedDstAddress.value)
-            assertNull(manager.dstAddressLabel.value)
-            assertEquals(1, emissions.size)
+            manager.resolvedDstAddress.value shouldBe "0xabc"
+            manager.dstAddressLabel.value.shouldBeNull()
+            emissions shouldHaveSize 1
         }
 
     @Test
@@ -126,15 +128,15 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertEquals("0xres", manager.resolvedDstAddress.value)
-            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
+            manager.resolvedDstAddress.value shouldBe "0xres"
+            manager.dstAddressLabel.value shouldBe "vitalik.eth"
 
             addressFieldState.setTextAndPlaceCursorAtEnd("0xres")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
+            manager.dstAddressLabel.value shouldBe "vitalik.eth"
         }
 
     @Test
@@ -154,9 +156,9 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertEquals("0xres", manager.resolvedDstAddress.value)
-            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
-            assertEquals("0xres", addressFieldState.text.toString())
+            manager.resolvedDstAddress.value shouldBe "0xres"
+            manager.dstAddressLabel.value shouldBe "vitalik.eth"
+            addressFieldState.text.toString() shouldBe "0xres"
         }
 
     @Test
@@ -175,14 +177,20 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertNull(manager.resolvedDstAddress.value)
-            assertNull(manager.dstAddressLabel.value)
+            manager.resolvedDstAddress.value.shouldBeNull()
+            manager.dstAddressLabel.value.shouldBeNull()
         }
 
     @Test
     fun `empty input clears resolved state`() =
         runTest(mainDispatcher) {
-            every { chainAccountAddressRepository.isValid(any(), any()) } returns false
+            // Seed a real resolved state first, otherwise asserting "null after empty" would
+            // pass even if the clear path regressed (state would already be null).
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "vitalik.eth") } returns
+                false
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "0xres") } returns true
+            coEvery { addressParserRepository.resolveName("vitalik.eth", Chain.Ethereum) } returns
+                "0xres"
             val manager = build(backgroundScope)
             manager.start()
             selectedToken.value = ethToken()
@@ -192,13 +200,17 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
+            // Confirm we actually populated state before testing the clear.
+            manager.resolvedDstAddress.value shouldBe "0xres"
+            manager.dstAddressLabel.value shouldBe "vitalik.eth"
+
             addressFieldState.setTextAndPlaceCursorAtEnd("")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertNull(manager.resolvedDstAddress.value)
-            assertNull(manager.dstAddressLabel.value)
+            manager.resolvedDstAddress.value.shouldBeNull()
+            manager.dstAddressLabel.value.shouldBeNull()
         }
 
     @Test
@@ -217,8 +229,8 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertNull(manager.resolvedDstAddress.value)
-            assertNull(manager.dstAddressLabel.value)
+            manager.resolvedDstAddress.value.shouldBeNull()
+            manager.dstAddressLabel.value.shouldBeNull()
 
             coVerify { addressParserRepository.resolveName("explode.eth", Chain.Ethereum) }
         }
@@ -238,7 +250,7 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            assertTrue(emissions.isEmpty())
+            emissions.shouldBeEmpty()
         }
 
     private fun TestScope.collectValidations(manager: AddressManager): MutableList<Unit> {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
@@ -1,0 +1,271 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AddressManagerTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk(relaxed = true)
+    private val addressParserRepository: AddressParserRepository = mockk(relaxed = true)
+
+    private val addressFieldState = TextFieldState()
+    private val selectedToken = MutableStateFlow<Coin?>(null)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `isDstAddressComplete tracks non-blank field text`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+            manager.start()
+            advanceUntilIdle()
+
+            assertFalse(manager.isDstAddressComplete.value)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+            assertTrue(manager.isDstAddressComplete.value)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("   ")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+            assertFalse(manager.isDstAddressComplete.value)
+        }
+
+    @Test
+    fun `setOutputAddress writes to the field state`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+
+            manager.setOutputAddress("0xdeadbeef")
+
+            assertEquals("0xdeadbeef", addressFieldState.text.toString())
+        }
+
+    @Test
+    fun `valid address sets resolvedDstAddress and emits onAddressValidated`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "0xabc") } returns true
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            val emissions = collectValidations(manager)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertEquals("0xabc", manager.resolvedDstAddress.value)
+            assertNull(manager.dstAddressLabel.value)
+            assertEquals(1, emissions.size)
+        }
+
+    @Test
+    fun `repeated valid input does not clear an existing dstAddressLabel`() =
+        runTest(mainDispatcher) {
+            // First: ENS resolves "vitalik.eth" -> "0xres", label is set to "vitalik.eth".
+            // Then the resolved value flows through again as a valid address — the label
+            // must survive (the user did not type a new raw address).
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "vitalik.eth") } returns
+                false
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "0xres") } returns true
+            coEvery { addressParserRepository.resolveName("vitalik.eth", Chain.Ethereum) } returns
+                "0xres"
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("vitalik.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertEquals("0xres", manager.resolvedDstAddress.value)
+            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xres")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
+        }
+
+    @Test
+    fun `non-empty invalid input attempts ENS resolution and rewrites the field`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "vitalik.eth") } returns
+                false
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "0xres") } returns true
+            coEvery { addressParserRepository.resolveName("vitalik.eth", Chain.Ethereum) } returns
+                "0xres"
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("vitalik.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertEquals("0xres", manager.resolvedDstAddress.value)
+            assertEquals("vitalik.eth", manager.dstAddressLabel.value)
+            assertEquals("0xres", addressFieldState.text.toString())
+        }
+
+    @Test
+    fun `ENS resolving to invalid address clears state`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "bad.eth") } returns false
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "garbage") } returns false
+            coEvery { addressParserRepository.resolveName("bad.eth", Chain.Ethereum) } returns
+                "garbage"
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("bad.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertNull(manager.resolvedDstAddress.value)
+            assertNull(manager.dstAddressLabel.value)
+        }
+
+    @Test
+    fun `empty input clears resolved state`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(any(), any()) } returns false
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("vitalik.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertNull(manager.resolvedDstAddress.value)
+            assertNull(manager.dstAddressLabel.value)
+        }
+
+    @Test
+    fun `resolveName throwing leaves state cleared and does not crash`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "explode.eth") } returns
+                false
+            coEvery { addressParserRepository.resolveName("explode.eth", Chain.Ethereum) } throws
+                IllegalStateException("rpc down")
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("explode.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertNull(manager.resolvedDstAddress.value)
+            assertNull(manager.dstAddressLabel.value)
+
+            coVerify { addressParserRepository.resolveName("explode.eth", Chain.Ethereum) }
+        }
+
+    @Test
+    fun `onAddressValidated does not emit while no token is selected`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            val manager = build(backgroundScope)
+            manager.start()
+            // No token selected — combine never emits, handleAddressInput never runs.
+
+            val emissions = collectValidations(manager)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            assertTrue(emissions.isEmpty())
+        }
+
+    private fun TestScope.collectValidations(manager: AddressManager): MutableList<Unit> {
+        val emissions = mutableListOf<Unit>()
+        backgroundScope.launch { manager.onAddressValidated.collect { emissions += Unit } }
+        return emissions
+    }
+
+    private fun build(scope: CoroutineScope) =
+        AddressManager(
+            scope = scope,
+            addressFieldState = addressFieldState,
+            selectedToken = selectedToken,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = addressParserRepository,
+        )
+
+    private fun ethToken(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xself",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
@@ -207,7 +207,7 @@ internal class AmountManagerTest {
         }
 
     @Test
-    fun `resetUserInputCache lets next emission re-trigger conversion`() =
+    fun `resetUserInputCache lets a token switch re-run conversion on the same amount`() =
         runTest(mainDispatcher) {
             every { tokenPriceRepository.getPrice(any(), any()) } returns flowOf(BigDecimal("100"))
             val manager = build(backgroundScope)
@@ -219,14 +219,17 @@ internal class AmountManagerTest {
             advanceUntilIdle()
             assertEquals("100", fiatAmountFieldState.text.toString())
 
-            // Without resetUserInputCache, re-typing the same value would be a no-op.
+            // Mirror the VM behavior on a token swap: clear the cache, then push a new token
+            // through selectedToken. Without resetUserInputCache the cached "1" would block the
+            // re-conversion against the new token's price; with it, conversion must run again.
             manager.resetUserInputCache()
-            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
-            Snapshot.sendApplyNotifications()
+            selectedToken.value = polkadotToken()
             advanceUntilIdle()
 
-            // Conversion ran again — fiat field still holds the converted value.
-            assertEquals("100", fiatAmountFieldState.text.toString())
+            // Pin the behavior: the price lookup must have been invoked a second time. Without
+            // this assertion the test would still pass even if resetUserInputCache no longer
+            // cleared the user-input cache — the fiat field already held "100" from run 1.
+            coVerify(exactly = 2) { tokenPriceRepository.getPrice(any(), any()) }
         }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
@@ -1,0 +1,326 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.utils.TextFieldUtils
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AmountManagerTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+    private val fiatAmountFieldState = TextFieldState()
+    private val selectedToken = MutableStateFlow<Coin?>(null)
+    private val gasFee = MutableStateFlow<TokenValue?>(null)
+    private val appCurrency = MutableStateFlow(AppCurrency.USD)
+    private var account: Account? = null
+    private val chainValidationService = ChainValidationService()
+    private val tokenPriceRepository: TokenPriceRepository = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ──────── validateTokenAmount ────────
+
+    @Test
+    fun `validateTokenAmount empty returns no_amount error`() {
+        val manager = build(emptyScope())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("").stringId())
+    }
+
+    @Test
+    fun `validateTokenAmount zero returns no_amount error`() {
+        val manager = build(emptyScope())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("0").stringId())
+    }
+
+    @Test
+    fun `validateTokenAmount non-numeric returns no_amount error`() {
+        val manager = build(emptyScope())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("abc").stringId())
+    }
+
+    @Test
+    fun `validateTokenAmount over-length returns invalid_amount error`() {
+        val manager = build(emptyScope())
+        val tooLong = "1".repeat(TextFieldUtils.AMOUNT_MAX_LENGTH + 1)
+        assertEquals(
+            R.string.send_from_invalid_amount,
+            manager.validateTokenAmount(tooLong).stringId(),
+        )
+    }
+
+    @Test
+    fun `validateTokenAmount valid returns null`() {
+        val manager = build(emptyScope())
+        assertNull(manager.validateTokenAmount("1.5"))
+    }
+
+    // ──────── markMax ────────
+
+    @Test
+    fun `markMax with positive amount sets isMaxAmount and snapshot`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+
+            manager.markMax(BigDecimal("0.5"))
+
+            assertTrue(manager.isMaxAmount.value)
+            assertEquals(BigDecimal("0.5"), manager.currentMaxAmount)
+        }
+
+    @Test
+    fun `markMax with zero leaves isMaxAmount false`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+
+            manager.markMax(BigDecimal.ZERO)
+
+            assertFalse(manager.isMaxAmount.value)
+            assertEquals(BigDecimal.ZERO, manager.currentMaxAmount)
+        }
+
+    // ──────── conversion ────────
+
+    @Test
+    fun `typing token amount populates fiat amount`() =
+        runTest(mainDispatcher) {
+            every { tokenPriceRepository.getPrice(any(), any()) } returns flowOf(BigDecimal("2000"))
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            // 0.5 * 2000 = 1000.00, scale = 18, stripTrailingZeros → "1E+3"
+            // toPlainString gives "1000"
+            assertEquals("1000", fiatAmountFieldState.text.toString())
+        }
+
+    @Test
+    fun `typing fiat amount populates token amount`() =
+        runTest(mainDispatcher) {
+            every { tokenPriceRepository.getPrice(any(), any()) } returns flowOf(BigDecimal("2000"))
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            // First write to tokenField with empty user-input cache so the conversion runs.
+            // Then write to fiatField — different value triggers the fiat→token branch.
+            fiatAmountFieldState.setTextAndPlaceCursorAtEnd("1000")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            // 1000 / 2000 = 0.5, scaled to token decimal (18) — fiat→token branch does NOT
+            // stripTrailingZeros (intentional: preserves the user's typed precision in the field).
+            assertEquals("0.500000000000000000", tokenAmountFieldState.text.toString())
+        }
+
+    @Test
+    fun `zero price leaves fiat field empty`() =
+        runTest(mainDispatcher) {
+            every { tokenPriceRepository.getPrice(any(), any()) } returns flowOf(BigDecimal.ZERO)
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.0")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertEquals("", fiatAmountFieldState.text.toString())
+        }
+
+    @Test
+    fun `price-fetch exception leaves fiat field empty`() =
+        runTest(mainDispatcher) {
+            every { tokenPriceRepository.getPrice(any(), any()) } throws RuntimeException("network")
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.0")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertEquals("", fiatAmountFieldState.text.toString())
+        }
+
+    @Test
+    fun `non-numeric token input clears fiat field without calling price repo`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("abc")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            // convertValue returns "" for non-numeric input; the takeIf gate skips the field write.
+            assertEquals("", fiatAmountFieldState.text.toString())
+            coVerify(exactly = 0) { tokenPriceRepository.getPrice(any(), any()) }
+        }
+
+    @Test
+    fun `resetUserInputCache lets next emission re-trigger conversion`() =
+        runTest(mainDispatcher) {
+            every { tokenPriceRepository.getPrice(any(), any()) } returns flowOf(BigDecimal("100"))
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+            assertEquals("100", fiatAmountFieldState.text.toString())
+
+            // Without resetUserInputCache, re-typing the same value would be a no-op.
+            manager.resetUserInputCache()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            // Conversion ran again — fiat field still holds the converted value.
+            assertEquals("100", fiatAmountFieldState.text.toString())
+        }
+
+    // ──────── reaping flow ────────
+
+    @Test
+    fun `reapingError stays null until all three inputs are present`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+            // Token + amount but no gas fee yet — combine must not emit.
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.0")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertNull(manager.reapingError.value)
+        }
+
+    @Test
+    fun `reapingError mirrors chain validation result once all inputs present`() =
+        runTest(mainDispatcher) {
+            // Use Polkadot — that's a chain ChainValidationService actually checks for reaping.
+            val polkadot = polkadotToken()
+            val polkadotAccount =
+                Account(
+                    token = polkadot,
+                    tokenValue = TokenValue(value = BigInteger("1000000000"), token = polkadot),
+                    fiatValue = null,
+                    price = null,
+                )
+            account = polkadotAccount
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = polkadot
+            // Gas fee that would leave balance < existential deposit → reaping warning.
+            gasFee.value = TokenValue(value = BigInteger("999999999"), token = polkadot)
+
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.000000001")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            // We don't assert the exact UiText — that's ChainValidationService's job to test —
+            // but we do assert the manager wired the inputs through and surfaced the result.
+            // For Polkadot+DOT with under-existential remainder, the service returns non-null.
+            assertEquals(
+                UiText.StringResource(R.string.send_form_polka_reaping_warning),
+                manager.reapingError.value,
+            )
+        }
+
+    private fun build(scope: CoroutineScope) =
+        AmountManager(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            fiatAmountFieldState = fiatAmountFieldState,
+            selectedToken = selectedToken,
+            gasFee = gasFee,
+            accountProvider = { account },
+            appCurrency = appCurrency,
+            chainValidationService = chainValidationService,
+            tokenPriceRepository = tokenPriceRepository,
+        )
+
+    /** Empty scope for tests that only call pure helpers (no flow plumbing). */
+    private fun emptyScope(): CoroutineScope = CoroutineScope(mainDispatcher)
+
+    private fun ethToken(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xself",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun polkadotToken(): Coin =
+        Coin(
+            chain = Chain.Polkadot,
+            ticker = "DOT",
+            logo = "",
+            address = "1polkadot",
+            decimal = 10,
+            hexPublicKey = "",
+            priceProviderID = "polkadot",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    /** Convenience: pull the StringResource id out of a UiText for terse assertions. */
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
@@ -229,6 +229,24 @@ internal class AmountManagerTest {
             assertEquals("100", fiatAmountFieldState.text.toString())
         }
 
+    @Test
+    fun `resetUserInputCache clears the max snapshot to avoid carry-over across token switches`() =
+        runTest(mainDispatcher) {
+            val manager = build(backgroundScope)
+
+            manager.markMax(BigDecimal("0.5"))
+            assertTrue(manager.isMaxAmount.value)
+            assertEquals(BigDecimal("0.5"), manager.currentMaxAmount)
+
+            // Simulating selectToken: the VM calls resetUserInputCache. The max snapshot from
+            // the previous token must NOT survive — otherwise an unrelated amount matching the
+            // old max would set isMaxAmount=true on the new token.
+            manager.resetUserInputCache()
+
+            assertFalse(manager.isMaxAmount.value)
+            assertEquals(BigDecimal.ZERO, manager.currentMaxAmount)
+        }
+
     // ──────── reaping flow ────────
 
     @Test


### PR DESCRIPTION
## Summary
- Extract destination-address handling (debounce + ENS resolution + `isDstAddressComplete` gate) into a new **`AddressManager`** (120 LOC).
- Extract bidirectional token↔fiat conversion + reaping check into a new **`AmountManager`** (168 LOC).
- `SendFormViewModel` drops ~150 LOC of inline flow logic. **No public-surface changes** — all 47 Phase A tests (#4377) pass unchanged.

## Why
With the Phase A characterization safety net in place (47 tests across 5 files), `SendFormViewModel` (3415 LOC) is now safe to split. This PR carves out the two clearest sub-responsibilities without touching the parts that still need design work (`defiType` percentage/submit branches).

Each new manager has a single responsibility and a narrow `StateFlow` API. The VM observes them and mirrors their state into `uiState`, preserving every consumer contract that `SendFormScreen` and the section composables depend on.

## What moved

### `AddressManager` (6 deps, 120 LOC)
| State / behaviour | Before | After |
|---|---|---|
| `addressFieldState` debounce + ENS resolve (`collectAddress`) | `SendFormViewModel:377` | `AddressManager.collectResolvedAddress` |
| `isDstAddressComplete` derivation (`collectDstAddress`) | `SendFormViewModel:609` | `AddressManager.collectIsComplete` |
| `resolvedDstAddress`, `dstAddressLabel` private fields | VM state | `AddressManager` private state, exposed as read-only `StateFlow` |
| `setOutputAddress(String)` | direct `addressFieldState.setText...` | delegates to `AddressManager` |
| `expandSection(Amount)` on validation | inlined inside `mapLatest` | manager emits `onAddressValidated`; VM observes |

The 80-line nested `when/try` from `collectAddress` is split into `handleAddressInput` + `tryResolveName` for readability.

### `AmountManager` (9 deps, 168 LOC)
| State / behaviour | Before | After |
|---|---|---|
| Bidirectional token↔fiat conversion (`collectAmountChanges`) | `SendFormViewModel:2930` | `AmountManager.collectConversion` (split into `handleTokenInput` + `handleFiatInput`) |
| Reaping check (`collectAmountChecks`) | `SendFormViewModel:2978` | `AmountManager.collectReaping` |
| `convertValue` price lookup | private VM helper | private manager helper, narrowed signature (`token: Coin` non-null) |
| `validateTokenAmount(String)` length/parse rules | private VM | public manager method; VM's public `validateTokenAmount()` delegates |
| `lastTokenValueUserInput`, `lastFiatValueUserInput`, `maxAmount`, `isMaxAmount` | VM private fields | manager private state |
| `chooseMaxTokenAmount` direct field writes | `maxAmount = …; isMaxAmount.value = true` | `amountManager.markMax(amount)` |
| `selectToken` cache reset | `lastTokenValueUserInput = ""` | `amountManager.resetUserInputCache()` |
| `collectMaxAmount` (UTXO `specific` orchestration) | reads VM `isMaxAmount` | reads `amountManager.isMaxAmount` (stays in VM — gas concern) |

## What deliberately stays in the VM (deferred)
- `chooseMaxTokenAmount`, `choosePercentageAmount`, `calculatePercentageWithAccurateFee`, `fetchPercentageOfAvailableBalance` — these branch on 13 `defiType` enum values, write to `gasFee`, and call `feeServiceComposite` directly. Pulling them into `AmountManager` would require an 11-dep constructor and a leaky `MutableStateFlow<TokenValue?>` parameter — defeating the goal of a focused manager.
- `setProviderAddress` / `scanProviderAddress` (bond-provider field, distinct from destination).
- All gas-fee orchestration, token/account loading, defiType dispatch, Tron staking specifics.

These come out cleanly once a per-chain submit dispatcher is introduced (next phase).

## Public surface (unchanged)
Every consumer of the VM stays byte-compatible:
- 7 `TextFieldState` fields (`addressFieldState`, `tokenAmountFieldState`, `fiatAmountFieldState`, `memoFieldState`, `operatorFeesBondFieldState`, `providerBondFieldState`, `slippageFieldState`)
- 23 public methods (`validateTokenAmount`, `setOutputAddress`, `chooseMaxTokenAmount`, `onClickContinue`, etc.)
- `uiState: StateFlow<SendFormUiModel>` and `focusFieldFlow` — same fields, same emission semantics

`SendFormScreen.kt` and the sibling `SendForm*Section.kt` composables are untouched.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.send.SendFormViewModel*Test"` — all 47 tests pass (force re-run, no caching)
- [x] `./gradlew :app:ktfmtFormat` — formatted
- [x] `./gradlew :app:compileDebugKotlin` — clean compile
- [ ] CI green
- [ ] Manual smoke (post-merge): send native, send token, swap, deposit, change network — verify destination-address validation, ENS resolve, max-amount picker, fiat toggle behave identically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Send form internals delegated to dedicated address and amount managers, simplifying ViewModel state and flows
* **New Features**
  * Smarter destination input: debounced validation, name/ENS resolution, automatic address replacement and label handling
  * Improved amount input: bidirectional token↔fiat conversion, explicit max-amount support, and real-time reaping validation
* **Tests**
  * Added comprehensive unit tests covering address resolution/validation, amount conversion, max behavior, and reaping scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->