### PR TITLE
Fix THORChain secured asset swap quotes

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -104,7 +104,7 @@ fun Coin.swapAssetName(): String =
         ) {
             "${chain.swapAssetName()}.${ticker}"
         } else if (chain == Chain.ThorChain) {
-            if (contractAddress.contains(Regex("""^\w+-\w+$"""))) contractAddress
+            if (isSecuredAsset()) contractAddress
             else "${chain.swapAssetName()}.${ticker}"
         } else {
             "${chain.swapAssetName()}.${ticker}-${contractAddress}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -104,8 +104,7 @@ fun Coin.swapAssetName(): String =
         ) {
             "${chain.swapAssetName()}.${ticker}"
         } else if (chain == Chain.ThorChain) {
-            if (isSecuredAsset()) contractAddress
-            else "${chain.swapAssetName()}.${ticker}"
+            if (isSecuredAsset()) contractAddress else "${chain.swapAssetName()}.${ticker}"
         } else {
             "${chain.swapAssetName()}.${ticker}-${contractAddress}"
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
@@ -67,8 +67,18 @@ class CoinSwapAssetNameTest {
 
     @Test
     fun `ThorChain secured asset address word-dash-word returned as-is`() {
-        val c = coin(Chain.ThorChain, "ETH", "eth-eth", isNativeToken = false)
-        assertEquals("eth-eth", c.swapAssetName())
+        listOf(
+                "BTC" to "btc-btc",
+                "ETH" to "eth-eth",
+                "LTC" to "ltc-ltc",
+                "DOGE" to "doge-doge",
+                "AVAX" to "avax-avax",
+                "BNB" to "bsc-bnb",
+            )
+            .forEach { (ticker, denom) ->
+                val c = coin(Chain.ThorChain, ticker, denom, isNativeToken = false)
+                assertEquals(denom, c.swapAssetName())
+            }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
@@ -78,10 +78,18 @@ class CoinSwapAssetNameTest {
     }
 
     @Test
-    fun `ThorChain address with multiple dashes does not match anchored regex`() {
-        // "abc-def-ghi" does not match ^\w+-\w+$ so falls through to THOR.ticker
-        val c = coin(Chain.ThorChain, "FOO", "abc-def-ghi", isNativeToken = false)
-        assertEquals("THOR.FOO", c.swapAssetName())
+    fun `ThorChain secured USDC address returned as-is`() {
+        val c =
+            coin(
+                Chain.ThorChain,
+                "USDC",
+                "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                isNativeToken = false,
+            )
+        assertEquals(
+            "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            c.swapAssetName(),
+        )
     }
 
     // swapAssetName — EVM non-native

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinSwapAssetNameTest.kt
@@ -86,10 +86,7 @@ class CoinSwapAssetNameTest {
                 "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                 isNativeToken = false,
             )
-        assertEquals(
-            "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-            c.swapAssetName(),
-        )
+        assertEquals("eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", c.swapAssetName())
     }
 
     // swapAssetName — EVM non-native


### PR DESCRIPTION
## Summary

- Use the raw THORChain secured-asset denom for swap quote asset names.
- Keep regular non-secured THORChain tokens on the existing `THOR.<ticker>` path.
- Add regression coverage for secured USDC (`eth-usdc-<contract>`).

## Issue

Secured USDC swaps on THORChain could request quotes as `THOR.USDC` instead of the actual secured denom, causing the quote API to fail with a missing pool.

## Simplify

- Removed the synthetic multi-dash regression case and kept the real production failure shape: `eth-usdc-0xa0...`.

## Test Plan

- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/paaaotc/Library/Android/sdk ./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.models.CoinSwapAssetNameTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of THORChain non-native secured assets so secured-denom names are preserved and other assets use the expected formatted swap name.

* **Tests**
  * Expanded test coverage for THORChain non-native secured assets, adding parameterized checks and explicit cases to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->