### PR TITLE
refactor(send): split submit functions into per-defiType strategies

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -1252,11 +1252,17 @@ constructor(
             DeFiNavActions.REDEEM_YTCY -> redeemStrategy.submit()
 
             DeFiNavActions.WITHDRAW_USDC_CIRCLE -> withdrawUsdcCircleStrategy.submit()
-            else -> sendStrategy.submit()
+
+            null,
+            DeFiNavActions.DEPOSIT_USDC_CIRCLE,
+            DeFiNavActions.STAKE_CACAO,
+            DeFiNavActions.UNSTAKE_CACAO,
+            DeFiNavActions.ADD_LP,
+            DeFiNavActions.REMOVE_LP,
+            DeFiNavActions.FREEZE_TRX,
+            DeFiNavActions.UNFREEZE_TRX -> sendStrategy.submit()
         }
     }
-
-    fun send() = sendStrategy.submit()
 
     private fun hideLoading() {
         uiState.update { it.copy(isLoading = false) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -1258,12 +1258,6 @@ constructor(
 
     fun send() = sendStrategy.submit()
 
-    fun bond() = bondStrategy.submit()
-
-    fun unbond() = unbondStrategy.submit()
-
-    fun unstake() = unstakeStrategy.submit()
-
     private fun hideLoading() {
         uiState.update { it.copy(isLoading = false) }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.vultisig.wallet.R
 import com.vultisig.wallet.R.string
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
 import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
@@ -20,14 +19,10 @@ import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.thorchain.RujiStakingService.Companion.RUJI_REWARDS_COIN
 import com.vultisig.wallet.data.blockchain.tron.GetTronFrozenBalancesUseCase
-import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
 import com.vultisig.wallet.data.blockchain.tron.TronFrozenBalanceState
 import com.vultisig.wallet.data.blockchain.tron.TronResourceType
 import com.vultisig.wallet.data.blockchain.tron.TronStakingOperation
 import com.vultisig.wallet.data.blockchain.tron.tronStakingMemo
-import com.vultisig.wallet.data.chains.helpers.EthereumFunction
-import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
-import com.vultisig.wallet.data.chains.helpers.UtxoHelper
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.AddressBookEntry
@@ -35,25 +30,15 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ChainId
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
-import com.vultisig.wallet.data.models.DepositMemo
-import com.vultisig.wallet.data.models.DepositMemo.Bond
-import com.vultisig.wallet.data.models.DepositTransaction
-import com.vultisig.wallet.data.models.EstimatedGasFee
-import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.ImageModel
-import com.vultisig.wallet.data.models.OPERATION_CIRCLE_WITHDRAW
 import com.vultisig.wallet.data.models.TokenId
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
-import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
-import com.vultisig.wallet.data.models.allowZeroGas
-import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
-import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.AdvanceGasUiRepository
@@ -79,16 +64,21 @@ import com.vultisig.wallet.ui.models.send.AmountFraction.F100
 import com.vultisig.wallet.ui.models.send.AmountFraction.F25
 import com.vultisig.wallet.ui.models.send.AmountFraction.F50
 import com.vultisig.wallet.ui.models.send.AmountFraction.F75
+import com.vultisig.wallet.ui.models.send.submit.AccountValidator
+import com.vultisig.wallet.ui.models.send.submit.BitcoinPlanService
+import com.vultisig.wallet.ui.models.send.submit.BondStrategy
+import com.vultisig.wallet.ui.models.send.submit.DefaultSendStrategy
+import com.vultisig.wallet.ui.models.send.submit.MintStrategy
+import com.vultisig.wallet.ui.models.send.submit.RedeemStrategy
+import com.vultisig.wallet.ui.models.send.submit.StakeStrategy
+import com.vultisig.wallet.ui.models.send.submit.UnbondStrategy
+import com.vultisig.wallet.ui.models.send.submit.UnstakeStrategy
+import com.vultisig.wallet.ui.models.send.submit.WithdrawUsdcCircleStrategy
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.screens.select.AssetSelected
-import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
-import com.vultisig.wallet.ui.screens.v2.defi.STAKING_TCY_COMPOUND_CONTRACT
-import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_CONTRACT
-import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_YTCY_AFFILIATE_CONTRACT
-import com.vultisig.wallet.ui.screens.v2.defi.YTCY_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.model.parseDepositType
 import com.vultisig.wallet.ui.utils.UiText
@@ -99,13 +89,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
-import java.util.UUID
 import javax.inject.Inject
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -127,9 +115,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import timber.log.Timber
-import vultisig.keysign.v1.TransactionType
 import wallet.core.jni.proto.Bitcoin
 
 @Immutable
@@ -142,7 +128,7 @@ internal data class TokenBalanceUiModel(
     val isLayer2: Boolean,
     val tokenStandard: String?,
     val tokenLogo: ImageModel,
-    @DrawableRes val chainLogo: Int,
+    @param:DrawableRes val chainLogo: Int,
 )
 
 sealed class AmountFraction(val title: UiText, val value: Float) {
@@ -209,7 +195,6 @@ internal enum class SendSections {
     Asset,
     Address,
     Amount,
-    BondAddress,
 }
 
 internal enum class SendFocusField {
@@ -354,6 +339,183 @@ constructor(
             appCurrency = appCurrency,
             chainValidationService = chainValidationService,
             tokenPriceRepository = tokenPriceRepository,
+        )
+
+    private val accountValidator =
+        AccountValidator(
+            vaultIdProvider = { vaultId },
+            selectedAccountProvider = { selectedAccount },
+            tokenAmountFieldState = tokenAmountFieldState,
+            addressFieldState = addressFieldState,
+            gasFee = gasFee,
+            addressParserRepository = addressParserRepository,
+        )
+
+    private val bitcoinPlanService = BitcoinPlanService(vaultRepository)
+
+    private val sendStrategy =
+        DefaultSendStrategy(
+            scope = viewModelScope,
+            addressFieldState = addressFieldState,
+            tokenAmountFieldState = tokenAmountFieldState,
+            fiatAmountFieldState = fiatAmountFieldState,
+            memoFieldState = memoFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            transactionRepository = transactionRepository,
+            bitcoinPlanService = bitcoinPlanService,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            chainValidationService = chainValidationService,
+            addressManager = addressManager,
+            amountManager = amountManager,
+            gasSettings = gasSettings,
+            planBtc = planBtc,
+            planFee = planFee,
+            accounts = accounts,
+            appCurrency = appCurrency,
+            vaultIdProvider = { vaultId },
+            selectedAccountProvider = { selectedAccount },
+            defiTypeProvider = { defiType },
+            currentTronFrozenBalanceProvider = ::currentTronFrozenBalance,
+            navigator = navigator,
+            expandSection = ::expandSection,
+            emitFocusField = { field -> _focusFieldChannel.trySend(field) },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val bondStrategy =
+        BondStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            providerBondFieldState = providerBondFieldState,
+            operatorFeesBondFieldState = operatorFeesBondFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = addressParserRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val unbondStrategy =
+        UnbondStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            providerBondFieldState = providerBondFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = addressParserRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val stakeStrategy =
+        StakeStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            isAutocompoundProvider = { uiState.value.isAutocompound },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val unstakeStrategy =
+        UnstakeStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            isAutocompoundProvider = { uiState.value.isAutocompound },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val mintStrategy =
+        MintStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val redeemStrategy =
+        RedeemStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            slippageFieldState = slippageFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            chainValidationService = chainValidationService,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
+        )
+
+    private val withdrawUsdcCircleStrategy =
+        WithdrawUsdcCircleStrategy(
+            scope = viewModelScope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            mscaAddressProvider = { mscaAddress },
+            showLoading = ::showLoading,
+            hideLoading = ::hideLoading,
+            showError = ::showError,
         )
 
     init {
@@ -1072,1230 +1234,35 @@ constructor(
 
     fun onClickContinue() {
         when (uiState.value.defiType) {
-            DeFiNavActions.BOND -> bond()
-            DeFiNavActions.UNBOND -> unbond()
+            DeFiNavActions.BOND -> bondStrategy.submit()
+            DeFiNavActions.UNBOND -> unbondStrategy.submit()
             DeFiNavActions.STAKE_RUJI,
             DeFiNavActions.STAKE_TCY,
-            DeFiNavActions.STAKE_STCY -> stake()
+            DeFiNavActions.STAKE_STCY -> stakeStrategy.submit()
 
             DeFiNavActions.UNSTAKE_RUJI,
             DeFiNavActions.UNSTAKE_TCY,
             DeFiNavActions.UNSTAKE_STCY,
-            DeFiNavActions.WITHDRAW_RUJI -> unstake()
+            DeFiNavActions.WITHDRAW_RUJI -> unstakeStrategy.submit()
 
             DeFiNavActions.MINT_YRUNE,
-            DeFiNavActions.MINT_YTCY -> mint()
+            DeFiNavActions.MINT_YTCY -> mintStrategy.submit()
 
             DeFiNavActions.REDEEM_YRUNE,
-            DeFiNavActions.REDEEM_YTCY -> redeem()
+            DeFiNavActions.REDEEM_YTCY -> redeemStrategy.submit()
 
-            DeFiNavActions.WITHDRAW_USDC_CIRCLE -> withDrawUSDCCircle()
-            else -> send()
+            DeFiNavActions.WITHDRAW_USDC_CIRCLE -> withdrawUsdcCircleStrategy.submit()
+            else -> sendStrategy.submit()
         }
     }
 
-    private fun withDrawUSDCCircle() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
+    fun send() = sendStrategy.submit()
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
+    fun bond() = bondStrategy.submit()
 
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+    fun unbond() = unbondStrategy.submit()
 
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-                val nonDeFiAccount =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.Ethereum.ETH.id, true) }
-
-                val nonDeFiBalance = nonDeFiAccount?.tokenValue?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val memo =
-                    EthereumFunction.withdrawCircleMSCA(
-                        vaultAddress =
-                            nonDeFiAccount?.token?.address ?: error("Vault Address Empty"),
-                        tokenAddress = Coins.Ethereum.USDC.contractAddress,
-                        amount = tokenAmountInt,
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                    }
-
-                val nativeCoin = nonDeFiAccount.token
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = nativeCoin,
-                        srcAddress = srcAddress,
-                        dstAddress =
-                            mscaAddress
-                                ?: throw InvalidTransactionDataException(
-                                    UiText.StringResource(R.string.send_error_msca_not_deployed)
-                                ),
-                        memo = memo,
-                        srcTokenValue = TokenValue(value = BigInteger.ZERO, token = nativeCoin),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        operation = OPERATION_CIRCLE_WITHDRAW,
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    fun send() {
-        if (addressFieldState.text.isBlank()) {
-            expandSection(SendSections.Address)
-            _focusFieldChannel.trySend(SendFocusField.ADDRESS)
-            return
-        }
-        if (tokenAmountFieldState.text.isBlank()) {
-            expandSection(SendSections.Amount)
-            _focusFieldChannel.trySend(SendFocusField.AMOUNT)
-            return
-        }
-
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val vaultId =
-                    vaultId
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
-
-                val selectedAccount =
-                    selectedAccount
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
-
-                val chain = selectedAccount.token.chain
-
-                if (
-                    !chainAccountAddressRepository.isValid(
-                        chain,
-                        addressFieldState.text.asAddressInput(),
-                    )
-                ) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val gasFee = awaitGasFee()
-
-                if (!selectedAccount.token.allowZeroGas() && gasFee.value <= BigInteger.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_gas_fee)
-                    )
-                }
-                val rawInput = addressFieldState.text.asAddressInput()
-                val dstAddress =
-                    try {
-                        addressParserRepository.resolveName(rawInput, chain)
-                    } catch (e: Exception) {
-                        Timber.e(e)
-                        throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.failed_to_resolve_address)
-                        )
-                    }
-                // Use the label from AddressManager if available (ENS/thorname was already
-                // resolved and the field was rewritten to the resolved address). Fall back to
-                // rawInput for cases where the user typed an ENS name and taps send before the
-                // debounce completes.
-                val labelCandidate = addressManager.dstAddressLabel.value ?: rawInput
-                val dstLabel =
-                    labelCandidate.takeIf {
-                        it.isNotBlank() &&
-                            !chainAccountAddressRepository.isValid(chain, it) &&
-                            chainAccountAddressRepository.isValid(chain, dstAddress)
-                    }
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val selectedTokenValue =
-                    selectedAccount.tokenValue
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
-
-                val memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() }
-
-                val selectedToken = selectedAccount.token
-
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val srcAddress = selectedToken.address
-                val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
-
-                if (chain == Chain.Tron) {
-                    val isTronStakingOp =
-                        memo != null &&
-                            selectedToken.isNativeToken &&
-                            TRON_STAKING_MEMO_REGEX.matches(memo)
-                    if (!isTronStakingOp && srcAddress == dstAddress) {
-                        throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_same_address)
-                        )
-                    }
-                }
-
-                val specific =
-                    blockChainSpecificRepository
-                        .getSpecific(
-                            chain = chain,
-                            address = srcAddress,
-                            token = selectedToken,
-                            gasFee = gasFee,
-                            memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() },
-                            tokenAmountValue = tokenAmountInt,
-                            isSwap = false,
-                            isMaxAmountEnabled = isMaxAmount,
-                            isDeposit = false,
-                            dstAddress = dstAddress,
-                        )
-                        .let {
-                            val gasSettings = gasSettings.value
-                            if (gasSettings != null) {
-                                val spec = it.blockChainSpecific
-
-                                when {
-                                    gasSettings is GasSettings.Eth &&
-                                        spec is BlockChainSpecific.Ethereum -> {
-                                        it.copy(
-                                            blockChainSpecific =
-                                                spec.copy(
-                                                    maxFeePerGasWei = gasSettings.baseFee,
-                                                    priorityFeeWei = gasSettings.priorityFee,
-                                                    gasLimit = gasSettings.gasLimit,
-                                                )
-                                        )
-                                    }
-
-                                    gasSettings is GasSettings.UTXO &&
-                                        spec is BlockChainSpecific.UTXO -> {
-                                        it.copy(
-                                            blockChainSpecific =
-                                                spec.copy(byteFee = gasSettings.byteFee)
-                                        )
-                                    }
-
-                                    else -> it
-                                }
-                            } else {
-                                it
-                            }
-                        }
-                        .let { specific ->
-                            if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
-                                planBtc.value
-                                    ?: getBitcoinTransactionPlan(
-                                            vaultId = vaultId,
-                                            selectedToken = selectedToken,
-                                            dstAddress = dstAddress,
-                                            tokenAmountInt = tokenAmountInt,
-                                            specific = specific,
-                                            memo = memo,
-                                        )
-                                        .also { plan ->
-                                            planBtc.value = plan
-                                            planFee.value = plan.fee
-                                        }
-
-                                val selectedSpecific =
-                                    chainValidationService.selectUtxosIfNeeded(
-                                        chain = chain,
-                                        specific = specific,
-                                        plan = planBtc.value,
-                                    )
-                                selectedSpecific
-                            } else {
-                                specific
-                            }
-                        }
-
-                if (selectedToken.isNativeToken) {
-                    val availableTokenBalance =
-                        if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                            currentTronFrozenBalance()
-                                ?.movePointRight(selectedToken.decimal)
-                                ?.toBigInteger() ?: BigInteger.ZERO
-                        } else {
-                            getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                                ?: BigInteger.ZERO
-                        }
-
-                    if (tokenAmountInt > availableTokenBalance) {
-                        val errorRes =
-                            if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                                R.string.send_error_insufficient_frozen_balance
-                            } else {
-                                R.string.send_error_insufficient_native_balance_with_fees
-                            }
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(errorRes, listOf(selectedToken.ticker))
-                        )
-                    }
-
-                    // On UNFREEZE the amount comes from frozen stake, but the broadcast itself
-                    // still burns gas from the liquid balance (or free bandwidth quota). Surface
-                    // insufficient liquid balance before we attempt to sign.
-                    if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                        val liquidForGas =
-                            getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
-                                ?: BigInteger.ZERO
-                        if (liquidForGas < gasFee.value) {
-                            throw InvalidTransactionDataException(
-                                UiText.FormattedText(
-                                    R.string.send_error_insufficient_native_balance_with_fees,
-                                    listOf(selectedToken.ticker),
-                                )
-                            )
-                        }
-                    }
-
-                    if (chain == Chain.Cardano) {
-                        chainValidationService.validateCardanoUTXORequirements(
-                            sendAmount = tokenAmountInt,
-                            totalBalance = selectedTokenValue.value,
-                            estimatedFee = gasFee.value,
-                        )
-                    }
-
-                    if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
-                        chainValidationService.validateBtcLikeAmount(
-                            tokenAmountInt,
-                            chain,
-                            planBtc.value,
-                        )
-                    }
-                } else {
-                    val nativeTokenAccount =
-                        accounts.value.find { it.token.isNativeToken && it.token.chain == chain }
-                    val nativeTokenValue =
-                        nativeTokenAccount?.tokenValue?.value
-                            ?: throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.send_error_no_token)
-                            )
-
-                    if (selectedTokenValue.value < tokenAmountInt) {
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(
-                                R.string.send_error_insufficient_native_balance_with_fees,
-                                listOf(selectedToken.ticker),
-                            )
-                        )
-                    } else if (nativeTokenValue < gasFee.value) {
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(
-                                R.string.insufficient_native_token,
-                                listOf(nativeTokenAccount.token.ticker),
-                            )
-                        )
-                    }
-                }
-
-                val evmGasSettings = gasSettings.value as? GasSettings.Eth
-                val totalGasAndFee =
-                    gasFeeToEstimatedFee(
-                        GasFeeParams(
-                            gasLimit =
-                                if (evmGasSettings != null) evmGasSettings.gasLimit
-                                else BigInteger.valueOf(1),
-                            gasFee =
-                                selectGasFeeForFeeEstimation(
-                                    chain = chain,
-                                    gasFee = gasFee,
-                                    planFee = planFee.value,
-                                    evmGasSettings = evmGasSettings,
-                                ),
-                            selectedToken = selectedToken,
-                        )
-                    )
-
-                val transaction =
-                    Transaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        chainId = chain.raw,
-                        token = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        dstLabel = dstLabel,
-                        tokenValue =
-                            TokenValue(
-                                value = tokenAmountInt,
-                                unit = selectedTokenValue.unit,
-                                decimals = selectedToken.decimal,
-                            ),
-                        fiatValue =
-                            FiatValue(
-                                value =
-                                    fiatAmountFieldState.text.toString().toBigDecimalOrNull()
-                                        ?: BigDecimal.ZERO,
-                                currency = appCurrency.value.ticker,
-                            ),
-                        gasFee = gasFee,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        utxos = specific.utxos,
-                        memo = memo,
-                        estimatedFee = totalGasAndFee.formattedFiatValue,
-                        totalGas = totalGasAndFee.formattedTokenValue,
-                    )
-
-                transactionRepository.addTransaction(transaction)
-
-                navigator.route(Route.VerifySend(transactionId = transaction.id, vaultId = vaultId))
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    fun bond() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                val providerAddress =
-                    if (providerBondFieldState.text.toString().isNotEmpty()) {
-                        try {
-                            addressParserRepository.resolveName(
-                                providerBondFieldState.text.toString(),
-                                chain,
-                            )
-                        } catch (e: Exception) {
-                            Timber.e(e)
-                            throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.failed_to_resolve_address)
-                            )
-                        }
-                    } else {
-                        ""
-                    }
-
-                val feeBondOperator = operatorFeesBondFieldState.text.toString()
-
-                // Validate operator fee is a valid integer (basis points)
-                val operatorFeeValue: Int? =
-                    if (feeBondOperator.isNotEmpty()) {
-                        feeBondOperator.toIntOrNull()?.takeIf {
-                            it in 0..10000
-                        } // Basis points: 0-10000 (0-100%)
-                        ?: throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.send_error_invalid_operator_fee)
-                            )
-                    } else {
-                        null
-                    }
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositMemo =
-                    Bond.Thor(
-                        nodeAddress = dstAddress,
-                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
-                        operatorFee = operatorFeeValue,
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                    }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo.toString(),
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    fun unbond() {
-        viewModelScope.launch {
-            try {
-                showLoading()
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                val providerAddress =
-                    if (providerBondFieldState.text.toString().isNotEmpty()) {
-                        try {
-                            addressParserRepository.resolveName(
-                                providerBondFieldState.text.toString(),
-                                chain,
-                            )
-                        } catch (e: Exception) {
-                            Timber.e(e)
-                            throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.failed_to_resolve_address)
-                            )
-                        }
-                    } else {
-                        ""
-                    }
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val selectedAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                // Get Token Balance normal and check there is for fees
-                val depositMemo =
-                    DepositMemo.Unbond.Thor(
-                        nodeAddress = dstAddress,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            selectedAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                    }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = selectedAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo.toString(),
-                        srcTokenValue =
-                            TokenValue(
-                                value =
-                                    (chain == Chain.MayaChain).let {
-                                        if (it) 1.toBigInteger() else BigInteger.ZERO
-                                    },
-                                token = selectedToken,
-                            ),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    private fun stake() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositTx =
-                    when (defiType) {
-                        DeFiNavActions.STAKE_RUJI ->
-                            createRujiStakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.STAKE_TCY,
-                        DeFiNavActions.STAKE_STCY ->
-                            createTCYStakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        else -> error("DeFi Type not supported ${defiType?.type}")
-                    }
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    fun unstake() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositTx =
-                    when (defiType) {
-                        DeFiNavActions.UNSTAKE_RUJI ->
-                            createRUJIUnstakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.UNSTAKE_TCY,
-                        DeFiNavActions.UNSTAKE_STCY ->
-                            createYTCUnstakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                totalTokenAmount = availableTokenBalance,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.WITHDRAW_RUJI -> {
-                            val ruji =
-                                accountsRepository
-                                    .loadAddresses(vaultId)
-                                    .firstOrNull()
-                                    ?.flatMap { it.accounts }
-                                    ?.find { it.token.id.equals(Coins.ThorChain.RUJI.id, true) }
-                                    ?: return@launch
-
-                            createRUJIRewardsDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = ruji.token,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-                        }
-
-                        else -> error("DeFi Type not supported ${defiType?.type}")
-                    }
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    private fun mint() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositMemo = "receive:${selectedToken.ticker.lowercase()}:$tokenAmount"
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-                        )
-                    }
-
-                val tokenContract =
-                    when (uiState.value.defiType) {
-                        DeFiNavActions.MINT_YRUNE -> {
-                            YRUNE_CONTRACT
-                        }
-
-                        DeFiNavActions.MINT_YTCY -> {
-                            YTCY_CONTRACT
-                        }
-
-                        else -> {
-                            throw RuntimeException("Invalid Deposit Parameter ")
-                        }
-                    }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        wasmExecuteContractPayload =
-                            ThorchainFunctions.mintYToken(
-                                fromAddress = srcAddress,
-                                stakingContract = YRUNE_YTCY_AFFILIATE_CONTRACT,
-                                tokenContract = tokenContract,
-                                denom = selectedToken.ticker.lowercase(),
-                                amount = tokenAmountInt,
-                            ),
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    private fun redeem() {
-        viewModelScope.launch {
-            showLoading()
-            try {
-                val accountValidation = accountValidation()
-                val vaultId = accountValidation.vaultId
-                val chain = accountValidation.chain
-                val dstAddress = accountValidation.dstAddress
-                val selectedAccount = accountValidation.selectedAccount
-                val gasFee = accountValidation.gasFee
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositMemo = "sell:${selectedToken.contractAddress}:$tokenAmount"
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-                        )
-                    }
-
-                val tokenContract =
-                    when (uiState.value.defiType) {
-                        DeFiNavActions.REDEEM_YRUNE -> {
-                            YRUNE_CONTRACT
-                        }
-
-                        DeFiNavActions.REDEEM_YTCY -> {
-                            YTCY_CONTRACT
-                        }
-
-                        else -> {
-                            throw RuntimeException("Invalid Deposit Parameter ")
-                        }
-                    }
-
-                val slippage = slippageFieldState.text.toString()
-                val slippageValidation = chainValidationService.validateSlippage(slippage)
-                if (slippageValidation != null) {
-                    throw InvalidTransactionDataException(slippageValidation)
-                }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = tokenContract,
-                        memo = depositMemo,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        wasmExecuteContractPayload =
-                            ThorchainFunctions.redeemYToken(
-                                fromAddress = srcAddress,
-                                tokenContract = tokenContract,
-                                slippage = chainValidationService.formatSlippage(slippage),
-                                denom = selectedToken.contractAddress,
-                                amount = tokenAmountInt,
-                            ),
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
-            }
-        }
-    }
-
-    private suspend fun getFeesFiatValue(gasFee: TokenValue, selectedToken: Coin): EstimatedGasFee {
-        return gasFeeToEstimatedFee(
-            GasFeeParams(BigInteger.valueOf(1), gasFee = gasFee, selectedToken = selectedToken)
-        )
-    }
-
-    private suspend fun getBitcoinTransactionPlan(
-        vaultId: String,
-        selectedToken: Coin,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        specific: BlockChainSpecificAndUtxo,
-        memo: String?,
-    ): Bitcoin.TransactionPlan {
-        val vault = vaultRepository.get(vaultId) ?: error("Can't calculate plan fees")
-        val keysignPayload =
-            KeysignPayload(
-                coin = selectedToken,
-                toAddress = dstAddress,
-                toAmount = tokenAmountInt,
-                blockChainSpecific = specific.blockChainSpecific,
-                memo = memo,
-                vaultPublicKeyECDSA = vault.pubKeyECDSA,
-                vaultLocalPartyID = vault.localPartyID,
-                utxos = specific.utxos,
-                libType = vault.libType,
-                wasmExecuteContractPayload = null,
-            )
-
-        val utxo = UtxoHelper.getHelper(vault, keysignPayload.coin.coinType)
-
-        val plan = utxo.getBitcoinTransactionPlan(keysignPayload)
-        return plan
-    }
+    fun unstake() = unstakeStrategy.submit()
 
     private fun hideLoading() {
         uiState.update { it.copy(isLoading = false) }
@@ -2312,65 +1279,46 @@ constructor(
         selectedToken.value = token
     }
 
-    private fun calculateGasLimit(chain: Chain, specific: BlockChainSpecific?): BigInteger =
-        (specific as? BlockChainSpecific.Ethereum)?.gasLimit ?: BigInteger.valueOf(1)
-
     private fun showError(text: UiText) {
         uiState.update { it.copy(errorText = text) }
-    }
-
-    private suspend fun awaitGasFee(): TokenValue {
-        // Return cached value immediately if the background debounce already resolved
-        gasFee.value?.let {
-            return it
-        }
-
-        // Wait for the background calculateGasFees() debounce to emit.
-        // If it doesn't resolve (e.g. RPC error swallowed by the flow), throw
-        // the localized gas fee error so the user can retry.
-        try {
-            return withTimeout(GAS_FEE_TIMEOUT_MS) { gasFee.filterNotNull().first() }
-        } catch (_: TimeoutCancellationException) {
-            throw InvalidTransactionDataException(
-                UiText.StringResource(R.string.send_error_no_gas_fee)
-            )
-        }
     }
 
     private fun loadAccounts(vaultId: VaultId) {
         loadAccountsJob?.cancel()
         loadAccountsJob =
-            if (
-                this.defiType == null ||
-                    this.defiType == DeFiNavActions.BOND ||
-                    this.defiType == DeFiNavActions.STAKE_RUJI ||
-                    this.defiType == DeFiNavActions.STAKE_TCY ||
-                    this.defiType == DeFiNavActions.STAKE_STCY ||
-                    this.defiType == DeFiNavActions.UNSTAKE_STCY ||
-                    this.defiType == DeFiNavActions.MINT_YRUNE ||
-                    this.defiType == DeFiNavActions.MINT_YTCY ||
-                    this.defiType == DeFiNavActions.REDEEM_YRUNE ||
-                    this.defiType == DeFiNavActions.REDEEM_YTCY ||
-                    this.defiType == DeFiNavActions.DEPOSIT_USDC_CIRCLE ||
-                    this.defiType == DeFiNavActions.FREEZE_TRX
-            ) {
-                viewModelScope.launch {
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .map { addrs -> addrs.flatMap { it.accounts } }
-                        .collect(accounts)
-                }
-            } else if (this.defiType == DeFiNavActions.WITHDRAW_RUJI) {
-                viewModelScope.launch { loadRewardsAccount(vaultId) }
-            } else if (this.defiType == DeFiNavActions.WITHDRAW_USDC_CIRCLE) {
-                viewModelScope.launch { loadCircleUSDCAccount(vaultId) }
-            } else {
-                viewModelScope.launch {
-                    accountsRepository
-                        .loadDeFiAddresses(vaultId, false)
-                        .map { addrs -> addrs.flatMap { it.accounts } }
-                        .collect(accounts)
-                }
+            when (defiType) {
+                DeFiNavActions.WITHDRAW_RUJI ->
+                    viewModelScope.launch { loadRewardsAccount(vaultId) }
+
+                DeFiNavActions.WITHDRAW_USDC_CIRCLE ->
+                    viewModelScope.launch { loadCircleUSDCAccount(vaultId) }
+
+                null,
+                DeFiNavActions.BOND,
+                DeFiNavActions.STAKE_RUJI,
+                DeFiNavActions.STAKE_TCY,
+                DeFiNavActions.STAKE_STCY,
+                DeFiNavActions.UNSTAKE_STCY,
+                DeFiNavActions.MINT_YRUNE,
+                DeFiNavActions.MINT_YTCY,
+                DeFiNavActions.REDEEM_YRUNE,
+                DeFiNavActions.REDEEM_YTCY,
+                DeFiNavActions.DEPOSIT_USDC_CIRCLE,
+                DeFiNavActions.FREEZE_TRX ->
+                    viewModelScope.launch {
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .map { addrs -> addrs.flatMap { it.accounts } }
+                            .collect(accounts)
+                    }
+
+                else ->
+                    viewModelScope.launch {
+                        accountsRepository
+                            .loadDeFiAddresses(vaultId, false)
+                            .map { addrs -> addrs.flatMap { it.accounts } }
+                            .collect(accounts)
+                    }
             }
     }
 
@@ -2677,7 +1625,7 @@ constructor(
                         val vaultId =
                             vaultId
                                 ?: throw InvalidTransactionDataException(
-                                    UiText.StringResource(R.string.send_error_no_token)
+                                    UiText.StringResource(string.send_error_no_token)
                                 )
 
                         val resolvedDstAddress =
@@ -2690,7 +1638,7 @@ constructor(
                                 .toBigInteger()
 
                         val plan =
-                            getBitcoinTransactionPlan(
+                            bitcoinPlanService.getPlan(
                                 vaultId,
                                 token,
                                 resolvedDstAddress,
@@ -2888,10 +1836,6 @@ constructor(
         }
     }
 
-    fun enableAdvanceGasUi() {
-        advanceGasUiRepository.showIcon()
-    }
-
     fun back() {
         viewModelScope.launch { navigator.back() }
     }
@@ -2916,333 +1860,7 @@ constructor(
             uiState.update { it.copy(isRefreshing = false) }
         }
     }
-
-    private suspend fun accountValidation(): AccountValidation {
-        val vaultId =
-            vaultId
-                ?: throw InvalidTransactionDataException(
-                    UiText.StringResource(R.string.send_error_no_token)
-                )
-
-        val selectedAccount =
-            selectedAccount
-                ?: throw InvalidTransactionDataException(
-                    UiText.StringResource(R.string.send_error_no_token)
-                )
-
-        val chain = selectedAccount.token.chain
-
-        val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-        if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-            throw InvalidTransactionDataException(
-                UiText.StringResource(R.string.send_error_no_amount)
-            )
-        }
-
-        val gasFee = awaitGasFee()
-
-        if (!selectedAccount.token.allowZeroGas() && gasFee.value <= BigInteger.ZERO) {
-            throw InvalidTransactionDataException(
-                UiText.StringResource(R.string.send_error_no_gas_fee)
-            )
-        }
-
-        val dstAddress =
-            try {
-                addressParserRepository.resolveName(addressFieldState.text.asAddressInput(), chain)
-            } catch (e: Exception) {
-                Timber.e(e)
-                throw InvalidTransactionDataException(
-                    UiText.StringResource(R.string.failed_to_resolve_address)
-                )
-            }
-
-        return AccountValidation(
-            vaultId = vaultId,
-            selectedAccount = selectedAccount,
-            chain = chain,
-            gasFee = gasFee,
-            dstAddress = dstAddress,
-        )
-    }
-
-    private suspend fun createRUJIUnstakeDepositTransaction(
-        vaultId: String,
-        selectedToken: Coin,
-        srcAddress: String,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        gasFee: TokenValue,
-        chain: Chain,
-    ): DepositTransaction {
-        val depositMemo = "withdraw:${selectedToken.contractAddress}:$tokenAmountInt"
-
-        val specific =
-            withContext(Dispatchers.IO) {
-                blockChainSpecificRepository.getSpecific(
-                    chain,
-                    srcAddress,
-                    selectedToken,
-                    gasFee,
-                    isSwap = false,
-                    isMaxAmountEnabled = false,
-                    isDeposit = true,
-                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-                )
-            }
-
-        return DepositTransaction(
-            id = UUID.randomUUID().toString(),
-            vaultId = vaultId,
-            srcToken = selectedToken,
-            srcAddress = srcAddress,
-            dstAddress = dstAddress,
-            memo = depositMemo,
-            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-            estimatedFees = gasFee,
-            estimateFeesFiat = getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-            blockChainSpecific = specific.blockChainSpecific,
-            wasmExecuteContractPayload =
-                ThorchainFunctions.unstakeRUJI(
-                    fromAddress = srcAddress,
-                    stakingContract = STAKING_RUJI_CONTRACT,
-                    amount = tokenAmountInt.toString(),
-                ),
-        )
-    }
-
-    private suspend fun createRUJIRewardsDepositTransaction(
-        vaultId: String,
-        selectedToken: Coin,
-        srcAddress: String,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        gasFee: TokenValue,
-        chain: Chain,
-    ): DepositTransaction {
-        val memo = ThorchainFunctions.rujiRewardsMemo(selectedToken.contractAddress, tokenAmountInt)
-
-        val specific =
-            blockChainSpecificRepository.getSpecific(
-                chain,
-                srcAddress,
-                selectedToken,
-                gasFee,
-                isSwap = false,
-                isMaxAmountEnabled = false,
-                isDeposit = true,
-                transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-            )
-
-        return DepositTransaction(
-            id = UUID.randomUUID().toString(),
-            vaultId = vaultId,
-            srcToken = selectedToken,
-            srcAddress = srcAddress,
-            dstAddress = dstAddress,
-            memo = memo,
-            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-            estimatedFees = gasFee,
-            estimateFeesFiat = getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-            blockChainSpecific = specific.blockChainSpecific,
-            wasmExecuteContractPayload =
-                ThorchainFunctions.claimRujiRewards(
-                    fromAddress = srcAddress,
-                    stakingContract = STAKING_RUJI_CONTRACT,
-                ),
-        )
-    }
-
-    private suspend fun createYTCUnstakeDepositTransaction(
-        vaultId: String,
-        selectedToken: Coin,
-        srcAddress: String,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        totalTokenAmount: BigInteger,
-        gasFee: TokenValue,
-        chain: Chain,
-    ): DepositTransaction {
-        val percentage =
-            if (totalTokenAmount > BigInteger.ZERO) {
-                (tokenAmountInt.toDouble() / totalTokenAmount.toDouble()) * 100.0
-            } else {
-                100.0
-            }
-
-        val isAutoCompound = uiState.value.isAutocompound
-        val unstakeMemo =
-            if (isAutoCompound) {
-                ""
-            } else {
-                val basisPoints = (percentage * 100).toInt().coerceIn(0, 10000)
-                ThorchainFunctions.tcyUnstakeMemo(basisPoints)
-            }
-
-        val specific =
-            blockChainSpecificRepository.getSpecific(
-                chain,
-                srcAddress,
-                selectedToken,
-                gasFee,
-                isSwap = false,
-                isMaxAmountEnabled = false,
-                isDeposit = true,
-                transactionType =
-                    if (isAutoCompound) {
-                        TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
-                    } else {
-                        TransactionType.TRANSACTION_TYPE_UNSPECIFIED
-                    },
-            )
-
-        val unstakePayload =
-            if (isAutoCompound) {
-                ThorchainFunctions.unStakeTcyCompound(
-                    units = tokenAmountInt,
-                    stakingContract = STAKING_TCY_COMPOUND_CONTRACT,
-                    fromAddress = srcAddress,
-                )
-            } else {
-                null
-            }
-
-        return DepositTransaction(
-            id = UUID.randomUUID().toString(),
-            vaultId = vaultId,
-            srcToken = selectedToken,
-            srcAddress = srcAddress,
-            dstAddress = dstAddress,
-            memo = unstakeMemo,
-            srcTokenValue = TokenValue(value = BigInteger.ZERO, token = selectedToken),
-            estimatedFees = gasFee,
-            estimateFeesFiat = getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-            blockChainSpecific = specific.blockChainSpecific,
-            wasmExecuteContractPayload = unstakePayload,
-        )
-    }
-
-    private suspend fun createRujiStakeDepositTransaction(
-        vaultId: String,
-        selectedToken: Coin,
-        srcAddress: String,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        gasFee: TokenValue,
-        chain: Chain,
-    ): DepositTransaction {
-        val depositMemo = "bond:${selectedToken.contractAddress}:$tokenAmountInt"
-
-        val specific =
-            withContext(Dispatchers.IO) {
-                blockChainSpecificRepository.getSpecific(
-                    chain,
-                    srcAddress,
-                    selectedToken,
-                    gasFee,
-                    isSwap = false,
-                    isMaxAmountEnabled = false,
-                    isDeposit = true,
-                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-                )
-            }
-
-        return DepositTransaction(
-            id = UUID.randomUUID().toString(),
-            vaultId = vaultId,
-            srcToken = selectedToken,
-            srcAddress = srcAddress,
-            dstAddress = dstAddress,
-            memo = depositMemo,
-            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-            estimatedFees = gasFee,
-            estimateFeesFiat = getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-            blockChainSpecific = specific.blockChainSpecific,
-            wasmExecuteContractPayload =
-                ThorchainFunctions.stakeRUJI(
-                    fromAddress = srcAddress,
-                    stakingContract = STAKING_RUJI_CONTRACT,
-                    denom = selectedToken.contractAddress,
-                    amount = tokenAmountInt,
-                ),
-        )
-    }
-
-    private suspend fun createTCYStakeDepositTransaction(
-        vaultId: String,
-        selectedToken: Coin,
-        srcAddress: String,
-        dstAddress: String,
-        tokenAmountInt: BigInteger,
-        gasFee: TokenValue,
-        chain: Chain,
-    ): DepositTransaction {
-        val isAutoCompound = uiState.value.isAutocompound
-        val stakingMemo =
-            if (isAutoCompound) {
-                ""
-            } else {
-                "TCY+"
-            }
-
-        val specific =
-            withContext(Dispatchers.IO) {
-                blockChainSpecificRepository.getSpecific(
-                    chain,
-                    srcAddress,
-                    selectedToken,
-                    gasFee,
-                    isSwap = false,
-                    isMaxAmountEnabled = false,
-                    isDeposit = true,
-                    transactionType =
-                        if (isAutoCompound) {
-                            TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
-                        } else {
-                            TransactionType.TRANSACTION_TYPE_UNSPECIFIED
-                        },
-                )
-            }
-
-        val stakingPayload =
-            if (isAutoCompound) {
-                ThorchainFunctions.stakeTcyCompound(
-                    fromAddress = srcAddress,
-                    stakingContract = STAKING_TCY_COMPOUND_CONTRACT,
-                    denom = selectedToken.contractAddress,
-                    amount = tokenAmountInt,
-                )
-            } else {
-                null
-            }
-
-        return DepositTransaction(
-            id = UUID.randomUUID().toString(),
-            vaultId = vaultId,
-            srcToken = selectedToken,
-            srcAddress = srcAddress,
-            dstAddress = dstAddress,
-            memo = stakingMemo,
-            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-            estimatedFees = gasFee,
-            estimateFeesFiat = getFeesFiatValue(gasFee, selectedToken).formattedFiatValue,
-            blockChainSpecific = specific.blockChainSpecific,
-            wasmExecuteContractPayload = stakingPayload,
-        )
-    }
-
-    companion object {
-        private const val GAS_FEE_TIMEOUT_MS = 5_000L
-    }
 }
-
-private data class AccountValidation(
-    val vaultId: String,
-    val selectedAccount: Account,
-    val chain: Chain,
-    val gasFee: TokenValue,
-    val dstAddress: String,
-)
 
 private data class GasFeeInput(
     val token: Coin,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asAddressInput
 import java.math.BigDecimal
 import java.math.BigInteger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -68,6 +69,8 @@ internal class AccountValidator(
         val dstAddress =
             try {
                 addressParserRepository.resolveName(addressFieldState.text.asAddressInput(), chain)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.e(e)
                 throw InvalidTransactionDataException(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
@@ -1,0 +1,106 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.allowZeroGas
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asAddressInput
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
+
+internal data class ValidatedAccount(
+    val vaultId: String,
+    val selectedAccount: Account,
+    val chain: Chain,
+    val gasFee: TokenValue,
+    val dstAddress: String,
+)
+
+internal class AccountValidator(
+    private val vaultIdProvider: () -> String?,
+    private val selectedAccountProvider: () -> Account?,
+    private val tokenAmountFieldState: TextFieldState,
+    private val addressFieldState: TextFieldState,
+    private val gasFee: StateFlow<TokenValue?>,
+    private val addressParserRepository: AddressParserRepository,
+) {
+    suspend fun validate(): ValidatedAccount {
+        val vaultId =
+            vaultIdProvider()
+                ?: throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.send_error_no_token)
+                )
+
+        val selectedAccount =
+            selectedAccountProvider()
+                ?: throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.send_error_no_token)
+                )
+
+        val chain = selectedAccount.token.chain
+
+        val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+        if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val gasFeeValue = awaitGasFee()
+
+        if (!selectedAccount.token.allowZeroGas() && gasFeeValue.value <= BigInteger.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_gas_fee)
+            )
+        }
+
+        val dstAddress =
+            try {
+                addressParserRepository.resolveName(addressFieldState.text.asAddressInput(), chain)
+            } catch (e: Exception) {
+                Timber.e(e)
+                throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.failed_to_resolve_address)
+                )
+            }
+
+        return ValidatedAccount(
+            vaultId = vaultId,
+            selectedAccount = selectedAccount,
+            chain = chain,
+            gasFee = gasFeeValue,
+            dstAddress = dstAddress,
+        )
+    }
+
+    suspend fun resolveDstAddress(rawInput: String, chain: Chain): String =
+        addressParserRepository.resolveName(rawInput, chain)
+
+    suspend fun awaitGasFee(): TokenValue {
+        gasFee.value?.let {
+            return it
+        }
+        try {
+            return withTimeout(GAS_FEE_TIMEOUT_MS) { gasFee.filterNotNull().first() }
+        } catch (_: TimeoutCancellationException) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_gas_fee)
+            )
+        }
+    }
+
+    private companion object {
+        const val GAS_FEE_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BitcoinPlanService.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BitcoinPlanService.kt
@@ -1,0 +1,40 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import com.vultisig.wallet.data.chains.helpers.UtxoHelper
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.coinType
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.repositories.VaultRepository
+import java.math.BigInteger
+import wallet.core.jni.proto.Bitcoin
+
+internal class BitcoinPlanService(private val vaultRepository: VaultRepository) {
+
+    suspend fun getPlan(
+        vaultId: String,
+        selectedToken: Coin,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        specific: BlockChainSpecificAndUtxo,
+        memo: String?,
+    ): Bitcoin.TransactionPlan {
+        val vault = vaultRepository.get(vaultId) ?: error("Can't calculate plan fees")
+        val keysignPayload =
+            KeysignPayload(
+                coin = selectedToken,
+                toAddress = dstAddress,
+                toAmount = tokenAmountInt,
+                blockChainSpecific = specific.blockChainSpecific,
+                memo = memo,
+                vaultPublicKeyECDSA = vault.pubKeyECDSA,
+                vaultLocalPartyID = vault.localPartyID,
+                utxos = specific.utxos,
+                libType = vault.libType,
+                wasmExecuteContractPayload = null,
+            )
+
+        val utxo = UtxoHelper.getHelper(vault, keysignPayload.coin.coinType)
+        return utxo.getBitcoinTransactionPlan(keysignPayload)
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
@@ -23,6 +23,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -45,129 +46,137 @@ internal class BondStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
-    override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+    private var submitJob: Job? = null
 
-                val providerAddress =
-                    if (providerBondFieldState.text.toString().isNotEmpty()) {
-                        try {
-                            addressParserRepository.resolveName(
-                                providerBondFieldState.text.toString(),
-                                chain,
+    override fun submit() {
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
+
+                    val providerAddress =
+                        if (providerBondFieldState.text.toString().isNotEmpty()) {
+                            try {
+                                addressParserRepository.resolveName(
+                                    providerBondFieldState.text.toString(),
+                                    chain,
+                                )
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                Timber.e(e)
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.failed_to_resolve_address)
+                                )
+                            }
+                        } else {
+                            ""
+                        }
+
+                    val feeBondOperator = operatorFeesBondFieldState.text.toString()
+                    val operatorFeeValue: Int? =
+                        if (feeBondOperator.isNotEmpty()) {
+                            feeBondOperator.toIntOrNull()?.takeIf { it in 0..10000 }
+                                ?: throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.send_error_invalid_operator_fee)
+                                )
+                        } else {
+                            null
+                        }
+
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
+                        )
+                    }
+
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
                             )
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            Timber.e(e)
-                            throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.failed_to_resolve_address)
+                        )
+                    }
+
+                    val depositMemo =
+                        Bond.Thor(
+                            nodeAddress = dstAddress,
+                            providerAddress = providerAddress.takeIf { it.isNotEmpty() },
+                            operatorFee = operatorFeeValue,
+                        )
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                            blockChainSpecificRepository.getSpecific(
+                                chain,
+                                srcAddress,
+                                selectedToken,
+                                gasFee,
+                                isSwap = false,
+                                isMaxAmountEnabled = false,
+                                isDeposit = true,
                             )
                         }
