### PR TITLE
fix(cardano): use require() so bad key length throws IllegalArgumentException

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -12,11 +12,11 @@ object CardanoUtils {
     fun createExtendedKey(spendingKeyHex: String, chainCodeHex: String): ByteArray {
         val spendingKeyData = Numeric.hexStringToByteArray(spendingKeyHex)
         val chainCodeData = Numeric.hexStringToByteArray(chainCodeHex)
-        if (spendingKeyData.size != 32) {
-            error("spending key must be 32 bytes, got ${spendingKeyData.size}")
+        require(spendingKeyData.size == 32) {
+            "spending key must be 32 bytes, got ${spendingKeyData.size}"
         }
-        if (chainCodeData.size != 32) {
-            error("chain code must be 32 bytes, got ${chainCodeData.size}")
+        require(chainCodeData.size == 32) {
+            "chain code must be 32 bytes, got ${chainCodeData.size}"
         }
 
         val extendedKeyData = ByteArray(128)
@@ -34,9 +34,8 @@ object CardanoUtils {
 
     fun createEnterpriseAddress(spendingKeyHex: String): String {
         val spendingKeyData = Numeric.hexStringToByteArray(spendingKeyHex)
-
-        if (spendingKeyData.size != 32) {
-            error("spending key must be 32 bytes, got ${spendingKeyData.size}")
+        require(spendingKeyData.size == 32) {
+            "spending key must be 32 bytes, got ${spendingKeyData.size}"
         }
 
         // Use Blake2b hash with 28 bytes output size

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -9,14 +9,16 @@ import wallet.core.jni.Hash
 
 object CardanoUtils {
 
+    private const val KEY_SIZE = 32
+
     fun createExtendedKey(spendingKeyHex: String, chainCodeHex: String): ByteArray {
         val spendingKeyData = Numeric.hexStringToByteArray(spendingKeyHex)
         val chainCodeData = Numeric.hexStringToByteArray(chainCodeHex)
-        require(spendingKeyData.size == 32) {
-            "spending key must be 32 bytes, got ${spendingKeyData.size}"
+        require(spendingKeyData.size == KEY_SIZE) {
+            "spending key must be $KEY_SIZE bytes, got ${spendingKeyData.size}"
         }
-        require(chainCodeData.size == 32) {
-            "chain code must be 32 bytes, got ${chainCodeData.size}"
+        require(chainCodeData.size == KEY_SIZE) {
+            "chain code must be $KEY_SIZE bytes, got ${chainCodeData.size}"
         }
 
         val extendedKeyData = ByteArray(128)
@@ -34,8 +36,8 @@ object CardanoUtils {
 
     fun createEnterpriseAddress(spendingKeyHex: String): String {
         val spendingKeyData = Numeric.hexStringToByteArray(spendingKeyHex)
-        require(spendingKeyData.size == 32) {
-            "spending key must be 32 bytes, got ${spendingKeyData.size}"
+        require(spendingKeyData.size == KEY_SIZE) {
+            "spending key must be $KEY_SIZE bytes, got ${spendingKeyData.size}"
         }
 
         // Use Blake2b hash with 28 bytes output size

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.data.crypto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Tests for [CardanoUtils.createEnterpriseAddress] — guards against non-32-byte spending key inputs
+ * that would otherwise surface as an [IllegalStateException] crash instead of a well-typed
+ * [IllegalArgumentException] caught by the chain-enable error handler.
+ *
+ * Mirrors [com.vultisig.wallet.data.repositories.ChainAccountAddressRepositoryEddsaValidationTest]
+ * for the Cardano-specific code path.
+ */
+class CardanoUtilsTest {
+
+    @Test
+    fun `createEnterpriseAddress throws for empty hex`() {
+        val ex = assertThrows<IllegalArgumentException> { CardanoUtils.createEnterpriseAddress("") }
+        assertEquals("spending key must be 32 bytes, got 0", ex.message)
+    }
+
+    @Test
+    fun `createEnterpriseAddress throws for 31-byte hex (62 chars)`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createEnterpriseAddress("aa".repeat(31))
+            }
+        assertEquals("spending key must be 32 bytes, got 31", ex.message)
+    }
+
+    @Test
+    fun `createEnterpriseAddress throws for 33-byte hex (66 chars)`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createEnterpriseAddress("aa".repeat(33))
+            }
+        assertEquals("spending key must be 32 bytes, got 33", ex.message)
+    }
+
+    @Test
+    fun `createEnterpriseAddress throws for 1-byte hex`() {
+        assertThrows<IllegalArgumentException> { CardanoUtils.createEnterpriseAddress("aa") }
+    }
+
+    @Test
+    fun `createExtendedKey throws for spending key shorter than 32 bytes`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createExtendedKey("aa".repeat(31), "bb".repeat(32))
+            }
+        assertEquals("spending key must be 32 bytes, got 31", ex.message)
+    }
+
+    @Test
+    fun `createExtendedKey throws for chain code shorter than 32 bytes`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createExtendedKey("aa".repeat(32), "bb".repeat(31))
+            }
+        assertEquals("chain code must be 32 bytes, got 31", ex.message)
+    }
+
+    @Test
+    fun `createExtendedKey throws for spending key longer than 32 bytes`() {
+        assertThrows<IllegalArgumentException> {
+            CardanoUtils.createExtendedKey("aa".repeat(33), "bb".repeat(32))
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -40,7 +40,9 @@ class CardanoUtilsTest {
 
     @Test
     fun `createEnterpriseAddress throws for 1-byte hex`() {
-        assertThrows<IllegalArgumentException> { CardanoUtils.createEnterpriseAddress("aa") }
+        val ex =
+            assertThrows<IllegalArgumentException> { CardanoUtils.createEnterpriseAddress("aa") }
+        assertEquals("spending key must be 32 bytes, got 1", ex.message)
     }
 
     @Test
@@ -63,8 +65,19 @@ class CardanoUtilsTest {
 
     @Test
     fun `createExtendedKey throws for spending key longer than 32 bytes`() {
-        assertThrows<IllegalArgumentException> {
-            CardanoUtils.createExtendedKey("aa".repeat(33), "bb".repeat(32))
-        }
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createExtendedKey("aa".repeat(33), "bb".repeat(32))
+            }
+        assertEquals("spending key must be 32 bytes, got 33", ex.message)
+    }
+
+    @Test
+    fun `createExtendedKey throws for chain code longer than 32 bytes`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                CardanoUtils.createExtendedKey("aa".repeat(32), "bb".repeat(33))
+            }
+        assertEquals("chain code must be 32 bytes, got 33", ex.message)
     }
 }


### PR DESCRIPTION
## Summary
- Replace `error()` with `require()` in `CardanoUtils.createEnterpriseAddress` and `createExtendedKey` for the 32-byte length preconditions
- `error()` throws `IllegalStateException`; the chain-enable error handler in `ChainSelectionViewModel` catches `CancellationException` (which extends `IllegalStateException`) separately first — so an `IllegalStateException` from `error()` could slip past the intended handler and crash the app
- `require()` throws `IllegalArgumentException`, which is caught by the generic `Exception` handler correctly, surfacing a per-chain error instead of crashing
- Adds `CardanoUtilsTest` with 7 unit tests covering empty, short, and long key inputs for both functions

## Issue
Closes #4541

## Test Plan
- [x] Unit tests pass: `./gradlew :data:test`
- [x] Lint passes: `./gradlew :data:lintDebug`
- [ ] Manual: enable Cardano chain in chain selection — should not crash on malformed key material

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation and clearer error messages for Cardano key and address creation to reject inputs of incorrect byte lengths.

* **Tests**
  * Added tests covering invalid spending-key and chain-code inputs and address/key creation failure cases to ensure validation behaves as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->