### PR TITLE
[DO NOT MERGE] Diagnostic logs for cold-launch hang #4360

### DIFF
--- a/.github/workflows/debug-apk-trace-4360.yml
+++ b/.github/workflows/debug-apk-trace-4360.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build-debug-apk:
     runs-on: ubuntu-latest

--- a/.github/workflows/debug-apk-trace-4360.yml
+++ b/.github/workflows/debug-apk-trace-4360.yml
@@ -44,9 +44,60 @@ jobs:
         run: ./gradlew :app:assembleDebug --no-daemon --build-cache
 
       - name: Upload debug APK
+        id: upload_apk
         uses: actions/upload-artifact@v4
         with:
           name: vultisig-4360-trace-debug-apk
           path: app/build/outputs/apk/debug/*.apk
           if-no-files-found: error
           retention-days: 30
+
+      - name: Write APK download link to run summary
+        run: |
+          APK_PATH=$(find app/build/outputs/apk/debug -name "*.apk" | head -1)
+          APK_NAME=$(basename "$APK_PATH")
+          APK_SIZE=$(du -h "$APK_PATH" | cut -f1)
+          APK_SHA=$(sha256sum "$APK_PATH" | cut -d' ' -f1)
+          ARTIFACT_URL="${{ steps.upload_apk.outputs.artifact-url }}"
+          {
+            echo "## 📦 Debug APK ready"
+            echo ""
+            echo "**Direct download:** $ARTIFACT_URL"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| File | \`$APK_NAME\` |"
+            echo "| Size | $APK_SIZE |"
+            echo "| SHA-256 | \`$APK_SHA\` |"
+            echo ""
+            echo "Capture command:"
+            echo '```bash'
+            echo "adb install -r $APK_NAME"
+            echo "adb logcat -c"
+            echo "adb logcat -v time | grep boot4360 > 4360-trace.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post APK link as PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "${{ github.ref_name }}" --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
+            exit 0
+          fi
+          ARTIFACT_URL="${{ steps.upload_apk.outputs.artifact-url }}"
+          APK_PATH=$(find app/build/outputs/apk/debug -name "*.apk" | head -1)
+          APK_SHA=$(sha256sum "$APK_PATH" | cut -d' ' -f1)
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "📦 **Debug APK ready** — commit \`${{ github.sha }}\`
+
+[Download \`vultisig-4360-trace-debug-apk\`]($ARTIFACT_URL) (requires GitHub login + repo access)
+
+SHA-256: \`$APK_SHA\`
+
+\`\`\`bash
+adb install -r app-debug.apk
+adb logcat -c
+adb logcat -v time | grep boot4360 > 4360-trace.log
+\`\`\`"

--- a/.github/workflows/debug-apk-trace-4360.yml
+++ b/.github/workflows/debug-apk-trace-4360.yml
@@ -90,14 +90,18 @@ jobs:
           ARTIFACT_URL="${{ steps.upload_apk.outputs.artifact-url }}"
           APK_PATH=$(find app/build/outputs/apk/debug -name "*.apk" | head -1)
           APK_SHA=$(sha256sum "$APK_PATH" | cut -d' ' -f1)
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "📦 **Debug APK ready** — commit \`${{ github.sha }}\`
-
-[Download \`vultisig-4360-trace-debug-apk\`]($ARTIFACT_URL) (requires GitHub login + repo access)
-
-SHA-256: \`$APK_SHA\`
-
-\`\`\`bash
-adb install -r app-debug.apk
-adb logcat -c
-adb logcat -v time | grep boot4360 > 4360-trace.log
-\`\`\`"
+          BODY_FILE=$(mktemp)
+          {
+            echo "📦 **Debug APK ready** — commit \`${{ github.sha }}\`"
+            echo ""
+            echo "[Download \`vultisig-4360-trace-debug-apk\`]($ARTIFACT_URL) (requires GitHub login + repo access)"
+            echo ""
+            echo "SHA-256: \`$APK_SHA\`"
+            echo ""
+            echo '```bash'
+            echo "adb install -r app-debug.apk"
+            echo "adb logcat -c"
+            echo "adb logcat -v time | grep boot4360 > 4360-trace.log"
+            echo '```'
+          } > "$BODY_FILE"
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file "$BODY_FILE"

--- a/.github/workflows/debug-apk-trace-4360.yml
+++ b/.github/workflows/debug-apk-trace-4360.yml
@@ -1,0 +1,52 @@
+name: Debug APK (4360 trace)
+
+on:
+  push:
+    branches:
+      - roman/4360-trace-logs
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-debug-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: git submodule update
+        run: git submodule update --init --recursive
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/nodejs || true
+          sudo apt-get clean
+          df -h
+
+      - name: Build debug APK
+        env:
+          TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
+          TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
+        run: ./gradlew :app:assembleDebug --no-daemon --build-cache
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: vultisig-4360-trace-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+          retention-days: 30

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -29,14 +29,25 @@ internal fun initializeRive(context: Context) {
 internal open class VsBaseApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        WalletCoreLoader
-        SharedPrefsMasterKeyInitializer.prewarm()
-
+        // [boot4360] plant Timber FIRST so all subsequent boot-trace logs are captured.
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+        val t0 = System.nanoTime()
+        Timber.i("[boot4360] App.onCreate start, thread=%s", Thread.currentThread().name)
+        WalletCoreLoader
+        Timber.i(
+            "[boot4360] App.onCreate WalletCoreLoader done, elapsed=%dms",
+            (System.nanoTime() - t0) / 1_000_000,
+        )
+        SharedPrefsMasterKeyInitializer.prewarm()
+        Timber.i(
+            "[boot4360] App.onCreate prewarm dispatched, elapsed=%dms",
+            (System.nanoTime() - t0) / 1_000_000,
+        )
 
         initializeRive(this)
+        Timber.i("[boot4360] App.onCreate end, elapsed=%dms", (System.nanoTime() - t0) / 1_000_000)
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -65,6 +65,13 @@ class MainActivity : AppCompatActivity() {
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val tAct = System.nanoTime()
+        val hasQrExtra = intent?.hasExtra(VultisigFirebaseMessagingService.QR_CODE_DATA) == true
+        Timber.i(
+            "[boot4360] MainActivity.onCreate start, thread=%s, hasQrExtra=%b",
+            Thread.currentThread().name,
+            hasQrExtra,
+        )
         // Workaround for Android 8.0 (API 26) crash: "Only fullscreen opaque activities can
         // request orientation". Theme.SplashScreen sets windowIsTranslucent=true on API 26,
         // which conflicts with screenOrientation in the manifest. Setting it programmatically
@@ -78,6 +85,10 @@ class MainActivity : AppCompatActivity() {
 
         // Handle notification tap when app was killed — ViewModel awaits navigation readiness.
         intent?.getStringExtra(VultisigFirebaseMessagingService.QR_CODE_DATA)?.let {
+            Timber.i(
+                "[boot4360] MainActivity.onCreate Path A: about to deref mainViewModel for push, elapsed=%dms",
+                (System.nanoTime() - tAct) / 1_000_000,
+            )
             mainViewModel.onPushNotificationReceived(it)
         }
 
@@ -93,8 +104,25 @@ class MainActivity : AppCompatActivity() {
 
         observePreventScreenshots()
 
+        Timber.i(
+            "[boot4360] MainActivity.onCreate setContent called, elapsed=%dms",
+            (System.nanoTime() - tAct) / 1_000_000,
+        )
         setContent {
+            // Brackets the opaque Compose-runtime + theme-init window. Fires once per setContent.
+            remember {
+                Timber.i(
+                    "[boot4360] setContent lambda entered, elapsed=%dms",
+                    (System.nanoTime() - tAct) / 1_000_000,
+                )
+            }
             OnBoardingComposeTheme {
+                remember {
+                    Timber.i(
+                        "[boot4360] First Compose composition reached, elapsed=%dms",
+                        (System.nanoTime() - tAct) / 1_000_000,
+                    )
+                }
                 val screen by mainViewModel.startDestination.collectAsStateWithLifecycle()
 
                 val navController = rememberNavController()

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -94,9 +94,20 @@ constructor(
         VSSnackbarState(duration = 1.seconds, coroutineScope = CoroutineScope(Dispatchers.Default))
 
     init {
+        Timber.i("[boot4360] MainViewModel ctor done, thread=%s", Thread.currentThread().name)
         viewModelScope.safeLaunch {
+            val tInit = System.nanoTime()
+            Timber.i(
+                "[boot4360] MainViewModel init coroutine started, thread=%s",
+                Thread.currentThread().name,
+            )
             _startDestination.value = resolveStartDestination()
+            Timber.i(
+                "[boot4360] MainViewModel resolveStartDestination done, elapsed=%dms",
+                (System.nanoTime() - tInit) / 1_000_000,
+            )
             _isLoading.value = false
+            Timber.i("[boot4360] MainViewModel _isLoading=false set")
 
             snackbarFlow.collectMessage { (message, type) -> snakeBarHostState.show(message, type) }
         }
@@ -219,6 +230,10 @@ constructor(
         try {
             withTimeoutOrNull(SPLASH_VAULT_QUERY_TIMEOUT) { vaultRepository.hasVaults() }
                 ?: false.also {
+                    Timber.i(
+                        "[boot4360] hasVaults() timed out after %ds; assuming no vaults",
+                        SPLASH_VAULT_QUERY_TIMEOUT.inWholeSeconds,
+                    )
                     Timber.w(
                         "hasVaults() timed out after %ds; assuming no vaults",
                         SPLASH_VAULT_QUERY_TIMEOUT.inWholeSeconds,
@@ -227,6 +242,7 @@ constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
+            Timber.i("[boot4360] hasVaults() failed: %s", e::class.simpleName)
             Timber.e(e, "hasVaults() failed; assuming no vaults")
             false
         }

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/AnimatedSplash.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/AnimatedSplash.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import com.airbnb.lottie.compose.LottieAnimation
@@ -14,6 +15,7 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.theme.Theme
+import timber.log.Timber
 
 @Composable
 internal fun AnimatedSplash(
@@ -26,8 +28,15 @@ internal fun AnimatedSplash(
 
     val lottieState = animateLottieCompositionAsState(composition = composition)
 
+    remember { Timber.i("[boot4360] AnimatedSplash first composition, isLoading=%b", isLoading) }
+
     LaunchedEffect(lottieState.isAtEnd, isLoading) {
         if (lottieState.progress == 1f && !isLoading) {
+            Timber.i(
+                "[boot4360] AnimatedSplash dismissing, progress=%.2f, isLoading=%b",
+                lottieState.progress,
+                isLoading,
+            )
             onSplashComplete()
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
@@ -27,11 +27,21 @@ class VultisigFirebaseMessagingService : FirebaseMessagingService() {
     @Inject lateinit var pushNotificationManager: PushNotificationManager
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    override fun onCreate() {
+        super.onCreate()
+        Timber.i(
+            "[boot4360] VultisigFirebaseMessagingService.onCreate, thread=%s",
+            Thread.currentThread().name,
+        )
+    }
+
     override fun onNewToken(token: String) {
+        Timber.i("[boot4360] FCM onNewToken, thread=%s", Thread.currentThread().name)
         serviceScope.launch { pushNotificationManager.onNewToken(token) }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
+        Timber.i("[boot4360] FCM onMessageReceived, thread=%s", Thread.currentThread().name)
         Timber.d(
             "FCM message received from: ${message.from}, data keys: ${message.data.keys}, notification: title=${message.notification?.title} body=${message.notification?.body?.take(80)}"
         )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
@@ -75,12 +75,22 @@ internal interface MainDataModule {
         @Provides
         fun provideEncryptedSharedPrefs(@ApplicationContext context: Context): SharedPreferences {
             fun create(): SharedPreferences {
+                val tProv = System.nanoTime()
                 // Use the prewarm result if it completed before Hilt arrived; otherwise fall back
                 // to a fresh keystore lookup.
                 val prewarm = SharedPrefsMasterKeyInitializer.prewarmResult
+                Timber.i(
+                    "[boot4360] provideEncryptedSharedPrefs enter, thread=%s, prewarm.isCompleted=%b",
+                    Thread.currentThread().name,
+                    prewarm.isCompleted,
+                )
                 val key =
                     if (prewarm.isCompleted) prewarm.getCompleted() ?: buildSecurePrefsKey()
                     else buildSecurePrefsKey()
+                Timber.i(
+                    "[boot4360] provideEncryptedSharedPrefs key obtained, elapsed=%dms",
+                    (System.nanoTime() - tProv) / 1_000_000,
+                )
                 val rawPrefs = context.getSharedPreferences(SECURE_PREFS_FILE, Context.MODE_PRIVATE)
                 val prefs = EncryptingSharedPreferences(rawPrefs, key)
                 // Eagerly probe the key: KeyPermanentlyInvalidatedException (a
@@ -91,10 +101,15 @@ internal interface MainDataModule {
                 CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
                     migrateFromEncryptedSharedPrefs(context, prefs)
                 }
+                Timber.i(
+                    "[boot4360] provideEncryptedSharedPrefs returning, total=%dms",
+                    (System.nanoTime() - tProv) / 1_000_000,
+                )
                 return prefs
             }
 
             fun recoverAndRetry(cause: Exception): SharedPreferences {
+                Timber.i("[boot4360] recoverAndRetry triggered, cause=%s", cause::class.simpleName)
                 Timber.e(cause, "SecureSharedPrefs init failed, attempting recovery")
                 val prefsFile = File(context.filesDir.parent, "shared_prefs/$SECURE_PREFS_FILE.xml")
                 if (prefsFile.exists() && !prefsFile.delete()) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecureSharedPreferences.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecureSharedPreferences.kt
@@ -35,17 +35,37 @@ private val secureKeyLock = ReentrantLock()
  * blocking indefinitely if the keystore daemon stalls.
  */
 internal fun buildSecurePrefsKey(): SecretKey {
+    val t0 = System.nanoTime()
+    Timber.i("[boot4360] buildSecurePrefsKey enter, thread=%s", Thread.currentThread().name)
     if (!secureKeyLock.tryLock(3_000L, TimeUnit.MILLISECONDS)) {
+        Timber.w("[boot4360] buildSecurePrefsKey lock timeout after 3s")
         error("Timed out waiting for secure prefs key lock after 3 s")
     }
+    val tLock = System.nanoTime()
+    Timber.i(
+        "[boot4360] buildSecurePrefsKey lock acquired, lockWait=%dms",
+        (tLock - t0) / 1_000_000,
+    )
     try {
         val ks = KeyStore.getInstance(KEYSTORE).apply { load(null) }
         val entry = ks.getEntry(SECURE_PREFS_KEY_ALIAS, null)
+        val tEntry = System.nanoTime()
+        Timber.i(
+            "[boot4360] buildSecurePrefsKey keystore load+getEntry done, elapsed=%dms, hasEntry=%b",
+            (tEntry - tLock) / 1_000_000,
+            entry != null,
+        )
         if (entry != null) {
-            return (entry as? KeyStore.SecretKeyEntry)?.secretKey
-                ?: error(
-                    "Alias $SECURE_PREFS_KEY_ALIAS holds unexpected entry type: ${entry::class.simpleName}"
-                )
+            val key =
+                (entry as? KeyStore.SecretKeyEntry)?.secretKey
+                    ?: error(
+                        "Alias $SECURE_PREFS_KEY_ALIAS holds unexpected entry type: ${entry::class.simpleName}"
+                    )
+            Timber.i(
+                "[boot4360] buildSecurePrefsKey returning existing key, total=%dms",
+                (System.nanoTime() - t0) / 1_000_000,
+            )
+            return key
         }
         val spec =
             KeyGenParameterSpec.Builder(
@@ -56,9 +76,16 @@ internal fun buildSecurePrefsKey(): SecretKey {
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setKeySize(256)
                 .build()
-        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
-            .apply { init(spec) }
-            .generateKey()
+        val key =
+            KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+                .apply { init(spec) }
+                .generateKey()
+        Timber.i(
+            "[boot4360] buildSecurePrefsKey generateKey done, generateElapsed=%dms, total=%dms",
+            (System.nanoTime() - tEntry) / 1_000_000,
+            (System.nanoTime() - t0) / 1_000_000,
+        )
+        return key
     } finally {
         secureKeyLock.unlock()
     }
@@ -171,7 +198,22 @@ internal class EncryptingSharedPreferences(
      * trigger recovery before the first real read or write silently returns defaults.
      */
     internal fun selfTest() {
-        encryptRaw(secretKey, "probe")
+        val t0 = System.nanoTime()
+        Timber.i("[boot4360] selfTest start, thread=%s", Thread.currentThread().name)
+        // Inline the cipher init+doFinal so each step can be timed independently. Functionally
+        // equivalent to encryptRaw(secretKey, "probe") for the purpose of surfacing
+        // KeyPermanentlyInvalidatedException eagerly — both errors fire at Cipher.init() /
+        // doFinal().
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val tInit = System.nanoTime()
+        Timber.i("[boot4360] selfTest cipher.init done, elapsed=%dms", (tInit - t0) / 1_000_000)
+        cipher.doFinal("probe".toByteArray(Charsets.UTF_8))
+        Timber.i(
+            "[boot4360] selfTest cipher.doFinal done, doFinalElapsed=%dms, total=%dms",
+            (System.nanoTime() - tInit) / 1_000_000,
+            (System.nanoTime() - t0) / 1_000_000,
+        )
     }
 
     private val listenerWrappers =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
@@ -34,14 +34,33 @@ object SharedPrefsMasterKeyInitializer {
     fun prewarm() {
         CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineName("SecurePrefsPrewarm"))
             .launch {
+                val t0 = System.nanoTime()
+                Timber.i(
+                    "[boot4360] Prewarm coroutine started, thread=%s",
+                    Thread.currentThread().name,
+                )
                 try {
                     _prewarmResult.complete(buildSecurePrefsKey())
+                    Timber.i(
+                        "[boot4360] Prewarm complete OK, elapsed=%dms",
+                        (System.nanoTime() - t0) / 1_000_000,
+                    )
                 } catch (e: GeneralSecurityException) {
                     Timber.w(e, "Secure prefs key prewarm failed; deferring to sync path")
                     _prewarmResult.complete(null)
+                    Timber.i(
+                        "[boot4360] Prewarm complete FAIL(GSE), elapsed=%dms, err=%s",
+                        (System.nanoTime() - t0) / 1_000_000,
+                        e::class.simpleName,
+                    )
                 } catch (e: IOException) {
                     Timber.w(e, "Secure prefs key prewarm failed; deferring to sync path")
                     _prewarmResult.complete(null)
+                    Timber.i(
+                        "[boot4360] Prewarm complete FAIL(IOE), elapsed=%dms, err=%s",
+                        (System.nanoTime() - t0) / 1_000_000,
+                        e::class.simpleName,
+                    )
                 }
             }
     }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Diagnostic build only

Logs added to troubleshoot **#4360** (cold-launch splash hang). This branch is intended to produce a debug APK that a reproducing dev installs to capture a single-shot logcat that pinpoints exactly which phase of the cold-launch sequence stalls.

Closes nothing. Will be deleted after the diagnostic capture is collected.

## What's instrumented

All logs use the prefix `[boot4360]` so the dev can filter logcat with:

```bash
adb logcat -v time -c
adb logcat -v time | grep boot4360 > 4360-trace.log
# (cold-launch the app)
```

Phase boundaries bracketed:

| Phase | File | Captures |
|---|---|---|
| `Application.onCreate` | `VoltixApplication.kt` | start, WalletCoreLoader, prewarm dispatch, end (with elapsed) |
| Prewarm coroutine (off-main) | `SharedPrefsMasterKeyInitializer.kt` | enter, complete OK / FAIL |
| `buildSecurePrefsKey` | `SecureSharedPreferences.kt` | enter, lock acquired, KeyStore.load+getEntry, generateKey (conditional), return — each step elapsed |
| `selfTest` | `SecureSharedPreferences.kt` | start, `Cipher.init` done, `cipher.doFinal` done — discriminates which sub-call stalls |
| `provideEncryptedSharedPrefs` | `MainDataModule.kt` | enter (with prewarm.isCompleted), key obtained, returning, recoverAndRetry triggered (cause class) |
| `MainActivity.onCreate` | `MainActivity.kt` | start (hasQrExtra flag), Path A push deref, setContent called, setContent lambda entered, first Compose composition |
| `MainViewModel` | `MainViewModel.kt` | ctor done, init coroutine started, resolveStartDestination done, _isLoading=false, hasVaults timeout |
| `AnimatedSplash` | `AnimatedSplash.kt` | first composition, dismissing |
| FCM service | `VultisigFirebaseMessagingService.kt` | onCreate, onNewToken, onMessageReceived (each with thread name) |

Also moved `Timber.plant(Timber.DebugTree())` to the **first** line of `Application.onCreate` so logs are captured from t=0.

`selfTest()` was inlined to surface `Cipher.init`/`doFinal` timing per-step. Functionally equivalent to `encryptRaw(secretKey, "probe")` — both surface `KeyPermanentlyInvalidatedException` at the same call sites.

## Validated locally

- Built `:app:assembleDebug` cleanly.
- Installed on emulator `Medium_Phone_API_36.1`.
- Cold-launched. All 25+ instrumented log lines fire in expected order. Sample timeline (warm-keystore boot):

```
App.onCreate start, thread=main
App.onCreate WalletCoreLoader done, elapsed=497ms
App.onCreate prewarm dispatched, elapsed=500ms
Prewarm coroutine started, thread=DefaultDispatcher-worker-1
buildSecurePrefsKey enter, thread=DefaultDispatcher-worker-1
buildSecurePrefsKey lock acquired, lockWait=0ms
App.onCreate end, elapsed=583ms
buildSecurePrefsKey keystore load+getEntry done, elapsed=111ms, hasEntry=false
buildSecurePrefsKey generateKey done, generateElapsed=117ms, total=230ms
Prewarm complete OK, elapsed=271ms
MainActivity.onCreate start, thread=main, hasQrExtra=false
MainActivity.onCreate setContent called, elapsed=662ms
setContent lambda entered, elapsed=1507ms
First Compose composition reached, elapsed=1652ms
MainViewModel ctor done, thread=main
MainViewModel init coroutine started, thread=main
AnimatedSplash first composition, isLoading=true
MainViewModel resolveStartDestination done, elapsed=396ms
MainViewModel _isLoading=false set
AnimatedSplash dismissing, progress=1.00, isLoading=false
```

## ⚠️ Important finding from the local validation

On a **healthy normal-bootup** the singleton `provideEncryptedSharedPrefs` (the suspected hang point in the issue body) is **never invoked** during the cold-launch sequence shown above. The `selfTest`/`buildSecurePrefsKey`-on-main-thread hypothesis can only fire if some consumer (FCM service, vault password screen, etc.) realizes the binding while the splash is still on screen. The reproducing dev's logcat will tell us whether that's actually what happens on stuck devices, or whether the hang is somewhere we hadn't suspected (e.g. the 845-1500 ms gap between `setContent called` and `setContent lambda entered`, which is now bracketed).

## How the dev runs it

1. Wait for the **Debug APK (4360 trace)** workflow on this PR to go green.
2. Download the `vultisig-4360-trace-debug-apk` artifact from the workflow run summary page.
3. Install on a **device that reproduces the hang**:
   ```bash
   adb install -r app-debug.apk
   ```
4. Capture logs while reproducing the hang:
   ```bash
   adb logcat -c
   adb logcat -v time | grep boot4360 > 4360-trace.log
   # cold-launch the app (or tap the FCM notification) — wait until the splash hangs OR dismisses
   # ctrl-c when done
   ```
5. Upload `4360-trace.log` here as a comment.

If the splash hangs, the **last `[boot4360]` line in the log** identifies the exact phase that's blocked.

## CI

A new workflow `.github/workflows/debug-apk-trace-4360.yml` builds the debug APK on every push to this branch and uploads it as `vultisig-4360-trace-debug-apk` artifact (30-day retention). It is scoped to `roman/4360-trace-logs` only and can also be triggered via `workflow_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow to build and upload debug APK artifacts and publish run summaries.
* **Chores**
  * Enhanced app startup instrumentation with richer boot/timing traces across launch and UI composition.
* **Chores**
  * Expanded runtime logging for messaging, service startup, and secure preferences initialization to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->