### PR TITLE
fix: THORName lookup crashes when aliases is null in API response

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -451,9 +451,9 @@ constructor(
 
         val thorName = response.bodyOrThrow<ThorOwnerData>()
 
-        return thorName.aliases.any { alias ->
+        return thorName.aliases?.any { alias ->
             alias.chain.equals(THOR_CHAIN_NAME, ignoreCase = true) && alias.address.isNotBlank()
-        }
+        } ?: false
     }
 
     override suspend fun getReferralCodeInfo(code: String): ThorOwnerData {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorOwnerData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorOwnerData.kt
@@ -12,7 +12,7 @@ data class ThorOwnerData(
     @SerialName("preferred_asset") val preferredAsset: String,
     @SerialName("preferred_asset_swap_threshold_rune") val preferredAssetSwapThresholdRune: String,
     @SerialName("affiliate_collector_rune") val affiliateCollectorRune: String,
-    @SerialName("aliases") val aliases: List<Aliases> = emptyList(),
+    @SerialName("aliases") val aliases: List<Aliases>? = null,
 ) {
     /** A chain-specific alias address registered under a THORName. */
     @Serializable data class Aliases(val chain: String, val address: String)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
@@ -137,6 +137,50 @@ class ThorChainApiImplTest {
     }
 
     @Test
+    fun `existsReferralCode returns false when aliases is null in API response`() = runBlocking {
+        val body =
+            """
+            {
+              "name": "maya",
+              "expire_block_height": 36942828,
+              "owner": "thor19d9fem39wayv4ydpp7kgufda940acvepjqmqtl",
+              "preferred_asset": ".",
+              "preferred_asset_swap_threshold_rune": "0",
+              "affiliate_collector_rune": "0",
+              "aliases": null
+            }
+            """
+                .trimIndent()
+        val api = newApi(HttpStatusCode.OK, body)
+
+        val result = api.existsReferralCode("maya")
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `existsReferralCode returns true when aliases contains THOR chain entry`() = runBlocking {
+        val body =
+            """
+            {
+              "name": "vultisig",
+              "expire_block_height": 36942828,
+              "owner": "thor19d9fem39wayv4ydpp7kgufda940acvepjqmqtl",
+              "preferred_asset": ".",
+              "preferred_asset_swap_threshold_rune": "0",
+              "affiliate_collector_rune": "0",
+              "aliases": [{"chain": "THOR", "address": "thor1abc"}]
+            }
+            """
+                .trimIndent()
+        val api = newApi(HttpStatusCode.OK, body)
+
+        val result = api.existsReferralCode("vultisig")
+
+        assertEquals(true, result)
+    }
+
+    @Test
     fun `broadcastTransaction throws on non-zero non-mempool-cache code`() {
         val body =
             """


### PR DESCRIPTION
## Summary
- Make `ThorOwnerData.aliases` nullable (`List<Aliases>?`) so kotlinx.serialization accepts `"aliases": null` from the API
- Guard the single call-site in `existsReferralCode` with a safe call (`?.any { … } ?: false`)
- Add two unit tests covering the null-aliases deserialization case and the happy path

## Issue
Closes #4172

## Root Cause
kotlinx.serialization only uses a field's default value when the key is **absent** from JSON. When THORNode returns `"aliases": null` explicitly, deserializing into a non-nullable `List<Aliases>` throws `JsonConvertException` even though the HTTP response is 200 OK.

## Test Plan
- [x] New unit tests pass (`./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.ThorChainApiImplTest"`)
- [x] Lint passes (`./gradlew lint`)
- [ ] Manual: look up THORName `maya` on the Referral screen — lookup should succeed without error

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referral-code validation to handle missing or absent alias data from the blockchain provider, preventing errors and improving app stability.
* **Tests**
  * Added tests covering missing alias responses and valid alias detection to ensure consistent behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4457)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->