### PR TITLE
fix(keysign): show dapp-supplied cosmos fee on Network Fee row

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.common.Endpoints
 import com.vultisig.wallet.data.common.normalizeMessageFormat
 import com.vultisig.wallet.data.mappers.KeysignMessageFromProtoMapper
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.cosmosNativeDenom
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.EstimatedGasFee
@@ -564,13 +565,26 @@ constructor(
                             }
                             TokenValue(value = BigInteger.valueOf(plan.fee), token = nativeToken)
                         }
-                        blockChainSpecific is BlockChainSpecific.Ethereum ||
-                            blockChainSpecific is BlockChainSpecific.THORChain ->
+                        blockChainSpecific is BlockChainSpecific.Ethereum ->
                             computeJoinKeysignSwapNetworkFee(
                                 blockChainSpecific = blockChainSpecific,
                                 nativeCoin = nativeToken,
                                 chain = chain,
                             )
+                        blockChainSpecific is BlockChainSpecific.THORChain -> {
+                            val dappFee = payload.dappSuppliedNativeFee(chain, parseCosmosMessage)
+                            TokenValue(
+                                value = dappFee ?: blockChainSpecific.fee,
+                                token = nativeToken,
+                            )
+                        }
+                        blockChainSpecific is BlockChainSpecific.MayaChain -> {
+                            val dappFee = payload.dappSuppliedNativeFee(chain, parseCosmosMessage)
+                            TokenValue(
+                                value = dappFee ?: BigInteger.valueOf(2_000_000_000L),
+                                token = nativeToken,
+                            )
+                        }
                         else -> {
                             val (nativeTokenAddress, _) =
                                 chainAccountAddressRepository.getAddress(nativeToken, _currentVault)
@@ -996,8 +1010,11 @@ constructor(
 
                     val nativeCoin =
                         withContext(Dispatchers.IO) { tokenRepository.getNativeToken(chain.id) }
+                    val dappSuppliedFee = payload.dappSuppliedNativeFee(chain, parseCosmosMessage)
                     val gasFee =
-                        if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
+                        if (dappSuppliedFee != null) {
+                            TokenValue(value = dappSuppliedFee, token = nativeCoin)
+                        } else if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
                             val utxoHelper = UtxoHelper.getHelper(vault, payloadToken.coinType)
                             val plan = utxoHelper.getBitcoinTransactionPlan(payload)
                             if (plan.error != SigningError.OK) {
@@ -1847,3 +1864,48 @@ internal fun computeJoinKeysignSwapNetworkFee(
 internal fun defaultEvmSwapGasLimit(chain: Chain): BigInteger =
     if (chain == Chain.Mantle) EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
     else EthereumFeeService.DEFAULT_SWAP_LIMIT
+
+/**
+ * Returns the dApp-supplied native fee from [KeysignPayload.signAmino] or
+ * [KeysignPayload.signDirect], or `null` when no native-denom entry is present.
+ * Callers should fall back to the estimated fee when `null`.
+ *
+ * Uses [Chain.cosmosNativeDenom] (an explicit on-chain denom table) instead of [Chain.feeUnit] so
+ * the comparison is never confused by UI-only labels like "Gwei".
+ *
+ * If any matched entry has a missing or unparseable amount, the function returns `null` rather than
+ * silently summing to zero — forcing the caller to use the estimated fee instead of displaying a
+ * misleading "0" row.
+ */
+private fun KeysignPayload.dappSuppliedNativeFee(
+    chain: Chain,
+    parseCosmosMessage: ParseCosmosMessageUseCase,
+): BigInteger? {
+    val nativeDenom = chain.cosmosNativeDenom ?: return null
+
+    // 1. Try signAmino
+    val aminoEntries = signAmino?.fee?.amount
+    if (aminoEntries != null) {
+        val matched = aminoEntries.filter { it?.denom?.lowercase() == nativeDenom }
+        if (matched.isNotEmpty()) {
+            val parsed = matched.map { it?.amount?.toBigIntegerOrNull() ?: return null }
+            return parsed.fold(BigInteger.ZERO, BigInteger::add)
+        }
+    }
+
+    // 2. Try signDirect
+    val signDirectPayload = signDirect
+    if (signDirectPayload != null) {
+        val directFee =
+            runCatching { parseCosmosMessage(signDirectPayload) }.getOrNull()?.authInfoFee
+        if (directFee != null) {
+            val matched = directFee.amount.filter { it.denom.lowercase() == nativeDenom }
+            if (matched.isNotEmpty()) {
+                val parsed = matched.map { it.amount.toBigIntegerOrNull() ?: return null }
+                return parsed.fold(BigInteger.ZERO, BigInteger::add)
+            }
+        }
+    }
+
+    return null
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -454,6 +454,32 @@ val Chain.blockTimeMs: Long
             else -> 4_000L
         }
 
+/**
+ * The on-chain native fee denomination for Cosmos-family chains.
+ *
+ * Unlike [feeUnit], which may contain UI display labels (e.g. "Gwei", "BTC/vbyte"), this property
+ * always returns the actual denomination string used in Cosmos `Fee` messages. Returns `null` for
+ * non-Cosmos chains.
+ *
+ * Mirrors the Windows `cosmosFeeCoinDenom` map so both platforms resolve the same denom.
+ */
+val Chain.cosmosNativeDenom: String?
+    get() =
+        when (this) {
+            Chain.ThorChain -> "rune"
+            Chain.MayaChain -> "cacao"
+            Chain.GaiaChain -> "uatom"
+            Chain.Kujira -> "ukuji"
+            Chain.Dydx -> "adydx"
+            Chain.Osmosis -> "uosmo"
+            Chain.Terra -> "uluna"
+            Chain.TerraClassic -> "uluna"
+            Chain.Noble -> "uusdc"
+            Chain.Akash -> "uakt"
+            Chain.Qbtc -> "qbtc"
+            else -> null
+        }
+
 fun Chain.toValue(value: BigInteger): BigDecimal = coinType.toValue(value)
 
 fun Chain.toValue(value: BigDecimal): BigDecimal = coinType.toValue(value)


### PR DESCRIPTION
## Summary

When a Rujira CosmWasm dApp sends a transaction with `fee.amount = 0`, the **Join Keysign** screen was displaying an estimated non-zero fee (e.g. `0.02 RUNE`) because the UI read from `blockChainSpecific.fee` instead of the dApp-supplied `signAmino.fee.amount`.

## Changes

### `JoinKeysignViewModel.kt`
- **Swap path** (THORChain branch): Added `dappFee` extraction from `payload.signAmino?.fee?.amount` — when present, uses the dApp-supplied fee instead of `blockChainSpecific.fee`
- **Send path**: Added `dappSuppliedFee` extraction with the same logic — inserted as the first branch in the `gasFee` computation, before UTXO and generic fee estimation

Both paths sum all fee amounts from signAmino via `sumOf` and use `BigInteger` for precision.

## Cross-platform parity

This is the Android counterpart of the Windows fix merged in [PR #3843](https://github.com/vultisig/vultisig-windows/pull/3843). The iOS counterpart is submitted as [vultisig-ios PR](https://github.com/vultisig/vultisig-ios/pulls).

Closes #4390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Join-flow signing now prefers dApp-provided native fees when available, improving fee accuracy during multisig joins.
  * THORChain swaps use a dApp native-denom fee when provided, falling back to parsed or estimated fees only if needed.
  * Non-deposit sends now select gas fees in priority: dApp native fee → UTXO transaction-plan fee (non-Cardano) → estimated fee.

* **New Features**
  * Added explicit native-denom mapping for Cosmos-family chains to improve native-fee detection and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4410)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->