### PR TITLE
feat(terra): auto-discover bank-denom tokens on Terra and Terra Classic

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -2,6 +2,8 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.api.errors.parseCosmosBroadcastResponse
+import com.vultisig.wallet.data.api.models.DenomMetadata
+import com.vultisig.wallet.data.api.models.MetadataResponse
 import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.api.models.cosmos.CosmosBalanceResponse
 import com.vultisig.wallet.data.api.models.cosmos.CosmosIbcDenomTraceDenomTraceJson
@@ -11,6 +13,7 @@ import com.vultisig.wallet.data.api.models.cosmos.CosmosTxStatusJson
 import com.vultisig.wallet.data.api.models.cosmos.THORChainAccountValue
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.utils.CosmosThorChainResponseSerializer
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -19,9 +22,12 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.util.encodeBase64
+import java.net.URLEncoder
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -38,6 +44,12 @@ interface CosmosApi {
     suspend fun getWasmTokenBalance(address: String, contractAddress: String): CosmosBalance
 
     suspend fun getIbcDenomTraces(contractAddress: String): CosmosIbcDenomTraceDenomTraceJson
+
+    /**
+     * Chain-declared metadata for the given bank denom, or `null` when the chain has no entry or
+     * the request fails. Used by token auto-discovery to resolve display ticker and decimals.
+     */
+    suspend fun getDenomMetadata(denom: String): DenomMetadata?
 
     suspend fun getLatestBlock(): String
 
@@ -149,6 +161,28 @@ internal class CosmosApiImp(
             .get("$rpcEndpoint/ibc/apps/transfer/v1/denom_traces/$hash")
             .body<CosmosIbcDenomTraceJson>()
             .denomTrace!!
+    }
+
+    override suspend fun getDenomMetadata(denom: String): DenomMetadata? {
+        return try {
+            val encoded = URLEncoder.encode(denom, Charsets.UTF_8.name())
+            httpClient
+                .get("$rpcEndpoint/cosmos/bank/v1beta1/denoms_metadata/$encoded")
+                .bodyOrThrow<MetadataResponse>()
+                .metadata
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: NetworkException) {
+            if (e.httpStatusCode == HttpStatusCode.NotFound.value) {
+                Timber.d("No denom metadata for %s (expected for non-standard denoms)", denom)
+            } else {
+                Timber.e(e, "Failed to fetch denom metadata for %s", denom)
+            }
+            null
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to fetch denom metadata for %s", denom)
+            null
+        }
     }
 
     override suspend fun getLatestBlock(): String {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.CosmosBankCoinFinder
 import com.vultisig.wallet.data.usecases.EvmCoinFinder
 import java.math.BigInteger
 import javax.inject.Inject
@@ -45,6 +46,7 @@ constructor(
     private val thorApi: ThorChainApi,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val evmCoinFinder: EvmCoinFinder,
+    private val cosmosBankCoinFinder: CosmosBankCoinFinder,
 ) : TokenRepository {
 
     override suspend fun getToken(tokenId: String): Coin? =
@@ -159,6 +161,8 @@ constructor(
                     }
                 }
             }
+            Chain.Terra,
+            Chain.TerraClassic -> cosmosBankCoinFinder.find(chain, address)
             else -> {
                 if (chain.standard != TokenStandard.EVM) emptyList()
                 else evmCoinFinder.find(chain, address)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
@@ -165,7 +165,10 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFind
             ?.let {
                 return it.value
             }
-        return fetch().also { cache[key] = CacheEntry(it, now + CACHE_TTL_MILLIS) }
+        // Cache only successful lookups. A `null` here is indistinguishable between a true 404 and
+        // a transient LCD failure the API method swallowed — pinning either for 24h would freeze
+        // the outage into the session, so retry on the next refresh instead.
+        return fetch()?.also { cache[key] = CacheEntry(it, now + CACHE_TTL_MILLIS) }
     }
 
     private fun DenomMetadata.symbolOrDisplay(): String? =
@@ -174,9 +177,11 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFind
     private fun DenomMetadata.decimalsFromUnits(): Int? {
         val units = denomUnits ?: return null
         val byName =
-            listOfNotNull(symbol, display).firstNotNullOfOrNull { name ->
-                units.firstOrNull { it.denom == name }?.exponent?.takeIf { it > 0 }
-            }
+            listOfNotNull(symbol, display)
+                .filter { it.isNotEmpty() }
+                .firstNotNullOfOrNull { name ->
+                    units.firstOrNull { it.denom == name }?.exponent?.takeIf { it > 0 }
+                }
         return byName ?: units.mapNotNull { it.exponent }.maxOrNull()?.takeIf { it > 0 }
     }
 
@@ -201,7 +206,7 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFind
 
     private data class DenomKey(val chainId: String, val denom: String)
 
-    private data class CacheEntry<T : Any>(val value: T?, val expiresAt: Long)
+    private data class CacheEntry<T : Any>(val value: T, val expiresAt: Long)
 
     companion object {
         /** Chains the bank auto-discovery is enabled for; matches the ticket scope. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
@@ -1,0 +1,218 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.models.DenomMetadata
+import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
+import com.vultisig.wallet.data.api.models.cosmos.CosmosIbcDenomTraceDenomTraceJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.utils.NetworkException
+import java.net.SocketTimeoutException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
+
+/**
+ * Auto-discovers bank-denom holdings on Terra and Terra Classic.
+ *
+ * Companion to [EvmCoinFinder]: the chain-detail screen and the background token-refresh worker
+ * both route through `TokenRepository.getTokensWithBalance`, which delegates here for chains in
+ * [SUPPORTED_CHAINS]. For every entry returned by `/cosmos/bank/v1beta1/balances/{addr}` we
+ * surface, in order of preference:
+ * 1. the curated [Coins] entry whose `contractAddress` matches the denom — preserves logo and
+ *    `priceProviderID`;
+ * 2. a coin built from `/cosmos/bank/v1beta1/denoms_metadata/{denom}` — ticker from the symbol or
+ *    display, decimals from the matching `denom_units` exponent;
+ * 3. for `ibc/HASH` vouchers without chain metadata: the trace's `base_denom`, plus a metadata
+ *    lookup for that base denom so decimals stay correct when the chain advertises them;
+ * 4. otherwise a coin with a ticker derived from the denom string and the Cosmos-default six
+ *    decimals.
+ *
+ * Metadata and IBC traces are immutable per chain, so both are cached in-memory for 24h. Failures
+ * are logged at debug level — a transient LCD blip falls through to the fallback derivation and is
+ * retried on the next refresh.
+ *
+ * Tracks vultisig/vultisig-android#4500 and the parallel iOS work in vultisig/vultisig-ios#4366.
+ */
+interface CosmosBankCoinFinder {
+    suspend fun find(chain: Chain, address: String): List<Coin>
+}
+
+internal class CosmosBankCoinFinderImpl
+@Inject
+constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFinder {
+
+    private val metadataCache = ConcurrentHashMap<DenomKey, CacheEntry<DenomMetadata>>()
+    private val traceCache =
+        ConcurrentHashMap<DenomKey, CacheEntry<CosmosIbcDenomTraceDenomTraceJson>>()
+
+    override suspend fun find(chain: Chain, address: String): List<Coin> {
+        if (chain !in SUPPORTED_CHAINS) return emptyList()
+
+        val api = cosmosApiFactory.createCosmosApi(chain)
+        val discoverable =
+            fetchBalances(chain, api, address)?.filterNot {
+                it.denom.equals(chain.feeUnit, ignoreCase = true)
+            } ?: return emptyList()
+
+        return coroutineScope {
+            discoverable
+                .map { balance -> async { resolveCoin(chain, api, balance.denom) } }
+                .awaitAll()
+        }
+    }
+
+    private suspend fun fetchBalances(
+        chain: Chain,
+        api: CosmosApi,
+        address: String,
+    ): List<CosmosBalance>? =
+        try {
+            api.getBalance(address)
+        } catch (e: SocketTimeoutException) {
+            Timber.e(e, "Cosmos bank balances timed out for %s", chain.id)
+            null
+        } catch (e: NetworkException) {
+            Timber.e(e, "Cosmos bank balances failed for %s: status=%d", chain.id, e.httpStatusCode)
+            null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Cosmos bank balances failed for %s", chain.id)
+            null
+        }
+
+    private suspend fun resolveCoin(chain: Chain, api: CosmosApi, denom: String): Coin =
+        preferCurated(chain, denom)
+            ?: cachedMetadata(chain, api, denom)?.let {
+                buildCoin(chain, denom, metadata = it, fallbackTicker = denom.toCosmosTicker())
+            }
+            ?: resolveIbcVoucher(chain, api, denom)
+            ?: buildCoin(chain, denom, metadata = null, fallbackTicker = denom.toCosmosTicker())
+
+    private fun preferCurated(chain: Chain, denom: String): Coin? =
+        Coins.coins[chain]?.firstOrNull { it.contractAddress.equals(denom, ignoreCase = true) }
+
+    private suspend fun resolveIbcVoucher(chain: Chain, api: CosmosApi, denom: String): Coin? {
+        if (!denom.startsWith(IBC_DENOM_PREFIX)) return null
+        val trace = cachedTrace(chain, api, denom) ?: return null
+        val baseMeta = cachedMetadata(chain, api, trace.baseDenom)
+        return buildCoin(
+            chain = chain,
+            denom = denom,
+            metadata = baseMeta,
+            fallbackTicker = trace.baseDenom.toCosmosTicker(),
+        )
+    }
+
+    private fun buildCoin(
+        chain: Chain,
+        denom: String,
+        metadata: DenomMetadata?,
+        fallbackTicker: String,
+    ): Coin =
+        Coin(
+            chain = chain,
+            ticker = metadata?.symbolOrDisplay() ?: fallbackTicker,
+            logo = "",
+            address = "",
+            decimal = metadata?.decimalsFromUnits() ?: COSMOS_DEFAULT_DECIMALS,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = denom,
+            isNativeToken = false,
+        )
+
+    private suspend fun cachedMetadata(
+        chain: Chain,
+        api: CosmosApi,
+        denom: String,
+    ): DenomMetadata? = cached(metadataCache, chain, denom) { api.getDenomMetadata(denom) }
+
+    private suspend fun cachedTrace(
+        chain: Chain,
+        api: CosmosApi,
+        denom: String,
+    ): CosmosIbcDenomTraceDenomTraceJson? =
+        cached(traceCache, chain, denom) {
+            try {
+                api.getIbcDenomTraces(denom)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.d(e, "IBC denom trace fetch failed for %s on %s", denom, chain.id)
+                null
+            }
+        }
+
+    private suspend fun <V : Any> cached(
+        cache: ConcurrentHashMap<DenomKey, CacheEntry<V>>,
+        chain: Chain,
+        denom: String,
+        fetch: suspend () -> V?,
+    ): V? {
+        val key = DenomKey(chain.id, denom)
+        val now = System.currentTimeMillis()
+        cache[key]
+            ?.takeIf { it.expiresAt > now }
+            ?.let {
+                return it.value
+            }
+        return fetch().also { cache[key] = CacheEntry(it, now + CACHE_TTL_MILLIS) }
+    }
+
+    private fun DenomMetadata.symbolOrDisplay(): String? =
+        symbol?.takeIf { it.isNotEmpty() } ?: display?.takeIf { it.isNotEmpty() }
+
+    private fun DenomMetadata.decimalsFromUnits(): Int? {
+        val units = denomUnits ?: return null
+        val byName =
+            listOfNotNull(symbol, display).firstNotNullOfOrNull { name ->
+                units.firstOrNull { it.denom == name }?.exponent?.takeIf { it > 0 }
+            }
+        return byName ?: units.mapNotNull { it.exponent }.maxOrNull()?.takeIf { it > 0 }
+    }
+
+    /**
+     * Best-effort ticker for denoms with no metadata or trace data. Mirrors the conventions used by
+     * the THORChain auto-discovery in `TokenRepositoryImpl.deriveTicker`: factory subdenoms get the
+     * trailing component, native units with a leading `u`/`a` get the prefix stripped, and IBC
+     * vouchers fall back to a short hash prefix so they stay distinguishable.
+     */
+    private fun String.toCosmosTicker(): String =
+        when {
+            startsWith(IBC_DENOM_PREFIX) ->
+                IBC_TICKER_PREFIX +
+                    removePrefix(IBC_DENOM_PREFIX).take(IBC_HASH_PREVIEW_LENGTH).uppercase()
+            startsWith(FACTORY_DENOM_PREFIX) ->
+                substringAfterLast('/').stripDenomUnitPrefix().uppercase()
+            else -> stripDenomUnitPrefix().uppercase()
+        }
+
+    private fun String.stripDenomUnitPrefix(): String =
+        if (length > 1 && first() in DENOM_UNIT_PREFIXES && this[1].isLetter()) drop(1) else this
+
+    private data class DenomKey(val chainId: String, val denom: String)
+
+    private data class CacheEntry<T : Any>(val value: T?, val expiresAt: Long)
+
+    companion object {
+        /** Chains the bank auto-discovery is enabled for; matches the ticket scope. */
+        val SUPPORTED_CHAINS: Set<Chain> = setOf(Chain.Terra, Chain.TerraClassic)
+
+        private const val IBC_DENOM_PREFIX = "ibc/"
+        private const val FACTORY_DENOM_PREFIX = "factory/"
+        private const val IBC_TICKER_PREFIX = "IBC-"
+        private const val IBC_HASH_PREVIEW_LENGTH = 6
+        private const val COSMOS_DEFAULT_DECIMALS = 6
+        private val DENOM_UNIT_PREFIXES = setOf('u', 'a')
+        private val CACHE_TTL_MILLIS = TimeUnit.HOURS.toMillis(24)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
@@ -182,7 +182,10 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFind
                 .firstNotNullOfOrNull { name ->
                     units.firstOrNull { it.denom == name }?.exponent?.takeIf { it > 0 }
                 }
-        return byName ?: units.mapNotNull { it.exponent }.maxOrNull()?.takeIf { it > 0 }
+        // The max fallback accepts `0` for genuine zero-decimal denoms — only the named lookup
+        // skips zero, where matching the base unit instead of the display unit signals malformed
+        // metadata that should fall through to the max.
+        return byName ?: units.mapNotNull { it.exponent }.maxOrNull()?.takeIf { it >= 0 }
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -168,6 +168,10 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindCosmosBankCoinFinder(impl: CosmosBankCoinFinderImpl): CosmosBankCoinFinder
+
+    @Binds
+    @Singleton
     fun bindGetChainTokenUseCase(impl: GetChainTokensUseCaseImpl): GetChainTokensUseCase
 
     @Binds

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
@@ -13,6 +13,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
@@ -49,7 +50,7 @@ class CosmosApiTest {
     }
 
     @Test
-    fun `getDenomMetadata returns parsed metadata for a known denom`() = runBlocking {
+    fun `getDenomMetadata returns parsed metadata for a known denom`() = runTest {
         val api =
             cosmosApi(
                 MockEngine { request ->
@@ -76,7 +77,7 @@ class CosmosApiTest {
     }
 
     @Test
-    fun `getDenomMetadata percent-encodes denoms with reserved characters`() = runBlocking {
+    fun `getDenomMetadata percent-encodes denoms with reserved characters`() = runTest {
         var capturedPath: String? = null
         val api =
             cosmosApi(
@@ -96,14 +97,14 @@ class CosmosApiTest {
     }
 
     @Test
-    fun `getDenomMetadata returns null on 404 without throwing`() = runBlocking {
+    fun `getDenomMetadata returns null on 404 without throwing`() = runTest {
         val api = cosmosApi(MockEngine { respond(content = "", status = HttpStatusCode.NotFound) })
 
         assertNull(api.getDenomMetadata("ibc/UNKNOWN"))
     }
 
     @Test
-    fun `getDenomMetadata returns null on 5xx without throwing`() = runBlocking {
+    fun `getDenomMetadata returns null on 5xx without throwing`() = runTest {
         val api =
             cosmosApi(
                 MockEngine {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
@@ -48,6 +48,72 @@ class CosmosApiTest {
         assertEquals(0, result?.txResponse?.code)
     }
 
+    @Test
+    fun `getDenomMetadata returns parsed metadata for a known denom`() = runBlocking {
+        val api =
+            cosmosApi(
+                MockEngine { request ->
+                    assertEquals(
+                        "/cosmos/bank/v1beta1/denoms_metadata/uluna",
+                        request.url.encodedPath,
+                    )
+                    respond(
+                        content =
+                            """{"metadata":{"base":"uluna","symbol":"LUNA","display":"luna",""" +
+                                """"denom_units":[{"denom":"uluna","exponent":0},""" +
+                                """{"denom":"luna","exponent":6}]}}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val metadata = api.getDenomMetadata("uluna")
+
+        assertEquals("uluna", metadata?.base)
+        assertEquals("LUNA", metadata?.symbol)
+        assertEquals(6, metadata?.denomUnits?.last()?.exponent)
+    }
+
+    @Test
+    fun `getDenomMetadata percent-encodes denoms with reserved characters`() = runBlocking {
+        var capturedPath: String? = null
+        val api =
+            cosmosApi(
+                MockEngine { request ->
+                    capturedPath = request.url.encodedPath
+                    respond(
+                        content = """{"metadata":null}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        api.getDenomMetadata("ibc/ABC123")
+
+        assertEquals("/cosmos/bank/v1beta1/denoms_metadata/ibc%2FABC123", capturedPath)
+    }
+
+    @Test
+    fun `getDenomMetadata returns null on 404 without throwing`() = runBlocking {
+        val api = cosmosApi(MockEngine { respond(content = "", status = HttpStatusCode.NotFound) })
+
+        assertNull(api.getDenomMetadata("ibc/UNKNOWN"))
+    }
+
+    @Test
+    fun `getDenomMetadata returns null on 5xx without throwing`() = runBlocking {
+        val api =
+            cosmosApi(
+                MockEngine {
+                    respond(content = "boom", status = HttpStatusCode.InternalServerError)
+                }
+            )
+
+        assertNull(api.getDenomMetadata("uluna"))
+    }
+
     private fun cosmosApi(engine: MockEngine): CosmosApi {
         val json = Json { ignoreUnknownKeys = true }
         return CosmosApiImp(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -7,6 +7,8 @@ import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.DenomMetadata
 import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.usecases.CosmosBankCoinFinder
 import com.vultisig.wallet.data.usecases.EvmCoinFinder
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -128,15 +130,65 @@ internal class TokenRepositoryImplTest {
             assertEquals(listOf("x/ruji"), coins.map { it.contractAddress })
         }
 
-    private fun newRepository(thorApi: ThorChainApi): TokenRepositoryImpl =
+    @Test
+    fun `getTokensWithBalance for Terra delegates to the Cosmos bank coin finder`() = runTest {
+        val cosmosBankCoinFinder: CosmosBankCoinFinder = mockk()
+        val expected = listOf(Coins.Terra.ASTRO_IBC)
+        coEvery { cosmosBankCoinFinder.find(Chain.Terra, TERRA_ADDRESS) } returns expected
+
+        val coins =
+            newRepository(cosmosBankCoinFinder = cosmosBankCoinFinder)
+                .getTokensWithBalance(Chain.Terra, TERRA_ADDRESS)
+
+        assertEquals(expected, coins)
+    }
+
+    @Test
+    fun `getTokensWithBalance for TerraClassic delegates to the Cosmos bank coin finder`() =
+        runTest {
+            val cosmosBankCoinFinder: CosmosBankCoinFinder = mockk()
+            val expected = listOf(Coins.TerraClassic.USTC)
+            coEvery { cosmosBankCoinFinder.find(Chain.TerraClassic, TERRA_CLASSIC_ADDRESS) } returns
+                expected
+
+            val coins =
+                newRepository(cosmosBankCoinFinder = cosmosBankCoinFinder)
+                    .getTokensWithBalance(Chain.TerraClassic, TERRA_CLASSIC_ADDRESS)
+
+            assertEquals(expected, coins)
+        }
+
+    @Test
+    fun `getTokensWithBalance leaves other Cosmos chains untouched and returns empty`() = runTest {
+        // Defensive: the dispatch must scope the new finder to Terra / TerraClassic only — the
+        // ticket explicitly limits this discovery to those two chains.
+        val cosmosBankCoinFinder: CosmosBankCoinFinder = mockk()
+
+        val coins =
+            newRepository(cosmosBankCoinFinder = cosmosBankCoinFinder)
+                .getTokensWithBalance(Chain.GaiaChain, COSMOS_ADDRESS)
+
+        assertTrue(coins.isEmpty())
+        coVerify(exactly = 0) { cosmosBankCoinFinder.find(any(), any()) }
+    }
+
+    private fun newRepository(
+        thorApi: ThorChainApi = mockk(relaxed = true),
+        evmCoinFinder: EvmCoinFinder = mockk(relaxed = true),
+        cosmosBankCoinFinder: CosmosBankCoinFinder = mockk(relaxed = true),
+    ): TokenRepositoryImpl =
         TokenRepositoryImpl(
             evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
             thorApi = thorApi,
             chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
-            evmCoinFinder = mockk<EvmCoinFinder>(relaxed = true),
+            evmCoinFinder = evmCoinFinder,
+            cosmosBankCoinFinder = cosmosBankCoinFinder,
         )
 
     private companion object {
         const val ADDRESS = "thor1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v"
+        const val TERRA_ADDRESS = "terra1abc"
+        const val TERRA_CLASSIC_ADDRESS = "terra1classic"
+        const val COSMOS_ADDRESS = "cosmos1abc"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
@@ -1,0 +1,287 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.models.DenomMetadata
+import com.vultisig.wallet.data.api.models.DenomUnit
+import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
+import com.vultisig.wallet.data.api.models.cosmos.CosmosIbcDenomTraceDenomTraceJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class CosmosBankCoinFinderTest {
+
+    private val cosmosApi: CosmosApi = mockk()
+    private val cosmosApiFactory: CosmosApiFactory = mockk()
+    private val finder = CosmosBankCoinFinderImpl(cosmosApiFactory)
+
+    init {
+        every { cosmosApiFactory.createCosmosApi(any()) } returns cosmosApi
+    }
+
+    @Test
+    fun `SUPPORTED_CHAINS matches the ticket scope`() {
+        // Mirrors vultisig/vultisig-android#4500 and the parallel iOS work in
+        // vultisig/vultisig-ios#4366; widening this set is a deliberate cross-platform decision.
+        assertEquals(
+            setOf(Chain.Terra, Chain.TerraClassic),
+            CosmosBankCoinFinderImpl.SUPPORTED_CHAINS,
+        )
+    }
+
+    @Test
+    fun `find on a non-supported Cosmos chain returns empty without calling the API`() = runTest {
+        val coins = finder.find(Chain.GaiaChain, TERRA_ADDRESS)
+
+        assertTrue(coins.isEmpty())
+        coVerify(exactly = 0) { cosmosApi.getBalance(any()) }
+    }
+
+    @Test
+    fun `find skips the native fee unit denom`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(
+                CosmosBalance(denom = "uluna", amount = "100"),
+                CosmosBalance(denom = "uusdc-stub", amount = "200"),
+            )
+        coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+
+        val coins = finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        assertEquals(listOf("uusdc-stub"), coins.map { it.contractAddress })
+        coVerify(exactly = 0) { cosmosApi.getDenomMetadata("uluna") }
+    }
+
+    @Test
+    fun `find prefers the curated catalog entry when the denom matches case-insensitively`() =
+        runTest {
+            // USTC on TerraClassic is curated with contractAddress "uusd"; the catalog entry should
+            // win over any metadata-derived coin so the bundled logo + priceProviderID are
+            // preserved.
+            coEvery { cosmosApi.getBalance(TERRA_CLASSIC_ADDRESS) } returns
+                listOf(CosmosBalance(denom = "UUSD", amount = "100"))
+
+            val coins = finder.find(Chain.TerraClassic, TERRA_CLASSIC_ADDRESS)
+
+            val ustc = coins.single()
+            assertEquals(Coins.TerraClassic.USTC, ustc)
+            coVerify(exactly = 0) { cosmosApi.getDenomMetadata(any()) }
+        }
+
+    @Test
+    fun `find reads ticker from metadata symbol and decimals from the matching denom_unit`() =
+        runTest {
+            // Acceptance criterion: "Decimals correct for at least one non-6-decimal denom." A bank
+            // denom whose metadata declares an 18-exponent display unit (the Axelar WETH shape)
+            // must surface as 18 decimals, not the Cosmos default of 6.
+            coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+                listOf(CosmosBalance(denom = "axlweth", amount = "1"))
+            coEvery { cosmosApi.getDenomMetadata("axlweth") } returns
+                DenomMetadata(
+                    base = "axlweth",
+                    symbol = "axlWETH",
+                    display = "axlweth",
+                    denomUnits =
+                        listOf(
+                            DenomUnit(denom = "axlweth", exponent = 0),
+                            DenomUnit(denom = "axlWETH", exponent = 18),
+                        ),
+                )
+
+            val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+            assertEquals("axlweth", coin.contractAddress)
+            assertEquals("axlWETH", coin.ticker)
+            assertEquals(18, coin.decimal)
+            assertEquals("", coin.priceProviderID)
+            assertEquals(false, coin.isNativeToken)
+        }
+
+    @Test
+    fun `find falls back to display when metadata symbol is blank`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = "uosmo", amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata("uosmo") } returns
+            DenomMetadata(
+                base = "uosmo",
+                symbol = "",
+                display = "OSMO",
+                denomUnits =
+                    listOf(
+                        DenomUnit(denom = "uosmo", exponent = 0),
+                        DenomUnit(denom = "OSMO", exponent = 6),
+                    ),
+            )
+
+        val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+        assertEquals("OSMO", coin.ticker)
+        assertEquals(6, coin.decimal)
+    }
+
+    @Test
+    fun `find without metadata derives the ticker by stripping the leading u or a unit prefix`() =
+        runTest {
+            coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+                listOf(
+                    CosmosBalance(denom = "ufoo", amount = "1"),
+                    CosmosBalance(denom = "abar", amount = "1"),
+                    CosmosBalance(denom = "BAZ", amount = "1"),
+                )
+            coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+
+            val coins = finder.find(Chain.Terra, TERRA_ADDRESS).associateBy { it.contractAddress }
+
+            assertEquals("FOO", coins.getValue("ufoo").ticker)
+            assertEquals("BAR", coins.getValue("abar").ticker)
+            assertEquals("BAZ", coins.getValue("BAZ").ticker)
+            assertEquals(6, coins.getValue("ufoo").decimal, "Cosmos default decimals when no meta")
+        }
+
+    @Test
+    fun `find derives the ticker from the last factory subdenom segment`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = "factory/terra1abc/upips", amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata("factory/terra1abc/upips") } returns null
+
+        val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+        assertEquals("PIPS", coin.ticker)
+    }
+
+    @Test
+    fun `find resolves an IBC voucher via denom_traces and applies base-denom metadata`() =
+        runTest {
+            val ibcDenom = "ibc/E3D7E58DD5BB1FBC1289A60CDBFCCDA0023B3DE3D2C347D9E1FFEEA4F1A1AE03"
+            coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+                listOf(CosmosBalance(denom = ibcDenom, amount = "1"))
+            // Chain has no metadata for the IBC voucher itself ...
+            coEvery { cosmosApi.getDenomMetadata(ibcDenom) } returns null
+            coEvery { cosmosApi.getIbcDenomTraces(ibcDenom) } returns
+                CosmosIbcDenomTraceDenomTraceJson(path = "transfer/channel-1", baseDenom = "uusdc")
+            // ... but it does for the unwrapped base denom, which the finder must apply.
+            coEvery { cosmosApi.getDenomMetadata("uusdc") } returns
+                DenomMetadata(
+                    base = "uusdc",
+                    symbol = "USDC",
+                    display = "usdc",
+                    denomUnits =
+                        listOf(
+                            DenomUnit(denom = "uusdc", exponent = 0),
+                            DenomUnit(denom = "usdc", exponent = 6),
+                        ),
+                )
+
+            val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+            assertEquals(ibcDenom, coin.contractAddress)
+            assertEquals("USDC", coin.ticker)
+            assertEquals(6, coin.decimal)
+        }
+
+    @Test
+    fun `find falls back to base-denom-derived ticker when IBC base-denom has no metadata`() =
+        runTest {
+            val ibcDenom = "ibc/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+                listOf(CosmosBalance(denom = ibcDenom, amount = "1"))
+            coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+            coEvery { cosmosApi.getIbcDenomTraces(ibcDenom) } returns
+                CosmosIbcDenomTraceDenomTraceJson(path = "transfer/channel-72", baseDenom = "uatom")
+
+            val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+            assertEquals(ibcDenom, coin.contractAddress)
+            assertEquals("ATOM", coin.ticker)
+            assertEquals(6, coin.decimal)
+        }
+
+    @Test
+    fun `find falls back to a hashed ticker when the IBC trace lookup fails`() = runTest {
+        val ibcDenom = "ibc/DEAD0000000000000000000000000000000000000000000000000000000000"
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = ibcDenom, amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+        coEvery { cosmosApi.getIbcDenomTraces(ibcDenom) } throws RuntimeException("404")
+
+        val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+        assertEquals(ibcDenom, coin.contractAddress)
+        assertEquals("IBC-DEAD00", coin.ticker)
+    }
+
+    @Test
+    fun `find returns empty when the balance call fails`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } throws RuntimeException("boom")
+
+        val coins = finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        assertTrue(coins.isEmpty())
+        coVerify(exactly = 0) { cosmosApi.getDenomMetadata(any()) }
+        coVerify(exactly = 0) { cosmosApi.getIbcDenomTraces(any()) }
+    }
+
+    @Test
+    fun `find caches denom metadata across calls for the same chain and denom`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = "axlweth", amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata("axlweth") } returns
+            DenomMetadata(
+                base = "axlweth",
+                symbol = "axlWETH",
+                display = "axlweth",
+                denomUnits =
+                    listOf(
+                        DenomUnit(denom = "axlweth", exponent = 0),
+                        DenomUnit(denom = "axlWETH", exponent = 18),
+                    ),
+            )
+
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        coVerify(exactly = 1) { cosmosApi.getDenomMetadata("axlweth") }
+    }
+
+    @Test
+    fun `find caches IBC denom traces across calls for the same chain and denom`() = runTest {
+        val ibcDenom = "ibc/CACHE0000000000000000000000000000000000000000000000000000000000"
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = ibcDenom, amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+        coEvery { cosmosApi.getIbcDenomTraces(ibcDenom) } returns
+            CosmosIbcDenomTraceDenomTraceJson(path = "transfer/channel-9", baseDenom = "uatom")
+
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        coVerify(exactly = 1) { cosmosApi.getIbcDenomTraces(ibcDenom) }
+    }
+
+    @Test
+    fun `find returns an empty list when the address holds only the native fee unit`() = runTest {
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = "uluna", amount = "100"))
+
+        val coins = finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        assertTrue(coins.isEmpty())
+        coVerify(exactly = 0) { cosmosApi.getDenomMetadata(any()) }
+    }
+
+    private companion object {
+        const val TERRA_ADDRESS = "terra1abc"
+        const val TERRA_CLASSIC_ADDRESS = "terra1classic"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
@@ -298,6 +298,27 @@ internal class CosmosBankCoinFinderTest {
         }
 
     @Test
+    fun `find honours a zero-decimal denom declared by chain metadata`() = runTest {
+        // Cosmos rarely ships NFT-like bank denoms, but when metadata declares no fractional unit
+        // we must surface zero decimals rather than the default six — otherwise a balance of 100
+        // would render as 0.000100.
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = "ticket", amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata("ticket") } returns
+            DenomMetadata(
+                base = "ticket",
+                symbol = "TICKET",
+                display = "TICKET",
+                denomUnits = listOf(DenomUnit(denom = "ticket", exponent = 0)),
+            )
+
+        val coin = finder.find(Chain.Terra, TERRA_ADDRESS).single()
+
+        assertEquals(0, coin.decimal)
+        assertEquals("TICKET", coin.ticker)
+    }
+
+    @Test
     fun `find does not cache failing IBC denom traces so the next refresh retries`() = runTest {
         val ibcDenom = "ibc/FFFF0000000000000000000000000000000000000000000000000000000000"
         coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinderTest.kt
@@ -280,6 +280,37 @@ internal class CosmosBankCoinFinderTest {
         coVerify(exactly = 0) { cosmosApi.getDenomMetadata(any()) }
     }
 
+    @Test
+    fun `find does not cache null metadata so transient LCD failures retry next refresh`() =
+        runTest {
+            // A `null` from `getDenomMetadata` is indistinguishable between a true 404 and a 5xx
+            // the
+            // API method swallowed. Pinning either for 24h would freeze a transient LCD outage into
+            // the session — instead the next refresh must hit the endpoint again.
+            coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+                listOf(CosmosBalance(denom = "uglitch", amount = "1"))
+            coEvery { cosmosApi.getDenomMetadata("uglitch") } returns null
+
+            finder.find(Chain.Terra, TERRA_ADDRESS)
+            finder.find(Chain.Terra, TERRA_ADDRESS)
+
+            coVerify(exactly = 2) { cosmosApi.getDenomMetadata("uglitch") }
+        }
+
+    @Test
+    fun `find does not cache failing IBC denom traces so the next refresh retries`() = runTest {
+        val ibcDenom = "ibc/FFFF0000000000000000000000000000000000000000000000000000000000"
+        coEvery { cosmosApi.getBalance(TERRA_ADDRESS) } returns
+            listOf(CosmosBalance(denom = ibcDenom, amount = "1"))
+        coEvery { cosmosApi.getDenomMetadata(any()) } returns null
+        coEvery { cosmosApi.getIbcDenomTraces(ibcDenom) } throws RuntimeException("LCD down")
+
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+        finder.find(Chain.Terra, TERRA_ADDRESS)
+
+        coVerify(exactly = 2) { cosmosApi.getIbcDenomTraces(ibcDenom) }
+    }
+
     private companion object {
         const val TERRA_ADDRESS = "terra1abc"
         const val TERRA_CLASSIC_ADDRESS = "terra1classic"


### PR DESCRIPTION
Closes #4500. Companion to the iOS work tracked in vultisig/vultisig-ios#4366.

## Why

`TokenRepository.getTokensWithBalance` returned `emptyList()` for Terra and Terra Classic, so IBC-wrapped assets (axlUSDC), legacy stablecoins (USTC), and factory tokens stayed invisible until the user typed the denom into the manual-add flow. Asymmetric with EVM/UTXO and with the THORChain path already in the repository.

## What

`CosmosBankCoinFinder` mirrors `EvmCoinFinder` (#4560). For every entry from `/cosmos/bank/v1beta1/balances/{addr}`, in order of preference:

1. the curated `Coins` entry whose `contractAddress` matches the denom (case-insensitive) — preserves bundled logo and `priceProviderID`;
2. a coin built from `/cosmos/bank/v1beta1/denoms_metadata/{denom}` — ticker from the symbol or display, decimals from the matching `denom_units` exponent so non-six-decimal denoms (axlWETH-style) are correct;
3. for `ibc/HASH` vouchers without chain metadata: the trace's `base_denom` plus a metadata lookup for that base denom so decimals stay correct when the chain advertises them;
4. otherwise the denom-derived ticker (factory-subdenom tail, native `u`/`a` unit-prefix strip, IBC short hash) with the Cosmos-default six decimals.

`CosmosApi` gains `getDenomMetadata(denom)`, which URL-encodes the denom, treats 404 as "no entry" at debug level, and returns null on any other failure. Metadata and IBC traces are cached in-memory for 24h — errors are logged but never cached, so a transient LCD blip falls through to the fallback derivation and retries on the next refresh.

Dispatch in `TokenRepository.getTokensWithBalance` is scoped to `Chain.Terra` / `Chain.TerraClassic` so other Cosmos chains stay unchanged. The new finder is bound as a `@Singleton` in `DataUsecasesModule`.

## Tests

* `./gradlew :data:testDebugUnitTest :data:ktfmtCheck :data:lintDebug`
* `./gradlew :app:compileDebugKotlin :app:ktfmtCheckMain`
* `./gradlew :app:testDebugUnitTest --tests "*DepositFormViewModelTest" --tests "*ChainSelectionViewModelTest" --tests "*SwapGasCalculatorTest" --tests "*GasFeeOrchestratorTest" --tests "*AmountFractionManagerTest" --tests "*SaveVaultUseCaseImplTest"`

New tests cover SUPPORTED_CHAINS scope, native-fee-unit filtering, curated preference (case-insensitive), 18-decimal metadata, display fallback for blank symbol, denom-derived tickers (`u`/`a` strip, factory tail), IBC voucher resolution with and without base-denom metadata, IBC trace failure, balance-call failure, metadata + trace caching, and the dispatch boundary in `TokenRepositoryImpl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic token discovery for Terra and Terra Classic with denom metadata resolution, IBC unwrapping, best-effort ticker/decimals, and 24h in-memory caching.

* **Reliability**
  * Safer denom metadata fetching with percent-encoded requests, graceful null returns on failures, and improved error/cancellation handling.

* **Tests**
  * Expanded tests for metadata fetching, encoding, error cases, caching, and token discovery behavior.

* **Chores**
  * Added DI binding to wire the new discovery component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->