### PR TITLE
fix(maya): preserve selected DeFi tab across back navigation (#4447)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -167,7 +167,9 @@ constructor(
 
     fun setData(vaultId: VaultId) {
         this.vaultId = vaultId
-        _state.value = MayachainDefiUiState.Success(MayachainDefiPositionsUiModel())
+        if (_state.value !is MayachainDefiUiState.Success) {
+            _state.value = MayachainDefiUiState.Success(MayachainDefiPositionsUiModel())
+        }
         loadBalanceVisibility()
         savedPositionsJob?.cancel()
         savedPositionsJob = loadSavedPositions()


### PR DESCRIPTION
Closes #4447.

## Summary
- `MayachainDefiPositionsViewModel.setData` was called from `LaunchedEffect(vaultId)` every time the screen re-entered composition (e.g. after returning from `Add MayaChain LP`), and unconditionally reset `_state` to a fresh `MayachainDefiPositionsUiModel()` — snapping `selectedTab` back to the default `Bonded`.
- Initialize the `Success` state only on the first call (when state is still `Loading`); on subsequent re-entries and pull-to-refresh, keep the existing model so `selectedTab` and other tab-scoped UI state are preserved. All loaders use `updateModel`, which only touches the fields they own.
- Sibling `ThorchainDefiPositionsViewModel.setData` already follows this pattern — no equivalent reset — so this aligns Maya with the existing convention.

## Test plan
- [ ] Open MayaChain DeFi screen, switch to the **LP** tab, tap **Add LP**, then press back → returns to MayaChain DeFi with the **LP** tab still selected.
- [ ] Repeat from the **Staked** tab (Add Stake → back) → returns to **Staked** tab.
- [ ] Pull-to-refresh on the **LP** tab → data reloads, tab remains **LP**.
- [ ] Cold-enter MayaChain DeFi screen → defaults to **Bonded** tab as before.
- [ ] Position selection dialog still works and persists across the same back-navigation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the DeFi positions view by preventing unnecessary state resets when data is updated, resulting in a more responsive and stable UI experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->