### PR TITLE
fix(evm): handle non-2xx RPC responses without crashing balance fetch (#4414)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -18,7 +18,9 @@ import com.vultisig.wallet.data.common.stripHexPrefix
 import com.vultisig.wallet.data.common.toKeccak256
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.Numeric
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.post
@@ -124,6 +126,13 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
             else getERC20Balance(coin.address, coin.contractAddress)
         } catch (e: SocketTimeoutException) {
             Timber.d("request time out, message: ${e.message}")
+            BigInteger.ZERO
+        } catch (e: NetworkException) {
+            Timber.d(
+                "RPC error fetching balance: status=%d message=%s",
+                e.httpStatusCode,
+                e.message,
+            )
             BigInteger.ZERO
         }
     }
@@ -487,7 +496,9 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         params: JsonArray,
         id: Int = 1,
     ): T =
-        http.post(rpcUrl) { setBody(RpcPayload(method = method, params = params, id = id)) }.body()
+        http
+            .post(rpcUrl) { setBody(RpcPayload(method = method, params = params, id = id)) }
+            .bodyOrThrow()
 
     private fun generateCustomTokenPayload(contractAddress: String): Pair<RpcPayload, RpcPayload> {
         val payload1 =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
@@ -1,0 +1,50 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class EvmApiBalanceTest {
+
+    private val nativeCoin =
+        Coin(
+            chain = Chain.Hyperliquid,
+            ticker = "ETH",
+            logo = "",
+            address = "0x0000000000000000000000000000000000000001",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    // Reproduces issue #4414: HyperEVM RPC proxy returns 403 with no Content-Type. Before the fix,
+    // the raw `.body<RpcResponse>()` call threw NoTransformationFoundException out of
+    // getETHBalance,
+    // surfacing in keysign as a misleading "Invalid QR code content" error.
+    @Test
+    fun `getBalance returns zero when RPC returns 403`() = runBlocking {
+        val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
+        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/")
+
+        assertEquals(BigInteger.ZERO, api.getBalance(nativeCoin))
+    }
+
+    @Test
+    fun `getBalance returns parsed amount on 200`() = runBlocking {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x5","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/")
+
+        assertEquals(BigInteger.valueOf(5), api.getBalance(nativeCoin))
+    }
+}


### PR DESCRIPTION
## Summary

- `https://api.vultisig.com/hyperevm/` was replying 403 with a null Content-Type, so the raw `.body<RpcResponse>()` in `EvmApi.fetch` threw `NoTransformationFoundException` out of `getETHBalance`. During keysign that bubbled up as a misleading "Invalid QR code content" + offline banner.
- Switched the shared `fetch<T>` helper to `bodyOrThrow<T>()` so non-2xx responses now throw a typed `NetworkException(statusCode, body)`.
- Extended `getBalance`'s catch block to handle `NetworkException`, returning `BigInteger.ZERO` and logging the status — matches the existing `SocketTimeoutException` recovery path so `BalanceRepository` / keysign refresh stop crashing on RPC errors.
- Added unit tests: 403 reproduction returns ZERO without throwing, and 200 still parses the result so the new catch can't accidentally swallow real responses.

Note: the misleading "Invalid QR code content" copy itself comes from a separate keysign error-classification path; with this fix the balance call no longer throws, so that classification is never reached. Tracing the message itself is out of scope for this ticket.

Closes #4414

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.EvmApiBalanceTest"` passes
- [x] `./gradlew :data:compileDebugKotlin :app:compileDebugKotlin` clean
- [ ] Manual: trigger a HyperEVM keysign while the upstream RPC is returning 403 — verify the flow no longer surfaces "Invalid QR code content" / offline banner
- [ ] Manual: regression check — a working chain (e.g. ETH) still shows correct balance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for blockchain network requests: network failures and invalid RPC responses are now caught, RPC error status/messages are logged, and balance retrieval returns zero instead of throwing.

* **Tests**
  * Added automated tests for balance retrieval covering failed RPC responses (e.g., forbidden/empty body) and successful RPC responses with parsed numeric results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->