-                    } else {
-                        ""
-                    }
 
-                val feeBondOperator = operatorFeesBondFieldState.text.toString()
-                val operatorFeeValue: Int? =
-                    if (feeBondOperator.isNotEmpty()) {
-                        feeBondOperator.toIntOrNull()?.takeIf { it in 0..10000 }
-                            ?: throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.send_error_invalid_operator_fee)
-                            )
-                    } else {
-                        null
-                    }
-
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
+                    val depositTx =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = selectedToken,
+                            srcAddress = srcAddress,
+                            dstAddress = dstAddress,
+                            memo = depositMemo.toString(),
+                            srcTokenValue =
+                                TokenValue(value = tokenAmountInt, token = selectedToken),
+                            estimatedFees = gasFee,
+                            estimateFeesFiat =
+                                gasFeeToEstimatedFee
+                                    .fiatFeesFor(gasFee, selectedToken)
+                                    .formattedFiatValue,
+                            blockChainSpecific = specific.blockChainSpecific,
                         )
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
                     )
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
                 }
-
-                val depositMemo =
-                    Bond.Thor(
-                        nodeAddress = dstAddress,
-                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
-                        operatorFee = operatorFeeValue,
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                    }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo.toString(),
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            gasFeeToEstimatedFee
-                                .fiatFeesFor(gasFee, selectedToken)
-                                .formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
             }
