### PR TITLE
fix(defi): Tron header shows DeFi-locked TRX instead of wallet balance

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
@@ -192,12 +192,15 @@ constructor(
         val availableBalanceTrx = (account.balance ?: 0L).sunToTrx()
         val frozenTotal =
             account.frozenBandwidthSun.sunToTrx().add(account.frozenEnergySun.sunToTrx())
+        // Header reflects the user's DeFi-locked position: actively frozen TRX plus
+        // TRX in the unfreezing cooldown. Mirrors vultisig-ios `DefiBalanceService`.
+        val defiTotal = frozenTotal.add(account.unfreezingTotalSun.sunToTrx())
 
         val stats = resource.calculateResourceStats()
         val pendingWithdrawals = mapPendingWithdrawals(account)
 
         return TronStakingUiModel(
-            totalAmountPrice = currencyFormat.format(availableBalanceTrx.multiply(trxPrice)),
+            totalAmountPrice = currencyFormat.format(defiTotal.multiply(trxPrice)),
             frozenTotalPrice = currencyFormat.format(frozenTotal.multiply(trxPrice)),
             frozenTotalTrx = frozenTotal.stripTrailingZeros().toPlainString(),
             availableBandwidth = stats.availableBandwidth,


### PR DESCRIPTION
## Summary

On the Tron DeFi screen the header amount was reading `availableBalanceTrx` (the spendable wallet balance) rather than the user's actual DeFi position. With a vault holding both spendable and frozen TRX, the header would display the full wallet total while the "Frozen" row directly below showed the much smaller frozen amount — making the two numbers contradict each other.

## Fix

`TronDeFiPositionsViewModel.buildStakingUiModel` now feeds `totalAmountPrice` from `frozenTotal + unfreezingTotalSun` (in TRX), so the header reflects the user's DeFi-locked position — actively frozen bandwidth + energy + TRX still in the 14-day unbond cooldown. The "Frozen" row (`frozenTotalPrice` / `frozenTotalTrx`) keeps showing frozen-only, unchanged.

Reused the existing `TronAccountJson.unfreezingTotalSun` extension property already defined in `TronResponseJson.kt`.

## Cross-platform parity

Mirrors vultisig-ios:

- `BalanceService.swift` (fetchStakedBalance, Tron branch): `account.frozenBandwidthSun + account.frozenEnergySun + account.unfreezingTotalSun`
- `DefiBalanceService.swift` (`tronTotalBalanceFiatDecimal`): explicit comment "frozen + unfreezing TRX, not the wallet balance"

## Maya / Thor cross-check (issue ask)

Verified both already report DeFi-side totals — no change needed:

- `MayachainDefiPositionsViewModel.kt:400` — `totalAmountPrice` formats `fiatValue.value` derived from `_totalStakingRaw` (staked CACAO only).
- `ThorchainDefiPositionsViewModel.kt:312` — `totalAmountPrice` sums bond + RUJI stake + TCY stake + default-staking positions; no wallet balance term.

## Test Plan

- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:ktfmtFormat` — clean
- [ ] Manual: vault with Tron + spendable TRX + frozen TRX — header should equal the "Frozen" amount (plus any unfreezing TRX), not the wallet total.

Closes #4569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display of total locked TRX in DeFi staking positions to accurately reflect both actively frozen resources (bandwidth and energy) and TRX currently unfreezing, rather than showing only available balance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->