### PR TITLE
fix(secure-prefs): narrow destructive recovery to KeyPermanentlyInvalidatedException only (#4401)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.security.crypto.EncryptedSharedPreferences
@@ -9,7 +10,6 @@ import androidx.security.crypto.MasterKey
 import com.vultisig.wallet.data.sources.AppDataStore
 import com.vultisig.wallet.data.sources.AppDataStoreImpl
 import com.vultisig.wallet.data.utils.EncryptingSharedPreferences
-import com.vultisig.wallet.data.utils.InMemorySharedPreferences
 import com.vultisig.wallet.data.utils.SECURE_PREFS_KEY_ALIAS
 import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
 import com.vultisig.wallet.data.utils.buildSecurePrefsKey
@@ -20,8 +20,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.io.File
-import java.io.IOException
-import java.security.GeneralSecurityException
 import java.security.KeyStore
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -94,7 +92,7 @@ internal interface MainDataModule {
                 return prefs
             }
 
-            fun recoverAndRetry(cause: Exception): SharedPreferences {
+            fun recoverAndRetry(cause: KeyPermanentlyInvalidatedException): SharedPreferences {
                 Timber.e(cause, "SecureSharedPrefs init failed, attempting recovery")
                 val prefsFile = File(context.filesDir.parent, "shared_prefs/$SECURE_PREFS_FILE.xml")
                 if (prefsFile.exists() && !prefsFile.delete()) {
@@ -119,21 +117,14 @@ internal interface MainDataModule {
                             .commit()
                     }
                     .onFailure { Timber.w(it, "Failed to clear migration marker during recovery") }
-                // Guard the retry: if the keystore is irrecoverably broken, return a non-persistent
-                // in-memory fallback so the app boots in a degraded state rather than crashing.
-                return try {
-                    create()
-                } catch (e: Exception) {
-                    Timber.e(e, "SecureSharedPrefs recovery failed; using in-memory fallback")
-                    InMemorySharedPreferences()
-                }
+                return create()
             }
 
+            // Issue #4401: only KeyPermanentlyInvalidatedException is destructive; transient
+            // GeneralSecurityException / IOException must propagate so user data is not wiped.
             return try {
                 create()
-            } catch (e: GeneralSecurityException) {
-                recoverAndRetry(e)
-            } catch (e: IOException) {
+            } catch (e: KeyPermanentlyInvalidatedException) {
                 recoverAndRetry(e)
             }
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
@@ -93,7 +93,13 @@ internal interface MainDataModule {
             }
 
             fun recoverAndRetry(cause: KeyPermanentlyInvalidatedException): SharedPreferences {
-                Timber.e(cause, "SecureSharedPrefs init failed, attempting recovery")
+                Timber.w(
+                    cause,
+                    "KeyPermanentlyInvalidatedException detected; performing destructive recovery",
+                )
+                // File first so a partial recovery (alias delete fails below) leaves no
+                // ciphertext readable by the next launch; that next launch will re-enter recovery
+                // and retry the alias delete.
                 val prefsFile = File(context.filesDir.parent, "shared_prefs/$SECURE_PREFS_FILE.xml")
                 if (prefsFile.exists() && !prefsFile.delete()) {
                     Timber.w(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicy.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicy.kt
@@ -1,0 +1,23 @@
+package com.vultisig.wallet.data.utils
+
+import android.security.keystore.KeyPermanentlyInvalidatedException
+
+/**
+ * Decides whether a failure raised while opening the encrypted [android.content.SharedPreferences]
+ * justifies the destructive recovery path (delete prefs file, delete the AndroidKeyStore alias,
+ * clear the migration sentinel).
+ *
+ * Returns `true` ONLY for [KeyPermanentlyInvalidatedException], which signals that the
+ * AndroidKeyStore entry backing the prefs cannot decrypt the existing payload anymore (e.g. after
+ * the user changes device credentials), so the encrypted file is unreadable for the remainder of
+ * its lifetime and recovery is the only forward path. Returns `false` for every other throwable —
+ * including transient [java.security.GeneralSecurityException] (keystore daemon stalls on certain
+ * OEM ROMs) and [java.io.IOException] (disk hiccups) — so the user's encrypted state is preserved
+ * and the failure surfaces as a deterministic crash for telemetry.
+ *
+ * See issue vultisig/vultisig-android#4401: the previous policy invoked destructive recovery on any
+ * `GeneralSecurityException` or `IOException`, occasionally wiping a user's encrypted state on a
+ * single transient stall.
+ */
+internal fun shouldDestructivelyRecover(cause: Throwable): Boolean =
+    cause is KeyPermanentlyInvalidatedException

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicy.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicy.kt
@@ -3,21 +3,9 @@ package com.vultisig.wallet.data.utils
 import android.security.keystore.KeyPermanentlyInvalidatedException
 
 /**
- * Decides whether a failure raised while opening the encrypted [android.content.SharedPreferences]
- * justifies the destructive recovery path (delete prefs file, delete the AndroidKeyStore alias,
- * clear the migration sentinel).
- *
- * Returns `true` ONLY for [KeyPermanentlyInvalidatedException], which signals that the
- * AndroidKeyStore entry backing the prefs cannot decrypt the existing payload anymore (e.g. after
- * the user changes device credentials), so the encrypted file is unreadable for the remainder of
- * its lifetime and recovery is the only forward path. Returns `false` for every other throwable —
- * including transient [java.security.GeneralSecurityException] (keystore daemon stalls on certain
- * OEM ROMs) and [java.io.IOException] (disk hiccups) — so the user's encrypted state is preserved
- * and the failure surfaces as a deterministic crash for telemetry.
- *
- * See issue vultisig/vultisig-android#4401: the previous policy invoked destructive recovery on any
- * `GeneralSecurityException` or `IOException`, occasionally wiping a user's encrypted state on a
- * single transient stall.
+ * Returns true only for [KeyPermanentlyInvalidatedException]; transient
+ * [java.security.GeneralSecurityException] and [java.io.IOException] must propagate so a single
+ * keystore stall cannot wipe encrypted state. See issue #4401.
  */
 internal fun shouldDestructivelyRecover(cause: Throwable): Boolean =
     cause is KeyPermanentlyInvalidatedException

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicyTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicyTest.kt
@@ -1,9 +1,3 @@
-/**
- * Verifies the policy encoded in [shouldDestructivelyRecover]: ONLY
- * [android.security.keystore.KeyPermanentlyInvalidatedException] may trigger destructive deletion
- * of EncryptedSharedPreferences; every other throwable — including superclasses, siblings, and
- * unrelated runtime exceptions — must NOT. Covers the hard rule in issue #4401.
- */
 package com.vultisig.wallet.data.utils
 
 import android.security.keystore.KeyPermanentlyInvalidatedException
@@ -18,10 +12,9 @@ import org.junit.jupiter.api.Test
 
 internal class SecurePrefsRecoveryPolicyTest {
 
-    // KeyPermanentlyInvalidatedException lives in android.security.keystore.
-    // The data/src/test source set runs on the JVM against Android stub jars where every Android
-    // class constructor throws RuntimeException("Stub!"). Use mockk to obtain an instance without
-    // triggering the stub, mirroring the pattern documented in QrShareInfoTest.kt.
+    // KPIE lives in android.security.keystore; the JVM test classpath binds an Android stub jar
+    // whose constructors throw RuntimeException("Stub!"). MockK gives a real subtype instance that
+    // satisfies the `is` check without triggering the stub.
     private val kpie: KeyPermanentlyInvalidatedException =
         mockk<KeyPermanentlyInvalidatedException>(relaxed = true)
 
@@ -58,5 +51,13 @@ internal class SecurePrefsRecoveryPolicyTest {
     @Test
     fun `RuntimeException does not trigger destructive recovery`() {
         assertFalse(shouldDestructivelyRecover(RuntimeException("unexpected crash")))
+    }
+
+    // Pins the deliberate no-unwrap policy: a wrapped KPIE is reported via its outer type and is
+    // therefore on a non-KPIE catch path, which the hard rule for #4401 forbids from destroying
+    // user data. If we ever decide to honor wrapped KPIE, the production catch must change too.
+    @Test
+    fun `KPIE wrapped as cause of IOException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(IOException("oem keystore wrapper", kpie)))
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicyTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/SecurePrefsRecoveryPolicyTest.kt
@@ -1,0 +1,62 @@
+/**
+ * Verifies the policy encoded in [shouldDestructivelyRecover]: ONLY
+ * [android.security.keystore.KeyPermanentlyInvalidatedException] may trigger destructive deletion
+ * of EncryptedSharedPreferences; every other throwable — including superclasses, siblings, and
+ * unrelated runtime exceptions — must NOT. Covers the hard rule in issue #4401.
+ */
+package com.vultisig.wallet.data.utils
+
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import io.mockk.mockk
+import java.io.IOException
+import java.security.GeneralSecurityException
+import java.security.InvalidKeyException
+import java.security.UnrecoverableKeyException
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class SecurePrefsRecoveryPolicyTest {
+
+    // KeyPermanentlyInvalidatedException lives in android.security.keystore.
+    // The data/src/test source set runs on the JVM against Android stub jars where every Android
+    // class constructor throws RuntimeException("Stub!"). Use mockk to obtain an instance without
+    // triggering the stub, mirroring the pattern documented in QrShareInfoTest.kt.
+    private val kpie: KeyPermanentlyInvalidatedException =
+        mockk<KeyPermanentlyInvalidatedException>(relaxed = true)
+
+    @Test
+    fun `KeyPermanentlyInvalidatedException triggers destructive recovery`() {
+        assertTrue(shouldDestructivelyRecover(kpie))
+    }
+
+    @Test
+    fun `transient GeneralSecurityException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(GeneralSecurityException("transient")))
+    }
+
+    @Test
+    fun `IOException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(IOException("disk")))
+    }
+
+    @Test
+    fun `InvalidKeyException superclass alone does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(InvalidKeyException()))
+    }
+
+    @Test
+    fun `UnrecoverableKeyException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(UnrecoverableKeyException()))
+    }
+
+    @Test
+    fun `IllegalStateException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(IllegalStateException()))
+    }
+
+    @Test
+    fun `RuntimeException does not trigger destructive recovery`() {
+        assertFalse(shouldDestructivelyRecover(RuntimeException("unexpected crash")))
+    }
+}


### PR DESCRIPTION
## Summary
- Catch only `KeyPermanentlyInvalidatedException` in `MainDataModule.provideEncryptedSharedPrefs`. Transient `GeneralSecurityException`/`IOException` from cold-launch keystore stalls now propagate to Hilt and Crashlytics instead of silently destroying `shared_prefs/token_secure_prefs.xml` and the `vultisig_secure_prefs_key` alias.
- Drop the second-tier `InMemorySharedPreferences` fallback so a still-broken keystore surfaces as a real failure rather than a non-persistent store that loses every write at process death.
- Specialize `recoverAndRetry` to `KeyPermanentlyInvalidatedException` (future widening is now a compile error). Demote recovery log from `Timber.e` to `Timber.w` and name the trigger. Pin file-then-alias delete order so a partial recovery leaves no readable ciphertext for the next launch.
- Extract `SecurePrefsRecoveryPolicy.shouldDestructivelyRecover(Throwable)` covered by 8 JUnit 5 cases (KPIE → true; GSE, IOException, InvalidKeyException, UnrecoverableKeyException, IllegalStateException, RuntimeException, KPIE-as-`cause` → false). Drop now-unused imports.

Closes #4401

## Deferred
- OEM-wrapped KPIE (Samsung/Xiaomi/Huawei nest KPIE inside `IllegalStateException`/`KeyStoreException`): policy intentionally does not unwrap `cause` — revisit when Crashlytics signal justifies it.
- `InMemorySharedPreferences` in `SecureSharedPreferences.kt` is orphaned; separate cleanup PR.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.utils.SecurePrefsRecoveryPolicyTest"` (8/8 pass)
- [x] `./gradlew :data:compileDebugKotlin` clean
- [x] `./gradlew lint` passes (abortOnError = true)
- [ ] **Manual**: change device credential to invalidate the master key, cold-launch, confirm KPIE path recovers cleanly and reseeds prefs; then cold-launch after a transient keystore stall (throttle `keystored`, force-stop, relaunch) and confirm encrypted prefs survive instead of being destroyed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure storage error recovery to distinguish between permanent and transient failures. The app now only performs destructive cleanup when absolutely necessary, reducing data loss from temporary security or I/O errors.

* **Tests**
  * Added comprehensive test coverage for the secure storage recovery policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->