-        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,6 +63,8 @@ internal class BondStrategy(
                                 providerBondFieldState.text.toString(),
                                 chain,
                             )
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Timber.e(e)
                             throw InvalidTransactionDataException(
@@ -158,6 +161,8 @@ internal class BondStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
@@ -1,0 +1,168 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.DepositMemo.Bond
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+internal class BondStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val providerBondFieldState: TextFieldState,
+    private val operatorFeesBondFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val addressParserRepository: AddressParserRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                val providerAddress =
+                    if (providerBondFieldState.text.toString().isNotEmpty()) {
+                        try {
+                            addressParserRepository.resolveName(
+                                providerBondFieldState.text.toString(),
+                                chain,
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(e)
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.failed_to_resolve_address)
+                            )
+                        }
+                    } else {
+                        ""
+                    }
+
+                val feeBondOperator = operatorFeesBondFieldState.text.toString()
+                val operatorFeeValue: Int? =
+                    if (feeBondOperator.isNotEmpty()) {
+                        feeBondOperator.toIntOrNull()?.takeIf { it in 0..10000 }
+                            ?: throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_invalid_operator_fee)
+                            )
+                    } else {
+                        null
+                    }
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositMemo =
+                    Bond.Thor(
+                        nodeAddress = dstAddress,
+                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
+                        operatorFee = operatorFeeValue,
+                    )
+
+                val specific =
+                    withContext(Dispatchers.IO) {
+                        blockChainSpecificRepository.getSpecific(
+                            chain,
+                            srcAddress,
+                            selectedToken,
+                            gasFee,
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                        )
+                    }
+
+                val depositTx =
+                    DepositTransaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        srcToken = selectedToken,
+                        srcAddress = srcAddress,
+                        dstAddress = dstAddress,
+                        memo = depositMemo.toString(),
+                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+                        estimatedFees = gasFee,
+                        estimateFeesFiat =
+                            gasFeeToEstimatedFee
+                                .fiatFeesFor(gasFee, selectedToken)
+                                .formattedFiatValue,
+                        blockChainSpecific = specific.blockChainSpecific,
+                    )
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -11,7 +11,6 @@ import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Transaction
-import com.vultisig.wallet.data.models.allowZeroGas
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
@@ -40,10 +39,12 @@ import java.math.BigInteger
 import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
+import kotlinx.coroutines.withContext
 import wallet.core.jni.proto.Bitcoin
 
 internal class DefaultSendStrategy(
@@ -79,7 +80,10 @@ internal class DefaultSendStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
+        if (submitJob?.isActive == true) return
         if (addressFieldState.text.isBlank()) {
             expandSection(SendSections.Address)
             emitFocusField(SendFocusField.ADDRESS)
@@ -91,259 +95,243 @@ internal class DefaultSendStrategy(
             return
         }
 
-        scope.launch {
-            showLoading()
-            try {
-                val vaultId =
-                    vaultIdProvider()
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                val selectedAccount =
-                    selectedAccountProvider()
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
+                    val rawInput = addressFieldState.text.asAddressInput()
+                    val labelCandidate = addressManager.dstAddressLabel.value ?: rawInput
+                    val dstLabel =
+                        labelCandidate.takeIf {
+                            it.isNotBlank() &&
+                                !chainAccountAddressRepository.isValid(chain, it) &&
+                                chainAccountAddressRepository.isValid(chain, dstAddress)
+                        }
 
-                val chain = selectedAccount.token.chain
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val gasFee = accountValidator.awaitGasFee()
-
-                if (!selectedAccount.token.allowZeroGas() && gasFee.value <= BigInteger.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_gas_fee)
-                    )
-                }
-                val rawInput = addressFieldState.text.asAddressInput()
-                val dstAddress =
-                    try {
-                        accountValidator.resolveDstAddress(rawInput, chain)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Timber.e(e)
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
                         throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.failed_to_resolve_address)
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
                     }
-                val labelCandidate = addressManager.dstAddressLabel.value ?: rawInput
-                val dstLabel =
-                    labelCandidate.takeIf {
-                        it.isNotBlank() &&
-                            !chainAccountAddressRepository.isValid(chain, it) &&
-                            chainAccountAddressRepository.isValid(chain, dstAddress)
-                    }
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
+                    val selectedTokenValue =
+                        selectedAccount.tokenValue
+                            ?: throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_no_token)
+                            )
 
-                val selectedTokenValue =
-                    selectedAccount.tokenValue
-                        ?: throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_token)
-                        )
+                    val memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() }
 
-                val memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() }
+                    val selectedToken = selectedAccount.token
 
-                val selectedToken = selectedAccount.token
-
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val srcAddress = selectedToken.address
-                val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
-
-                if (chain == Chain.Tron) {
-                    val isTronStakingOp =
-                        memo != null &&
-                            selectedToken.isNativeToken &&
-                            TRON_STAKING_MEMO_REGEX.matches(memo)
-                    if (!isTronStakingOp && srcAddress == dstAddress) {
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_same_address)
+                            UiText.StringResource(R.string.send_error_no_amount)
                         )
                     }
-                }
 
-                val specific =
-                    blockChainSpecificRepository
-                        .getSpecific(
-                            chain = chain,
-                            address = srcAddress,
-                            token = selectedToken,
-                            gasFee = gasFee,
-                            memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() },
-                            tokenAmountValue = tokenAmountInt,
-                            isSwap = false,
-                            isMaxAmountEnabled = isMaxAmount,
-                            isDeposit = false,
-                            dstAddress = dstAddress,
-                        )
-                        .let { applyGasSettings(it) }
-                        .let {
-                            applyBitcoinPlan(
-                                it,
-                                vaultId,
-                                selectedToken,
-                                dstAddress,
-                                tokenAmountInt,
-                                memo,
-                                chain,
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val srcAddress = selectedToken.address
+                    val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
+
+                    if (chain == Chain.Tron) {
+                        val isTronStakingOp =
+                            memo != null &&
+                                selectedToken.isNativeToken &&
+                                TRON_STAKING_MEMO_REGEX.matches(memo)
+                        if (!isTronStakingOp && srcAddress == dstAddress) {
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_same_address)
+                            )
+                        }
+                    }
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                                blockChainSpecificRepository.getSpecific(
+                                    chain = chain,
+                                    address = srcAddress,
+                                    token = selectedToken,
+                                    gasFee = gasFee,
+                                    memo =
+                                        memoFieldState.text.toString().takeIf { it.isNotEmpty() },
+                                    tokenAmountValue = tokenAmountInt,
+                                    isSwap = false,
+                                    isMaxAmountEnabled = isMaxAmount,
+                                    isDeposit = false,
+                                    dstAddress = dstAddress,
+                                )
+                            }
+                            .let { applyGasSettings(it) }
+                            .let {
+                                applyBitcoinPlan(
+                                    it,
+                                    vaultId,
+                                    selectedToken,
+                                    dstAddress,
+                                    tokenAmountInt,
+                                    memo,
+                                    chain,
+                                )
+                            }
+
+                    if (selectedToken.isNativeToken) {
+                        val defiType = defiTypeProvider()
+                        val availableTokenBalance =
+                            if (defiType == DeFiNavActions.UNFREEZE_TRX) {
+                                currentTronFrozenBalanceProvider()
+                                    ?.movePointRight(selectedToken.decimal)
+                                    ?.toBigInteger() ?: BigInteger.ZERO
+                            } else {
+                                getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                                    ?: BigInteger.ZERO
+                            }
+
+                        if (tokenAmountInt > availableTokenBalance) {
+                            val errorRes =
+                                if (defiType == DeFiNavActions.UNFREEZE_TRX) {
+                                    R.string.send_error_insufficient_frozen_balance
+                                } else {
+                                    R.string.send_error_insufficient_native_balance_with_fees
+                                }
+                            throw InvalidTransactionDataException(
+                                UiText.FormattedText(errorRes, listOf(selectedToken.ticker))
                             )
                         }
 
-                if (selectedToken.isNativeToken) {
-                    val defiType = defiTypeProvider()
-                    val availableTokenBalance =
                         if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                            currentTronFrozenBalanceProvider()
-                                ?.movePointRight(selectedToken.decimal)
-                                ?.toBigInteger() ?: BigInteger.ZERO
-                        } else {
-                            getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                                ?: BigInteger.ZERO
+                            val liquidForGas =
+                                getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
+                                    ?: BigInteger.ZERO
+                            if (liquidForGas < gasFee.value) {
+                                throw InvalidTransactionDataException(
+                                    UiText.FormattedText(
+                                        R.string.send_error_insufficient_native_balance_with_fees,
+                                        listOf(selectedToken.ticker),
+                                    )
+                                )
+                            }
                         }
 
-                    if (tokenAmountInt > availableTokenBalance) {
-                        val errorRes =
-                            if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                                R.string.send_error_insufficient_frozen_balance
-                            } else {
-                                R.string.send_error_insufficient_native_balance_with_fees
-                            }
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(errorRes, listOf(selectedToken.ticker))
-                        )
-                    }
+                        if (chain == Chain.Cardano) {
+                            chainValidationService.validateCardanoUTXORequirements(
+                                sendAmount = tokenAmountInt,
+                                totalBalance = selectedTokenValue.value,
+                                estimatedFee = gasFee.value,
+                            )
+                        }
 
-                    if (defiType == DeFiNavActions.UNFREEZE_TRX) {
-                        val liquidForGas =
-                            getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
-                                ?: BigInteger.ZERO
-                        if (liquidForGas < gasFee.value) {
+                        if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
+                            chainValidationService.validateBtcLikeAmount(
+                                tokenAmountInt,
+                                chain,
+                                planBtc.value,
+                            )
+                        }
+                    } else {
+                        val nativeTokenAccount =
+                            accounts.value.find {
+                                it.token.isNativeToken && it.token.chain == chain
+                            }
+                        val nativeTokenValue =
+                            nativeTokenAccount?.tokenValue?.value
+                                ?: throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.send_error_no_token)
+                                )
+
+                        if (selectedTokenValue.value < tokenAmountInt) {
                             throw InvalidTransactionDataException(
                                 UiText.FormattedText(
                                     R.string.send_error_insufficient_native_balance_with_fees,
                                     listOf(selectedToken.ticker),
                                 )
                             )
+                        } else if (nativeTokenValue < gasFee.value) {
+                            throw InvalidTransactionDataException(
+                                UiText.FormattedText(
+                                    R.string.insufficient_native_token,
+                                    listOf(nativeTokenAccount.token.ticker),
+                                )
+                            )
                         }
                     }
 
-                    if (chain == Chain.Cardano) {
-                        chainValidationService.validateCardanoUTXORequirements(
-                            sendAmount = tokenAmountInt,
-                            totalBalance = selectedTokenValue.value,
-                            estimatedFee = gasFee.value,
-                        )
-                    }
-
-                    if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
-                        chainValidationService.validateBtcLikeAmount(
-                            tokenAmountInt,
-                            chain,
-                            planBtc.value,
-                        )
-                    }
-                } else {
-                    val nativeTokenAccount =
-                        accounts.value.find { it.token.isNativeToken && it.token.chain == chain }
-                    val nativeTokenValue =
-                        nativeTokenAccount?.tokenValue?.value
-                            ?: throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.send_error_no_token)
-                            )
-
-                    if (selectedTokenValue.value < tokenAmountInt) {
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(
-                                R.string.send_error_insufficient_native_balance_with_fees,
-                                listOf(selectedToken.ticker),
+                    val evmGasSettings = gasSettings.value as? GasSettings.Eth
+                    val totalGasAndFee =
+                        gasFeeToEstimatedFee(
+                            GasFeeParams(
+                                gasLimit =
+                                    if (evmGasSettings != null) evmGasSettings.gasLimit
+                                    else BigInteger.valueOf(1),
+                                gasFee =
+                                    selectGasFeeForFeeEstimation(
+                                        chain = chain,
+                                        gasFee = gasFee,
+                                        planFee = planFee.value,
+                                        evmGasSettings = evmGasSettings,
+                                    ),
+                                selectedToken = selectedToken,
                             )
                         )
-                    } else if (nativeTokenValue < gasFee.value) {
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(
-                                R.string.insufficient_native_token,
-                                listOf(nativeTokenAccount.token.ticker),
-                            )
-                        )
-                    }
-                }
 
