### PR TITLE
fix: raise Osmosis fee to 25,000 uosmo to prevent tx rejection

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -7,6 +7,11 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.models.Chain
 
 class CosmosFeeService : FeeService {
+
+    companion object {
+        internal const val OSMOSIS_MIN_FEE_UOSMO = 25_000L
+    }
+
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
         return calculateDefaultFees(transaction)
     }
@@ -23,9 +28,12 @@ class CosmosFeeService : FeeService {
             }
         return when (chain) {
             Chain.Osmosis -> {
-                // Osmosis uses EIP-1559 dynamic fees; 25,000 uosmo matches iOS and covers the
-                // 300k gas × 0.03 uosmo/gas minimum with headroom for base fee spikes.
-                GasFees(limit = gasLimit.toBigInteger(), amount = 25000.toBigInteger())
+                // Osmosis uses EIP-1559 dynamic fees; OSMOSIS_MIN_FEE_UOSMO matches iOS and covers
+                // the 300k gas × 0.03 uosmo/gas minimum with headroom for base fee spikes.
+                GasFees(
+                    limit = gasLimit.toBigInteger(),
+                    amount = OSMOSIS_MIN_FEE_UOSMO.toBigInteger(),
+                )
             }
             Chain.GaiaChain,
             Chain.Kujira,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -22,9 +22,13 @@ class CosmosFeeService : FeeService {
                 else -> 200000L
             }
         return when (chain) {
+            Chain.Osmosis -> {
+                // Osmosis uses EIP-1559 dynamic fees; 25,000 uosmo matches iOS and covers the
+                // 300k gas × 0.03 uosmo/gas minimum with headroom for base fee spikes.
+                GasFees(limit = gasLimit.toBigInteger(), amount = 25000.toBigInteger())
+            }
             Chain.GaiaChain,
             Chain.Kujira,
-            Chain.Osmosis,
             Chain.Terra,
             Chain.Akash,
             Chain.Qbtc -> {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -73,7 +73,7 @@ class CosmosFeeServiceTest {
     @Test
     fun `Osmosis fee amount is 25000`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Osmosis)) as GasFees
-        assertEquals(BigInteger("25000"), fee.amount)
+        assertEquals(CosmosFeeService.OSMOSIS_MIN_FEE_UOSMO.toBigInteger(), fee.amount)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -71,6 +71,12 @@ class CosmosFeeServiceTest {
     }
 
     @Test
+    fun `Osmosis fee amount is 25000`() = runTest {
+        val fee = feeService.calculateDefaultFees(transfer(Chain.Osmosis)) as GasFees
+        assertEquals(BigInteger("25000"), fee.amount)
+    }
+
+    @Test
     fun `QBTC returns GasFees type`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Qbtc))
         assertTrue(fee is GasFees)


### PR DESCRIPTION
## Summary
- Osmosis uses EIP-1559 dynamic fees; the old hardcoded value of `7,500 uosmo` was below the network minimum (`300,000 gas × 0.03 uosmo/gas = 9,000 uosmo`), causing transactions to be rejected
- Raised Osmosis fee amount to `25,000 uosmo`, matching iOS which uses the same value and succeeds reliably
- Added an explicit unit test asserting the Osmosis fee amount

## Issue
Closes #3762

## Test Plan
- [ ] Osmosis send transaction completes without fee rejection error
- [ ] Unit test `Osmosis fee amount is 25000` passes
- [ ] All other Cosmos chains unaffected (GaiaChain, Kujira, Terra, Akash, Qbtc, Noble, TerraClassic, Dydx still use their original values)
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas fee calculation for Osmosis by introducing a dedicated minimum fee (25,000 uosmo) and separate handling, yielding more accurate fee estimates and more reliable transaction processing on Osmosis.

* **Tests**
  * Added a unit test to verify the Osmosis fee calculation returns the expected minimum fee.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4465)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->