### PR TITLE
fix(reshare): remove device-count cap to support any vault topology

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -262,11 +262,13 @@ constructor(
 
     fun selectDevice(device: ParticipantName) {
         state.update {
+            val isReshare = args?.action == TssAction.ReShare
             val maxOtherDevices = it.minimumDevices - 1
             it.copy(
                 selectedDevices =
                     if (device in it.selectedDevices) it.selectedDevices - device
-                    else if (it.selectedDevices.size >= maxOtherDevices) it.selectedDevices
+                    else if (!isReshare && it.selectedDevices.size >= maxOtherDevices)
+                        it.selectedDevices
                     else it.selectedDevices + device
             )
         }
@@ -513,11 +515,16 @@ constructor(
                     val existingDevices = currentState.devices.toSet()
                     val newDevices = devices - existingDevices
 
-                    val maxOtherDevices =
-                        if (currentState.minimumDevices > 1) currentState.minimumDevices - 1
-                        else currentState.minimumDevices
-                    val remainingSlots = maxOtherDevices - currentState.selectedDevices.size
-                    val devicesToAutoSelect = newDevices.take(remainingSlots.coerceAtLeast(0))
+                    val devicesToAutoSelect =
+                        if (args?.action == TssAction.ReShare) {
+                            newDevices
+                        } else {
+                            val maxOtherDevices =
+                                if (currentState.minimumDevices > 1) currentState.minimumDevices - 1
+                                else currentState.minimumDevices
+                            val remainingSlots = maxOtherDevices - currentState.selectedDevices.size
+                            newDevices.take(remainingSlots.coerceAtLeast(0))
+                        }
                     val selectedDevices = currentState.selectedDevices.toSet() + devicesToAutoSelect
 
                     state.update {


### PR DESCRIPTION
## Summary

- Reshare peer discovery was capped at `minimumDevices - 1` (default: 1) other devices, which is correct for keygen but wrong for reshare
- Any reshare needing more than 2 total devices (e.g. 2/2 → 2/3, 2/3 → 2/2, 2/3 → 3/4) was silently broken: joining devices appeared in the discovered list but were never added to `selectedDevices` and were excluded from `keygenCommittee`
- For `TssAction.ReShare`, the cap is now bypassed in both `startParticipantDiscovery` (auto-selection) and `selectDevice` (manual toggle); minimum stays at 2 total devices, no maximum

## Root Cause

`startParticipantDiscovery()` computes `maxOtherDevices = minimumDevices - 1` and only auto-selects up to that many new devices. `selectDevice()` enforces the same ceiling. Because `ReshareStartViewModel` doesn't pass `deviceCount`, `minimumDevices` defaults to `MIN_KEYGEN_DEVICES = 2`, so only **1** other device was ever selectable — all subsequent joiners were silently dropped.

## Test Plan

- [ ] 2/2 vault reshare (replace one device) — paired device is included ✓
- [ ] 2/2 vault reshare to 2/3 (add a device) — both non-initiator devices are included ✓
- [ ] 2/3 vault reshare (all three join) — all three participants in `keygenCommittee` ✓
- [ ] 2/3 vault reshare to 2/2 (drop one device) — correct subset included ✓
- [ ] Keygen peer discovery (non-reshare) — device cap still enforced ✓
- [ ] `./gradlew lint` passes ✓
- [ ] Unit tests pass (`./gradlew :app:testDebugUnitTest`) ✓

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed device selection behavior during key resharing to properly support multi-device scenarios
  * Improved automatic device discovery during resharing to correctly include all newly discovered devices in the network

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4487)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->