### PR TITLE
fix: guard EVM broadcast against non-2xx RPC proxy responses

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -22,11 +22,9 @@ import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
-import io.ktor.http.isSuccess
 import java.math.BigInteger
 import java.net.SocketTimeoutException
 import javax.inject.Inject
@@ -382,13 +380,10 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
     override suspend fun findCustomToken(contractAddress: String): List<CustomTokenResponse> {
         val (payload1, payload2) = generateCustomTokenPayload(contractAddress)
         return try {
-            val response = http.post(rpcUrl) { setBody(listOf(payload1, payload2)) }
-            if (!response.status.isSuccess()) {
-                throw Exception(
-                    "findCustomToken failed (${response.status.value}): ${response.bodyAsText()}"
-                )
-            }
-            val responseList = response.body<List<RpcResponse>>()
+            val responseList =
+                http
+                    .post(rpcUrl) { setBody(listOf(payload1, payload2)) }
+                    .bodyOrThrow<List<RpcResponse>>()
             responseList.map { CustomTokenResponse(id = it.id, result = it.result) }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -352,13 +352,7 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         val response = http.post(rpcUrl) { setBody(payload) }
         val responseBody = response.bodyAsText()
         Timber.d("broadcast response: $responseBody")
-        if (!response.status.isSuccess()) {
-            throw NetworkException(
-                response.status.value,
-                "EVM broadcast failed (${response.status.value})",
-            )
-        }
-        val jsonObject = response.body<SendTransactionJson>()
+        val jsonObject = response.bodyOrThrow<SendTransactionJson>()
         if (jsonObject.error != null) {
             val message = jsonObject.error.message
             if (

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -353,7 +353,10 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         val responseBody = response.bodyAsText()
         Timber.d("broadcast response: $responseBody")
         if (!response.status.isSuccess()) {
-            throw Exception("EVM broadcast failed (${response.status.value}): $responseBody")
+            throw NetworkException(
+                response.status.value,
+                "EVM broadcast failed (${response.status.value})",
+            )
         }
         val jsonObject = response.body<SendTransactionJson>()
         if (jsonObject.error != null) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -26,6 +26,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
 import java.math.BigInteger
 import java.net.SocketTimeoutException
 import javax.inject.Inject
@@ -351,6 +352,9 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         val response = http.post(rpcUrl) { setBody(payload) }
         val responseBody = response.bodyAsText()
         Timber.d("broadcast response: $responseBody")
+        if (!response.status.isSuccess()) {
+            throw Exception("EVM broadcast failed (${response.status.value}): $responseBody")
+        }
         val jsonObject = response.body<SendTransactionJson>()
         if (jsonObject.error != null) {
             val message = jsonObject.error.message
@@ -382,6 +386,11 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         val (payload1, payload2) = generateCustomTokenPayload(contractAddress)
         return try {
             val response = http.post(rpcUrl) { setBody(listOf(payload1, payload2)) }
+            if (!response.status.isSuccess()) {
+                throw Exception(
+                    "findCustomToken failed (${response.status.value}): ${response.bodyAsText()}"
+                )
+            }
             val responseList = response.body<List<RpcResponse>>()
             responseList.map { CustomTokenResponse(id = it.id, result = it.result) }
         } catch (e: Exception) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/utils/Rpc.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/utils/Rpc.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.data.api.utils
 
 import com.vultisig.wallet.data.api.models.RpcError
 import com.vultisig.wallet.data.api.models.RpcPayload
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import kotlinx.serialization.SerialName
@@ -23,4 +23,4 @@ internal suspend inline fun <reified T> HttpClient.postRpc(
     method: String,
     params: JsonArray,
     id: Int = 1,
-): T = post(url) { setBody(RpcPayload(method = method, params = params, id = id)) }.body()
+): T = post(url) { setBody(RpcPayload(method = method, params = params, id = id)) }.bodyOrThrow()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/utils/Rpc.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/utils/Rpc.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.data.api.utils
 
 import com.vultisig.wallet.data.api.models.RpcError
 import com.vultisig.wallet.data.api.models.RpcPayload
-import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import kotlinx.serialization.SerialName
@@ -23,4 +23,4 @@ internal suspend inline fun <reified T> HttpClient.postRpc(
     method: String,
     params: JsonArray,
     id: Int = 1,
-): T = post(url) { setBody(RpcPayload(method = method, params = params, id = id)) }.bodyOrThrow()
+): T = post(url) { setBody(RpcPayload(method = method, params = params, id = id)) }.body()


### PR DESCRIPTION
## Summary
- In `EvmApiImp.sendTransaction`, check `response.status.isSuccess()` after reading the body as text, and throw a descriptive `Exception("EVM broadcast failed (403): ...")` for non-2xx responses — eliminating the raw `NoTransformationFoundException` that was shown verbatim on the Keysign error screen
- Applied the same guard to `findCustomToken` which had the identical unconditional-deserialization pattern

## Issue
Closes #4409

## Test Plan
- [ ] `./gradlew assembleDebug` succeeds
- [ ] `./gradlew lint` passes
- [ ] A simulated 403 from the RPC proxy results in a clean error message on the Keysign screen (no `NoTransformationFoundException` in the trace)
- [ ] A successful 2xx broadcast continues to work correctly — the happy path is unchanged

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of custom token search with stricter response validation and clearer failure detection.
  * Enhanced transaction sending with more robust response parsing and error surfacing to reduce silent/ambiguous failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->