### PR TITLE
fix(polkadot): joined-device sees broadcast success, stop polling on exit (#4544)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/KeySignWrapperViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/KeySignWrapperViewModel.kt
@@ -25,6 +25,11 @@ constructor(@Assisted val viewModel: KeysignViewModel) : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
+        // The wrapped KeysignViewModel is not registered with any ViewModelStore, so its own
+        // `onCleared` never runs. Cancel its polling explicitly so the foreground status service
+        // stops as soon as the user navigates away from the keysign flow, instead of polling
+        // until the next terminal status or until the chain-specific timeout fires.
+        viewModel.stopPolling()
         viewModel.viewModelScope.cancel()
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1567,7 +1567,7 @@ constructor(
      * the polling service would keep firing until its own timeout.
      */
     fun complete() {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch {
             navigator.route(Route.Home(), NavigationOptions(clearBackStack = true))
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1560,6 +1560,18 @@ constructor(
         }
     }
 
+    /**
+     * Finishes the joined-device flow after a successful keysign. Clears the back stack so the
+     * wrapping ViewModelStore (and the foreground status-polling service it owns) tears down
+     * promptly — without this, navigating to home would leave the join destination on the stack and
+     * the polling service would keep firing until its own timeout.
+     */
+    fun complete() {
+        viewModelScope.launch {
+            navigator.route(Route.Home(), NavigationOptions(clearBackStack = true))
+        }
+    }
+
     override fun onCleared() {
         cleanUp()
         super.onCleared()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -806,14 +806,16 @@ constructor(
         error: Throwable,
     ): String? {
         if (isInitiatingDevice) return null
-        val localHash = signedTx.transactionHash.takeIf { it.isNotBlank() } ?: return null
-        Timber.w(
-            error,
-            "Joined-device broadcast for %s failed; using locally computed hash %s",
-            chain.raw,
-            localHash,
-        )
-        return localHash
+        return signedTx.transactionHash
+            .takeUnless { it.isBlank() }
+            ?.also { hash ->
+                Timber.w(
+                    error,
+                    "Joined-device broadcast for %s failed; using locally computed hash %s",
+                    chain.raw,
+                    hash,
+                )
+            }
     }
 
     internal suspend fun saveTransactionHistory(txHash: String, chain: Chain) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -22,6 +22,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.CommonTransactionHistoryData
 import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.SendTransactionHistoryData
+import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
 import com.vultisig.wallet.data.models.TokenStandard
@@ -734,7 +735,7 @@ constructor(
                 nonceAcc = nonceAcc,
             )
 
-        val txHash = broadcastTx(chain = chain, tx = signedTx)
+        val txHash = broadcastOrRecover(chain = chain, signedTx = signedTx)
 
         Timber.d("transaction hash: $txHash")
         if (txHash != null) {
@@ -766,6 +767,45 @@ constructor(
                 explorerLinkRepository.getTransactionLink(chain, approveTxHash.value)
         }
     }
+
+    /**
+     * Broadcasts [signedTx] for [chain], falling back to the deterministic locally computed hash
+     * when a non-initiator's duplicate broadcast is rejected.
+     *
+     * In a multi-device vault both peers compute the same signed extrinsic and call this path;
+     * whichever device's broadcast reaches the network first wins. The losing device's broadcast is
+     * then rejected — Substrate in particular surfaces this as `Transaction has a bad signature`
+     * (code 1010) when the initiator's extrinsic has already advanced the nonce. The signed bytes
+     * are byte-identical on both devices, so the locally computed
+     * [SignedTransactionResult.transactionHash] is the canonical on-chain hash, and we use it
+     * instead of failing the joined-device screen.
+     *
+     * iOS does the same recovery in `KeysignViewModel.handleBroadcastError` / `isAlreadyOnChain`.
+     * We keep it scoped to non-initiator devices so a real broadcast failure on the initiator is
+     * still surfaced as an error.
+     */
+    internal suspend fun broadcastOrRecover(
+        chain: Chain,
+        signedTx: SignedTransactionResult,
+    ): String? =
+        try {
+            broadcastTx(chain = chain, tx = signedTx)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val localHash = signedTx.transactionHash
+            if (!isInitiatingDevice && localHash.isNotBlank()) {
+                Timber.w(
+                    e,
+                    "Joined-device broadcast for %s failed; using locally computed hash %s",
+                    chain.raw,
+                    localHash,
+                )
+                localHash
+            } else {
+                throw e
+            }
+        }
 
     internal suspend fun saveTransactionHistory(txHash: String, chain: Chain) {
         transactionHistoryData?.let {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -793,19 +793,28 @@ constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            val localHash = signedTx.transactionHash
-            if (!isInitiatingDevice && localHash.isNotBlank()) {
-                Timber.w(
-                    e,
-                    "Joined-device broadcast for %s failed; using locally computed hash %s",
-                    chain.raw,
-                    localHash,
-                )
-                localHash
-            } else {
-                throw e
-            }
+            recoverJoinedDeviceBroadcast(chain, signedTx, e) ?: throw e
         }
+
+    /**
+     * Returns the locally computed transaction hash if this is a joined-device broadcast failure we
+     * should swallow; `null` if the caller must re-throw the original error.
+     */
+    private fun recoverJoinedDeviceBroadcast(
+        chain: Chain,
+        signedTx: SignedTransactionResult,
+        error: Throwable,
+    ): String? {
+        if (isInitiatingDevice) return null
+        val localHash = signedTx.transactionHash.takeIf { it.isNotBlank() } ?: return null
+        Timber.w(
+            error,
+            "Joined-device broadcast for %s failed; using locally computed hash %s",
+            chain.raw,
+            localHash,
+        )
+        return localHash
+    }
 
     internal suspend fun saveTransactionHistory(txHash: String, chain: Chain) {
         transactionHistoryData?.let {

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -332,7 +332,7 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
         composable<VerifyDeposit> { VerifyDepositScreen(navController = navController) }
 
         // keysign
-        composable<Keysign.Join> { JoinKeysignView(navController = navController) }
+        composable<Keysign.Join> { JoinKeysignView() }
 
         dialog<Keysign.Password> { KeysignPasswordScreen() }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
@@ -29,7 +28,6 @@ import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.WaitingForKeysignS
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignState
 import com.vultisig.wallet.ui.models.keysign.VerifyUiModel
-import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.sign.VerifySignMessageScreen
@@ -37,7 +35,7 @@ import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
 import com.vultisig.wallet.ui.utils.asString
 
 @Composable
-internal fun JoinKeysignView(navController: NavHostController) {
+internal fun JoinKeysignView() {
     val viewModel: JoinKeysignViewModel = hiltViewModel()
     val context = LocalContext.current
     var keysignState: KeysignState by remember { mutableStateOf(KeysignState.CreatingInstance) }
@@ -157,7 +155,7 @@ internal fun JoinKeysignView(navController: NavHostController) {
                     transactionLink = keysignViewModel.txLink.collectAsState().value,
                     approveTransactionLink = keysignViewModel.approveTxLink.collectAsState().value,
                     progressLink = keysignViewModel.swapProgressLink.collectAsState().value,
-                    onComplete = { navController.navigate(Route.Home()) },
+                    onComplete = viewModel::complete,
                     onBack = keysignViewModel::navigateToHome,
                     transactionTypeUiModel =
                         keysignViewModel.resolvedTransactionUiModel.collectAsState().value,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelBroadcastRecoveryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelBroadcastRecoveryTest.kt
@@ -1,0 +1,127 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.models.TssKeyType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.BroadcastTxUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class KeysignViewModelBroadcastRecoveryTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val vault = Vault(id = "v1", name = "Test Vault")
+
+    private val signedTx =
+        SignedTransactionResult(rawTransaction = "0xraw", transactionHash = "0xlocal-hash")
+
+    private lateinit var broadcastTx: BroadcastTxUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        broadcastTx = mockk()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `joined-device broadcast failure falls back to locally computed hash`() =
+        runTest(testDispatcher) {
+            coEvery { broadcastTx(Chain.Polkadot, signedTx) } throws
+                Exception("Error broadcasting transaction: Transaction has a bad signature")
+
+            val vm = createViewModel(isInitiating = false)
+
+            vm.broadcastOrRecover(Chain.Polkadot, signedTx) shouldBe signedTx.transactionHash
+            coVerify(exactly = 1) { broadcastTx(Chain.Polkadot, signedTx) }
+        }
+
+    @Test
+    fun `joined-device propagates failure when the signed tx has no local hash`() =
+        runTest(testDispatcher) {
+            val signedTxNoHash = signedTx.copy(transactionHash = "")
+            coEvery { broadcastTx(Chain.Polkadot, signedTxNoHash) } throws
+                Exception("broadcast failed")
+
+            val vm = createViewModel(isInitiating = false)
+
+            shouldThrow<Exception> { vm.broadcastOrRecover(Chain.Polkadot, signedTxNoHash) }
+        }
+
+    @Test
+    fun `initiator broadcast failure is never recovered`() =
+        runTest(testDispatcher) {
+            val failure =
+                Exception("Error broadcasting transaction: Transaction has a bad signature")
+            coEvery { broadcastTx(Chain.Polkadot, signedTx) } throws failure
+
+            val vm = createViewModel(isInitiating = true)
+
+            shouldThrow<Exception> { vm.broadcastOrRecover(Chain.Polkadot, signedTx) }
+                .message shouldBe failure.message
+        }
+
+    @Test
+    fun `successful broadcast returns the network-provided hash`() =
+        runTest(testDispatcher) {
+            coEvery { broadcastTx(Chain.Polkadot, signedTx) } returns "0xnetwork-hash"
+
+            val vm = createViewModel(isInitiating = false)
+
+            vm.broadcastOrRecover(Chain.Polkadot, signedTx) shouldBe "0xnetwork-hash"
+        }
+
+    private fun createViewModel(isInitiating: Boolean) =
+        KeysignViewModel(
+            vault = vault,
+            keysignCommittee = emptyList(),
+            serverUrl = "",
+            sessionId = "",
+            encryptionKeyHex = "",
+            messagesToSign = emptyList(),
+            keyType = TssKeyType.ECDSA,
+            keysignPayload = null,
+            customMessagePayload = null,
+            transactionTypeUiModel = null,
+            isInitiatingDevice = isInitiating,
+            transactionHistoryData = null,
+            thorChainApi = mockk(relaxed = true),
+            evmApiFactory = mockk(relaxed = true),
+            broadcastTx = broadcastTx,
+            explorerLinkRepository = mockk(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            sessionApi = mockk(relaxed = true),
+            encryption = mockk(relaxed = true),
+            featureFlagApi = mockk(relaxed = true),
+            pullTssMessages = mockk(relaxed = true),
+            addressBookRepository = mockk(relaxed = true),
+            txStatusConfigurationProvider = mockk(relaxed = true),
+            transactionStatusServiceManager = mockk(relaxed = true),
+            vaultRepository = mockk(relaxed = true),
+            transactionHistoryRepository = mockk(relaxed = true),
+            balanceRepository = mockk(relaxed = true),
+            gasFeeToEstimatedFee = mockk(relaxed = true),
+            awaitApprovalConfirmation = mockk(relaxed = true),
+        )
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -39,9 +39,12 @@ class PolkadotStatusProvider @Inject constructor(private val polkadotApi: Polkad
         val networkException = this as? NetworkException ?: return false
         // Subscan returns HTTP 400 with body `{"code": 403, "message": "Subscan API strictly
         // requires an API key. Unauthenticated access is disabled."}` when the request omits
-        // the API key — match on the body text since the surface HTTP code (400) is generic.
+        // the API key. Require both the 400 status and one of the key-specific phrases — a
+        // looser match could classify unrelated bad-request responses as terminal and stop
+        // polling early.
+        if (networkException.httpStatusCode != 400) return false
         val body = networkException.message
-        return body.contains("API key", ignoreCase = true) ||
-            body.contains("Subscan", ignoreCase = true)
+        return body.contains("requires an API key", ignoreCase = true) ||
+            body.contains("Unauthenticated access is disabled", ignoreCase = true)
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.api.PolkadotApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
+import com.vultisig.wallet.data.utils.NetworkException
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
@@ -22,7 +23,25 @@ class PolkadotStatusProvider @Inject constructor(private val polkadotApi: Polkad
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Polkadot status check failed for %s", txHash)
-            TransactionResult.Pending
+            if (e.isExplorerUnauthorized()) {
+                // Subscan's free tier now rejects unauthenticated traffic, so the lookup will
+                // never succeed. Surface a terminal result instead of polling for the full
+                // timeout window and hammering an endpoint that will keep refusing us.
+                Timber.w("Polkadot explorer unauthorized; ending status check for %s", txHash)
+                TransactionResult.TimedOut
+            } else {
+                Timber.w(e, "Polkadot status check failed for %s", txHash)
+                TransactionResult.Pending
+            }
         }
+
+    private fun Throwable.isExplorerUnauthorized(): Boolean {
+        val networkException = this as? NetworkException ?: return false
+        // Subscan returns HTTP 400 with body `{"code": 403, "message": "Subscan API strictly
+        // requires an API key. Unauthenticated access is disabled."}` when the request omits
+        // the API key — match on the body text since the surface HTTP code (400) is generic.
+        val body = networkException.message
+        return body.contains("API key", ignoreCase = true) ||
+            body.contains("Subscan", ignoreCase = true)
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -36,15 +36,17 @@ class PolkadotStatusProvider @Inject constructor(private val polkadotApi: Polkad
         }
 
     private fun Throwable.isExplorerUnauthorized(): Boolean {
-        val networkException = this as? NetworkException ?: return false
+        val exception = this as? NetworkException ?: return false
+        if (exception.httpStatusCode != 400) return false
+        return SUBSCAN_AUTH_WALL_PHRASES.any { exception.message.contains(it, ignoreCase = true) }
+    }
+
+    private companion object {
         // Subscan returns HTTP 400 with body `{"code": 403, "message": "Subscan API strictly
         // requires an API key. Unauthenticated access is disabled."}` when the request omits
-        // the API key. Require both the 400 status and one of the key-specific phrases — a
-        // looser match could classify unrelated bad-request responses as terminal and stop
-        // polling early.
-        if (networkException.httpStatusCode != 400) return false
-        val body = networkException.message
-        return body.contains("requires an API key", ignoreCase = true) ||
-            body.contains("Unauthenticated access is disabled", ignoreCase = true)
+        // the API key. Match both phrases — looser matching could classify unrelated
+        // bad-request responses as terminal and stop polling early.
+        val SUBSCAN_AUTH_WALL_PHRASES =
+            listOf("requires an API key", "Unauthenticated access is disabled")
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
@@ -1,0 +1,104 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotErrorData
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotExtrinsicDataJson
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotExtrinsicResponseJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import com.vultisig.wallet.data.utils.NetworkException
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class PolkadotStatusProviderTest {
+
+    private val polkadotApi = mockk<PolkadotApi>()
+    private val provider = PolkadotStatusProvider(polkadotApi)
+
+    @Test
+    fun `maps subscan success response to Confirmed`() = runTest {
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns
+            successResponse(extrinsicHash = TX_HASH)
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Confirmed, result)
+    }
+
+    @Test
+    fun `maps null subscan response to NotFound`() = runTest {
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns null
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.NotFound, result)
+    }
+
+    @Test
+    fun `maps on-chain failure to Failed with the error value`() = runTest {
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns
+            PolkadotExtrinsicResponseJson(
+                code = 0,
+                message = "indexer reports error",
+                generatedAt = 0,
+                data =
+                    PolkadotExtrinsicDataJson(
+                        polkadotErrorData =
+                            PolkadotErrorData(
+                                batchIndex = 0,
+                                doc = "",
+                                module = "system",
+                                name = "BadOrigin",
+                                value = "BadOrigin: invalid origin",
+                                version = 0,
+                            ),
+                        extrinsicHash = TX_HASH,
+                    ),
+            )
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Failed("BadOrigin: invalid origin"), result)
+    }
+
+    @Test
+    fun `subscan API key rejection terminates polling with TimedOut`() = runTest {
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
+            NetworkException(
+                httpStatusCode = 400,
+                message =
+                    "{\"code\": 403, \"message\": \"Subscan API strictly requires an API key. " +
+                        "Unauthenticated access is disabled.\"}",
+            )
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.TimedOut, result)
+    }
+
+    @Test
+    fun `transient network errors keep polling alive as Pending`() = runTest {
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
+            NetworkException(httpStatusCode = 0, message = "Connection timed out")
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    private fun successResponse(extrinsicHash: String) =
+        PolkadotExtrinsicResponseJson(
+            code = 0,
+            message = "success",
+            generatedAt = 1_700_000_000,
+            data =
+                PolkadotExtrinsicDataJson(polkadotErrorData = null, extrinsicHash = extrinsicHash),
+        )
+
+    private companion object {
+        const val TX_HASH = "0xdeadbeef"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
@@ -89,6 +89,18 @@ class PolkadotStatusProviderTest {
         assertEquals(TransactionResult.Pending, result)
     }
 
+    @Test
+    fun `generic 400 without API-key phrasing keeps polling alive as Pending`() = runTest {
+        // An unrelated bad-request response — for example a malformed payload — must not be
+        // mistaken for the Subscan auth wall and stop polling early.
+        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
+            NetworkException(httpStatusCode = 400, message = "{\"error\":\"invalid hash format\"}")
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
     private fun successResponse(extrinsicHash: String) =
         PolkadotExtrinsicResponseJson(
             code = 0,


### PR DESCRIPTION
Closes #4544.

## Summary

Three related issues on Polkadot multi-device sends:

- **Joined device showed a "bad signature" error for a tx that actually broadcast.**
  Both peers compute byte-identical signed extrinsics and call broadcast; whichever loses the race is rejected by Substrate (typically code 1010, `Transaction has a bad signature`, once the initiator's tx has advanced the nonce). On the joined-device path we now fall back to the locally computed transaction hash instead of failing the screen — the hash is deterministic and the initiator's broadcast is the canonical one. Initiator failures still surface as errors. Mirrors iOS's `handleBroadcastError` / `isAlreadyOnChain` recovery.
- **Subscan status check looped forever on 403.**
  Subscan's free tier now returns HTTP 400 with `{"code": 403, "message": "Subscan API strictly requires an API key…"}`. `PolkadotStatusProvider` now detects that body and surfaces `TimedOut` so the poller stops on the first response instead of hammering Subscan for the full 5-minute window.
- **Polling kept firing after the user navigated away.**
  The wrapping `KeySignWrapperViewModel` cancelled its scope on clear but never invoked the wrapped `KeysignViewModel.onCleared`, so the foreground status service kept polling. The wrapper now calls `stopPolling()` on clear. `JoinKeysignViewModel` also gets a `complete()` that mirrors `KeysignFlowViewModel.complete()` and clears the back stack on Done so the joined-device flow tears down the same way as the initiator's.

## Testing

- `./gradlew :app:testDebugUnitTest :data:test` (full unit suites green)
- New tests:
  - `KeysignViewModelBroadcastRecoveryTest` — joined-device falls back to the local hash, initiator failure still propagates, empty local hash propagates, successful broadcast returns the network hash.
  - `PolkadotStatusProviderTest` — success / not-found / on-chain failure / Subscan API-key rejection → TimedOut / transient network error → Pending.
- `./gradlew :app:lintDebug` clean
- `./gradlew :app:assembleDebug` builds

No emulator run — this is a multi-device co-signing path, requires two real vaults wired through the relay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Join-device keysign flow now completes and returns to Home automatically after success.

* **Bug Fixes**
  * Improved broadcast recovery for multi-device transactions to handle duplicate-rejection cases.
  * Polkadot transaction status polling now stops on explorer unauthorized responses instead of retrying.
  * Background polling tied to the keysign flow is now stopped when leaving that flow.

* **Tests**
  * Added tests covering broadcast recovery scenarios and Polkadot status mapping/behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->