### PR TITLE
fix(secure-prefs): complete prewarm deferred on every non-cancellation throwable

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
@@ -36,17 +36,10 @@ object SharedPrefsMasterKeyInitializer {
     }
 
     /**
-     * Runs the prewarm body against [target]. Settles [target] with the [supplier] result on
-     * success, or with `null` after a WARN-level Timber log on any non-cancellation [Exception] —
-     * the previous catch-list of `GeneralSecurityException | IOException` left the deferred
-     * uncompleted on `IllegalStateException` (the lock-timeout `error(...)` in
-     * [buildSecurePrefsKey]), `ProviderException`, OEM `RuntimeException`, etc., so any future
-     * awaiter would hang forever (issue #4402). Re-throws [CancellationException] without touching
-     * [target] so structured concurrency keeps propagating cancellation; the consumer in
-     * [com.vultisig.wallet.data.MainDataModule.provideEncryptedSharedPrefs] reads
-     * [Deferred.isCompleted] non-blockingly and falls through to a synchronous keystore lookup when
-     * the deferred is still active. A second call against an already-settled target is a no-op
-     * because [CompletableDeferred.complete] returns `false` on the second invocation.
+     * Settles [target] with [supplier]'s result, or with `null` after a WARN log on any
+     * non-cancellation [Exception]. Rethrows [CancellationException] without touching [target] so
+     * structured concurrency keeps propagating cancellation. Idempotent: a second call against an
+     * already-settled target is a no-op.
      */
     internal fun runPrewarmInto(
         target: CompletableDeferred<SecretKey?>,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializer.kt
@@ -1,8 +1,7 @@
 package com.vultisig.wallet.data.utils
 
-import java.io.IOException
-import java.security.GeneralSecurityException
 import javax.crypto.SecretKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -33,16 +32,33 @@ object SharedPrefsMasterKeyInitializer {
     /** Fires a background key pre-warm; safe to call from Application.onCreate. */
     fun prewarm() {
         CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineName("SecurePrefsPrewarm"))
-            .launch {
-                try {
-                    _prewarmResult.complete(buildSecurePrefsKey())
-                } catch (e: GeneralSecurityException) {
-                    Timber.w(e, "Secure prefs key prewarm failed; deferring to sync path")
-                    _prewarmResult.complete(null)
-                } catch (e: IOException) {
-                    Timber.w(e, "Secure prefs key prewarm failed; deferring to sync path")
-                    _prewarmResult.complete(null)
-                }
-            }
+            .launch { runPrewarmInto(_prewarmResult, ::buildSecurePrefsKey) }
+    }
+
+    /**
+     * Runs the prewarm body against [target]. Settles [target] with the [supplier] result on
+     * success, or with `null` after a WARN-level Timber log on any non-cancellation [Exception] —
+     * the previous catch-list of `GeneralSecurityException | IOException` left the deferred
+     * uncompleted on `IllegalStateException` (the lock-timeout `error(...)` in
+     * [buildSecurePrefsKey]), `ProviderException`, OEM `RuntimeException`, etc., so any future
+     * awaiter would hang forever (issue #4402). Re-throws [CancellationException] without touching
+     * [target] so structured concurrency keeps propagating cancellation; the consumer in
+     * [com.vultisig.wallet.data.MainDataModule.provideEncryptedSharedPrefs] reads
+     * [Deferred.isCompleted] non-blockingly and falls through to a synchronous keystore lookup when
+     * the deferred is still active. A second call against an already-settled target is a no-op
+     * because [CompletableDeferred.complete] returns `false` on the second invocation.
+     */
+    internal fun runPrewarmInto(
+        target: CompletableDeferred<SecretKey?>,
+        supplier: () -> SecretKey,
+    ) {
+        try {
+            target.complete(supplier())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Secure prefs key prewarm failed; deferring to sync path")
+            target.complete(null)
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
@@ -50,9 +50,6 @@ internal class SharedPrefsMasterKeyInitializerTest {
             }
         }
 
-    // android.util.Log.WARN == 5; use the literal to avoid the Android SDK in JVM tests.
-    private val WARN = 5
-
     @AfterEach
     fun tearDown() {
         Timber.uprootAll()
@@ -193,6 +190,9 @@ internal class SharedPrefsMasterKeyInitializerTest {
     // ── (j) Parameterized invariant: every non-cancellation throwable settles to null ───
 
     companion object {
+        // android.util.Log.WARN == 5; the literal avoids the Android SDK in JVM tests.
+        private const val WARN_PRIORITY = 5
+
         private class CustomUncheckedException : Exception("custom")
 
         @JvmStatic
@@ -237,7 +237,7 @@ internal class SharedPrefsMasterKeyInitializerTest {
         )
         val entry = capturedLogs.single()
         assertEquals(
-            WARN,
+            WARN_PRIORITY,
             entry.priority,
             "log priority must be WARN (5) for ${t::class.simpleName}",
         )
@@ -247,9 +247,5 @@ internal class SharedPrefsMasterKeyInitializerTest {
             entry.throwable,
             "logged throwable must be the same instance for ${t::class.simpleName}",
         )
-
-        // Reset for the next parameterized iteration.
-        capturedLogs.clear()
-        Timber.uprootAll()
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
@@ -1,0 +1,253 @@
+package com.vultisig.wallet.data.utils
+
+import java.io.IOException
+import java.security.GeneralSecurityException
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import timber.log.Timber
+
+/**
+ * Verifies the contract of [SharedPrefsMasterKeyInitializer.runPrewarmInto]:
+ * 1. On success the target is completed with the supplied key.
+ * 2. On every non-cancellation throwable the target is completed with null and exactly one WARN log
+ *    entry is emitted for that throwable.
+ * 3. [CancellationException] is rethrown WITHOUT completing the target.
+ * 4. A second call on an already-completed target is a no-op (first-write semantics).
+ *
+ * Issue #4402: the original `prewarm()` catch-list was `GeneralSecurityException | IOException` —
+ * it missed [IllegalStateException] (the lock-timeout `error(...)` at
+ * SecureSharedPreferences.kt:39), [IllegalArgumentException], raw [RuntimeException],
+ * [InterruptedException], and [NullPointerException]. Test (d) is the canonical regression guard:
+ * it MUST fail on origin/main and pass after the fix.
+ */
+internal class SharedPrefsMasterKeyInitializerTest {
+
+    // ── Log-capture infrastructure ────────────────────────────────────────────
+
+    private data class LogEntry(val priority: Int, val throwable: Throwable?)
+
+    private val capturedLogs = mutableListOf<LogEntry>()
+
+    private val capturingTree =
+        object : Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                capturedLogs += LogEntry(priority, t)
+            }
+        }
+
+    // android.util.Log.WARN == 5; use the literal to avoid the Android SDK in JVM tests.
+    private val WARN = 5
+
+    @AfterEach
+    fun tearDown() {
+        Timber.uprootAll()
+        capturedLogs.clear()
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun fakeKey(): SecretKey = SecretKeySpec(ByteArray(32), "AES")
+
+    private fun freshTarget(): CompletableDeferred<SecretKey?> = CompletableDeferred()
+
+    // ── (a) Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with supplied key on success`() {
+        val key = fakeKey()
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { key }
+
+        assertTrue(target.isCompleted)
+        assertSame(key, target.getCompleted())
+    }
+
+    // ── (b) GeneralSecurityException ─────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with null on GeneralSecurityException`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) {
+            throw GeneralSecurityException("test")
+        }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (c) IOException ───────────────────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with null on IOException`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { throw IOException("test") }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (d) THE BUG — IllegalStateException from lock timeout ─────────────────
+    // This test MUST fail on origin/main (GSE+IOE-only catch) and pass after the fix.
+
+    @Test
+    fun `runPrewarmInto completes target with null on IllegalStateException from lock timeout`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) {
+            throw IllegalStateException("Timed out waiting for secure prefs key lock after 3 s")
+        }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (e) IllegalArgumentException ─────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with null on IllegalArgumentException`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) {
+            throw IllegalArgumentException("bad spec")
+        }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (f) Raw RuntimeException ──────────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with null on RuntimeException`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) {
+            throw RuntimeException("oem keystore null")
+        }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (g) InterruptedException ──────────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto completes target with null on InterruptedException`() {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { throw InterruptedException() }
+
+        assertTrue(target.isCompleted)
+        assertNull(target.getCompleted())
+    }
+
+    // ── (h) CancellationException — must NOT be swallowed ────────────────────
+
+    @Test
+    fun `runPrewarmInto rethrows CancellationException without completing target`() {
+        val target = freshTarget()
+
+        assertThrows<CancellationException> {
+            SharedPrefsMasterKeyInitializer.runPrewarmInto(target) {
+                throw CancellationException("cancelled")
+            }
+        }
+
+        assertFalse(target.isCompleted)
+        assertFalse(target.isCancelled)
+    }
+
+    // ── (i) First-write semantics ─────────────────────────────────────────────
+
+    @Test
+    fun `runPrewarmInto preserves first-write on already-completed target`() {
+        val preStub = fakeKey()
+        val target = freshTarget()
+        target.complete(preStub)
+
+        val later = SecretKeySpec(ByteArray(32), "AES")
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { later }
+
+        // CompletableDeferred.complete() returns false on the second call; first-write wins.
+        assertSame(preStub, target.getCompleted())
+    }
+
+    // ── (j) Parameterized invariant: every non-cancellation throwable settles to null ───
+
+    companion object {
+        private class CustomUncheckedException : Exception("custom")
+
+        @JvmStatic
+        fun nonCancellationThrowables(): List<Throwable> =
+            listOf(
+                GeneralSecurityException("gse"),
+                IOException("ioe"),
+                IllegalStateException("ise"),
+                IllegalArgumentException("iae"),
+                RuntimeException("rte"),
+                InterruptedException(),
+                NullPointerException("npe"),
+                CustomUncheckedException(),
+            )
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonCancellationThrowables")
+    fun `every non-cancellation throwable settles target with null`(t: Throwable) {
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { throw t }
+
+        assertTrue(target.isCompleted, "target must be completed for ${t::class.simpleName}")
+        assertNull(target.getCompleted(), "completed value must be null for ${t::class.simpleName}")
+    }
+
+    // ── (k) Every failure path logs exactly one WARN entry ────────────────────
+
+    @ParameterizedTest
+    @MethodSource("nonCancellationThrowables")
+    fun `every failure path logs once via Timber at WARN level`(t: Throwable) {
+        Timber.plant(capturingTree)
+        val target = freshTarget()
+
+        SharedPrefsMasterKeyInitializer.runPrewarmInto(target) { throw t }
+
+        assertEquals(
+            1,
+            capturedLogs.size,
+            "expected exactly 1 log entry for ${t::class.simpleName}, got ${capturedLogs.size}",
+        )
+        val entry = capturedLogs.single()
+        assertEquals(
+            WARN,
+            entry.priority,
+            "log priority must be WARN (5) for ${t::class.simpleName}",
+        )
+        assertNotNull(entry.throwable, "log entry must carry the throwable")
+        assertSame(
+            t,
+            entry.throwable,
+            "logged throwable must be the same instance for ${t::class.simpleName}",
+        )
+
+        // Reset for the next parameterized iteration.
+        capturedLogs.clear()
+        Timber.uprootAll()
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/SharedPrefsMasterKeyInitializerTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -33,6 +34,7 @@ import timber.log.Timber
  * [InterruptedException], and [NullPointerException]. Test (d) is the canonical regression guard:
  * it MUST fail on origin/main and pass after the fix.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class SharedPrefsMasterKeyInitializerTest {
 
     // ── Log-capture infrastructure ────────────────────────────────────────────


### PR DESCRIPTION
The narrow `GeneralSecurityException | IOException` catch in `SharedPrefsMasterKeyInitializer.prewarm()` left `_prewarmResult` uncompleted on `IllegalStateException` (the lock-timeout `error(...)` at `SecureSharedPreferences.kt:39`), `ProviderException`, OEM `RuntimeException`, `InterruptedException`, and `NullPointerException`. Any awaiter would hang forever instead of falling back to the synchronous path.

## Summary

- Extract the prewarm body into `internal fun runPrewarmInto(target, supplier)` that rethrows `CancellationException` first so structured concurrency wins, then catches every other `Exception` with a single Timber WARN and settles `target` with `null`. Catching `Exception` (not `Throwable`) matches the existing log-and-swallow precedent in `MainDataModule` / `SecureSharedPreferences` and lets JVM `Error`s propagate.
- First-write semantics are preserved via `CompletableDeferred.complete()` returning `false` on the second call, making the helper idempotent against an already-settled target.
- Add `SharedPrefsMasterKeyInitializerTest` covering happy path, `GeneralSecurityException`, `IOException`, the `IllegalStateException` lock-timeout regression, `IllegalArgumentException`, raw `RuntimeException`, `InterruptedException`, `CancellationException` rethrow without touching the target, first-write idempotency, and parameterized log-once-at-WARN invariants.

## Why this is safe

The sole consumer at `MainDataModule.kt:80-82` reads `_prewarmResult.isCompleted` non-blockingly and falls back via `getCompleted() ?: buildSecurePrefsKey()`. The new "completed with `null`" outcome lands on the exact same synchronous keystore lookup the previous "uncompleted" outcome did, so the success path and the destructive-recovery path from #4401 are unchanged — this PR only widens which throwables reach that fallback.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`
- [x] `ktfmt` clean (auto-formatted by pre-commit hook)

Closes #4402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured key initialization logic with improved exception handling and diagnostic logging for failure scenarios.

* **Tests**
  * Added comprehensive test coverage for key initialization, including success paths, failure handling, cancellation semantics, and write-once verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->