### PR TITLE
test(preview): add SelectChainPopup PreviewActivity entry (#4411)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -1036,6 +1036,7 @@ private fun SelectChainPopupPreview() {
                 isLongPressActive = true,
                 pressPosition = Offset(pressX, pressY),
             ),
+        key = { it.chain },
         onItemSelected = {},
         itemContent = { item, distanceFromCenter ->
             ChainSelectorPickerItem(item = item, distanceFromCenter = distanceFromCenter)

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -17,10 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
@@ -38,6 +41,9 @@ import com.vultisig.wallet.ui.components.SignTonDisplayView
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
 import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.components.v2.fastselection.SelectPopupUiModel
+import com.vultisig.wallet.ui.components.v2.fastselection.components.ChainSelectorPickerItem
+import com.vultisig.wallet.ui.components.v2.fastselection.components.SelectPopup
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
@@ -52,6 +58,7 @@ import com.vultisig.wallet.ui.models.swap.SwapFormUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
+import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.screens.TransactionDoneView
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
@@ -134,6 +141,7 @@ class PreviewActivity : ComponentActivity() {
                     "blockaid_hero_done_unverified" -> BlockaidHeroDoneUnverifiedPreview()
                     "blockaid_popup_high" -> BlockaidPopupHighRiskPreview()
                     "blockaid_popup_medium" -> BlockaidPopupMediumRiskPreview()
+                    "select_chain_popup" -> SelectChainPopupPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -997,6 +1005,43 @@ private fun blockaidHeroUnverifiedState() =
         // body / network failure).
         txScanStatus = TransactionScanStatus.NotStarted,
     )
+
+@Composable
+private fun SelectChainPopupPreview() {
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+
+    val networks =
+        listOf(
+            Chain.Ethereum.toNetworkUiModel(),
+            Chain.Bitcoin.toNetworkUiModel(),
+            Chain.Solana.toNetworkUiModel(),
+            Chain.ThorChain.toNetworkUiModel(),
+            Chain.MayaChain.toNetworkUiModel(),
+            Chain.BitcoinCash.toNetworkUiModel(),
+            Chain.Hyperliquid.toNetworkUiModel(),
+            Chain.TerraClassic.toNetworkUiModel(),
+        )
+
+    val pressX = with(density) { (configuration.screenWidthDp.dp / 2).toPx() }
+    val pressY = with(density) { (configuration.screenHeightDp.dp / 2).toPx() }
+
+    SwapScreen(state = SwapFormUiModel(), srcAmountTextFieldState = TextFieldState())
+
+    SelectPopup(
+        uiModel =
+            SelectPopupUiModel(
+                items = networks,
+                initialIndex = 2,
+                isLongPressActive = true,
+                pressPosition = Offset(pressX, pressY),
+            ),
+        onItemSelected = {},
+        itemContent = { item, distanceFromCenter ->
+            ChainSelectorPickerItem(item = item, distanceFromCenter = distanceFromCenter)
+        },
+    )
+}
 
 @Composable
 private fun ShareQrPreview(info: QrShareInfo) {


### PR DESCRIPTION
## Summary

- Adds a `SelectChainPopupPreview` entry to debug-only `PreviewActivity` so the fast-selection chain picker can be screencap'd without a real long-press gesture.
- Renders `SelectPopup` (the layer underneath `SelectChainPopup` — the higher-level wrapper requires NavController/Hilt plumbing that isn't worth recreating in a preview) with `isLongPressActive = true` and a mid-screen `pressPosition`, so the modal is visible on first composition.
- Mocked list covers ETH, BTC, SOL, THORChain, MayaChain, Bitcoin-Cash, Hyperliquid, TerraClassic — short + long names exercise the picker row width.
- `SwapScreen` with default `SwapFormUiModel` is rendered behind so the screenshot looks like the real parent screen.
- Debug source set only — no production code touched.

Closes #4411

## Test plan

- [ ] `./gradlew :app:compileDebugKotlin` succeeds
- [ ] Launch debug build with `adb shell am start -n com.vultisig.wallet.app.debug/com.vultisig.wallet.debug.PreviewActivity --es screen select_chain_popup` and confirm the chain picker modal renders centered with Solana selected
- [ ] `adb shell screencap` produces a usable screenshot for visual review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced an internal debug preview to showcase the chain-selection popup with fast-selection behavior, display available networks, simulate long-press positioning, and render the swap screen behind the selector for layout and interaction validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->