### PR TITLE
fix(start): bump welcome screen logo to match Figma (#4532)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
@@ -94,7 +94,7 @@ private fun StartScreen(
                 Image(
                     painter = painterResource(id = R.drawable.logo),
                     contentDescription = "vultisig",
-                    modifier = Modifier.width(60.dp).scale(logoScale.value),
+                    modifier = Modifier.width(74.5.dp).scale(logoScale.value),
                 )
                 UiSpacer(12.dp)
                 Text(


### PR DESCRIPTION
## Summary
- Welcome / start screen Vultisig logo was hardcoded to `60.dp`; Figma node `58996:163436` specifies a `74.5px` outer container.
- Bump `Modifier.width(60.dp)` → `Modifier.width(74.5.dp)` at `StartScreen.kt:97`.

## Figma
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=58996-163436

Closes #4532

## Test plan
- [ ] Fresh install (no vaults) → land on start screen, confirm logo size visually matches Figma
- [ ] From vault list → "+" / Add vault entry that routes through `StartScreen`, same logo size
- [ ] Logo scale-in animation still plays smoothly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the start screen logo size for improved visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->