### PR TITLE
refactor(viewmodels): drop Context fields to resolve StaticFieldLeak

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -41,6 +41,7 @@ import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.services.VultisigFirebaseMessagingService
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 import com.vultisig.wallet.ui.theme.v2.V2.colors
+import com.vultisig.wallet.ui.utils.SnackbarFlow
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -54,6 +55,8 @@ class MainActivity : AppCompatActivity() {
     @Inject lateinit var appUpdateManager: AppUpdateManager
 
     @Inject lateinit var preventScreenshotsRepository: PreventScreenshotsRepository
+
+    @Inject internal lateinit var snackbarFlow: SnackbarFlow
 
     private val pushNotificationReceiver =
         object : BroadcastReceiver() {
@@ -116,6 +119,7 @@ class MainActivity : AppCompatActivity() {
                     MainActivityContent(
                         navController = navController,
                         mainViewModel = mainViewModel,
+                        snackbarFlow = snackbarFlow,
                         startDestination = screen,
                         onNavigationReady = { isNavigationReady = true },
                     )

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -16,6 +16,7 @@ import com.vultisig.wallet.data.usecases.InitializeThorChainNetworkIdUseCase
 import com.vultisig.wallet.data.usecases.KeysignTransactionSummary
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
+import com.vultisig.wallet.ui.components.v2.snackbar.VSSnackbarState
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigateAction
@@ -87,6 +88,8 @@ constructor(
     val destination: Flow<NavigateAction<Destination>> = navigator.destination
 
     val route: Flow<NavigateAction<Any>> = navigator.route
+
+    val snackbarState: VSSnackbarState = VSSnackbarState(1.seconds, viewModelScope)
 
     init {
         viewModelScope.safeLaunch {

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.app.activity
 
-import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -17,7 +16,6 @@ import com.vultisig.wallet.data.usecases.InitializeThorChainNetworkIdUseCase
 import com.vultisig.wallet.data.usecases.KeysignTransactionSummary
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
-import com.vultisig.wallet.ui.components.v2.snackbar.VSSnackbarState
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigateAction
@@ -25,15 +23,12 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.NetworkUtils
 import com.vultisig.wallet.ui.utils.SnackbarFlow
-import com.vultisig.wallet.ui.utils.asString
+import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,14 +48,13 @@ import timber.log.Timber
 internal data class ForegroundNotificationState(
     val qrCodeData: String,
     val vaultName: String = "",
-    val transactionSummary: String = "",
+    val transactionSummary: UiText = UiText.Empty,
 )
 
 @HiltViewModel
 internal class MainViewModel
 @Inject
 constructor(
-    @param:ApplicationContext private val context: Context,
     private val navigator: Navigator<Destination>,
     private val snackbarFlow: SnackbarFlow,
     private val vaultRepository: VaultRepository,
@@ -94,19 +88,10 @@ constructor(
 
     val route: Flow<NavigateAction<Any>> = navigator.route
 
-    val snakeBarHostState =
-        VSSnackbarState(duration = 1.seconds, coroutineScope = CoroutineScope(Dispatchers.Default))
-
     init {
         viewModelScope.safeLaunch {
             _startDestination.value = resolveStartDestination()
             _isLoading.value = false
-
-            snackbarFlow.collectMessage { (message, type) ->
-                val resolved = message.asString(context)
-                if (resolved.isBlank()) return@collectMessage
-                snakeBarHostState.show(resolved, type)
-            }
         }
 
         viewModelScope.safeLaunch {
@@ -144,20 +129,22 @@ constructor(
             viewModelScope.safeLaunch {
                 val pubKeyEcdsa = DeepLinkHelper(qrCodeData).getParameter("vault")
                 val vault = pubKeyEcdsa?.let { vaultRepository.getByEcdsa(it) }
-                val transactionSummary =
+                val transactionSummary: UiText =
                     when (val summary = getKeysignTransactionSummary(qrCodeData)) {
                         is KeysignTransactionSummary.Swap ->
-                            context.getString(
+                            UiText.FormattedText(
                                 R.string.notification_banner_swap_summary,
-                                mapTokenValueToStringWithUnit(summary.srcTokenValue),
-                                summary.dstTicker,
+                                listOf(
+                                    mapTokenValueToStringWithUnit(summary.srcTokenValue),
+                                    summary.dstTicker,
+                                ),
                             )
                         is KeysignTransactionSummary.Send ->
-                            context.getString(
+                            UiText.FormattedText(
                                 R.string.notification_banner_send_summary,
-                                mapTokenValueToStringWithUnit(summary.tokenValue),
+                                listOf(mapTokenValueToStringWithUnit(summary.tokenValue)),
                             )
-                        null -> ""
+                        null -> UiText.Empty
                     }
                 _foregroundNotification.value =
                     ForegroundNotificationState(
@@ -186,7 +173,7 @@ constructor(
             val vault = pubKeyEcdsa?.let { vaultRepository.getByEcdsa(it) }
             if (vault == null) {
                 snackbarFlow.showMessage(
-                    context.getString(R.string.push_notification_vault_not_found),
+                    UiText.StringResource(R.string.push_notification_vault_not_found),
                     SnackbarType.Error,
                 )
                 return@safeLaunch

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -40,7 +40,6 @@ import com.vultisig.wallet.ui.components.BiometryAuthScreen
 import com.vultisig.wallet.ui.components.banners.ForegroundNotificationBanner
 import com.vultisig.wallet.ui.components.banners.OfflineBanner
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
-import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.navigation.Route
@@ -67,7 +66,7 @@ internal fun MainActivityContent(
     if (foregroundNotification != null) lastNotification = foregroundNotification
 
     val context = LocalContext.current
-    val snackbarState = rememberVsSnackbarState()
+    val snackbarState = mainViewModel.snackbarState
     LaunchedEffect(snackbarFlow) {
         snackbarFlow.collectMessage { (message, type) ->
             val resolved = message.asString(context)

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -39,6 +40,7 @@ import com.vultisig.wallet.ui.components.BiometryAuthScreen
 import com.vultisig.wallet.ui.components.banners.ForegroundNotificationBanner
 import com.vultisig.wallet.ui.components.banners.OfflineBanner
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
+import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.navigation.Route
@@ -46,6 +48,8 @@ import com.vultisig.wallet.ui.navigation.SetupNavGraph
 import com.vultisig.wallet.ui.navigation.route
 import com.vultisig.wallet.ui.screens.home.VaultAccountsScreen
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.SnackbarFlow
+import com.vultisig.wallet.ui.utils.asString
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -54,12 +58,23 @@ import kotlinx.coroutines.launch
 internal fun MainActivityContent(
     navController: NavHostController,
     mainViewModel: MainViewModel,
+    snackbarFlow: SnackbarFlow,
     startDestination: Any,
     onNavigationReady: () -> Unit,
 ) {
     val foregroundNotification by mainViewModel.foregroundNotification.collectAsStateWithLifecycle()
     var lastNotification by remember { mutableStateOf<ForegroundNotificationState?>(null) }
     if (foregroundNotification != null) lastNotification = foregroundNotification
+
+    val context = LocalContext.current
+    val snackbarState = rememberVsSnackbarState()
+    LaunchedEffect(snackbarFlow) {
+        snackbarFlow.collectMessage { (message, type) ->
+            val resolved = message.asString(context)
+            if (resolved.isBlank()) return@collectMessage
+            snackbarState.show(resolved, type)
+        }
+    }
 
     MainActivityContent(
         foregroundNotification = foregroundNotification,
@@ -101,7 +116,7 @@ internal fun MainActivityContent(
 
             VsSnackBar(
                 modifier = Modifier.align(Alignment.BottomCenter),
-                snackbarState = mainViewModel.snakeBarHostState,
+                snackbarState = snackbarState,
             )
         },
     )
@@ -173,7 +188,8 @@ private fun MainActivityContentPreview() {
         ForegroundNotificationState(
             qrCodeData = "preview",
             vaultName = "Main Vault",
-            transactionSummary = "Swap 10 ETH → USDC",
+            transactionSummary =
+                com.vultisig.wallet.ui.utils.UiText.DynamicString("Swap 10 ETH → USDC"),
         )
     MainActivityContent(
         foregroundNotification = notification,

--- a/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
@@ -1,11 +1,9 @@
 package com.vultisig.wallet.data.services
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.google.firebase.messaging.FirebaseMessaging
-import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.DeviceRegistrationRequest
 import com.vultisig.wallet.data.api.DeviceUnregisterRequest
 import com.vultisig.wallet.data.api.NotificationApi
@@ -227,30 +225,4 @@ sealed class PushNotificationError(message: String) : Exception(message) {
 
     class PartialFailure(val successCount: Int, val failureCount: Int) :
         PushNotificationError("Updated $successCount vaults, $failureCount failed")
-}
-
-private fun PushNotificationError.toStringRes(): Int =
-    when (this) {
-        is PushNotificationError.VaultNotFound -> R.string.push_notification_vault_not_found
-        is PushNotificationError.VaultNotSupported ->
-            R.string.push_notification_error_vault_not_supported
-        is PushNotificationError.TokenNotAvailable ->
-            R.string.push_notification_error_token_not_available
-        is PushNotificationError.ApiFailure -> R.string.push_notification_error_api_failure
-        is PushNotificationError.PartialFailure -> R.string.push_notification_error_api_failure
-    }
-
-fun pushNotificationErrorMessage(e: Throwable, context: Context): String {
-    val err = e as? PushNotificationError
-    return if (err is PushNotificationError.PartialFailure) {
-        context.resources.getQuantityString(
-            R.plurals.push_notification_partial_failure,
-            err.failureCount,
-            err.successCount,
-            err.successCount + err.failureCount,
-            err.failureCount,
-        )
-    } else {
-        context.getString(err?.toStringRes() ?: R.string.push_notifications_failed)
-    }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/ShareBitmapUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/ShareBitmapUseCase.kt
@@ -1,0 +1,17 @@
+package com.vultisig.wallet.data.usecases
+
+import android.content.Context
+import android.graphics.Bitmap
+import com.vultisig.wallet.ui.utils.share
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+fun interface ShareBitmapUseCase {
+    operator fun invoke(bitmap: Bitmap, fileName: String)
+}
+
+internal class ShareBitmapUseCaseImpl
+@Inject
+constructor(@param:ApplicationContext private val context: Context) : ShareBitmapUseCase {
+    override fun invoke(bitmap: Bitmap, fileName: String) = context.share(bitmap, fileName)
+}

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
@@ -2,6 +2,8 @@ package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCaseImpl
+import com.vultisig.wallet.ui.usecases.ShareBitmapUseCase
+import com.vultisig.wallet.ui.usecases.ShareBitmapUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
@@ -109,4 +109,6 @@ internal interface UseCasesModule {
     fun bindGetKeysignTransactionSummaryUseCase(
         impl: GetKeysignTransactionSummaryUseCaseImpl
     ): GetKeysignTransactionSummaryUseCase
+
+    @Binds @Singleton fun bindShareBitmapUseCase(impl: ShareBitmapUseCaseImpl): ShareBitmapUseCase
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
@@ -31,6 +31,8 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
@@ -70,10 +72,11 @@ private fun Modifier.bannerBackground(
 internal fun ForegroundNotificationBanner(
     qrCodeData: String,
     vaultName: String,
-    transactionSummary: String,
+    transactionSummary: UiText,
     onTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val summary = transactionSummary.asString()
     val shape = RoundedCornerShape(bottomStart = 40.dp, bottomEnd = 40.dp)
     val imagePainter = painterResource(R.drawable.foreground_layer)
 
@@ -132,9 +135,9 @@ internal fun ForegroundNotificationBanner(
                 UiSpacer(size = 8.dp)
             }
 
-            if (transactionSummary.isNotEmpty()) {
+            if (summary.isNotEmpty()) {
                 Text(
-                    text = transactionSummary,
+                    text = summary,
                     style = Theme.brockmann.supplementary.footnote,
                     color = Theme.v2.colors.text.secondary,
                     textAlign = TextAlign.Center,
@@ -158,7 +161,7 @@ private fun ForegroundNotificationBannerPreview() {
     ForegroundNotificationBanner(
         qrCodeData = "preview",
         vaultName = "Vault #2",
-        transactionSummary = "Swap 10 ETH → USDC",
+        transactionSummary = UiText.DynamicString("Swap 10 ETH → USDC"),
         onTap = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -8,8 +7,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.common.deleteDocument
-import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
@@ -17,9 +14,11 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
 import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
 import com.vultisig.wallet.data.usecases.backup.MimeType
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
 import com.vultisig.wallet.data.usecases.backup.toMimeType
 import com.vultisig.wallet.ui.navigation.BackupType
 import com.vultisig.wallet.ui.navigation.BackupTypeNavType
@@ -32,7 +31,6 @@ import com.vultisig.wallet.ui.screens.backup.PasswordViewModelDelegate
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
@@ -59,7 +57,6 @@ internal class BackupPasswordViewModel
 @Inject
 constructor(
     savedStateHandle: SavedStateHandle,
-    @ApplicationContext private val context: Context,
     private val vaultRepository: VaultRepository,
     private val mapVaultToProto: MapVaultToProto,
     private val createVaultBackupFileName: CreateVaultBackupFileNameUseCase,
@@ -69,6 +66,8 @@ constructor(
     private val navigator: Navigator<Destination>,
     private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val snackbarFlow: SnackbarFlow,
+    private val saveBackupToUri: SaveBackupToUriUseCase,
+    private val deleteBackupDocument: DeleteBackupDocumentUseCase,
 ) : ViewModel() {
 
     private val passwordDelegate = PasswordViewModelDelegate()
@@ -209,7 +208,7 @@ constructor(
         if (!isGranted) {
             viewModelScope.launch {
                 snackbarFlow.showMessage(
-                    context.getString(R.string.backup_password_screen_permission_required)
+                    UiText.StringResource(R.string.backup_password_screen_permission_required)
                 )
 
                 if (vaultId != null) {
@@ -243,7 +242,7 @@ constructor(
                     }
                 completeBackupVault(isSuccess)
             } else {
-                context.deleteDocument(uri)
+                deleteBackupDocument(uri)
 
                 state.update {
                     it.copy(
@@ -273,7 +272,7 @@ constructor(
             return false
         }
 
-        return context.saveContentToUri(uri, backup)
+        return saveBackupToUri(uri, backup)
     }
 
     private suspend fun backupAllVaults(password: String, uri: Uri): Boolean {
@@ -288,7 +287,7 @@ constructor(
                 }
             } ?: return false
 
-        return context.saveContentToUri(uri, content)
+        return saveBackupToUri(uri, content)
     }
 
     private fun completeBackupVault(backupSuccess: Boolean) {
@@ -316,7 +315,7 @@ constructor(
                 }
 
                 snackbarFlow.showMessage(
-                    context.getString(R.string.vault_settings_success_backup_message)
+                    UiText.StringResource(R.string.vault_settings_success_backup_message)
                 )
                 if (backupType is BackupType.CurrentVault && backupType.vaultType != null) {
                     navigator.route(
@@ -341,6 +340,6 @@ constructor(
     }
 
     private suspend fun showError() {
-        snackbarFlow.showMessage(context.getString(R.string.vault_settings_error_backup_file))
+        snackbarFlow.showMessage(UiText.StringResource(R.string.vault_settings_error_backup_file))
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -24,7 +24,7 @@ import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
-import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
@@ -72,7 +72,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val snackBarFlow: SnackbarFlow,
-    private val vaultFileReader: VaultFileReaderUseCase,
+    private val uriFileReader: UriFileReaderUseCase,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -280,7 +280,7 @@ constructor(
     fun saveFileToAppDir() {
         val uri = uiModel.value.fileUri ?: return
         viewModelScope.launch {
-            val fileContent = vaultFileReader.readContent(uri)
+            val fileContent = uriFileReader.readContent(uri)
             if (fileContent == null) {
                 uiModel.update {
                     it.copy(
@@ -301,12 +301,12 @@ constructor(
     fun fetchFileName(uri: Uri?) {
         uri ?: return
         viewModelScope.launch {
-            val fileName = vaultFileReader.readName(uri)?.takeUnless { it.isBlank() }
+            val fileName = uriFileReader.readName(uri)?.takeUnless { it.isBlank() }
             if (fileName == null) {
                 resetPickerWithError()
                 return@launch
             }
-            val isZip = vaultFileReader.isValidZip(uri)
+            val isZip = uriFileReader.isValidZip(uri)
             val hasAllowedExtension = File(fileName).extension in FILE_ALLOWED_EXTENSIONS
             when {
                 !isZip && !hasAllowedExtension -> resetPickerWithError()
@@ -329,7 +329,7 @@ constructor(
     }
 
     private suspend fun acceptZip(uri: Uri, fileName: String) {
-        val entries = vaultFileReader.extractZipEntries(uri)
+        val entries = uriFileReader.extractZipEntries(uri)
         uiModel.update {
             it.copy(
                 fileUri = uri,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
 import androidx.annotation.StringRes
@@ -13,10 +12,6 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.DefaultDispatcher
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.common.fileContent
-import com.vultisig.wallet.data.common.fileName
-import com.vultisig.wallet.data.common.isValidZipFile
-import com.vultisig.wallet.data.common.processZip
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
@@ -29,6 +24,7 @@ import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
+import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
@@ -38,7 +34,6 @@ import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
@@ -71,13 +66,13 @@ internal class ImportFileViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
-    @param:ApplicationContext private val context: Context,
     private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val saveVault: SaveVaultUseCase,
     private val parseVaultFromString: ParseVaultFromStringUseCase,
     private val vaultRepository: VaultRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val snackBarFlow: SnackbarFlow,
+    private val vaultFileReader: VaultFileReaderUseCase,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -152,11 +147,11 @@ constructor(
 
     private fun showSuccessImport() =
         showSnackBarMessage(
-            message = context.getString(R.string.import_file_screen_success_import),
+            message = UiText.StringResource(R.string.import_file_screen_success_import),
             type = SnackbarType.Success,
         )
 
-    private fun showSnackBarMessage(message: String, type: SnackbarType) {
+    private fun showSnackBarMessage(message: UiText, type: SnackbarType) {
         viewModelScope.launch { snackBarFlow.showMessage(message = message, type = type) }
     }
 
@@ -178,7 +173,7 @@ constructor(
             // The archive itself stays usable (fileName/fileUri preserved); only the bad
             // entry is pruned from zipOutputs and its content cleared, so the user can pick
             // another share from the same zip.
-            showSnackBarMessage(context.getString(resId), SnackbarType.Error)
+            showSnackBarMessage(UiText.StringResource(resId), SnackbarType.Error)
             if (policy == FailurePolicy.DropFile) {
                 val badContent = state.fileContent
                 uiModel.update {
@@ -285,7 +280,7 @@ constructor(
     fun saveFileToAppDir() {
         val uri = uiModel.value.fileUri ?: return
         viewModelScope.launch {
-            val fileContent = uri.fileContent(context)
+            val fileContent = vaultFileReader.readContent(uri)
             if (fileContent == null) {
                 uiModel.update {
                     it.copy(
@@ -306,12 +301,12 @@ constructor(
     fun fetchFileName(uri: Uri?) {
         uri ?: return
         viewModelScope.launch {
-            val fileName = uri.fileName(context)?.takeUnless { it.isBlank() }
+            val fileName = vaultFileReader.readName(uri)?.takeUnless { it.isBlank() }
             if (fileName == null) {
                 resetPickerWithError()
                 return@launch
             }
-            val isZip = uri.isValidZipFile(context)
+            val isZip = vaultFileReader.isValidZip(uri)
             val hasAllowedExtension = File(fileName).extension in FILE_ALLOWED_EXTENSIONS
             when {
                 !isZip && !hasAllowedExtension -> resetPickerWithError()
@@ -334,7 +329,7 @@ constructor(
     }
 
     private suspend fun acceptZip(uri: Uri, fileName: String) {
-        val entries = uri.processZip(context)
+        val entries = vaultFileReader.extractZipEntries(uri)
         uiModel.update {
             it.copy(
                 fileUri = uri,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenAddressQrViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenAddressQrViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
@@ -8,20 +7,18 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.vultisig.wallet.R
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GenerateAccountQrUseCase
 import com.vultisig.wallet.data.usecases.QrBitmapData
+import com.vultisig.wallet.data.usecases.ShareBitmapUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.utils.ShareType
 import com.vultisig.wallet.ui.utils.SnackbarFlow
-import com.vultisig.wallet.ui.utils.share
 import com.vultisig.wallet.ui.utils.shareFileName
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,7 +42,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val navigator: Navigator<Destination>,
     private val snackbarFlow: SnackbarFlow,
-    @param:ApplicationContext private val context: Context,
+    private val shareBitmap: ShareBitmapUseCase,
 ) : ViewModel() {
     val args = savedStateHandle.toRoute<Route.AddressQr>()
     val uiState = MutableStateFlow(TokenAddressQr())
@@ -64,7 +61,7 @@ constructor(
         }
     }
 
-    fun shareQRCode(graphicsLayer: GraphicsLayer, context: Context) {
+    fun shareQRCode(graphicsLayer: GraphicsLayer) {
         viewModelScope.launch {
             try {
                 val bitmap =
@@ -73,7 +70,7 @@ constructor(
                     }
                 try {
                     withContext(Dispatchers.Main) {
-                        context.share(
+                        shareBitmap(
                             bitmap = bitmap,
                             fileName =
                                 shareFileName(
@@ -94,15 +91,10 @@ constructor(
         }
     }
 
-    fun copy() {
+    fun copy(addressCopiedMessage: String) {
         viewModelScope.launch {
             back()
-            snackbarFlow.showMessage(
-                context.getString(
-                    R.string.chain_token_screen_address_copied,
-                    uiState.value.chainName,
-                )
-            )
+            snackbarFlow.showMessage(addressCopiedMessage)
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenAddressQrViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenAddressQrViewModel.kt
@@ -10,11 +10,11 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GenerateAccountQrUseCase
 import com.vultisig.wallet.data.usecases.QrBitmapData
-import com.vultisig.wallet.data.usecases.ShareBitmapUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
+import com.vultisig.wallet.ui.usecases.ShareBitmapUseCase
 import com.vultisig.wallet.ui.utils.ShareType
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.shareFileName
@@ -63,22 +63,22 @@ constructor(
 
     fun shareQRCode(graphicsLayer: GraphicsLayer) {
         viewModelScope.launch {
+            var shared = false
             try {
                 val bitmap =
                     withContext(Dispatchers.Default) {
                         graphicsLayer.toImageBitmap().asAndroidBitmap()
                     }
                 try {
-                    withContext(Dispatchers.Main) {
-                        shareBitmap(
-                            bitmap = bitmap,
-                            fileName =
-                                shareFileName(
-                                    requireNotNull(vaultRepository.get(args.vaultId)),
-                                    ShareType.TOKENADDRESS,
-                                ),
-                        )
-                    }
+                    shareBitmap(
+                        bitmap = bitmap,
+                        fileName =
+                            shareFileName(
+                                requireNotNull(vaultRepository.get(args.vaultId)),
+                                ShareType.TOKENADDRESS,
+                            ),
+                    )
+                    shared = true
                 } finally {
                     bitmap.recycle()
                 }
@@ -87,7 +87,7 @@ constructor(
                 Timber.e(e, "Failed to capture and share qr address screenshot")
             }
 
-            back()
+            if (shared) back()
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Immutable
@@ -34,7 +33,6 @@ import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
-import com.vultisig.wallet.data.services.pushNotificationErrorMessage
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.IsGlobalBackupReminderRequiredUseCase
 import com.vultisig.wallet.data.usecases.NeverShowGlobalBackupReminderUseCase
@@ -48,9 +46,9 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.VaultIntroItem
 import com.vultisig.wallet.ui.utils.SnackbarFlow
+import com.vultisig.wallet.ui.utils.pushNotificationErrorUiText
 import com.vultisig.wallet.ui.utils.textAsFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -123,7 +121,6 @@ internal data class AccountUiModel(
 internal class VaultAccountsViewModel
 @Inject
 constructor(
-    @param:ApplicationContext private val context: Context,
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
     private val requestResultRepository: RequestResultRepository,
@@ -689,10 +686,7 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.w(e, "Failed to opt in vaults for notifications")
-                snackbarFlow.showMessage(
-                    pushNotificationErrorMessage(e, context),
-                    SnackbarType.Error,
-                )
+                snackbarFlow.showMessage(pushNotificationErrorUiText(e), SnackbarType.Error)
             }
         ) {
             pushNotificationManager.setVaultsOptIn(vaultsToOptIn.map { it.vaultId to it.isEnabled })

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.lifecycle.SavedStateHandle
@@ -11,7 +10,7 @@ import com.vultisig.wallet.data.models.getVaultPart
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Route
-import com.vultisig.wallet.ui.utils.share
+import com.vultisig.wallet.ui.usecases.ShareBitmapUseCase
 import com.vultisig.wallet.ui.utils.shareVaultDetailName
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -37,8 +36,11 @@ internal data class DeviceMeta(val name: String, val isThisDevice: Boolean)
 @HiltViewModel
 internal class VaultDetailViewModel
 @Inject
-constructor(savedStateHandle: SavedStateHandle, private val vaultRepository: VaultRepository) :
-    ViewModel() {
+constructor(
+    savedStateHandle: SavedStateHandle,
+    private val vaultRepository: VaultRepository,
+    private val shareBitmap: ShareBitmapUseCase,
+) : ViewModel() {
 
     private val vaultId: String = savedStateHandle.toRoute<Route.Details>().vaultId
 
@@ -66,7 +68,7 @@ constructor(savedStateHandle: SavedStateHandle, private val vaultRepository: Vau
         }
     }
 
-    fun takeScreenShot(graphicsLayer: GraphicsLayer, context: Context) {
+    fun takeScreenShot(graphicsLayer: GraphicsLayer) {
         viewModelScope.launch {
             try {
                 val bitmap =
@@ -74,16 +76,14 @@ constructor(savedStateHandle: SavedStateHandle, private val vaultRepository: Vau
                         graphicsLayer.toImageBitmap().asAndroidBitmap()
                     }
                 try {
-                    withContext(Dispatchers.Main) {
-                        context.share(
-                            bitmap = bitmap,
-                            fileName =
-                                shareVaultDetailName(
-                                    vaultName = uiModel.value.name,
-                                    vaultPart = uiModel.value.vaultPart,
-                                ),
-                        )
-                    }
+                    shareBitmap(
+                        bitmap = bitmap,
+                        fileName =
+                            shareVaultDetailName(
+                                vaultName = uiModel.value.name,
+                                vaultPart = uiModel.value.vaultPart,
+                            ),
+                    )
                 } finally {
                     bitmap.recycle()
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
@@ -1,14 +1,11 @@
 package com.vultisig.wallet.ui.models.keygen
 
-import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.common.deleteDocument
-import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.models.Vault
@@ -17,8 +14,10 @@ import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
 import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
 import com.vultisig.wallet.data.usecases.backup.toMimeType
 import com.vultisig.wallet.ui.navigation.BackupPasswordTypeNavType
 import com.vultisig.wallet.ui.navigation.BackupType
@@ -30,9 +29,7 @@ import com.vultisig.wallet.ui.navigation.Route.BackupVault.BackupPasswordType
 import com.vultisig.wallet.ui.navigation.Route.VaultInfo
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.UiText
-import com.vultisig.wallet.ui.utils.asString
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
@@ -49,7 +46,6 @@ internal class BackupVaultViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
-    @param:ApplicationContext private val context: Context,
     private val vaultRepository: VaultRepository,
     private val createVaultBackupFileName: CreateVaultBackupFileNameUseCase,
     private val isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase,
@@ -57,6 +53,8 @@ constructor(
     private val mapVaultToProto: MapVaultToProto,
     private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val snackbarFlow: SnackbarFlow,
+    private val saveBackupToUri: SaveBackupToUriUseCase,
+    private val deleteBackupDocument: DeleteBackupDocumentUseCase,
 ) : ViewModel() {
 
     private val args =
@@ -139,7 +137,7 @@ constructor(
                 val isSuccess = backupCurrentVault(password, uri)
                 completeBackupVault(isSuccess)
             } else {
-                context.deleteDocument(uri)
+                deleteBackupDocument(uri)
                 showError(
                     UiText.FormattedText(
                         R.string.vault_settings_error_extension_backup_file,
@@ -169,11 +167,11 @@ constructor(
             return false
         }
 
-        return context.saveContentToUri(uri, backup)
+        return saveBackupToUri(uri, backup)
     }
 
     private suspend fun showError(message: UiText) {
-        snackbarFlow.showMessage(message.asString(context))
+        snackbarFlow.showMessage(message)
     }
 
     private fun completeBackupVault(backupSuccess: Boolean) {
@@ -196,7 +194,7 @@ constructor(
                 }
 
                 snackbarFlow.showMessage(
-                    context.getString(R.string.vault_settings_success_backup_message)
+                    UiText.StringResource(R.string.vault_settings_success_backup_message)
                 )
 
                 when (backupType.action) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModel.kt
@@ -1,21 +1,19 @@
 package com.vultisig.wallet.ui.models.settings
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.data.models.isFastVault
 import com.vultisig.wallet.data.models.isSecureVault
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.services.PushNotificationManager
-import com.vultisig.wallet.data.services.pushNotificationErrorMessage
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.utils.SnackbarFlow
+import com.vultisig.wallet.ui.utils.pushNotificationErrorUiText
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
@@ -43,7 +41,6 @@ internal data class NotificationsSettingsUiState(
 internal class NotificationsSettingsViewModel
 @Inject
 constructor(
-    @param:ApplicationContext private val context: Context,
     private val navigator: Navigator<Destination>,
     private val vaultRepository: VaultRepository,
     private val pushNotificationManager: PushNotificationManager,
@@ -89,10 +86,7 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.w(e, "Failed to opt out all vaults from notifications")
-                snackbarFlow.showMessage(
-                    pushNotificationErrorMessage(e, context),
-                    SnackbarType.Error,
-                )
+                snackbarFlow.showMessage(pushNotificationErrorUiText(e), SnackbarType.Error)
             }
         ) {
             if (enabled) {
@@ -108,10 +102,7 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.w(e, "Failed to opt out vault $vaultId from notifications")
-                snackbarFlow.showMessage(
-                    pushNotificationErrorMessage(e, context),
-                    SnackbarType.Error,
-                )
+                snackbarFlow.showMessage(pushNotificationErrorUiText(e), SnackbarType.Error)
             }
         ) {
             if (enabled) {
@@ -128,10 +119,7 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.w(e, "Failed to opt in vault(s) for notifications")
-                snackbarFlow.showMessage(
-                    pushNotificationErrorMessage(e, context),
-                    SnackbarType.Error,
-                )
+                snackbarFlow.showMessage(pushNotificationErrorUiText(e), SnackbarType.Error)
             }
         ) {
             when (val pending = pendingAction.getAndSet(PendingAction.AllVaults)) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,13 +52,12 @@ internal fun VaultDetailScreen(
     val state by model.uiModel.collectAsState()
     val snackbarState = rememberVsSnackbarState()
     val graphicsLayer = rememberGraphicsLayer()
-    val context = LocalContext.current
 
     VaultDetailScreen(
         state = state,
         snackBarState = snackbarState,
         graphicsLayer = graphicsLayer,
-        onShareClick = { model.takeScreenShot(graphicsLayer = graphicsLayer, context = context) },
+        onShareClick = { model.takeScreenShot(graphicsLayer = graphicsLayer) },
         onBackClick = { navHostController.popBackStack() },
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
@@ -1,15 +1,12 @@
 package com.vultisig.wallet.ui.screens.backup
 
-import android.content.Context
 import android.net.Uri
-import android.provider.DocumentsContract
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.common.saveContentToUri
 import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
@@ -17,10 +14,12 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
 import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
 import com.vultisig.wallet.data.usecases.backup.MimeType
 import com.vultisig.wallet.data.usecases.backup.MimeType.*
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
 import com.vultisig.wallet.data.usecases.backup.toMimeType
 import com.vultisig.wallet.ui.navigation.BackupType
 import com.vultisig.wallet.ui.navigation.BackupTypeNavType
@@ -31,7 +30,6 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
@@ -59,7 +57,6 @@ internal class BackupPasswordRequestViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
-    @ApplicationContext private val context: Context,
     private val snackbarFlow: SnackbarFlow,
     private val createVaultBackupFileName: CreateVaultBackupFileNameUseCase,
     private val createZipVaultsBackupFileName: CreateZipVaultBackupFileNameUseCase,
@@ -68,6 +65,8 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val mapVaultToProto: MapVaultToProto,
+    private val saveBackupToUri: SaveBackupToUriUseCase,
+    private val deleteBackupDocument: DeleteBackupDocumentUseCase,
 ) : ViewModel() {
 
     private val args =
@@ -109,7 +108,7 @@ constructor(
         if (!isGranted) {
             viewModelScope.launch {
                 snackbarFlow.showMessage(
-                    context.getString(R.string.backup_password_screen_permission_required)
+                    UiText.StringResource(R.string.backup_password_screen_permission_required)
                 )
                 navigator.route(
                     Route.VaultSettings(vaultId),
@@ -125,7 +124,7 @@ constructor(
                 val isSuccess = backup(uri)
                 completeBackupVault(isSuccess)
             } else {
-                DocumentsContract.deleteDocument(context.contentResolver, uri)
+                deleteBackupDocument(uri)
 
                 state.update {
                     it.copy(
@@ -160,7 +159,7 @@ constructor(
             withContext(Dispatchers.Default) { createVaultBackup(mapVaultToProto(vault), null) }
                 ?: return false
 
-        return context.saveContentToUri(uri, vaultBackupData)
+        return saveBackupToUri(uri, vaultBackupData)
     }
 
     private suspend fun backupAllVaults(uri: Uri): Boolean {
@@ -174,7 +173,7 @@ constructor(
                 }
             } ?: return false
 
-        return context.saveContentToUri(uri, content)
+        return saveBackupToUri(uri, content)
     }
 
     private fun completeBackupVault(backupSuccess: Boolean) {
@@ -183,7 +182,7 @@ constructor(
                 updateBackupStatus()
 
                 snackbarFlow.showMessage(
-                    context.getString(R.string.vault_settings_success_backup_message)
+                    UiText.StringResource(R.string.vault_settings_success_backup_message)
                 )
 
                 if (backupType is BackupType.CurrentVault && backupType.vaultType != null) {
@@ -199,7 +198,7 @@ constructor(
                 }
             } else {
                 snackbarFlow.showMessage(
-                    context.getString(R.string.vault_settings_error_backup_file)
+                    UiText.StringResource(R.string.vault_settings_error_backup_file)
                 )
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/bottomsheets/TokenAddressQrBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/bottomsheets/TokenAddressQrBottomSheet.kt
@@ -39,6 +39,8 @@ internal fun TokenAddressQrBottomSheet(viewModel: TokenAddressQrViewModel = hilt
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     val graphicsLayer = rememberGraphicsLayer()
+    val addressCopiedMessage =
+        stringResource(R.string.chain_token_screen_address_copied, uiState.chainName)
 
     TokenAddressQrBottomSheet(
         chainName = uiState.chainName,
@@ -47,12 +49,10 @@ internal fun TokenAddressQrBottomSheet(viewModel: TokenAddressQrViewModel = hilt
         graphicsLayer = graphicsLayer,
         onDismiss = viewModel::back,
         onBottomSheetExpanded = viewModel::loadData,
-        onShareQrClick = {
-            viewModel.shareQRCode(graphicsLayer = graphicsLayer, context = context)
-        },
+        onShareQrClick = { viewModel.shareQRCode(graphicsLayer = graphicsLayer) },
         onCopyAddressClick = {
             VsClipboardService.copy(context, uiState.chainAddress)
-            viewModel.copy()
+            viewModel.copy(addressCopiedMessage)
         },
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/usecases/ShareBitmapUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/usecases/ShareBitmapUseCase.kt
@@ -1,17 +1,20 @@
-package com.vultisig.wallet.data.usecases
+package com.vultisig.wallet.ui.usecases
 
 import android.content.Context
 import android.graphics.Bitmap
 import com.vultisig.wallet.ui.utils.share
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 fun interface ShareBitmapUseCase {
-    operator fun invoke(bitmap: Bitmap, fileName: String)
+    suspend operator fun invoke(bitmap: Bitmap, fileName: String)
 }
 
 internal class ShareBitmapUseCaseImpl
 @Inject
 constructor(@param:ApplicationContext private val context: Context) : ShareBitmapUseCase {
-    override fun invoke(bitmap: Bitmap, fileName: String) = context.share(bitmap, fileName)
+    override suspend fun invoke(bitmap: Bitmap, fileName: String) =
+        withContext(Dispatchers.IO) { context.share(bitmap, fileName) }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/PushNotificationErrorText.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/PushNotificationErrorText.kt
@@ -1,0 +1,29 @@
+package com.vultisig.wallet.ui.utils
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.services.PushNotificationError
+
+internal fun pushNotificationErrorUiText(e: Throwable): UiText {
+    val err = e as? PushNotificationError
+    return if (err is PushNotificationError.PartialFailure) {
+        UiText.PluralText(
+            resId = R.plurals.push_notification_partial_failure,
+            quantity = err.failureCount,
+            formatArgs =
+                listOf(err.successCount, err.successCount + err.failureCount, err.failureCount),
+        )
+    } else {
+        UiText.StringResource(err?.toStringRes() ?: R.string.push_notifications_failed)
+    }
+}
+
+private fun PushNotificationError.toStringRes(): Int =
+    when (this) {
+        is PushNotificationError.VaultNotFound -> R.string.push_notification_vault_not_found
+        is PushNotificationError.VaultNotSupported ->
+            R.string.push_notification_error_vault_not_supported
+        is PushNotificationError.TokenNotAvailable ->
+            R.string.push_notification_error_token_not_available
+        is PushNotificationError.ApiFailure -> R.string.push_notification_error_api_failure
+        is PushNotificationError.PartialFailure -> R.string.push_notification_error_api_failure
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/ShareUtils.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/ShareUtils.kt
@@ -47,9 +47,10 @@ fun Context.share(bitmap: Bitmap, fileName: String) {
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             shareIntent.setDataAndType(contentUri, contentResolver.getType(contentUri))
             shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri)
-            startActivity(
+            val chooser =
                 Intent.createChooser(shareIntent, getString(R.string.share_qr_utils_choose_an_app))
-            )
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(chooser)
         }
     } catch (e: IOException) {
         e.printStackTrace()

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/SnackbarFlow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/SnackbarFlow.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 @Singleton
 internal class SnackbarFlow @Inject constructor() {
 
-    private val messageFlow = Channel<Pair<UiText, SnackbarType>>()
+    private val messageFlow = Channel<Pair<UiText, SnackbarType>>(capacity = Channel.BUFFERED)
 
     suspend fun showMessage(message: String, type: SnackbarType = SnackbarType.Success) {
         showMessage(message.asUiText(), type)

--- a/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/activity/MainViewModelTest.kt
@@ -2,7 +2,6 @@
 
 package com.vultisig.wallet.app.activity
 
-import android.content.Context
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GetDirectionByQrCodeUseCase
@@ -41,7 +40,6 @@ internal class MainViewModelTest {
 
     private val dispatcher = StandardTestDispatcher()
 
-    private val context: Context = mockk(relaxed = true)
     private val navigator: Navigator<Destination> = mockk(relaxed = true)
     private val snackbarFlow: SnackbarFlow = mockk(relaxed = true)
     private val vaultRepository: VaultRepository = mockk(relaxed = true)
@@ -68,7 +66,6 @@ internal class MainViewModelTest {
 
     private fun createViewModel() =
         MainViewModel(
-            context = context,
             navigator = navigator,
             snackbarFlow = snackbarFlow,
             vaultRepository = vaultRepository,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.models
 
-import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -8,7 +7,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.common.fileContent
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
@@ -21,6 +19,7 @@ import com.vultisig.wallet.data.usecases.MalformedVaultException
 import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
+import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -55,13 +54,13 @@ internal class ImportFileViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var navigator: Navigator<Destination>
-    private lateinit var context: Context
     private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var saveVault: SaveVaultUseCase
     private lateinit var parseVaultFromString: ParseVaultFromStringUseCase
     private lateinit var vaultRepository: VaultRepository
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var snackbarFlow: SnackbarFlow
+    private lateinit var vaultFileReader: VaultFileReaderUseCase
 
     @BeforeEach
     fun setUp() {
@@ -69,18 +68,17 @@ internal class ImportFileViewModelTest {
         mockkStatic("androidx.navigation.SavedStateHandleKt")
         every { any<SavedStateHandle>().toRoute<Route.ImportVault>() } returns Route.ImportVault()
         navigator = mockk(relaxed = true)
-        context = mockk(relaxed = true)
         vaultDataStoreRepository = mockk(relaxed = true)
         saveVault = mockk(relaxed = true)
         parseVaultFromString = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
         chainAccountAddressRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
+        vaultFileReader = mockk(relaxed = true)
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
         unmockkStatic("androidx.navigation.SavedStateHandleKt")
         Dispatchers.resetMain()
     }
@@ -97,13 +95,13 @@ internal class ImportFileViewModelTest {
             ImportFileViewModel(
                 savedStateHandle = savedStateHandle,
                 navigator = navigator,
-                context = context,
                 vaultDataStoreRepository = vaultDataStoreRepository,
                 saveVault = saveVault,
                 parseVaultFromString = parseVaultFromString,
                 vaultRepository = vaultRepository,
                 chainAccountAddressRepository = chainAccountAddressRepository,
                 snackBarFlow = snackbarFlow,
+                vaultFileReader = vaultFileReader,
                 defaultDispatcher = testDispatcher,
             )
         vm.uiModel.value =
@@ -345,8 +343,8 @@ internal class ImportFileViewModelTest {
     fun `parseFileContent on WrongPassword opens password prompt and clears stale hint`() =
         runTest {
             val uri = mockk<Uri>()
-            mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-            coEvery { uri.fileContent(context) } returns "encrypted-file-content"
+
+            coEvery { vaultFileReader.readContent(uri) } returns "encrypted-file-content"
             // Encrypted new-format without password → parser throws WrongPasswordException.
             coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
 
@@ -364,8 +362,8 @@ internal class ImportFileViewModelTest {
     fun `parseFileContent on Malformed shows unsupported-file error and does not open prompt`() =
         runTest {
             val uri = mockk<Uri>()
-            mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-            coEvery { uri.fileContent(context) } returns "garbage"
+
+            coEvery { vaultFileReader.readContent(uri) } returns "garbage"
             coEvery { parseVaultFromString(any(), null) } throws MalformedVaultException()
 
             val vm = createViewModel(fileContent = null, isZip = false, fileName = "vault.bak")
@@ -383,8 +381,8 @@ internal class ImportFileViewModelTest {
     @Test
     fun `parseFileContent on Success imports without prompting for a password`() = runTest {
         val uri = mockk<Uri>()
-        mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-        coEvery { uri.fileContent(context) } returns "unencrypted-valid"
+
+        coEvery { vaultFileReader.readContent(uri) } returns "unencrypted-valid"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
 
         val vm = createViewModel(fileContent = null, isZip = false, fileName = "vault.bak")
@@ -401,8 +399,8 @@ internal class ImportFileViewModelTest {
     @Test
     fun `parseFileContent on Duplicate closes any prompt and shows duplicate error`() = runTest {
         val uri = mockk<Uri>()
-        mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-        coEvery { uri.fileContent(context) } returns "unencrypted-duplicate"
+
+        coEvery { vaultFileReader.readContent(uri) } returns "unencrypted-duplicate"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
         coEvery { saveVault(any(), false) } throws DuplicateVaultException()
 
@@ -428,8 +426,8 @@ internal class ImportFileViewModelTest {
         // would pop a password prompt and confuse the user into typing a password
         // for a vault that's already decoded.
         val uri = mockk<Uri>()
-        mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-        coEvery { uri.fileContent(context) } returns "valid-unencrypted"
+
+        coEvery { vaultFileReader.readContent(uri) } returns "valid-unencrypted"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
         coEvery { saveVault(any(), false) } throws RuntimeException("db locked")
 
@@ -529,8 +527,8 @@ internal class ImportFileViewModelTest {
     @Test
     fun `saveFileToAppDir shows error state on SQLite constraint`() = runTest {
         val uri = mockk<Uri>()
-        mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-        coEvery { uri.fileContent(context) } returns "test-content"
+
+        coEvery { vaultFileReader.readContent(uri) } returns "test-content"
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
         coEvery { saveVault(any(), false) } throws SQLiteConstraintException()
 
@@ -588,8 +586,8 @@ internal class ImportFileViewModelTest {
     @Test
     fun `saveFileToAppDir surfaces unsupported error when fileContent returns null`() = runTest {
         val uri = mockk<Uri>()
-        mockkStatic("com.vultisig.wallet.data.common.FileHelperKt")
-        coEvery { uri.fileContent(context) } returns null
+
+        coEvery { vaultFileReader.readContent(uri) } returns null
 
         val vm = createViewModel(fileContent = null)
         vm.uiModel.value =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -19,7 +19,7 @@ import com.vultisig.wallet.data.usecases.MalformedVaultException
 import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
-import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -60,7 +60,7 @@ internal class ImportFileViewModelTest {
     private lateinit var vaultRepository: VaultRepository
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var snackbarFlow: SnackbarFlow
-    private lateinit var vaultFileReader: VaultFileReaderUseCase
+    private lateinit var uriFileReader: UriFileReaderUseCase
 
     @BeforeEach
     fun setUp() {
@@ -74,7 +74,7 @@ internal class ImportFileViewModelTest {
         vaultRepository = mockk(relaxed = true)
         chainAccountAddressRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
-        vaultFileReader = mockk(relaxed = true)
+        uriFileReader = mockk(relaxed = true)
     }
 
     @AfterEach
@@ -101,7 +101,7 @@ internal class ImportFileViewModelTest {
                 vaultRepository = vaultRepository,
                 chainAccountAddressRepository = chainAccountAddressRepository,
                 snackBarFlow = snackbarFlow,
-                vaultFileReader = vaultFileReader,
+                uriFileReader = uriFileReader,
                 defaultDispatcher = testDispatcher,
             )
         vm.uiModel.value =
@@ -344,7 +344,7 @@ internal class ImportFileViewModelTest {
         runTest {
             val uri = mockk<Uri>()
 
-            coEvery { vaultFileReader.readContent(uri) } returns "encrypted-file-content"
+            coEvery { uriFileReader.readContent(uri) } returns "encrypted-file-content"
             // Encrypted new-format without password → parser throws WrongPasswordException.
             coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
 
@@ -363,7 +363,7 @@ internal class ImportFileViewModelTest {
         runTest {
             val uri = mockk<Uri>()
 
-            coEvery { vaultFileReader.readContent(uri) } returns "garbage"
+            coEvery { uriFileReader.readContent(uri) } returns "garbage"
             coEvery { parseVaultFromString(any(), null) } throws MalformedVaultException()
 
             val vm = createViewModel(fileContent = null, isZip = false, fileName = "vault.bak")
@@ -382,7 +382,7 @@ internal class ImportFileViewModelTest {
     fun `parseFileContent on Success imports without prompting for a password`() = runTest {
         val uri = mockk<Uri>()
 
-        coEvery { vaultFileReader.readContent(uri) } returns "unencrypted-valid"
+        coEvery { uriFileReader.readContent(uri) } returns "unencrypted-valid"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
 
         val vm = createViewModel(fileContent = null, isZip = false, fileName = "vault.bak")
@@ -400,7 +400,7 @@ internal class ImportFileViewModelTest {
     fun `parseFileContent on Duplicate closes any prompt and shows duplicate error`() = runTest {
         val uri = mockk<Uri>()
 
-        coEvery { vaultFileReader.readContent(uri) } returns "unencrypted-duplicate"
+        coEvery { uriFileReader.readContent(uri) } returns "unencrypted-duplicate"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
         coEvery { saveVault(any(), false) } throws DuplicateVaultException()
 
@@ -427,7 +427,7 @@ internal class ImportFileViewModelTest {
         // for a vault that's already decoded.
         val uri = mockk<Uri>()
 
-        coEvery { vaultFileReader.readContent(uri) } returns "valid-unencrypted"
+        coEvery { uriFileReader.readContent(uri) } returns "valid-unencrypted"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
         coEvery { saveVault(any(), false) } throws RuntimeException("db locked")
 
@@ -528,7 +528,7 @@ internal class ImportFileViewModelTest {
     fun `saveFileToAppDir shows error state on SQLite constraint`() = runTest {
         val uri = mockk<Uri>()
 
-        coEvery { vaultFileReader.readContent(uri) } returns "test-content"
+        coEvery { uriFileReader.readContent(uri) } returns "test-content"
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
         coEvery { saveVault(any(), false) } throws SQLiteConstraintException()
 
@@ -587,7 +587,7 @@ internal class ImportFileViewModelTest {
     fun `saveFileToAppDir surfaces unsupported error when fileContent returns null`() = runTest {
         val uri = mockk<Uri>()
 
-        coEvery { vaultFileReader.readContent(uri) } returns null
+        coEvery { uriFileReader.readContent(uri) } returns null
 
         val vm = createViewModel(fileContent = null)
         vm.uiModel.value =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -2,7 +2,6 @@
 
 package com.vultisig.wallet.ui.models.home
 
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.blockchain.TierRemoteNFTService
@@ -72,7 +71,6 @@ internal class VaultAccountsViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private lateinit var context: Context
     private lateinit var navigator: Navigator<Destination>
     private lateinit var requestResultRepository: RequestResultRepository
     private lateinit var addressToUiModelMapper: AddressToUiModelMapper
@@ -99,7 +97,6 @@ internal class VaultAccountsViewModelTest {
         Dispatchers.setMain(testDispatcher)
         mockkStatic("androidx.navigation.SavedStateHandleKt")
         every { any<SavedStateHandle>().toRoute<Route.Home>() } returns Route.Home()
-        context = mockk(relaxed = true)
         navigator = mockk(relaxed = true)
         requestResultRepository = mockk(relaxed = true)
         addressToUiModelMapper = mockk(relaxed = true)
@@ -138,7 +135,6 @@ internal class VaultAccountsViewModelTest {
 
     private fun createViewModel() =
         VaultAccountsViewModel(
-            context = context,
             savedStateHandle = SavedStateHandle(),
             navigator = navigator,
             requestResultRepository = requestResultRepository,

--- a/app/src/test/java/com/vultisig/wallet/ui/utils/PushNotificationErrorTextTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/utils/PushNotificationErrorTextTest.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.ui.utils
 
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.services.PushNotificationError
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 
 internal class PushNotificationErrorTextTest {
@@ -15,34 +15,34 @@ internal class PushNotificationErrorTextTest {
                 PushNotificationError.PartialFailure(successCount = 2, failureCount = 3)
             )
 
-        val plural = result as UiText.PluralText
-        assertEquals(R.plurals.push_notification_partial_failure, plural.resId)
-        assertEquals(3, plural.quantity)
-        assertEquals(listOf<Any>(2, 5, 3), plural.formatArgs)
+        val plural = result.shouldBeInstanceOf<UiText.PluralText>()
+        plural.resId shouldBe R.plurals.push_notification_partial_failure
+        plural.quantity shouldBe 3
+        plural.formatArgs shouldBe listOf<Any>(2, 5, 3)
     }
 
     @Test
     fun `vault not found maps to dedicated string resource`() {
         val result = pushNotificationErrorUiText(PushNotificationError.VaultNotFound())
 
-        val stringRes = result as UiText.StringResource
-        assertEquals(R.string.push_notification_vault_not_found, stringRes.resId)
+        val stringRes = result.shouldBeInstanceOf<UiText.StringResource>()
+        stringRes.resId shouldBe R.string.push_notification_vault_not_found
     }
 
     @Test
     fun `vault not supported maps to dedicated string resource`() {
         val result = pushNotificationErrorUiText(PushNotificationError.VaultNotSupported())
 
-        val stringRes = result as UiText.StringResource
-        assertEquals(R.string.push_notification_error_vault_not_supported, stringRes.resId)
+        val stringRes = result.shouldBeInstanceOf<UiText.StringResource>()
+        stringRes.resId shouldBe R.string.push_notification_error_vault_not_supported
     }
 
     @Test
     fun `token not available maps to dedicated string resource`() {
         val result = pushNotificationErrorUiText(PushNotificationError.TokenNotAvailable())
 
-        val stringRes = result as UiText.StringResource
-        assertEquals(R.string.push_notification_error_token_not_available, stringRes.resId)
+        val stringRes = result.shouldBeInstanceOf<UiText.StringResource>()
+        stringRes.resId shouldBe R.string.push_notification_error_token_not_available
     }
 
     @Test
@@ -50,21 +50,20 @@ internal class PushNotificationErrorTextTest {
         val result =
             pushNotificationErrorUiText(PushNotificationError.ApiFailure(RuntimeException("boom")))
 
-        val stringRes = result as UiText.StringResource
-        assertEquals(R.string.push_notification_error_api_failure, stringRes.resId)
+        val stringRes = result.shouldBeInstanceOf<UiText.StringResource>()
+        stringRes.resId shouldBe R.string.push_notification_error_api_failure
     }
 
     @Test
     fun `non-PushNotificationError falls back to generic string`() {
         val result = pushNotificationErrorUiText(IllegalStateException("unrelated"))
 
-        val stringRes = result as UiText.StringResource
-        assertEquals(R.string.push_notifications_failed, stringRes.resId)
+        val stringRes = result.shouldBeInstanceOf<UiText.StringResource>()
+        stringRes.resId shouldBe R.string.push_notifications_failed
     }
 
     @Test
     fun `null-safe cast does not throw when error type is unrelated`() {
-        // Smoke test: branching uses safe cast `as?` — must not propagate ClassCastException.
-        assertTrue(pushNotificationErrorUiText(Throwable("plain")) is UiText.StringResource)
+        pushNotificationErrorUiText(Throwable("plain")).shouldBeInstanceOf<UiText.StringResource>()
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/utils/PushNotificationErrorTextTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/utils/PushNotificationErrorTextTest.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.ui.utils
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.services.PushNotificationError
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class PushNotificationErrorTextTest {
+
+    @Test
+    fun `partial failure maps to plural with success-total-failure args`() {
+        val result =
+            pushNotificationErrorUiText(
+                PushNotificationError.PartialFailure(successCount = 2, failureCount = 3)
+            )
+
+        val plural = result as UiText.PluralText
+        assertEquals(R.plurals.push_notification_partial_failure, plural.resId)
+        assertEquals(3, plural.quantity)
+        assertEquals(listOf<Any>(2, 5, 3), plural.formatArgs)
+    }
+
+    @Test
+    fun `vault not found maps to dedicated string resource`() {
+        val result = pushNotificationErrorUiText(PushNotificationError.VaultNotFound())
+
+        val stringRes = result as UiText.StringResource
+        assertEquals(R.string.push_notification_vault_not_found, stringRes.resId)
+    }
+
+    @Test
+    fun `vault not supported maps to dedicated string resource`() {
+        val result = pushNotificationErrorUiText(PushNotificationError.VaultNotSupported())
+
+        val stringRes = result as UiText.StringResource
+        assertEquals(R.string.push_notification_error_vault_not_supported, stringRes.resId)
+    }
+
+    @Test
+    fun `token not available maps to dedicated string resource`() {
+        val result = pushNotificationErrorUiText(PushNotificationError.TokenNotAvailable())
+
+        val stringRes = result as UiText.StringResource
+        assertEquals(R.string.push_notification_error_token_not_available, stringRes.resId)
+    }
+
+    @Test
+    fun `api failure maps to api failure string resource`() {
+        val result =
+            pushNotificationErrorUiText(PushNotificationError.ApiFailure(RuntimeException("boom")))
+
+        val stringRes = result as UiText.StringResource
+        assertEquals(R.string.push_notification_error_api_failure, stringRes.resId)
+    }
+
+    @Test
+    fun `non-PushNotificationError falls back to generic string`() {
+        val result = pushNotificationErrorUiText(IllegalStateException("unrelated"))
+
+        val stringRes = result as UiText.StringResource
+        assertEquals(R.string.push_notifications_failed, stringRes.resId)
+    }
+
+    @Test
+    fun `null-safe cast does not throw when error type is unrelated`() {
+        // Smoke test: branching uses safe cast `as?` — must not propagate ClassCastException.
+        assertTrue(pushNotificationErrorUiText(Throwable("plain")) is UiText.StringResource)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -4,12 +4,18 @@ import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCaseImpl
 import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCaseImpl
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCaseImpl
 import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
 import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCaseImpl
 import com.vultisig.wallet.data.usecases.backup.RequestServerBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.RequestServerBackupUseCaseImpl
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCaseImpl
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCaseImpl
+import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
+import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCaseImpl
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCaseImpl
 import com.vultisig.wallet.data.usecases.tss.PullTssMessagesUseCase
@@ -243,4 +249,18 @@ internal interface DataUsecasesModule {
     @Binds
     @Singleton
     fun bindThorchainMemoParser(impl: ThorchainMemoParserImpl): ThorchainMemoParser
+
+    @Binds
+    @Singleton
+    fun bindSaveBackupToUriUseCase(impl: SaveBackupToUriUseCaseImpl): SaveBackupToUriUseCase
+
+    @Binds
+    @Singleton
+    fun bindDeleteBackupDocumentUseCase(
+        impl: DeleteBackupDocumentUseCaseImpl
+    ): DeleteBackupDocumentUseCase
+
+    @Binds
+    @Singleton
+    fun bindVaultFileReaderUseCase(impl: VaultFileReaderUseCaseImpl): VaultFileReaderUseCase
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -14,8 +14,8 @@ import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
 import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCaseImpl
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCaseImpl
-import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCase
-import com.vultisig.wallet.data.usecases.file.VaultFileReaderUseCaseImpl
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCaseImpl
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCaseImpl
 import com.vultisig.wallet.data.usecases.tss.PullTssMessagesUseCase
@@ -262,5 +262,5 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
-    fun bindVaultFileReaderUseCase(impl: VaultFileReaderUseCaseImpl): VaultFileReaderUseCase
+    fun bindUriFileReaderUseCase(impl: UriFileReaderUseCaseImpl): UriFileReaderUseCase
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/DeleteBackupDocumentUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/DeleteBackupDocumentUseCase.kt
@@ -1,0 +1,17 @@
+package com.vultisig.wallet.data.usecases.backup
+
+import android.content.Context
+import android.net.Uri
+import com.vultisig.wallet.data.common.deleteDocument
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+fun interface DeleteBackupDocumentUseCase {
+    suspend operator fun invoke(uri: Uri): Boolean
+}
+
+internal class DeleteBackupDocumentUseCaseImpl
+@Inject
+constructor(@param:ApplicationContext private val context: Context) : DeleteBackupDocumentUseCase {
+    override suspend fun invoke(uri: Uri): Boolean = context.deleteDocument(uri)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/SaveBackupToUriUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/SaveBackupToUriUseCase.kt
@@ -2,13 +2,15 @@ package com.vultisig.wallet.data.usecases.backup
 
 import android.content.Context
 import android.net.Uri
-import com.vultisig.wallet.data.common.deleteDocument
+import com.vultisig.wallet.data.common.AppZipEntry
 import com.vultisig.wallet.data.common.saveContentToUri
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-fun interface SaveBackupToUriUseCase {
+interface SaveBackupToUriUseCase {
     suspend operator fun invoke(uri: Uri, content: String): Boolean
+
+    suspend operator fun invoke(uri: Uri, content: List<AppZipEntry>): Boolean
 }
 
 internal class SaveBackupToUriUseCaseImpl
@@ -16,14 +18,7 @@ internal class SaveBackupToUriUseCaseImpl
 constructor(@param:ApplicationContext private val context: Context) : SaveBackupToUriUseCase {
     override suspend fun invoke(uri: Uri, content: String): Boolean =
         context.saveContentToUri(uri, content)
-}
 
-fun interface DeleteBackupDocumentUseCase {
-    suspend operator fun invoke(uri: Uri): Boolean
-}
-
-internal class DeleteBackupDocumentUseCaseImpl
-@Inject
-constructor(@param:ApplicationContext private val context: Context) : DeleteBackupDocumentUseCase {
-    override suspend fun invoke(uri: Uri): Boolean = context.deleteDocument(uri)
+    override suspend fun invoke(uri: Uri, content: List<AppZipEntry>): Boolean =
+        context.saveContentToUri(uri, content)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/SaveBackupToUriUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/SaveBackupToUriUseCase.kt
@@ -1,0 +1,29 @@
+package com.vultisig.wallet.data.usecases.backup
+
+import android.content.Context
+import android.net.Uri
+import com.vultisig.wallet.data.common.deleteDocument
+import com.vultisig.wallet.data.common.saveContentToUri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+fun interface SaveBackupToUriUseCase {
+    suspend operator fun invoke(uri: Uri, content: String): Boolean
+}
+
+internal class SaveBackupToUriUseCaseImpl
+@Inject
+constructor(@param:ApplicationContext private val context: Context) : SaveBackupToUriUseCase {
+    override suspend fun invoke(uri: Uri, content: String): Boolean =
+        context.saveContentToUri(uri, content)
+}
+
+fun interface DeleteBackupDocumentUseCase {
+    suspend operator fun invoke(uri: Uri): Boolean
+}
+
+internal class DeleteBackupDocumentUseCaseImpl
+@Inject
+constructor(@param:ApplicationContext private val context: Context) : DeleteBackupDocumentUseCase {
+    override suspend fun invoke(uri: Uri): Boolean = context.deleteDocument(uri)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/file/UriFileReaderUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/file/UriFileReaderUseCase.kt
@@ -10,7 +10,7 @@ import com.vultisig.wallet.data.common.processZip
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-interface VaultFileReaderUseCase {
+interface UriFileReaderUseCase {
     suspend fun readContent(uri: Uri): String?
 
     suspend fun readName(uri: Uri): String?
@@ -20,9 +20,9 @@ interface VaultFileReaderUseCase {
     suspend fun extractZipEntries(uri: Uri): List<AppZipEntry>
 }
 
-internal class VaultFileReaderUseCaseImpl
+internal class UriFileReaderUseCaseImpl
 @Inject
-constructor(@param:ApplicationContext private val context: Context) : VaultFileReaderUseCase {
+constructor(@param:ApplicationContext private val context: Context) : UriFileReaderUseCase {
     override suspend fun readContent(uri: Uri): String? = uri.fileContent(context)
 
     override suspend fun readName(uri: Uri): String? = uri.fileName(context)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/file/VaultFileReaderUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/file/VaultFileReaderUseCase.kt
@@ -1,0 +1,33 @@
+package com.vultisig.wallet.data.usecases.file
+
+import android.content.Context
+import android.net.Uri
+import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.common.fileContent
+import com.vultisig.wallet.data.common.fileName
+import com.vultisig.wallet.data.common.isValidZipFile
+import com.vultisig.wallet.data.common.processZip
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+interface VaultFileReaderUseCase {
+    suspend fun readContent(uri: Uri): String?
+
+    suspend fun readName(uri: Uri): String?
+
+    suspend fun isValidZip(uri: Uri): Boolean
+
+    suspend fun extractZipEntries(uri: Uri): List<AppZipEntry>
+}
+
+internal class VaultFileReaderUseCaseImpl
+@Inject
+constructor(@param:ApplicationContext private val context: Context) : VaultFileReaderUseCase {
+    override suspend fun readContent(uri: Uri): String? = uri.fileContent(context)
+
+    override suspend fun readName(uri: Uri): String? = uri.fileName(context)
+
+    override suspend fun isValidZip(uri: Uri): Boolean = uri.isValidZipFile(context)
+
+    override suspend fun extractZipEntries(uri: Uri): List<AppZipEntry> = uri.processZip(context)
+}


### PR DESCRIPTION
## Summary
- Eliminates `@ApplicationContext Context` fields from six ViewModels (MainViewModel, NotificationsSettingsViewModel, VaultAccountsViewModel, BackupVaultViewModel, ImportFileViewModel, TokenAddressQrViewModel) so lint stops flagging `StaticFieldLeak`.
- **Group A — strings**: `context.getString(...)` calls converted to `UiText`, resolved in the composable (e.g. transactionSummary, address-copied, push-notification errors). Snackbar collection/resolve moved from `MainViewModel` into `MainActivityContent`. A new UI-layer helper `pushNotificationErrorUiText(e): UiText` replaces the data-layer `pushNotificationErrorMessage(e, context)` function (deleted).
- **Group B — system services / file I/O**: extracted to `@ApplicationContext`-scoped use-cases:
  - `SaveBackupToUriUseCase`, `DeleteBackupDocumentUseCase` (BackupVaultViewModel)
  - `VaultFileReaderUseCase` (ImportFileViewModel: fileContent / fileName / isValidZipFile / processZip)
  - `ShareBitmapUseCase` (TokenAddressQrViewModel)
- ViewModels now have no Context or Application field.

Closes #3782

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` succeeds.
- [x] `./gradlew lint` succeeds; `grep -c StaticFieldLeak app/build/reports/lint-results-debug.html` returns **0** (all six original warnings cleared).
- [x] `./gradlew test` passes after updating constructor params in MainViewModel / ImportFileViewModel / VaultAccountsViewModel unit tests.
- [ ] Manual smoke: backup vault flow, import vault (.bak / .zip), copy + share address from token QR sheet, toggle push notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * More reliable, non-blocking snackbars and improved localized push-notification error messages
  * Fixes to copy/share flows to avoid failures and ensure consistent feedback

* **New Features**
  * New sharing use-case improving QR and screenshot sharing reliability
  * Backup save/delete support with safer persistence

* **Refactor**
  * Streamlined file import and URI handling for more stable imports and clearer error reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->