### PR TITLE
refactor(keysign): consolidate join keysign fee into single helper (#4391)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1470,29 +1470,28 @@ constructor(
     }
 
     private fun waitForKeysignToStart() {
-        _jobWaitingForKeysignStart =
-            viewModelScope.launch {
-                withContext(Dispatchers.IO) {
-                    while (isActive) {
-                        try {
-                            if (checkKeygenStarted()) {
-                                currentState.value = JoinKeysignState.Keysign
-                                return@withContext
-                            }
-                        } catch (e: KeysignMessagesException) {
-                            Timber.e(e, "Failed to prepare messages to sign")
-                            currentState.value =
-                                JoinKeysignState.Error(
-                                    JoinKeysignError.FailedToCheck(
-                                        e.message ?: "Failed to prepare messages to sign"
-                                    )
-                                )
+        _jobWaitingForKeysignStart = viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                while (isActive) {
+                    try {
+                        if (checkKeygenStarted()) {
+                            currentState.value = JoinKeysignState.Keysign
                             return@withContext
                         }
-                        delay(1000)
+                    } catch (e: KeysignMessagesException) {
+                        Timber.e(e, "Failed to prepare messages to sign")
+                        currentState.value =
+                            JoinKeysignState.Error(
+                                JoinKeysignError.FailedToCheck(
+                                    e.message ?: "Failed to prepare messages to sign"
+                                )
+                            )
+                        return@withContext
                     }
+                    delay(1000)
                 }
             }
+        }
     }
 
     private suspend fun checkKeygenStarted(): Boolean {
@@ -1769,6 +1768,16 @@ internal fun prettifyEvmFunctionName(signature: String): String? {
     }
 }
 
+/**
+ * Polymorphic fee helper shared by the join-keysign deposit, send, and swap branches — mirrors
+ * iOS's `BlockChainSpecific.fee` getter. Ethereum returns `maxFeePerGasWei * gasLimit`, THORChain
+ * returns `blockChainSpecific.fee`, and every other chain returns [fallbackFeeAmount] (the swap
+ * branch passes ZERO since it never enters the else branch).
+ *
+ * @param evmGasLimitOverride when non-null, replaces `blockChainSpecific.gasLimit` for the Ethereum
+ *   case. The swap branch passes [defaultEvmSwapGasLimit] so joiner output matches the initiator's
+ *   swap-fee display; deposit and send leave it null to preserve the payload gas limit.
+ */
 internal fun computeJoinKeysignNetworkFee(
     blockChainSpecific: BlockChainSpecific,
     nativeCoin: Coin,
@@ -1788,10 +1797,14 @@ internal fun computeJoinKeysignNetworkFee(
         else -> TokenValue(value = fallbackFeeAmount, token = nativeCoin)
     }
 
-// The initiator's swap path always displays maxFeePerGas * DEFAULT_SWAP_LIMIT (via
-// EthereumFeeService.calculateDefaultFees(Swap)), ignoring BlockChainSpecific.gasLimit —
-// which can be as low as 40k for native ETH/Arb swaps. Mirror that here so joiner output
-// matches initiator output instead of being ~15× lower.
+/**
+ * The initiator's swap path always displays `maxFeePerGas * DEFAULT_SWAP_LIMIT` (via
+ * [EthereumFeeService.calculateDefaultFees] for Swap), ignoring `BlockChainSpecific.gasLimit` —
+ * which can be as low as 40k for native ETH/Arb swaps. Mirror that here so joiner output matches
+ * initiator output instead of being ~15× lower. Mantle uses
+ * [EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT] because its per-gas limit is an order of magnitude
+ * higher than other EVM chains.
+ */
 internal fun defaultEvmSwapGasLimit(chain: Chain): BigInteger =
     if (chain == Chain.Mantle) EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
     else EthereumFeeService.DEFAULT_SWAP_LIMIT

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -564,15 +564,14 @@ constructor(
                             }
                             TokenValue(value = BigInteger.valueOf(plan.fee), token = nativeToken)
                         }
-                        blockChainSpecific is BlockChainSpecific.Ethereum ->
-                            TokenValue(
-                                value =
-                                    blockChainSpecific.maxFeePerGasWei *
-                                        defaultEvmSwapGasLimit(chain),
-                                token = nativeToken,
+                        blockChainSpecific is BlockChainSpecific.Ethereum ||
+                            blockChainSpecific is BlockChainSpecific.THORChain ->
+                            computeJoinKeysignNetworkFee(
+                                blockChainSpecific = blockChainSpecific,
+                                nativeCoin = nativeToken,
+                                fallbackFeeAmount = BigInteger.ZERO,
+                                evmGasLimitOverride = defaultEvmSwapGasLimit(chain),
                             )
-                        blockChainSpecific is BlockChainSpecific.THORChain ->
-                            TokenValue(value = blockChainSpecific.fee, token = nativeToken)
                         else -> {
                             val (nativeTokenAddress, _) =
                                 chainAccountAddressRepository.getAddress(nativeToken, _currentVault)
@@ -1471,29 +1470,28 @@ constructor(
     }
 
     private fun waitForKeysignToStart() {
-        _jobWaitingForKeysignStart =
-            viewModelScope.launch {
-                withContext(Dispatchers.IO) {
-                    while (isActive) {
-                        try {
-                            if (checkKeygenStarted()) {
-                                currentState.value = JoinKeysignState.Keysign
-                                return@withContext
-                            }
-                        } catch (e: KeysignMessagesException) {
-                            Timber.e(e, "Failed to prepare messages to sign")
-                            currentState.value =
-                                JoinKeysignState.Error(
-                                    JoinKeysignError.FailedToCheck(
-                                        e.message ?: "Failed to prepare messages to sign"
-                                    )
-                                )
+        _jobWaitingForKeysignStart = viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                while (isActive) {
+                    try {
+                        if (checkKeygenStarted()) {
+                            currentState.value = JoinKeysignState.Keysign
                             return@withContext
                         }
-                        delay(1000)
+                    } catch (e: KeysignMessagesException) {
+                        Timber.e(e, "Failed to prepare messages to sign")
+                        currentState.value =
+                            JoinKeysignState.Error(
+                                JoinKeysignError.FailedToCheck(
+                                    e.message ?: "Failed to prepare messages to sign"
+                                )
+                            )
+                        return@withContext
                     }
+                    delay(1000)
                 }
             }
+        }
     }
 
     private suspend fun checkKeygenStarted(): Boolean {
@@ -1774,11 +1772,14 @@ internal fun computeJoinKeysignNetworkFee(
     blockChainSpecific: BlockChainSpecific,
     nativeCoin: Coin,
     fallbackFeeAmount: BigInteger,
+    evmGasLimitOverride: BigInteger? = null,
 ): TokenValue =
     when (blockChainSpecific) {
         is BlockChainSpecific.Ethereum ->
             TokenValue(
-                value = blockChainSpecific.maxFeePerGasWei * blockChainSpecific.gasLimit,
+                value =
+                    blockChainSpecific.maxFeePerGasWei *
+                        (evmGasLimitOverride ?: blockChainSpecific.gasLimit),
                 token = nativeCoin,
             )
         is BlockChainSpecific.THORChain ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -566,11 +566,10 @@ constructor(
                         }
                         blockChainSpecific is BlockChainSpecific.Ethereum ||
                             blockChainSpecific is BlockChainSpecific.THORChain ->
-                            computeJoinKeysignNetworkFee(
+                            computeJoinKeysignSwapNetworkFee(
                                 blockChainSpecific = blockChainSpecific,
                                 nativeCoin = nativeToken,
-                                fallbackFeeAmount = BigInteger.ZERO,
-                                evmGasLimitOverride = defaultEvmSwapGasLimit(chain),
+                                chain = chain,
                             )
                         else -> {
                             val (nativeTokenAddress, _) =
@@ -1770,27 +1769,23 @@ internal fun prettifyEvmFunctionName(signature: String): String? {
 }
 
 /**
- * Polymorphic fee helper shared by the join-keysign deposit, send, and swap branches — mirrors
- * iOS's `BlockChainSpecific.fee` getter. Ethereum returns `maxFeePerGasWei * gasLimit`, THORChain
- * returns `blockChainSpecific.fee`, and every other chain returns [fallbackFeeAmount] (the swap
- * branch passes ZERO since it never enters the else branch).
+ * Polymorphic fee helper shared by the join-keysign deposit and send branches — mirrors iOS's
+ * `BlockChainSpecific.fee` getter. Ethereum returns `maxFeePerGasWei * gasLimit`, THORChain returns
+ * `blockChainSpecific.fee`, and every other chain returns [fallbackFeeAmount].
  *
- * @param evmGasLimitOverride when non-null, replaces `blockChainSpecific.gasLimit` for the Ethereum
- *   case. The swap branch passes [defaultEvmSwapGasLimit] so joiner output matches the initiator's
- *   swap-fee display; deposit and send leave it null to preserve the payload gas limit.
+ * Swap callers must use [computeJoinKeysignSwapNetworkFee] instead — it bakes in the
+ * initiator-aligned EVM swap gas limit and rejects subtypes the swap branch can't reach, so an
+ * accidental zero-fee fallback is impossible.
  */
 internal fun computeJoinKeysignNetworkFee(
     blockChainSpecific: BlockChainSpecific,
     nativeCoin: Coin,
     fallbackFeeAmount: BigInteger,
-    evmGasLimitOverride: BigInteger? = null,
 ): TokenValue =
     when (blockChainSpecific) {
         is BlockChainSpecific.Ethereum ->
             TokenValue(
-                value =
-                    blockChainSpecific.maxFeePerGasWei *
-                        (evmGasLimitOverride ?: blockChainSpecific.gasLimit),
+                value = blockChainSpecific.maxFeePerGasWei * blockChainSpecific.gasLimit,
                 token = nativeCoin,
             )
         is BlockChainSpecific.THORChain ->
@@ -1799,10 +1794,41 @@ internal fun computeJoinKeysignNetworkFee(
     }
 
 /**
+ * Swap-only fee helper. Only [BlockChainSpecific.Ethereum] and [BlockChainSpecific.THORChain] are
+ * reachable in the swap branch — every other subtype goes through `feeServiceComposite`. The
+ * Ethereum case uses [defaultEvmSwapGasLimit] for [chain] so joiner output matches the initiator's
+ * swap-fee display (see [EthereumFeeService.calculateDefaultFees] for Swap) instead of being ~15×
+ * lower for native ETH/Arb transfers.
+ *
+ * The [error] branch is the safety net for [JoinKeysignViewModel.loadTransaction]'s swap path: if a
+ * new [BlockChainSpecific] subtype is ever added to that branch's type check, this helper crashes
+ * loudly instead of silently shipping a zero fee.
+ */
+internal fun computeJoinKeysignSwapNetworkFee(
+    blockChainSpecific: BlockChainSpecific,
+    nativeCoin: Coin,
+    chain: Chain,
+): TokenValue =
+    when (blockChainSpecific) {
+        is BlockChainSpecific.Ethereum ->
+            TokenValue(
+                value = blockChainSpecific.maxFeePerGasWei * defaultEvmSwapGasLimit(chain),
+                token = nativeCoin,
+            )
+        is BlockChainSpecific.THORChain ->
+            TokenValue(value = blockChainSpecific.fee, token = nativeCoin)
+        else ->
+            error(
+                "computeJoinKeysignSwapNetworkFee does not support " +
+                    "${blockChainSpecific::class.simpleName} — extend this helper when adding " +
+                    "new swap-branch subtypes"
+            )
+    }
+
+/**
  * The initiator's swap path always displays `maxFeePerGas * DEFAULT_SWAP_LIMIT` (via
  * [EthereumFeeService.calculateDefaultFees] for Swap), ignoring `BlockChainSpecific.gasLimit` —
- * which can be as low as 40k for native ETH/Arb swaps. Mirror that here so joiner output matches
- * initiator output instead of being ~15× lower. Mantle uses
+ * which can be as low as 40k for native ETH/Arb swaps. Mantle uses
  * [EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT] because its per-gas limit is an order of magnitude
  * higher than other EVM chains.
  */

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1470,28 +1470,29 @@ constructor(
     }
 
     private fun waitForKeysignToStart() {
-        _jobWaitingForKeysignStart = viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                while (isActive) {
-                    try {
-                        if (checkKeygenStarted()) {
-                            currentState.value = JoinKeysignState.Keysign
+        _jobWaitingForKeysignStart =
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    while (isActive) {
+                        try {
+                            if (checkKeygenStarted()) {
+                                currentState.value = JoinKeysignState.Keysign
+                                return@withContext
+                            }
+                        } catch (e: KeysignMessagesException) {
+                            Timber.e(e, "Failed to prepare messages to sign")
+                            currentState.value =
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToCheck(
+                                        e.message ?: "Failed to prepare messages to sign"
+                                    )
+                                )
                             return@withContext
                         }
-                    } catch (e: KeysignMessagesException) {
-                        Timber.e(e, "Failed to prepare messages to sign")
-                        currentState.value =
-                            JoinKeysignState.Error(
-                                JoinKeysignError.FailedToCheck(
-                                    e.message ?: "Failed to prepare messages to sign"
-                                )
-                            )
-                        return@withContext
+                        delay(1000)
                     }
-                    delay(1000)
                 }
             }
-        }
     }
 
     private suspend fun checkKeygenStarted(): Boolean {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models.keysign
 
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
@@ -46,6 +47,19 @@ internal class JoinKeysignSendGasFeeTest {
             decimal = 8,
             hexPublicKey = "hex",
             priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val mntCoin =
+        Coin(
+            chain = Chain.Mantle,
+            ticker = "MNT",
+            logo = "mnt",
+            address = "0xmntaddr",
+            decimal = 18,
+            hexPublicKey = "hex",
+            priceProviderID = "mantle",
             contractAddress = "",
             isNativeToken = true,
         )
@@ -167,6 +181,45 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         result shouldBe TokenValue(value = maxFeePerGasWei * swapGasLimitOverride, token = ethCoin)
+    }
+
+    /**
+     * defaultEvmSwapGasLimit must return DEFAULT_MANTLE_SWAP_LIMIT for Mantle and
+     * DEFAULT_SWAP_LIMIT for every other EVM chain (Mantle has a much higher per-gas limit, so this
+     * branch is the only thing keeping joiner output aligned with the initiator on Mantle swaps).
+     */
+    @Test
+    fun `defaultEvmSwapGasLimit selects Mantle limit for Mantle and default elsewhere`() {
+        defaultEvmSwapGasLimit(Chain.Mantle) shouldBe EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
+        defaultEvmSwapGasLimit(Chain.Ethereum) shouldBe EthereumFeeService.DEFAULT_SWAP_LIMIT
+    }
+
+    /** Swap branch: Mantle uses DEFAULT_MANTLE_SWAP_LIMIT when fed through the helper. */
+    @Test
+    fun `evm swap branch on Mantle applies Mantle gasLimit`() {
+        val payloadGasLimit = BigInteger.valueOf(21_000)
+        val maxFeePerGasWei = BigInteger.valueOf(30_000_000_000L)
+        val specific =
+            BlockChainSpecific.Ethereum(
+                maxFeePerGasWei = maxFeePerGasWei,
+                priorityFeeWei = BigInteger.valueOf(1_000_000_000L),
+                nonce = BigInteger.ZERO,
+                gasLimit = payloadGasLimit,
+            )
+
+        val result =
+            computeJoinKeysignNetworkFee(
+                blockChainSpecific = specific,
+                nativeCoin = mntCoin,
+                fallbackFeeAmount = BigInteger.ZERO,
+                evmGasLimitOverride = defaultEvmSwapGasLimit(Chain.Mantle),
+            )
+
+        result shouldBe
+            TokenValue(
+                value = maxFeePerGasWei * EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT,
+                token = mntCoin,
+            )
     }
 
     /** Swap branch: THORChain ignores the override and still returns blockChainSpecific.fee. */

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -140,4 +140,56 @@ internal class JoinKeysignSendGasFeeTest {
 
         result shouldBe TokenValue(value = fee, token = runeCoin)
     }
+
+    /**
+     * Swap branch: Ethereum case must use the override (DEFAULT_SWAP_LIMIT) instead of the
+     * payload's gasLimit, so joiner output matches initiator output.
+     */
+    @Test
+    fun `evm swap branch uses gasLimit override`() {
+        val payloadGasLimit = BigInteger.valueOf(21_000)
+        val swapGasLimitOverride = BigInteger.valueOf(600_000)
+        val maxFeePerGasWei = BigInteger.valueOf(30_000_000_000L)
+        val specific =
+            BlockChainSpecific.Ethereum(
+                maxFeePerGasWei = maxFeePerGasWei,
+                priorityFeeWei = BigInteger.valueOf(1_000_000_000L),
+                nonce = BigInteger.ZERO,
+                gasLimit = payloadGasLimit,
+            )
+
+        val result =
+            computeJoinKeysignNetworkFee(
+                blockChainSpecific = specific,
+                nativeCoin = ethCoin,
+                fallbackFeeAmount = BigInteger.ZERO,
+                evmGasLimitOverride = swapGasLimitOverride,
+            )
+
+        result shouldBe TokenValue(value = maxFeePerGasWei * swapGasLimitOverride, token = ethCoin)
+    }
+
+    /** Swap branch: THORChain ignores the override and still returns blockChainSpecific.fee. */
+    @Test
+    fun `thorchain swap branch ignores gasLimit override`() {
+        val fee = BigInteger.valueOf(2_000_000)
+        val specific =
+            BlockChainSpecific.THORChain(
+                accountNumber = BigInteger.ONE,
+                sequence = BigInteger.ZERO,
+                fee = fee,
+                isDeposit = false,
+                transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+            )
+
+        val result =
+            computeJoinKeysignNetworkFee(
+                blockChainSpecific = specific,
+                nativeCoin = runeCoin,
+                fallbackFeeAmount = BigInteger.ZERO,
+                evmGasLimitOverride = BigInteger.valueOf(600_000),
+            )
+
+        result shouldBe TokenValue(value = fee, token = runeCoin)
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.math.BigInteger
 import org.junit.jupiter.api.Test
@@ -47,19 +48,6 @@ internal class JoinKeysignSendGasFeeTest {
             decimal = 8,
             hexPublicKey = "hex",
             priceProviderID = "thorchain",
-            contractAddress = "",
-            isNativeToken = true,
-        )
-
-    private val mntCoin =
-        Coin(
-            chain = Chain.Mantle,
-            ticker = "MNT",
-            logo = "mnt",
-            address = "0xmntaddr",
-            decimal = 18,
-            hexPublicKey = "hex",
-            priceProviderID = "mantle",
             contractAddress = "",
             isNativeToken = true,
         )
@@ -156,13 +144,12 @@ internal class JoinKeysignSendGasFeeTest {
     }
 
     /**
-     * Swap branch: Ethereum case must use the override (DEFAULT_SWAP_LIMIT) instead of the
-     * payload's gasLimit, so joiner output matches initiator output.
+     * Swap helper: Ethereum case must apply [EthereumFeeService.DEFAULT_SWAP_LIMIT] regardless of
+     * the payload's gasLimit, so joiner output matches initiator output.
      */
     @Test
-    fun `evm swap branch uses gasLimit override`() {
+    fun `evm swap helper uses default swap limit`() {
         val payloadGasLimit = BigInteger.valueOf(21_000)
-        val swapGasLimitOverride = BigInteger.valueOf(600_000)
         val maxFeePerGasWei = BigInteger.valueOf(30_000_000_000L)
         val specific =
             BlockChainSpecific.Ethereum(
@@ -173,14 +160,17 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         val result =
-            computeJoinKeysignNetworkFee(
+            computeJoinKeysignSwapNetworkFee(
                 blockChainSpecific = specific,
                 nativeCoin = ethCoin,
-                fallbackFeeAmount = BigInteger.ZERO,
-                evmGasLimitOverride = swapGasLimitOverride,
+                chain = Chain.Ethereum,
             )
 
-        result shouldBe TokenValue(value = maxFeePerGasWei * swapGasLimitOverride, token = ethCoin)
+        result shouldBe
+            TokenValue(
+                value = maxFeePerGasWei * EthereumFeeService.DEFAULT_SWAP_LIMIT,
+                token = ethCoin,
+            )
     }
 
     /**
@@ -194,37 +184,9 @@ internal class JoinKeysignSendGasFeeTest {
         defaultEvmSwapGasLimit(Chain.Ethereum) shouldBe EthereumFeeService.DEFAULT_SWAP_LIMIT
     }
 
-    /** Swap branch: Mantle uses DEFAULT_MANTLE_SWAP_LIMIT when fed through the helper. */
+    /** Swap helper: THORChain returns blockChainSpecific.fee. */
     @Test
-    fun `evm swap branch on Mantle applies Mantle gasLimit`() {
-        val payloadGasLimit = BigInteger.valueOf(21_000)
-        val maxFeePerGasWei = BigInteger.valueOf(30_000_000_000L)
-        val specific =
-            BlockChainSpecific.Ethereum(
-                maxFeePerGasWei = maxFeePerGasWei,
-                priorityFeeWei = BigInteger.valueOf(1_000_000_000L),
-                nonce = BigInteger.ZERO,
-                gasLimit = payloadGasLimit,
-            )
-
-        val result =
-            computeJoinKeysignNetworkFee(
-                blockChainSpecific = specific,
-                nativeCoin = mntCoin,
-                fallbackFeeAmount = BigInteger.ZERO,
-                evmGasLimitOverride = defaultEvmSwapGasLimit(Chain.Mantle),
-            )
-
-        result shouldBe
-            TokenValue(
-                value = maxFeePerGasWei * EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT,
-                token = mntCoin,
-            )
-    }
-
-    /** Swap branch: THORChain ignores the override and still returns blockChainSpecific.fee. */
-    @Test
-    fun `thorchain swap branch ignores gasLimit override`() {
+    fun `thorchain swap helper uses blockChainSpecific fee`() {
         val fee = BigInteger.valueOf(2_000_000)
         val specific =
             BlockChainSpecific.THORChain(
@@ -236,13 +198,34 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         val result =
-            computeJoinKeysignNetworkFee(
+            computeJoinKeysignSwapNetworkFee(
                 blockChainSpecific = specific,
                 nativeCoin = runeCoin,
-                fallbackFeeAmount = BigInteger.ZERO,
-                evmGasLimitOverride = BigInteger.valueOf(600_000),
+                chain = Chain.ThorChain,
             )
 
         result shouldBe TokenValue(value = fee, token = runeCoin)
+    }
+
+    /**
+     * Swap helper must reject subtypes the swap branch in [JoinKeysignViewModel.loadTransaction]
+     * never reaches — guards against a future extension silently shipping a zero fee.
+     */
+    @Test
+    fun `swap helper throws for unsupported subtype`() {
+        val specific =
+            BlockChainSpecific.Solana(
+                recentBlockHash = "hash",
+                priorityFee = BigInteger.ZERO,
+                priorityLimit = BigInteger.ZERO,
+            )
+
+        shouldThrow<IllegalStateException> {
+            computeJoinKeysignSwapNetworkFee(
+                blockChainSpecific = specific,
+                nativeCoin = solCoin,
+                chain = Chain.Solana,
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Extend `computeJoinKeysignNetworkFee` with an optional `evmGasLimitOverride: BigInteger? = null` parameter. Default is null → existing `blockChainSpecific.gasLimit` semantics preserved for the deposit (line 927) and send (line 1015) call sites.
- Collapse the swap branch's inlined Ethereum + THORChain cases (previously 9 lines) into a single helper call that passes `defaultEvmSwapGasLimit(chain)` as the override, so joiner output continues to match initiator output for swaps (the reason the swap branch overrode `gasLimit` in the first place — see comment near `defaultEvmSwapGasLimit`).
- THORChain branch ignores the override and still returns `blockChainSpecific.fee` unchanged.

Closes #4391. Follow-up from review thread on PR #4381: https://github.com/vultisig/vultisig-android/pull/4381#discussion_r3178602598

iOS exposes the equivalent shape as a single polymorphic `fee` getter on `BlockChainSpecific.swift:75-86`; this brings Android in line.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "JoinKeysignSendGasFeeTest"` — all 6 tests pass (4 existing + 2 new)
- [x] New tests: `evm swap branch uses gasLimit override`, `thorchain swap branch ignores gasLimit override`
- [x] ktfmt applied
- [ ] Manual smoke: join a swap keysign on EVM (e.g. ETH→USDC) and verify Network Fee row on the joiner matches the initiator's display
- [ ] Manual smoke: join a swap keysign on THORChain (e.g. BTC.BTC→ETH.ETH) and verify the joiner fee row matches the initiator's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap fee estimation updated: Ethereum swaps use a swap-specific gas-limit override; THORChain swaps use native chain fee values. Unsupported chains in swap paths now raise an explicit error to prevent silent zero-fee behavior. Mantle uses its chain-specific default gas limit.

* **Tests**
  * Added tests verifying Ethereum swap gas-limit override, Mantle default selection, THORChain fee handling, and erroring on unsupported swap chains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->