### PR TITLE
fix(onboarding): blend Rive backgrounds + repair spotlight layout (#4533, #4534)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportFeatureSpotlightScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportFeatureSpotlightScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,15 +20,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -74,26 +72,6 @@ private fun KeyImportFeatureSpotlightScreenContent(
         contentVisible = true
     }
 
-    val density = LocalDensity.current
-    var availableHeightPx by remember { mutableIntStateOf(0) }
-
-    val centerTop = with(density) { (availableHeightPx.toDp() - RiveHeight) / 2 }
-    val riveTop by
-        animateDpAsState(
-            targetValue = if (revealed) RevealedTopPadding else centerTop,
-            animationSpec = spring(stiffness = Spring.StiffnessLow),
-            label = "riveTop",
-        )
-    val contentAlpha by
-        animateFloatAsState(
-            targetValue = if (contentVisible) 1f else 0f,
-            animationSpec = spring(stiffness = Spring.StiffnessLow),
-            label = "contentAlpha",
-        )
-
-    val effectiveRiveTop = if (skipAnimation) RevealedTopPadding else riveTop
-    val effectiveContentAlpha = if (skipAnimation) 1f else contentAlpha
-
     V2Scaffold(
         onBackClick = onBack,
         bottomBar = {
@@ -104,67 +82,82 @@ private fun KeyImportFeatureSpotlightScreenContent(
             )
         },
         content = {
-            Column(
-                modifier =
-                    Modifier.fillMaxSize().verticalScroll(rememberScrollState()).onSizeChanged {
-                        availableHeightPx = it.height
-                    }
-            ) {
-                Spacer(modifier = Modifier.height(effectiveRiveTop))
-
-                RiveAnimation(
-                    animation = R.raw.riv_import_seedphrase,
-                    modifier = Modifier.fillMaxWidth().height(RiveHeight),
-                    fit = Fit.CONTAIN,
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Column(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .padding(horizontal = 8.dp)
-                            .alpha(effectiveContentAlpha)
-                ) {
-                    Text(
-                        text = stringResource(R.string.key_import_spotlight_before_you_start),
-                        style = Theme.brockmann.supplementary.caption,
-                        color = Theme.v2.colors.text.secondary,
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val centerTop = (maxHeight - RiveHeight) / 2
+                val riveTop by
+                    animateDpAsState(
+                        targetValue = if (revealed) RevealedTopPadding else centerTop,
+                        animationSpec = spring(stiffness = Spring.StiffnessLow),
+                        label = "riveTop",
+                    )
+                val contentAlpha by
+                    animateFloatAsState(
+                        targetValue = if (contentVisible) 1f else 0f,
+                        animationSpec = spring(stiffness = Spring.StiffnessLow),
+                        label = "contentAlpha",
                     )
 
-                    UiSpacer(12.dp)
+                val effectiveRiveTop = if (skipAnimation) RevealedTopPadding else riveTop
+                val effectiveContentAlpha = if (skipAnimation) 1f else contentAlpha
 
-                    val headingText = buildAnnotatedString {
-                        append(stringResource(R.string.key_import_spotlight_heading_part1))
-                        withStyle(SpanStyle(brush = Theme.v2.colors.gradients.primary)) {
-                            append(stringResource(R.string.key_import_spotlight_heading_highlight))
+                Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                    Spacer(modifier = Modifier.height(effectiveRiveTop))
+
+                    RiveAnimation(
+                        animation = R.raw.riv_import_seedphrase,
+                        modifier = Modifier.fillMaxWidth().height(RiveHeight),
+                        fit = Fit.COVER,
+                    )
+
+                    Column(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .padding(horizontal = 8.dp)
+                                .alpha(effectiveContentAlpha)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.key_import_spotlight_before_you_start),
+                            style = Theme.brockmann.supplementary.caption,
+                            color = Theme.v2.colors.text.secondary,
+                        )
+
+                        UiSpacer(12.dp)
+
+                        val headingText = buildAnnotatedString {
+                            append(stringResource(R.string.key_import_spotlight_heading_part1))
+                            withStyle(SpanStyle(brush = Theme.v2.colors.gradients.primary)) {
+                                append(
+                                    stringResource(R.string.key_import_spotlight_heading_highlight)
+                                )
+                            }
+                            append(stringResource(R.string.key_import_spotlight_heading_part2))
                         }
-                        append(stringResource(R.string.key_import_spotlight_heading_part2))
+
+                        Text(
+                            text = headingText,
+                            style = Theme.brockmann.headings.title2.copy(lineHeight = 30.sp),
+                            color = Theme.v2.colors.text.primary,
+                        )
+
+                        UiSpacer(32.dp)
+
+                        BulletItem(
+                            icon = R.drawable.ic_seedphrase,
+                            title = stringResource(R.string.key_import_spotlight_seedphrase_title),
+                            description =
+                                stringResource(R.string.key_import_spotlight_seedphrase_desc),
+                        )
+
+                        UiSpacer(24.dp)
+
+                        BulletItem(
+                            icon = R.drawable.ic_devices,
+                            title = stringResource(R.string.key_import_spotlight_device_title),
+                            description = stringResource(R.string.key_import_spotlight_device_desc),
+                        )
+
+                        UiSpacer(65.dp)
                     }
-
-                    Text(
-                        text = headingText,
-                        style = Theme.brockmann.headings.title2.copy(lineHeight = 30.sp),
-                        color = Theme.v2.colors.text.primary,
-                    )
-
-                    UiSpacer(32.dp)
-
-                    BulletItem(
-                        icon = R.drawable.ic_seedphrase,
-                        title = stringResource(R.string.key_import_spotlight_seedphrase_title),
-                        description = stringResource(R.string.key_import_spotlight_seedphrase_desc),
-                    )
-
-                    UiSpacer(24.dp)
-
-                    BulletItem(
-                        icon = R.drawable.ic_devices,
-                        title = stringResource(R.string.key_import_spotlight_device_title),
-                        description = stringResource(R.string.key_import_spotlight_device_desc),
-                    )
-
-                    UiSpacer(65.dp)
                 }
             }
         },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportFeatureSpotlightScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportFeatureSpotlightScreen.kt
@@ -83,7 +83,7 @@ private fun KeyImportFeatureSpotlightScreenContent(
         },
         content = {
             BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                val centerTop = (maxHeight - RiveHeight) / 2
+                val centerTop = ((maxHeight - RiveHeight) / 2).coerceAtLeast(0.dp)
                 val riveTop by
                     animateDpAsState(
                         targetValue = if (revealed) RevealedTopPadding else centerTop,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultRive.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultRive.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.screens.v3.onboarding.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -9,16 +8,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
-import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
 fun SetupVaultRive(animationRes: Int, modifier: Modifier = Modifier) {
-    Box(
-        modifier =
-            modifier
-                .size(width = 350.dp, height = 240.dp)
-                .background(color = Theme.v2.colors.backgrounds.secondary)
-    ) {
+    Box(modifier = modifier.size(width = 350.dp, height = 240.dp)) {
         RiveAnimation(animation = animationRes)
     }
 }


### PR DESCRIPTION
## Summary

Two related Rive-animation bugs on the onboarding flow.

### #4533 — Vault setup: Rive background doesn't match page
`SetupVaultRive` hardcoded `Theme.v2.colors.backgrounds.secondary` on its container, so the animation sat in a lighter rectangle on top of the scaffold's primary background. Drops the `.background(...)` modifier so the Rive container is transparent and inherits the page color. The fix lands once and covers every vault-type variant rendered by `SetupVaultInfoScreen`.

### #4534 — KeyImportFeatureSpotlight: Rive at wrong position + wrong size
- `Modifier.weight(1f)` inside a `verticalScroll()` Column collapsed unpredictably (unbounded parent height), pushing the heading + bullets off-screen and breaking the "centered, then animate to top" transition.
- `availableHeightPx` was measured via `onSizeChanged` on the scroll column itself — i.e. content height, not viewport — so the centered position drifted as bullets faded in.
- `Fit.CONTAIN` letterboxed the pill animation inside the 300dp row, shrinking it below the Figma spec.

Fix: wrap content in `BoxWithConstraints` so `maxHeight` is the actual viewport, derive `centerTop` from it, drop the broken `weight(1f)` spacer, and switch the Rive to `Fit.COVER` so it fills the 300dp row.

## Files changed
- `app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultRive.kt`
- `app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportFeatureSpotlightScreen.kt`

Closes #4533
Closes #4534

## Test plan
- [ ] Fresh install → start vault creation → pick any vault type → on "Your vault setup" screen, animation blends with page background (no rectangle seam)
- [ ] Same flow across Fast Vault, Secure Vault variants
- [ ] Fresh install → Get started → seedphrase import spotlight: pills appear centered, animate to top after ~3s, heading + 2 bullets fade in below, "Get started" button stays anchored at the bottom
- [ ] Spotlight screen on a small device (e.g. 360x640): content does not get clipped — scroll still works if needed
- [ ] No regression on other vault-type Rive screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked key import screen layout and animation to compute geometry and animations inside the screen, simplifying spacing and scroll behavior.
  * Updated Rive animation sizing on the key import screen to use a cover-style fit for better visual fill.
  * Simplified vault setup component by removing its themed background and fixing its display size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->