### PR TITLE
feat: surface dApp request banner on verify and done screens (#4060)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
 import com.vultisig.wallet.data.usecases.GenerateQrBitmap
@@ -142,6 +143,12 @@ class PreviewActivity : ComponentActivity() {
                     "blockaid_popup_high" -> BlockaidPopupHighRiskPreview()
                     "blockaid_popup_medium" -> BlockaidPopupMediumRiskPreview()
                     "select_chain_popup" -> SelectChainPopupPreview()
+                    "dapp_banner_verify_full" -> DappBannerVerifyPreview(DappBannerVariant.FULL)
+                    "dapp_banner_verify_name_only" ->
+                        DappBannerVerifyPreview(DappBannerVariant.NAME_ONLY)
+                    "dapp_banner_verify_host_only" ->
+                        DappBannerVerifyPreview(DappBannerVariant.HOST_ONLY)
+                    "dapp_banner_send_done" -> DappBannerSendDonePreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1006,6 +1013,75 @@ private fun blockaidHeroUnverifiedState() =
         // body / network failure).
         txScanStatus = TransactionScanStatus.NotStarted,
     )
+
+private enum class DappBannerVariant {
+    FULL,
+    NAME_ONLY,
+    HOST_ONLY,
+}
+
+@Composable
+private fun DappBannerVerifyPreview(variant: DappBannerVariant) {
+    val metadata =
+        when (variant) {
+            DappBannerVariant.FULL ->
+                DAppMetadata(
+                    name = "Uniswap",
+                    url = "https://app.uniswap.org/swap",
+                    iconUrl = "https://app.uniswap.org/favicon.ico",
+                )
+            DappBannerVariant.NAME_ONLY -> DAppMetadata(name = "Uniswap", url = "", iconUrl = "")
+            DappBannerVariant.HOST_ONLY ->
+                DAppMetadata(name = "", url = "https://app.uniswap.org/swap", iconUrl = "")
+        }
+    VerifySendScreen(
+        state = blockaidHeroSendState(),
+        dappMetadata = metadata,
+        isConsentsEnabled = false,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
+    )
+}
+
+@Composable
+private fun DappBannerSendDonePreview() {
+    val ethCoin = Coins.Ethereum.ETH
+    SendTxOverviewScreen(
+        showToolbar = true,
+        showSaveToAddressBook = true,
+        transactionHash = "0x1a2b3c...d4e5f6",
+        transactionLink = "https://etherscan.io/tx/0x1a2b3c",
+        transactionStatus = TransactionStatus.Broadcasted,
+        onComplete = {},
+        onBack = {},
+        onAddToAddressBook = {},
+        tx =
+            UiTransactionInfo(
+                type = UiTransactionInfoType.Send,
+                token = ValuedToken(token = ethCoin, value = "1.5", fiatValue = "$3,847.50"),
+                from = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+                to = "0x9876543210FeDcBa9876543210FeDcBa98765432",
+                memo = "",
+                networkFeeTokenValue = "0.0024 ETH",
+                networkFeeFiatValue = "$6.15",
+            ),
+        isTransactionDetailVisible = false,
+        onTransactionDetailVisibleChange = {},
+        dappMetadata =
+            DAppMetadata(
+                name = "Uniswap",
+                url = "https://app.uniswap.org/swap",
+                iconUrl = "https://app.uniswap.org/favicon.ico",
+            ),
+    )
+}
 
 @Composable
 private fun SelectChainPopupPreview() {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
@@ -15,8 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -24,7 +22,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.theme.Theme
@@ -37,6 +34,13 @@ import com.vultisig.wallet.ui.theme.Theme
  * Layout mirrors the iOS `DAppRequestBanner`: a "Request from" header followed by a 32dp circular
  * icon and a name/host stack. Empty fields are treated as absent so partially-populated metadata
  * still renders cleanly.
+ *
+ * **Privacy stance — Android intentionally does NOT fetch the dApp-supplied `iconUrl`.** Loading
+ * the favicon would expose the signing device IP and TLS fingerprint to a host the user has not yet
+ * consented to interact with, and feed a default Coil pipeline an attacker-controlled URL with no
+ * size cap or timeout (decoder-CVE surface). iOS and Windows currently load the icon — Android
+ * leads on this and ships a placeholder glyph instead. The name and host already identify the dApp;
+ * the icon was visual polish, not load-bearing.
  */
 @Composable
 internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modifier) {
@@ -46,7 +50,11 @@ internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modi
     val announcement = buildString {
         append(label)
         if (metadata.name.isNotEmpty()) append(' ').append(metadata.name)
-        if (metadata.host.isNotEmpty()) append(", ").append(metadata.host)
+        if (metadata.host.isNotEmpty()) {
+            // Use a comma to separate name from host, but a plain space when name is absent so
+            // TalkBack reads "Request from app.uniswap.org" instead of "Request from, app…".
+            append(if (metadata.name.isNotEmpty()) ", " else " ").append(metadata.host)
+        }
     }
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -70,43 +78,28 @@ internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modi
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            DappIcon(safeIconUrl = metadata.safeIconUrl)
+            DappIcon()
             DappInfo(name = metadata.name, host = metadata.host, modifier = Modifier.weight(1f))
         }
     }
 }
 
 @Composable
-private fun DappIcon(safeIconUrl: String?) {
-    val placeholder: @Composable () -> Unit = {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier =
-                Modifier.size(ICON_SIZE)
-                    .background(Theme.v2.colors.backgrounds.surface1, CircleShape),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.settings_globe),
-                contentDescription = null,
-                tint = Theme.v2.colors.text.tertiary,
-                modifier = Modifier.size(PLACEHOLDER_GLYPH_SIZE),
-            )
-        }
+private fun DappIcon() {
+    // Intentionally no `iconUrl` parameter. See class kdoc — Android does not fetch dApp-supplied
+    // icons so a hostile origin can't fingerprint the signing device the moment verify renders.
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier.size(ICON_SIZE).background(Theme.v2.colors.backgrounds.surface1, CircleShape),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.settings_globe),
+            contentDescription = null,
+            tint = Theme.v2.colors.text.tertiary,
+            modifier = Modifier.size(PLACEHOLDER_GLYPH_SIZE),
+        )
     }