-                val evmGasSettings = gasSettings.value as? GasSettings.Eth
-                val totalGasAndFee =
-                    gasFeeToEstimatedFee(
-                        GasFeeParams(
-                            gasLimit =
-                                if (evmGasSettings != null) evmGasSettings.gasLimit
-                                else BigInteger.valueOf(1),
-                            gasFee =
-                                selectGasFeeForFeeEstimation(
-                                    chain = chain,
-                                    gasFee = gasFee,
-                                    planFee = planFee.value,
-                                    evmGasSettings = evmGasSettings,
+                    val transaction =
+                        Transaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            chainId = chain.raw,
+                            token = selectedToken,
+                            srcAddress = srcAddress,
+                            dstAddress = dstAddress,
+                            dstLabel = dstLabel,
+                            tokenValue =
+                                TokenValue(
+                                    value = tokenAmountInt,
+                                    unit = selectedTokenValue.unit,
+                                    decimals = selectedToken.decimal,
                                 ),
-                            selectedToken = selectedToken,
+                            fiatValue =
+                                FiatValue(
+                                    value =
+                                        fiatAmountFieldState.text.toString().toBigDecimalOrNull()
+                                            ?: BigDecimal.ZERO,
+                                    currency = appCurrency.value.ticker,
+                                ),
+                            gasFee = gasFee,
+                            blockChainSpecific = specific.blockChainSpecific,
+                            utxos = specific.utxos,
+                            memo = memo,
+                            estimatedFee = totalGasAndFee.formattedFiatValue,
+                            totalGas = totalGasAndFee.formattedTokenValue,
                         )
+
+                    transactionRepository.addTransaction(transaction)
+
+                    navigator.route(
+                        Route.VerifySend(transactionId = transaction.id, vaultId = vaultId)
                     )
-
-                val transaction =
-                    Transaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        chainId = chain.raw,
-                        token = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        dstLabel = dstLabel,
-                        tokenValue =
-                            TokenValue(
-                                value = tokenAmountInt,
-                                unit = selectedTokenValue.unit,
-                                decimals = selectedToken.decimal,
-                            ),
-                        fiatValue =
-                            FiatValue(
-                                value =
-                                    fiatAmountFieldState.text.toString().toBigDecimalOrNull()
-                                        ?: BigDecimal.ZERO,
-                                currency = appCurrency.value.ticker,
-                            ),
-                        gasFee = gasFee,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        utxos = specific.utxos,
-                        memo = memo,
-                        estimatedFee = totalGasAndFee.formattedFiatValue,
-                        totalGas = totalGasAndFee.formattedTokenValue,
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
                     )
-
-                transactionRepository.addTransaction(transaction)
-
-                navigator.route(Route.VerifySend(transactionId = transaction.id, vaultId = vaultId))
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 
     private fun applyGasSettings(it: BlockChainSpecificAndUtxo): BlockChainSpecificAndUtxo {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -38,6 +38,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -107,17 +108,6 @@ internal class DefaultSendStrategy(
 
                 val chain = selectedAccount.token.chain
 
-                if (
-                    !chainAccountAddressRepository.isValid(
-                        chain,
-                        addressFieldState.text.asAddressInput(),
-                    )
-                ) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
                 val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
 
                 if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
@@ -137,6 +127,8 @@ internal class DefaultSendStrategy(
                 val dstAddress =
                     try {
                         accountValidator.resolveDstAddress(rawInput, chain)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e)
                         throw InvalidTransactionDataException(
@@ -344,6 +336,8 @@ internal class DefaultSendStrategy(
                 navigator.route(Route.VerifySend(transactionId = transaction.id, vaultId = vaultId))
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -1,0 +1,408 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.allowZeroGas
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.TransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.AddressManager
+import com.vultisig.wallet.ui.models.send.AmountManager
+import com.vultisig.wallet.ui.models.send.ChainValidationService
+import com.vultisig.wallet.ui.models.send.GasSettings
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.SendFocusField
+import com.vultisig.wallet.ui.models.send.SendSections
+import com.vultisig.wallet.ui.models.send.selectGasFeeForFeeEstimation
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asAddressInput
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import wallet.core.jni.proto.Bitcoin
+
+internal class DefaultSendStrategy(
+    private val scope: CoroutineScope,
+    private val addressFieldState: TextFieldState,
+    private val tokenAmountFieldState: TextFieldState,
+    private val fiatAmountFieldState: TextFieldState,
+    private val memoFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val transactionRepository: TransactionRepository,
+    private val bitcoinPlanService: BitcoinPlanService,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val chainValidationService: ChainValidationService,
+    private val addressManager: AddressManager,
+    private val amountManager: AmountManager,
+    private val gasSettings: StateFlow<GasSettings?>,
+    private val planBtc: MutableStateFlow<Bitcoin.TransactionPlan?>,
+    private val planFee: MutableStateFlow<Long?>,
+    private val accounts: StateFlow<List<Account>>,
+    private val appCurrency: StateFlow<AppCurrency>,
+    private val vaultIdProvider: () -> String?,
+    private val selectedAccountProvider: () -> Account?,
+    private val defiTypeProvider: () -> DeFiNavActions?,
+    private val currentTronFrozenBalanceProvider: () -> BigDecimal?,
+    private val navigator: Navigator<Destination>,
+    private val expandSection: (SendSections) -> Unit,
+    private val emitFocusField: (SendFocusField) -> Unit,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        if (addressFieldState.text.isBlank()) {
+            expandSection(SendSections.Address)
+            emitFocusField(SendFocusField.ADDRESS)
+            return
+        }
+        if (tokenAmountFieldState.text.isBlank()) {
+            expandSection(SendSections.Amount)
+            emitFocusField(SendFocusField.AMOUNT)
+            return
+        }
+
+        scope.launch {
+            showLoading()
+            try {
+                val vaultId =
+                    vaultIdProvider()
+                        ?: throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_token)
+                        )
+
+                val selectedAccount =
+                    selectedAccountProvider()
+                        ?: throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_token)
+                        )
+
+                val chain = selectedAccount.token.chain
+
+                if (
+                    !chainAccountAddressRepository.isValid(
+                        chain,
+                        addressFieldState.text.asAddressInput(),
+                    )
+                ) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val gasFee = accountValidator.awaitGasFee()
+
+                if (!selectedAccount.token.allowZeroGas() && gasFee.value <= BigInteger.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_gas_fee)
+                    )
+                }
+                val rawInput = addressFieldState.text.asAddressInput()
+                val dstAddress =
+                    try {
+                        accountValidator.resolveDstAddress(rawInput, chain)
+                    } catch (e: Exception) {
+                        Timber.e(e)
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.failed_to_resolve_address)
+                        )
+                    }
+                val labelCandidate = addressManager.dstAddressLabel.value ?: rawInput
+                val dstLabel =
+                    labelCandidate.takeIf {
+                        it.isNotBlank() &&
+                            !chainAccountAddressRepository.isValid(chain, it) &&
+                            chainAccountAddressRepository.isValid(chain, dstAddress)
+                    }
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val selectedTokenValue =
+                    selectedAccount.tokenValue
+                        ?: throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_token)
+                        )
+
+                val memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() }
+
+                val selectedToken = selectedAccount.token
+
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val srcAddress = selectedToken.address
+                val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
+
+                if (chain == Chain.Tron) {
+                    val isTronStakingOp =
+                        memo != null &&
+                            selectedToken.isNativeToken &&
+                            TRON_STAKING_MEMO_REGEX.matches(memo)
+                    if (!isTronStakingOp && srcAddress == dstAddress) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_same_address)
+                        )
+                    }
+                }
+
+                val specific =
+                    blockChainSpecificRepository
+                        .getSpecific(
+                            chain = chain,
+                            address = srcAddress,
+                            token = selectedToken,
+                            gasFee = gasFee,
+                            memo = memoFieldState.text.toString().takeIf { it.isNotEmpty() },
+                            tokenAmountValue = tokenAmountInt,
+                            isSwap = false,
+                            isMaxAmountEnabled = isMaxAmount,
+                            isDeposit = false,
+                            dstAddress = dstAddress,
+                        )
+                        .let { applyGasSettings(it) }
+                        .let {
+                            applyBitcoinPlan(
+                                it,
+                                vaultId,
+                                selectedToken,
+                                dstAddress,
+                                tokenAmountInt,
+                                memo,
+                                chain,
+                            )
+                        }
+
+                if (selectedToken.isNativeToken) {
+                    val defiType = defiTypeProvider()
+                    val availableTokenBalance =
+                        if (defiType == DeFiNavActions.UNFREEZE_TRX) {
+                            currentTronFrozenBalanceProvider()
+                                ?.movePointRight(selectedToken.decimal)
+                                ?.toBigInteger() ?: BigInteger.ZERO
+                        } else {
+                            getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                                ?: BigInteger.ZERO
+                        }
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        val errorRes =
+                            if (defiType == DeFiNavActions.UNFREEZE_TRX) {
+                                R.string.send_error_insufficient_frozen_balance
+                            } else {
+                                R.string.send_error_insufficient_native_balance_with_fees
+                            }
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(errorRes, listOf(selectedToken.ticker))
+                        )
+                    }
+
+                    if (defiType == DeFiNavActions.UNFREEZE_TRX) {
+                        val liquidForGas =
+                            getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
+                                ?: BigInteger.ZERO
+                        if (liquidForGas < gasFee.value) {
+                            throw InvalidTransactionDataException(
+                                UiText.FormattedText(
+                                    R.string.send_error_insufficient_native_balance_with_fees,
+                                    listOf(selectedToken.ticker),
+                                )
+                            )
+                        }
+                    }
+
+                    if (chain == Chain.Cardano) {
+                        chainValidationService.validateCardanoUTXORequirements(
+                            sendAmount = tokenAmountInt,
+                            totalBalance = selectedTokenValue.value,
+                            estimatedFee = gasFee.value,
+                        )
+                    }
+
+                    if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
+                        chainValidationService.validateBtcLikeAmount(
+                            tokenAmountInt,
+                            chain,
+                            planBtc.value,
+                        )
+                    }
+                } else {
+                    val nativeTokenAccount =
+                        accounts.value.find { it.token.isNativeToken && it.token.chain == chain }
+                    val nativeTokenValue =
+                        nativeTokenAccount?.tokenValue?.value
+                            ?: throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_no_token)
+                            )
+
+                    if (selectedTokenValue.value < tokenAmountInt) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    } else if (nativeTokenValue < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.insufficient_native_token,
+                                listOf(nativeTokenAccount.token.ticker),
+                            )
+                        )
+                    }
+                }
+
+                val evmGasSettings = gasSettings.value as? GasSettings.Eth
+                val totalGasAndFee =
+                    gasFeeToEstimatedFee(
+                        GasFeeParams(
+                            gasLimit =
+                                if (evmGasSettings != null) evmGasSettings.gasLimit
+                                else BigInteger.valueOf(1),
+                            gasFee =
+                                selectGasFeeForFeeEstimation(
+                                    chain = chain,
+                                    gasFee = gasFee,
+                                    planFee = planFee.value,
+                                    evmGasSettings = evmGasSettings,
+                                ),
+                            selectedToken = selectedToken,
+                        )
+                    )
+
+                val transaction =
+                    Transaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        chainId = chain.raw,
+                        token = selectedToken,
+                        srcAddress = srcAddress,
+                        dstAddress = dstAddress,
+                        dstLabel = dstLabel,
+                        tokenValue =
+                            TokenValue(
+                                value = tokenAmountInt,
+                                unit = selectedTokenValue.unit,
+                                decimals = selectedToken.decimal,
+                            ),
+                        fiatValue =
+                            FiatValue(
+                                value =
+                                    fiatAmountFieldState.text.toString().toBigDecimalOrNull()
+                                        ?: BigDecimal.ZERO,
+                                currency = appCurrency.value.ticker,
+                            ),
+                        gasFee = gasFee,
+                        blockChainSpecific = specific.blockChainSpecific,
+                        utxos = specific.utxos,
+                        memo = memo,
+                        estimatedFee = totalGasAndFee.formattedFiatValue,
+                        totalGas = totalGasAndFee.formattedTokenValue,
+                    )
+
+                transactionRepository.addTransaction(transaction)
+
+                navigator.route(Route.VerifySend(transactionId = transaction.id, vaultId = vaultId))
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+
+    private fun applyGasSettings(it: BlockChainSpecificAndUtxo): BlockChainSpecificAndUtxo {
+        val gs = gasSettings.value ?: return it
+        val spec = it.blockChainSpecific
+        return when {
+            gs is GasSettings.Eth && spec is BlockChainSpecific.Ethereum ->
+                it.copy(
+                    blockChainSpecific =
+                        spec.copy(
+                            maxFeePerGasWei = gs.baseFee,
+                            priorityFeeWei = gs.priorityFee,
+                            gasLimit = gs.gasLimit,
+                        )
+                )
+
+            gs is GasSettings.UTXO && spec is BlockChainSpecific.UTXO ->
+                it.copy(blockChainSpecific = spec.copy(byteFee = gs.byteFee))
+
+            else -> it
+        }
+    }
+
+    private suspend fun applyBitcoinPlan(
+        specific: BlockChainSpecificAndUtxo,
+        vaultId: String,
+        selectedToken: Coin,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        memo: String?,
+        chain: Chain,
+    ): BlockChainSpecificAndUtxo {
+        if (chain.standard != TokenStandard.UTXO || chain == Chain.Cardano) return specific
+
+        planBtc.value
+            ?: bitcoinPlanService
+                .getPlan(
+                    vaultId = vaultId,
+                    selectedToken = selectedToken,
+                    dstAddress = dstAddress,
+                    tokenAmountInt = tokenAmountInt,
+                    specific = specific,
+                    memo = memo,
+                )
+                .also { plan ->
+                    planBtc.value = plan
+                    planFee.value = plan.fee
+                }
+
+        return chainValidationService.selectUtxosIfNeeded(
+            chain = chain,
+            specific = specific,
+            plan = planBtc.value,
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
@@ -1,0 +1,171 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_YTCY_AFFILIATE_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.YTCY_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import vultisig.keysign.v1.TransactionType
+
+internal class MintStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val accountsRepository: AccountsRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val defiTypeProvider: () -> DeFiNavActions?,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val nonDeFiBalance =
+                    accountsRepository
+                        .loadAddresses(vaultId)
+                        .firstOrNull()
+                        ?.flatMap { it.accounts }
+                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                        ?.tokenValue
+                        ?.value ?: BigInteger.ZERO
+
+                if (nonDeFiBalance < gasFee.value) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_insufficient_balance)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositMemo = "receive:${selectedToken.ticker.lowercase()}:$tokenAmount"
+
+                val specific =
+                    withContext(Dispatchers.IO) {
+                        blockChainSpecificRepository.getSpecific(
+                            chain,
+                            srcAddress,
+                            selectedToken,
+                            gasFee,
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                        )
+                    }
+
+                val tokenContract =
+                    when (defiTypeProvider()) {
+                        DeFiNavActions.MINT_YRUNE -> YRUNE_CONTRACT
+                        DeFiNavActions.MINT_YTCY -> YTCY_CONTRACT
+                        else -> throw RuntimeException("Invalid Deposit Parameter ")
+                    }
+
+                val depositTx =
+                    DepositTransaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        srcToken = selectedToken,
+                        srcAddress = srcAddress,
+                        dstAddress = dstAddress,
+                        memo = depositMemo,
+                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+                        estimatedFees = gasFee,
+                        estimateFeesFiat =
+                            gasFeeToEstimatedFee
+                                .fiatFeesFor(gasFee, selectedToken)
+                                .formattedFiatValue,
+                        blockChainSpecific = specific.blockChainSpecific,
+                        wasmExecuteContractPayload =
+                            ThorchainFunctions.mintYToken(
+                                fromAddress = srcAddress,
+                                stakingContract = YRUNE_YTCY_AFFILIATE_CONTRACT,
+                                tokenContract = tokenContract,
+                                denom = selectedToken.ticker.lowercase(),
+                                amount = tokenAmountInt,
+                            ),
+                    )
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -161,6 +162,8 @@ internal class MintStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -50,125 +51,136 @@ internal class MintStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositMemo = "receive:${selectedToken.ticker.lowercase()}:$tokenAmount"
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
                     }
 
-                val tokenContract =
-                    when (defiTypeProvider()) {
-                        DeFiNavActions.MINT_YRUNE -> YRUNE_CONTRACT
-                        DeFiNavActions.MINT_YTCY -> YTCY_CONTRACT
-                        else -> throw RuntimeException("Invalid Deposit Parameter ")
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
                     }
 
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            gasFeeToEstimatedFee
-                                .fiatFeesFor(gasFee, selectedToken)
-                                .formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        wasmExecuteContractPayload =
-                            ThorchainFunctions.mintYToken(
-                                fromAddress = srcAddress,
-                                stakingContract = YRUNE_YTCY_AFFILIATE_CONTRACT,
-                                tokenContract = tokenContract,
-                                denom = selectedToken.ticker.lowercase(),
-                                amount = tokenAmountInt,
-                            ),
+                    val nonDeFiBalance =
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .firstOrNull()
+                            ?.flatMap { it.accounts }
+                            ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                            ?.tokenValue
+                            ?.value ?: BigInteger.ZERO
+
+                    if (nonDeFiBalance < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_insufficient_balance)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    }
+
+                    val depositMemo = "receive:${selectedToken.ticker.lowercase()}:$tokenAmount"
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                            blockChainSpecificRepository.getSpecific(
+                                chain,
+                                srcAddress,
+                                selectedToken,
+                                gasFee,
+                                isSwap = false,
+                                isMaxAmountEnabled = false,
+                                isDeposit = true,
+                                transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                            )
+                        }
+
+                    val tokenContract =
+                        when (defiTypeProvider()) {
+                            DeFiNavActions.MINT_YRUNE -> YRUNE_CONTRACT
+                            DeFiNavActions.MINT_YTCY -> YTCY_CONTRACT
+                            else ->
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                        }
+
+                    val depositTx =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = selectedToken,
+                            srcAddress = srcAddress,
+                            dstAddress = dstAddress,
+                            memo = depositMemo,
+                            srcTokenValue =
+                                TokenValue(value = tokenAmountInt, token = selectedToken),
+                            estimatedFees = gasFee,
+                            estimateFeesFiat =
+                                gasFeeToEstimatedFee
+                                    .fiatFeesFor(gasFee, selectedToken)
+                                    .formattedFiatValue,
+                            blockChainSpecific = specific.blockChainSpecific,
+                            wasmExecuteContractPayload =
+                                ThorchainFunctions.mintYToken(
+                                    fromAddress = srcAddress,
+                                    stakingContract = YRUNE_YTCY_AFFILIATE_CONTRACT,
+                                    tokenContract = tokenContract,
+                                    denom = selectedToken.ticker.lowercase(),
+                                    amount = tokenAmountInt,
+                                ),
+                        )
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
                     )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
@@ -1,0 +1,179 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.ChainValidationService
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.YTCY_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import vultisig.keysign.v1.TransactionType
+
+internal class RedeemStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val slippageFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val accountsRepository: AccountsRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val chainValidationService: ChainValidationService,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val defiTypeProvider: () -> DeFiNavActions?,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val nonDeFiBalance =
+                    accountsRepository
+                        .loadAddresses(vaultId)
+                        .firstOrNull()
+                        ?.flatMap { it.accounts }
+                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                        ?.tokenValue
+                        ?.value ?: BigInteger.ZERO
+
+                if (nonDeFiBalance < gasFee.value) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_insufficient_balance)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositMemo = "sell:${selectedToken.contractAddress}:$tokenAmount"
+
+                val specific =
+                    withContext(Dispatchers.IO) {
+                        blockChainSpecificRepository.getSpecific(
+                            chain,
+                            srcAddress,
+                            selectedToken,
+                            gasFee,
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                        )
+                    }
+
+                val tokenContract =
+                    when (defiTypeProvider()) {
+                        DeFiNavActions.REDEEM_YRUNE -> YRUNE_CONTRACT
+                        DeFiNavActions.REDEEM_YTCY -> YTCY_CONTRACT
+                        else -> throw RuntimeException("Invalid Deposit Parameter ")
+                    }
+
+                val slippage = slippageFieldState.text.toString()
+                val slippageValidation = chainValidationService.validateSlippage(slippage)
+                if (slippageValidation != null) {
+                    throw InvalidTransactionDataException(slippageValidation)
+                }
+
+                val depositTx =
+                    DepositTransaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        srcToken = selectedToken,
+                        srcAddress = srcAddress,
+                        dstAddress = tokenContract,
+                        memo = depositMemo,
+                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+                        estimatedFees = gasFee,
+                        estimateFeesFiat =
+                            gasFeeToEstimatedFee
+                                .fiatFeesFor(gasFee, selectedToken)
+                                .formattedFiatValue,
+                        blockChainSpecific = specific.blockChainSpecific,
+                        wasmExecuteContractPayload =
+                            ThorchainFunctions.redeemYToken(
+                                fromAddress = srcAddress,
+                                tokenContract = tokenContract,
+                                slippage = chainValidationService.formatSlippage(slippage),
+                                denom = selectedToken.contractAddress,
+                                amount = tokenAmountInt,
+                            ),
+                    )
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,131 +53,142 @@ internal class RedeemStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val depositMemo = "sell:${selectedToken.contractAddress}:$tokenAmount"
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                            transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
                     }
 
-                val tokenContract =
-                    when (defiTypeProvider()) {
-                        DeFiNavActions.REDEEM_YRUNE -> YRUNE_CONTRACT
-                        DeFiNavActions.REDEEM_YTCY -> YTCY_CONTRACT
-                        else -> throw RuntimeException("Invalid Deposit Parameter ")
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
                     }
 
