### PR TITLE
fix(keysign): guard joinKeysign against duplicate startSession calls

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -101,6 +101,7 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -250,6 +251,7 @@ constructor(
 
     private var _jobWaitingForKeysignStart: Job? = null
     private var blockaidSimulationJob: Job? = null
+    private val isJoiningKeysign = AtomicBoolean(false)
     private var isNavigateToHome: Boolean = false
 
     private var transactionTypeUiModel: TransactionTypeUiModel? = null
@@ -1380,35 +1382,42 @@ constructor(
     }
 
     fun joinKeysign() {
+        if (!isJoiningKeysign.compareAndSet(false, true)) return
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                try {
-                    Timber.tag("JoinKeysignViewModel").d("Joining keysign")
-                    sessionApi.startSession(_serverAddress, _sessionID, listOf(_localPartyID))
-                    waitForKeysignToStart()
-                    currentState.value = JoinKeysignState.WaitingForKeysignStart
-                } catch (e: HttpException) {
-                    Timber.tag("JoinKeysignViewModel")
-                        .e(
-                            "Failed to join keysign (HTTP %d): %s",
-                            e.statusCode,
-                            e.stackTraceToString(),
-                        )
-                    currentState.value =
-                        if (e.statusCode >= 500) {
-                            JoinKeysignState.Error(JoinKeysignError.RelayUnavailable)
-                        } else {
+            try {
+                withContext(Dispatchers.IO) {
+                    try {
+                        Timber.tag("JoinKeysignViewModel").d("Joining keysign")
+                        sessionApi.startSession(_serverAddress, _sessionID, listOf(_localPartyID))
+                        waitForKeysignToStart()
+                        currentState.value = JoinKeysignState.WaitingForKeysignStart
+                    } catch (e: HttpException) {
+                        Timber.tag("JoinKeysignViewModel")
+                            .e(
+                                "Failed to join keysign (HTTP %d): %s",
+                                e.statusCode,
+                                e.stackTraceToString(),
+                            )
+                        currentState.value =
+                            if (e.statusCode >= 500) {
+                                JoinKeysignState.Error(JoinKeysignError.RelayUnavailable)
+                            } else {
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToStart(e.message.toString())
+                                )
+                            }
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        Timber.tag("JoinKeysignViewModel")
+                            .e("Failed to join keysign: %s", e.stackTraceToString())
+                        currentState.value =
                             JoinKeysignState.Error(
                                 JoinKeysignError.FailedToStart(e.message.toString())
                             )
-                        }
-                } catch (e: Exception) {
-                    if (e is kotlinx.coroutines.CancellationException) throw e
-                    Timber.tag("JoinKeysignViewModel")
-                        .e("Failed to join keysign: %s", e.stackTraceToString())
-                    currentState.value =
-                        JoinKeysignState.Error(JoinKeysignError.FailedToStart(e.message.toString()))
+                    }
                 }
+            } finally {
+                isJoiningKeysign.set(false)
             }
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1383,41 +1383,38 @@ constructor(
 
     fun joinKeysign() {
         if (!isJoiningKeysign.compareAndSet(false, true)) return
-        viewModelScope.launch {
-            try {
-                withContext(Dispatchers.IO) {
-                    try {
-                        Timber.tag("JoinKeysignViewModel").d("Joining keysign")
-                        sessionApi.startSession(_serverAddress, _sessionID, listOf(_localPartyID))
-                        waitForKeysignToStart()
-                        currentState.value = JoinKeysignState.WaitingForKeysignStart
-                    } catch (e: HttpException) {
-                        Timber.tag("JoinKeysignViewModel")
-                            .e(
-                                "Failed to join keysign (HTTP %d): %s",
-                                e.statusCode,
-                                e.stackTraceToString(),
-                            )
-                        currentState.value =
-                            if (e.statusCode >= 500) {
-                                JoinKeysignState.Error(JoinKeysignError.RelayUnavailable)
-                            } else {
-                                JoinKeysignState.Error(
-                                    JoinKeysignError.FailedToStart(e.message.toString())
-                                )
-                            }
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
-                        Timber.tag("JoinKeysignViewModel")
-                            .e("Failed to join keysign: %s", e.stackTraceToString())
-                        currentState.value =
+        viewModelScope.safeLaunch {
+            withContext(Dispatchers.IO) {
+                try {
+                    Timber.tag("JoinKeysignViewModel").d("Joining keysign")
+                    sessionApi.startSession(_serverAddress, _sessionID, listOf(_localPartyID))
+                    waitForKeysignToStart()
+                    currentState.value = JoinKeysignState.WaitingForKeysignStart
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: HttpException) {
+                    Timber.tag("JoinKeysignViewModel")
+                        .e(
+                            "Failed to join keysign (HTTP %d): %s",
+                            e.statusCode,
+                            e.stackTraceToString(),
+                        )
+                    currentState.value =
+                        if (e.statusCode >= 500) {
+                            JoinKeysignState.Error(JoinKeysignError.RelayUnavailable)
+                        } else {
                             JoinKeysignState.Error(
                                 JoinKeysignError.FailedToStart(e.message.toString())
                             )
-                    }
+                        }
+                    isJoiningKeysign.set(false)
+                } catch (e: Exception) {
+                    Timber.tag("JoinKeysignViewModel")
+                        .e("Failed to join keysign: %s", e.stackTraceToString())
+                    currentState.value =
+                        JoinKeysignState.Error(JoinKeysignError.FailedToStart(e.message.toString()))
+                    isJoiningKeysign.set(false)
                 }
-            } finally {
-                isJoiningKeysign.set(false)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add an `AtomicBoolean` re-entrancy guard to `joinKeysign()` in `JoinKeysignViewModel`
- Only one `POST /router/{sessionId}` is issued per keysign session, even on double-tap or recomposition of the Confirm button
- The flag is reset in a `finally` block so legitimate "Try again" retries after a genuine first-attempt failure still work correctly

## Root Cause
`joinKeysign()` had no guard against concurrent invocations. The Confirm button is wired to `viewModel::joinKeysign` in 4 places in `JoinKeysignView.kt`. A double-tap (or any recomposition during the async call) could fire two overlapping coroutines. The relay returns 201 on the first POST and 500 on every duplicate, exhausting the retry budget and displaying a false "Relay server unavailable" error — even though the join had already succeeded.

## Issue
Closes #4475

## Test Plan
- [ ] On a 2-of-2 vault, initiate keysign on device A; rapidly double-tap Confirm on device B — joiner should transition to "Waiting for keysign start" without hitting the error screen
- [ ] On a genuinely unavailable relay, the first attempt fails and the "Try again" button successfully re-attempts
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple simultaneous key-signing session starts to avoid duplicate or overlapping joins.
  * Improved error reporting and cleanup for key-signing flows, with clearer failure handling and better logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4493)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->