### PR TITLE
fix(send): skip fee round-trip on non-native percentage chips

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountFractionManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountFractionManager.kt
@@ -148,9 +148,14 @@ internal class AmountFractionManager(
             if (gasFee.value != null) {
                 fetchPercentageOfAvailableBalance(percentage)
             } else {
+                // Mirror fetchPercentageOfAvailableBalance's normalization so the
+                // short-circuit below returns the same shape as the fresh-fee path,
+                // e.g. "6" instead of "6.00" when 0.75f × 8 leaves trailing zeros.
                 getAvailableTokenBalance(selectedAccount, BigInteger.ZERO)
                     ?.decimal
-                    ?.multiply(percentage.toBigDecimal()) ?: BigDecimal.ZERO
+                    ?.multiply(percentage.toBigDecimal())
+                    ?.setScale(token.decimal, RoundingMode.DOWN)
+                    ?.stripTrailingZeros() ?: BigDecimal.ZERO
             }
 
         if (
@@ -174,7 +179,15 @@ internal class AmountFractionManager(
 
         val chain = token.chain
 
-        if (gasFee.value != null && chain.standard == TokenStandard.EVM) {
+        // Skip the fresh-fee round-trip when it cannot change the percentage amount:
+        //   - Non-native tokens pay chain gas in the native coin (see
+        //     GetAvailableTokenBalanceUseCase), so the fee never reduces the
+        //     selected balance and the cached estimate is already accurate.
+        //   - EVM gas is amount-independent once collectGasFees has run, so the
+        //     cached fee is reusable.
+        // GasFeeOrchestrator still refreshes gasFee in the background when the
+        // amount field updates, so the fee display reflects the new amount.
+        if (!token.isNativeToken || (gasFee.value != null && chain.standard == TokenStandard.EVM)) {
             return amount
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountFractionManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountFractionManagerTest.kt
@@ -156,6 +156,29 @@ internal class AmountFractionManagerTest {
             coVerify(exactly = 0) { tokenRepository.getNativeToken(any()) }
         }
 
+    @Test
+    fun `chooseMaxTokenAmount non-native token - short-circuits without fee recalculation`() =
+        runTest(mainDispatcher) {
+            // Non-native SPL token on a non-EVM chain (USDC on Solana). Chain gas is paid in
+            // the native coin (SOL) and never reduces the USDC balance, so the chip must not
+            // block on a fresh-fee RPC.
+            val usdc = usdcSolanaAccount()
+            account = usdc
+            gasFee.value = TokenValue(value = BigInteger("5000"), token = solAccount().token)
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(value = BigInteger("12500000"), token = usdc.token)
+            val manager = build(backgroundScope)
+
+            manager.chooseMaxTokenAmount()
+            advanceUntilIdle()
+
+            // 12.5 USDC × 1.0 → 12.5 (6 decimals, trailing zeros stripped).
+            assertEquals("12.5", tokenAmountFieldState.text.toString())
+            coVerify { amountManager.markMax(BigDecimal("12.5")) }
+            coVerify(exactly = 0) { feeServiceComposite.calculateFees(any()) }
+            coVerify(exactly = 0) { tokenRepository.getNativeToken(any()) }
+        }
+
     // ──────── choosePercentageAmount ────────
 
     @Test
@@ -203,6 +226,51 @@ internal class AmountFractionManagerTest {
             assertEquals(AmountFraction.F75, uiState.value.selectedAmountFraction)
             assertFalse(uiState.value.isAmountSelectionLoading)
             assertEquals("0", tokenAmountFieldState.text.toString())
+        }
+
+    @Test
+    fun `choosePercentageAmount non-native token - short-circuits without fee recalculation`() =
+        runTest(mainDispatcher) {
+            val usdc = usdcSolanaAccount()
+            account = usdc
+            gasFee.value = TokenValue(value = BigInteger("5000"), token = solAccount().token)
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(value = BigInteger("10000000"), token = usdc.token)
+            val manager = build(backgroundScope)
+
+            manager.choosePercentageAmount(AmountFraction.F50)
+            advanceUntilIdle()
+
+            // 10 USDC × 0.5 → "5".
+            assertEquals(AmountFraction.F50, uiState.value.selectedAmountFraction)
+            assertFalse(uiState.value.isAmountSelectionLoading)
+            assertEquals("5", tokenAmountFieldState.text.toString())
+            coVerify(exactly = 0) { feeServiceComposite.calculateFees(any()) }
+            coVerify(exactly = 0) { tokenRepository.getNativeToken(any()) }
+            coVerify(exactly = 0) { amountManager.markMax(any()) }
+        }
+
+    @Test
+    fun `choosePercentageAmount non-native token with null gasFee - short-circuits without fee recalculation`() =
+        runTest(mainDispatcher) {
+            // gasFee.value stays null. For non-native tokens this is still safe: the fee never
+            // reduces the selected balance, and GasFeeOrchestrator refreshes the fee in the
+            // background once the amount field is populated.
+            val usdc = usdcSolanaAccount()
+            account = usdc
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(value = BigInteger("8000000"), token = usdc.token)
+            val manager = build(backgroundScope)
+
+            manager.choosePercentageAmount(AmountFraction.F75)
+            advanceUntilIdle()
+
+            // 8 USDC × 0.75 → "6".
+            assertEquals(AmountFraction.F75, uiState.value.selectedAmountFraction)
+            assertFalse(uiState.value.isAmountSelectionLoading)
+            assertEquals("6", tokenAmountFieldState.text.toString())
+            coVerify(exactly = 0) { feeServiceComposite.calculateFees(any()) }
+            coVerify(exactly = 0) { tokenRepository.getNativeToken(any()) }
         }
 
     @Test
@@ -318,6 +386,48 @@ internal class AmountFractionManagerTest {
         return Account(
             token = token,
             tokenValue = TokenValue(value = BigInteger("0"), token = token),
+            fiatValue = null,
+            price = null,
+        )
+    }
+
+    private fun solAccount(): Account {
+        val token =
+            Coin(
+                chain = Chain.Solana,
+                ticker = "SOL",
+                logo = "",
+                address = "Sol...",
+                decimal = 9,
+                hexPublicKey = "",
+                priceProviderID = "solana",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        return Account(
+            token = token,
+            tokenValue = TokenValue(value = BigInteger("0"), token = token),
+            fiatValue = null,
+            price = null,
+        )
+    }
+
+    private fun usdcSolanaAccount(): Account {
+        val token =
+            Coin(
+                chain = Chain.Solana,
+                ticker = "USDC",
+                logo = "",
+                address = "Sol...",
+                decimal = 6,
+                hexPublicKey = "",
+                priceProviderID = "usd-coin",
+                contractAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                isNativeToken = false,
+            )
+        return Account(
+            token = token,
+            tokenValue = TokenValue(value = BigInteger("10000000"), token = token),
             fiatValue = null,
             price = null,
         )


### PR DESCRIPTION
Closes #4563.

## Summary

Tapping 50%/75%/MAX on the Send screen for a non-native token on a non-EVM chain (USDC on Solana in the report) buffers for a few seconds before the amount field populates. The chip-tap path in `AmountFractionManager` always re-runs `feeServiceComposite.calculateFees` for that case, even though chain gas on non-native tokens is paid in the native coin and never reduces the selected balance (see `GetAvailableTokenBalanceUseCase`). The fresh fetch is a multi-second Solana RPC round-trip that the percentage calc ignores.

Extend the existing EVM short-circuit to also fire when the token is non-native, so the chip-tap returns the cached estimate immediately. `GasFeeOrchestrator` still refreshes `gasFee` in the background once the amount field updates, so the fee display catches up without blocking the input.

While in the same code path, mirror `fetchPercentageOfAvailableBalance`'s `setScale + stripTrailingZeros` normalization in the null-gasFee fallback so the new short-circuit returns the same "6" / "12.5" shape as the cached-fee path, instead of leaking "6.00" when `0.75f × 8` leaves trailing zeros.

Native tokens on non-EVM chains (native SOL, BTC, etc.) keep the current fresh-fee fetch, since fee freshness matters there (MAX needs the actual fee, BTC fee depends on UTXO selection) — that matches iOS behavior.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.send.*"` — 159 send.* tests, 0 failures.
- `./gradlew :app:lintDebug` — clean.
- Three new tests in `AmountFractionManagerTest` cover the non-native short-circuit for both percentage and max paths, including the null-gasFee variant. They assert no `feeServiceComposite.calculateFees` / `tokenRepository.getNativeToken` call is issued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee calculation consistency for percentage-based amount selection across different fee scenarios.
  * Enhanced handling of non-native token transactions to prevent unnecessary recalculations.

* **Tests**
  * Expanded test coverage for non-native token transactions on non-EVM chains.
  * Added validation to ensure fee recalculation is correctly bypassed when appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->