### PR TITLE
fix(ton): treat Duplicate msg_seqno as successful broadcast

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
@@ -56,10 +56,14 @@ internal class TonApiImpl @Inject constructor(private val http: HttpClient) : To
                 }
                 .bodyOrThrow<TonBroadcastTransactionResponseJson>()
         if (response.error != null) {
-            // Returning null for duplicate-message lets the caller fall back to the
-            // already-known hash via orKnownHash; treating it as an error would surface
-            // a spurious failure on retried broadcasts.
-            if (response.error.lowercase().contains(DUPLICATE_MESSAGE_MARKER)) {
+            // Returning null for these cases lets the caller fall back to the already-known hash
+            // via orKnownHash. Both errors indicate the tx (or an equivalent one with the same
+            // seqno) was already accepted — typically two devices broadcasting simultaneously.
+            val lowerError = response.error.lowercase()
+            if (
+                lowerError.contains(DUPLICATE_MESSAGE_MARKER) ||
+                    lowerError.contains(DUPLICATE_SEQNO_MARKER)
+            ) {
                 return null
             }
             error("Error broadcasting transaction: ${response.error}")
@@ -115,5 +119,6 @@ internal class TonApiImpl @Inject constructor(private val http: HttpClient) : To
     private companion object {
         const val BASE_URL = "https://api.vultisig.com/ton"
         const val DUPLICATE_MESSAGE_MARKER = "duplicate message"
+        const val DUPLICATE_SEQNO_MARKER = "duplicate msg_seqno"
     }
 }


### PR DESCRIPTION
## Summary
- Extends the existing duplicate-broadcast guard in `TonApiImpl.broadcastTransaction` to also match `"Duplicate msg_seqno"` lite-server errors
- When two devices sign the same TON transaction simultaneously, the second broadcast fails with this error because the first device already consumed the seqno — the transaction is on-chain and the result should be treated as a success
- Returning `null` lets the caller fall back to the pre-computed hash via `orKnownHash`, and `recoverIfAlreadyBroadcast` verifies on-chain presence before returning it

## Issue
Closes #4314

## Test Plan
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)
- [ ] Two-device TON keysign: both devices complete without error when the second broadcast receives `Duplicate msg_seqno`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcast reliability by treating additional duplicate indications (including a new sequence-number duplicate marker) as non-fatal, allowing the system to fall back to previously confirmed transaction hashes rather than failing outright.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4456)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->