### PR TITLE
fix(explorer): correct Bittensor and Polkadot address URLs

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -76,7 +76,9 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
         get() =
             when (this) {
                 Chain.Ton -> explorerUrl
-                Chain.Ripple -> "${explorerUrl}account/"
+                Chain.Ripple,
+                Chain.Polkadot,
+                Chain.Bittensor -> "${explorerUrl}account/"
                 else -> "${explorerUrl}address/"
             }
 
@@ -103,8 +105,8 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
                 Chain.Polygon -> "https://polygonscan.com/"
                 Chain.Solana -> "https://orb.helius.dev/"
                 Chain.ThorChain -> "https://runescan.io/"
-                Chain.Polkadot -> "https://assethub-polkadot.subscan.io/account/"
-                Chain.Bittensor -> "https://taostats.io/account/"
+                Chain.Polkadot -> "https://assethub-polkadot.subscan.io/"
+                Chain.Bittensor -> "https://taostats.io/"
                 Chain.ZkSync -> "https://explorer.zksync.io/"
                 Chain.Sui -> "https://suiscan.xyz/mainnet/"
                 Chain.Ton -> "https://tonviewer.com/"


### PR DESCRIPTION
## Summary
- Bittensor address links produced `https://taostats.io/account/address/{addr}` instead of the correct `https://taostats.io/account/{addr}`
- Polkadot had the same issue: `https://assethub-polkadot.subscan.io/account/address/{addr}` instead of `https://assethub-polkadot.subscan.io/account/{addr}`
- Normalized both `explorerUrl` entries to the site root and routed both chains through the existing `account/` branch in `blockExplorerUrl` (alongside Ripple)
- Transaction URLs (`extrinsic/...`) were already hardcoded with full paths, so they're unaffected

## Test plan
- [ ] Open a Bittensor account in the app and tap the explorer link — verify it opens `https://taostats.io/account/{addr}`
- [ ] Open a Polkadot account and verify it opens `https://assethub-polkadot.subscan.io/account/{addr}`
- [ ] Verify Bittensor and Polkadot transaction links still resolve correctly (unchanged paths)
- [ ] Sanity check Ripple, Ton, and a couple of EVM/UTXO chains still link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed explorer link generation for Polkadot and Bittensor so account and address URLs are correctly formatted.
  * Adjusted address link behavior to treat Polkadot and Bittensor as account-based explorers and aligned base explorer URLs accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->