### PR TITLE
fix(keysign): remove double V2Scaffold padding from join verify screens

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -209,7 +209,7 @@ private fun SwapConfirmPreview() {
                     ),
                 vaultName = "Main Vault",
             ),
-        showToolbar = true,
+        hasToolbar = true,
         confirmTitle = "Sign",
         onFastSignClick = {},
         onConfirm = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -367,3 +367,33 @@ private fun VerifyDepositScreenPreview() {
         onFastSignClick = {},
     )
 }
+
+@Preview
+@Composable
+private fun JoinKeysignDepositVerifyPreview() {
+    VerifyDepositScreen(
+        state =
+            VerifyDepositUiModel(
+                depositTransactionUiModel =
+                    DepositTransactionUiModel(
+                        token =
+                            ValuedToken(
+                                token = Coins.ThorChain.RUNE,
+                                value = "1 RUNE",
+                                fiatValue = "$1.37",
+                            ),
+                        networkFeeFiatValue = "$0.03",
+                        networkFeeTokenValue = "0.02 RUNE",
+                        srcAddress = "thor1abc456bca",
+                        dstAddress = "thor1abc456bca",
+                        operation = "mint",
+                        memo = "BOND:addressHere",
+                    )
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -15,15 +15,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.KeySignWrapperViewModel
-import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
-import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
-import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
-import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignError
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.DiscoverService
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.DiscoveringSessionID
@@ -34,11 +29,6 @@ import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.WaitingForKeysignS
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignState
 import com.vultisig.wallet.ui.models.keysign.VerifyUiModel
-import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
-import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
-import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
-import com.vultisig.wallet.ui.models.swap.ValuedToken
-import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
@@ -74,7 +64,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     dappMetadata = dappMetadata,
                     isConsentsEnabled = false,
                     hasToolbar = true,
-                    confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
+                    confirmTitle = stringResource(R.string.verify_swap_sign_button),
                     onBackClick = viewModel::navigateToHome,
                     onFastSignClick = {},
                     onConfirm = viewModel::joinKeysign,
@@ -85,7 +75,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                 VerifySwapScreen(
                     state = model.model,
                     dappMetadata = dappMetadata,
-                    showToolbar = true,
+                    hasToolbar = true,
                     onBackClick = viewModel::navigateToHome,
                     confirmTitle = stringResource(R.string.verify_swap_sign_button),
                     isConsentsEnabled = false,
@@ -260,94 +250,5 @@ private fun JoinKeysignViewPreview() {
                     ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
             )
         },
-    )
-}
-
-@Preview
-@Composable
-private fun JoinKeysignSendVerifyPreview() {
-    VerifySendScreen(
-        state =
-            VerifyTransactionUiModel(
-                transaction =
-                    TransactionDetailsUiModel(
-                        srcAddress = "0x1111111111111111111111111111111111111111",
-                        dstAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                    )
-            ),
-        isConsentsEnabled = false,
-        hasToolbar = true,
-        confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
-        onBackClick = {},
-        onFastSignClick = {},
-        onConfirm = {},
-    )
-}
-
-@Preview
-@Composable
-private fun JoinKeysignSwapVerifyPreview() {
-    VerifySwapScreen(
-        state =
-            VerifySwapUiModel(
-                tx = SwapTransactionUiModel(totalFee = "1.00$", hasConsentAllowance = true),
-                vaultName = "Main Vault",
-            ),
-        showToolbar = true,
-        onBackClick = {},
-        confirmTitle = stringResource(R.string.verify_swap_sign_button),
-        isConsentsEnabled = false,
-        onFastSignClick = {},
-        onConfirm = {},
-    )
-}
-
-@Preview
-@Composable
-private fun JoinKeysignDepositVerifyPreview() {
-    VerifyDepositScreen(
-        state =
-            VerifyDepositUiModel(
-                depositTransactionUiModel =
-                    DepositTransactionUiModel(
-                        token =
-                            ValuedToken(
-                                token = Coins.ThorChain.RUNE,
-                                value = "1 RUNE",
-                                fiatValue = "$1.37",
-                            ),
-                        networkFeeFiatValue = "$0.03",
-                        networkFeeTokenValue = "0.02 RUNE",
-                        srcAddress = "thor1abc456bca",
-                        dstAddress = "thor1abc456bca",
-                        operation = "mint",
-                        memo = "BOND:addressHere",
-                    )
-            ),
-        hasToolbar = true,
-        confirmTitle = stringResource(R.string.verify_swap_sign_button),
-        onBackClick = {},
-        onFastSignClick = {},
-        onConfirm = {},
-    )
-}
-
-@Preview
-@Composable
-private fun JoinKeysignSignMessageVerifyPreview() {
-    VerifySignMessageScreen(
-        state =
-            VerifySignMessageUiModel(
-                model =
-                    SignMessageTransactionUiModel(
-                        method = "personal_sign",
-                        message = "Sign in to Uniswap",
-                    )
-            ),
-        hasToolbar = true,
-        confirmTitle = stringResource(R.string.verify_swap_sign_button),
-        onBackClick = {},
-        onFastSignClick = {},
-        onConfirm = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -15,10 +15,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.KeySignWrapperViewModel
+import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
+import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
+import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
+import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignError
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.DiscoverService
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.DiscoveringSessionID
@@ -29,6 +34,11 @@ import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.WaitingForKeysignS
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignState
 import com.vultisig.wallet.ui.models.keysign.VerifyUiModel
+import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
+import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
+import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
+import com.vultisig.wallet.ui.models.swap.ValuedToken
+import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
@@ -51,17 +61,70 @@ internal fun JoinKeysignView(navController: NavHostController) {
     val isKeysignFinished = keysignState is KeysignState.KeysignFinished
     val isKeysignInProgress = state == Keysign && keysignState.isInProgress
     val isSignMessageDone = isKeysignFinished && verifyUiModel is VerifyUiModel.SignMessage
+
+    if (state == JoinKeysign) {
+        // Each Verify*Screen owns its scaffold + toolbar, so the join path renders
+        // them directly — avoids the double V2Scaffold padding that previously
+        // pushed the verify card and its button off-position vs the initiator path.
+        BackHandler(onBack = viewModel::navigateToHome)
+        when (val model = verifyUiModel) {
+            is VerifyUiModel.Send -> {
+                VerifySendScreen(
+                    state = model.model,
+                    dappMetadata = dappMetadata,
+                    isConsentsEnabled = false,
+                    hasToolbar = true,
+                    confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
+                    onBackClick = viewModel::navigateToHome,
+                    onFastSignClick = {},
+                    onConfirm = viewModel::joinKeysign,
+                )
+            }
+
+            is VerifyUiModel.Swap -> {
+                VerifySwapScreen(
+                    state = model.model,
+                    dappMetadata = dappMetadata,
+                    showToolbar = true,
+                    onBackClick = viewModel::navigateToHome,
+                    confirmTitle = stringResource(R.string.verify_swap_sign_button),
+                    isConsentsEnabled = false,
+                    onFastSignClick = {},
+                    onConfirm = viewModel::joinKeysign,
+                )
+            }
+
+            is VerifyUiModel.Deposit -> {
+                VerifyDepositScreen(
+                    state = model.model,
+                    dappMetadata = dappMetadata,
+                    hasToolbar = true,
+                    confirmTitle = stringResource(R.string.verify_swap_sign_button),
+                    onBackClick = viewModel::navigateToHome,
+                    onFastSignClick = {},
+                    onConfirm = viewModel::joinKeysign,
+                )
+            }
+
+            is VerifyUiModel.SignMessage -> {
+                VerifySignMessageScreen(
+                    state = model.model,
+                    hasToolbar = true,
+                    confirmTitle = stringResource(R.string.verify_swap_sign_button),
+                    onBackClick = viewModel::navigateToHome,
+                    onFastSignClick = {},
+                    onConfirm = viewModel::joinKeysign,
+                )
+            }
+        }
+        return
+    }
+
     val title =
         stringResource(
             when {
                 isSignMessageDone -> R.string.transaction_done_overview
                 isKeysignFinished -> R.string.transaction_complete_screen_title
-                state == JoinKeysign && verifyUiModel is VerifyUiModel.Send ->
-                    R.string.verify_send_send_overview
-                state == JoinKeysign && verifyUiModel is VerifyUiModel.Swap ->
-                    R.string.verify_swap_swap_overview
-                state == JoinKeysign && verifyUiModel is VerifyUiModel.SignMessage ->
-                    R.string.verify_transaction_screen_title
                 else -> R.string.sign_transaction
             }
         )
@@ -70,8 +133,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
         onBack = viewModel::navigateToHome,
         isError = state is Error,
         fullScreen = isKeysignInProgress,
-        applyDefaultPaddings =
-            !(state == JoinKeysign && verifyUiModel is VerifyUiModel.Swap) && !isKeysignFinished,
+        applyDefaultPaddings = !isKeysignFinished,
     ) {
         when (state) {
             DiscoveringSessionID,
@@ -93,52 +155,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                 KeysignLoadingScreen(text = stringResource(R.string.join_keysign_discovery_service))
             }
 
-            JoinKeysign -> {
-                when (val model = verifyUiModel) {
-                    is VerifyUiModel.Send -> {
-                        VerifySendScreen(
-                            state = model.model,
-                            dappMetadata = dappMetadata,
-                            isConsentsEnabled = false,
-                            confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
-                            onFastSignClick = {},
-                            onConfirm = viewModel::joinKeysign,
-                        )
-                    }
-
-                    is VerifyUiModel.Swap -> {
-                        VerifySwapScreen(
-                            state = model.model,
-                            dappMetadata = dappMetadata,
-                            showToolbar = false,
-                            onBackClick = {},
-                            confirmTitle = stringResource(R.string.verify_swap_sign_button),
-                            isConsentsEnabled = false,
-                            onFastSignClick = {},
-                            onConfirm = viewModel::joinKeysign,
-                        )
-                    }
-
-                    is VerifyUiModel.Deposit -> {
-                        VerifyDepositScreen(
-                            state = model.model,
-                            dappMetadata = dappMetadata,
-                            confirmTitle = stringResource(R.string.verify_swap_sign_button),
-                            onFastSignClick = {},
-                            onConfirm = viewModel::joinKeysign,
-                        )
-                    }
-
-                    is VerifyUiModel.SignMessage -> {
-                        VerifySignMessageScreen(
-                            state = model.model,
-                            confirmTitle = stringResource(R.string.verify_swap_sign_button),
-                            onFastSignClick = {},
-                            onConfirm = viewModel::joinKeysign,
-                        )
-                    }
-                }
-            }
+            JoinKeysign -> Unit // handled above, before the JoinKeysignScreen wrapper
 
             Keysign -> {
                 val wrapperViewModel =
@@ -243,5 +260,94 @@ private fun JoinKeysignViewPreview() {
                     ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
             )
         },
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignSendVerifyPreview() {
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        srcAddress = "0x1111111111111111111111111111111111111111",
+                        dstAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    )
+            ),
+        isConsentsEnabled = false,
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_transaction_join_keysign),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignSwapVerifyPreview() {
+    VerifySwapScreen(
+        state =
+            VerifySwapUiModel(
+                tx = SwapTransactionUiModel(totalFee = "1.00$", hasConsentAllowance = true),
+                vaultName = "Main Vault",
+            ),
+        showToolbar = true,
+        onBackClick = {},
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        isConsentsEnabled = false,
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignDepositVerifyPreview() {
+    VerifyDepositScreen(
+        state =
+            VerifyDepositUiModel(
+                depositTransactionUiModel =
+                    DepositTransactionUiModel(
+                        token =
+                            ValuedToken(
+                                token = Coins.ThorChain.RUNE,
+                                value = "1 RUNE",
+                                fiatValue = "$1.37",
+                            ),
+                        networkFeeFiatValue = "$0.03",
+                        networkFeeTokenValue = "0.02 RUNE",
+                        srcAddress = "thor1abc456bca",
+                        dstAddress = "thor1abc456bca",
+                        operation = "mint",
+                        memo = "BOND:addressHere",
+                    )
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignSignMessageVerifyPreview() {
+    VerifySignMessageScreen(
+        state =
+            VerifySignMessageUiModel(
+                model =
+                    SignMessageTransactionUiModel(
+                        method = "personal_sign",
+                        message = "Sign in to Uniswap",
+                    )
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -626,3 +626,24 @@ private fun PreviewVerifySendScreen() {
         onConfirm = {},
     )
 }
+
+@Preview
+@Composable
+private fun JoinKeysignSendVerifyPreview() {
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        srcAddress = "0x1111111111111111111111111111111111111111",
+                        dstAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    )
+            ),
+        isConsentsEnabled = false,
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
+import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageViewModel
 import com.vultisig.wallet.ui.utils.asString
@@ -57,8 +58,10 @@ internal fun VerifySignMessageScreen(viewModel: VerifySignMessageViewModel = hil
 
     VerifySignMessageScreen(
         state = state,
+        hasToolbar = false,
         confirmTitle = stringResource(R.string.verify_swap_sign_button),
         onConfirm = viewModel::confirm,
+        onBackClick = {},
         onFastSignClick = {
             if (!viewModel.tryToFastSignWithPassword()) {
                 authorize()
@@ -70,11 +73,11 @@ internal fun VerifySignMessageScreen(viewModel: VerifySignMessageViewModel = hil
 @Composable
 internal fun VerifySignMessageScreen(
     state: VerifySignMessageUiModel,
+    hasToolbar: Boolean,
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
-    hasToolbar: Boolean = false,
-    onBackClick: () -> Unit = {},
+    onBackClick: () -> Unit,
 ) {
     val transactionUiModel = state.model
     VerifySignMessageScreen(
@@ -94,11 +97,11 @@ private fun VerifySignMessageScreen(
     method: String,
     message: String,
     hasFastSign: Boolean,
+    hasToolbar: Boolean,
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
-    hasToolbar: Boolean = false,
-    onBackClick: () -> Unit = {},
+    onBackClick: () -> Unit,
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -165,6 +168,28 @@ private fun VerifySignMessageScreenPreview() {
         message = "message",
         confirmTitle = "Sign",
         hasFastSign = false,
+        hasToolbar = false,
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignSignMessageVerifyPreview() {
+    VerifySignMessageScreen(
+        state =
+            VerifySignMessageUiModel(
+                model =
+                    SignMessageTransactionUiModel(
+                        method = "personal_sign",
+                        message = "Sign in to Uniswap",
+                    )
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
         onFastSignClick = {},
         onConfirm = {},
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
+import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageViewModel
 import com.vultisig.wallet.ui.utils.asString
@@ -72,6 +73,8 @@ internal fun VerifySignMessageScreen(
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
+    hasToolbar: Boolean = false,
+    onBackClick: () -> Unit = {},
 ) {
     val transactionUiModel = state.model
     VerifySignMessageScreen(
@@ -81,6 +84,8 @@ internal fun VerifySignMessageScreen(
         hasFastSign = state.hasFastSign,
         onFastSignClick = onFastSignClick,
         onConfirm = onConfirm,
+        hasToolbar = hasToolbar,
+        onBackClick = onBackClick,
     )
 }
 
@@ -92,9 +97,19 @@ private fun VerifySignMessageScreen(
     confirmTitle: String,
     onFastSignClick: () -> Unit,
     onConfirm: () -> Unit,
+    hasToolbar: Boolean = false,
+    onBackClick: () -> Unit = {},
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
+        topBar = {
+            if (hasToolbar) {
+                VsTopAppBar(
+                    title = stringResource(R.string.verify_transaction_screen_title),
+                    onBackClick = onBackClick,
+                )
+            }
+        },
         bottomBar = {
             Column(modifier = Modifier.fillMaxWidth().padding(all = 16.dp)) {
                 if (hasFastSign) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -108,7 +108,7 @@ internal fun VerifySwapScreen(viewModel: VerifySwapViewModel = hiltViewModel()) 
 
     VerifySwapScreen(
         state = state,
-        showToolbar = true,
+        hasToolbar = true,
         confirmTitle = stringResource(R.string.verify_swap_sign_button),
         onConsentReceiveAmount = viewModel::consentReceiveAmount,
         onConsentAmount = viewModel::consentAmount,
@@ -124,7 +124,7 @@ internal fun VerifySwapScreen(viewModel: VerifySwapViewModel = hiltViewModel()) 
 @Composable
 internal fun VerifySwapScreen(
     state: VerifySwapUiModel,
-    showToolbar: Boolean,
+    hasToolbar: Boolean,
     confirmTitle: String,
     isConsentsEnabled: Boolean = true,
     dappMetadata: DAppMetadata? = null,
@@ -138,7 +138,7 @@ internal fun VerifySwapScreen(
     onDismissRequest: () -> Unit = {},
 ) {
     VerifySwapScreen(
-        showToolbar = showToolbar,
+        hasToolbar = hasToolbar,
         tx = state.tx,
         scanStatus = state.txScanStatus,
         hasToShowWarningScanning = state.showScanningWarning,
@@ -164,7 +164,7 @@ internal fun VerifySwapScreen(
 
 @Composable
 private fun VerifySwapScreen(
-    showToolbar: Boolean,
+    hasToolbar: Boolean,
     tx: SwapTransactionUiModel,
     scanStatus: TransactionScanStatus,
     hasToShowWarningScanning: Boolean,
@@ -187,8 +187,8 @@ private fun VerifySwapScreen(
     onDismissRequest: () -> Unit,
 ) {
     V2Scaffold(
-        title = stringResource(R.string.verify_swap_swap_overview).takeIf { showToolbar },
-        onBackClick = onBackClick.takeIf { showToolbar },
+        title = stringResource(R.string.verify_swap_swap_overview).takeIf { hasToolbar },
+        onBackClick = onBackClick.takeIf { hasToolbar },
         content = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
@@ -652,7 +652,7 @@ internal fun VerifyCardJsonDetails(title: String, subtitle: String, modifier: Mo
 @Composable
 private fun VerifySwapScreenPreview() {
     VerifySwapScreen(
-        showToolbar = true,
+        hasToolbar = true,
         onBackClick = {},
         hasAllConsents = false,
         hasToShowWarningScanning = false,
@@ -672,5 +672,23 @@ private fun VerifySwapScreenPreview() {
         onConfirm = {},
         onContinueAnyway = {},
         onDismissRequest = {},
+    )
+}
+
+@Preview
+@Composable
+private fun JoinKeysignSwapVerifyPreview() {
+    VerifySwapScreen(
+        state =
+            VerifySwapUiModel(
+                tx = SwapTransactionUiModel(totalFee = "1.00$", hasConsentAllowance = true),
+                vaultName = "Main Vault",
+            ),
+        hasToolbar = true,
+        onBackClick = {},
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        isConsentsEnabled = false,
+        onFastSignClick = {},
+        onConfirm = {},
     )
 }


### PR DESCRIPTION
Closes #4538.

## Problem

The joined-device verify screen wrapped each `Verify*Screen` inside an outer `V2Scaffold` that already applied default 16dp/12dp padding, while each verify composable provided its **own** scaffold with the same padding — netting double container padding and a stacked top bar (showing the fallback `Sign Transaction` title instead of the correct per-variant title).

Effective padding per join-keysign variant before this PR:

| Variant | Inner pad | Outer pad | Total | Initiator (correct) |
|---|---|---|---|---|
| Send | 16h/12v | 16h/12v | **32h/24v** | 16h/12v |
| Swap | 16h/12v | suppressed | 16h/12v | 16h/12v |
| Deposit | 16h/16v | 16h/12v | **32h/28v** | 16h/16v |
| SignMessage | 16h/12v | 16h/12v | **32h/24v** | 16h/12v |

Only Swap was already correct, via an existing `applyDefaultPaddings = false` carve-out for the swap branch.

## Fix

Pull the `JoinKeysign` state branch out of the outer `JoinKeysignScreen { … }` wrapper so each `Verify*Screen` owns its own scaffold + toolbar via `hasToolbar = true` / `showToolbar = true`, mirroring what the initiator path does.

- `JoinKeysignView.kt`: handle `state == JoinKeysign` before the `JoinKeysignScreen` wrapper; each Verify variant now passes `hasToolbar = true` and `onBackClick = viewModel::navigateToHome`. A top-level `BackHandler` is added for the JoinKeysign branch (since the one inside `JoinKeysignScreen` no longer fires for this state). Drop the Swap-only `applyDefaultPaddings` carve-out and the inner-verify title cases (they were only there to fake what the inner toolbars now provide).
- `VerifySignMessageScreen.kt`: add `hasToolbar`/`onBackClick` params (defaulting to false / no-op so existing call sites are unaffected) and a `VsTopAppBar` in its `Scaffold.topBar`. Mirrors the pattern already in `VerifyDepositScreen`.
- Add four `@Preview` composables to `JoinKeysignView.kt` — one per variant — to make the new layout reviewable side-by-side with the existing initiator-path previews in `VerifySendScreen.kt`, `VerifySwapScreen.kt`, `VerifyDepositScreen.kt`, `VerifySignMessageScreen.kt`.

After this PR, each variant renders with a single scaffold and the correct per-variant title (`Send overview`, `Swap overview`, `Function overview`, `Verify`).

## Test plan

- [x] `./gradlew :app:compileDebugKotlin --rerun-tasks` — green
- [x] `./gradlew :app:ktfmtFormat` — clean
- [x] All other call sites of the four verify screens (NavGraph, SignMessageScreen, DepositScreen, BondFormScreen, PreviewActivity) verified unaffected — the new params have defaults
- [ ] Manual smoke on multi-device keysign:
  - [ ] Send: joined-device verify card matches initiator's `Send overview` position + padding, title reads `Send overview`
  - [ ] Swap: joined-device verify still renders correctly (regression check), title reads `Swap overview`
  - [ ] Deposit: joined-device verify matches initiator's `Function overview` padding, title reads `Function overview`
  - [ ] SignMessage: joined-device verify shows the new toolbar with title `Verify`, no double padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Streamlined keysign join flow to render verification screens earlier, improve back navigation, and simplify transaction titles.
  * Added optional toolbar with back-button support to sign-message, swap, send, and deposit verification screens.
  * Refined default paddings when keysign is finished for consistent layout.
  * Added preview configurations for send, swap, and deposit verification screens to aid visual testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->