-
-    if (safeIconUrl == null) {
-        placeholder()
-        return
-    }
-
-    SubcomposeAsyncImage(
-        model = safeIconUrl,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
-        modifier = Modifier.size(ICON_SIZE).clip(CircleShape),
-        loading = { placeholder() },
-        error = { placeholder() },
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
@@ -1,0 +1,168 @@
+package com.vultisig.wallet.ui.components.dapp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.payload.DAppMetadata
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Informational card showing which dApp produced a keysign request. Rendered above the transaction
+ * hero on verify and done screens; trust decisions stay with Blockaid and the independently-decoded
+ * calldata, so this only echoes the metadata the dApp self-declared.
+ *
+ * Layout mirrors the iOS `DAppRequestBanner`: a "Request from" header followed by a 32dp circular
+ * icon and a name/host stack. Empty fields are treated as absent so partially-populated metadata
+ * still renders cleanly.
+ */
+@Composable
+internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modifier) {
+    val label = stringResource(R.string.request_from)
+    // Merge the three texts into one TalkBack announcement: "Request from Uniswap, app.uniswap.org"
+    // instead of three separate nodes.
+    val announcement = buildString {
+        append(label)
+        if (metadata.name.isNotEmpty()) append(' ').append(metadata.name)
+        if (metadata.host.isNotEmpty()) append(", ").append(metadata.host)
+    }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(
+                    color = Theme.v2.colors.backgrounds.surface2,
+                    shape = RoundedCornerShape(16.dp),
+                )
+                .padding(20.dp)
+                .semantics(mergeDescendants = true) { contentDescription = announcement },
+    ) {
+        Text(
+            text = label,
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DappIcon(safeIconUrl = metadata.safeIconUrl)
+            DappInfo(name = metadata.name, host = metadata.host, modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun DappIcon(safeIconUrl: String?) {
+    val placeholder: @Composable () -> Unit = {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier.size(ICON_SIZE)
+                    .background(Theme.v2.colors.backgrounds.surface1, CircleShape),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.settings_globe),
+                contentDescription = null,
+                tint = Theme.v2.colors.text.tertiary,
+                modifier = Modifier.size(PLACEHOLDER_GLYPH_SIZE),
+            )
+        }
+    }
+
+    if (safeIconUrl == null) {
+        placeholder()
+        return
+    }
+
+    SubcomposeAsyncImage(
+        model = safeIconUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier.size(ICON_SIZE).clip(CircleShape),
+        loading = { placeholder() },
+        error = { placeholder() },
+    )
+}
+
+@Composable
+private fun DappInfo(name: String, host: String, modifier: Modifier = Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        if (name.isNotEmpty()) {
+            Text(
+                text = name,
+                style = Theme.brockmann.body.m.medium,
+                color = Theme.v2.colors.text.primary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (host.isNotEmpty()) {
+            // When name is absent the host carries the identity on its own — bump up to the same
+            // body-m size so it doesn't look like an afterthought.
+            Text(
+                text = host,
+                style =
+                    if (name.isEmpty()) Theme.brockmann.body.m.medium
+                    else Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.tertiary,
+                maxLines = 1,
+                overflow = TextOverflow.MiddleEllipsis,
+            )
+        }
+    }
+}
+
+private val ICON_SIZE = 32.dp
+private val PLACEHOLDER_GLYPH_SIZE = 20.dp
+
+@Preview
+@Composable
+private fun PreviewDappRequestBannerFullMetadata() {
+    DappRequestBanner(
+        metadata =
+            DAppMetadata(
+                name = "Cross-chain swaps across 13+ networks | 1inch",
+                url = "https://1inch.io/",
+                iconUrl = "https://1inch.io/favicon.ico",
+            )
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewDappRequestBannerNameOnly() {
+    DappRequestBanner(metadata = DAppMetadata(name = "Uniswap", url = "", iconUrl = ""))
+}
+
+@Preview
+@Composable
+private fun PreviewDappRequestBannerHostFallback() {
+    DappRequestBanner(
+        metadata = DAppMetadata(name = "", url = "https://app.uniswap.org/swap", iconUrl = "")
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.isSecuredAssetEligible
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.models.proto.v1.KeysignMessageProto
@@ -263,6 +264,22 @@ constructor(
     private var tempKeysignMessageProto: KeysignMessageProto? = null
 
     private val deepLinkHelper = MutableStateFlow<DeepLinkHelper?>(null)
+
+    /**
+     * dApp identity attached to the keysign request, if any. Read by the verify and done banners on
+     * the joining-device path. Independent of [verifyUiModel] so every variant (Send/Swap/Deposit)
+     * shares one source.
+     *
+     * **Compose observability:** [_keysignPayload] is a plain `var`, so this getter is *not*
+     * observable on its own. The verify screens that read it also `collectAsState()` on
+     * [verifyUiModel]; because [loadTransaction] sets `_keysignPayload` before the matching
+     * `verifyUiModel.value = …` assignment, the state-flow emission triggers the recomposition that
+     * re-reads this getter and picks up the populated value. If a future change emits to
+     * `verifyUiModel` *before* `_keysignPayload` is populated, the banner will read stale `null`
+     * until the next unrelated recomposition.
+     */
+    val dappMetadata: DAppMetadata?
+        get() = _keysignPayload?.dappMetadata
 
     val keysignViewModel: KeysignViewModel
         get() =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -111,6 +111,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
@@ -249,6 +251,14 @@ constructor(
     private var _discoveryListener: MediatorServiceDiscoveryListener? = null
     private var _nsdManager: NsdManager? = null
     private var _keysignPayload: KeysignPayload? = null
+        set(value) {
+            field = value
+            // Mirror dappMetadata into the StateFlow so the verify banner is observable on its own,
+            // independent of [verifyUiModel] emission ordering.
+            _dappMetadata.value = value?.dappMetadata
+        }
+
+    private val _dappMetadata = MutableStateFlow<DAppMetadata?>(null)
     private var customMessagePayload: CustomMessagePayload? = null
     private var messagesToSign: List<String> = emptyList()
 
@@ -270,16 +280,11 @@ constructor(
      * the joining-device path. Independent of [verifyUiModel] so every variant (Send/Swap/Deposit)
      * shares one source.
      *
-     * **Compose observability:** [_keysignPayload] is a plain `var`, so this getter is *not*
-     * observable on its own. The verify screens that read it also `collectAsState()` on
-     * [verifyUiModel]; because [loadTransaction] sets `_keysignPayload` before the matching
-     * `verifyUiModel.value = …` assignment, the state-flow emission triggers the recomposition that
-     * re-reads this getter and picks up the populated value. If a future change emits to
-     * `verifyUiModel` *before* `_keysignPayload` is populated, the banner will read stale `null`
-     * until the next unrelated recomposition.
+     * Driven by the custom setter on [_keysignPayload] so consumers observing this flow are
+     * notified the moment the payload is parsed — no implicit dependency on the ordering of
+     * `verifyUiModel.value = …` emissions.
      */
-    val dappMetadata: DAppMetadata?
-        get() = _keysignPayload?.dappMetadata
+    val dappMetadata: StateFlow<DAppMetadata?> = _dappMetadata.asStateFlow()
 
     val keysignViewModel: KeysignViewModel
         get() =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -33,6 +33,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.getEcdsaSigningKey
 import com.vultisig.wallet.data.models.getEddsaSigningKey
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
@@ -269,6 +270,12 @@ constructor(
     val showSaveToAddressBook = MutableStateFlow(false)
     /** Transaction UI model, potentially enriched after signing completes. */
     val resolvedTransactionUiModel = MutableStateFlow(transactionTypeUiModel)
+
+    /**
+     * dApp identity attached to the keysign request, if any. Read by the verify and done banners.
+     */
+    val dappMetadata: DAppMetadata?
+        get() = keysignPayload?.dappMetadata
 
     private var tssInstance: ServiceImpl? = null
     private var tssMessenger: TssMessenger? = null

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -35,11 +35,13 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
+import com.vultisig.wallet.ui.components.dapp.DappRequestBanner
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
@@ -104,6 +106,7 @@ internal fun VerifyDepositScreen(
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
+    dappMetadata: DAppMetadata? = null,
     onBackClick: () -> Unit = {},
 ) {
     Scaffold(
@@ -126,6 +129,8 @@ internal fun VerifyDepositScreen(
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState()),
             ) {
+                dappMetadata?.takeUnless { it.isEmpty }?.let { DappRequestBanner(metadata = it) }
+
                 val tx = state.depositTransactionUiModel
 
                 Column(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -47,6 +47,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
     }
     val state by viewModel.currentState.collectAsState()
     val verifyUiModel by viewModel.verifyUiModel.collectAsState()
+    val dappMetadata by viewModel.dappMetadata.collectAsState()
     val isKeysignFinished = keysignState is KeysignState.KeysignFinished
     val isKeysignInProgress = state == Keysign && keysignState.isInProgress
     val isSignMessageDone = isKeysignFinished && verifyUiModel is VerifyUiModel.SignMessage
@@ -95,7 +96,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Send -> {
                         VerifySendScreen(
                             state = model.model,
-                            dappMetadata = viewModel.dappMetadata,
+                            dappMetadata = dappMetadata,
                             isConsentsEnabled = false,
                             confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
                             onFastSignClick = {},
@@ -106,7 +107,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Swap -> {
                         VerifySwapScreen(
                             state = model.model,
-                            dappMetadata = viewModel.dappMetadata,
+                            dappMetadata = dappMetadata,
                             showToolbar = false,
                             onBackClick = {},
                             confirmTitle = stringResource(R.string.verify_swap_sign_button),
@@ -119,7 +120,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Deposit -> {
                         VerifyDepositScreen(
                             state = model.model,
-                            dappMetadata = viewModel.dappMetadata,
+                            dappMetadata = dappMetadata,
                             confirmTitle = stringResource(R.string.verify_swap_sign_button),
                             onFastSignClick = {},
                             onConfirm = viewModel::joinKeysign,
@@ -162,7 +163,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     showSaveToAddressBook =
                         keysignViewModel.showSaveToAddressBook.collectAsState().value,
                     hasBackClick = false,
-                    dappMetadata = viewModel.dappMetadata,
+                    dappMetadata = dappMetadata,
                 )
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -95,6 +95,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Send -> {
                         VerifySendScreen(
                             state = model.model,
+                            dappMetadata = viewModel.dappMetadata,
                             isConsentsEnabled = false,
                             confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
                             onFastSignClick = {},
@@ -105,6 +106,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Swap -> {
                         VerifySwapScreen(
                             state = model.model,
+                            dappMetadata = viewModel.dappMetadata,
                             showToolbar = false,
                             onBackClick = {},
                             confirmTitle = stringResource(R.string.verify_swap_sign_button),
@@ -117,6 +119,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     is VerifyUiModel.Deposit -> {
                         VerifyDepositScreen(
                             state = model.model,
+                            dappMetadata = viewModel.dappMetadata,
                             confirmTitle = stringResource(R.string.verify_swap_sign_button),
                             onFastSignClick = {},
                             onConfirm = viewModel::joinKeysign,
@@ -159,6 +162,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     showSaveToAddressBook =
                         keysignViewModel.showSaveToAddressBook.collectAsState().value,
                     hasBackClick = false,
+                    dappMetadata = viewModel.dappMetadata,
                 )
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -18,6 +18,7 @@ import app.rive.Fit
 import app.rive.ViewModelSource
 import app.rive.rememberViewModelInstance
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.loader.VsSigningProgressIndicator
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
@@ -50,6 +51,7 @@ internal fun KeysignView(
     showToolbar: Boolean = false,
     hasBackClick: Boolean,
     showSaveToAddressBook: Boolean,
+    dappMetadata: DAppMetadata? = null,
 ) {
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         if (state.isInProgress) {
@@ -73,6 +75,7 @@ internal fun KeysignView(
                             transactionTypeUiModel = transactionTypeUiModel.swapTransactionUiModel,
                             isTransactionDetailVisible = isTransactionDetailVisible,
                             onTransactionDetailVisibleChange = { isTransactionDetailVisible = it },
+                            dappMetadata = dappMetadata,
                         )
                     }
                     is TransactionTypeUiModel.Deposit,
@@ -90,6 +93,7 @@ internal fun KeysignView(
                             showSaveToAddressBook = showSaveToAddressBook,
                             isTransactionDetailVisible = isTransactionDetailVisible,
                             onTransactionDetailVisibleChange = { isTransactionDetailVisible = it },
+                            dappMetadata = dappMetadata,
                         )
                     }
                     else -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
@@ -110,5 +110,6 @@ private fun Keysign(
         onAddToAddressBook = keysignViewModel::navigateToAddressBook,
         showSaveToAddressBook = keysignViewModel.showSaveToAddressBook.collectAsState().value,
         hasBackClick = true,
+        dappMetadata = keysignViewModel.dappMetadata,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.ui.components.SignSolanaDisplayView
 import com.vultisig.wallet.ui.components.SignTonDisplayView
@@ -52,6 +53,7 @@ import com.vultisig.wallet.ui.components.VsOverviewToken
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
+import com.vultisig.wallet.ui.components.dapp.DappRequestBanner
 import com.vultisig.wallet.ui.components.hero.TransactionHero
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBadget
@@ -124,6 +126,7 @@ internal fun VerifySendScreen(
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
+    dappMetadata: DAppMetadata? = null,
     onConsentAddress: (Boolean) -> Unit = {},
     onConsentAmount: (Boolean) -> Unit = {},
     onBackClick: () -> Unit = {},
@@ -187,6 +190,8 @@ internal fun VerifySendScreen(
                 modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
             ) {
                 val tx = state.transaction
+
+                dappMetadata?.takeUnless { it.isEmpty }?.let { DappRequestBanner(metadata = it) }
 
                 SecurityScannerBadget(state.txScanStatus)
 
@@ -558,6 +563,31 @@ private fun PreviewVerifySendScreenUnlimitedApproval() {
         confirmTitle = stringResource(R.string.keysign_sign_transaction),
         onConsentAddress = {},
         onConsentAmount = {},
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewVerifySendScreenWithDappBanner() {
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        srcAddress = "0x1111111111111111111111111111111111111111",
+                        dstAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    )
+            ),
+        dappMetadata =
+            DAppMetadata(
+                name = "Uniswap",
+                url = "https://app.uniswap.org/swap",
+                iconUrl = "https://app.uniswap.org/favicon.ico",
+            ),
+        isConsentsEnabled = false,
+        confirmTitle = stringResource(R.string.keysign_sign_transaction),
         onFastSignClick = {},
         onConfirm = {},
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -49,6 +49,7 @@ import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.getProviderLogo
 import com.vultisig.wallet.data.models.isLayer2
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
@@ -57,6 +58,7 @@ import com.vultisig.wallet.ui.components.VsCheckField
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsHoldableButton
+import com.vultisig.wallet.ui.components.dapp.DappRequestBanner
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBadget
@@ -125,6 +127,7 @@ internal fun VerifySwapScreen(
     showToolbar: Boolean,
     confirmTitle: String,
     isConsentsEnabled: Boolean = true,
+    dappMetadata: DAppMetadata? = null,
     onConsentReceiveAmount: (Boolean) -> Unit = {},
     onConsentAmount: (Boolean) -> Unit = {},
     onConsentAllowance: (Boolean) -> Unit = {},
@@ -147,6 +150,7 @@ internal fun VerifySwapScreen(
         isConsentsEnabled = isConsentsEnabled,
         hasFastSign = state.hasFastSign,
         vaultName = state.vaultName,
+        dappMetadata = dappMetadata,
         onConsentReceiveAmount = onConsentReceiveAmount,
         onConsentAmount = onConsentAmount,
         onConsentAllowance = onConsentAllowance,
@@ -172,6 +176,7 @@ private fun VerifySwapScreen(
     isConsentsEnabled: Boolean = true,
     hasFastSign: Boolean,
     vaultName: String,
+    dappMetadata: DAppMetadata?,
     onConsentReceiveAmount: (Boolean) -> Unit,
     onConsentAmount: (Boolean) -> Unit,
     onConsentAllowance: (Boolean) -> Unit,
@@ -189,6 +194,8 @@ private fun VerifySwapScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
                 modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
             ) {
+                dappMetadata?.takeUnless { it.isEmpty }?.let { DappRequestBanner(metadata = it) }
+
                 Column(modifier = Modifier.align(alignment = Alignment.CenterHorizontally)) {
                     SecurityScannerBadget(scanStatus)
                 }
@@ -657,6 +664,7 @@ private fun VerifySwapScreenPreview() {
         confirmTitle = "Sign",
         hasFastSign = false,
         vaultName = "Main Vault",
+        dappMetadata = null,
         onConsentReceiveAmount = {},
         onConsentAmount = {},
         onConsentAllowance = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -60,6 +61,7 @@ internal fun SendTxOverviewScreen(
     tx: UiTransactionInfo,
     isTransactionDetailVisible: Boolean,
     onTransactionDetailVisibleChange: (Boolean) -> Unit,
+    dappMetadata: DAppMetadata? = null,
 ) {
     TxDoneScaffold(
         transactionHash = transactionHash,
@@ -69,6 +71,7 @@ internal fun SendTxOverviewScreen(
         onBack = onBack,
         isTransactionDetailVisible = isTransactionDetailVisible,
         onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
+        dappMetadata = dappMetadata,
         bottomBarContent = {
             VsButton(
                 label = stringResource(R.string.transaction_done_title),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsOverviewToken
 import com.vultisig.wallet.ui.components.buttons.VsButton
@@ -56,6 +57,7 @@ internal fun SwapTransactionOverviewScreen(
     transactionTypeUiModel: SwapTransactionUiModel,
     isTransactionDetailVisible: Boolean,
     onTransactionDetailVisibleChange: (Boolean) -> Unit,
+    dappMetadata: DAppMetadata? = null,
 ) {
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -69,6 +71,7 @@ internal fun SwapTransactionOverviewScreen(
         onBack = onBack,
         isTransactionDetailVisible = isTransactionDetailVisible,
         onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
+        dappMetadata = dappMetadata,
         tokenContent = {
             Box {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -38,9 +38,11 @@ import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsOverviewToken
+import com.vultisig.wallet.ui.components.dapp.DappRequestBanner
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.components.v2.topbar.V2Topbar
 import com.vultisig.wallet.ui.models.keysign.TransactionStatus
@@ -61,6 +63,7 @@ internal fun TxDoneScaffold(
     isTransactionDetailVisible: Boolean,
     onTransactionDetailVisibleChange: (Boolean) -> Unit,
     onBack: () -> Unit = {},
+    dappMetadata: DAppMetadata? = null,
     tokenContent: @Composable () -> Unit,
     detailContent: @Composable () -> Unit,
     bottomBarContent: @Composable () -> Unit,
@@ -94,6 +97,7 @@ internal fun TxDoneScaffold(
                 snackbarHostState = snackbarHostState,
                 context = context,
                 detailContent = detailContent,
+                dappMetadata = dappMetadata,
                 isTransactionDetailVisible = isTransactionDetailVisible,
                 onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
             )
@@ -115,6 +119,7 @@ private fun SuccessTransaction(
     detailContent: @Composable (() -> Unit),
     isTransactionDetailVisible: Boolean,
     onTransactionDetailVisibleChange: (Boolean) -> Unit,
+    dappMetadata: DAppMetadata? = null,
 ) {
 
     Column(
@@ -173,6 +178,13 @@ private fun SuccessTransaction(
                 )
             }
         }
+
+        dappMetadata
+            ?.takeUnless { it.isEmpty }
+            ?.let {
+                DappRequestBanner(metadata = it)
+                UiSpacer(8.dp)
+            }
 
         tokenContent()
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -426,6 +426,7 @@
     <string name="verify_transaction_function_inputs_title">Funktionsargumente</string>
     <string name="dapp_hero_unverified_function_title">Nicht verifizierte Funktion</string>
     <string name="dapp_hero_unverified_function_subtitle">Überprüfen Sie die Details unten, bevor Sie signieren</string>
+    <string name="request_from">Anfrage von</string>
     <string name="send_shares_currency_hint">Anteile eingeben</string>
     <string name="send_error_max_shares">Betrag darf den Kontostand nicht überschreiten</string>
     <string name="deposit_form_shares_title">Anteile (Guthaben: %1$s)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -426,6 +426,7 @@
     <string name="verify_transaction_function_inputs_title">Argumentos de función</string>
     <string name="dapp_hero_unverified_function_title">Función no verificada</string>
     <string name="dapp_hero_unverified_function_subtitle">Revisa los detalles antes de firmar</string>
+    <string name="request_from">Solicitud de</string>
     <string name="send_shares_currency_hint">Introduce acciones</string>
     <string name="send_error_max_shares">La cantidad no debe exceder el saldo</string>
     <string name="deposit_form_shares_title">Acciones (Saldo: %1$s)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -427,6 +427,7 @@
     <string name="verify_transaction_function_inputs_title">Argumenti funkcije</string>
     <string name="dapp_hero_unverified_function_title">Neprovjerena funkcija</string>
     <string name="dapp_hero_unverified_function_subtitle">Pregledajte detalje prije potpisivanja</string>
+    <string name="request_from">Zahtjev od</string>
     <string name="send_shares_currency_hint">Unesite udjele</string>
     <string name="send_error_max_shares">Iznos ne smije premašiti stanje</string>
     <string name="deposit_form_shares_title">Udjeli (Stanje: %1$s)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -426,6 +426,7 @@
     <string name="verify_transaction_function_inputs_title">Argomenti della funzione</string>
     <string name="dapp_hero_unverified_function_title">Funzione non verificata</string>
     <string name="dapp_hero_unverified_function_subtitle">Controlla i dettagli prima di firmare</string>
+    <string name="request_from">Richiesta da</string>
     <string name="send_shares_currency_hint">Inserisci quote</string>
     <string name="send_error_max_shares">L\'importo non deve superare il saldo</string>
     <string name="deposit_form_shares_title">Quote (Saldo: %1$s)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -631,6 +631,7 @@
     <string name="verify_transaction_function_inputs_title">함수 인수</string>
     <string name="dapp_hero_unverified_function_title">확인되지 않은 함수</string>
     <string name="dapp_hero_unverified_function_subtitle">서명 전에 아래 세부정보를 확인하세요</string>
+    <string name="request_from">요청 출처</string>
     <string name="fast_vault_password_reminder_title">비밀번호를 확인하세요:</string>
     <string name="fast_vault_password_reminder_done_button">완료</string>
     <string name="periodically_ask_verify_password">비밀번호를 잊지 않도록 주기적으로 확인을 요청합니다.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -425,6 +425,7 @@
     <string name="verify_transaction_function_inputs_title">Functie-argumenten</string>
     <string name="dapp_hero_unverified_function_title">Niet-geverifieerde functie</string>
     <string name="dapp_hero_unverified_function_subtitle">Bekijk de details hieronder voordat je ondertekent</string>
+    <string name="request_from">Verzoek van</string>
     <string name="send_shares_currency_hint">Voer aandelen in</string>
     <string name="send_error_max_shares">Bedrag mag het saldo niet overschrijden</string>
     <string name="deposit_form_shares_title">Aandelen (Saldo: %1$s)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -426,6 +426,7 @@
     <string name="verify_transaction_function_inputs_title">Argumentos de função</string>
     <string name="dapp_hero_unverified_function_title">Função não verificada</string>
     <string name="dapp_hero_unverified_function_subtitle">Reveja os detalhes antes de assinar</string>
+    <string name="request_from">Pedido de</string>
     <string name="send_shares_currency_hint">Insira cotas</string>
     <string name="send_error_max_shares">O valor não deve exceder o saldo</string>
     <string name="deposit_form_shares_title">Cotas (Saldo: %1$s)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -427,6 +427,7 @@
     <string name="verify_transaction_function_inputs_title">Аргументы функции</string>
     <string name="dapp_hero_unverified_function_title">Непроверенная функция</string>
     <string name="dapp_hero_unverified_function_subtitle">Просмотрите детали ниже перед подписанием</string>
+    <string name="request_from">Запрос от</string>
     <string name="send_shares_currency_hint">Введите доли</string>
     <string name="send_error_max_shares">Сумма не должна превышать баланс</string>
     <string name="deposit_form_shares_title">Доли (Баланс: %1$s)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -708,6 +708,7 @@
     <string name="verify_transaction_function_inputs_title">函数参数</string>
     <string name="dapp_hero_unverified_function_title">未验证的功能</string>
     <string name="dapp_hero_unverified_function_subtitle">请在签名前查看下方详情</string>
+    <string name="request_from">请求来自</string>
 
     <!-- Fast Vault Password Reminder -->
     <string name="fast_vault_password_reminder_title">验证您的密码：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -639,6 +639,7 @@
     <string name="verify_transaction_function_inputs_title">Function Arguments</string>
     <string name="dapp_hero_unverified_function_title">Unverified function</string>
     <string name="dapp_hero_unverified_function_subtitle">Review the details below before signing</string>
+    <string name="request_from">Request from</string>
     <string name="fast_vault_password_reminder_title">Verify your password for:</string>
     <string name="fast_vault_password_reminder_done_button">Done</string>
     <string name="periodically_ask_verify_password">We periodically ask for a verification so you don\'t forget your password.</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.ERC20ApprovePayload
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.payload.SwapPayload
@@ -238,6 +239,18 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             tronTransferContractPayload = from.tronTransferContractPayload,
             tronTransferAssetContractPayload = from.tronTransferAssetContractPayload,
             tronTriggerSmartContractPayload = from.tronTriggerSmartContractPayload,
+            // Trim whitespace at the boundary so consumers (host derivation, isEmpty gate, UI)
+            // don't have to re-normalize. Empty after trim ⇒ treat the whole banner as absent.
+            dappMetadata =
+                from.dappMetadata
+                    ?.let {
+                        DAppMetadata(
+                            name = it.name.trim(),
+                            url = it.url.trim(),
+                            iconUrl = it.iconUrl.trim(),
+                        )
+                    }
+                    ?.takeUnless { it.isEmpty },
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -243,6 +243,17 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
             tronTransferContractPayload = keysignPayload.tronTransferContractPayload,
             tronTransferAssetContractPayload = keysignPayload.tronTransferAssetContractPayload,
             tronTriggerSmartContractPayload = keysignPayload.tronTriggerSmartContractPayload,
+            // Symmetric with the inbound mapper: when Android relays a payload (e.g. as the
+            // initiator for a future dApp-initiated flow) the dApp identity must round-trip to the
+            // peers, matching iOS `mapToProtobuff` and Windows `buildDappMetadata`.
+            dappMetadata =
+                keysignPayload.dappMetadata?.let {
+                    vultisig.keysign.v1.DAppMetadata(
+                        name = it.name,
+                        url = it.url,
+                        iconUrl = it.iconUrl,
+                    )
+                },
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadata.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadata.kt
@@ -21,6 +21,13 @@ data class DAppMetadata(val name: String, val url: String, val iconUrl: String) 
      * input, malformed input, or non-http(s) schemes (`javascript:`, `data:`, `file:`, …) so the UI
      * never echoes attacker-controlled text as if it were a hostname. The banner hides the host
      * line when this is empty.
+     *
+     * **Deliberate divergence from iOS/Windows:** both other platforms fall back to the raw [url]
+     * string when host parsing fails. Android returns `""` in those cases, which is stricter — a
+     * hostile dApp can't surface `javascript:alert(1)` as if it were a hostname — at the cost of
+     * silently hiding legitimate-but-unparseable URIs (e.g. onion services that don't normalise
+     * through [URI]). If that case turns out to matter, narrow the empty-return to non-http(s)
+     * schemes only rather than re-introducing the unconditional fallback.
      */
     val host: String by lazy {
         runCatching {
@@ -32,23 +39,15 @@ data class DAppMetadata(val name: String, val url: String, val iconUrl: String) 
     }
 
     /**
-     * True when every field is empty. Use at the construction boundary (proto mapper) to avoid
-     * surfacing meaningless banners.
+     * True when the banner has nothing meaningful to show. Use at the construction boundary (proto
+     * mapper) to avoid surfacing identity-less banners.
+     *
+     * Only [name] and [url] count — [iconUrl] alone is not enough identity to render the banner (it
+     * would be a circle with empty text), and gating on it would also let a hostile dApp force a
+     * network fetch to an attacker-controlled origin via icon-only metadata.
      */
     val isEmpty: Boolean
-        get() = name.isEmpty() && url.isEmpty() && iconUrl.isEmpty()
-
-    /**
-     * Safe URL to feed into an image loader for [iconUrl]. Returns `null` for empty input or
-     * non-https schemes so the banner falls back to the placeholder icon instead of fetching from
-     * `file://`, `content://`, `data:` etc. when a hostile dApp passes an odd URL.
-     */
-    val safeIconUrl: String?
-        get() =
-            iconUrl.takeIf {
-                it.isNotEmpty() &&
-                    runCatching { URI(it).scheme?.lowercase() == "https" }.getOrDefault(false)
-            }
+        get() = name.isEmpty() && url.isEmpty()
 
     private companion object {
         val HTTP_SCHEMES = setOf("http", "https")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadata.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadata.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.data.models.payload
+
+import androidx.compose.runtime.Immutable
+import java.net.URI
+
+/**
+ * Identity of the dApp that produced a keysign request.
+ *
+ * Surfaced on the verify and done screens so signers can see which dApp originated the transaction.
+ * Trust decisions stay with Blockaid and the independently-decoded calldata; this is informational
+ * only.
+ *
+ * Mirrors the `DAppMetadata` proto on `KeysignPayload`. Proto strings are non-nullable, so empty
+ * strings are treated as missing.
+ */
+@Immutable
+data class DAppMetadata(val name: String, val url: String, val iconUrl: String) {
+
+    /**
+     * Hostname extracted from [url] when [url] is a well-formed http(s) URI. Returns `""` for empty
+     * input, malformed input, or non-http(s) schemes (`javascript:`, `data:`, `file:`, …) so the UI
+     * never echoes attacker-controlled text as if it were a hostname. The banner hides the host
+     * line when this is empty.
+     */
+    val host: String by lazy {
+        runCatching {
+                if (url.isEmpty()) return@runCatching ""
+                val uri = URI(url)
+                if (uri.scheme?.lowercase() in HTTP_SCHEMES) uri.host.orEmpty() else ""
+            }
+            .getOrDefault("")
+    }
+
+    /**
+     * True when every field is empty. Use at the construction boundary (proto mapper) to avoid
+     * surfacing meaningless banners.
+     */
+    val isEmpty: Boolean
+        get() = name.isEmpty() && url.isEmpty() && iconUrl.isEmpty()
+
+    /**
+     * Safe URL to feed into an image loader for [iconUrl]. Returns `null` for empty input or
+     * non-https schemes so the banner falls back to the placeholder icon instead of fetching from
+     * `file://`, `content://`, `data:` etc. when a hostile dApp passes an odd URL.
+     */
+    val safeIconUrl: String?
+        get() =
+            iconUrl.takeIf {
+                it.isNotEmpty() &&
+                    runCatching { URI(it).scheme?.lowercase() == "https" }.getOrDefault(false)
+            }
+
+    private companion object {
+        val HTTP_SCHEMES = setOf("http", "https")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
@@ -41,6 +41,12 @@ data class KeysignPayload(
     val tronTransferAssetContractPayload: TronTransferAssetContractPayload? = null,
     val skipBroadcast: Boolean = false,
     val defiAction: DeFiAction = DeFiAction.NONE,
+    /**
+     * Identity of the dApp that originated this keysign request (name, URL, icon), if the request
+     * came from an external dApp via the extension. Informational only — Blockaid + decoded
+     * calldata remain the security source of truth.
+     */
+    val dappMetadata: DAppMetadata? = null,
 )
 
 enum class DeFiAction {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperDAppMetadataTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperDAppMetadataTest.kt
@@ -12,6 +12,7 @@ import vultisig.keysign.v1.TransactionType
 class KeysignPayloadProtoMapperDAppMetadataTest {
 
     private val mapper = KeysignPayloadProtoMapperImpl()
+    private val outboundMapper = PayloadToProtoMapperImpl()
 
     @Test
     fun `dappMetadata is null when proto does not carry it`() {
@@ -78,6 +79,38 @@ class KeysignPayloadProtoMapperDAppMetadataTest {
         assertEquals("Uniswap", metadata.name)
         assertEquals("https://app.uniswap.org", metadata.url)
         assertEquals("https://app.uniswap.org/favicon.ico", metadata.iconUrl)
+    }
+
+    @Test
+    fun `dappMetadata round-trips through outbound proto mapper for relay parity with iOS and Windows`() {
+        // A future dApp-initiated flow may have Android serve as the initiator that relays the
+        // payload to joining peers. The outbound mapper must carry dappMetadata so the joining
+        // device renders the banner — matching iOS `mapToProtobuff` and Windows
+        // `buildDappMetadata`.
+        val inboundProto =
+            basePayload(
+                dappMetadata =
+                    DAppMetadataProto(
+                        name = "Uniswap",
+                        url = "https://app.uniswap.org",
+                        iconUrl = "https://app.uniswap.org/favicon.ico",
+                    )
+            )
+        val domain = mapper.invoke(inboundProto)
+        val outboundProto = outboundMapper.invoke(domain)
+
+        val outboundDapp =
+            requireNotNull(outboundProto?.dappMetadata) { "outbound dappMetadata must not be null" }
+        assertEquals("Uniswap", outboundDapp.name)
+        assertEquals("https://app.uniswap.org", outboundDapp.url)
+        assertEquals("https://app.uniswap.org/favicon.ico", outboundDapp.iconUrl)
+    }
+
+    @Test
+    fun `outbound mapper writes null dappMetadata when domain has none`() {
+        val domain = mapper.invoke(basePayload())
+        val outboundProto = outboundMapper.invoke(domain)
+        assertNull(outboundProto?.dappMetadata)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperDAppMetadataTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperDAppMetadataTest.kt
@@ -1,0 +1,131 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.proto.v1.CoinProto
+import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.DAppMetadata as DAppMetadataProto
+import vultisig.keysign.v1.THORChainSpecific
+import vultisig.keysign.v1.TransactionType
+
+class KeysignPayloadProtoMapperDAppMetadataTest {
+
+    private val mapper = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `dappMetadata is null when proto does not carry it`() {
+        val result = mapper.invoke(basePayload())
+        assertNull(result.dappMetadata)
+    }
+
+    @Test
+    fun `dappMetadata is mapped through with all fields populated`() {
+        val result =
+            mapper.invoke(
+                basePayload(
+                    dappMetadata =
+                        DAppMetadataProto(
+                            name = "Uniswap",
+                            url = "https://app.uniswap.org",
+                            iconUrl = "https://app.uniswap.org/favicon.ico",
+                        )
+                )
+            )
+
+        val metadata = requireNotNull(result.dappMetadata) { "expected non-null dappMetadata" }
+        assertEquals("Uniswap", metadata.name)
+        assertEquals("https://app.uniswap.org", metadata.url)
+        assertEquals("https://app.uniswap.org/favicon.ico", metadata.iconUrl)
+    }
+
+    @Test
+    fun `dappMetadata is null when every field is empty after trim`() {
+        val result =
+            mapper.invoke(
+                basePayload(dappMetadata = DAppMetadataProto(name = "", url = "", iconUrl = ""))
+            )
+        assertNull(result.dappMetadata)
+    }
+
+    @Test
+    fun `dappMetadata is null when every field is whitespace-only`() {
+        val result =
+            mapper.invoke(
+                basePayload(
+                    dappMetadata =
+                        DAppMetadataProto(name = "   ", url = "\t\n", iconUrl = "  \r\n ")
+                )
+            )
+        assertNull(result.dappMetadata)
+    }
+
+    @Test
+    fun `dappMetadata trims whitespace on every field`() {
+        val result =
+            mapper.invoke(
+                basePayload(
+                    dappMetadata =
+                        DAppMetadataProto(
+                            name = "  Uniswap  ",
+                            url = "\thttps://app.uniswap.org\n",
+                            iconUrl = " https://app.uniswap.org/favicon.ico ",
+                        )
+                )
+            )
+
+        val metadata = requireNotNull(result.dappMetadata)
+        assertEquals("Uniswap", metadata.name)
+        assertEquals("https://app.uniswap.org", metadata.url)
+        assertEquals("https://app.uniswap.org/favicon.ico", metadata.iconUrl)
+    }
+
+    @Test
+    fun `dappMetadata preserves partial fields when only url is set`() {
+        val result =
+            mapper.invoke(
+                basePayload(
+                    dappMetadata =
+                        DAppMetadataProto(name = "", url = "https://app.uniswap.org", iconUrl = "")
+                )
+            )
+
+        val metadata = requireNotNull(result.dappMetadata)
+        assertEquals("", metadata.name)
+        assertEquals("https://app.uniswap.org", metadata.url)
+        assertEquals("", metadata.iconUrl)
+    }
+
+    private fun basePayload(dappMetadata: DAppMetadataProto? = null) =
+        KeysignPayloadProto(
+            coin = testCoin,
+            toAddress = "thor1x6f63myfwktevd6mkspdeus9rea5a72w6ynax2",
+            toAmount = "10000000",
+            vaultPublicKeyEcdsa = "pubkey",
+            vaultLocalPartyId = "party-1",
+            thorchainSpecific =
+                THORChainSpecific(
+                    accountNumber = 1uL,
+                    sequence = 0uL,
+                    fee = 2_000_000uL,
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            dappMetadata = dappMetadata,
+        )
+
+    private companion object {
+        val testCoin =
+            CoinProto(
+                chain = "thorChain",
+                ticker = "RUNE",
+                address = "",
+                contractAddress = "",
+                decimals = 8,
+                priceProviderId = "thorchain",
+                isNativeToken = true,
+                hexPublicKey = "",
+                logo = "rune",
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadataTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadataTest.kt
@@ -51,7 +51,7 @@ class DAppMetadataTest {
     }
 
     @Test
-    fun `isEmpty is true only when every field is empty`() {
+    fun `isEmpty is true when name and url are both empty`() {
         assertTrue(DAppMetadata(name = "", url = "", iconUrl = "").isEmpty)
     }
 
@@ -66,34 +66,10 @@ class DAppMetadataTest {
     }
 
     @Test
-    fun `isEmpty is false when iconUrl is set`() {
-        assertFalse(DAppMetadata(name = "", url = "", iconUrl = "https://x.io/favicon.ico").isEmpty)
-    }
-
-    @Test
-    fun `safeIconUrl returns https iconUrl unchanged`() {
-        val metadata = DAppMetadata(name = "", url = "", iconUrl = "https://1inch.io/favicon.ico")
-        assertEquals("https://1inch.io/favicon.ico", metadata.safeIconUrl)
-    }
-
-    @Test
-    fun `safeIconUrl is null for non-https schemes so Coil never loads file or data URIs`() {
-        val cases =
-            listOf(
-                "http://insecure.example/favicon.ico",
-                "file:///etc/passwd",
-                "data:image/svg+xml,<svg/>",
-                "content://com.attacker.fileprovider/x",
-            )
-        for (icon in cases) {
-            val metadata = DAppMetadata(name = "", url = "", iconUrl = icon)
-            assertEquals(null, metadata.safeIconUrl, "expected null safeIconUrl for $icon")
-        }
-    }
-
-    @Test
-    fun `safeIconUrl is null when iconUrl is empty`() {
-        val metadata = DAppMetadata(name = "", url = "", iconUrl = "")
-        assertEquals(null, metadata.safeIconUrl)
+    fun `isEmpty is true when only iconUrl is set so attacker can't force a network fetch via icon-only metadata`() {
+        // Without name or url there's nothing identifying to show — gating on iconUrl alone would
+        // both render an empty text stack and let a hostile dApp trigger a fetch to an
+        // attacker-controlled origin via the banner.
+        assertTrue(DAppMetadata(name = "", url = "", iconUrl = "https://x.io/favicon.ico").isEmpty)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadataTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/DAppMetadataTest.kt
@@ -1,0 +1,99 @@
+package com.vultisig.wallet.data.models.payload
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DAppMetadataTest {
+
+    @Test
+    fun `host extracts hostname from a well-formed https url`() {
+        val metadata =
+            DAppMetadata(name = "Uniswap", url = "https://app.uniswap.org/swap", iconUrl = "")
+        assertEquals("app.uniswap.org", metadata.host)
+    }
+
+    @Test
+    fun `host returns empty string when url is empty`() {
+        val metadata = DAppMetadata(name = "Uniswap", url = "", iconUrl = "")
+        assertEquals("", metadata.host)
+    }
+
+    @Test
+    fun `host returns empty for unparseable url so banner hides it`() {
+        val metadata = DAppMetadata(name = "", url = "not a url", iconUrl = "")
+        assertEquals("", metadata.host)
+    }
+
+    @Test
+    fun `host returns empty for non-http schemes so we never display attacker-controlled text`() {
+        // A hostile dApp could send `javascript:`, `data:`, `file:`, mailto: — none should leak
+        // into the banner as if they were hostnames.
+        val cases =
+            listOf(
+                "javascript:alert(1)",
+                "data:text/html,<script>alert(1)</script>",
+                "file:///etc/passwd",
+                "mailto:nobody@example.com",
+            )
+        for (url in cases) {
+            val metadata = DAppMetadata(name = "", url = url, iconUrl = "")
+            assertEquals("", metadata.host, "expected empty host for $url")
+        }
+    }
+
+    @Test
+    fun `host preserves port and path off the hostname`() {
+        val metadata =
+            DAppMetadata(name = "", url = "https://app.uniswap.org:8443/swap?x=1", iconUrl = "")
+        assertEquals("app.uniswap.org", metadata.host)
+    }
+
+    @Test
+    fun `isEmpty is true only when every field is empty`() {
+        assertTrue(DAppMetadata(name = "", url = "", iconUrl = "").isEmpty)
+    }
+
+    @Test
+    fun `isEmpty is false when name is set`() {
+        assertFalse(DAppMetadata(name = "Uniswap", url = "", iconUrl = "").isEmpty)
+    }
+
+    @Test
+    fun `isEmpty is false when url is set`() {
+        assertFalse(DAppMetadata(name = "", url = "https://x.io", iconUrl = "").isEmpty)
+    }
+
+    @Test
+    fun `isEmpty is false when iconUrl is set`() {
+        assertFalse(DAppMetadata(name = "", url = "", iconUrl = "https://x.io/favicon.ico").isEmpty)
+    }
+
+    @Test
+    fun `safeIconUrl returns https iconUrl unchanged`() {
+        val metadata = DAppMetadata(name = "", url = "", iconUrl = "https://1inch.io/favicon.ico")
+        assertEquals("https://1inch.io/favicon.ico", metadata.safeIconUrl)
+    }
+
+    @Test
+    fun `safeIconUrl is null for non-https schemes so Coil never loads file or data URIs`() {
+        val cases =
+            listOf(
+                "http://insecure.example/favicon.ico",
+                "file:///etc/passwd",
+                "data:image/svg+xml,<svg/>",
+                "content://com.attacker.fileprovider/x",
+            )
+        for (icon in cases) {
+            val metadata = DAppMetadata(name = "", url = "", iconUrl = icon)
+            assertEquals(null, metadata.safeIconUrl, "expected null safeIconUrl for $icon")
+        }
+    }
+
+    @Test
+    fun `safeIconUrl is null when iconUrl is empty`() {
+        val metadata = DAppMetadata(name = "", url = "", iconUrl = "")
+        assertEquals(null, metadata.safeIconUrl)
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 3 of dApp signing UX (#4060). Surfaces the requesting dApp's name, URL, and icon above the hero on **Verify** (Send/Swap/Deposit) and **Done** (Send/Swap) screens for keysigns originated by external dApps
- Mirrors iOS [#4303](https://github.com/vultisig/vultisig-ios/pull/4303) and Windows [#3819](https://github.com/vultisig/vultisig-windows/pull/3819). Trust decisions stay with Blockaid + decoded calldata; the banner is informational only
- Bumps `commondata` from `6d61f4de` → `798af15` to pick up [commondata#82](https://github.com/vultisig/commondata/pull/82) (DAppMetadata proto). Also pulls in commondata#75 (Cardano token asset proto)

## What's wired

| Surface | Source | Screen |
|---|---|---|
| Send Verify (joiner) | `JoinKeysignViewModel.dappMetadata` | `VerifySendScreen` |
| Swap Verify (joiner) | `JoinKeysignViewModel.dappMetadata` | `VerifySwapScreen` |
| Deposit Verify (joiner) | `JoinKeysignViewModel.dappMetadata` | `VerifyDepositScreen` |
| Send Done (initiator + joiner) | `KeysignViewModel.dappMetadata` | `SendTxOverviewScreen` → `TxDoneScaffold` |
| Swap Done (initiator + joiner) | `KeysignViewModel.dappMetadata` | `SwapTransactionOverviewScreen` → `TxDoneScaffold` |

Vault-initiated keysigns leave the field `null`, so no banner appears on those flows.

## Not wired (intentional)
- **SignMessage variants** — `commondata` only carries `dapp_metadata` on `KeysignPayload`, not on `KeysignMessage` where `CustomMessagePayload` lives. Needs a separate proto change.

## Security hardening
- `DAppMetadata.host` returns empty for non-http(s) schemes so `javascript:`/`data:`/`file:`/`mailto:` URLs never display as if they were hostnames
- `DAppMetadata.safeIconUrl` returns `null` for non-https schemes so Coil can't be tricked into loading `file:///`, `content://`, or `data:` images
- 12 unit tests cover the defensive parsing semantics

## Test plan
- [x] \`./gradlew :data:ktfmtFormat :app:ktfmtFormat\` — clean
- [x] \`./gradlew :app:compileDebugKotlin\` — green
- [x] \`./gradlew :data:testDebugUnitTest :app:testDebugUnitTest\` — 18 new tests pass, no regressions
- [ ] Manual: scan a TonConnect/WalletConnect QR with \`dapp_metadata\` populated → banner shows on Verify and Done
- [ ] Manual: scan a legacy QR without \`dapp_metadata\` → no banner, existing screens unchanged

## Companion PRs
- iOS: vultisig/vultisig-ios#4303 (merged 2026-05-05)
- Windows: vultisig/vultisig-windows#3819 (merged 2026-05-02)

Closes #4060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a dApp request banner shown on verify and transaction-done screens with name, host and icon variants to improve transparency during signing flows.
  * Propagates dApp metadata into relevant transaction and keysign screens so the banner appears where applicable.

* **Tests**
  * Added unit tests covering dApp metadata parsing, trimming, host extraction, emptiness semantics, and round-trip proto mapping.

* **Chores**
  * Added localized "Request from" strings for multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->