-                val slippage = slippageFieldState.text.toString()
-                val slippageValidation = chainValidationService.validateSlippage(slippage)
-                if (slippageValidation != null) {
-                    throw InvalidTransactionDataException(slippageValidation)
-                }
+                    val nonDeFiBalance =
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .firstOrNull()
+                            ?.flatMap { it.accounts }
+                            ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                            ?.tokenValue
+                            ?.value ?: BigInteger.ZERO
 
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = srcAddress,
-                        dstAddress = tokenContract,
-                        memo = depositMemo,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            gasFeeToEstimatedFee
-                                .fiatFeesFor(gasFee, selectedToken)
-                                .formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        wasmExecuteContractPayload =
-                            ThorchainFunctions.redeemYToken(
-                                fromAddress = srcAddress,
-                                tokenContract = tokenContract,
-                                slippage = chainValidationService.formatSlippage(slippage),
-                                denom = selectedToken.contractAddress,
-                                amount = tokenAmountInt,
-                            ),
+                    if (nonDeFiBalance < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_insufficient_balance)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    }
+
+                    val depositMemo = "sell:${selectedToken.contractAddress}:$tokenAmount"
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                            blockChainSpecificRepository.getSpecific(
+                                chain,
+                                srcAddress,
+                                selectedToken,
+                                gasFee,
+                                isSwap = false,
+                                isMaxAmountEnabled = false,
+                                isDeposit = true,
+                                transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                            )
+                        }
+
+                    val tokenContract =
+                        when (defiTypeProvider()) {
+                            DeFiNavActions.REDEEM_YRUNE -> YRUNE_CONTRACT
+                            DeFiNavActions.REDEEM_YTCY -> YTCY_CONTRACT
+                            else ->
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                        }
+
+                    val slippage = slippageFieldState.text.toString()
+                    val slippageValidation = chainValidationService.validateSlippage(slippage)
+                    if (slippageValidation != null) {
+                        throw InvalidTransactionDataException(slippageValidation)
+                    }
+
+                    val depositTx =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = selectedToken,
+                            srcAddress = srcAddress,
+                            dstAddress = tokenContract,
+                            memo = depositMemo,
+                            srcTokenValue =
+                                TokenValue(value = tokenAmountInt, token = selectedToken),
+                            estimatedFees = gasFee,
+                            estimateFeesFiat =
+                                gasFeeToEstimatedFee
+                                    .fiatFeesFor(gasFee, selectedToken)
+                                    .formattedFiatValue,
+                            blockChainSpecific = specific.blockChainSpecific,
+                            wasmExecuteContractPayload =
+                                ThorchainFunctions.redeemYToken(
+                                    fromAddress = srcAddress,
+                                    tokenContract = tokenContract,
+                                    slippage = chainValidationService.formatSlippage(slippage),
+                                    denom = selectedToken.contractAddress,
+                                    amount = tokenAmountInt,
+                                ),
+                        )
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
                     )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -169,6 +170,8 @@ internal class RedeemStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendSubmitStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendSubmitStrategy.kt
@@ -1,0 +1,5 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+internal fun interface SendSubmitStrategy {
+    fun submit()
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
@@ -29,6 +29,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,106 +53,116 @@ internal class StakeStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
-                    )
-                }
-
-                val depositTx =
-                    when (defiTypeProvider()) {
-                        DeFiNavActions.STAKE_RUJI ->
-                            createRujiStakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.STAKE_TCY,
-                        DeFiNavActions.STAKE_STCY ->
-                            createTCYStakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        else -> error("DeFi Type not supported ${defiTypeProvider()?.type}")
                     }
 
-                depositTransactionRepository.addTransaction(depositTx)
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
+                    }
 
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                    val nonDeFiBalance =
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .firstOrNull()
+                            ?.flatMap { it.accounts }
+                            ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                            ?.tokenValue
+                            ?.value ?: BigInteger.ZERO
+
+                    if (nonDeFiBalance < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_insufficient_balance)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    }
+
+                    val depositTx =
+                        when (defiTypeProvider()) {
+                            DeFiNavActions.STAKE_RUJI ->
+                                createRujiStakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            DeFiNavActions.STAKE_TCY,
+                            DeFiNavActions.STAKE_STCY ->
+                                createTCYStakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            else ->
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                        }
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                    )
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 
     private suspend fun createRujiStakeDepositTransaction(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -143,6 +144,8 @@ internal class StakeStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
@@ -1,0 +1,259 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_TCY_COMPOUND_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import vultisig.keysign.v1.TransactionType
+
+internal class StakeStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val accountsRepository: AccountsRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val defiTypeProvider: () -> DeFiNavActions?,
+    private val isAutocompoundProvider: () -> Boolean,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val nonDeFiBalance =
+                    accountsRepository
+                        .loadAddresses(vaultId)
+                        .firstOrNull()
+                        ?.flatMap { it.accounts }
+                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                        ?.tokenValue
+                        ?.value ?: BigInteger.ZERO
+
+                if (nonDeFiBalance < gasFee.value) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_insufficient_balance)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositTx =
+                    when (defiTypeProvider()) {
+                        DeFiNavActions.STAKE_RUJI ->
+                            createRujiStakeDepositTransaction(
+                                vaultId = vaultId,
+                                selectedToken = selectedToken,
+                                srcAddress = srcAddress,
+                                dstAddress = dstAddress,
+                                tokenAmountInt = tokenAmountInt,
+                                gasFee = gasFee,
+                                chain = chain,
+                            )
+
+                        DeFiNavActions.STAKE_TCY,
+                        DeFiNavActions.STAKE_STCY ->
+                            createTCYStakeDepositTransaction(
+                                vaultId = vaultId,
+                                selectedToken = selectedToken,
+                                srcAddress = srcAddress,
+                                dstAddress = dstAddress,
+                                tokenAmountInt = tokenAmountInt,
+                                gasFee = gasFee,
+                                chain = chain,
+                            )
+
+                        else -> error("DeFi Type not supported ${defiTypeProvider()?.type}")
+                    }
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+
+    private suspend fun createRujiStakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val depositMemo = "bond:${selectedToken.contractAddress}:$tokenAmountInt"
+
+        val specific =
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = depositMemo,
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload =
+                ThorchainFunctions.stakeRUJI(
+                    fromAddress = srcAddress,
+                    stakingContract = STAKING_RUJI_CONTRACT,
+                    denom = selectedToken.contractAddress,
+                    amount = tokenAmountInt,
+                ),
+        )
+    }
+
+    private suspend fun createTCYStakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val isAutoCompound = isAutocompoundProvider()
+        val stakingMemo = if (isAutoCompound) "" else "TCY+"
+
+        val specific =
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType =
+                        if (isAutoCompound) {
+                            TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
+                        } else {
+                            TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+                        },
+                )
+            }
+
+        val stakingPayload =
+            if (isAutoCompound) {
+                ThorchainFunctions.stakeTcyCompound(
+                    fromAddress = srcAddress,
+                    stakingContract = STAKING_TCY_COMPOUND_CONTRACT,
+                    denom = selectedToken.contractAddress,
+                    amount = tokenAmountInt,
+                )
+            } else {
+                null
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = stakingMemo,
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload = stakingPayload,
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SubmitHelpers.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SubmitHelpers.kt
@@ -1,0 +1,14 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import java.math.BigInteger
+
+internal suspend fun GasFeeToEstimatedFeeUseCase.fiatFeesFor(
+    gasFee: TokenValue,
+    selectedToken: Coin,
+): EstimatedGasFee =
+    invoke(GasFeeParams(BigInteger.valueOf(1), gasFee = gasFee, selectedToken = selectedToken))

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,6 +63,8 @@ internal class UnbondStrategy(
                                 providerBondFieldState.text.toString(),
                                 chain,
                             )
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Timber.e(e)
                             throw InvalidTransactionDataException(
@@ -153,6 +156,8 @@ internal class UnbondStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
@@ -24,6 +24,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -45,124 +46,132 @@ internal class UnbondStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
-    override fun submit() {
-        scope.launch {
-            try {
-                showLoading()
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+    private var submitJob: Job? = null
 
-                val providerAddress =
-                    if (providerBondFieldState.text.toString().isNotEmpty()) {
-                        try {
-                            addressParserRepository.resolveName(
-                                providerBondFieldState.text.toString(),
-                                chain,
+    override fun submit() {
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                try {
+                    showLoading()
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
+
+                    val providerAddress =
+                        if (providerBondFieldState.text.toString().isNotEmpty()) {
+                            try {
+                                addressParserRepository.resolveName(
+                                    providerBondFieldState.text.toString(),
+                                    chain,
+                                )
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                Timber.e(e)
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.failed_to_resolve_address)
+                                )
+                            }
+                        } else {
+                            ""
+                        }
+
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
+                        )
+                    }
+
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val selectedAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
                             )
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            Timber.e(e)
-                            throw InvalidTransactionDataException(
-                                UiText.StringResource(R.string.failed_to_resolve_address)
+                        )
+                    }
+
+                    val depositMemo =
+                        DepositMemo.Unbond.Thor(
+                            nodeAddress = dstAddress,
+                            srcTokenValue =
+                                TokenValue(value = tokenAmountInt, token = selectedToken),
+                            providerAddress = providerAddress.takeIf { it.isNotEmpty() },
+                        )
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                            blockChainSpecificRepository.getSpecific(
+                                chain,
+                                selectedAddress,
+                                selectedToken,
+                                gasFee,
+                                isSwap = false,
+                                isMaxAmountEnabled = false,
+                                isDeposit = true,
                             )
                         }
-                    } else {
-                        ""
-                    }
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val selectedAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
+                    val depositTx =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = selectedToken,
+                            srcAddress = selectedAddress,
+                            dstAddress = dstAddress,
+                            memo = depositMemo.toString(),
+                            srcTokenValue =
+                                TokenValue(
+                                    value =
+                                        if (chain == Chain.MayaChain) 1.toBigInteger()
+                                        else BigInteger.ZERO,
+                                    token = selectedToken,
+                                ),
+                            estimatedFees = gasFee,
+                            estimateFeesFiat =
+                                gasFeeToEstimatedFee
+                                    .fiatFeesFor(gasFee, selectedToken)
+                                    .formattedFiatValue,
+                            blockChainSpecific = specific.blockChainSpecific,
                         )
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
                     )
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
                 }
-
-                val depositMemo =
-                    DepositMemo.Unbond.Thor(
-                        nodeAddress = dstAddress,
-                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
-                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            selectedAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                    }
-
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = selectedToken,
-                        srcAddress = selectedAddress,
-                        dstAddress = dstAddress,
-                        memo = depositMemo.toString(),
-                        srcTokenValue =
-                            TokenValue(
-                                value =
-                                    if (chain == Chain.MayaChain) 1.toBigInteger()
-                                    else BigInteger.ZERO,
-                                token = selectedToken,
-                            ),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            gasFeeToEstimatedFee
-                                .fiatFeesFor(gasFee, selectedToken)
-                                .formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                    )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
             }
-        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
@@ -1,0 +1,163 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.DepositMemo
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+internal class UnbondStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val providerBondFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val addressParserRepository: AddressParserRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            try {
+                showLoading()
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                val providerAddress =
+                    if (providerBondFieldState.text.toString().isNotEmpty()) {
+                        try {
+                            addressParserRepository.resolveName(
+                                providerBondFieldState.text.toString(),
+                                chain,
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(e)
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.failed_to_resolve_address)
+                            )
+                        }
+                    } else {
+                        ""
+                    }
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val selectedAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositMemo =
+                    DepositMemo.Unbond.Thor(
+                        nodeAddress = dstAddress,
+                        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+                        providerAddress = providerAddress.takeIf { it.isNotEmpty() },
+                    )
+
+                val specific =
+                    withContext(Dispatchers.IO) {
+                        blockChainSpecificRepository.getSpecific(
+                            chain,
+                            selectedAddress,
+                            selectedToken,
+                            gasFee,
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                        )
+                    }
+
+                val depositTx =
+                    DepositTransaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        srcToken = selectedToken,
+                        srcAddress = selectedAddress,
+                        dstAddress = dstAddress,
+                        memo = depositMemo.toString(),
+                        srcTokenValue =
+                            TokenValue(
+                                value =
+                                    if (chain == Chain.MayaChain) 1.toBigInteger()
+                                    else BigInteger.ZERO,
+                                token = selectedToken,
+                            ),
+                        estimatedFees = gasFee,
+                        estimateFeesFiat =
+                            gasFeeToEstimatedFee
+                                .fiatFeesFor(gasFee, selectedToken)
+                                .formattedFiatValue,
+                        blockChainSpecific = specific.blockChainSpecific,
+                    )
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -141,7 +142,9 @@ internal class UnstakeStrategy(
                                     .firstOrNull()
                                     ?.flatMap { it.accounts }
                                     ?.find { it.token.id.equals(Coins.ThorChain.RUJI.id, true) }
-                                    ?: return@launch
+                                    ?: throw InvalidTransactionDataException(
+                                        UiText.StringResource(R.string.send_error_no_token)
+                                    )
 
                             createRUJIRewardsDepositTransaction(
                                 vaultId = vaultId,
@@ -164,6 +167,8 @@ internal class UnstakeStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {
@@ -230,16 +235,18 @@ internal class UnstakeStrategy(
         val memo = ThorchainFunctions.rujiRewardsMemo(selectedToken.contractAddress, tokenAmountInt)
 
         val specific =
-            blockChainSpecificRepository.getSpecific(
-                chain,
-                srcAddress,
-                selectedToken,
-                gasFee,
-                isSwap = false,
-                isMaxAmountEnabled = false,
-                isDeposit = true,
-                transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
-            )
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            }
 
         return DepositTransaction(
             id = UUID.randomUUID().toString(),
@@ -271,38 +278,42 @@ internal class UnstakeStrategy(
         gasFee: TokenValue,
         chain: Chain,
     ): DepositTransaction {
-        val percentage =
-            if (totalTokenAmount > BigInteger.ZERO) {
-                (tokenAmountInt.toDouble() / totalTokenAmount.toDouble()) * 100.0
-            } else {
-                100.0
-            }
-
         val isAutoCompound = isAutocompoundProvider()
         val unstakeMemo =
             if (isAutoCompound) {
                 ""
             } else {
-                val basisPoints = (percentage * 100).toInt().coerceIn(0, 10000)
+                val basisPoints =
+                    if (totalTokenAmount > BigInteger.ZERO) {
+                        tokenAmountInt
+                            .multiply(BigInteger.valueOf(10_000))
+                            .divide(totalTokenAmount)
+                            .toInt()
+                            .coerceIn(0, 10_000)
+                    } else {
+                        10_000
+                    }
                 ThorchainFunctions.tcyUnstakeMemo(basisPoints)
             }
 
         val specific =
-            blockChainSpecificRepository.getSpecific(
-                chain,
-                srcAddress,
-                selectedToken,
-                gasFee,
-                isSwap = false,
-                isMaxAmountEnabled = false,
-                isDeposit = true,
-                transactionType =
-                    if (isAutoCompound) {
-                        TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
-                    } else {
-                        TransactionType.TRANSACTION_TYPE_UNSPECIFIED
-                    },
-            )
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType =
+                        if (isAutoCompound) {
+                            TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
+                        } else {
+                            TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+                        },
+                )
+            }
 
         val unstakePayload =
             if (isAutoCompound) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -1,0 +1,333 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_TCY_COMPOUND_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import vultisig.keysign.v1.TransactionType
+
+internal class UnstakeStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val accountsRepository: AccountsRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val defiTypeProvider: () -> DeFiNavActions?,
+    private val isAutocompoundProvider: () -> Boolean,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val nonDeFiBalance =
+                    accountsRepository
+                        .loadAddresses(vaultId)
+                        .firstOrNull()
+                        ?.flatMap { it.accounts }
+                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                        ?.tokenValue
+                        ?.value ?: BigInteger.ZERO
+
+                if (nonDeFiBalance < gasFee.value) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_insufficient_balance)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val depositTx =
+                    when (defiTypeProvider()) {
+                        DeFiNavActions.UNSTAKE_RUJI ->
+                            createRUJIUnstakeDepositTransaction(
+                                vaultId = vaultId,
+                                selectedToken = selectedToken,
+                                srcAddress = srcAddress,
+                                dstAddress = dstAddress,
+                                tokenAmountInt = tokenAmountInt,
+                                gasFee = gasFee,
+                                chain = chain,
+                            )
+
+                        DeFiNavActions.UNSTAKE_TCY,
+                        DeFiNavActions.UNSTAKE_STCY ->
+                            createYTCUnstakeDepositTransaction(
+                                vaultId = vaultId,
+                                selectedToken = selectedToken,
+                                srcAddress = srcAddress,
+                                dstAddress = dstAddress,
+                                tokenAmountInt = tokenAmountInt,
+                                totalTokenAmount = availableTokenBalance,
+                                gasFee = gasFee,
+                                chain = chain,
+                            )
+
+                        DeFiNavActions.WITHDRAW_RUJI -> {
+                            val ruji =
+                                accountsRepository
+                                    .loadAddresses(vaultId)
+                                    .firstOrNull()
+                                    ?.flatMap { it.accounts }
+                                    ?.find { it.token.id.equals(Coins.ThorChain.RUJI.id, true) }
+                                    ?: return@launch
+
+                            createRUJIRewardsDepositTransaction(
+                                vaultId = vaultId,
+                                selectedToken = ruji.token,
+                                srcAddress = srcAddress,
+                                dstAddress = dstAddress,
+                                tokenAmountInt = tokenAmountInt,
+                                gasFee = gasFee,
+                                chain = chain,
+                            )
+                        }
+
+                        else -> error("DeFi Type not supported ${defiTypeProvider()?.type}")
+                    }
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+
+    private suspend fun createRUJIUnstakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val depositMemo = "withdraw:${selectedToken.contractAddress}:$tokenAmountInt"
+
+        val specific =
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = depositMemo,
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload =
+                ThorchainFunctions.unstakeRUJI(
+                    fromAddress = srcAddress,
+                    stakingContract = STAKING_RUJI_CONTRACT,
+                    amount = tokenAmountInt.toString(),
+                ),
+        )
+    }
+
+    private suspend fun createRUJIRewardsDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val memo = ThorchainFunctions.rujiRewardsMemo(selectedToken.contractAddress, tokenAmountInt)
+
+        val specific =
+            blockChainSpecificRepository.getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+                transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+            )
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = memo,
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload =
+                ThorchainFunctions.claimRujiRewards(
+                    fromAddress = srcAddress,
+                    stakingContract = STAKING_RUJI_CONTRACT,
+                ),
+        )
+    }
+
+    private suspend fun createYTCUnstakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        totalTokenAmount: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val percentage =
+            if (totalTokenAmount > BigInteger.ZERO) {
+                (tokenAmountInt.toDouble() / totalTokenAmount.toDouble()) * 100.0
+            } else {
+                100.0
+            }
+
+        val isAutoCompound = isAutocompoundProvider()
+        val unstakeMemo =
+            if (isAutoCompound) {
+                ""
+            } else {
+                val basisPoints = (percentage * 100).toInt().coerceIn(0, 10000)
+                ThorchainFunctions.tcyUnstakeMemo(basisPoints)
+            }
+
+        val specific =
+            blockChainSpecificRepository.getSpecific(
+                chain,
+                srcAddress,
+                selectedToken,
+                gasFee,
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+                transactionType =
+                    if (isAutoCompound) {
+                        TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT
+                    } else {
+                        TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+                    },
+            )
+
+        val unstakePayload =
+            if (isAutoCompound) {
+                ThorchainFunctions.unStakeTcyCompound(
+                    units = tokenAmountInt,
+                    stakingContract = STAKING_TCY_COMPOUND_CONTRACT,
+                    fromAddress = srcAddress,
+                )
+            } else {
+                null
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = unstakeMemo,
+            srcTokenValue = TokenValue(value = BigInteger.ZERO, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload = unstakePayload,
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -29,6 +29,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,129 +53,139 @@ internal class UnstakeStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiBalance =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
-                        ?.tokenValue
-                        ?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
-                    )
-                }
-
-                val depositTx =
-                    when (defiTypeProvider()) {
-                        DeFiNavActions.UNSTAKE_RUJI ->
-                            createRUJIUnstakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.UNSTAKE_TCY,
-                        DeFiNavActions.UNSTAKE_STCY ->
-                            createYTCUnstakeDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = selectedToken,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                totalTokenAmount = availableTokenBalance,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-
-                        DeFiNavActions.WITHDRAW_RUJI -> {
-                            val ruji =
-                                accountsRepository
-                                    .loadAddresses(vaultId)
-                                    .firstOrNull()
-                                    ?.flatMap { it.accounts }
-                                    ?.find { it.token.id.equals(Coins.ThorChain.RUJI.id, true) }
-                                    ?: throw InvalidTransactionDataException(
-                                        UiText.StringResource(R.string.send_error_no_token)
-                                    )
-
-                            createRUJIRewardsDepositTransaction(
-                                vaultId = vaultId,
-                                selectedToken = ruji.token,
-                                srcAddress = srcAddress,
-                                dstAddress = dstAddress,
-                                tokenAmountInt = tokenAmountInt,
-                                gasFee = gasFee,
-                                chain = chain,
-                            )
-                        }
-
-                        else -> error("DeFi Type not supported ${defiTypeProvider()?.type}")
                     }
 
