### PR TITLE
fix(migration): prompt for server share location before contacting VultiServer

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/flows/migration/MigrateGg20FastVaultFlowTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/flows/migration/MigrateGg20FastVaultFlowTest.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.ui.pages.keygen.FastVaultVerificationPage
 import com.vultisig.wallet.ui.pages.onboarding.VaultBackupOnboardingPage
 import com.vultisig.wallet.ui.screens.backup.BackupPasswordRequestScreenTags
 import com.vultisig.wallet.ui.screens.migration.MigrationOnboardingScreenTags
+import com.vultisig.wallet.ui.screens.migration.MigrationServerShareLocationSheetTags
 import com.vultisig.wallet.ui.utils.click
 import com.vultisig.wallet.ui.utils.waitUntilShown
 import com.vultisig.wallet.util.CleanTest
@@ -85,6 +86,9 @@ class MigrateGg20FastVaultFlowTest : CleanTest() {
         compose.waitUntilShown(MigrationOnboardingScreenTags.NEXT)
         compose.click(MigrationOnboardingScreenTags.NEXT)
         compose.click(MigrationOnboardingScreenTags.NEXT)
+
+        compose.waitUntilShown(MigrationServerShareLocationSheetTags.ONLINE)
+        compose.click(MigrationServerShareLocationSheetTags.ONLINE)
 
         compose.waitUntilShown("InputPasswordScreen.password")
         compose.textField("InputPasswordScreen.password").performTextInput(TEST_VAULT_PASSWORD)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingScreen.kt
@@ -40,6 +40,7 @@ internal fun MigrationOnboardingScreen(model: MigrationOnboardingViewModel = hil
     MigrationOnboardingScreen(
         currentPage = currentPage,
         pages = pages,
+        isServerShareLocationSheetVisible = state.isServerShareLocationSheetVisible,
         onBackClick = {
             if (currentPage <= 0) {
                 model.back()
@@ -54,6 +55,9 @@ internal fun MigrationOnboardingScreen(model: MigrationOnboardingViewModel = hil
                 currentPage++
             }
         },
+        onDismissServerShareLocationSheet = model::dismissServerShareLocationSheet,
+        onUseOnlineVultiServer = model::continueWithOnlineVultiServer,
+        onUseAnotherDevice = model::continueWithSelfHostedServer,
     )
 }
 
@@ -61,8 +65,12 @@ internal fun MigrationOnboardingScreen(model: MigrationOnboardingViewModel = hil
 private fun MigrationOnboardingScreen(
     currentPage: Int,
     pages: List<MigrationOnboardingPage>,
+    isServerShareLocationSheetVisible: Boolean,
     onBackClick: () -> Unit,
     onNext: () -> Unit,
+    onDismissServerShareLocationSheet: () -> Unit,
+    onUseOnlineVultiServer: () -> Unit,
+    onUseAnotherDevice: () -> Unit,
 ) {
     V2Scaffold(
         title = stringResource(R.string.migration_onboarding_upgrade_your_vault),
@@ -75,6 +83,14 @@ private fun MigrationOnboardingScreen(
                 text = page.text,
                 buttonText = page.buttonText,
             )
+
+            if (isServerShareLocationSheetVisible) {
+                MigrationServerShareLocationBottomSheet(
+                    onDismissRequest = onDismissServerShareLocationSheet,
+                    onUseOnlineVultiServer = onUseOnlineVultiServer,
+                    onUseAnotherDevice = onUseAnotherDevice,
+                )
+            }
         },
     )
 }
@@ -185,8 +201,12 @@ private fun MigrationOnboardingScreenPreview() {
     MigrationOnboardingScreen(
         currentPage = 0,
         pages = getPages(Route.VaultInfo.VaultType.Secure),
+        isServerShareLocationSheetVisible = false,
         onBackClick = {},
         onNext = {},
+        onDismissServerShareLocationSheet = {},
+        onUseOnlineVultiServer = {},
+        onUseAnotherDevice = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModel.kt
@@ -17,7 +17,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal data class MigrationOnboardingUiModel(
-    val vaultType: Route.VaultInfo.VaultType = Route.VaultInfo.VaultType.Secure
+    val vaultType: Route.VaultInfo.VaultType = Route.VaultInfo.VaultType.Secure,
+    val isServerShareLocationSheetVisible: Boolean = false,
 )
 
 @HiltViewModel
@@ -33,6 +34,9 @@ constructor(
 
     private val args = savedStateHandle.toRoute<Route.Migration.Onboarding>()
     private val vaultId = args.vaultId
+
+    // Cached when [upgrade] detects a fast vault, so the sheet callbacks don't need to refetch.
+    private var fastVaultName: String? = null
 
     init {
         viewModelScope.launch {
@@ -56,20 +60,47 @@ constructor(
             val vault = vaultRepository.get(vaultId) ?: error("Vault with $vaultId doesn't exist")
 
             if (vault.isFastVault()) {
-                navigator.route(Route.Migration.Password(vaultId = vaultId))
+                // The vault has a server signer, but the user may have imported that share onto
+                // another device they own. Ask before silently hitting the online VultiServer.
+                fastVaultName = vault.name
+                state.update { it.copy(isServerShareLocationSheetVisible = true) }
             } else {
-                navigator.route(
-                    Route.Keygen.PeerDiscovery(
-                        action = TssAction.Migrate,
-                        vaultName = vault.name,
-                        vaultId = vaultId,
-                    )
-                )
+                routeToPeerMigrate(vault.name)
             }
         }
     }
 
+    fun continueWithOnlineVultiServer() {
+        closeServerShareLocationSheet()
+        viewModelScope.launch { navigator.route(Route.Migration.Password(vaultId = vaultId)) }
+    }
+
+    fun continueWithSelfHostedServer() {
+        val vaultName = fastVaultName ?: return
+        closeServerShareLocationSheet()
+        viewModelScope.launch { routeToPeerMigrate(vaultName) }
+    }
+
+    fun dismissServerShareLocationSheet() {
+        closeServerShareLocationSheet()
+    }
+
     fun back() {
         viewModelScope.launch { navigator.navigate(Destination.Back) }
+    }
+
+    private fun closeServerShareLocationSheet() {
+        fastVaultName = null
+        state.update { it.copy(isServerShareLocationSheetVisible = false) }
+    }
+
+    private suspend fun routeToPeerMigrate(vaultName: String) {
+        navigator.route(
+            Route.Keygen.PeerDiscovery(
+                action = TssAction.Migrate,
+                vaultName = vaultName,
+                vaultId = vaultId,
+            )
+        )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModel.kt
@@ -7,6 +7,7 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.models.isFastVault
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -14,7 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 internal data class MigrationOnboardingUiModel(
     val vaultType: Route.VaultInfo.VaultType = Route.VaultInfo.VaultType.Secure,
@@ -32,32 +32,25 @@ constructor(
 
     val state = MutableStateFlow(MigrationOnboardingUiModel())
 
-    private val args = savedStateHandle.toRoute<Route.Migration.Onboarding>()
-    private val vaultId = args.vaultId
+    private val vaultId = savedStateHandle.toRoute<Route.Migration.Onboarding>().vaultId
 
-    // Cached when [upgrade] detects a fast vault, so the sheet callbacks don't need to refetch.
+    // Cached when [upgrade] detects a fast vault, so the sheet callbacks don't have to refetch.
     private var fastVaultName: String? = null
 
     init {
-        viewModelScope.launch {
-            vaultRepository.get(vaultId = vaultId)?.let { vault ->
-                state.update {
-                    it.copy(
-                        vaultType =
-                            if (vault.isFastVault()) {
-                                Route.VaultInfo.VaultType.Fast
-                            } else {
-                                Route.VaultInfo.VaultType.Secure
-                            }
-                    )
-                }
-            }
+        viewModelScope.safeLaunch {
+            val vault = vaultRepository.get(vaultId) ?: return@safeLaunch
+            val vaultType =
+                if (vault.isFastVault()) Route.VaultInfo.VaultType.Fast
+                else Route.VaultInfo.VaultType.Secure
+            state.update { it.copy(vaultType = vaultType) }
         }
     }
 
     fun upgrade() {
-        viewModelScope.launch {
-            val vault = vaultRepository.get(vaultId) ?: error("Vault with $vaultId doesn't exist")
+        viewModelScope.safeLaunch {
+            val vault =
+                requireNotNull(vaultRepository.get(vaultId)) { "Vault $vaultId doesn't exist" }
 
             if (vault.isFastVault()) {
                 // The vault has a server signer, but the user may have imported that share onto
@@ -72,13 +65,13 @@ constructor(
 
     fun continueWithOnlineVultiServer() {
         closeServerShareLocationSheet()
-        viewModelScope.launch { navigator.route(Route.Migration.Password(vaultId = vaultId)) }
+        viewModelScope.safeLaunch { navigator.route(Route.Migration.Password(vaultId = vaultId)) }
     }
 
     fun continueWithSelfHostedServer() {
         val vaultName = fastVaultName ?: return
         closeServerShareLocationSheet()
-        viewModelScope.launch { routeToPeerMigrate(vaultName) }
+        viewModelScope.safeLaunch { routeToPeerMigrate(vaultName) }
     }
 
     fun dismissServerShareLocationSheet() {
@@ -86,7 +79,7 @@ constructor(
     }
 
     fun back() {
-        viewModelScope.launch { navigator.navigate(Destination.Back) }
+        viewModelScope.safeLaunch { navigator.navigate(Destination.Back) }
     }
 
     private fun closeServerShareLocationSheet() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationServerShareLocationBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/migration/MigrationServerShareLocationBottomSheet.kt
@@ -1,0 +1,135 @@
+package com.vultisig.wallet.ui.screens.migration
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
+import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
+import com.vultisig.wallet.ui.components.v2.containers.ContainerType
+import com.vultisig.wallet.ui.components.v2.containers.V2Container
+import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Lets the user say whether their VultiServer share is still hosted online by Vultisig, or whether
+ * they have imported it onto another device of theirs. This prevents the GG20 → DKLS migration from
+ * silently calling the online VultiServer when the share has been self-hosted.
+ */
+@Composable
+internal fun MigrationServerShareLocationBottomSheet(
+    onDismissRequest: () -> Unit,
+    onUseOnlineVultiServer: () -> Unit,
+    onUseAnotherDevice: () -> Unit,
+) {
+    VsModalBottomSheet(onDismissRequest = onDismissRequest) {
+        Content(
+            onUseOnlineVultiServer = onUseOnlineVultiServer,
+            onUseAnotherDevice = onUseAnotherDevice,
+        )
+    }
+}
+
+@Composable
+private fun Content(onUseOnlineVultiServer: () -> Unit, onUseAnotherDevice: () -> Unit) {
+    Column(
+        Modifier.padding(horizontal = 24.dp).verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        UiSpacer(24.dp)
+
+        Text(
+            text = stringResource(R.string.migration_server_share_location_title),
+            style = Theme.brockmann.headings.title2,
+            color = Theme.v2.colors.text.primary,
+        )
+
+        FadingHorizontalDivider(modifier = Modifier.padding(vertical = 24.dp))
+
+        LocationOption(
+            title = stringResource(R.string.migration_server_share_location_online_title),
+            description =
+                stringResource(R.string.migration_server_share_location_online_description),
+            icon = R.drawable.settings_globe,
+            onClick = onUseOnlineVultiServer,
+            modifier = Modifier.testTag(MigrationServerShareLocationSheetTags.ONLINE),
+        )
+
+        UiSpacer(16.dp)
+
+        LocationOption(
+            title = stringResource(R.string.migration_server_share_location_another_device_title),
+            description =
+                stringResource(R.string.migration_server_share_location_another_device_description),
+            icon = R.drawable.ic_devices,
+            onClick = onUseAnotherDevice,
+            modifier = Modifier.testTag(MigrationServerShareLocationSheetTags.ANOTHER_DEVICE),
+        )
+
+        UiSpacer(24.dp)
+    }
+}
+
+@Composable
+private fun LocationOption(
+    title: String,
+    description: String,
+    @DrawableRes icon: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    V2Container(
+        modifier = modifier.fillMaxWidth().clickOnce(onClick = onClick),
+        type = ContainerType.SECONDARY,
+        borderType = ContainerBorderType.Bordered(color = Theme.v2.colors.border.normal),
+    ) {
+        Row(modifier = Modifier.padding(20.dp), verticalAlignment = Alignment.CenterVertically) {
+            UiIcon(drawableResId = icon, size = 24.dp, tint = Theme.v2.colors.primary.accent4)
+
+            UiSpacer(16.dp)
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = Theme.brockmann.body.m.medium,
+                    color = Theme.v2.colors.text.primary,
+                )
+
+                UiSpacer(4.dp)
+
+                Text(
+                    text = description,
+                    style = Theme.brockmann.supplementary.footnote,
+                    color = Theme.v2.colors.text.secondary,
+                )
+            }
+
+            UiSpacer(12.dp)
+
+            UiIcon(
+                drawableResId = R.drawable.ic_caret_right,
+                size = 20.dp,
+                tint = Theme.v2.colors.text.secondary,
+            )
+        }
+    }
+}
+
+object MigrationServerShareLocationSheetTags {
+    const val ONLINE = "MigrationServerShareLocationSheet.online"
+    const val ANOTHER_DEVICE = "MigrationServerShareLocationSheet.anotherDevice"
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -904,6 +904,11 @@
     <string name="migration_onboarding_step_3_text_end">Beim Upgrade</string>
     <string name="migration_onboarding_upgrade_your_vault">Verbessern Sie Ihren Tresor</string>
     <string name="migration_onboarding_upgrade_now">Jetzt upgraden</string>
+    <string name="migration_server_share_location_title">Wo befindet sich Ihre Serverfreigabe?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Verwenden Sie die von Vultisig gehostete Serverfreigabe</string>
+    <string name="migration_server_share_location_another_device_title">Ein anderes meiner Geräte</string>
+    <string name="migration_server_share_location_another_device_description">Ich habe die Serverfreigabe auf ein anderes Gerät importiert</string>
     <string name="migration_onboarding_step_1_text_start">Verbessere diesen Tresor auf die</string>
     <string name="onboarding_desc_page_1_part_2">Tresorfreigaben</string>
     <string name="verify_swap_youre_swapping_title">Sie tauschen gerade Daten aus.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -902,6 +902,11 @@
     <string name="migration_onboarding_step_3_text_end">Al actualizar</string>
     <string name="migration_onboarding_upgrade_your_vault">Mejora tu bóveda</string>
     <string name="migration_onboarding_upgrade_now">Actualízate ahora</string>
+    <string name="migration_server_share_location_title">¿Dónde está tu servidor compartido?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Usa el servidor compartido alojado por Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Otro dispositivo mío</string>
+    <string name="migration_server_share_location_another_device_description">Importé el servidor compartido a otro dispositivo</string>
     <string name="migration_onboarding_step_1_text_start">Mejora esta bóveda a la versión mejorada</string>
     <string name="onboarding_desc_page_1_part_2">Recursos compartidos de la bóveda</string>
     <string name="verify_swap_youre_swapping_title">Estás intercambiando</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -907,6 +907,11 @@
     <string name="migration_onboarding_step_3_text_end">prilikom nadogradnje</string>
     <string name="migration_onboarding_upgrade_your_vault">Nadogradi svoj trezor</string>
     <string name="migration_onboarding_upgrade_now">Nadogradite sada</string>
+    <string name="migration_server_share_location_title">Gdje se nalazi vaš dijeljeni poslužitelj?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Koristite dijeljeni poslužitelj kojeg održava Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Drugi moj uređaj</string>
+    <string name="migration_server_share_location_another_device_description">Uvezao sam dijeljeni poslužitelj na drugi uređaj</string>
     <string name="migration_onboarding_step_1_text_start">Nadogradi ovaj trezor na</string>
     <string name="onboarding_desc_page_1_part_2">dijeljenja trezora,</string>
     <string name="verify_swap_youre_swapping_title">Zamjenjujete</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -902,6 +902,11 @@
     <string name="migration_onboarding_step_3_text_end">durante l\'aggiornamento</string>
     <string name="migration_onboarding_upgrade_your_vault">Aggiorna il tuo caveau</string>
     <string name="migration_onboarding_upgrade_now">Aggiorna ora</string>
+    <string name="migration_server_share_location_title">Dov\'è la tua condivisione server?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Usa la condivisione server gestita da Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Un altro mio dispositivo</string>
+    <string name="migration_server_share_location_another_device_description">Ho importato la condivisione server su un altro dispositivo</string>
     <string name="migration_onboarding_step_1_text_start">Aggiorna questo caveau a</string>
     <string name="onboarding_desc_page_1_part_2">Condivisioni del Vault,</string>
     <string name="verify_swap_youre_swapping_title">Stai effettuando uno scambio</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -609,6 +609,11 @@
     <string name="migration_onboarding_step_3_text_end">확인하세요</string>
     <string name="migration_onboarding_upgrade_your_vault">볼트 업그레이드</string>
     <string name="migration_onboarding_upgrade_now">지금 업그레이드</string>
+    <string name="migration_server_share_location_title">서버 공유는 어디에 있나요?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Vultisig에서 호스팅하는 서버 공유 사용</string>
+    <string name="migration_server_share_location_another_device_title">내 다른 기기</string>
+    <string name="migration_server_share_location_another_device_description">다른 기기에 서버 공유를 가져왔습니다</string>
     <string name="upgrade_banner_title">지금 볼트를 업그레이드하세요</string>
     <string name="deposit_form_custom_memo_optional_title">사용자 정의 메모 (선택사항)</string>
     <string name="transfer_ibc_function_memo_title">메모</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -899,6 +899,11 @@
     <string name="migration_onboarding_step_3_text_end">bij het upgraden</string>
     <string name="migration_onboarding_upgrade_your_vault">Upgrade uw kluis</string>
     <string name="migration_onboarding_upgrade_now">Upgrade nu</string>
+    <string name="migration_server_share_location_title">Waar staat uw servershare?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Gebruik de servershare die door Vultisig wordt gehost</string>
+    <string name="migration_server_share_location_another_device_title">Een ander apparaat van mij</string>
+    <string name="migration_server_share_location_another_device_description">Ik heb de servershare naar een ander apparaat geïmporteerd</string>
     <string name="migration_onboarding_step_1_text_start">Upgrade deze kluis naar</string>
     <string name="onboarding_desc_page_1_part_2">Vault-shares,</string>
     <string name="verify_swap_youre_swapping_title">Je wisselt</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -901,6 +901,11 @@
     <string name="migration_onboarding_step_3_text_end">Ao atualizar</string>
     <string name="migration_onboarding_upgrade_your_vault">Atualize o seu cofre</string>
     <string name="migration_onboarding_upgrade_now">Atualize agora</string>
+    <string name="migration_server_share_location_title">Onde está a sua Partilha de Servidor?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Use a Partilha de Servidor alojada pela Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Outro dispositivo meu</string>
+    <string name="migration_server_share_location_another_device_description">Importei a Partilha de Servidor para outro dispositivo</string>
     <string name="migration_onboarding_step_1_text_start">Atualize este cofre para</string>
     <string name="onboarding_desc_page_1_part_2">Partilhas do cofre</string>
     <string name="verify_swap_youre_swapping_title">Está a trocar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -907,11 +907,11 @@
     <string name="migration_onboarding_step_3_text_end">при обновлении</string>
     <string name="migration_onboarding_upgrade_your_vault">Обновите своё хранилище</string>
     <string name="migration_onboarding_upgrade_now">Обновите сейчас</string>
-    <string name="migration_server_share_location_title">Где находится ваш общий сервер?</string>
+    <string name="migration_server_share_location_title">Где находится ваша доля сервера?</string>
     <string name="migration_server_share_location_online_title">VultiServer</string>
-    <string name="migration_server_share_location_online_description">Использовать общий сервер, размещённый Vultisig</string>
+    <string name="migration_server_share_location_online_description">Использовать долю сервера, размещённую в VultiServer</string>
     <string name="migration_server_share_location_another_device_title">Другое моё устройство</string>
-    <string name="migration_server_share_location_another_device_description">Я импортировал общий сервер на другое устройство</string>
+    <string name="migration_server_share_location_another_device_description">Я импортировал долю сервера на другое устройство</string>
     <string name="migration_onboarding_step_1_text_start">Обновите это хранилище до</string>
     <string name="onboarding_desc_page_1_part_2">Общие ресурсы хранилища</string>
     <string name="verify_swap_youre_swapping_title">Вы выполняете обмен</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -907,6 +907,11 @@
     <string name="migration_onboarding_step_3_text_end">при обновлении</string>
     <string name="migration_onboarding_upgrade_your_vault">Обновите своё хранилище</string>
     <string name="migration_onboarding_upgrade_now">Обновите сейчас</string>
+    <string name="migration_server_share_location_title">Где находится ваш общий сервер?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Использовать общий сервер, размещённый Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Другое моё устройство</string>
+    <string name="migration_server_share_location_another_device_description">Я импортировал общий сервер на другое устройство</string>
     <string name="migration_onboarding_step_1_text_start">Обновите это хранилище до</string>
     <string name="onboarding_desc_page_1_part_2">Общие ресурсы хранилища</string>
     <string name="verify_swap_youre_swapping_title">Вы выполняете обмен</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1233,6 +1233,11 @@
     <string name="migration_onboarding_step_3_text_end">升级时</string>
     <string name="migration_onboarding_upgrade_your_vault">升级您的保险库</string>
     <string name="migration_onboarding_upgrade_now">立即升级</string>
+    <string name="migration_server_share_location_title">您的服务器份额在哪里？</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">使用由 Vultisig 托管的服务器份额</string>
+    <string name="migration_server_share_location_another_device_title">我的另一台设备</string>
+    <string name="migration_server_share_location_another_device_description">我已将服务器份额导入到另一台设备</string>
     <string name="migration_onboarding_step_1_text_start">将此保险库升级至</string>
     <string name="onboarding_desc_page_1_part_2">保险库共享</string>
     <string name="verify_swap_youre_swapping_title">您正在交换</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -617,6 +617,11 @@
     <string name="migration_onboarding_step_3_text_end">when upgrading</string>
     <string name="migration_onboarding_upgrade_your_vault">Upgrade your vault</string>
     <string name="migration_onboarding_upgrade_now">Upgrade now</string>
+    <string name="migration_server_share_location_title">Where is your Server Share?</string>
+    <string name="migration_server_share_location_online_title">VultiServer</string>
+    <string name="migration_server_share_location_online_description">Use the Server Share hosted by Vultisig</string>
+    <string name="migration_server_share_location_another_device_title">Another device of mine</string>
+    <string name="migration_server_share_location_another_device_description">I imported the Server Share to another device</string>
     <string name="upgrade_banner_title">Upgrade your vault now</string>
     <string name="deposit_form_custom_memo_optional_title">Custom Memo (optional)</string>
     <string name="transfer_ibc_function_memo_title">Memo</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/migration/MigrationOnboardingViewModelTest.kt
@@ -1,0 +1,231 @@
+package com.vultisig.wallet.ui.screens.migration
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.TssAction
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class MigrationOnboardingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val vaultId = "vault-1"
+    private val savedStateHandle = SavedStateHandle()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var vaultRepository: VaultRepository
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        every { savedStateHandle.toRoute<Route.Migration.Onboarding>() } returns
+            Route.Migration.Onboarding(vaultId = vaultId)
+        navigator = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `secure vault upgrade routes straight to peer discovery without showing sheet`() = runTest {
+        val vault = secureVault()
+        coEvery { vaultRepository.get(vaultId) } returns vault
+
+        val vm = createViewModel()
+        vm.upgrade()
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Keygen.PeerDiscovery(
+                    action = TssAction.Migrate,
+                    vaultName = vault.name,
+                    vaultId = vaultId,
+                )
+            )
+        }
+        coVerify(exactly = 0) { navigator.route(match { it is Route.Migration.Password }) }
+        assertFalse(vm.state.first().isServerShareLocationSheetVisible)
+    }
+
+    @Test
+    fun `self-hosted server vault is treated as secure and skips the choice sheet`() = runTest {
+        val vault =
+            secureVault().copy(localPartyID = "Server-1", signers = listOf("Android-1", "Server-1"))
+        coEvery { vaultRepository.get(vaultId) } returns vault
+
+        val vm = createViewModel()
+        vm.upgrade()
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Keygen.PeerDiscovery(
+                    action = TssAction.Migrate,
+                    vaultName = vault.name,
+                    vaultId = vaultId,
+                )
+            )
+        }
+        assertFalse(vm.state.first().isServerShareLocationSheetVisible)
+    }
+
+    @Test
+    fun `fast vault upgrade shows the server share location sheet instead of navigating`() =
+        runTest {
+            coEvery { vaultRepository.get(vaultId) } returns fastVault()
+
+            val vm = createViewModel()
+            vm.upgrade()
+
+            assertTrue(vm.state.first().isServerShareLocationSheetVisible)
+            coVerify(exactly = 0) {
+                navigator.route(
+                    match { it is Route.Migration.Password || it is Route.Keygen.PeerDiscovery }
+                )
+            }
+        }
+
+    @Test
+    fun `choosing online VultiServer hides the sheet and routes to the password screen`() =
+        runTest {
+            coEvery { vaultRepository.get(vaultId) } returns fastVault()
+            val vm = createViewModel()
+            vm.upgrade()
+
+            vm.continueWithOnlineVultiServer()
+
+            assertFalse(vm.state.first().isServerShareLocationSheetVisible)
+            coVerify(exactly = 1) { navigator.route(Route.Migration.Password(vaultId = vaultId)) }
+            coVerify(exactly = 0) { navigator.route(match { it is Route.Keygen.PeerDiscovery }) }
+        }
+
+    @Test
+    fun `choosing self-hosted server hides the sheet and routes to peer discovery for migrate`() =
+        runTest {
+            val vault = fastVault()
+            coEvery { vaultRepository.get(vaultId) } returns vault
+            val vm = createViewModel()
+            vm.upgrade()
+
+            vm.continueWithSelfHostedServer()
+
+            assertFalse(vm.state.first().isServerShareLocationSheetVisible)
+            coVerify(exactly = 1) {
+                navigator.route(
+                    Route.Keygen.PeerDiscovery(
+                        action = TssAction.Migrate,
+                        vaultName = vault.name,
+                        vaultId = vaultId,
+                    )
+                )
+            }
+            coVerify(exactly = 0) { navigator.route(match { it is Route.Migration.Password }) }
+        }
+
+    @Test
+    fun `choosing self-hosted server without an open sheet is a no-op`() = runTest {
+        coEvery { vaultRepository.get(vaultId) } returns fastVault()
+        val vm = createViewModel()
+
+        vm.continueWithSelfHostedServer()
+
+        coVerify(exactly = 0) {
+            navigator.route(
+                match { it is Route.Migration.Password || it is Route.Keygen.PeerDiscovery }
+            )
+        }
+    }
+
+    @Test
+    fun `dismissing the sheet does not navigate anywhere`() = runTest {
+        coEvery { vaultRepository.get(vaultId) } returns fastVault()
+        val vm = createViewModel()
+        vm.upgrade()
+
+        vm.dismissServerShareLocationSheet()
+
+        assertFalse(vm.state.first().isServerShareLocationSheetVisible)
+        coVerify(exactly = 0) {
+            navigator.route(
+                match { it is Route.Migration.Password || it is Route.Keygen.PeerDiscovery }
+            )
+        }
+    }
+
+    @Test
+    fun `initial vault load classifies fast vault as Fast in ui state`() = runTest {
+        coEvery { vaultRepository.get(vaultId) } returns fastVault()
+        val vm = createViewModel()
+        assertEquals(Route.VaultInfo.VaultType.Fast, vm.state.first().vaultType)
+    }
+
+    @Test
+    fun `initial vault load classifies secure vault as Secure in ui state`() = runTest {
+        coEvery { vaultRepository.get(vaultId) } returns secureVault()
+        val vm = createViewModel()
+        assertEquals(Route.VaultInfo.VaultType.Secure, vm.state.first().vaultType)
+    }
+
+    @Test
+    fun `back delegates to navigator with Back destination`() = runTest {
+        coEvery { vaultRepository.get(vaultId) } returns secureVault()
+        val vm = createViewModel()
+
+        vm.back()
+
+        coVerify(exactly = 1) { navigator.navigate(Destination.Back) }
+    }
+
+    private fun createViewModel(): MigrationOnboardingViewModel =
+        MigrationOnboardingViewModel(
+            savedStateHandle = savedStateHandle,
+            navigator = navigator,
+            vaultRepository = vaultRepository,
+        )
+
+    private fun fastVault(): Vault =
+        Vault(
+            id = vaultId,
+            name = "Fast Vault",
+            localPartyID = "Android-1",
+            signers = listOf("Android-1", "Server-1"),
+            libType = SigningLibType.GG20,
+        )
+
+    private fun secureVault(): Vault =
+        Vault(
+            id = vaultId,
+            name = "Secure Vault",
+            localPartyID = "Android-1",
+            signers = listOf("Android-1", "iPhone-1"),
+            libType = SigningLibType.GG20,
+        )
+}


### PR DESCRIPTION
## Summary

Upgrading a vault with a `server-*` signer used to go straight to the online VultiServer migrate API. When the user had already imported that share onto another device they own, that silent server upgrade orphaned the self-hosted share and produced a brand-new fast vault without the user's consent — exactly the case in #4481.

On a fast vault, the GG20 → DKLS onboarding now opens a bottom sheet asking where the Server Share lives. Picking **VultiServer** keeps the existing password → email → online migrate flow; picking **Another device of mine** routes to peer discovery so the user can pair with the device that holds the imported server share. Secure vaults and the device that already holds the imported server share (i.e. `localPartyID` starts with `Server`) keep their current direct routing to peer discovery.

## Notes

- Strings added to all 10 locale files using the existing terminology for "Server Share" in each language.
- The peer migrate route reuses `Route.Keygen.PeerDiscovery(action = Migrate, vaultName, vaultId)` with no email/password, which `KeygenPeerDiscoveryViewModel.loadData()` already handles as plain peer discovery (no `/vault/migrate` call).
- iOS has the same bug filed at vultisig/vultisig-ios#4348 and has not shipped a fix yet; the strings here are picked so an iOS port is a search-and-replace.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.screens.migration.MigrationOnboardingViewModelTest"` — 10/10 pass
- `./gradlew :app:ktfmtCheck` — pass
- `./gradlew :app:lintDebug` — pass
- New unit test class `MigrationOnboardingViewModelTest` covers: secure vault routes straight to peer discovery, self-hosted server vault treated as secure, fast vault upgrade shows the sheet instead of navigating, choosing VultiServer routes to password, choosing self-hosted routes to peer discovery, choosing self-hosted with no open sheet is a no-op, dismiss is a no-op for navigation, initial vault-type classification, and back delegates to the navigator.
- Updated the `@Ignore`d instrumented test `MigrateGg20FastVaultFlowTest` to click the new "VultiServer" option after the onboarding pages.

Closes #4481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-share location bottom sheet to migration onboarding with choices: use online VultiServer or use another device; onboarding now waits for the user selection.

* **Localization**
  * Added strings for this screen in English, German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.

* **Bug Fixes / Behavior**
  * Deferred fast-vault navigation until a selection is made; added handlers to continue or dismiss the sheet.

* **Tests**
  * Added unit tests for onboarding view-model flows and updated integration test to cover the sheet interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->