### PR TITLE
fix: preflight THORChain LP adds against pool/mimir/inbound pause state

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -64,6 +64,8 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
+import com.vultisig.wallet.data.usecases.ThorChainLpPreflightBlock
+import com.vultisig.wallet.data.usecases.ThorChainLpPreflightUseCase
 import com.vultisig.wallet.data.usecases.ValidateMayaTransactionHeightUseCase
 import com.vultisig.wallet.data.utils.TextFieldUtils
 import com.vultisig.wallet.data.utils.getChain
@@ -220,6 +222,7 @@ constructor(
     private val gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl,
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase,
     private val getThorChainLpPositionUseCase: GetThorChainLpPositionUseCase,
+    private val thorChainLpPreflight: ThorChainLpPreflightUseCase,
 ) : ViewModel() {
 
     private val appCurrency =
@@ -1737,6 +1740,13 @@ constructor(
         }
         val tokenAmountInt = tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
 
+        // Preflight against THORChain network state — pool status + mimir pause keys + inbound
+        // chain_lp_actions_paused. Refuses to build the keysign payload when the network would
+        // refund the inbound, sparing the user the inbound gas spend.
+        if (chain == Chain.ThorChain) {
+            thorChainLpPreflight(poolId)?.let { block -> throw block.toError() }
+        }
+
         val srcAddress = selectedToken.address
         val gasFee = calculateGasFee(chain, selectedToken, srcAddress)
         val pairedAddress = resolvePairedAddress(chain, vaultId, poolId)
@@ -2933,6 +2943,26 @@ internal data class TokenMergeInfo(val ticker: String, val contract: String) {
     val denom: String
         get() = "thor.$ticker".lowercase()
 }
+
+private fun ThorChainLpPreflightBlock.toError(): InvalidTransactionDataException =
+    when (this) {
+        is ThorChainLpPreflightBlock.LpPaused ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_lp_paused_pool, listOf(pool))
+            )
+        is ThorChainLpPreflightBlock.ChainLpHalted ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
+            )
+        is ThorChainLpPreflightBlock.InboundLpPaused ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
+            )
+        is ThorChainLpPreflightBlock.PoolNotAvailable ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_pool_not_available, listOf(pool))
+            )
+    }
 
 internal data class TokenWithdrawSecureAsset(
     val ticker: String,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -1739,9 +1739,9 @@ constructor(
         }
         val tokenAmountInt = tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
 
-        // Preflight against THORChain network state — pool status + mimir pause keys + inbound
-        // chain_lp_actions_paused. Refuses to build the keysign payload when the network would
-        // refund the inbound, sparing the user the inbound gas spend.
+        // Preflight against THORChain network state — pool status and the relevant mimir pause
+        // keys. Refuses to build the keysign payload when the network would refund the inbound,
+        // sparing the user the inbound gas spend.
         if (chain == Chain.ThorChain) {
             thorChainLpPreflight(poolId)?.let { block -> throw block.toError() }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -2954,10 +2954,6 @@ private fun ThorChainLpPreflightBlock.toError(): InvalidTransactionDataException
             InvalidTransactionDataException(
                 UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
             )
-        is ThorChainLpPreflightBlock.InboundLpPaused ->
-            InvalidTransactionDataException(
-                UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
-            )
         is ThorChainLpPreflightBlock.PoolNotAvailable ->
             InvalidTransactionDataException(
                 UiText.FormattedText(R.string.deposit_error_pool_not_available, listOf(pool))

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -64,7 +64,6 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
-import com.vultisig.wallet.data.usecases.ThorChainLpPreflightBlock
 import com.vultisig.wallet.data.usecases.ThorChainLpPreflightUseCase
 import com.vultisig.wallet.data.usecases.ValidateMayaTransactionHeightUseCase
 import com.vultisig.wallet.data.utils.TextFieldUtils
@@ -2943,22 +2942,6 @@ internal data class TokenMergeInfo(val ticker: String, val contract: String) {
     val denom: String
         get() = "thor.$ticker".lowercase()
 }
-
-private fun ThorChainLpPreflightBlock.toError(): InvalidTransactionDataException =
-    when (this) {
-        is ThorChainLpPreflightBlock.LpPaused ->
-            InvalidTransactionDataException(
-                UiText.FormattedText(R.string.deposit_error_lp_paused_pool, listOf(pool))
-            )
-        is ThorChainLpPreflightBlock.ChainLpHalted ->
-            InvalidTransactionDataException(
-                UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
-            )
-        is ThorChainLpPreflightBlock.PoolNotAvailable ->
-            InvalidTransactionDataException(
-                UiText.FormattedText(R.string.deposit_error_pool_not_available, listOf(pool))
-            )
-    }
 
 internal data class TokenWithdrawSecureAsset(
     val ticker: String,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/ThorChainLpPreflightErrors.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/ThorChainLpPreflightErrors.kt
@@ -1,0 +1,22 @@
+package com.vultisig.wallet.ui.models.deposit
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.usecases.ThorChainLpPreflightBlock
+import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.utils.UiText
+
+internal fun ThorChainLpPreflightBlock.toError(): InvalidTransactionDataException =
+    when (this) {
+        is ThorChainLpPreflightBlock.LpPaused ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_lp_paused_pool, listOf(pool))
+            )
+        is ThorChainLpPreflightBlock.ChainLpHalted ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_lp_halted_chain, listOf(chainPrefix))
+            )
+        is ThorChainLpPreflightBlock.PoolNotAvailable ->
+            InvalidTransactionDataException(
+                UiText.FormattedText(R.string.deposit_error_pool_not_available, listOf(pool))
+            )
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/AddLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/AddLpScreen.kt
@@ -33,6 +33,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.PercentageChip
 import com.vultisig.wallet.ui.components.TokenAmountInput
 import com.vultisig.wallet.ui.components.TokenFiatToggle
+import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiGradientHorizontalDivider
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -63,6 +64,16 @@ internal fun AddLpScreen(
             depositType = DeFiNavActions.ADD_LP.type,
             bondAddress = null,
             poolId = poolId,
+        )
+    }
+
+    val errorText = state.errorText
+    if (errorText != null) {
+        UiAlertDialog(
+            title = stringResource(R.string.dialog_default_error_title),
+            text = errorText.asString(),
+            confirmTitle = stringResource(R.string.try_again),
+            onDismiss = viewModel::dismissError,
         )
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -316,6 +316,9 @@
     <string name="deposit_error_invalid_assets">Assets ist ungültig</string>
     <string name="deposit_error_chain_not_enabled">Aktivieren Sie %1$s in diesem Tresor, um %2$s abzuheben</string>
     <string name="deposit_error_has_not_reached_maturity">Diese Einlage hat ihre Fälligkeit noch nicht erreicht.</string>
+    <string name="deposit_error_lp_paused_pool">Liquidität hinzufügen ist für %1$s pausiert. THORChain würde diese Transaktion erstatten.</string>
+    <string name="deposit_error_lp_halted_chain">Liquiditätsaktionen auf %1$s sind derzeit angehalten. THORChain würde diese Transaktion erstatten.</string>
+    <string name="deposit_error_pool_not_available">Pool %1$s ist derzeit nicht für Einzahlungen verfügbar.</string>
     <string name="deposit_form_screen_assets">Vermögenswert</string>
     <string name="deposit_form_screen_asset_selection">Anlagenauswahl</string>
     <string name="deposit_form_screen_lpunits">LP-Einheiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -316,6 +316,9 @@
     <string name="deposit_error_invalid_assets">Los activos no son válidos</string>
     <string name="deposit_error_chain_not_enabled">Habilita %1$s en esta bóveda para retirar %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Este depósito aún no ha alcanzado su período de vencimiento.</string>
+    <string name="deposit_error_lp_paused_pool">Agregar liquidez está pausado para %1$s. THORChain reembolsaría esta transacción.</string>
+    <string name="deposit_error_lp_halted_chain">Las acciones de liquidez en %1$s están actualmente detenidas. THORChain reembolsaría esta transacción.</string>
+    <string name="deposit_error_pool_not_available">El pool %1$s no está disponible actualmente para depósitos.</string>
     <string name="deposit_form_screen_assets">Activo</string>
     <string name="deposit_form_screen_asset_selection">Selección de activos</string>
     <string name="deposit_form_screen_lpunits">Unidades LP</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -316,6 +316,9 @@
     <string name="deposit_error_invalid_assets">Sredstva su nevažeća</string>
     <string name="deposit_error_chain_not_enabled">Omogućite %1$s u ovom trezoru za povlačenje %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Ovaj depozit još nije dostigao rok dospijeća</string>
+    <string name="deposit_error_lp_paused_pool">Dodavanje likvidnosti je pauzirano za %1$s. THORChain bi vratio ovu transakciju.</string>
+    <string name="deposit_error_lp_halted_chain">Akcije likvidnosti na %1$s su trenutno zaustavljene. THORChain bi vratio ovu transakciju.</string>
+    <string name="deposit_error_pool_not_available">Pool %1$s trenutno nije dostupan za depozite.</string>
     <string name="deposit_form_screen_assets">Imovina</string>
     <string name="deposit_form_screen_asset_selection">Odabir imovine</string>
     <string name="deposit_form_screen_lpunits">LP jedinice</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -316,6 +316,9 @@
     <string name="deposit_error_invalid_assets">Le risorse non sono valide</string>
     <string name="deposit_error_chain_not_enabled">Abilita %1$s in questo vault per prelevare %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Questo deposito non ha ancora raggiunto il suo periodo di scadenza</string>
+    <string name="deposit_error_lp_paused_pool">Aggiungere liquidità è in pausa per %1$s. THORChain rimborserebbe questa transazione.</string>
+    <string name="deposit_error_lp_halted_chain">Le azioni di liquidità su %1$s sono attualmente sospese. THORChain rimborserebbe questa transazione.</string>
+    <string name="deposit_error_pool_not_available">Il pool %1$s non è attualmente disponibile per i depositi.</string>
     <string name="deposit_form_screen_assets">Attività</string>
     <string name="deposit_form_screen_asset_selection">Selezione asset</string>
     <string name="deposit_form_screen_lpunits">Unità LP</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -411,6 +411,9 @@
     <string name="deposit_error_invalid_assets">자산이 유효하지 않습니다</string>
     <string name="deposit_error_chain_not_enabled">%2$s을(를) 출금하려면 이 볼트에서 %1$s을(를) 활성화하세요</string>
     <string name="deposit_error_has_not_reached_maturity">이 예치는 아직 만기에 도달하지 않았습니다</string>
+    <string name="deposit_error_lp_paused_pool">%1$s에 대한 유동성 추가가 일시 중지되었습니다. THORChain이 이 거래를 환불합니다.</string>
+    <string name="deposit_error_lp_halted_chain">%1$s의 유동성 작업이 현재 중단되었습니다. THORChain이 이 거래를 환불합니다.</string>
+    <string name="deposit_error_pool_not_available">풀 %1$s은(는) 현재 입금에 사용할 수 없습니다.</string>
     <string name="deposit_form_screen_assets">자산</string>
     <string name="deposit_form_screen_asset_selection">자산 선택</string>
     <string name="deposit_form_screen_lpunits">LP 유닛</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -315,6 +315,9 @@
     <string name="deposit_error_invalid_assets">Activa zijn ongeldig</string>
     <string name="deposit_error_chain_not_enabled">Schakel %1$s in deze kluis in om %2$s op te nemen</string>
     <string name="deposit_error_has_not_reached_maturity">Deze deposito heeft de vervaldatum nog niet bereikt</string>
+    <string name="deposit_error_lp_paused_pool">Liquiditeit toevoegen is gepauzeerd voor %1$s. THORChain zou deze transactie terugbetalen.</string>
+    <string name="deposit_error_lp_halted_chain">Liquiditeitsacties op %1$s zijn momenteel stilgelegd. THORChain zou deze transactie terugbetalen.</string>
+    <string name="deposit_error_pool_not_available">Pool %1$s is momenteel niet beschikbaar voor stortingen.</string>
     <string name="deposit_form_screen_assets">Activa</string>
     <string name="deposit_form_screen_asset_selection">Activaselectie</string>
     <string name="deposit_form_screen_lpunits">LP-eenheden</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -316,6 +316,9 @@
     <string name="deposit_error_invalid_assets">Os recursos são inválidos</string>
     <string name="deposit_error_chain_not_enabled">Ative %1$s neste cofre para retirar %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Este depósito ainda não atingiu o seu prazo de vencimento.</string>
+    <string name="deposit_error_lp_paused_pool">Adicionar liquidez está pausado para %1$s. THORChain reembolsaria esta transação.</string>
+    <string name="deposit_error_lp_halted_chain">As ações de liquidez em %1$s estão atualmente interrompidas. THORChain reembolsaria esta transação.</string>
+    <string name="deposit_error_pool_not_available">O pool %1$s não está disponível para depósitos no momento.</string>
     <string name="deposit_form_screen_assets">Ativo</string>
     <string name="deposit_form_screen_asset_selection">Seleção de ativos</string>
     <string name="deposit_form_screen_lpunits">Unidades LP</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -315,6 +315,9 @@
     <string name="deposit_error_invalid_assets">Активы недействительны</string>
     <string name="deposit_error_chain_not_enabled">Включите %1$s в этом хранилище, чтобы вывести %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Срок действия этого депозита еще не наступил.</string>
+    <string name="deposit_error_lp_paused_pool">Добавление ликвидности приостановлено для %1$s. THORChain вернёт эту транзакцию.</string>
+    <string name="deposit_error_lp_halted_chain">Операции с ликвидностью в %1$s в настоящее время остановлены. THORChain вернёт эту транзакцию.</string>
+    <string name="deposit_error_pool_not_available">Пул %1$s в настоящее время недоступен для депозитов.</string>
     <string name="deposit_form_screen_assets">Актив</string>
     <string name="deposit_form_screen_asset_selection">Выбор актива</string>
     <string name="deposit_form_screen_lpunits">Единицы LP</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -583,6 +583,9 @@
 
     <!-- Deposit Form Screen -->
     <string name="deposit_error_has_not_reached_maturity">这笔存款尚未到期。</string>
+    <string name="deposit_error_lp_paused_pool">已暂停 %1$s 的添加流动性。THORChain 将退回此交易。</string>
+    <string name="deposit_error_lp_halted_chain">%1$s 上的流动性操作目前已停止。THORChain 将退回此交易。</string>
+    <string name="deposit_error_pool_not_available">池 %1$s 目前不可用于存款。</string>
     <string name="deposit_form_screen_assets">资产</string>
     <string name="deposit_form_screen_asset_selection">选择资产</string>
     <string name="deposit_form_screen_lpunits">LP 单位</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,9 @@
     <string name="deposit_error_invalid_assets">Assets are invalid</string>
     <string name="deposit_error_chain_not_enabled">Enable %1$s in this vault to withdraw %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">This deposit has not reached its maturity period yet</string>
+    <string name="deposit_error_lp_paused_pool">Add liquidity is paused for %1$s. THORChain would refund this transaction.</string>
+    <string name="deposit_error_lp_halted_chain">Liquidity actions on %1$s are currently halted. THORChain would refund this transaction.</string>
+    <string name="deposit_error_pool_not_available">Pool %1$s is not currently available for deposits.</string>
     <string name="deposit_form_screen_assets">Asset</string>
     <string name="deposit_form_screen_asset_selection">Asset selection</string>
     <string name="deposit_form_screen_lpunits">LP Units</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -7,6 +7,8 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
@@ -23,8 +25,11 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
+import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
+import com.vultisig.wallet.data.usecases.ThorChainLpPreflightBlock
+import com.vultisig.wallet.data.usecases.ThorChainLpPreflightUseCase
 import com.vultisig.wallet.data.usecases.ValidateMayaTransactionHeightUseCase
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
@@ -39,6 +44,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -80,12 +86,8 @@ internal class DepositFormViewModelTest {
     private val tokenRepository: TokenRepository = mockk(relaxed = true)
     private val gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl = mockk(relaxed = true)
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase = mockk(relaxed = true)
-    private val getThorChainLpPositionUseCase:
-        com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase =
-        mockk(relaxed = true)
-    private val thorChainLpPreflight:
-        com.vultisig.wallet.data.usecases.ThorChainLpPreflightUseCase =
-        mockk(relaxed = true)
+    private val getThorChainLpPositionUseCase: GetThorChainLpPositionUseCase = mockk(relaxed = true)
+    private val thorChainLpPreflight: ThorChainLpPreflightUseCase = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
@@ -236,6 +238,45 @@ internal class DepositFormViewModelTest {
         vm.validateCustomMemo()
 
         assertNotNull(vm.state.value.customMemoError)
+    }
+
+    @Test
+    fun `deposit for AddLiquidity surfaces preflight block as errorText`() = runTest {
+        val pool = "ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"
+        val vm = buildViewModel()
+        coEvery { accountsRepository.loadAddress("vault1", Chain.ThorChain) } returns
+            flowOf(
+                Address(
+                    chain = Chain.ThorChain,
+                    address = "thor1somevalidaddress",
+                    accounts =
+                        listOf(
+                            Account(
+                                token = Coins.ThorChain.RUNE,
+                                tokenValue = null,
+                                fiatValue = null,
+                                price = null,
+                            )
+                        ),
+                )
+            )
+        coEvery { thorChainLpPreflight.invoke(pool) } returns
+            ThorChainLpPreflightBlock.LpPaused(pool)
+
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null, pool)
+        advanceUntilIdle()
+        vm.selectDepositOption(DepositOption.AddLiquidity)
+        vm.tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
+        vm.deposit()
+        advanceUntilIdle()
+
+        val errorText = vm.state.value.errorText
+        assertNotNull(errorText)
+        assertTrue(errorText is UiText.FormattedText)
+        assertEquals(
+            R.string.deposit_error_lp_paused_pool,
+            (errorText as UiText.FormattedText).resId,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -83,6 +83,9 @@ internal class DepositFormViewModelTest {
     private val getThorChainLpPositionUseCase:
         com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase =
         mockk(relaxed = true)
+    private val thorChainLpPreflight:
+        com.vultisig.wallet.data.usecases.ThorChainLpPreflightUseCase =
+        mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
@@ -120,6 +123,7 @@ internal class DepositFormViewModelTest {
             gasFeeToEstimate = gasFeeToEstimate,
             requestAddressBookEntry = requestAddressBookEntry,
             getThorChainLpPositionUseCase = getThorChainLpPositionUseCase,
+            thorChainLpPreflight = thorChainLpPreflight,
         )
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -93,6 +93,18 @@ interface ThorChainApi {
     suspend fun getPools(): List<ThorChainPoolJson>
 
     /**
+     * Fetch a single pool's state from thornode. Returns null when the pool does not exist (404).
+     * Includes the `status` field used by the LP preflight to detect Suspended/Staged pools.
+     */
+    suspend fun getPool(asset: String): ThorChainPoolJson?
+
+    /**
+     * Returns the full mimir key/value map from thornode. Used by the LP preflight to detect
+     * pause/halt flags like `PAUSELP`, `PAUSELP-<ASSET>`, `HALT<CHAIN>LP`, etc.
+     */
+    suspend fun getMimir(): Map<String, Long>
+
+    /**
      * Midgard pool statistics including LUVI-based APR. Pass [period] (e.g. "7d", "30d", "100d") to
      * control the APR window; defaults to 30d to match thorchain.org.
      */
@@ -346,6 +358,20 @@ constructor(
     override suspend fun getPools(): List<ThorChainPoolJson> =
         httpClient
             .get("$THORNODE_BASE/thorchain/pools") { header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE) }
+            .bodyOrThrow()
+
+    override suspend fun getPool(asset: String): ThorChainPoolJson? {
+        val response =
+            httpClient.get("$THORNODE_BASE/thorchain/pool/$asset") {
+                header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE)
+            }
+        return if (response.status == HttpStatusCode.NotFound) null
+        else response.bodyOrThrow<ThorChainPoolJson>()
+    }
+
+    override suspend fun getMimir(): Map<String, Long> =
+        httpClient
+            .get("$THORNODE_BASE/thorchain/mimir") { header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE) }
             .bodyOrThrow()
 
     override suspend fun getPoolStats(period: String?): List<ThorChainPoolStatsJson> =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
@@ -12,4 +12,6 @@ data class ThorChainPoolJson(
     @SerialName("asset") val asset: String,
     // asset price in usd with 8 decimals
     @Contextual @SerialName("asset_tor_price") val assetTorPrice: BigInteger,
+    // pool status — typically Available / Staged / Suspended; absent on older endpoints
+    @SerialName("status") val status: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -131,6 +131,10 @@ internal interface RepositoriesModule {
 
     @Binds
     @Singleton
+    fun bindThorMimirRepository(impl: ThorMimirRepositoryImpl): ThorMimirRepository
+
+    @Binds
+    @Singleton
     fun bindExplorerLinkRepository(impl: ExplorerLinkRepositoryImpl): ExplorerLinkRepository
 
     @Binds

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
@@ -16,8 +16,10 @@ import kotlinx.coroutines.sync.withLock
 interface ThorMimirRepository {
     /**
      * True when add-liquidity is paused either globally (`PAUSELP`) or for the specific [pool]
-     * (`PAUSELP-<CHAIN>-<TICKER>`). [pool] is the canonical THORChain pool identifier (e.g.
-     * `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`).
+     * (`PAUSELPDEPOSIT-<CHAIN>-<ASSET[-CONTRACT]>`). [pool] is the canonical THORChain pool
+     * identifier (e.g. `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`). The contract suffix
+     * is preserved so ERC20 pools — which thornode pauses by full asset id — are matched correctly
+     * (the 2026-04-10 `BTC.BTC` refund incident surfaced this requirement).
      */
     suspend fun isLpPaused(pool: String): Boolean
 
@@ -38,7 +40,7 @@ internal class ThorMimirRepositoryImpl @Inject constructor(private val thorChain
     override suspend fun isLpPaused(pool: String): Boolean {
         val mimir = mimir()
         if (mimir.isOn(KEY_GLOBAL_LP_PAUSE)) return true
-        val key = "$KEY_GLOBAL_LP_PAUSE-${pool.toMimirAssetSuffix()}"
+        val key = "$KEY_PER_POOL_LP_DEPOSIT_PAUSE-${pool.toMimirAssetSuffix()}"
         return mimir.isOn(key)
     }
 
@@ -67,17 +69,15 @@ internal class ThorMimirRepositoryImpl @Inject constructor(private val thorChain
     private fun Map<String, Long>.isOn(key: String): Boolean = (this[key.uppercase()] ?: 0L) > 0L
 
     /**
-     * Mimir per-asset pause keys are formatted as `PAUSELP-<CHAIN>-<TICKER>` (no contract suffix,
-     * dashes instead of dots, all uppercase). Convert a canonical pool id (`ETH.USDT-0xdac...`) to
-     * that form.
+     * Per-pool LP-deposit pause keys are formatted as `PAUSELPDEPOSIT-<CHAIN>-<ASSET[-CONTRACT]>`:
+     * dashes instead of dots, full asset identifier including any ERC20 contract suffix, all
+     * uppercase. Convert a canonical pool id (`ETH.USDT-0xdac...`) to that form.
      */
-    private fun String.toMimirAssetSuffix(): String {
-        val withoutContract = substringBefore('-')
-        return withoutContract.replace('.', '-').uppercase()
-    }
+    private fun String.toMimirAssetSuffix(): String = replace('.', '-').uppercase()
 
     private companion object {
         const val TTL_MILLIS = 30_000L
         const val KEY_GLOBAL_LP_PAUSE = "PAUSELP"
+        const val KEY_PER_POOL_LP_DEPOSIT_PAUSE = "PAUSELPDEPOSIT"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
@@ -17,9 +17,8 @@ interface ThorMimirRepository {
     /**
      * True when add-liquidity is paused either globally (`PAUSELP`) or for the specific [pool]
      * (`PAUSELPDEPOSIT-<CHAIN>-<ASSET[-CONTRACT]>`). [pool] is the canonical THORChain pool
-     * identifier (e.g. `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`). The contract suffix
-     * is preserved so ERC20 pools — which thornode pauses by full asset id — are matched correctly
-     * (the 2026-04-10 `BTC.BTC` refund incident surfaced this requirement).
+     * identifier (e.g. `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`). The full asset id
+     * including any ERC20 contract suffix is used, since thornode pauses ERC20 pools by full id.
      */
     suspend fun isLpPaused(pool: String): Boolean
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepository.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import javax.inject.Inject
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Typed view over THORChain's `/thorchain/mimir` flags. Mimir keys are dynamic on-chain governance
+ * values used (among other things) to pause or halt specific actions. THORChain treats any positive
+ * integer value for these keys as "on"; absent keys are off.
+ *
+ * Results are cached for a short TTL so several validators in one screen (e.g. the LP preflight
+ * checking global + per-asset + chain LP halt) hit the network only once.
+ */
+interface ThorMimirRepository {
+    /**
+     * True when add-liquidity is paused either globally (`PAUSELP`) or for the specific [pool]
+     * (`PAUSELP-<CHAIN>-<TICKER>`). [pool] is the canonical THORChain pool identifier (e.g.
+     * `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`).
+     */
+    suspend fun isLpPaused(pool: String): Boolean
+
+    /**
+     * True when LP activity for the given chain (THORChain inbound-chain identifier, e.g. `ETH`,
+     * `BTC`, `BSC`) is halted via either `HALT<CHAIN>LP` or `HALT<CHAIN>CHAIN`.
+     */
+    suspend fun isLpHalted(chainPrefix: String): Boolean
+}
+
+internal class ThorMimirRepositoryImpl @Inject constructor(private val thorChainApi: ThorChainApi) :
+    ThorMimirRepository {
+
+    private val mutex = Mutex()
+    private var cached: Map<String, Long>? = null
+    private var cachedAtMillis: Long = 0L
+
+    override suspend fun isLpPaused(pool: String): Boolean {
+        val mimir = mimir()
+        if (mimir.isOn(KEY_GLOBAL_LP_PAUSE)) return true
+        val key = "$KEY_GLOBAL_LP_PAUSE-${pool.toMimirAssetSuffix()}"
+        return mimir.isOn(key)
+    }
+
+    override suspend fun isLpHalted(chainPrefix: String): Boolean {
+        val mimir = mimir()
+        val upper = chainPrefix.uppercase()
+        return mimir.isOn("HALT${upper}LP") || mimir.isOn("HALT${upper}CHAIN")
+    }
+
+    private suspend fun mimir(): Map<String, Long> =
+        mutex.withLock {
+            val now = nowMillis()
+            val current = cached
+            if (current != null && now - cachedAtMillis < TTL_MILLIS) {
+                current
+            } else {
+                val fresh = thorChainApi.getMimir().mapKeys { it.key.uppercase() }
+                cached = fresh
+                cachedAtMillis = now
+                fresh
+            }
+        }
+
+    private fun nowMillis(): Long = System.currentTimeMillis()
+
+    private fun Map<String, Long>.isOn(key: String): Boolean = (this[key.uppercase()] ?: 0L) > 0L
+
+    /**
+     * Mimir per-asset pause keys are formatted as `PAUSELP-<CHAIN>-<TICKER>` (no contract suffix,
+     * dashes instead of dots, all uppercase). Convert a canonical pool id (`ETH.USDT-0xdac...`) to
+     * that form.
+     */
+    private fun String.toMimirAssetSuffix(): String {
+        val withoutContract = substringBefore('-')
+        return withoutContract.replace('.', '-').uppercase()
+    }
+
+    private companion object {
+        const val TTL_MILLIS = 30_000L
+        const val KEY_GLOBAL_LP_PAUSE = "PAUSELP"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -232,5 +232,11 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindThorChainLpPreflightUseCase(
+        impl: ThorChainLpPreflightUseCaseImpl
+    ): ThorChainLpPreflightUseCase
+
+    @Binds
+    @Singleton
     fun bindThorchainMemoParser(impl: ThorchainMemoParserImpl): ThorchainMemoParser
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
@@ -3,6 +3,8 @@ package com.vultisig.wallet.data.usecases
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.repositories.ThorMimirRepository
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 
@@ -13,17 +15,14 @@ import kotlinx.coroutines.coroutineScope
  * THORChain to accept the inbound, refund it, and leave the user out the inbound gas.
  */
 sealed class ThorChainLpPreflightBlock {
-    /** The pool is paused via `PAUSELP` (global) or `PAUSELP-<CHAIN>-<TICKER>` (per-asset). */
+    /**
+     * Add-liquidity is paused via `PAUSELP` (global) or `PAUSELPDEPOSIT-<CHAIN>-<ASSET[-CONTRACT]>`
+     * (per-pool).
+     */
     data class LpPaused(val pool: String) : ThorChainLpPreflightBlock()
 
     /** LP activity on the asset's chain is halted via `HALT<CHAIN>LP`/`HALT<CHAIN>CHAIN`. */
     data class ChainLpHalted(val chainPrefix: String) : ThorChainLpPreflightBlock()
-
-    /**
-     * Inbound addresses for the asset's chain report `halted`, `chain_lp_actions_paused`, or
-     * `global_trading_paused`. [chainPrefix] is the THORChain inbound-chain identifier (BTC/ETH/…).
-     */
-    data class InboundLpPaused(val chainPrefix: String) : ThorChainLpPreflightBlock()
 
     /** Pool exists but its `status` is not `Available` (typically `Staged` or `Suspended`). */
     data class PoolNotAvailable(val pool: String, val status: String?) :
@@ -31,21 +30,26 @@ sealed class ThorChainLpPreflightBlock {
 }
 
 /**
- * Validates THORChain network state before an LP add-liquidity inbound is signed and broadcast.
+ * Validates THORChain network state before a RUNE-side add-liquidity inbound is signed and
+ * broadcast.
  *
  * Companion to #4468 (refund *reporting*) — this use case is the *prevention* half: by reading
- * mimir, the pool's `status`, and the inbound `chain_lp_actions_paused` for the asset chain, we
- * refuse to build the keysign payload when the network would refund it.
+ * mimir and the pool's `status`, we refuse to build the keysign payload when the network would
+ * refund it.
  *
- * The asset chain is the chain identified by the pool prefix (e.g. `ETH` from `ETH.USDT-0xdac…`).
- * The native chain (THORChain) itself is never the inbound-chain target for an LP add — RUNE
- * deposits go on-chain locally — so we only check the asset chain's inbound flags.
+ * Scope is intentionally limited to the RUNE side. The asset chain's inbound flags are NOT
+ * inspected here because a RUNE deposit never traverses the asset-chain inbound — iOS
+ * (`FunctionCallAddThorLP`) and the browser extension's `assertPoolDepositable` make the same
+ * choice. The asset chain is identified by the pool prefix (e.g. `ETH` from `ETH.USDT-0xdac…`) and
+ * is only used for the mimir `HALT<CHAIN>LP`/`HALT<CHAIN>CHAIN` checks, which capture LP-specific
+ * halts independently of inbound trading state.
  */
 interface ThorChainLpPreflightUseCase {
     /**
      * Returns the first blocking reason found, or `null` when the LP add is safe to broadcast.
      * Calls are parallelized; failures of individual signals are swallowed (fail-open) so a
-     * transient thornode hiccup does not block a healthy deposit.
+     * transient thornode hiccup does not block a healthy deposit. `CancellationException` is
+     * propagated so parent-scope cancellation still works.
      *
      * @param pool canonical THORChain pool id, e.g.
      *   `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`.
@@ -63,22 +67,18 @@ constructor(
     override suspend fun invoke(pool: String): ThorChainLpPreflightBlock? = coroutineScope {
         val chainPrefix = pool.substringBefore('.', missingDelimiterValue = "").uppercase()
 
-        val lpPausedDeferred = async {
-            runCatching { mimirRepository.isLpPaused(pool) }.getOrNull()
-        }
+        val lpPausedDeferred = async { probe { mimirRepository.isLpPaused(pool) } }
         val chainHaltedDeferred = async {
-            if (chainPrefix.isEmpty()) null
-            else runCatching { mimirRepository.isLpHalted(chainPrefix) }.getOrNull()
+            if (chainPrefix.isEmpty()) null else probe { mimirRepository.isLpHalted(chainPrefix) }
         }
-        val poolDeferred = async { runCatching { thorChainApi.getPool(pool) }.getOrNull() }
-        val inboundDeferred = async {
-            runCatching { thorChainApi.getTHORChainInboundAddresses() }.getOrNull()
-        }
+        val poolDeferred = async { probe { thorChainApi.getPool(pool) } }
 
         if (lpPausedDeferred.await() == true) {
+            cancelAll(chainHaltedDeferred, poolDeferred)
             return@coroutineScope ThorChainLpPreflightBlock.LpPaused(pool)
         }
         if (chainHaltedDeferred.await() == true) {
+            cancelAll(poolDeferred)
             return@coroutineScope ThorChainLpPreflightBlock.ChainLpHalted(chainPrefix)
         }
 
@@ -90,18 +90,21 @@ constructor(
             }
         }
 
-        val inbound =
-            inboundDeferred.await()?.firstOrNull { it.chain.equals(chainPrefix, ignoreCase = true) }
-        if (inbound != null) {
-            val blocked =
-                inbound.halted || inbound.chainLPActionsPaused || inbound.globalTradingPaused
-            if (blocked) {
-                return@coroutineScope ThorChainLpPreflightBlock.InboundLpPaused(chainPrefix)
-            }
-        }
-
         null
     }
+
+    private fun cancelAll(vararg deferreds: Deferred<*>) {
+        deferreds.forEach { it.cancel() }
+    }
+
+    private suspend fun <T> probe(block: suspend () -> T): T? =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
     private companion object {
         const val POOL_STATUS_AVAILABLE = "Available"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
@@ -31,18 +31,14 @@ sealed class ThorChainLpPreflightBlock {
 
 /**
  * Validates THORChain network state before a RUNE-side add-liquidity inbound is signed and
- * broadcast.
+ * broadcast. By reading mimir and the pool's `status`, we refuse to build the keysign payload when
+ * the network would refund it.
  *
- * Companion to #4468 (refund *reporting*) — this use case is the *prevention* half: by reading
- * mimir and the pool's `status`, we refuse to build the keysign payload when the network would
- * refund it.
- *
- * Scope is intentionally limited to the RUNE side. The asset chain's inbound flags are NOT
- * inspected here because a RUNE deposit never traverses the asset-chain inbound — iOS
- * (`FunctionCallAddThorLP`) and the browser extension's `assertPoolDepositable` make the same
- * choice. The asset chain is identified by the pool prefix (e.g. `ETH` from `ETH.USDT-0xdac…`) and
- * is only used for the mimir `HALT<CHAIN>LP`/`HALT<CHAIN>CHAIN` checks, which capture LP-specific
- * halts independently of inbound trading state.
+ * Scope is intentionally limited to the RUNE side: a RUNE deposit never traverses the asset-chain
+ * inbound, so asset-chain inbound flags are not inspected. The asset chain is identified by the
+ * pool prefix (e.g. `ETH` from `ETH.USDT-0xdac…`) and is only used for the mimir
+ * `HALT<CHAIN>LP`/`HALT<CHAIN>CHAIN` checks, which capture LP-specific halts independently of
+ * inbound trading state.
  */
 interface ThorChainLpPreflightUseCase {
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCase.kt
@@ -1,0 +1,109 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.repositories.ThorMimirRepository
+import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Reason a THORChain add-liquidity inbound was blocked before it could be broadcast.
+ *
+ * Each case mirrors a signal the network publishes that — left unchecked — would have caused
+ * THORChain to accept the inbound, refund it, and leave the user out the inbound gas.
+ */
+sealed class ThorChainLpPreflightBlock {
+    /** The pool is paused via `PAUSELP` (global) or `PAUSELP-<CHAIN>-<TICKER>` (per-asset). */
+    data class LpPaused(val pool: String) : ThorChainLpPreflightBlock()
+
+    /** LP activity on the asset's chain is halted via `HALT<CHAIN>LP`/`HALT<CHAIN>CHAIN`. */
+    data class ChainLpHalted(val chainPrefix: String) : ThorChainLpPreflightBlock()
+
+    /**
+     * Inbound addresses for the asset's chain report `halted`, `chain_lp_actions_paused`, or
+     * `global_trading_paused`. [chainPrefix] is the THORChain inbound-chain identifier (BTC/ETH/…).
+     */
+    data class InboundLpPaused(val chainPrefix: String) : ThorChainLpPreflightBlock()
+
+    /** Pool exists but its `status` is not `Available` (typically `Staged` or `Suspended`). */
+    data class PoolNotAvailable(val pool: String, val status: String?) :
+        ThorChainLpPreflightBlock()
+}
+
+/**
+ * Validates THORChain network state before an LP add-liquidity inbound is signed and broadcast.
+ *
+ * Companion to #4468 (refund *reporting*) — this use case is the *prevention* half: by reading
+ * mimir, the pool's `status`, and the inbound `chain_lp_actions_paused` for the asset chain, we
+ * refuse to build the keysign payload when the network would refund it.
+ *
+ * The asset chain is the chain identified by the pool prefix (e.g. `ETH` from `ETH.USDT-0xdac…`).
+ * The native chain (THORChain) itself is never the inbound-chain target for an LP add — RUNE
+ * deposits go on-chain locally — so we only check the asset chain's inbound flags.
+ */
+interface ThorChainLpPreflightUseCase {
+    /**
+     * Returns the first blocking reason found, or `null` when the LP add is safe to broadcast.
+     * Calls are parallelized; failures of individual signals are swallowed (fail-open) so a
+     * transient thornode hiccup does not block a healthy deposit.
+     *
+     * @param pool canonical THORChain pool id, e.g.
+     *   `ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7`.
+     */
+    suspend operator fun invoke(pool: String): ThorChainLpPreflightBlock?
+}
+
+internal class ThorChainLpPreflightUseCaseImpl
+@Inject
+constructor(
+    private val thorChainApi: ThorChainApi,
+    private val mimirRepository: ThorMimirRepository,
+) : ThorChainLpPreflightUseCase {
+
+    override suspend fun invoke(pool: String): ThorChainLpPreflightBlock? = coroutineScope {
+        val chainPrefix = pool.substringBefore('.', missingDelimiterValue = "").uppercase()
+
+        val lpPausedDeferred = async {
+            runCatching { mimirRepository.isLpPaused(pool) }.getOrNull()
+        }
+        val chainHaltedDeferred = async {
+            if (chainPrefix.isEmpty()) null
+            else runCatching { mimirRepository.isLpHalted(chainPrefix) }.getOrNull()
+        }
+        val poolDeferred = async { runCatching { thorChainApi.getPool(pool) }.getOrNull() }
+        val inboundDeferred = async {
+            runCatching { thorChainApi.getTHORChainInboundAddresses() }.getOrNull()
+        }
+
+        if (lpPausedDeferred.await() == true) {
+            return@coroutineScope ThorChainLpPreflightBlock.LpPaused(pool)
+        }
+        if (chainHaltedDeferred.await() == true) {
+            return@coroutineScope ThorChainLpPreflightBlock.ChainLpHalted(chainPrefix)
+        }
+
+        val poolJson = poolDeferred.await()
+        if (poolJson != null) {
+            val status = poolJson.status
+            if (status != null && !status.equals(POOL_STATUS_AVAILABLE, ignoreCase = true)) {
+                return@coroutineScope ThorChainLpPreflightBlock.PoolNotAvailable(pool, status)
+            }
+        }
+
+        val inbound =
+            inboundDeferred.await()?.firstOrNull { it.chain.equals(chainPrefix, ignoreCase = true) }
+        if (inbound != null) {
+            val blocked =
+                inbound.halted || inbound.chainLPActionsPaused || inbound.globalTradingPaused
+            if (blocked) {
+                return@coroutineScope ThorChainLpPreflightBlock.InboundLpPaused(chainPrefix)
+            }
+        }
+
+        null
+    }
+
+    private companion object {
+        const val POOL_STATUS_AVAILABLE = "Available"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepositoryTest.kt
@@ -38,29 +38,44 @@ internal class ThorMimirRepositoryTest {
     }
 
     @Test
-    fun `per-asset pause key matches the pool's chain and ticker without contract suffix`() =
+    fun `per-pool deposit pause key matches the full asset identifier including contract`() =
         runTest {
-            coEvery { api.getMimir() } returns mapOf("PAUSELP-ETH-USDT" to 1L)
+            coEvery { api.getMimir() } returns
+                mapOf("PAUSELPDEPOSIT-ETH-USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7" to 1L)
 
             assertTrue(repository.isLpPaused("ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"))
+            // Same ticker, different contract — must not match.
             assertFalse(
-                repository.isLpPaused("ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+                repository.isLpPaused("ETH.USDT-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
             )
             assertFalse(repository.isLpPaused("BTC.BTC"))
         }
 
     @Test
-    fun `per-asset pause key matches case-insensitively`() = runTest {
-        coEvery { api.getMimir() } returns mapOf("pauselp-eth-usdt" to 1L)
+    fun `per-pool deposit pause key matches native pools without contract suffix`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("PAUSELPDEPOSIT-BTC-BTC" to 1L)
 
-        assertTrue(repository.isLpPaused("ETH.USDT-0xdac"))
+        assertTrue(repository.isLpPaused("BTC.BTC"))
+        assertFalse(repository.isLpPaused("ETH.ETH"))
+    }
+
+    @Test
+    fun `per-pool deposit pause key matches case-insensitively`() = runTest {
+        coEvery { api.getMimir() } returns
+            mapOf("pauselpdeposit-eth-usdt-0xdac17f958d2ee523a2206206994597c13d831ec7" to 1L)
+
+        assertTrue(repository.isLpPaused("ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"))
     }
 
     @Test
     fun `zero value is treated as off`() = runTest {
-        coEvery { api.getMimir() } returns mapOf("PAUSELP" to 0L, "PAUSELP-ETH-USDT" to 0L)
+        coEvery { api.getMimir() } returns
+            mapOf(
+                "PAUSELP" to 0L,
+                "PAUSELPDEPOSIT-ETH-USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7" to 0L,
+            )
 
-        assertFalse(repository.isLpPaused("ETH.USDT-0xdac"))
+        assertFalse(repository.isLpPaused("ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"))
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ThorMimirRepositoryTest.kt
@@ -1,0 +1,98 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class ThorMimirRepositoryTest {
+
+    private lateinit var api: ThorChainApi
+    private lateinit var repository: ThorMimirRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        repository = ThorMimirRepositoryImpl(api)
+    }
+
+    @Test
+    fun `clean state returns false for all checks`() = runTest {
+        coEvery { api.getMimir() } returns emptyMap()
+
+        assertFalse(repository.isLpPaused("ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"))
+        assertFalse(repository.isLpHalted("ETH"))
+    }
+
+    @Test
+    fun `global PAUSELP blocks all pools`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("PAUSELP" to 1L)
+
+        assertTrue(repository.isLpPaused("BTC.BTC"))
+        assertTrue(repository.isLpPaused("ETH.USDT-0xdac"))
+    }
+
+    @Test
+    fun `per-asset pause key matches the pool's chain and ticker without contract suffix`() =
+        runTest {
+            coEvery { api.getMimir() } returns mapOf("PAUSELP-ETH-USDT" to 1L)
+
+            assertTrue(repository.isLpPaused("ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"))
+            assertFalse(
+                repository.isLpPaused("ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+            )
+            assertFalse(repository.isLpPaused("BTC.BTC"))
+        }
+
+    @Test
+    fun `per-asset pause key matches case-insensitively`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("pauselp-eth-usdt" to 1L)
+
+        assertTrue(repository.isLpPaused("ETH.USDT-0xdac"))
+    }
+
+    @Test
+    fun `zero value is treated as off`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("PAUSELP" to 0L, "PAUSELP-ETH-USDT" to 0L)
+
+        assertFalse(repository.isLpPaused("ETH.USDT-0xdac"))
+    }
+
+    @Test
+    fun `chain halt key blocks LP on that chain`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("HALTETHLP" to 1L)
+
+        assertTrue(repository.isLpHalted("ETH"))
+        assertFalse(repository.isLpHalted("BTC"))
+    }
+
+    @Test
+    fun `HALTxxxCHAIN also halts LP`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("HALTBTCCHAIN" to 1L)
+
+        assertTrue(repository.isLpHalted("BTC"))
+    }
+
+    @Test
+    fun `chain prefix lookup is case-insensitive`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("HALTETHLP" to 1L)
+
+        assertTrue(repository.isLpHalted("eth"))
+    }
+
+    @Test
+    fun `multiple checks within TTL hit the network only once`() = runTest {
+        coEvery { api.getMimir() } returns mapOf("PAUSELP" to 1L)
+
+        repository.isLpPaused("ETH.USDT-0xdac")
+        repository.isLpHalted("ETH")
+        repository.isLpPaused("BTC.BTC")
+
+        coVerify(exactly = 1) { api.getMimir() }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
@@ -69,6 +69,30 @@ internal class ThorChainLpPreflightUseCaseTest {
     }
 
     @Test
+    fun `when multiple signals block, mimir LP pause wins over chain halt and pool status`() =
+        runTest {
+            coEvery { mimir.isLpPaused(POOL_USDT) } returns true
+            coEvery { mimir.isLpHalted("ETH") } returns true
+            coEvery { api.getPool(POOL_USDT) } returns
+                ThorChainPoolJson(
+                    asset = POOL_USDT,
+                    assetTorPrice = BigInteger.ZERO,
+                    status = "Staged",
+                )
+
+            assertTrue(useCase(POOL_USDT) is ThorChainLpPreflightBlock.LpPaused)
+        }
+
+    @Test
+    fun `when chain halt and pool status both block, chain halt wins`() = runTest {
+        coEvery { mimir.isLpHalted("ETH") } returns true
+        coEvery { api.getPool(POOL_USDT) } returns
+            ThorChainPoolJson(asset = POOL_USDT, assetTorPrice = BigInteger.ZERO, status = "Staged")
+
+        assertTrue(useCase(POOL_USDT) is ThorChainLpPreflightBlock.ChainLpHalted)
+    }
+
+    @Test
     fun `network errors are swallowed - clean state still passes`() = runTest {
         coEvery { mimir.isLpPaused(any()) } throws RuntimeException("thornode down")
         coEvery { mimir.isLpHalted(any()) } throws RuntimeException("thornode down")

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
@@ -1,7 +1,6 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.api.ThorChainApi
-import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
 import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolJson
 import com.vultisig.wallet.data.repositories.ThorMimirRepository
 import io.mockk.coEvery
@@ -26,12 +25,10 @@ internal class ThorChainLpPreflightUseCaseTest {
         mimir = mockk()
         useCase = ThorChainLpPreflightUseCaseImpl(api, mimir)
 
-        // Default: clean state — every signal off, pool Available, no inbound flags.
+        // Default: clean state — every signal off, pool Available.
         coEvery { mimir.isLpPaused(any()) } returns false
         coEvery { mimir.isLpHalted(any()) } returns false
         coEvery { api.getPool(any()) } returns availablePool(POOL_USDT)
-        coEvery { api.getTHORChainInboundAddresses() } returns
-            listOf(inbound(chain = "ETH", halted = false))
     }
 
     @Test fun `clean state passes`() = runTest { assertNull(useCase(POOL_USDT)) }
@@ -72,49 +69,10 @@ internal class ThorChainLpPreflightUseCaseTest {
     }
 
     @Test
-    fun `inbound chain_lp_actions_paused is reported`() = runTest {
-        coEvery { api.getTHORChainInboundAddresses() } returns
-            listOf(inbound(chain = "ETH", chainLpActionsPaused = true))
-
-        val block = useCase(POOL_USDT)
-
-        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
-    }
-
-    @Test
-    fun `inbound halted is reported`() = runTest {
-        coEvery { api.getTHORChainInboundAddresses() } returns
-            listOf(inbound(chain = "ETH", halted = true))
-
-        val block = useCase(POOL_USDT)
-
-        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
-    }
-
-    @Test
-    fun `inbound global trading paused is reported`() = runTest {
-        coEvery { api.getTHORChainInboundAddresses() } returns
-            listOf(inbound(chain = "ETH", globalTradingPaused = true))
-
-        val block = useCase(POOL_USDT)
-
-        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
-    }
-
-    @Test
-    fun `inbound entry for unrelated chain is ignored`() = runTest {
-        coEvery { api.getTHORChainInboundAddresses() } returns
-            listOf(inbound(chain = "BTC", halted = true), inbound(chain = "ETH", halted = false))
-
-        assertNull(useCase(POOL_USDT))
-    }
-
-    @Test
     fun `network errors are swallowed - clean state still passes`() = runTest {
         coEvery { mimir.isLpPaused(any()) } throws RuntimeException("thornode down")
         coEvery { mimir.isLpHalted(any()) } throws RuntimeException("thornode down")
         coEvery { api.getPool(any()) } throws RuntimeException("thornode down")
-        coEvery { api.getTHORChainInboundAddresses() } throws RuntimeException("thornode down")
 
         assertNull(useCase(POOL_USDT))
     }
@@ -141,23 +99,6 @@ internal class ThorChainLpPreflightUseCaseTest {
 
     private fun availablePool(asset: String): ThorChainPoolJson =
         ThorChainPoolJson(asset = asset, assetTorPrice = BigInteger.ZERO, status = "Available")
-
-    private fun inbound(
-        chain: String,
-        halted: Boolean = false,
-        chainLpActionsPaused: Boolean = false,
-        globalTradingPaused: Boolean = false,
-    ): THORChainInboundAddress =
-        THORChainInboundAddress(
-            chain = chain,
-            address = "0xinbound",
-            halted = halted,
-            globalTradingPaused = globalTradingPaused,
-            chainTradingPaused = false,
-            chainLPActionsPaused = chainLpActionsPaused,
-            gasRate = "0",
-            gasRateUnits = "gwei",
-        )
 
     private companion object {
         const val POOL_USDT = "ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
@@ -1,0 +1,165 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolJson
+import com.vultisig.wallet.data.repositories.ThorMimirRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class ThorChainLpPreflightUseCaseTest {
+
+    private lateinit var api: ThorChainApi
+    private lateinit var mimir: ThorMimirRepository
+    private lateinit var useCase: ThorChainLpPreflightUseCaseImpl
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        mimir = mockk()
+        useCase = ThorChainLpPreflightUseCaseImpl(api, mimir)
+
+        // Default: clean state — every signal off, pool Available, no inbound flags.
+        coEvery { mimir.isLpPaused(any()) } returns false
+        coEvery { mimir.isLpHalted(any()) } returns false
+        coEvery { api.getPool(any()) } returns availablePool(POOL_USDT)
+        coEvery { api.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "ETH", halted = false))
+    }
+
+    @Test fun `clean state passes`() = runTest { assertNull(useCase(POOL_USDT)) }
+
+    @Test
+    fun `mimir LP pause is reported first`() = runTest {
+        coEvery { mimir.isLpPaused(POOL_USDT) } returns true
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.LpPaused)
+        assertEquals(POOL_USDT, (block as ThorChainLpPreflightBlock.LpPaused).pool)
+    }
+
+    @Test
+    fun `chain LP halt is reported when mimir LP is not paused`() = runTest {
+        coEvery { mimir.isLpHalted("ETH") } returns true
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.ChainLpHalted)
+        assertEquals("ETH", (block as ThorChainLpPreflightBlock.ChainLpHalted).chainPrefix)
+    }
+
+    @Test
+    fun `pool status not Available is reported`() = runTest {
+        coEvery { api.getPool(POOL_USDT) } returns
+            ThorChainPoolJson(
+                asset = "ETH.USDT-0xdac",
+                assetTorPrice = BigInteger.ZERO,
+                status = "Staged",
+            )
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.PoolNotAvailable)
+        assertEquals("Staged", (block as ThorChainLpPreflightBlock.PoolNotAvailable).status)
+    }
+
+    @Test
+    fun `inbound chain_lp_actions_paused is reported`() = runTest {
+        coEvery { api.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "ETH", chainLpActionsPaused = true))
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
+    }
+
+    @Test
+    fun `inbound halted is reported`() = runTest {
+        coEvery { api.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "ETH", halted = true))
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
+    }
+
+    @Test
+    fun `inbound global trading paused is reported`() = runTest {
+        coEvery { api.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "ETH", globalTradingPaused = true))
+
+        val block = useCase(POOL_USDT)
+
+        assertTrue(block is ThorChainLpPreflightBlock.InboundLpPaused)
+    }
+
+    @Test
+    fun `inbound entry for unrelated chain is ignored`() = runTest {
+        coEvery { api.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "BTC", halted = true), inbound(chain = "ETH", halted = false))
+
+        assertNull(useCase(POOL_USDT))
+    }
+
+    @Test
+    fun `network errors are swallowed - clean state still passes`() = runTest {
+        coEvery { mimir.isLpPaused(any()) } throws RuntimeException("thornode down")
+        coEvery { mimir.isLpHalted(any()) } throws RuntimeException("thornode down")
+        coEvery { api.getPool(any()) } throws RuntimeException("thornode down")
+        coEvery { api.getTHORChainInboundAddresses() } throws RuntimeException("thornode down")
+
+        assertNull(useCase(POOL_USDT))
+    }
+
+    @Test
+    fun `pool status missing is treated as Available`() = runTest {
+        coEvery { api.getPool(POOL_USDT) } returns
+            ThorChainPoolJson(asset = POOL_USDT, assetTorPrice = BigInteger.ZERO, status = null)
+
+        assertNull(useCase(POOL_USDT))
+    }
+
+    @Test
+    fun `pool status Available is not flagged regardless of case`() = runTest {
+        coEvery { api.getPool(POOL_USDT) } returns
+            ThorChainPoolJson(
+                asset = POOL_USDT,
+                assetTorPrice = BigInteger.ZERO,
+                status = "available",
+            )
+
+        assertNull(useCase(POOL_USDT))
+    }
+
+    private fun availablePool(asset: String): ThorChainPoolJson =
+        ThorChainPoolJson(asset = asset, assetTorPrice = BigInteger.ZERO, status = "Available")
+
+    private fun inbound(
+        chain: String,
+        halted: Boolean = false,
+        chainLpActionsPaused: Boolean = false,
+        globalTradingPaused: Boolean = false,
+    ): THORChainInboundAddress =
+        THORChainInboundAddress(
+            chain = chain,
+            address = "0xinbound",
+            halted = halted,
+            globalTradingPaused = globalTradingPaused,
+            chainTradingPaused = false,
+            chainLPActionsPaused = chainLpActionsPaused,
+            gasRate = "0",
+            gasRateUnits = "gwei",
+        )
+
+    private companion object {
+        const val POOL_USDT = "ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ThorChainLpPreflightUseCaseTest.kt
@@ -6,7 +6,9 @@ import com.vultisig.wallet.data.repositories.ThorMimirRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -99,6 +101,13 @@ internal class ThorChainLpPreflightUseCaseTest {
         coEvery { api.getPool(any()) } throws RuntimeException("thornode down")
 
         assertNull(useCase(POOL_USDT))
+    }
+
+    @Test
+    fun `CancellationException is propagated, not swallowed by the fail-open probe`() = runTest {
+        coEvery { mimir.isLpPaused(any()) } throws CancellationException("parent cancelled")
+
+        assertFailsWith<CancellationException> { useCase(POOL_USDT) }
     }
 
     @Test


### PR DESCRIPTION
Closes #4471

## Summary

Before signing a THORChain add-liquidity inbound, fetch the pool status, mimir pause/halt keys, and the inbound `chain_lp_actions_paused` flag in parallel and refuse to build the keysign payload when the network would refund the deposit. This spares users from spending inbound gas on a transaction THORChain immediately returns.

Scope is intentionally narrow: **THORChain LP add-liquidity only**. Maya, savers, loan-open, bond, and the swap-path reinforcement described in #4471 are left for follow-ups so this change is easy to review.


## Screenshot

<img width="540" height="1200" alt="Image" src="https://github.com/user-attachments/assets/11b199a0-3b98-4dc3-805d-d52cbf01b964" />


### What changed

- **`ThorChainPoolJson`** — deserializes the `status` field (Available / Staged / Suspended).
- **`ThorChainApi`** — adds `getPool(asset)` and `getMimir()` against `/thorchain/pool/<asset>` and `/thorchain/mimir`.
- **`ThorMimirRepository`** — typed view over the mimir flag map (`PAUSELP`, `PAUSELP-<CHAIN>-<TICKER>`, `HALT<CHAIN>LP`, `HALT<CHAIN>CHAIN`) with a 30s TTL so several validators in one screen hit the network once.
- **`ThorChainLpPreflightUseCase`** — runs the four signal checks in parallel, returns the first blocking reason or `null` (fail-open on transient errors so a thornode hiccup doesn't block a healthy deposit).
- **`DepositFormViewModel.createAddLiquidityTransaction()`** — invokes the preflight before building the keysign payload and surfaces the network's pause reason inline via the existing `InvalidTransactionDataException` path.
- Localized error strings added across all 10 locales.

## Test plan

- [x] Unit tests pass for `ThorMimirRepository` (9 tests) — covers global PAUSELP, per-asset PAUSELP-CHAIN-TICKER, HALT chain keys, case-insensitivity, zero-value off, and TTL caching.
- [x] Unit tests pass for `ThorChainLpPreflightUseCase` (11 tests) — covers clean state, each blocking signal, unrelated-chain inbound entries, network-error fail-open, and Available-status case handling.
- [x] `:data:compileDebugKotlin` and `:app:compileDebugKotlin` clean.
- [x] `:app:compileDebugUnitTestKotlin` clean.
- [ ] Manual: pick a real paused pool (or temporarily mock the mimir response to set `PAUSELP-ETH-USDT`) and confirm the LP form refuses to advance to keysign with the network's pause reason surfaced inline.
- [ ] Manual regression: a healthy LP add still completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight checks now prevent THORChain LP deposits to paused, halted, or unavailable pools and surface a localized error dialog with a retry option.

* **Localization**
  * Added localized LP deposit error messages (paused, chain halted, pool unavailable) across multiple languages.

* **Tests**
  * New unit tests cover preflight decision logic, pool status handling, fail-open behavior, and caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4496)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->