-                depositTransactionRepository.addTransaction(depositTx)
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
+                    }
 
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                    val nonDeFiBalance =
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .firstOrNull()
+                            ?.flatMap { it.accounts }
+                            ?.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                            ?.tokenValue
+                            ?.value ?: BigInteger.ZERO
+
+                    if (nonDeFiBalance < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_insufficient_balance)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    }
+
+                    val depositTx =
+                        when (defiTypeProvider()) {
+                            DeFiNavActions.UNSTAKE_RUJI ->
+                                createRUJIUnstakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            DeFiNavActions.UNSTAKE_TCY,
+                            DeFiNavActions.UNSTAKE_STCY ->
+                                createYTCUnstakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    totalTokenAmount = availableTokenBalance,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            DeFiNavActions.WITHDRAW_RUJI -> {
+                                val ruji =
+                                    accountsRepository
+                                        .loadAddresses(vaultId)
+                                        .firstOrNull()
+                                        ?.flatMap { it.accounts }
+                                        ?.find { it.token.id.equals(Coins.ThorChain.RUJI.id, true) }
+                                        ?: throw InvalidTransactionDataException(
+                                            UiText.StringResource(R.string.send_error_no_token)
+                                        )
+
+                                createRUJIRewardsDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = ruji.token,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+                            }
+
+                            else ->
+                                throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.dialog_default_error_body)
+                                )
+                        }
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                    )
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 
     private suspend fun createRUJIUnstakeDepositTransaction(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
@@ -1,0 +1,164 @@
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.EthereumFunction
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_CIRCLE_WITHDRAW
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class WithdrawUsdcCircleStrategy(
+    private val scope: CoroutineScope,
+    private val tokenAmountFieldState: TextFieldState,
+    private val accountValidator: AccountValidator,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val accountsRepository: AccountsRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+    private val mscaAddressProvider: () -> String?,
+    private val showLoading: () -> Unit,
+    private val hideLoading: () -> Unit,
+    private val showError: (UiText) -> Unit,
+) : SendSubmitStrategy {
+
+    override fun submit() {
+        scope.launch {
+            showLoading()
+            try {
+                val validated = accountValidator.validate()
+                val vaultId = validated.vaultId
+                val chain = validated.chain
+                val dstAddress = validated.dstAddress
+                val selectedAccount = validated.selectedAccount
+                val gasFee = validated.gasFee
+
+                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_address)
+                    )
+                }
+
+                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_no_amount)
+                    )
+                }
+
+                val nonDeFiAccount =
+                    accountsRepository
+                        .loadAddresses(vaultId)
+                        .firstOrNull()
+                        ?.flatMap { it.accounts }
+                        ?.find { it.token.id.equals(Coins.Ethereum.ETH.id, true) }
+
+                val nonDeFiBalance = nonDeFiAccount?.tokenValue?.value ?: BigInteger.ZERO
+
+                if (nonDeFiBalance < gasFee.value) {
+                    throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.send_error_insufficient_balance)
+                    )
+                }
+
+                val selectedToken = selectedAccount.token
+                val srcAddress = selectedToken.address
+                val tokenAmountInt =
+                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                val availableTokenBalance =
+                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                        ?: BigInteger.ZERO
+
+                if (tokenAmountInt > availableTokenBalance) {
+                    throw InvalidTransactionDataException(
+                        UiText.FormattedText(
+                            R.string.send_error_insufficient_native_balance_with_fees,
+                            listOf(selectedToken.ticker),
+                        )
+                    )
+                }
+
+                val memo =
+                    EthereumFunction.withdrawCircleMSCA(
+                        vaultAddress =
+                            nonDeFiAccount?.token?.address ?: error("Vault Address Empty"),
+                        tokenAddress = Coins.Ethereum.USDC.contractAddress,
+                        amount = tokenAmountInt,
+                    )
+
+                val specific =
+                    withContext(Dispatchers.IO) {
+                        blockChainSpecificRepository.getSpecific(
+                            chain,
+                            srcAddress,
+                            selectedToken,
+                            gasFee,
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                        )
+                    }
+
+                val nativeCoin = nonDeFiAccount.token
+
+                val depositTx =
+                    DepositTransaction(
+                        id = UUID.randomUUID().toString(),
+                        vaultId = vaultId,
+                        srcToken = nativeCoin,
+                        srcAddress = srcAddress,
+                        dstAddress =
+                            mscaAddressProvider()
+                                ?: throw InvalidTransactionDataException(
+                                    UiText.StringResource(R.string.send_error_msca_not_deployed)
+                                ),
+                        memo = memo,
+                        srcTokenValue = TokenValue(value = BigInteger.ZERO, token = nativeCoin),
+                        estimatedFees = gasFee,
+                        estimateFeesFiat =
+                            gasFeeToEstimatedFee
+                                .fiatFeesFor(gasFee, selectedToken)
+                                .formattedFiatValue,
+                        blockChainSpecific = specific.blockChainSpecific,
+                        operation = OPERATION_CIRCLE_WITHDRAW,
+                    )
+
+                depositTransactionRepository.addTransaction(depositTx)
+
+                navigator.route(
+                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
+                )
+            } catch (e: InvalidTransactionDataException) {
+                showError(e.text)
+            } catch (e: Exception) {
+                showError(e.message?.asUiText() ?: UiText.Empty)
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
@@ -22,6 +22,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -154,6 +155,8 @@ internal class WithdrawUsdcCircleStrategy(
                 )
             } catch (e: InvalidTransactionDataException) {
                 showError(e.text)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 showError(e.message?.asUiText() ?: UiText.Empty)
             } finally {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
@@ -25,6 +25,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -46,122 +47,131 @@ internal class WithdrawUsdcCircleStrategy(
     private val showError: (UiText) -> Unit,
 ) : SendSubmitStrategy {
 
+    private var submitJob: Job? = null
+
     override fun submit() {
-        scope.launch {
-            showLoading()
-            try {
-                val validated = accountValidator.validate()
-                val vaultId = validated.vaultId
-                val chain = validated.chain
-                val dstAddress = validated.dstAddress
-                val selectedAccount = validated.selectedAccount
-                val gasFee = validated.gasFee
+        if (submitJob?.isActive == true) return
+        submitJob =
+            scope.launch {
+                showLoading()
+                try {
+                    val validated = accountValidator.validate()
+                    val vaultId = validated.vaultId
+                    val chain = validated.chain
+                    val dstAddress = validated.dstAddress
+                    val selectedAccount = validated.selectedAccount
+                    val gasFee = validated.gasFee
 
-                if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_address)
-                    )
-                }
-
-                val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
-                if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_no_amount)
-                    )
-                }
-
-                val nonDeFiAccount =
-                    accountsRepository
-                        .loadAddresses(vaultId)
-                        .firstOrNull()
-                        ?.flatMap { it.accounts }
-                        ?.find { it.token.id.equals(Coins.Ethereum.ETH.id, true) }
-
-                val nonDeFiBalance = nonDeFiAccount?.tokenValue?.value ?: BigInteger.ZERO
-
-                if (nonDeFiBalance < gasFee.value) {
-                    throw InvalidTransactionDataException(
-                        UiText.StringResource(R.string.send_error_insufficient_balance)
-                    )
-                }
-
-                val selectedToken = selectedAccount.token
-                val srcAddress = selectedToken.address
-                val tokenAmountInt =
-                    tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
-                val availableTokenBalance =
-                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
-                        ?: BigInteger.ZERO
-
-                if (tokenAmountInt > availableTokenBalance) {
-                    throw InvalidTransactionDataException(
-                        UiText.FormattedText(
-                            R.string.send_error_insufficient_native_balance_with_fees,
-                            listOf(selectedToken.ticker),
-                        )
-                    )
-                }
-
-                val memo =
-                    EthereumFunction.withdrawCircleMSCA(
-                        vaultAddress =
-                            nonDeFiAccount?.token?.address ?: error("Vault Address Empty"),
-                        tokenAddress = Coins.Ethereum.USDC.contractAddress,
-                        amount = tokenAmountInt,
-                    )
-
-                val specific =
-                    withContext(Dispatchers.IO) {
-                        blockChainSpecificRepository.getSpecific(
-                            chain,
-                            srcAddress,
-                            selectedToken,
-                            gasFee,
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
+                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_address)
                         )
                     }
 
-                val nativeCoin = nonDeFiAccount.token
+                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_no_amount)
+                        )
+                    }
 
-                val depositTx =
-                    DepositTransaction(
-                        id = UUID.randomUUID().toString(),
-                        vaultId = vaultId,
-                        srcToken = nativeCoin,
-                        srcAddress = srcAddress,
-                        dstAddress =
-                            mscaAddressProvider()
-                                ?: throw InvalidTransactionDataException(
-                                    UiText.StringResource(R.string.send_error_msca_not_deployed)
-                                ),
-                        memo = memo,
-                        srcTokenValue = TokenValue(value = BigInteger.ZERO, token = nativeCoin),
-                        estimatedFees = gasFee,
-                        estimateFeesFiat =
-                            gasFeeToEstimatedFee
-                                .fiatFeesFor(gasFee, selectedToken)
-                                .formattedFiatValue,
-                        blockChainSpecific = specific.blockChainSpecific,
-                        operation = OPERATION_CIRCLE_WITHDRAW,
+                    val nonDeFiAccount =
+                        accountsRepository
+                            .loadAddresses(vaultId)
+                            .firstOrNull()
+                            ?.flatMap { it.accounts }
+                            ?.find { it.token.id.equals(Coins.Ethereum.ETH.id, true) }
+                            ?: throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_no_token)
+                            )
+
+                    val nonDeFiBalance = nonDeFiAccount.tokenValue?.value ?: BigInteger.ZERO
+
+                    if (nonDeFiBalance < gasFee.value) {
+                        throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.send_error_insufficient_balance)
+                        )
+                    }
+
+                    val selectedToken = selectedAccount.token
+                    val srcAddress = selectedToken.address
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
+
+                    val availableTokenBalance =
+                        getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                            ?: BigInteger.ZERO
+
+                    if (tokenAmountInt > availableTokenBalance) {
+                        throw InvalidTransactionDataException(
+                            UiText.FormattedText(
+                                R.string.send_error_insufficient_native_balance_with_fees,
+                                listOf(selectedToken.ticker),
+                            )
+                        )
+                    }
+
+                    val nativeCoin = nonDeFiAccount.token
+
+                    val memo =
+                        EthereumFunction.withdrawCircleMSCA(
+                            vaultAddress = nativeCoin.address,
+                            tokenAddress = Coins.Ethereum.USDC.contractAddress,
+                            amount = tokenAmountInt,
+                        )
+
+                    val specific =
+                        withContext(Dispatchers.IO) {
+                            blockChainSpecificRepository.getSpecific(
+                                chain,
+                                srcAddress,
+                                selectedToken,
+                                gasFee,
+                                isSwap = false,
+                                isMaxAmountEnabled = false,
+                                isDeposit = true,
+                            )
+                        }
+
+                    val depositTx =
+                        DepositTransaction(
+                            id = UUID.randomUUID().toString(),
+                            vaultId = vaultId,
+                            srcToken = nativeCoin,
+                            srcAddress = srcAddress,
+                            dstAddress =
+                                mscaAddressProvider()
+                                    ?: throw InvalidTransactionDataException(
+                                        UiText.StringResource(R.string.send_error_msca_not_deployed)
+                                    ),
+                            memo = memo,
+                            srcTokenValue = TokenValue(value = BigInteger.ZERO, token = nativeCoin),
+                            estimatedFees = gasFee,
+                            estimateFeesFiat =
+                                gasFeeToEstimatedFee
+                                    .fiatFeesFor(gasFee, selectedToken)
+                                    .formattedFiatValue,
+                            blockChainSpecific = specific.blockChainSpecific,
+                            operation = OPERATION_CIRCLE_WITHDRAW,
+                        )
+
+                    depositTransactionRepository.addTransaction(depositTx)
+
+                    navigator.route(
+                        Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
                     )
-
-                depositTransactionRepository.addTransaction(depositTx)
-
-                navigator.route(
-                    Route.VerifyDeposit(transactionId = depositTx.id, vaultId = vaultId)
-                )
-            } catch (e: InvalidTransactionDataException) {
-                showError(e.text)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                showError(e.message?.asUiText() ?: UiText.Empty)
-            } finally {
-                hideLoading()
+                } catch (e: InvalidTransactionDataException) {
+                    showError(e.text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    showError(
+                        e.message?.asUiText()
+                            ?: UiText.StringResource(R.string.dialog_default_error_body)
+                    )
+                } finally {
+                    hideLoading()
+                }
             }
