### PR TITLE
fix: reset TSS dedup caches on retries

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -601,7 +601,6 @@ class DKLSKeygen(
                 Timber.d("chaincode: ${chainCodeBytes.toHexString()}")
             }
         } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.d("Failed to reshare key, error: ${e.localizedMessage}")
             if (attempt < 3) {
                 Timber.d("keygen/reshare retry, attempt: $attempt")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -519,6 +519,7 @@ class DKLSKeygen(
 
     suspend fun reshareWithRetry(attempt: Int) {
         try {
+            cache.clear()
             val keyshareHandle = Handle()
             if (vault.pubKeyECDSA.isNotEmpty()) {
                 val keyshare = getKeyshareBytesFromVault()
@@ -600,6 +601,7 @@ class DKLSKeygen(
                 Timber.d("chaincode: ${chainCodeBytes.toHexString()}")
             }
         } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.d("Failed to reshare key, error: ${e.localizedMessage}")
             if (attempt < 3) {
                 Timber.d("keygen/reshare retry, attempt: $attempt")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -324,6 +324,7 @@ class DKLSKeysign(
             heardFromEver.clear()
             waitingNotified = false
         }
+        cache.clear()
         val msgHash = messageToSign.md5()
         val localMessenger =
             TssMessenger(

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -486,6 +486,7 @@ class SchnorrKeygen(
 
     suspend fun schnorrReshareWithRetry(attempt: Int) {
         try {
+            cache.clear()
             val keyshareHandle = Handle()
             if (vault.pubKeyEDDSA.isNotEmpty()) {
                 val keyshare = getKeyshareBytesFromVault()
@@ -570,6 +571,7 @@ class SchnorrKeygen(
                 delay(500) // slightly delay to give local party time to process outbound messages
             }
         } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.d("Failed to reshare key, error: ${e.localizedMessage}")
             if (attempt < 3) {
                 Timber.d("keygen/reshare retry, attempt: $attempt")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -571,7 +571,6 @@ class SchnorrKeygen(
                 delay(500) // slightly delay to give local party time to process outbound messages
             }
         } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.d("Failed to reshare key, error: ${e.localizedMessage}")
             if (attempt < 3) {
                 Timber.d("keygen/reshare retry, attempt: $attempt")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -326,6 +326,7 @@ class SchnorrKeysign(
             heardFromEver.clear()
             waitingNotified = false
         }
+        cache.clear()
         val msgHash = messageToSign.md5()
         val localMessenger =
             TssMessenger(


### PR DESCRIPTION
## Summary
- reset per-session inbound dedup caches at the start of each retry attempt in DKLS and Schnorr keysign flows
- apply the same per-attempt cache reset to DKLS and Schnorr reshare retry loops to avoid stale message dedup across new handles
- keep within-attempt dedup intact while preventing retry starvation from deterministic round messages (issue #4328)

## Testing
- ./gradlew :app:testDebugUnitTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry flows for key generation and signing now fully reset in-memory deduplication/cache between attempts to prevent previously seen inbound messages from blocking new retries.
  * Improved cancellation handling so cancellation requests propagate immediately rather than being treated as standard failures that trigger retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4467)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->