### PR TITLE
fix(keysign): stop polling loop when error state is reached

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1511,6 +1511,8 @@ constructor(
             }
         } catch (e: KeysignMessagesException) {
             throw e
+        } catch (ce: CancellationException) {
+            throw ce
         } catch (e: Exception) {
             throw KeysignMessagesException(e.message ?: "Failed to resolve messages to sign")
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -229,6 +229,8 @@ constructor(
         private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
     }
 
+    private class KeysignMessagesException(message: String) : Exception(message)
+
     private val args = savedStateHandle.toRoute<Route.Keysign.Join>()
     private val vaultId: String = args.vaultId
     private val qrBase64: String = args.qr
@@ -1445,11 +1447,22 @@ constructor(
             viewModelScope.launch {
                 withContext(Dispatchers.IO) {
                     while (isActive) {
-                        if (checkKeygenStarted()) {
-                            currentState.value = JoinKeysignState.Keysign
-                            return@withContext
-                        }
-                        if (currentState.value is JoinKeysignState.Error) {
+                        try {
+                            if (checkKeygenStarted()) {
+                                currentState.value = JoinKeysignState.Keysign
+                                return@withContext
+                            }
+                            if (currentState.value is JoinKeysignState.Error) {
+                                return@withContext
+                            }
+                        } catch (e: KeysignMessagesException) {
+                            Timber.e(e, "Failed to prepare messages to sign")
+                            currentState.value =
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToCheck(
+                                        e.message ?: "Failed to prepare messages to sign"
+                                    )
+                                )
                             return@withContext
                         }
                         delay(1000)
@@ -1464,31 +1477,11 @@ constructor(
             Timber.d("Keysign committee: $_keysignCommittee")
             Timber.d("local party: $_localPartyID")
             if (this._keysignCommittee.contains(_localPartyID)) {
-                when {
-                    _keysignPayload != null -> {
-                        val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
-                        messagesToSign =
-                            SigningHelper.getKeysignMessages(
-                                payload = payload,
-                                vault = _currentVault,
-                            )
-                    }
-
-                    customMessagePayload != null -> {
-                        val payload =
-                            customMessagePayload ?: error("customMessagePayload unexpectedly null")
-                        messagesToSign = SigningHelper.getKeysignMessages(payload)
-                    }
-
-                    else -> {
-                        Timber.e("Both keysign payload and custom message payload are null")
-                        currentState.value = JoinKeysignState.Error(JoinKeysignError.InvalidQr)
-                        return false
-                    }
-                }
-
+                resolveMessagesToSign()
                 return true
             }
+        } catch (e: KeysignMessagesException) {
+            throw e
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e(e, "Failed to check keysign start")
@@ -1496,6 +1489,33 @@ constructor(
                 JoinKeysignState.Error(JoinKeysignError.FailedToCheck(e.message.toString()))
         }
         return false
+    }
+
+    private fun resolveMessagesToSign() {
+        try {
+            when {
+                _keysignPayload != null -> {
+                    val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
+                    messagesToSign =
+                        SigningHelper.getKeysignMessages(payload = payload, vault = _currentVault)
+                }
+
+                customMessagePayload != null -> {
+                    val payload =
+                        customMessagePayload ?: error("customMessagePayload unexpectedly null")
+                    messagesToSign = SigningHelper.getKeysignMessages(payload)
+                }
+
+                else ->
+                    throw KeysignMessagesException(
+                        "Both keysign payload and custom message payload are null"
+                    )
+            }
+        } catch (e: KeysignMessagesException) {
+            throw e
+        } catch (e: Exception) {
+            throw KeysignMessagesException(e.message ?: "Failed to resolve messages to sign")
+        }
     }
 
     fun enableNavigationToHome() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -229,6 +229,8 @@ constructor(
         private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
     }
 
+    private class KeysignMessagesException(message: String) : Exception(message)
+
     private val args = savedStateHandle.toRoute<Route.Keysign.Join>()
     private val vaultId: String = args.vaultId
     private val qrBase64: String = args.qr
@@ -1445,11 +1447,21 @@ constructor(
             viewModelScope.launch {
                 withContext(Dispatchers.IO) {
                     while (isActive) {
-                        if (checkKeygenStarted()) {
-                            currentState.value = JoinKeysignState.Keysign
+                        try {
+                            if (checkKeygenStarted()) {
+                                currentState.value = JoinKeysignState.Keysign
+                                return@withContext
+                            }
+                        } catch (e: KeysignMessagesException) {
+                            Timber.e(e, "Failed to prepare messages to sign")
+                            currentState.value =
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToCheck(
+                                        e.message ?: "Failed to prepare messages to sign"
+                                    )
+                                )
                             return@withContext
                         }
-                        // backoff 1s
                         delay(1000)
                     }
                 }
@@ -1462,31 +1474,11 @@ constructor(
             Timber.d("Keysign committee: $_keysignCommittee")
             Timber.d("local party: $_localPartyID")
             if (this._keysignCommittee.contains(_localPartyID)) {
-                when {
-                    _keysignPayload != null -> {
-                        val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
-                        messagesToSign =
-                            SigningHelper.getKeysignMessages(
-                                payload = payload,
-                                vault = _currentVault,
-                            )
-                    }
-
-                    customMessagePayload != null -> {
-                        val payload =
-                            customMessagePayload ?: error("customMessagePayload unexpectedly null")
-                        messagesToSign = SigningHelper.getKeysignMessages(payload)
-                    }
-
-                    else -> {
-                        Timber.e("Both keysign payload and custom message payload are null")
-                        currentState.value = JoinKeysignState.Error(JoinKeysignError.InvalidQr)
-                        return false
-                    }
-                }
-
+                resolveMessagesToSign()
                 return true
             }
+        } catch (e: KeysignMessagesException) {
+            throw e
         } catch (ce: CancellationException) {
             throw ce
         } catch (e: Exception) {
@@ -1495,6 +1487,33 @@ constructor(
                 JoinKeysignState.Error(JoinKeysignError.FailedToCheck(e.message.toString()))
         }
         return false
+    }
+
+    private fun resolveMessagesToSign() {
+        try {
+            when {
+                _keysignPayload != null -> {
+                    val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
+                    messagesToSign =
+                        SigningHelper.getKeysignMessages(payload = payload, vault = _currentVault)
+                }
+
+                customMessagePayload != null -> {
+                    val payload =
+                        customMessagePayload ?: error("customMessagePayload unexpectedly null")
+                    messagesToSign = SigningHelper.getKeysignMessages(payload)
+                }
+
+                else ->
+                    throw KeysignMessagesException(
+                        "Both keysign payload and custom message payload are null"
+                    )
+            }
+        } catch (e: KeysignMessagesException) {
+            throw e
+        } catch (e: Exception) {
+            throw KeysignMessagesException(e.message ?: "Failed to resolve messages to sign")
+        }
     }
 
     fun enableNavigationToHome() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1449,7 +1449,9 @@ constructor(
                             currentState.value = JoinKeysignState.Keysign
                             return@withContext
                         }
-                        // backoff 1s
+                        if (currentState.value is JoinKeysignState.Error) {
+                            return@withContext
+                        }
                         delay(1000)
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -229,8 +229,6 @@ constructor(
         private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
     }
 
-    private class KeysignMessagesException(message: String) : Exception(message)
-
     private val args = savedStateHandle.toRoute<Route.Keysign.Join>()
     private val vaultId: String = args.vaultId
     private val qrBase64: String = args.qr
@@ -1447,21 +1445,11 @@ constructor(
             viewModelScope.launch {
                 withContext(Dispatchers.IO) {
                     while (isActive) {
-                        try {
-                            if (checkKeygenStarted()) {
-                                currentState.value = JoinKeysignState.Keysign
-                                return@withContext
-                            }
-                        } catch (e: KeysignMessagesException) {
-                            Timber.e(e, "Failed to prepare messages to sign")
-                            currentState.value =
-                                JoinKeysignState.Error(
-                                    JoinKeysignError.FailedToCheck(
-                                        e.message ?: "Failed to prepare messages to sign"
-                                    )
-                                )
+                        if (checkKeygenStarted()) {
+                            currentState.value = JoinKeysignState.Keysign
                             return@withContext
                         }
+                        // backoff 1s
                         delay(1000)
                     }
                 }
@@ -1474,11 +1462,31 @@ constructor(
             Timber.d("Keysign committee: $_keysignCommittee")
             Timber.d("local party: $_localPartyID")
             if (this._keysignCommittee.contains(_localPartyID)) {
-                resolveMessagesToSign()
+                when {
+                    _keysignPayload != null -> {
+                        val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
+                        messagesToSign =
+                            SigningHelper.getKeysignMessages(
+                                payload = payload,
+                                vault = _currentVault,
+                            )
+                    }
+
+                    customMessagePayload != null -> {
+                        val payload =
+                            customMessagePayload ?: error("customMessagePayload unexpectedly null")
+                        messagesToSign = SigningHelper.getKeysignMessages(payload)
+                    }
+
+                    else -> {
+                        Timber.e("Both keysign payload and custom message payload are null")
+                        currentState.value = JoinKeysignState.Error(JoinKeysignError.InvalidQr)
+                        return false
+                    }
+                }
+
                 return true
             }
-        } catch (e: KeysignMessagesException) {
-            throw e
         } catch (ce: CancellationException) {
             throw ce
         } catch (e: Exception) {
@@ -1487,33 +1495,6 @@ constructor(
                 JoinKeysignState.Error(JoinKeysignError.FailedToCheck(e.message.toString()))
         }
         return false
-    }
-
-    private fun resolveMessagesToSign() {
-        try {
-            when {
-                _keysignPayload != null -> {
-                    val payload = _keysignPayload ?: error("keysignPayload unexpectedly null")
-                    messagesToSign =
-                        SigningHelper.getKeysignMessages(payload = payload, vault = _currentVault)
-                }
-
-                customMessagePayload != null -> {
-                    val payload =
-                        customMessagePayload ?: error("customMessagePayload unexpectedly null")
-                    messagesToSign = SigningHelper.getKeysignMessages(payload)
-                }
-
-                else ->
-                    throw KeysignMessagesException(
-                        "Both keysign payload and custom message payload are null"
-                    )
-            }
-        } catch (e: KeysignMessagesException) {
-            throw e
-        } catch (e: Exception) {
-            throw KeysignMessagesException(e.message ?: "Failed to resolve messages to sign")
-        }
     }
 
     fun enableNavigationToHome() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1479,8 +1479,8 @@ constructor(
             }
         } catch (e: KeysignMessagesException) {
             throw e
-        } catch (_: CancellationException) {
-            throw CancellationException()
+        } catch (ce: CancellationException) {
+            throw ce
         } catch (e: Exception) {
             Timber.e(e, "Failed to check keysign start")
             currentState.value =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1452,9 +1452,6 @@ constructor(
                                 currentState.value = JoinKeysignState.Keysign
                                 return@withContext
                             }
-                            if (currentState.value is JoinKeysignState.Error) {
-                                return@withContext
-                            }
                         } catch (e: KeysignMessagesException) {
                             Timber.e(e, "Failed to prepare messages to sign")
                             currentState.value =
@@ -1482,8 +1479,9 @@ constructor(
             }
         } catch (e: KeysignMessagesException) {
             throw e
+        } catch (_: CancellationException) {
+            throw CancellationException()
         } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e(e, "Failed to check keysign start")
             currentState.value =
                 JoinKeysignState.Error(JoinKeysignError.FailedToCheck(e.message.toString()))


### PR DESCRIPTION
## Summary
- In `waitForKeysignToStart()`, the `while (isActive)` loop now exits immediately when `currentState` is `Error`, preventing the same exception from being re-thrown and re-logged every second while the error screen is shown

## Issue
Closes #4477

## Root cause
`checkKeygenStarted()` catches exceptions, sets `currentState = Error(...)`, and returns `false`. The loop previously only exited on `true` (success) or coroutine cancellation — so on error it kept sleeping 1s and retrying forever, flooding logcat and issuing a relay GET every second.

## Test Plan
- [ ] Trigger a UTXO keysign (e.g. BTC) on a joiner where the payload has missing/invalid UTXOs so `UtxoHelper.getPreSignedImageHash` throws `Error_missing_input_utxos`
- [ ] Confirm the error screen appears and the exception is logged exactly once
- [ ] Confirm no further `Failed to check keysign start` logs appear while the error screen is shown
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Join keysign flow now correctly honors cancellations and surfaces a clear error when message resolution fails instead of producing misleading states or retries.

* **Refactor**
  * Message-resolution has been reorganized into a single step that detects missing payloads earlier and reports failures consistently during the join process, improving error clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4494)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->