### PR TITLE
fix: Cosmos 404 treated as Pending instead of NotFound

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -163,6 +163,7 @@ internal class CosmosApiImp(
 
     override suspend fun getTxStatus(txHash: String): CosmosTxStatusJson? {
         val response = httpClient.get("$rpcEndpoint/cosmos/tx/v1beta1/txs/$txHash")
+        if (response.status.value == 404) return null
         return response.bodyOrThrow<CosmosTxStatusJson>()
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
@@ -1,0 +1,60 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.utils.CosmosThorChainResponseSerializerImpl
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class CosmosApiTest {
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    @Test
+    fun `getTxStatus returns null on 404 without throwing`() = runBlocking {
+        val api = cosmosApi(MockEngine { respond(content = "", status = HttpStatusCode.NotFound) })
+
+        assertNull(api.getTxStatus("ABC123"))
+    }
+
+    @Test
+    fun `getTxStatus returns parsed response on 200`() = runBlocking {
+        val api =
+            cosmosApi(
+                MockEngine {
+                    respond(
+                        content = """{"tx_response":{"height":"42","txhash":"ABC123","code":0}}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val result = api.getTxStatus("ABC123")
+
+        assertEquals("42", result?.txResponse?.height)
+        assertEquals("ABC123", result?.txResponse?.txHash)
+        assertEquals(0, result?.txResponse?.code)
+    }
+
+    private fun cosmosApi(engine: MockEngine): CosmosApi {
+        val json = Json { ignoreUnknownKeys = true }
+        return CosmosApiImp(
+            HttpClient(engine) { install(ContentNegotiation) { json(json) } },
+            "https://example.test",
+            json,
+            CosmosThorChainResponseSerializerImpl(json),
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/CosmosStatusProviderTest.kt
@@ -1,0 +1,89 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.models.cosmos.CosmosTxStatusJson
+import com.vultisig.wallet.data.api.models.cosmos.TxResponse
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class CosmosStatusProviderTest {
+
+    private val cosmosApi = mockk<CosmosApi>()
+    private val cosmosApiFactory =
+        mockk<CosmosApiFactory> { every { createCosmosApi(any()) } returns cosmosApi }
+    private val provider = CosmosStatusProvider(cosmosApiFactory)
+
+    @Test
+    fun `404 response returns NotFound`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } returns null
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.NotFound, result)
+    }
+
+    @Test
+    fun `confirmed transaction returns Confirmed`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } returns
+            CosmosTxStatusJson(
+                txResponse = TxResponse(height = "12345", txHash = "DEADBEEF", code = 0)
+            )
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.Confirmed, result)
+    }
+
+    @Test
+    fun `failed transaction returns Failed with rawLog`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } returns
+            CosmosTxStatusJson(
+                txResponse =
+                    TxResponse(
+                        height = "12345",
+                        txHash = "DEADBEEF",
+                        code = 5,
+                        rawLog = "insufficient funds",
+                    )
+            )
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.Failed("insufficient funds"), result)
+    }
+
+    @Test
+    fun `zero height returns Pending`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } returns
+            CosmosTxStatusJson(txResponse = TxResponse(height = "0", txHash = "DEADBEEF", code = 0))
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `null txResponse returns Pending`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } returns CosmosTxStatusJson(txResponse = null)
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `network error returns Pending`() = runTest {
+        coEvery { cosmosApi.getTxStatus(any()) } throws RuntimeException("network error")
+
+        val result = provider.checkStatus("DEADBEEF", Chain.GaiaChain)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+}


### PR DESCRIPTION
## Summary
- `CosmosApi.getTxStatus` now returns `null` for HTTP 404 responses instead of letting `bodyOrThrow` throw a `NetworkException`
- `CosmosStatusProvider` already had the `null → NotFound` path — the provider itself needed no changes
- Adds `CosmosStatusProviderTest` with 6 cases covering the full status-check matrix (NotFound, Confirmed, Failed, Pending variants, network error)

## Issue
Closes #4026

## Root Cause
Cosmos REST nodes return HTTP 404 when a transaction hash doesn't exist. `bodyOrThrow` threw `NetworkException(404)` which the provider's broad `catch (e: Exception)` swallowed and mapped to `Pending`. This caused dropped/unbroadcast transactions to poll as `Pending` forever.

Other chains encode "not found" in an HTTP 200 JSON body, so they were unaffected.

## Test Plan
- [x] `./gradlew :data:testReleaseUnitTest --tests "com.vultisig.wallet.data.api.txstatus.CosmosStatusProviderTest"` — all 6 tests pass
- [x] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)
- [ ] Manual: broadcast a tx on a Cosmos chain, observe it transitions through Pending → Confirmed
- [ ] Manual: enter a made-up tx hash on a Cosmos chain, confirm it shows NotFound (not stuck on Pending)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction status queries now correctly treat missing transactions as not found (no parsing errors when a status is absent).

* **Tests**
  * Added comprehensive tests covering transaction status outcomes: confirmed, failed, pending, not found, and error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->