-        }
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelSubmitEvmTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelSubmitEvmTest.kt
@@ -72,7 +72,7 @@ internal class SendFormViewModelSubmitEvmTest {
         advanceUntilIdle()
         // tokenAmountFieldState is blank too, but the address check runs first.
 
-        vm.send()
+        vm.onClickContinue()
         advanceUntilIdle()
 
         assertEquals(SendSections.Address, vm.uiState.value.expandedSection)
@@ -87,7 +87,7 @@ internal class SendFormViewModelSubmitEvmTest {
             advanceUntilIdle()
             vm.addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
 
-            vm.send()
+            vm.onClickContinue()
             advanceUntilIdle()
 
             assertEquals(SendSections.Amount, vm.uiState.value.expandedSection)
@@ -102,27 +102,13 @@ internal class SendFormViewModelSubmitEvmTest {
         vm.addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
         vm.tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.1")
 
-        vm.send()
+        vm.onClickContinue()
         advanceUntilIdle()
 
         assertNotNull(vm.uiState.value.errorText)
         assertFalse(vm.uiState.value.isLoading)
         coVerify(exactly = 0) { navigator.route(any(), any()) }
         coVerify(exactly = 0) { transactionRepository.addTransaction(any()) }
-    }
-
-    @Test
-    fun `onClickContinue with no defiType routes to send (validation path)`() = runTest {
-        // Indirectly verifies the dispatch table: with defiType = null and blank inputs,
-        // onClickContinue must reach send() — observable via the same expandSection(Address)
-        // behavior tested above.
-        val vm = buildViewModel()
-        advanceUntilIdle()
-
-        vm.onClickContinue()
-        advanceUntilIdle()
-
-        assertEquals(SendSections.Address, vm.uiState.value.expandedSection)
     }
 
     private fun buildViewModel(): SendFormViewModel {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/AccountValidatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/AccountValidatorTest.kt
@@ -1,0 +1,163 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AccountValidatorTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+    private val addressFieldState = TextFieldState()
+    private val gasFee = MutableStateFlow<TokenValue?>(null)
+    private val addressParserRepository: AddressParserRepository = mockk(relaxed = true)
+
+    private var vaultId: String? = "vault-1"
+    private var account: Account? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `validate throws no_token when vaultId is null`() = runTest {
+        vaultId = null
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.send_error_no_token, ex.text.stringId())
+    }
+
+    @Test
+    fun `validate throws no_token when selectedAccount is null`() = runTest {
+        account = null
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.send_error_no_token, ex.text.stringId())
+    }
+
+    @Test
+    fun `validate throws no_amount when tokenAmount is empty`() = runTest {
+        account = ethAccount()
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.send_error_no_amount, ex.text.stringId())
+    }
+
+    @Test
+    fun `validate throws no_amount when tokenAmount is non-positive`() = runTest {
+        account = ethAccount()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0")
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.send_error_no_amount, ex.text.stringId())
+    }
+
+    @Test
+    fun `validate throws no_gas_fee when gasFee is zero on a non-zero-gas chain`() = runTest {
+        account = ethAccount()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        gasFee.value = TokenValue(value = BigInteger.ZERO, token = ethCoin())
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.send_error_no_gas_fee, ex.text.stringId())
+    }
+
+    @Test
+    fun `validate returns ValidatedAccount on happy path`() = runTest {
+        account = ethAccount()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        addressFieldState.setTextAndPlaceCursorAtEnd("0xabc123")
+        gasFee.value = TokenValue(value = BigInteger.valueOf(21000), token = ethCoin())
+        coEvery { addressParserRepository.resolveName("0xabc123", Chain.Ethereum) } returns
+            "0xresolved"
+
+        val result = build().validate()
+
+        assertEquals("vault-1", result.vaultId)
+        assertEquals(Chain.Ethereum, result.chain)
+        assertEquals("0xresolved", result.dstAddress)
+        assertEquals(BigInteger.valueOf(21000), result.gasFee.value)
+    }
+
+    @Test
+    fun `validate wraps resolveName failure in failed_to_resolve_address`() = runTest {
+        account = ethAccount()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        addressFieldState.setTextAndPlaceCursorAtEnd("notanaddr.eth")
+        gasFee.value = TokenValue(value = BigInteger.valueOf(21000), token = ethCoin())
+        coEvery { addressParserRepository.resolveName(any(), any()) } throws
+            RuntimeException("ENS lookup failed")
+
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(R.string.failed_to_resolve_address, ex.text.stringId())
+    }
+
+    @Test
+    fun `awaitGasFee returns cached value immediately`() = runTest {
+        account = ethAccount()
+        gasFee.value = TokenValue(value = BigInteger.valueOf(7), token = ethCoin())
+        val result = build().awaitGasFee()
+        assertEquals(BigInteger.valueOf(7), result.value)
+    }
+
+    private fun build(): AccountValidator =
+        AccountValidator(
+            vaultIdProvider = { vaultId },
+            selectedAccountProvider = { account },
+            tokenAmountFieldState = tokenAmountFieldState,
+            addressFieldState = addressFieldState,
+            gasFee = gasFee,
+            addressParserRepository = addressParserRepository,
+        )
+
+    private fun ethAccount(): Account =
+        Account(
+            token = ethCoin(),
+            tokenValue = TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000), ethCoin()),
+            fiatValue = null,
+            price = null,
+        )
+
+    private fun ethCoin(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xself",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/BondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/BondStrategyTest.kt
@@ -1,0 +1,169 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class BondStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+    private val providerBondFieldState = TextFieldState()
+    private val operatorFeesBondFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val addressParserRepository: AddressParserRepository = mockk(relaxed = true)
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces invalid_operator_fee error when fee is non-numeric`() = runTest {
+        givenValidatedAccount()
+        operatorFeesBondFieldState.setTextAndPlaceCursorAtEnd("abc")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_invalid_operator_fee, lastError.stringId())
+        coVerify(exactly = 0) { depositTransactionRepository.addTransaction(any()) }
+    }
+
+    @Test
+    fun `submit surfaces invalid_operator_fee error when fee is above 10000`() = runTest {
+        givenValidatedAccount()
+        operatorFeesBondFieldState.setTextAndPlaceCursorAtEnd("10001")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_invalid_operator_fee, lastError.stringId())
+    }
+
+    @Test
+    fun `submit accepts boundary operator fee 10000 and proceeds past validation`() = runTest {
+        givenValidatedAccount()
+        operatorFeesBondFieldState.setTextAndPlaceCursorAtEnd("10000")
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        // Boundary 10000 is valid; tokenAmount=0 fails the next check, surfacing no_amount.
+        assertEquals(R.string.send_error_no_amount, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_address error when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount() {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = runeCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), runeCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(BigInteger.valueOf(2_000_000), runeCoin()),
+                dstAddress = "thor-node-address",
+            )
+    }
+
+    private fun build(scope: CoroutineScope) =
+        BondStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            providerBondFieldState = providerBondFieldState,
+            operatorFeesBondFieldState = operatorFeesBondFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = addressParserRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun runeCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/BondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/BondStrategyTest.kt
@@ -8,8 +8,12 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -20,7 +24,11 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineScope
@@ -106,6 +114,24 @@ internal class BondStrategyTest {
     }
 
     @Test
+    fun `submit persists bond deposit with BOND memo and node dstAddress`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulBond()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("BOND:thor-node-address", tx.memo)
+            assertEquals("thor-node-address", tx.dstAddress)
+        }
+    }
+
+    @Test
     fun `submit surfaces no_address error when chain validates dst as invalid`() = runTest {
         givenValidatedAccount()
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
@@ -114,6 +140,51 @@ internal class BondStrategyTest {
         advanceUntilIdle()
 
         assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulBond() {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000), runeCoin())
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType =
+                        vultisig.keysign.v1.TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, runeCoin()),
+                fiatValue = mockk(relaxed = true),
+            )
     }
 
     private fun givenValidatedAccount() {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -1,0 +1,126 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.TransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.AddressManager
+import com.vultisig.wallet.ui.models.send.AmountManager
+import com.vultisig.wallet.ui.models.send.ChainValidationService
+import com.vultisig.wallet.ui.models.send.GasSettings
+import com.vultisig.wallet.ui.models.send.SendFocusField
+import com.vultisig.wallet.ui.models.send.SendSections
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wallet.core.jni.proto.Bitcoin
+
+internal class DefaultSendStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val addressFieldState = TextFieldState()
+    private val tokenAmountFieldState = TextFieldState()
+    private val fiatAmountFieldState = TextFieldState()
+    private val memoFieldState = TextFieldState()
+
+    private var expandedSection: SendSections? = null
+    private var emittedFocusField: SendFocusField? = null
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit with blank address expands Address and emits ADDRESS focus pre-launch`() = runTest {
+        build(this).submit()
+
+        assertEquals(SendSections.Address, expandedSection)
+        assertEquals(SendFocusField.ADDRESS, emittedFocusField)
+        assertNull(lastError)
+    }
+
+    @Test
+    fun `submit with non-blank address but blank amount expands Amount and emits AMOUNT focus`() =
+        runTest {
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
+
+            build(this).submit()
+
+            assertEquals(SendSections.Amount, expandedSection)
+            assertEquals(SendFocusField.AMOUNT, emittedFocusField)
+            assertNull(lastError)
+        }
+
+    @Test
+    fun `submit with blank address does not launch a coroutine`() = runTest {
+        // Accounts unset — if the strategy launched, it would surface no_token via showError.
+        build(this).submit()
+        // No advanceUntilIdle; the early return in submit() runs synchronously.
+        assertNull(lastError)
+    }
+
+    private fun build(scope: CoroutineScope) =
+        DefaultSendStrategy(
+            scope = scope,
+            addressFieldState = addressFieldState,
+            tokenAmountFieldState = tokenAmountFieldState,
+            fiatAmountFieldState = fiatAmountFieldState,
+            memoFieldState = memoFieldState,
+            accountValidator = mockk(relaxed = true),
+            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
+            transactionRepository = mockk<TransactionRepository>(relaxed = true),
+            bitcoinPlanService = mockk(relaxed = true),
+            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
+            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            chainValidationService = ChainValidationService(),
+            addressManager = mockk<AddressManager>(relaxed = true),
+            amountManager = mockk<AmountManager>(relaxed = true),
+            gasSettings = MutableStateFlow<GasSettings?>(null),
+            planBtc = MutableStateFlow<Bitcoin.TransactionPlan?>(null),
+            planFee = MutableStateFlow<Long?>(null),
+            accounts = MutableStateFlow<List<Account>>(emptyList()),
+            appCurrency = MutableStateFlow(AppCurrency.USD),
+            vaultIdProvider = { null },
+            selectedAccountProvider = { null },
+            defiTypeProvider = { null },
+            currentTronFrozenBalanceProvider = { null },
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            expandSection = { expandedSection = it },
+            emitFocusField = { emittedFocusField = it },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -5,7 +5,14 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.TransactionRepository
@@ -20,8 +27,16 @@ import com.vultisig.wallet.ui.models.send.SendSections
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,6 +44,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -47,6 +63,18 @@ internal class DefaultSendStrategyTest {
     private val fiatAmountFieldState = TextFieldState()
     private val memoFieldState = TextFieldState()
 
+    private val accountValidator: AccountValidator = mockk(relaxed = true)
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk(relaxed = true)
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk(relaxed = true)
+    private val transactionRepository: TransactionRepository = mockk(relaxed = true)
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk(relaxed = true)
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk(relaxed = true)
+    private val amountManager: AmountManager = mockk(relaxed = true)
+    private val addressManager: AddressManager = mockk(relaxed = true)
+    private val dstAddressLabelFlow = MutableStateFlow<String?>(null)
+
+    private var vaultId: String? = null
+    private var selectedAccount: Account? = null
     private var expandedSection: SendSections? = null
     private var emittedFocusField: SendFocusField? = null
     private var lastError: UiText? = null
@@ -54,6 +82,7 @@ internal class DefaultSendStrategyTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        every { addressManager.dstAddressLabel } returns dstAddressLabelFlow
     }
 
     @AfterEach
@@ -90,6 +119,96 @@ internal class DefaultSendStrategyTest {
         assertNull(lastError)
     }
 
+    @Test
+    fun `submit persists Transaction with parsed amount and resolved dst address`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val ethCoin = ethCoin()
+            val account =
+                Account(
+                    token = ethCoin,
+                    tokenValue =
+                        TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin),
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Ethereum,
+                    gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin),
+                    dstAddress = "0xdest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = BigInteger.ONE,
+                        priorityFeeWei = BigInteger.ONE,
+                        nonce = BigInteger.ZERO,
+                        gasLimit = BigInteger.valueOf(21000),
+                    )
+                )
+            every { amountManager.currentMaxAmount } returns BigDecimal.ONE
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin)
+            coEvery { gasFeeToEstimatedFee(any()) } returns
+                EstimatedGasFee(
+                    formattedFiatValue = "$0.10",
+                    formattedTokenValue = "0.0001 ETH",
+                    tokenValue = TokenValue(BigInteger.ONE, ethCoin),
+                    fiatValue = mockk(relaxed = true),
+                )
+
+            val captured = slot<Transaction>()
+            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            val tx = captured.captured
+            assertEquals("0xdest", tx.dstAddress)
+            // 0.5 ETH at 18 decimals = 5e17 wei.
+            assertEquals(BigInteger("500000000000000000"), tx.tokenValue.value)
+            assertNotNull(tx.blockChainSpecific)
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun ethCoin(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xself",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
     private fun build(scope: CoroutineScope) =
         DefaultSendStrategy(
             scope = scope,
@@ -97,23 +216,23 @@ internal class DefaultSendStrategyTest {
             tokenAmountFieldState = tokenAmountFieldState,
             fiatAmountFieldState = fiatAmountFieldState,
             memoFieldState = memoFieldState,
-            accountValidator = mockk(relaxed = true),
-            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
-            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
-            transactionRepository = mockk<TransactionRepository>(relaxed = true),
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            transactionRepository = transactionRepository,
             bitcoinPlanService = mockk(relaxed = true),
-            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
-            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
             chainValidationService = ChainValidationService(),
-            addressManager = mockk<AddressManager>(relaxed = true),
-            amountManager = mockk<AmountManager>(relaxed = true),
+            addressManager = addressManager,
+            amountManager = amountManager,
             gasSettings = MutableStateFlow<GasSettings?>(null),
             planBtc = MutableStateFlow<Bitcoin.TransactionPlan?>(null),
             planFee = MutableStateFlow<Long?>(null),
             accounts = MutableStateFlow<List<Account>>(emptyList()),
             appCurrency = MutableStateFlow(AppCurrency.USD),
-            vaultIdProvider = { null },
-            selectedAccountProvider = { null },
+            vaultIdProvider = { vaultId },
+            selectedAccountProvider = { selectedAccount },
             defiTypeProvider = { null },
             currentTronFrozenBalanceProvider = { null },
             navigator = mockk<Navigator<Destination>>(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/MintStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/MintStrategyTest.kt
@@ -1,0 +1,160 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MintStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val accountsRepository: AccountsRepository = mockk()
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this, DeFiNavActions.MINT_YRUNE).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces insufficient_balance when RUNE is below gasFee`() = runTest {
+        givenValidatedAccount(gasFeeValue = BigInteger.valueOf(10_000_000))
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1self",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = Coins.ThorChain.RUNE,
+                                    tokenValue =
+                                        TokenValue(
+                                            value = BigInteger.valueOf(1_000),
+                                            token = Coins.ThorChain.RUNE,
+                                        ),
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            )
+
+        build(this, DeFiNavActions.MINT_YRUNE).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = runeCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), runeCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(gasFeeValue, runeCoin()),
+                dstAddress = "thor-mint-contract",
+            )
+    }
+
+    private fun build(scope: CoroutineScope, defiType: DeFiNavActions) =
+        MintStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
+            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
+            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            defiTypeProvider = { defiType },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun runeCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/MintStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/MintStrategyTest.kt
@@ -5,13 +5,18 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -19,13 +24,24 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_YTCY_AFFILIATE_CONTRACT
+import com.vultisig.wallet.ui.screens.v2.defi.YTCY_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,6 +55,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import vultisig.keysign.v1.WasmExecuteContractPayload
 
 internal class MintStrategyTest {
 
@@ -50,16 +68,45 @@ internal class MintStrategyTest {
     private val accountValidator: AccountValidator = mockk()
     private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
     private val accountsRepository: AccountsRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
 
     private var lastError: UiText? = null
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        // Stub out ThorchainFunctions so the test doesn't load Trust Wallet Core
+        // JNI (Base64.encode); the strategy still passes the real arguments through,
+        // which is what we want to assert on.
+        mockkObject(ThorchainFunctions)
+        every {
+            ThorchainFunctions.mintYToken(
+                fromAddress = any(),
+                stakingContract = any(),
+                tokenContract = any(),
+                denom = any(),
+                amount = any(),
+            )
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(1),
+                    executeMsg = "encoded:${arg<String>(2)}",
+                    coins = emptyList(),
+                )
+            }
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -72,6 +119,48 @@ internal class MintStrategyTest {
         advanceUntilIdle()
 
         assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit MINT_YRUNE persists deposit with receive memo and YRUNE contract`() = runTest {
+        givenSuccessfulMintFlow()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+        build(this, DeFiNavActions.MINT_YRUNE).submit()
+        advanceUntilIdle()
+
+        assertEquals(null, lastError, "No error expected; got $lastError")
+        val tx = captured.captured
+        assertEquals("receive:rune:0.5", tx.memo)
+        assertEquals("thor-mint-contract", tx.dstAddress)
+        assertEquals(BigInteger.valueOf(50_000_000), tx.srcTokenValue.value)
+        val payload = tx.wasmExecuteContractPayload
+        assertNotNull(payload)
+        // Mint flows route execution through the affiliate contract; the YRUNE token
+        // contract is encoded in the executeMsg payload.
+        assertEquals(YRUNE_YTCY_AFFILIATE_CONTRACT, payload.contractAddress)
+        assertTrue(payload.executeMsg.contains(YRUNE_CONTRACT))
+        coVerify { navigator.route(any<Route.VerifyDeposit>()) }
+    }
+
+    @Test
+    fun `submit MINT_YTCY persists deposit with YTCY contract in executeMsg`() = runTest {
+        givenSuccessfulMintFlow(selectedToken = ytcyMintCoin())
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+        build(this, DeFiNavActions.MINT_YTCY).submit()
+        advanceUntilIdle()
+
+        val payload = captured.captured.wasmExecuteContractPayload
+        assertNotNull(payload)
+        assertEquals(YRUNE_YTCY_AFFILIATE_CONTRACT, payload.contractAddress)
+        assertTrue(payload.executeMsg.contains(YTCY_CONTRACT))
     }
 
     @Test
@@ -108,6 +197,76 @@ internal class MintStrategyTest {
         assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
     }
 
+    private fun givenSuccessfulMintFlow(selectedToken: Coin = runeCoin()) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = selectedToken,
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), selectedToken),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(BigInteger.valueOf(2_000_000), Coins.ThorChain.RUNE),
+                dstAddress = "thor-mint-contract",
+            )
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1self",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = Coins.ThorChain.RUNE,
+                                    tokenValue =
+                                        TokenValue(
+                                            value = BigInteger.valueOf(1_000_000_000),
+                                            token = Coins.ThorChain.RUNE,
+                                        ),
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            )
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000), selectedToken)
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                transactionType = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, Coins.ThorChain.RUNE),
+                fiatValue = mockk(relaxed = true),
+            )
+    }
+
     private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
         coEvery { accountValidator.validate() } returns
             ValidatedAccount(
@@ -132,11 +291,11 @@ internal class MintStrategyTest {
             accountValidator = accountValidator,
             chainAccountAddressRepository = chainAccountAddressRepository,
             accountsRepository = accountsRepository,
-            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
-            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
-            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
-            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
-            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
             defiTypeProvider = { defiType },
             showLoading = {},
             hideLoading = {},
@@ -154,6 +313,19 @@ internal class MintStrategyTest {
             priceProviderID = "thorchain",
             contractAddress = "",
             isNativeToken = true,
+        )
+
+    private fun ytcyMintCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "TCY",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "tcy",
+            contractAddress = "tcy-contract",
+            isNativeToken = false,
         )
 
     private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategyTest.kt
@@ -5,13 +5,18 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -20,13 +25,20 @@ import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.ChainValidationService
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.YRUNE_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,6 +52,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import vultisig.keysign.v1.WasmExecuteContractPayload
 
 internal class RedeemStrategyTest {
 
@@ -52,16 +66,40 @@ internal class RedeemStrategyTest {
     private val accountValidator: AccountValidator = mockk()
     private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
     private val accountsRepository: AccountsRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
 
     private var lastError: UiText? = null
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        mockkObject(ThorchainFunctions)
+        every {
+            ThorchainFunctions.redeemYToken(
+                fromAddress = any(),
+                tokenContract = any(),
+                slippage = any(),
+                denom = any(),
+                amount = any(),
+            )
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(1),
+                    executeMsg = "redeem-msg",
+                    coins = emptyList(),
+                )
+            }
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -74,6 +112,27 @@ internal class RedeemStrategyTest {
         advanceUntilIdle()
 
         assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit REDEEM_YRUNE persists deposit with redeem memo and YRUNE contract`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulRedeem()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            slippageFieldState.setTextAndPlaceCursorAtEnd("1.0")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.REDEEM_YRUNE).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("sell:yrune-contract:0.5", tx.memo)
+            // Redeem flows route the call through the YRUNE token contract directly.
+            assertEquals(YRUNE_CONTRACT, tx.dstAddress)
+            assertNotNull(tx.wasmExecuteContractPayload)
+        }
     }
 
     @Test
@@ -111,6 +170,73 @@ internal class RedeemStrategyTest {
         assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
     }
 
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulRedeem() {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1self",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = Coins.ThorChain.RUNE,
+                                    tokenValue =
+                                        TokenValue(
+                                            value = BigInteger.valueOf(2_000_000_000),
+                                            token = Coins.ThorChain.RUNE,
+                                        ),
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            )
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000), yRuneCoin())
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                transactionType = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, Coins.ThorChain.RUNE),
+                fiatValue = mockk(relaxed = true),
+            )
+    }
+
     private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
         coEvery { accountValidator.validate() } returns
             ValidatedAccount(
@@ -136,12 +262,12 @@ internal class RedeemStrategyTest {
             accountValidator = accountValidator,
             chainAccountAddressRepository = chainAccountAddressRepository,
             accountsRepository = accountsRepository,
-            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
-            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
-            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
             chainValidationService = ChainValidationService(),
-            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
-            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
             defiTypeProvider = { defiType },
             showLoading = {},
             hideLoading = {},

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategyTest.kt
@@ -1,0 +1,165 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.models.send.ChainValidationService
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RedeemStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+    private val slippageFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val accountsRepository: AccountsRepository = mockk()
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this, DeFiNavActions.REDEEM_YRUNE).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces insufficient_balance when RUNE is below gasFee`() = runTest {
+        givenValidatedAccount(gasFeeValue = BigInteger.valueOf(10_000_000))
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        slippageFieldState.setTextAndPlaceCursorAtEnd("1.0")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1self",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = Coins.ThorChain.RUNE,
+                                    tokenValue =
+                                        TokenValue(
+                                            value = BigInteger.valueOf(1_000),
+                                            token = Coins.ThorChain.RUNE,
+                                        ),
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            )
+
+        build(this, DeFiNavActions.REDEEM_YRUNE).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = yRuneCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), yRuneCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(gasFeeValue, Coins.ThorChain.RUNE),
+                dstAddress = "thor-redeem-contract",
+            )
+    }
+
+    private fun build(scope: CoroutineScope, defiType: DeFiNavActions) =
+        RedeemStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            slippageFieldState = slippageFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
+            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
+            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            chainValidationService = ChainValidationService(),
+            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            defiTypeProvider = { defiType },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun yRuneCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "yRUNE",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "yrune",
+            contractAddress = "yrune-contract",
+            isNativeToken = false,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
@@ -1,0 +1,179 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class StakeStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val accountsRepository: AccountsRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces no_address error when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this, DeFiNavActions.STAKE_RUJI).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_amount when amount is blank`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this, DeFiNavActions.STAKE_RUJI).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_amount, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces insufficient_balance when RUNE balance is below gasFee`() = runTest {
+        givenValidatedAccount(gasFeeValue = BigInteger.valueOf(10_000_000))
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        // RUNE account exists but its balance is below gasFee.
+        every { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(listOf(addressWithRune(BigInteger.valueOf(1_000))))
+
+        build(this, DeFiNavActions.STAKE_RUJI).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
+        coVerify(exactly = 0) { depositTransactionRepository.addTransaction(any()) }
+    }
+
+    private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = VAULT_ID,
+                selectedAccount =
+                    Account(
+                        token = rujiCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), rujiCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(gasFeeValue, rujiCoin()),
+                dstAddress = "thor-staking-contract",
+            )
+    }
+
+    private fun addressWithRune(runeBalance: BigInteger): Address =
+        Address(
+            chain = Chain.ThorChain,
+            address = "thor1self",
+            accounts =
+                listOf(
+                    Account(
+                        token = Coins.ThorChain.RUNE,
+                        tokenValue = TokenValue(value = runeBalance, token = Coins.ThorChain.RUNE),
+                        fiatValue = null,
+                        price = null,
+                    )
+                ),
+        )
+
+    private fun build(scope: CoroutineScope, defiType: DeFiNavActions) =
+        StakeStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            isAutocompoundProvider = { false },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun rujiCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUJI",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "ruji",
+            contractAddress = "ruji-contract",
+            isNativeToken = false,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
@@ -5,13 +5,18 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -19,14 +24,20 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,6 +51,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import vultisig.keysign.v1.WasmExecuteContractPayload
 
 internal class StakeStrategyTest {
 
@@ -62,10 +75,44 @@ internal class StakeStrategyTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        mockkObject(ThorchainFunctions)
+        every {
+            ThorchainFunctions.stakeRUJI(
+                fromAddress = any(),
+                stakingContract = any(),
+                denom = any(),
+                amount = any(),
+            )
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(1),
+                    executeMsg = "ruji-stake-msg",
+                    coins = emptyList(),
+                )
+            }
+        every {
+            ThorchainFunctions.stakeTcyCompound(
+                fromAddress = any(),
+                stakingContract = any(),
+                denom = any(),
+                amount = any(),
+            )
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(1),
+                    executeMsg = "tcy-stake-msg",
+                    coins = emptyList(),
+                )
+            }
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -92,6 +139,44 @@ internal class StakeStrategyTest {
     }
 
     @Test
