### PR TITLE
fix(broadcast): recover UTXO co-sign duplicate broadcasts (#4566, #4567)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.models.BlockChainStatusDeserialized
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Chain.Akash
 import com.vultisig.wallet.data.models.Chain.Arbitrum
@@ -84,9 +85,18 @@ constructor(
             Litecoin,
             Dogecoin,
             Dash,
-            Chain.Zcash -> {
-                blockChairApi.broadcastTransaction(chain, tx.rawTransaction)
-            }
+            Chain.Zcash ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = { blockChairApi.broadcastTransaction(chain, tx.rawTransaction) },
+                    verify = { hash ->
+                        val response = blockChairApi.getTsStatus(chain, hash)
+                        (response as? BlockChainStatusDeserialized.Result)
+                            ?.data
+                            ?.data
+                            ?.containsKey(hash) == true
+                    },
+                )
 
             Ethereum,
             CronosChain,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/UtxoStatusProviderTest.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.models.BlockChainStatusDeserialized
+import com.vultisig.wallet.data.api.models.BlockChairStatusResponse
+import com.vultisig.wallet.data.api.models.ContextData
+import com.vultisig.wallet.data.api.models.TransactionData
+import com.vultisig.wallet.data.api.models.TransactionInfo
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class UtxoStatusProviderTest {
+
+    private val blockChairApi = mockk<BlockChairApi>()
+    private val provider = UtxoStatusProvider(blockChairApi)
+
+    @Test
+    fun `confirmed bitcoin cash tx returns Confirmed`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } returns
+            result(blockId = 951320, state = 951460)
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Confirmed, result)
+    }
+
+    @Test
+    fun `mempool bitcoin cash tx returns Pending`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } returns
+            result(blockId = -1, state = 951460)
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `null api response returns Pending`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } returns null
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `error response returns Pending`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } returns
+            BlockChainStatusDeserialized.Error("")
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `empty data map returns Pending`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } returns
+            BlockChainStatusDeserialized.Result(
+                BlockChairStatusResponse(data = emptyMap(), context = ContextData(state = 951460))
+            )
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `network error returns Pending`() = runTest {
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, TX_HASH) } throws
+            RuntimeException("network error")
+
+        val result = provider.checkStatus(TX_HASH, Chain.BitcoinCash)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    private fun result(blockId: Int, state: Int) =
+        BlockChainStatusDeserialized.Result(
+            BlockChairStatusResponse(
+                data =
+                    mapOf(
+                        TX_HASH to TransactionData(transaction = TransactionInfo(blockId = blockId))
+                    ),
+                context = ContextData(state = state),
+            )
+        )
+
+    private companion object {
+        const val TX_HASH = "11f35b7131e85ac5197b0634e1bb4a8ae9f08a883ad7694f06f874da438f0a74"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -14,6 +14,11 @@ import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.models.BlockChainStatusDeserialized
+import com.vultisig.wallet.data.api.models.BlockChairStatusResponse
+import com.vultisig.wallet.data.api.models.ContextData
+import com.vultisig.wallet.data.api.models.TransactionData
+import com.vultisig.wallet.data.api.models.TransactionInfo
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import io.mockk.coEvery
@@ -21,6 +26,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 
 class BroadcastTxUseCaseTest {
@@ -73,15 +79,81 @@ class BroadcastTxUseCaseTest {
         assertEquals(BROADCAST_HASH, txHash)
     }
 
+    @Test
+    fun `bitcoin cash broadcast returns hash from blockchair on success`() = runTest {
+        val blockChairApi = mockk<BlockChairApi>()
+        coEvery { blockChairApi.broadcastTransaction(Chain.BitcoinCash, RAW_TRANSACTION) } returns
+            BROADCAST_HASH
+
+        val txHash =
+            createUseCase(blockChairApi = blockChairApi)(Chain.BitcoinCash, signedTransaction())
+
+        assertEquals(BROADCAST_HASH, txHash)
+    }
+
+    @Test
+    fun `bitcoin cash broadcast recovers when peer already broadcast`() = runTest {
+        val blockChairApi = mockk<BlockChairApi>()
+        coEvery { blockChairApi.broadcastTransaction(Chain.BitcoinCash, RAW_TRANSACTION) } throws
+            RuntimeException("fail to broadcast transaction: transaction already known")
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, KNOWN_TRANSACTION_HASH) } returns
+            blockchairResult(blockId = -1)
+
+        val txHash =
+            createUseCase(blockChairApi = blockChairApi)(Chain.BitcoinCash, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
+    @Test
+    fun `bitcoin cash broadcast propagates error when blockchair has no record`() = runTest {
+        val blockChairApi = mockk<BlockChairApi>()
+        coEvery { blockChairApi.broadcastTransaction(Chain.BitcoinCash, RAW_TRANSACTION) } throws
+            RuntimeException("fail to broadcast transaction: insufficient fee")
+        coEvery { blockChairApi.getTsStatus(Chain.BitcoinCash, KNOWN_TRANSACTION_HASH) } returns
+            BlockChainStatusDeserialized.Error("")
+
+        assertFailsWith<RuntimeException> {
+            createUseCase(blockChairApi = blockChairApi)(Chain.BitcoinCash, signedTransaction())
+        }
+    }
+
+    @Test
+    fun `bitcoin broadcast recovers when peer already broadcast`() = runTest {
+        val blockChairApi = mockk<BlockChairApi>()
+        coEvery { blockChairApi.broadcastTransaction(Chain.Bitcoin, RAW_TRANSACTION) } throws
+            RuntimeException("Failed to broadcast transaction")
+        coEvery { blockChairApi.getTsStatus(Chain.Bitcoin, KNOWN_TRANSACTION_HASH) } returns
+            blockchairResult(blockId = 951320)
+
+        val txHash =
+            createUseCase(blockChairApi = blockChairApi)(Chain.Bitcoin, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
+    private fun blockchairResult(blockId: Int) =
+        BlockChainStatusDeserialized.Result(
+            BlockChairStatusResponse(
+                data =
+                    mapOf(
+                        KNOWN_TRANSACTION_HASH to
+                            TransactionData(transaction = TransactionInfo(blockId = blockId))
+                    ),
+                context = ContextData(state = 951460),
+            )
+        )
+
     private fun createUseCase(
         thorChainApi: ThorChainApi = mockk(relaxed = true),
         mayaChainApi: MayaChainApi = mockk(relaxed = true),
         cosmosApiFactory: CosmosApiFactory = mockk(relaxed = true),
+        blockChairApi: BlockChairApi = mockk(relaxed = true),
     ) =
         BroadcastTxUseCaseImpl(
             thorChainApi = thorChainApi,
             evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
-            blockChairApi = mockk<BlockChairApi>(relaxed = true),
+            blockChairApi = blockChairApi,
             mayaChainApi = mayaChainApi,
             cosmosApiFactory = cosmosApiFactory,
             solanaApi = mockk<SolanaApi>(relaxed = true),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -132,6 +132,19 @@ class BroadcastTxUseCaseTest {
         assertEquals(KNOWN_TRANSACTION_HASH, txHash)
     }
 
+    @Test
+    fun `zcash broadcast recovers when peer already broadcast`() = runTest {
+        val blockChairApi = mockk<BlockChairApi>()
+        coEvery { blockChairApi.broadcastTransaction(Chain.Zcash, RAW_TRANSACTION) } throws
+            RuntimeException("fail to broadcast transaction: transaction already known")
+        coEvery { blockChairApi.getTsStatus(Chain.Zcash, KNOWN_TRANSACTION_HASH) } returns
+            blockchairResult(blockId = -1)
+
+        val txHash = createUseCase(blockChairApi = blockChairApi)(Chain.Zcash, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+    }
+
     private fun blockchairResult(blockId: Int) =
         BlockChainStatusDeserialized.Result(
             BlockChairStatusResponse(


### PR DESCRIPTION
## Summary

When a co-signing device wins the broadcast race on a UTXO chain (Bitcoin, Bitcoin Cash, Litecoin, Dogecoin, Dash, Zcash), the peer's broadcast call to Blockchair returns a non-200 with a duplicate-broadcast error. The current code throws on any non-200, so the post-keysign screen shows "Transaction failed" even though the transaction is already on-chain (see #4566). The keysign exception path also bypasses `saveTransactionHistory`/`startForegroundPolling`, so the History row stays in "In progress…" indefinitely (#4567).

UTXO chains now go through `recoverIfAlreadyBroadcast`, matching every other co-signable chain. When the broadcast call throws, the verifier looks the signed hash up via `getTsStatus` on Blockchair, and any record (mempool `block_id == -1` or confirmed `block_id > 0`) is treated as a successful send. With the hash restored, history persistence and status polling continue normally and eventually flip the row to Successful.

## Testing

- `./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.usecases.BroadcastTxUseCaseTest --tests com.vultisig.wallet.data.api.txstatus.UtxoStatusProviderTest` (14 tests, all green)
- `./gradlew :data:ktfmtFormat`

Tests cover the success path, the recovery path when Blockchair has the tx (mempool and confirmed), the error path when Blockchair has no record, and the status-provider mapping for confirmed / mempool / empty-data / API-error / network-error responses on Bitcoin Cash.

Closes #4566
Closes #4567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcast handling: when broadcast attempts fail, the app now verifies network status and recovers gracefully if the transaction is already known by the blockchain, reducing false failures across supported chains.

* **Tests**
  * Added comprehensive tests covering transaction status mapping and broadcast recovery scenarios for multiple supported networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->