### PR TITLE
fix(circle-defi): local cache failure no longer reverts account creation

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
@@ -240,28 +240,30 @@ constructor(
                 withContext(ioDispatcher) {
                     runCatching {
                         val ethereumVaultAddress = getEvmVaultAddress()
-                        circleApi.createScAccount(ethereumVaultAddress).also { newAddress ->
-                            scaCircleAccountRepository.saveAccount(vaultId, newAddress)
-                        }
+                        circleApi.createScAccount(ethereumVaultAddress)
                     }
                 }
 
             createdAddress
                 .onSuccess { newAddress ->
                     mscaAddress = newAddress
+                    _state.update { currentState ->
+                        currentState.copy(
+                            circleDefi = currentState.circleDefi.copy(isAccountOpen = true)
+                        )
+                    }
                     showSnackbar(R.string.circle_msca_account_created_success, SnackbarType.Success)
+                    runCatching {
+                            withContext(ioDispatcher) {
+                                scaCircleAccountRepository.saveAccount(vaultId, newAddress)
+                            }
+                        }
+                        .onFailure { Timber.e(it) }
                 }
                 .onFailure { t ->
                     Timber.e(t)
                     showSnackbar(R.string.circle_msca_account_created_failed, SnackbarType.Error)
                 }
-
-            _state.update { currentState ->
-                currentState.copy(
-                    circleDefi =
-                        currentState.circleDefi.copy(isAccountOpen = createdAddress.isSuccess)
-                )
-            }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
@@ -236,34 +236,34 @@ constructor(
     /** Creates a new Circle MSCA account for the current vault. */
     fun onCreateAccount() {
         viewModelScope.launch {
-            val createdAddress =
-                withContext(ioDispatcher) {
-                    runCatching {
+            try {
+                val newAddress =
+                    withContext(ioDispatcher) {
                         val ethereumVaultAddress = getEvmVaultAddress()
                         circleApi.createScAccount(ethereumVaultAddress)
                     }
+                mscaAddress = newAddress
+                _state.update { currentState ->
+                    currentState.copy(
+                        circleDefi = currentState.circleDefi.copy(isAccountOpen = true)
+                    )
                 }
-
-            createdAddress
-                .onSuccess { newAddress ->
-                    mscaAddress = newAddress
-                    _state.update { currentState ->
-                        currentState.copy(
-                            circleDefi = currentState.circleDefi.copy(isAccountOpen = true)
-                        )
+                showSnackbar(R.string.circle_msca_account_created_success, SnackbarType.Success)
+                try {
+                    withContext(ioDispatcher) {
+                        scaCircleAccountRepository.saveAccount(vaultId, newAddress)
                     }
-                    showSnackbar(R.string.circle_msca_account_created_success, SnackbarType.Success)
-                    runCatching {
-                            withContext(ioDispatcher) {
-                                scaCircleAccountRepository.saveAccount(vaultId, newAddress)
-                            }
-                        }
-                        .onFailure { Timber.e(it) }
-                }
-                .onFailure { t ->
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (t: Throwable) {
                     Timber.e(t)
-                    showSnackbar(R.string.circle_msca_account_created_failed, SnackbarType.Error)
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                Timber.e(t)
+                showSnackbar(R.string.circle_msca_account_created_failed, SnackbarType.Error)
+            }
         }
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
@@ -126,6 +126,7 @@ internal class CircleDeFiPositionsViewModelTest {
             val type = snackbarTypeShownBy { vm.onCreateAccount() }
 
             assertEquals(SnackbarType.Success, type)
+            coVerify(exactly = 1) { scaCircleAccountRepository.saveAccount(VAULT_ID, MSCA_ADDRESS) }
             assertTrue(vm.state.value.circleDefi.isAccountOpen)
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
@@ -115,6 +115,21 @@ internal class CircleDeFiPositionsViewModelTest {
         }
 
     @Test
+    fun `onCreateAccount shows Success and sets isAccountOpen true even when local save throws`() =
+        runTest {
+            val vm = createViewModel().also { it.setData(VAULT_ID) }
+            givenNoExistingAccount()
+            coEvery { circleApi.createScAccount(OWNER_ADDRESS) } returns MSCA_ADDRESS
+            coEvery { scaCircleAccountRepository.saveAccount(VAULT_ID, MSCA_ADDRESS) } throws
+                RuntimeException("DataStore IO error")
+
+            val type = snackbarTypeShownBy { vm.onCreateAccount() }
+
+            assertEquals(SnackbarType.Success, type)
+            assertTrue(vm.state.value.circleDefi.isAccountOpen)
+        }
+
+    @Test
     fun `onCreateAccount reports an Error when the vault cannot be resolved`() = runTest {
         val vm = createViewModel().also { it.setData(VAULT_ID) }
         givenNoExistingAccount()


### PR DESCRIPTION
## Summary
- Split the `runCatching` in `onCreateAccount` so only `circleApi.createScAccount(...)` determines success/failure
- `saveAccount` (DataStore write) now runs in its own `runCatching { }.onFailure { Timber.e(it) }` on the success path — a cache failure logs silently instead of showing an error snackbar and leaving `isAccountOpen = false`
- Added unit test: remote success + local save throwing → Success snackbar, `isAccountOpen = true`

## Issue
Closes #4088

## Test Plan
- [x] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)
- [x] Unit tests pass: `CircleDeFiPositionsViewModelTest` (4 tests, all green)
- [ ] Manual: open Circle account, confirm success snackbar and account UI appears
- [ ] Manual: next launch self-heals via `fetchAssociatedMscaAccount → GET /circle/wallet` if local save was skipped

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure account creation success is reflected in the UI and success notification even if local persistence fails
  * Improved error handling so failures during account creation reliably show the failure notification and are logged

* **Tests**
  * Added unit test covering account creation where local save throws, confirming success notification and UI state update remain consistent

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->