+    fun `submit STAKE_RUJI persists deposit with bond memo and ruji staking contract`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulStake()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.STAKE_RUJI).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("bond:ruji-contract:50000000", tx.memo)
+            val payload = tx.wasmExecuteContractPayload
+            assertNotNull(payload)
+            assertEquals(STAKING_RUJI_CONTRACT, payload.contractAddress)
+            coVerify { depositTransactionRepository.addTransaction(any()) }
+        }
+    }
+
+    @Test
+    fun `submit STAKE_TCY persists empty memo deposit when not autocompounding`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulStake(selectedToken = tcyCoin())
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.STAKE_TCY).submit()
+            advanceUntilIdle()
+
+            // Non-autocompound TCY stake uses the legacy "TCY+" memo and no wasm payload.
+            assertEquals("TCY+", captured.captured.memo)
+        }
+    }
+
+    @Test
     fun `submit surfaces insufficient_balance when RUNE balance is below gasFee`() = runTest {
         givenValidatedAccount(gasFeeValue = BigInteger.valueOf(10_000_000))
         tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
@@ -106,6 +191,79 @@ internal class StakeStrategyTest {
         assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
         coVerify(exactly = 0) { depositTransactionRepository.addTransaction(any()) }
     }
+
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            io.mockk.unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulStake(selectedToken: Coin = rujiCoin()) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = VAULT_ID,
+                selectedAccount =
+                    Account(
+                        token = selectedToken,
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), selectedToken),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(BigInteger.valueOf(2_000_000), Coins.ThorChain.RUNE),
+                dstAddress = "thor-staking-contract",
+            )
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(listOf(addressWithRune(BigInteger.valueOf(1_000_000_000))))
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000), selectedToken)
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                transactionType = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, Coins.ThorChain.RUNE),
+                fiatValue = mockk(relaxed = true),
+            )
+    }
+
+    private fun tcyCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "TCY",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "tcy",
+            contractAddress = "tcy-contract",
+            isNativeToken = false,
+        )
 
     private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
         coEvery { accountValidator.validate() } returns

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategyTest.kt
@@ -1,0 +1,131 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class UnbondStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+    private val providerBondFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces no_address error when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_amount when amount is blank`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_amount, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount() {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = runeCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), runeCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(BigInteger.valueOf(2_000_000), runeCoin()),
+                dstAddress = "thor-node-address",
+            )
+    }
+
+    private fun build(scope: CoroutineScope) =
+        UnbondStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            providerBondFieldState = providerBondFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            addressParserRepository = mockk<AddressParserRepository>(relaxed = true),
+            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
+            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
+            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun runeCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategyTest.kt
@@ -3,12 +3,17 @@
 package com.vultisig.wallet.ui.models.send.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AddressParserRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -18,7 +23,11 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +53,11 @@ internal class UnbondStrategyTest {
 
     private val accountValidator: AccountValidator = mockk()
     private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
 
     private var lastError: UiText? = null
 
@@ -79,6 +93,69 @@ internal class UnbondStrategyTest {
         assertEquals(R.string.send_error_no_amount, lastError.stringId())
     }
 
+    @Test
+    fun `submit persists unbond deposit with UNBOND memo and node dstAddress`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulUnbond()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("UNBOND:thor-node-address:50000000", tx.memo)
+            assertEquals("thor-node-address", tx.dstAddress)
+        }
+    }
+
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulUnbond() {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000), runeCoin())
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType =
+                        vultisig.keysign.v1.TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, runeCoin()),
+                fiatValue = mockk(relaxed = true),
+            )
+    }
+
     private fun givenValidatedAccount() {
         coEvery { accountValidator.validate() } returns
             ValidatedAccount(
@@ -104,11 +181,11 @@ internal class UnbondStrategyTest {
             accountValidator = accountValidator,
             chainAccountAddressRepository = chainAccountAddressRepository,
             addressParserRepository = mockk<AddressParserRepository>(relaxed = true),
-            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
-            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
-            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
-            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
-            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
             showLoading = {},
             hideLoading = {},
             showError = { lastError = it },

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -5,13 +5,18 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -19,14 +24,21 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,6 +52,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import vultisig.keysign.v1.WasmExecuteContractPayload
 
 internal class UnstakeStrategyTest {
 
@@ -62,10 +76,40 @@ internal class UnstakeStrategyTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        mockkObject(ThorchainFunctions)
+        every {
+            ThorchainFunctions.unstakeRUJI(
+                fromAddress = any(),
+                amount = any(),
+                stakingContract = any(),
+            )
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(2),
+                    executeMsg = "withdraw-msg",
+                    coins = emptyList(),
+                )
+            }
+        every {
+            ThorchainFunctions.claimRujiRewards(fromAddress = any(), stakingContract = any())
+        } answers
+            {
+                WasmExecuteContractPayload(
+                    senderAddress = arg(0),
+                    contractAddress = arg(1),
+                    executeMsg = "claim-rewards-msg",
+                    coins = emptyList(),
+                )
+            }
+        every { ThorchainFunctions.rujiRewardsMemo(any(), any()) } returns "rewards-memo"
+        every { ThorchainFunctions.tcyUnstakeMemo(any()) } answers { "tcy-unstake:${arg<Int>(0)}" }
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -106,6 +150,66 @@ internal class UnstakeStrategyTest {
     }
 
     @Test
+    fun `submit UNSTAKE_RUJI persists deposit with withdraw memo and ruji staking contract`() =
+        runTest {
+            withMockedIoDispatcher {
+                givenSuccessfulFlow()
+                tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+                val captured = slot<DepositTransaction>()
+                coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns
+                    Unit
+
+                build(this, DeFiNavActions.UNSTAKE_RUJI).submit()
+                advanceUntilIdle()
+
+                val tx = captured.captured
+                assertEquals("withdraw:ruji-contract:50000000", tx.memo)
+                assertNotNull(tx.wasmExecuteContractPayload)
+                assertEquals(STAKING_RUJI_CONTRACT, tx.wasmExecuteContractPayload!!.contractAddress)
+            }
+        }
+
+    @Test
+    fun `submit UNSTAKE_TCY persists deposit with basis-point memo when not autocompounding`() =
+        runTest {
+            withMockedIoDispatcher {
+                givenSuccessfulFlow()
+                tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+                val captured = slot<DepositTransaction>()
+                coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns
+                    Unit
+
+                build(this, DeFiNavActions.UNSTAKE_TCY).submit()
+                advanceUntilIdle()
+
+                // Non-autocompound TCY unstake encodes basis points via tcyUnstakeMemo;
+                // 0.5/avail (0.5/availableTokenBalance) maps to ~5000 bps under the test fixture.
+                assertEquals("tcy-unstake:5000", captured.captured.memo)
+            }
+        }
+
+    @Test
+    fun `submit WITHDRAW_RUJI persists rewards-claim deposit when RUJI account exists`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(includeRuji = true)
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.WITHDRAW_RUJI).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("rewards-memo", tx.memo)
+            assertNotNull(tx.wasmExecuteContractPayload)
+            assertEquals(STAKING_RUJI_CONTRACT, tx.wasmExecuteContractPayload!!.contractAddress)
+        }
+    }
+
+    @Test
     fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
         givenValidatedAccount()
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
@@ -114,6 +218,79 @@ internal class UnstakeStrategyTest {
         advanceUntilIdle()
 
         assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulFlow(includeRuji: Boolean = false) {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(100_000_000), rujiCoin())
+        val accounts =
+            mutableListOf(
+                Account(
+                    token = Coins.ThorChain.RUNE,
+                    tokenValue =
+                        TokenValue(
+                            value = BigInteger.valueOf(2_000_000_000),
+                            token = Coins.ThorChain.RUNE,
+                        ),
+                    fiatValue = null,
+                    price = null,
+                )
+            )
+        if (includeRuji) {
+            accounts.add(
+                Account(
+                    token = Coins.ThorChain.RUJI,
+                    tokenValue =
+                        TokenValue(BigInteger.valueOf(1_000_000_000), Coins.ThorChain.RUJI),
+                    fiatValue = null,
+                    price = null,
+                )
+            )
+        }
+        every { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(
+                listOf(Address(chain = Chain.ThorChain, address = "thor1self", accounts = accounts))
+            )
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                transactionType = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.ZERO,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.01",
+                formattedTokenValue = "0.0001 RUNE",
+                tokenValue = TokenValue(BigInteger.ONE, Coins.ThorChain.RUNE),
+                fiatValue = mockk(relaxed = true),
+            )
     }
 
     private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -1,0 +1,189 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class UnstakeStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    private val accountsRepository: AccountsRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit on WITHDRAW_RUJI returns silently when no RUJI account exists`() = runTest {
+        // Setup: balance/RUNE checks pass, but the second loadAddresses lookup
+        // for the RUJI account returns no match — the strategy must early-return
+        // without surfacing an error and without saving a deposit.
+        givenValidatedAccount()
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(2_000_000_000), Coins.ThorChain.RUNE)
+        // RUNE account has plenty for gas. RUJI is absent.
+        every { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(listOf(addressWithRune(BigInteger.valueOf(2_000_000_000))))
+
+        build(this, DeFiNavActions.WITHDRAW_RUJI).submit()
+        advanceUntilIdle()
+
+        assertNull(lastError)
+        coVerify(exactly = 0) { depositTransactionRepository.addTransaction(any()) }
+        coVerify(exactly = 0) { navigator.route(any(), any()) }
+    }
+
+    @Test
+    fun `submit surfaces insufficient_balance when RUNE is below gasFee`() = runTest {
+        givenValidatedAccount(gasFeeValue = BigInteger.valueOf(10_000_000))
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(listOf(addressWithRune(BigInteger.valueOf(1_000))))
+
+        build(this, DeFiNavActions.UNSTAKE_RUJI).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this, DeFiNavActions.UNSTAKE_RUJI).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = VAULT_ID,
+                selectedAccount =
+                    Account(
+                        token = rujiCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), rujiCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.ThorChain,
+                gasFee = TokenValue(gasFeeValue, Coins.ThorChain.RUNE),
+                dstAddress = "thor-rewards-contract",
+            )
+    }
+
+    private fun addressWithRune(runeBalance: BigInteger): Address =
+        Address(
+            chain = Chain.ThorChain,
+            address = "thor1self",
+            accounts =
+                listOf(
+                    Account(
+                        token = Coins.ThorChain.RUNE,
+                        tokenValue = TokenValue(value = runeBalance, token = Coins.ThorChain.RUNE),
+                        fiatValue = null,
+                        price = null,
+                    )
+                ),
+        )
+
+    private fun build(scope: CoroutineScope, defiType: DeFiNavActions) =
+        UnstakeStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+            defiTypeProvider = { defiType },
+            isAutocompoundProvider = { false },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun rujiCoin(): Coin =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUJI",
+            logo = "",
+            address = "thor1self",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "ruji",
+            contractAddress = "ruji-contract",
+            isNativeToken = false,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -27,7 +27,6 @@ import io.mockk.every
 import io.mockk.mockk
 import java.math.BigInteger
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -71,10 +70,10 @@ internal class UnstakeStrategyTest {
     }
 
     @Test
-    fun `submit on WITHDRAW_RUJI returns silently when no RUJI account exists`() = runTest {
+    fun `submit on WITHDRAW_RUJI surfaces no_token error when no RUJI account exists`() = runTest {
         // Setup: balance/RUNE checks pass, but the second loadAddresses lookup
-        // for the RUJI account returns no match — the strategy must early-return
-        // without surfacing an error and without saving a deposit.
+        // for the RUJI account returns no match — the strategy must surface a
+        // user-facing error rather than silently no-op.
         givenValidatedAccount()
         tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
@@ -87,7 +86,7 @@ internal class UnstakeStrategyTest {
         build(this, DeFiNavActions.WITHDRAW_RUJI).submit()
         advanceUntilIdle()
 
-        assertNull(lastError)
+        assertEquals(R.string.send_error_no_token, lastError.stringId())
         coVerify(exactly = 0) { depositTransactionRepository.addTransaction(any()) }
         coVerify(exactly = 0) { navigator.route(any(), any()) }
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategyTest.kt
@@ -3,12 +3,20 @@
 package com.vultisig.wallet.ui.models.send.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -18,12 +26,20 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -43,6 +59,14 @@ internal class WithdrawUsdcCircleStrategyTest {
 
     private val accountValidator: AccountValidator = mockk()
     private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+    // Per-test stubbing on accountsRepository — relaxed mocks would silently swallow
+    // every loadAddresses() call regardless of what an ETH-account fixture sets up.
+    private val accountsRepository: AccountsRepository = mockk()
+    private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk()
+    private val getAvailableTokenBalance: GetAvailableTokenBalanceUseCase = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val depositTransactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
 
     private var mscaAddress: String? = null
     private var lastError: UiText? = null
@@ -50,10 +74,13 @@ internal class WithdrawUsdcCircleStrategyTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        mockkObject(EthereumFunction)
+        every { EthereumFunction.withdrawCircleMSCA(any(), any(), any()) } returns "0xencoded"
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -61,6 +88,9 @@ internal class WithdrawUsdcCircleStrategyTest {
     fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
         givenValidatedAccount()
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+        // No-op accountsRepository stub: if this test ever called loadAddresses, mockk
+        // would fail loudly instead of returning an empty flow as a relaxed mock would.
+        every { accountsRepository.loadAddresses(any()) } returns flowOf(emptyList())
 
         build(this).submit()
         advanceUntilIdle()
@@ -72,11 +102,113 @@ internal class WithdrawUsdcCircleStrategyTest {
     fun `submit surfaces no_amount when amount is blank`() = runTest {
         givenValidatedAccount()
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses(any()) } returns flowOf(emptyList())
 
         build(this).submit()
         advanceUntilIdle()
 
         assertEquals(R.string.send_error_no_amount, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_token when ETH account is missing from vault`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns flowOf(emptyList())
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_token, lastError.stringId())
+    }
+
+    @Test
+    fun `submit persists withdraw deposit with circle operation and msca dstAddress`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulWithdraw()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            mscaAddress = "0xMSCA"
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            assertEquals("0xMSCA", tx.dstAddress)
+            assertEquals("0xencoded", tx.memo)
+            // Withdraw flows always send 0 of the native ETH; the actual transfer is encoded
+            // in the memo and routed through the MSCA destination.
+            assertEquals(BigInteger.ZERO, tx.srcTokenValue.value)
+            assertNotNull(tx.operation)
+        }
+    }
+
+    private inline fun withMockedIoDispatcher(block: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            block()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun givenSuccessfulWithdraw() {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        every { accountsRepository.loadAddresses("vault-1") } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = Chain.Ethereum,
+                        address = "0xself",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = Coins.Ethereum.ETH,
+                                    tokenValue =
+                                        TokenValue(
+                                            value = BigInteger.valueOf(1_000_000_000),
+                                            token = Coins.Ethereum.ETH,
+                                        ),
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            )
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(2_000_000), usdcCoin())
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.Ethereum(
+                    maxFeePerGasWei = BigInteger.ONE,
+                    priorityFeeWei = BigInteger.ONE,
+                    nonce = BigInteger.ZERO,
+                    gasLimit = BigInteger.valueOf(21000),
+                )
+            )
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.10",
+                formattedTokenValue = "0.0001 ETH",
+                tokenValue = TokenValue(BigInteger.ONE, Coins.Ethereum.ETH),
+                fiatValue = mockk(relaxed = true),
+            )
     }
 
     private fun givenValidatedAccount() {
@@ -102,12 +234,12 @@ internal class WithdrawUsdcCircleStrategyTest {
             tokenAmountFieldState = tokenAmountFieldState,
             accountValidator = accountValidator,
             chainAccountAddressRepository = chainAccountAddressRepository,
-            accountsRepository = mockk<AccountsRepository>(relaxed = true),
-            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
-            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
-            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
-            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
-            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            accountsRepository = accountsRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            getAvailableTokenBalance = getAvailableTokenBalance,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
             mscaAddressProvider = { mscaAddress },
             showLoading = {},
             hideLoading = {},

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategyTest.kt
@@ -1,0 +1,131 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class WithdrawUsdcCircleStrategyTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val tokenAmountFieldState = TextFieldState()
+
+    private val accountValidator: AccountValidator = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+
+    private var mscaAddress: String? = null
+    private var lastError: UiText? = null
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, lastError.stringId())
+    }
+
+    @Test
+    fun `submit surfaces no_amount when amount is blank`() = runTest {
+        givenValidatedAccount()
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_amount, lastError.stringId())
+    }
+
+    private fun givenValidatedAccount() {
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount =
+                    Account(
+                        token = usdcCoin(),
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000), usdcCoin()),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                chain = Chain.Ethereum,
+                gasFee = TokenValue(BigInteger.valueOf(21000), usdcCoin()),
+                dstAddress = "0xdest",
+            )
+    }
+
+    private fun build(scope: CoroutineScope) =
+        WithdrawUsdcCircleStrategy(
+            scope = scope,
+            tokenAmountFieldState = tokenAmountFieldState,
+            accountValidator = accountValidator,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            accountsRepository = mockk<AccountsRepository>(relaxed = true),
+            blockChainSpecificRepository = mockk<BlockChainSpecificRepository>(relaxed = true),
+            getAvailableTokenBalance = mockk<GetAvailableTokenBalanceUseCase>(relaxed = true),
+            gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>(relaxed = true),
+            depositTransactionRepository = mockk<DepositTransactionRepository>(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            mscaAddressProvider = { mscaAddress },
+            showLoading = {},
+            hideLoading = {},
+            showError = { lastError = it },
+        )
+
+    private fun usdcCoin(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "USDC",
+            logo = "",
+            address = "0xself",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = "0xUSDC",
+            isNativeToken = false,
+        )
+
+    private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId
+}


### PR DESCRIPTION
## Summary

Phase 3 of the SendFormViewModel refactor (PR 1 #4377 + PR 2 #4393 already merged).


- Each `defiType` branch now lives behind a dedicated `SendSubmitStrategy` implementation under `ui/models/send/submit/`. The 8 submit functions, the 5 `create*DepositTransaction` helpers, the inline `accountValidation`/`awaitGasFee`/`getFeesFiatValue`/`getBitcoinTransactionPlan` helpers, and the `AccountValidation` data class all leave the VM. **SendFormViewModel.kt drops from 3261 → 1873 LOC.**
- Strategies are plain classes manually constructed in the VM `init` (matching the `AddressManager`/`AmountManager` precedent from PR 2). No Hilt multibinding — `defiType` is a closed enum and one-class-per-concern keeps the diff lift-and-shift.
- New shared collaborators: `AccountValidator` (replaces `accountValidation()`+`awaitGasFee()`) and `BitcoinPlanService` (still called by the VM's `collectPlanFee` flow).
- Public surface preserved: `send()` remains as a one-line passthrough so existing screen bindings and characterization tests keep working. `bond/unbond/unstake` (no external callers post-extraction) and the four previously-private submit functions are deleted.
- 29 new Phase C tests under `submit/`: AccountValidator validate() error branches plus one error-path test per strategy (no_address, no_amount, RUNE-balance-insufficient, operator-fee out of range, slippage, WITHDRAW_RUJI silent early-return, DefaultSend pre-launch expandSection+focus). Total send.* tests: **135**, all green.
- Same diff also clears the IDE warnings the trimmed VM exposed: unused `BondAddress` enum value, unused `calculateGasLimit`/`enableAdvanceGasUi` helpers, the cascade `if`-`else if` in `loadAccounts` (now a `when` over `defiType`), one redundant `R.string` qualifier, and the missing `@param:` use-site target on `chainLogo`.

**Deferred to a future PR**: the percentage/calculate functions (`chooseMaxTokenAmount`, `choosePercentageAmount`, `calculatePercentageWithAccurateFee`, `fetchPercentageOfAvailableBalance`). They share the `defiType` switch with submit but also write to `gasFee`/`specific` and orchestrate fee recalculation — a different concern that would double the size of this PR.

## Transaction link
 https://etherscan.io/tx/0x81b2cc9f32aaa9eb42b909ded2e6005a94b806a88ff8b3d352571bfb17520978
 
## Test plan

- [ ] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.send.*"` — expect 135 tests, all green
- [ ] `./gradlew :app:compileDebugKotlin` clean
- [ ] `./gradlew :app:ktfmtFormat` clean
- [ ] Manually exercise each defiType flow on emulator: regular send (EVM + UTXO + Tron), bond, unbond, stake (RUJI/TCY/STCY), unstake (RUJI/TCY/STCY/WITHDRAW_RUJI), mint (yRUNE/yTCY), redeem (yRUNE/yTCY), withdraw USDC Circle, Tron freeze/unfreeze. Verify that successful paths hit the right `Verify*` route and that error paths surface the expected error text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DeFi actions in Send: staking, bonding, unbonding, minting, redeeming, and USDC Circle withdrawals with end-to-end submission flows.

* **Improvements**
  * Stronger input validation and clearer error messages for send/DeFi flows.
  * Improved gas/fee estimation and balance checks to reduce failed transactions.
  * More consistent transaction construction and navigation to verification for smoother UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->