### PR TITLE
feat(verify): rich decoded ABI parameters for dApp display

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -149,9 +149,12 @@ class PreviewActivity : ComponentActivity() {
                     "dapp_banner_verify_host_only" ->
                         DappBannerVerifyPreview(DappBannerVariant.HOST_ONLY)
                     "dapp_banner_send_done" -> DappBannerSendDonePreview()
-                    "decoded_function_before" -> DecodedFunctionDetailsBeforePreview()
-                    "decoded_function_after" -> DecodedFunctionDetailsAfterPreview()
-                    "decoded_function_transfer_after" -> DecodedFunctionTransferAfterPreview()
+                    "decoded_function_verify_collapsed" ->
+                        VerifyDecodedSendPreview(expanded = false)
+                    "decoded_function_verify_expanded_before" ->
+                        VerifyDecodedSendPreview(expanded = true, useRichRows = false)
+                    "decoded_function_verify_expanded_after" ->
+                        VerifyDecodedSendPreview(expanded = true, useRichRows = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1125,121 +1128,47 @@ private fun SelectChainPopupPreview() {
 }
 
 /**
- * Stand-in for the verify-send card's Transaction Details section pre-expanded so the BEFORE /
- * AFTER screenshots for #4058 capture the actual rendered output rather than relying on the user to
- * tap the expander before a `screencap`. Mirrors the production layout in [VerifySendScreen]'s
- * `TransactionDetailsSection`; deviations from production rendering must be mirrored here so the PR
- * screenshot stays faithful.
+ * Full-screen [VerifySendScreen] preview wired for #4058 PR screenshots. Renders the real verify
+ * card with a mocked decoded `approve(USDC, ∞)` call and toggles the Transaction Details section
+ * between collapsed and expanded variants. The `useRichRows` switch lets the capture script show
+ * the BEFORE state (raw JSON) by stripping the decoded rows, then re-launch with the AFTER state
+ * (labelled rows + copy icons) — both renders are otherwise identical so the PR comparison is
+ * apples-to-apples.
  */
 @Composable
-private fun DecodedFunctionPreviewCard(
-    title: String,
-    functionSignature: String,
-    rich: List<com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam>?,
-    rawInputs: String?,
-) {
-    androidx.compose.foundation.layout.Box(
-        modifier =
-            Modifier.fillMaxSize()
-                .background(com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.primary)
-                .padding(horizontal = 16.dp, vertical = 24.dp),
-        contentAlignment = androidx.compose.ui.Alignment.TopCenter,
-    ) {
-        androidx.compose.foundation.layout.Column(
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            modifier =
-                Modifier.fillMaxWidth()
-                    .background(
-                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.secondary,
-                        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
-                    )
-                    .padding(24.dp),
-        ) {
-            androidx.compose.material3.Text(
-                text = title,
-                style = com.vultisig.wallet.ui.theme.Theme.brockmann.headings.subtitle,
-                color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.primary,
-            )
-            androidx.compose.foundation.layout.Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .background(
-                            color = androidx.compose.ui.graphics.Color.Transparent,
-                            shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
-                        )
-                        .padding(top = 8.dp),
-            ) {
-                androidx.compose.foundation.layout.Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    androidx.compose.material3.Text(
-                        text = "Function Signature",
-                        style = com.vultisig.wallet.ui.theme.Theme.brockmann.supplementary.footnote,
-                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.tertiary,
-                    )
-                    androidx.compose.material3.Text(
-                        text = functionSignature,
-                        style =
-                            com.vultisig.wallet.ui.theme.Theme.brockmann.body.m.medium.copy(
-                                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
-                            ),
-                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.alerts.success,
-                    )
-                }
-
-                if (!rich.isNullOrEmpty()) {
-                    com.vultisig.wallet.ui.screens.send.DecodedFunctionParamRows(params = rich)
-                } else if (rawInputs != null) {
-                    androidx.compose.foundation.layout.Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        androidx.compose.material3.Text(
-                            text = "Function Arguments",
-                            style =
-                                com.vultisig.wallet.ui.theme.Theme.brockmann.supplementary.footnote,
-                            color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.tertiary,
-                        )
-                        androidx.compose.material3.Text(
-                            text = rawInputs,
-                            style =
-                                com.vultisig.wallet.ui.theme.Theme.brockmann.body.m.medium.copy(
-                                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
-                                ),
-                            color = com.vultisig.wallet.ui.theme.Theme.v2.colors.alerts.success,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DecodedFunctionDetailsBeforePreview() {
-    DecodedFunctionPreviewCard(
-        title = "Transaction Details",
-        functionSignature = "approve(address,uint256)",
-        rich = null,
-        rawInputs =
-            "[\"0x7a250d5630b4cf539739df2c5dacb4c659f2488d\",\"11579208923731619542357098500868790785326998466564056403945758400791312963993" +
-                "5\"]",
+private fun VerifyDecodedSendPreview(expanded: Boolean = false, useRichRows: Boolean = true) {
+    VerifySendScreen(
+        state = decodedApproveSendState(useRichRows),
+        isConsentsEnabled = false,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
+        initiallyExpandedDetails = expanded,
     )
 }
 
-@Composable
-private fun DecodedFunctionDetailsAfterPreview() {
-    val rows =
+private fun decodedApproveSendState(
+    useRichRows: Boolean
+): com.vultisig.wallet.ui.models.VerifyTransactionUiModel {
+    val ethCoin = Coins.Ethereum.ETH
+    val spender = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
+    val rawArgs =
+        "[\"$spender\",\"115792089237316195423570985008687907853269984665640564039457584007913129639935\"]"
+    val richRows =
         listOf(
             com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
                 label =
                     com.vultisig.wallet.ui.utils.UiText.StringResource(
                         com.vultisig.wallet.R.string.erc20_approval_spender
                     ),
-                value =
-                    com.vultisig.wallet.ui.utils.UiText.DynamicString(
-                        "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
-                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString(spender),
+                copyableValue = spender,
                 secondary = "Uniswap V2 Router",
             ),
             com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
@@ -1255,41 +1184,54 @@ private fun DecodedFunctionDetailsAfterPreview() {
                 isWarning = true,
             ),
         )
-    DecodedFunctionPreviewCard(
-        title = "Transaction Details",
-        functionSignature = "approve(address,uint256)",
-        rich = rows,
-        rawInputs = null,
-    )
-}
-
-@Composable
-private fun DecodedFunctionTransferAfterPreview() {
-    val rows =
-        listOf(
-            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
-                label =
-                    com.vultisig.wallet.ui.utils.UiText.StringResource(
-                        com.vultisig.wallet.R.string.verify_transaction_to_title
-                    ),
-                value =
-                    com.vultisig.wallet.ui.utils.UiText.DynamicString(
-                        "0x9876543210fedcba9876543210fedcba98765432"
-                    ),
-            ),
-            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
-                label =
-                    com.vultisig.wallet.ui.utils.UiText.StringResource(
-                        com.vultisig.wallet.R.string.decoded_function_amount
-                    ),
-                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("125 USDC"),
-            ),
+    val tx =
+        com.vultisig.wallet.ui.models.TransactionDetailsUiModel(
+            token = ValuedToken(token = ethCoin, value = "0", fiatValue = "$0.00"),
+            srcAddress = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+            srcVaultName = "Honeypot Vault DKLS",
+            // Realistic mock: approve(USDC, spender) — the call's destination is the USDC token
+            // contract, not the spender. `dstContractLabel` stays null because the USDC contract
+            // isn't on the [KnownEvmContracts] allowlist; the user sees "USDC" via `dstLabel`
+            // and the Uniswap V2 Router label only surfaces on the spender row.
+            dstAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            dstLabel = "USDC",
+            functionName = "Approve",
+            functionSignature = "approve(address,uint256)",
+            functionInputs = rawArgs,
+            isUnlimitedApproval = true,
+            approvalSpender = spender,
+            approvalTokenTicker = "USDC",
+            dstContractLabel = null,
+            decodedFunctionParams = if (useRichRows) richRows else null,
+            networkFeeFiatValue = "$1.84",
+            networkFeeTokenValue = "0.000482 ETH",
+            heroContent =
+                com.vultisig.wallet.ui.components.hero.HeroContent.Send(
+                    title = "Approve",
+                    coin =
+                        com.vultisig.wallet.ui.components.hero.HeroCoinAmount(
+                            amount = "Unlimited",
+                            ticker = "USDC",
+                            logo = "https://assets.coingecko.com/coins/images/6319/large/usdc.png",
+                        ),
+                ),
         )
-    DecodedFunctionPreviewCard(
-        title = "Transaction Details",
-        functionSignature = "transfer(address,uint256)",
-        rich = rows,
-        rawInputs = null,
+    return com.vultisig.wallet.ui.models.VerifyTransactionUiModel(
+        transaction = tx,
+        consentAddress = false,
+        consentAmount = false,
+        hasFastSign = false,
+        txScanStatus =
+            com.vultisig.wallet.ui.models.TransactionScanStatus.Scanned(
+                com.vultisig.wallet.data.securityscanner.SecurityScannerResult(
+                    provider = "blockaid",
+                    isSecure = true,
+                    riskLevel = com.vultisig.wallet.data.securityscanner.SecurityRiskLevel.NONE,
+                    warnings = emptyList(),
+                    description = "Transaction is safe",
+                    recommendations = "",
+                )
+            ),
     )
 }
 

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -149,6 +149,9 @@ class PreviewActivity : ComponentActivity() {
                     "dapp_banner_verify_host_only" ->
                         DappBannerVerifyPreview(DappBannerVariant.HOST_ONLY)
                     "dapp_banner_send_done" -> DappBannerSendDonePreview()
+                    "decoded_function_before" -> DecodedFunctionDetailsBeforePreview()
+                    "decoded_function_after" -> DecodedFunctionDetailsAfterPreview()
+                    "decoded_function_transfer_after" -> DecodedFunctionTransferAfterPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1118,6 +1121,175 @@ private fun SelectChainPopupPreview() {
         itemContent = { item, distanceFromCenter ->
             ChainSelectorPickerItem(item = item, distanceFromCenter = distanceFromCenter)
         },
+    )
+}
+
+/**
+ * Stand-in for the verify-send card's Transaction Details section pre-expanded so the BEFORE /
+ * AFTER screenshots for #4058 capture the actual rendered output rather than relying on the user to
+ * tap the expander before a `screencap`. Mirrors the production layout in [VerifySendScreen]'s
+ * `TransactionDetailsSection`; deviations from production rendering must be mirrored here so the PR
+ * screenshot stays faithful.
+ */
+@Composable
+private fun DecodedFunctionPreviewCard(
+    title: String,
+    functionSignature: String,
+    rich: List<com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam>?,
+    rawInputs: String?,
+) {
+    androidx.compose.foundation.layout.Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.primary)
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+        contentAlignment = androidx.compose.ui.Alignment.TopCenter,
+    ) {
+        androidx.compose.foundation.layout.Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .background(
+                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.backgrounds.secondary,
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+                    )
+                    .padding(24.dp),
+        ) {
+            androidx.compose.material3.Text(
+                text = title,
+                style = com.vultisig.wallet.ui.theme.Theme.brockmann.headings.subtitle,
+                color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.primary,
+            )
+            androidx.compose.foundation.layout.Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .background(
+                            color = androidx.compose.ui.graphics.Color.Transparent,
+                            shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                        )
+                        .padding(top = 8.dp),
+            ) {
+                androidx.compose.foundation.layout.Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    androidx.compose.material3.Text(
+                        text = "Function Signature",
+                        style = com.vultisig.wallet.ui.theme.Theme.brockmann.supplementary.footnote,
+                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.tertiary,
+                    )
+                    androidx.compose.material3.Text(
+                        text = functionSignature,
+                        style =
+                            com.vultisig.wallet.ui.theme.Theme.brockmann.body.m.medium.copy(
+                                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                            ),
+                        color = com.vultisig.wallet.ui.theme.Theme.v2.colors.alerts.success,
+                    )
+                }
+
+                if (!rich.isNullOrEmpty()) {
+                    com.vultisig.wallet.ui.screens.send.DecodedFunctionParamRows(params = rich)
+                } else if (rawInputs != null) {
+                    androidx.compose.foundation.layout.Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        androidx.compose.material3.Text(
+                            text = "Function Arguments",
+                            style =
+                                com.vultisig.wallet.ui.theme.Theme.brockmann.supplementary.footnote,
+                            color = com.vultisig.wallet.ui.theme.Theme.v2.colors.text.tertiary,
+                        )
+                        androidx.compose.material3.Text(
+                            text = rawInputs,
+                            style =
+                                com.vultisig.wallet.ui.theme.Theme.brockmann.body.m.medium.copy(
+                                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                                ),
+                            color = com.vultisig.wallet.ui.theme.Theme.v2.colors.alerts.success,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DecodedFunctionDetailsBeforePreview() {
+    DecodedFunctionPreviewCard(
+        title = "Transaction Details",
+        functionSignature = "approve(address,uint256)",
+        rich = null,
+        rawInputs =
+            "[\"0x7a250d5630b4cf539739df2c5dacb4c659f2488d\",\"11579208923731619542357098500868790785326998466564056403945758400791312963993" +
+                "5\"]",
+    )
+}
+
+@Composable
+private fun DecodedFunctionDetailsAfterPreview() {
+    val rows =
+        listOf(
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.erc20_approval_spender
+                    ),
+                value =
+                    com.vultisig.wallet.ui.utils.UiText.DynamicString(
+                        "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
+                    ),
+                secondary = "Uniswap V2 Router",
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_amount
+                    ),
+                value =
+                    com.vultisig.wallet.ui.utils.UiText.FormattedText(
+                        com.vultisig.wallet.R.string.decoded_function_unlimited_amount,
+                        listOf("USDC"),
+                    ),
+                isWarning = true,
+            ),
+        )
+    DecodedFunctionPreviewCard(
+        title = "Transaction Details",
+        functionSignature = "approve(address,uint256)",
+        rich = rows,
+        rawInputs = null,
+    )
+}
+
+@Composable
+private fun DecodedFunctionTransferAfterPreview() {
+    val rows =
+        listOf(
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.verify_transaction_to_title
+                    ),
+                value =
+                    com.vultisig.wallet.ui.utils.UiText.DynamicString(
+                        "0x9876543210fedcba9876543210fedcba98765432"
+                    ),
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_amount
+                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("125 USDC"),
+            ),
+        )
+    DecodedFunctionPreviewCard(
+        title = "Transaction Details",
+        functionSignature = "transfer(address,uint256)",
+        rich = rows,
+        rawInputs = null,
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.models.TransactionId
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.FourByteRepository
 import com.vultisig.wallet.data.repositories.PrettyJson
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -23,10 +24,11 @@ import com.vultisig.wallet.data.securityscanner.isChainSupported
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
 import com.vultisig.wallet.ui.models.keysign.FunctionInfo
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.keysign.approvalSpenderArgIndex
-import com.vultisig.wallet.ui.models.keysign.isTokenContractApproval
+import com.vultisig.wallet.ui.models.keysign.enrichDecodedCall
 import com.vultisig.wallet.ui.models.keysign.isUnlimitedApproval
 import com.vultisig.wallet.ui.models.keysign.prettifyEvmFunctionName
 import com.vultisig.wallet.ui.models.mappers.TransactionToUiModelMapper
@@ -84,8 +86,26 @@ internal data class TransactionDetailsUiModel(
     val approvalSpender: String? = null,
     /**
      * Resolved ERC-20 ticker for the token contract being approved (overrides native coin ticker).
+     * For tokens the active vault doesn't hold, this falls through to an on-chain `symbol()` call
+     * via [com.vultisig.wallet.data.repositories.TokenMetadataResolver] so unknown stablecoins and
+     * LP tokens still surface a ticker in the warning row.
      */
     val approvalTokenTicker: String? = null,
+    /**
+     * Friendly label for the destination contract when it is on the
+     * [com.vultisig.wallet.data.repositories.KnownEvmContracts] allowlist (Uniswap routers,
+     * Permit2, etc.). Displayed alongside the contract address so the `To` row reads as `Uniswap V3
+     * Router (0x68b3…fC45)` instead of a bare hash.
+     */
+    val dstContractLabel: String? = null,
+    /**
+     * Per-parameter labelled rows rendered inside the expandable Transaction Details section. For
+     * known function shapes the rows carry semantic labels (`Spender`, `Recipient`, `Amount`);
+     * unknown signatures fall back to positional `#N (type)` rows. Null when the decoder couldn't
+     * interpret the call — in that case the screen hides the rich rows and the raw signature line
+     * still serves as the disclosure.
+     */
+    val decodedFunctionParams: List<DecodedFunctionParam>? = null,
     /**
      * Resolved hero content for the dApp signing screens. Populated by [BuildHeroContentUseCase]
      * once the Blockaid simulation completes. When non-null, screens render this in place of the
@@ -143,6 +163,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val addressBookRepository: AddressBookRepository,
     private val fourByteRepository: FourByteRepository,
+    private val tokenMetadataResolver: TokenMetadataResolver,
     @param:PrettyJson private val json: Json,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -340,16 +361,16 @@ constructor(
                             .getOrNull()
                     } else null
                 } else null
-            val approvalTokenTicker =
-                if (isUnlimitedApproval && isTokenContractApproval(functionInfo?.signature ?: "")) {
-                    allVaults
-                        .flatMap { it.coins }
-                        .firstOrNull { coin ->
-                            coin.chain == chain &&
-                                coin.contractAddress.equals(tx.dstAddress, ignoreCase = true)
-                        }
-                        ?.ticker
-                } else null
+            val decodedExtras =
+                enrichDecodedCall(
+                    chain = chain,
+                    dstAddress = tx.dstAddress,
+                    functionInfo = functionInfo,
+                    allVaults = allVaults,
+                    isUnlimitedApproval = isUnlimitedApproval,
+                    json = json,
+                    tokenMetadataResolver = tokenMetadataResolver,
+                )
 
             val namedUiModel =
                 transactionUiModel.copy(
@@ -361,7 +382,9 @@ constructor(
                     functionName = functionInfo?.functionName,
                     isUnlimitedApproval = isUnlimitedApproval,
                     approvalSpender = approvalSpender,
-                    approvalTokenTicker = approvalTokenTicker,
+                    approvalTokenTicker = decodedExtras.approvalTokenTicker,
+                    dstContractLabel = decodedExtras.dstContractLabel,
+                    decodedFunctionParams = decodedExtras.decodedFunctionParams,
                 )
 
             _uiState.update { it.copy(transaction = namedUiModel) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
@@ -1,0 +1,113 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.KnownEvmContracts
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import kotlinx.serialization.json.Json
+
+/**
+ * Aggregated outputs of [enrichDecodedCall] — the per-screen ViewModel writes each field into the
+ * corresponding `TransactionDetailsUiModel` slot.
+ */
+internal data class DecodedCallExtras(
+    val decodedFunctionParams: List<DecodedFunctionParam>?,
+    val dstContractLabel: String?,
+    val approvalTokenTicker: String?,
+)
+
+/**
+ * Symbol + decimals pair resolved for an approval target. Internal to the enrichment helper — the
+ * UI model only persists [symbol] today, but [decimals] flows into [decodedFunctionParams] so the
+ * amount row can be scaled into human-readable units.
+ */
+private data class ApprovalToken(val symbol: String, val decimals: Int)
+
+/**
+ * Computes the extra dApp-display fields that the verify and join-keysign screens need on top of
+ * the already-decoded 4byte signature and argument array.
+ *
+ * Centralises three lookups that previously didn't exist or only existed in fragmented form:
+ * - Token symbol + decimals for ERC-20 approvals — first reuses the existing vault-coin lookup so
+ *   users see the ticker for tokens they already hold, then falls back to a live on-chain
+ *   `symbol()` / `decimals()` call via [TokenMetadataResolver] for tokens not held by any installed
+ *   vault. The resolver caches responses for 24h and coalesces concurrent lookups so the verify and
+ *   done screens share one RPC round-trip. Decimals carry through into [decodedFunctionParams] so
+ *   the amount row scales `1_000_000` into `1` for a 6-decimal token instead of displaying the raw
+ *   on-chain integer.
+ * - Friendly label for the destination contract — for major DEX routers and Permit2,
+ *   [KnownEvmContracts.lookup] returns e.g. `Uniswap V3 Router` so the `To` row no longer reads as
+ *   a bare `0x…`.
+ * - Per-parameter labelled rows for the expandable details section — replaces the raw JSON blob
+ *   with semantic rows (`Spender`, `Recipient`, `Amount`) for known function shapes, falling back
+ *   to positional `#N (type)` rows for everything else.
+ *
+ * The function returns blank fields when [functionInfo] is null (non-EVM or non-contract call),
+ * when [dstAddress] is blank, or when the parser fails to interpret the signature.
+ */
+internal suspend fun enrichDecodedCall(
+    chain: Chain,
+    dstAddress: String,
+    functionInfo: FunctionInfo?,
+    allVaults: List<Vault>,
+    isUnlimitedApproval: Boolean,
+    json: Json,
+    tokenMetadataResolver: TokenMetadataResolver,
+): DecodedCallExtras {
+    if (functionInfo == null) return EMPTY
+
+    val signature = functionInfo.signature
+
+    val approvalToken =
+        if (isTokenContractApproval(signature)) {
+            resolveApprovalToken(
+                chain = chain,
+                contractAddress = dstAddress,
+                allVaults = allVaults,
+                tokenMetadataResolver = tokenMetadataResolver,
+            )
+        } else null
+
+    val dstContractLabel = KnownEvmContracts.lookup(chain, dstAddress)
+
+    val rows =
+        decodedFunctionParams(
+            signature = signature,
+            inputsJson = functionInfo.inputs,
+            json = json,
+            tokenSymbol = approvalToken?.symbol,
+            tokenDecimals = approvalToken?.decimals,
+            contractLabel = { address -> KnownEvmContracts.lookup(chain, address) },
+            isUnlimitedApproval = isUnlimitedApproval,
+        )
+
+    return DecodedCallExtras(
+        decodedFunctionParams = rows,
+        dstContractLabel = dstContractLabel,
+        approvalTokenTicker = approvalToken?.symbol,
+    )
+}
+
+private suspend fun resolveApprovalToken(
+    chain: Chain,
+    contractAddress: String,
+    allVaults: List<Vault>,
+    tokenMetadataResolver: TokenMetadataResolver,
+): ApprovalToken? {
+    if (contractAddress.isBlank()) return null
+    val vaultCoin =
+        allVaults
+            .asSequence()
+            .flatMap { it.coins.asSequence() }
+            .firstOrNull { coin ->
+                coin.chain == chain &&
+                    coin.contractAddress.equals(contractAddress, ignoreCase = true)
+            }
+    if (vaultCoin != null && vaultCoin.ticker.isNotBlank()) {
+        return ApprovalToken(symbol = vaultCoin.ticker, decimals = vaultCoin.decimal)
+    }
+    val resolved = tokenMetadataResolver.resolve(chain, contractAddress) ?: return null
+    return ApprovalToken(symbol = resolved.symbol, decimals = resolved.decimals)
+}
+
+private val EMPTY = DecodedCallExtras(null, null, null)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParams.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParams.kt
@@ -1,0 +1,343 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import androidx.compose.runtime.Immutable
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.Locale
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+
+/**
+ * A single labelled row produced by [decodedFunctionParams]. Renders inside the verify and
+ * join-keysign expandable "Transaction Details" section in place of the raw JSON array of decoded
+ * ABI arguments.
+ * - [label] is the row's leading text (e.g. "Spender", "Recipient", or a positional fallback like
+ *   `#3 (address)`).
+ * - [value] is the trailing text. It uses [UiText] so localised values like "Unlimited USDC" can be
+ *   composed lazily at render time inside `@Composable` code rather than baked in here.
+ * - [secondary] supplements the trailing text — used for the friendly contract label that
+ *   [com.vultisig.wallet.data.repositories.KnownEvmContracts] returns for known DEX routers.
+ * - [isWarning] flips the row into the warning colour, mirroring the unlimited-approval banner.
+ */
+@Immutable
+internal data class DecodedFunctionParam(
+    val label: UiText,
+    val value: UiText,
+    val secondary: String? = null,
+    val isWarning: Boolean = false,
+)
+
+/**
+ * Parses a decoded EVM contract call into labelled rows for the verify-screen detail section.
+ *
+ * For well-known function shapes (ERC-20 approve/permit/transfer/transferFrom, ERC-721/1155
+ * setApprovalForAll) the rows carry semantic labels (`Spender`, `Recipient`, etc.) so the user can
+ * read the call at a glance. Unknown signatures fall back to positional `#N (type)` rows so
+ * something useful still appears instead of opaque JSON.
+ * - [signature] is the 4byte text signature like `approve(address,uint256)` (parameter names are
+ *   not part of 4byte data, so positional types are all we get).
+ * - [inputsJson] is the JSON array produced by
+ *   [com.vultisig.wallet.data.repositories.FourByteRepositoryImpl.decodeFunctionArgs].
+ * - [tokenSymbol] is the resolved ticker for an ERC-20 token contract, or null. Callers typically
+ *   pass the approval token ticker for approve/permit so the amount row reads `Unlimited USDC`
+ *   instead of bare numerals.
+ * - [tokenDecimals] is the resolved decimals for [tokenSymbol]. When non-null and bounded, the raw
+ *   `uint256` amount is shifted to human-readable units so `transfer(addr, 1_000_000)` on a
+ *   6-decimal token renders as `"1 USDC"` rather than `"1000000 USDC"`. A null here keeps the raw
+ *   integer in place to avoid silently misrepresenting an amount we cannot scale.
+ * - [contractLabel] returns the human-readable label for a known EVM contract address (Uniswap V3
+ *   Router, Permit2, etc.), or null when unknown.
+ * - [isUnlimitedApproval] flips the amount row into the warning style and uses an `Unlimited`
+ *   label, matching the existing unlimited-approval banner.
+ *
+ * Returns null when [signature] or [inputsJson] is blank or unparseable — callers should hide the
+ * rich-parameter UI in that case.
+ */
+internal fun decodedFunctionParams(
+    signature: String?,
+    inputsJson: String?,
+    json: Json,
+    tokenSymbol: String? = null,
+    tokenDecimals: Int? = null,
+    contractLabel: (String) -> String? = { null },
+    isUnlimitedApproval: Boolean = false,
+): List<DecodedFunctionParam>? {
+    if (signature.isNullOrBlank() || inputsJson.isNullOrBlank()) return null
+    val parsed = parseFunctionSignature(signature) ?: return null
+    val inputs = parseInputs(inputsJson, json) ?: return null
+
+    val ctx =
+        HandlerContext(
+            inputs = inputs,
+            tokenSymbol = tokenSymbol,
+            tokenDecimals = tokenDecimals,
+            contractLabel = contractLabel,
+            isUnlimitedApproval = isUnlimitedApproval,
+        )
+    val functionKey = parsed.name.lowercase(Locale.ROOT)
+    val handler = PARAM_HANDLERS[functionKey]
+    if (handler != null && inputs.size == parsed.types.size) {
+        handler(ctx)
+            ?.takeIf { it.isNotEmpty() }
+            ?.let {
+                return it
+            }
+    }
+    return genericParams(parsed.types, inputs, contractLabel)
+}
+
+private data class ParsedSignature(val name: String, val types: List<String>)
+
+private fun parseFunctionSignature(signature: String): ParsedSignature? {
+    val openParen = signature.indexOf('(')
+    val closeParen = signature.lastIndexOf(')')
+    if (openParen <= 0 || closeParen <= openParen) return null
+    val name = signature.substring(0, openParen).trim()
+    if (name.isEmpty()) return null
+    val paramString = signature.substring(openParen + 1, closeParen)
+    return ParsedSignature(name = name, types = splitTopLevelParamTypes(paramString))
+}
+
+private fun splitTopLevelParamTypes(params: String): List<String> {
+    if (params.isBlank()) return emptyList()
+    val out = mutableListOf<String>()
+    val buf = StringBuilder()
+    var depth = 0
+    for (ch in params) {
+        when (ch) {
+            '(' -> {
+                depth++
+                buf.append(ch)
+            }
+            ')' -> {
+                depth--
+                buf.append(ch)
+            }
+            ',' ->
+                if (depth == 0) {
+                    out += buf.toString().trim()
+                    buf.clear()
+                } else {
+                    buf.append(ch)
+                }
+            else -> buf.append(ch)
+        }
+    }
+    if (buf.isNotEmpty()) out += buf.toString().trim()
+    return out
+}
+
+private fun parseInputs(inputsJson: String, json: Json): List<JsonElement>? =
+    runCatching { json.parseToJsonElement(inputsJson).jsonArray.toList() }.getOrNull()
+
+private data class HandlerContext(
+    val inputs: List<JsonElement>,
+    val tokenSymbol: String?,
+    val tokenDecimals: Int?,
+    val contractLabel: (String) -> String?,
+    val isUnlimitedApproval: Boolean,
+)
+
+private typealias ParamHandler = (HandlerContext) -> List<DecodedFunctionParam>?
+
+private val PARAM_HANDLERS: Map<String, ParamHandler> =
+    mapOf(
+        "approve" to ::approveRows,
+        "permit" to ::permitRows,
+        "transfer" to ::transferRows,
+        "transferfrom" to ::transferFromRows,
+        "setapprovalforall" to ::setApprovalForAllRows,
+    )
+
+private fun approveRows(ctx: HandlerContext): List<DecodedFunctionParam>? {
+    val spender = ctx.inputs.flatString(0) ?: return null
+    val amount = ctx.inputs.flatString(1).orEmpty()
+    return listOf(
+        addressRow(R.string.erc20_approval_spender.asUiText(), spender, ctx.contractLabel),
+        amountRow(amount, ctx.tokenSymbol, ctx.tokenDecimals, ctx.isUnlimitedApproval),
+    )
+}
+
+private fun permitRows(ctx: HandlerContext): List<DecodedFunctionParam>? {
+    val owner = ctx.inputs.flatString(0) ?: return null
+    val spender = ctx.inputs.flatString(1) ?: return null
+    val value = ctx.inputs.flatString(2).orEmpty()
+    val deadline = ctx.inputs.flatString(3)
+    return buildList {
+        add(addressRow(R.string.decoded_function_owner.asUiText(), owner, ctx.contractLabel))
+        add(addressRow(R.string.erc20_approval_spender.asUiText(), spender, ctx.contractLabel))
+        add(amountRow(value, ctx.tokenSymbol, ctx.tokenDecimals, ctx.isUnlimitedApproval))
+        if (!deadline.isNullOrBlank()) {
+            add(
+                DecodedFunctionParam(
+                    label = R.string.decoded_function_deadline.asUiText(),
+                    value = UiText.DynamicString(deadline),
+                )
+            )
+        }
+    }
+}
+
+private fun transferRows(ctx: HandlerContext): List<DecodedFunctionParam>? {
+    val recipient = ctx.inputs.flatString(0) ?: return null
+    val amount = ctx.inputs.flatString(1).orEmpty()
+    return listOf(
+        addressRow(R.string.verify_transaction_to_title.asUiText(), recipient, ctx.contractLabel),
+        amountRow(amount, ctx.tokenSymbol, ctx.tokenDecimals, isUnlimited = false),
+    )
+}
+
+private fun transferFromRows(ctx: HandlerContext): List<DecodedFunctionParam>? {
+    val from = ctx.inputs.flatString(0) ?: return null
+    val to = ctx.inputs.flatString(1) ?: return null
+    val amount = ctx.inputs.flatString(2).orEmpty()
+    return listOf(
+        addressRow(R.string.verify_transaction_from_title.asUiText(), from, ctx.contractLabel),
+        addressRow(R.string.verify_transaction_to_title.asUiText(), to, ctx.contractLabel),
+        amountRow(amount, ctx.tokenSymbol, ctx.tokenDecimals, isUnlimited = false),
+    )
+}
+
+private fun setApprovalForAllRows(ctx: HandlerContext): List<DecodedFunctionParam>? {
+    val operator = ctx.inputs.flatString(0) ?: return null
+    val approved = ctx.inputs.flatString(1).orEmpty()
+    val isApproved = approved.equals("true", ignoreCase = true)
+    val statusRes =
+        if (isApproved) R.string.decoded_function_status_approved
+        else R.string.decoded_function_status_revoked
+    return listOf(
+        addressRow(R.string.decoded_function_operator.asUiText(), operator, ctx.contractLabel),
+        DecodedFunctionParam(
+            label = R.string.decoded_function_status.asUiText(),
+            value = UiText.StringResource(statusRes),
+            isWarning = isApproved,
+        ),
+    )
+}
+
+private fun genericParams(
+    types: List<String>,
+    inputs: List<JsonElement>,
+    contractLabel: (String) -> String?,
+): List<DecodedFunctionParam> {
+    val rowCount = maxOf(types.size, inputs.size)
+    return (0 until rowCount).map { index ->
+        val type = types.getOrNull(index)?.takeIf { it.isNotBlank() }
+        val element = inputs.getOrNull(index)
+        val value = element?.flatString().orEmpty()
+        val labelText = buildString {
+            append('#')
+            append(index + 1)
+            if (type != null) {
+                append(" (")
+                append(type)
+                append(')')
+            }
+        }
+        DecodedFunctionParam(
+            label = UiText.DynamicString(labelText),
+            value = UiText.DynamicString(value),
+            secondary =
+                if (type != null && type.equals("address", ignoreCase = true)) {
+                    contractLabel(value)
+                } else null,
+        )
+    }
+}
+
+private fun addressRow(
+    label: UiText,
+    address: String,
+    contractLabel: (String) -> String?,
+): DecodedFunctionParam =
+    DecodedFunctionParam(
+        label = label,
+        value = UiText.DynamicString(address),
+        secondary = contractLabel(address),
+    )
+
+private fun amountRow(
+    rawAmount: String,
+    tokenSymbol: String?,
+    tokenDecimals: Int?,
+    isUnlimited: Boolean,
+): DecodedFunctionParam {
+    val value: UiText =
+        when {
+            isUnlimited -> {
+                val ticker = tokenSymbol?.takeIf { it.isNotBlank() }
+                if (ticker != null) {
+                    UiText.FormattedText(R.string.decoded_function_unlimited_amount, listOf(ticker))
+                } else {
+                    UiText.StringResource(R.string.decoded_function_unlimited)
+                }
+            }
+            else -> {
+                val display = formatAmount(rawAmount, tokenDecimals)
+                val ticker = tokenSymbol?.takeIf { it.isNotBlank() }
+                UiText.DynamicString(
+                    when {
+                        display == null -> rawAmount
+                        ticker == null -> display
+                        else -> "$display $ticker"
+                    }
+                )
+            }
+        }
+    return DecodedFunctionParam(
+        label = R.string.decoded_function_amount.asUiText(),
+        value = value,
+        isWarning = isUnlimited,
+    )
+}
+
+/**
+ * Scales an ABI uint amount into the token's display units when [decimals] is known and bounded.
+ *
+ * Decimals are validated as `0..[MAX_TOKEN_DECIMALS]`; anything outside falls back to the raw
+ * integer, matching [com.vultisig.wallet.data.repositories.TokenMetadataResolver]'s own decimals
+ * ceiling so a hostile contract claiming `decimals() = 255` cannot make the verify screen render a
+ * million-character zero-padded string. Trailing zeros are stripped from the result so a clean `1`
+ * shows up instead of `1.000000`.
+ */
+private fun formatAmount(rawAmount: String, decimals: Int?): String? {
+    val raw = parseBigInteger(rawAmount) ?: return null
+    if (decimals == null || decimals !in 0..MAX_TOKEN_DECIMALS) return raw.toString()
+    if (decimals == 0) return raw.toString()
+    return BigDecimal(raw).movePointLeft(decimals).stripTrailingZeros().toPlainString()
+}
+
+private fun parseBigInteger(value: String): BigInteger? {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty()) return null
+    return try {
+        when {
+            trimmed.startsWith("0x", ignoreCase = true) -> BigInteger(trimmed.substring(2), 16)
+            else -> BigInteger(trimmed)
+        }
+    } catch (_: NumberFormatException) {
+        null
+    }
+}
+
+private const val MAX_TOKEN_DECIMALS = 36
+
+private fun List<JsonElement>.flatString(index: Int): String? =
+    getOrNull(index)?.flatString()?.takeIf { it.isNotBlank() }
+
+private fun JsonElement.flatString(): String? =
+    when (this) {
+        is JsonNull -> null
+        is JsonPrimitive -> content.takeIf { it.isNotEmpty() }
+        is JsonArray ->
+            joinToString(prefix = "[", postfix = "]") { it.flatString().orEmpty() }
+                .takeIf { it.isNotEmpty() }
+        else -> toString()
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParams.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParams.kt
@@ -22,6 +22,9 @@ import kotlinx.serialization.json.jsonArray
  *   `#3 (address)`).
  * - [value] is the trailing text. It uses [UiText] so localised values like "Unlimited USDC" can be
  *   composed lazily at render time inside `@Composable` code rather than baked in here.
+ * - [copyableValue] is the unellipsised string that goes to the clipboard when the user taps the
+ *   copy icon next to the row. Non-null for address-typed rows so the full 0x… stays accessible
+ *   even though the rendered value is middle-ellipsised. Null suppresses the copy affordance.
  * - [secondary] supplements the trailing text — used for the friendly contract label that
  *   [com.vultisig.wallet.data.repositories.KnownEvmContracts] returns for known DEX routers.
  * - [isWarning] flips the row into the warning colour, mirroring the unlimited-approval banner.
@@ -30,6 +33,7 @@ import kotlinx.serialization.json.jsonArray
 internal data class DecodedFunctionParam(
     val label: UiText,
     val value: UiText,
+    val copyableValue: String? = null,
     val secondary: String? = null,
     val isWarning: Boolean = false,
 )
@@ -241,13 +245,12 @@ private fun genericParams(
                 append(')')
             }
         }
+        val isAddress = type != null && type.equals("address", ignoreCase = true)
         DecodedFunctionParam(
             label = UiText.DynamicString(labelText),
             value = UiText.DynamicString(value),
-            secondary =
-                if (type != null && type.equals("address", ignoreCase = true)) {
-                    contractLabel(value)
-                } else null,
+            copyableValue = if (isAddress) value.takeIf { it.isNotBlank() } else null,
+            secondary = if (isAddress) contractLabel(value) else null,
         )
     }
 }
@@ -260,6 +263,7 @@ private fun addressRow(
     DecodedFunctionParam(
         label = label,
         value = UiText.DynamicString(address),
+        copyableValue = address,
         secondary = contractLabel(address),
     )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -57,6 +57,7 @@ import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.FourByteRepository
 import com.vultisig.wallet.data.repositories.PrettyJson
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
@@ -218,6 +219,7 @@ constructor(
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val routerApi: RouterApi,
     private val fourByteRepository: FourByteRepository,
+    private val tokenMetadataResolver: TokenMetadataResolver,
     private val securityScannerService: SecurityScannerContract,
     private val addressBookRepository: AddressBookRepository,
     private val feeServiceComposite: FeeServiceComposite,
@@ -1127,22 +1129,16 @@ constructor(
                                     .getOrNull()
                             } else null
                         } else null
-                    val approvalTokenTicker =
-                        if (
-                            isUnlimitedApproval &&
-                                isTokenContractApproval(functionInfo?.signature ?: "")
-                        ) {
-                            allVaults
-                                .flatMap { it.coins }
-                                .firstOrNull { coin ->
-                                    coin.chain == chain &&
-                                        coin.contractAddress.equals(
-                                            payload.toAddress,
-                                            ignoreCase = true,
-                                        )
-                                }
-                                ?.ticker
-                        } else null
+                    val decodedExtras =
+                        enrichDecodedCall(
+                            chain = chain,
+                            dstAddress = payload.toAddress,
+                            functionInfo = functionInfo,
+                            allVaults = allVaults,
+                            isUnlimitedApproval = isUnlimitedApproval,
+                            json = json,
+                            tokenMetadataResolver = tokenMetadataResolver,
+                        )
 
                     val namedTransactionUiModel =
                         transactionToUiModel.copy(
@@ -1154,7 +1150,9 @@ constructor(
                             functionName = functionInfo?.functionName,
                             isUnlimitedApproval = isUnlimitedApproval,
                             approvalSpender = approvalSpender,
-                            approvalTokenTicker = approvalTokenTicker,
+                            approvalTokenTicker = decodedExtras.approvalTokenTicker,
+                            dstContractLabel = decodedExtras.dstContractLabel,
+                            decodedFunctionParams = decodedExtras.decodedFunctionParams,
                         )
                     transactionTypeUiModel = TransactionTypeUiModel.Send(namedTransactionUiModel)
                     transactionHistoryData = mapTransactionHistoryData(namedTransactionUiModel)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/DecodedFunctionParamsRows.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/DecodedFunctionParamsRows.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
 import com.vultisig.wallet.ui.theme.Theme
@@ -24,23 +25,25 @@ import com.vultisig.wallet.ui.utils.asString
  * [com.vultisig.wallet.ui.models.keysign.decodedFunctionParams].
  *
  * Each row mirrors the layout of [com.vultisig.wallet.ui.screens.swap.VerifyCardDetails] — label on
- * the left, value end-aligned on the right — with two additions: an optional `secondary` tag (e.g.
- * `Uniswap V3 Router` for known DEX addresses) under the value, and a warning colour for
- * unlimited-approval amount rows so the dangerous case stays visually consistent with the inline
- * approval banner.
+ * the left, value end-aligned on the right — with two additions: a `CopyIcon` next to address
+ * values so the user can recover the full hex even though the visible string is middle-ellipsised,
+ * and an optional `secondary` tag (e.g. `Uniswap V3 Router` for known DEX addresses) under the
+ * value. The warning colour is preserved for unlimited-approval amount rows so the dangerous case
+ * stays visually consistent with the inline approval banner.
  */
 @Composable
 internal fun DecodedFunctionParamRows(
     params: List<DecodedFunctionParam>,
     modifier: Modifier = Modifier,
+    onCopy: (String) -> Unit = {},
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = modifier.fillMaxWidth()) {
-        params.forEach { DecodedFunctionParamRow(it) }
+        params.forEach { DecodedFunctionParamRow(it, onCopy = onCopy) }
     }
 }
 
 @Composable
-private fun DecodedFunctionParamRow(param: DecodedFunctionParam) {
+private fun DecodedFunctionParamRow(param: DecodedFunctionParam, onCopy: (String) -> Unit) {
     val valueColor =
         if (param.isWarning) Theme.v2.colors.alerts.warning else Theme.v2.colors.text.primary
     Row(
@@ -57,15 +60,37 @@ private fun DecodedFunctionParamRow(param: DecodedFunctionParam) {
 
         UiSpacer(weight = 1f)
 
-        Column(horizontalAlignment = Alignment.End) {
-            Text(
-                text = param.value.asString(),
-                style = Theme.brockmann.body.s.medium,
-                color = valueColor,
-                textAlign = TextAlign.End,
-                maxLines = 1,
-                overflow = TextOverflow.MiddleEllipsis,
-            )
+        Column(
+            horizontalAlignment = Alignment.End,
+            // Cap the value column so it always leaves room for the label. Without the cap, a long
+            // ellipsised address can push the label off-screen when the row reaches its min width.
+            modifier = Modifier.fillMaxWidth(fraction = 0.7f),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = param.value.asString(),
+                    style = Theme.brockmann.body.s.medium,
+                    color = valueColor,
+                    textAlign = TextAlign.End,
+                    maxLines = 1,
+                    overflow = TextOverflow.MiddleEllipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+
+                param.copyableValue
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { copyable ->
+                        CopyIcon(
+                            textToCopy = copyable,
+                            size = 14.dp,
+                            tint = Theme.v2.colors.text.tertiary,
+                            onCopyCompleted = onCopy,
+                        )
+                    }
+            }
 
             param.secondary
                 ?.takeIf { it.isNotBlank() }
@@ -93,6 +118,7 @@ private fun DecodedFunctionParamRowsPreview() {
                 DecodedFunctionParam(
                     label = UiText.DynamicString("Spender"),
                     value = UiText.DynamicString("0xE592427A0AEce92De3Edee1F18E0157C05861564"),
+                    copyableValue = "0xE592427A0AEce92De3Edee1F18E0157C05861564",
                     secondary = "Uniswap V3 Router",
                 ),
                 DecodedFunctionParam(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/DecodedFunctionParamsRows.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/DecodedFunctionParamsRows.kt
@@ -1,0 +1,105 @@
+package com.vultisig.wallet.ui.screens.send
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
+import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
+
+/**
+ * Renders a list of [DecodedFunctionParam] rows produced by
+ * [com.vultisig.wallet.ui.models.keysign.decodedFunctionParams].
+ *
+ * Each row mirrors the layout of [com.vultisig.wallet.ui.screens.swap.VerifyCardDetails] — label on
+ * the left, value end-aligned on the right — with two additions: an optional `secondary` tag (e.g.
+ * `Uniswap V3 Router` for known DEX addresses) under the value, and a warning colour for
+ * unlimited-approval amount rows so the dangerous case stays visually consistent with the inline
+ * approval banner.
+ */
+@Composable
+internal fun DecodedFunctionParamRows(
+    params: List<DecodedFunctionParam>,
+    modifier: Modifier = Modifier,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = modifier.fillMaxWidth()) {
+        params.forEach { DecodedFunctionParamRow(it) }
+    }
+}
+
+@Composable
+private fun DecodedFunctionParamRow(param: DecodedFunctionParam) {
+    val valueColor =
+        if (param.isWarning) Theme.v2.colors.alerts.warning else Theme.v2.colors.text.primary
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = param.label.asString(),
+            style = Theme.brockmann.supplementary.footnote,
+            color = Theme.v2.colors.text.tertiary,
+            maxLines = 1,
+        )
+
+        UiSpacer(weight = 1f)
+
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = param.value.asString(),
+                style = Theme.brockmann.body.s.medium,
+                color = valueColor,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                overflow = TextOverflow.MiddleEllipsis,
+            )
+
+            param.secondary
+                ?.takeIf { it.isNotBlank() }
+                ?.let { secondary ->
+                    Text(
+                        text = secondary,
+                        style = Theme.brockmann.supplementary.footnote,
+                        color = Theme.v2.colors.text.tertiary,
+                        textAlign = TextAlign.End,
+                        maxLines = 1,
+                        overflow = TextOverflow.MiddleEllipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DecodedFunctionParamRowsPreview() {
+    DecodedFunctionParamRows(
+        params =
+            listOf(
+                DecodedFunctionParam(
+                    label = UiText.DynamicString("Spender"),
+                    value = UiText.DynamicString("0xE592427A0AEce92De3Edee1F18E0157C05861564"),
+                    secondary = "Uniswap V3 Router",
+                ),
+                DecodedFunctionParam(
+                    label = UiText.DynamicString("Amount"),
+                    value = UiText.DynamicString("Unlimited USDC"),
+                    isWarning = true,
+                ),
+            )
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -133,6 +133,13 @@ internal fun VerifySendScreen(
     onBackClick: () -> Unit = {},
     onConfirmScanning: () -> Unit = {},
     onDismissScanning: () -> Unit = {},
+    /**
+     * Opens the Transaction Details disclosure on first composition. Only the debug-only
+     * [com.vultisig.wallet.debug.PreviewActivity] passes `true` so the PR screenshots can capture
+     * the expanded rich-row layout without simulating a touch event; production paths keep the
+     * default `false` so the user still has to tap the expander.
+     */
+    initiallyExpandedDetails: Boolean = false,
 ) {
     V2Scaffold(
         title = stringResource(R.string.verify_send_send_overview).takeIf { hasToolbar },
@@ -353,6 +360,7 @@ internal fun VerifySendScreen(
                             functionSignature = tx.functionSignature,
                             functionInputs = tx.functionInputs,
                             decodedFunctionParams = tx.decodedFunctionParams,
+                            initiallyExpanded = initiallyExpandedDetails,
                         )
                     }
 
@@ -450,12 +458,13 @@ internal fun AddressField(title: String, address: String, divider: Boolean = tru
 }
 
 @Composable
-private fun TransactionDetailsSection(
+internal fun TransactionDetailsSection(
     functionSignature: String?,
     functionInputs: String?,
     decodedFunctionParams: List<DecodedFunctionParam>?,
+    initiallyExpanded: Boolean = false,
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
 
     Column(modifier = Modifier.fillMaxWidth()) {
         // Whole row is the tap target so the WCAG 2.5.5 minimum (48dp) is met without enlarging

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -63,6 +63,7 @@ import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.VerifyTransactionViewModel
+import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
 import com.vultisig.wallet.ui.models.keysign.sanitizeDisplayString
 import com.vultisig.wallet.ui.screens.swap.VerifyCardDetails
 import com.vultisig.wallet.ui.screens.swap.VerifyCardDivider
@@ -256,7 +257,11 @@ internal fun VerifySendScreen(
 
                     VerifyCardDivider(0.dp)
 
-                    val toDstLabel = tx.dstVaultName ?: tx.dstAddressBookTitle ?: tx.dstLabel
+                    val toDstLabel =
+                        tx.dstVaultName
+                            ?: tx.dstAddressBookTitle
+                            ?: tx.dstContractLabel
+                            ?: tx.dstLabel
                     VerifyCardDetails(
                         title = stringResource(R.string.verify_transaction_to_title),
                         subtitle = toDstLabel ?: tx.dstAddress,
@@ -347,6 +352,7 @@ internal fun VerifySendScreen(
                         TransactionDetailsSection(
                             functionSignature = tx.functionSignature,
                             functionInputs = tx.functionInputs,
+                            decodedFunctionParams = tx.decodedFunctionParams,
                         )
                     }
 
@@ -444,7 +450,11 @@ internal fun AddressField(title: String, address: String, divider: Boolean = tru
 }
 
 @Composable
-private fun TransactionDetailsSection(functionSignature: String?, functionInputs: String?) {
+private fun TransactionDetailsSection(
+    functionSignature: String?,
+    functionInputs: String?,
+    decodedFunctionParams: List<DecodedFunctionParam>?,
+) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -498,11 +508,20 @@ private fun TransactionDetailsSection(functionSignature: String?, functionInputs
                     )
                 }
 
-                functionInputs?.let {
-                    VerifyCardJsonDetails(
-                        title = stringResource(R.string.verify_transaction_function_inputs_title),
-                        subtitle = it,
-                    )
+                // When the parser produces labelled rows we show them in place of the raw JSON —
+                // semantic labels read better than `["0xabc…", "115792…"]`. Fall back to the raw
+                // JSON when the function signature is something the parser doesn't recognise so
+                // the user still sees the underlying arguments rather than nothing.
+                if (!decodedFunctionParams.isNullOrEmpty()) {
+                    DecodedFunctionParamRows(params = decodedFunctionParams)
+                } else {
+                    functionInputs?.let {
+                        VerifyCardJsonDetails(
+                            title =
+                                stringResource(R.string.verify_transaction_function_inputs_title),
+                            subtitle = it,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
@@ -12,7 +12,11 @@ internal fun TransactionTypeUiModel.toUiTransactionInfo(): UiTransactionInfo {
                 from = this.tx.srcAddress,
                 fromLabel = this.tx.srcVaultName,
                 to = this.tx.dstAddress,
-                toLabel = this.tx.dstVaultName ?: this.tx.dstAddressBookTitle ?: this.tx.dstLabel,
+                toLabel =
+                    this.tx.dstVaultName
+                        ?: this.tx.dstAddressBookTitle
+                        ?: this.tx.dstContractLabel
+                        ?: this.tx.dstLabel,
                 memo = this.tx.memo ?: "",
                 networkFeeFiatValue = this.tx.networkFeeFiatValue,
                 networkFeeTokenValue = this.tx.networkFeeTokenValue,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1186,4 +1186,13 @@
     <string name="swap_error_approval_failed">Token-Genehmigungstransaktion fehlgeschlagen. Bitte versuchen Sie es erneut</string>
     <string name="erc20_approval_unlimited_amount">Unbegrenzte %1$s-Freigabe</string>
     <string name="erc20_approval_spender">Begünstigter</string>
+    <string name="decoded_function_owner">Inhaber</string>
+    <string name="decoded_function_operator">Operator</string>
+    <string name="decoded_function_status">Status</string>
+    <string name="decoded_function_status_approved">Genehmigt</string>
+    <string name="decoded_function_status_revoked">Widerrufen</string>
+    <string name="decoded_function_deadline">Frist</string>
+    <string name="decoded_function_amount">Betrag</string>
+    <string name="decoded_function_unlimited">Unbegrenzt</string>
+    <string name="decoded_function_unlimited_amount">Unbegrenzt %1$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1184,4 +1184,13 @@
     <string name="swap_error_approval_failed">La transacción de aprobación del token falló. Inténtalo de nuevo</string>
     <string name="erc20_approval_unlimited_amount">Aprobación ilimitada de %1$s</string>
     <string name="erc20_approval_spender">Gastador</string>
+    <string name="decoded_function_owner">Propietario</string>
+    <string name="decoded_function_operator">Operador</string>
+    <string name="decoded_function_status">Estado</string>
+    <string name="decoded_function_status_approved">Aprobado</string>
+    <string name="decoded_function_status_revoked">Revocado</string>
+    <string name="decoded_function_deadline">Plazo</string>
+    <string name="decoded_function_amount">Cantidad</string>
+    <string name="decoded_function_unlimited">Ilimitado</string>
+    <string name="decoded_function_unlimited_amount">Ilimitado %1$s</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1194,4 +1194,13 @@
     <string name="swap_error_approval_failed">Transakcija odobrenja tokena nije uspjela. Molimo pokušajte ponovno</string>
     <string name="erc20_approval_unlimited_amount">Neograničeno odobrenje %1$s</string>
     <string name="erc20_approval_spender">Trošač</string>
+    <string name="decoded_function_owner">Vlasnik</string>
+    <string name="decoded_function_operator">Operator</string>
+    <string name="decoded_function_status">Status</string>
+    <string name="decoded_function_status_approved">Odobreno</string>
+    <string name="decoded_function_status_revoked">Opozvano</string>
+    <string name="decoded_function_deadline">Rok</string>
+    <string name="decoded_function_amount">Iznos</string>
+    <string name="decoded_function_unlimited">Neograničeno</string>
+    <string name="decoded_function_unlimited_amount">Neograničeno %1$s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1187,4 +1187,13 @@
     <string name="swap_error_approval_failed">La transazione di approvazione del token non è riuscita. Riprova</string>
     <string name="erc20_approval_unlimited_amount">Approvazione illimitata di %1$s</string>
     <string name="erc20_approval_spender">Destinatario</string>
+    <string name="decoded_function_owner">Proprietario</string>
+    <string name="decoded_function_operator">Operatore</string>
+    <string name="decoded_function_status">Stato</string>
+    <string name="decoded_function_status_approved">Approvato</string>
+    <string name="decoded_function_status_revoked">Revocato</string>
+    <string name="decoded_function_deadline">Scadenza</string>
+    <string name="decoded_function_amount">Quantità</string>
+    <string name="decoded_function_unlimited">Illimitato</string>
+    <string name="decoded_function_unlimited_amount">Illimitato %1$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1203,4 +1203,13 @@
     <string name="swap_error_approval_failed">토큰 승인 거래에 실패했습니다. 다시 시도해 주세요</string>
     <string name="erc20_approval_unlimited_amount">무제한 %1$s 승인</string>
     <string name="erc20_approval_spender">수신자</string>
+    <string name="decoded_function_owner">소유자</string>
+    <string name="decoded_function_operator">운영자</string>
+    <string name="decoded_function_status">상태</string>
+    <string name="decoded_function_status_approved">승인됨</string>
+    <string name="decoded_function_status_revoked">취소됨</string>
+    <string name="decoded_function_deadline">마감 시각</string>
+    <string name="decoded_function_amount">금액</string>
+    <string name="decoded_function_unlimited">무제한</string>
+    <string name="decoded_function_unlimited_amount">무제한 %1$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1178,4 +1178,13 @@
     <string name="swap_error_approval_failed">Tokengoedkeuringstransactie mislukt. Probeer het opnieuw.</string>
     <string name="erc20_approval_unlimited_amount">Onbeperkte goedkeuring van %1$s</string>
     <string name="erc20_approval_spender">Ontvanger</string>
+    <string name="decoded_function_owner">Eigenaar</string>
+    <string name="decoded_function_operator">Operator</string>
+    <string name="decoded_function_status">Status</string>
+    <string name="decoded_function_status_approved">Goedgekeurd</string>
+    <string name="decoded_function_status_revoked">Ingetrokken</string>
+    <string name="decoded_function_deadline">Deadline</string>
+    <string name="decoded_function_amount">Bedrag</string>
+    <string name="decoded_function_unlimited">Onbeperkt</string>
+    <string name="decoded_function_unlimited_amount">Onbeperkt %1$s</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1182,4 +1182,13 @@
     <string name="swap_error_approval_failed">A transação de aprovação do token falhou. Por favor tente novamente</string>
     <string name="erc20_approval_unlimited_amount">Aprovação ilimitada de %1$s</string>
     <string name="erc20_approval_spender">Destinatário</string>
+    <string name="decoded_function_owner">Proprietário</string>
+    <string name="decoded_function_operator">Operador</string>
+    <string name="decoded_function_status">Estado</string>
+    <string name="decoded_function_status_approved">Aprovado</string>
+    <string name="decoded_function_status_revoked">Revogado</string>
+    <string name="decoded_function_deadline">Prazo</string>
+    <string name="decoded_function_amount">Montante</string>
+    <string name="decoded_function_unlimited">Ilimitado</string>
+    <string name="decoded_function_unlimited_amount">Ilimitado %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1196,4 +1196,13 @@
     <string name="swap_error_approval_failed">Транзакция одобрения токена не удалась. Пожалуйста, попробуйте снова</string>
     <string name="erc20_approval_unlimited_amount">Неограниченное одобрение %1$s</string>
     <string name="erc20_approval_spender">Получатель</string>
+    <string name="decoded_function_owner">Владелец</string>
+    <string name="decoded_function_operator">Оператор</string>
+    <string name="decoded_function_status">Статус</string>
+    <string name="decoded_function_status_approved">Одобрено</string>
+    <string name="decoded_function_status_revoked">Отозвано</string>
+    <string name="decoded_function_deadline">Срок</string>
+    <string name="decoded_function_amount">Сумма</string>
+    <string name="decoded_function_unlimited">Без ограничений</string>
+    <string name="decoded_function_unlimited_amount">Без ограничений %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1509,4 +1509,13 @@
     <string name="swap_error_approval_failed">代币批准交易失败。请重试</string>
     <string name="erc20_approval_unlimited_amount">无限制 %1$s 授权</string>
     <string name="erc20_approval_spender">接收方</string>
+    <string name="decoded_function_owner">所有者</string>
+    <string name="decoded_function_operator">操作员</string>
+    <string name="decoded_function_status">状态</string>
+    <string name="decoded_function_status_approved">已批准</string>
+    <string name="decoded_function_status_revoked">已撤销</string>
+    <string name="decoded_function_deadline">截止时间</string>
+    <string name="decoded_function_amount">金额</string>
+    <string name="decoded_function_unlimited">无限制</string>
+    <string name="decoded_function_unlimited_amount">无限制 %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1235,4 +1235,13 @@
     <string name="swap_error_approval_failed">Token approval transaction failed. Please try again</string>
     <string name="erc20_approval_unlimited_amount">Unlimited %1$s approval</string>
     <string name="erc20_approval_spender">Spender</string>
+    <string name="decoded_function_owner">Owner</string>
+    <string name="decoded_function_operator">Operator</string>
+    <string name="decoded_function_status">Status</string>
+    <string name="decoded_function_status_approved">Approved</string>
+    <string name="decoded_function_status_revoked">Revoked</string>
+    <string name="decoded_function_deadline">Deadline</string>
+    <string name="decoded_function_amount">Amount</string>
+    <string name="decoded_function_unlimited">Unlimited</string>
+    <string name="decoded_function_unlimited_amount">Unlimited %1$s</string>
 </resources>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParamsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/DecodedFunctionParamsTest.kt
@@ -1,0 +1,395 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.utils.UiText
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+internal class DecodedFunctionParamsTest {
+
+    private val json = Json
+
+    @Test
+    fun `approve produces labelled spender and amount rows`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = """["0x7a250d5630b4cf539739df2c5dacb4c659f2488d", "1000000"]""",
+                json = json,
+                tokenSymbol = "USDC",
+            )
+
+        assertNotNull(rows)
+        assertEquals(2, rows.size)
+        assertResId(R.string.erc20_approval_spender, rows[0].label)
+        assertEquals(
+            "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
+            (rows[0].value as UiText.DynamicString).text,
+        )
+        assertResId(R.string.decoded_function_amount, rows[1].label)
+        assertEquals("1000000 USDC", (rows[1].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `approve with unlimited flag renders the unlimited amount in warning style`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson =
+                    """["0xabc", "115792089237316195423570985008687907853269984665640564039457584007913129639935"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                isUnlimitedApproval = true,
+            )
+
+        assertNotNull(rows)
+        val amountRow = rows[1]
+        assertTrue(amountRow.isWarning)
+        val formatted = amountRow.value as UiText.FormattedText
+        assertEquals(R.string.decoded_function_unlimited_amount, formatted.resId)
+        assertEquals(listOf<Any>("USDC"), formatted.formatArgs)
+    }
+
+    @Test
+    fun `approve with unlimited flag and unknown symbol falls back to bare Unlimited`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = """["0xabc", "1"]""",
+                json = json,
+                tokenSymbol = null,
+                isUnlimitedApproval = true,
+            )
+
+        val amountRow = assertNotNull(rows)[1]
+        assertEquals(
+            R.string.decoded_function_unlimited,
+            (amountRow.value as UiText.StringResource).resId,
+        )
+        assertTrue(amountRow.isWarning)
+    }
+
+    @Test
+    fun `transfer produces recipient and amount rows`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0x1111111111111111111111111111111111111111", "250"]""",
+                json = json,
+                tokenSymbol = "USDC",
+            )
+
+        assertNotNull(rows)
+        assertEquals(2, rows.size)
+        assertResId(R.string.verify_transaction_to_title, rows[0].label)
+        assertResId(R.string.decoded_function_amount, rows[1].label)
+        assertEquals("250 USDC", (rows[1].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transferFrom produces from recipient and amount rows`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transferFrom(address,address,uint256)",
+                inputsJson = """["0xaaa", "0xbbb", "42"]""",
+                json = json,
+                tokenSymbol = "USDC",
+            )
+
+        assertNotNull(rows)
+        assertEquals(3, rows.size)
+        assertResId(R.string.verify_transaction_from_title, rows[0].label)
+        assertResId(R.string.verify_transaction_to_title, rows[1].label)
+        assertResId(R.string.decoded_function_amount, rows[2].label)
+    }
+
+    @Test
+    fun `permit produces owner spender amount and deadline rows`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)",
+                inputsJson = """["0xowner","0xspender","10","9999","27","0x00","0x00"]""",
+                json = json,
+                tokenSymbol = "DAI",
+            )
+
+        assertNotNull(rows)
+        assertEquals(4, rows.size)
+        assertResId(R.string.decoded_function_owner, rows[0].label)
+        assertResId(R.string.erc20_approval_spender, rows[1].label)
+        assertResId(R.string.decoded_function_amount, rows[2].label)
+        assertResId(R.string.decoded_function_deadline, rows[3].label)
+        assertEquals("9999", (rows[3].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `setApprovalForAll true emits the approved status with warning style`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "setApprovalForAll(address,bool)",
+                inputsJson = """["0xoperator", "true"]""",
+                json = json,
+            )
+
+        assertNotNull(rows)
+        assertEquals(2, rows.size)
+        assertResId(R.string.decoded_function_operator, rows[0].label)
+        assertResId(R.string.decoded_function_status, rows[1].label)
+        assertEquals(
+            R.string.decoded_function_status_approved,
+            (rows[1].value as UiText.StringResource).resId,
+        )
+        assertTrue(rows[1].isWarning)
+    }
+
+    @Test
+    fun `setApprovalForAll false emits the revoked status without warning style`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "setApprovalForAll(address,bool)",
+                inputsJson = """["0xoperator", "false"]""",
+                json = json,
+            )
+
+        assertNotNull(rows)
+        assertEquals(
+            R.string.decoded_function_status_revoked,
+            (rows[1].value as UiText.StringResource).resId,
+        )
+        assertEquals(false, rows[1].isWarning)
+    }
+
+    @Test
+    fun `unknown function falls back to positional labels with type tags`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "doStuff(address,uint256,bool)",
+                inputsJson = """["0xabc", "12345", "true"]""",
+                json = json,
+            )
+
+        assertNotNull(rows)
+        assertEquals(3, rows.size)
+        assertEquals("#1 (address)", (rows[0].label as UiText.DynamicString).text)
+        assertEquals("#2 (uint256)", (rows[1].label as UiText.DynamicString).text)
+        assertEquals("#3 (bool)", (rows[2].label as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `unknown function calls the contract label lookup for address parameters`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "doStuff(address,uint256)",
+                inputsJson = """["0xabc", "1"]""",
+                json = json,
+                contractLabel = { if (it == "0xabc") "Custom Router" else null },
+            )
+
+        assertNotNull(rows)
+        assertEquals("Custom Router", rows[0].secondary)
+        assertNull(rows[1].secondary)
+    }
+
+    @Test
+    fun `known function call resolves contract label on address arguments`() {
+        val routerAddress = "0xE592427A0AEce92De3Edee1F18E0157C05861564"
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = """["$routerAddress", "1"]""",
+                json = json,
+                contractLabel = { addr ->
+                    if (addr.equals(routerAddress, ignoreCase = true)) "Uniswap V3 Router" else null
+                },
+            )
+
+        val spender = assertNotNull(rows).first()
+        assertEquals("Uniswap V3 Router", spender.secondary)
+    }
+
+    @Test
+    fun `known function call returns null secondary when contract label lookup misses`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = """["0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead", "1"]""",
+                json = json,
+                contractLabel = { null },
+            )
+
+        val spender = assertNotNull(rows).first()
+        assertNull(spender.secondary)
+    }
+
+    @Test
+    fun `transfer scales the amount by token decimals`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "1000000"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                tokenDecimals = 6,
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("1 USDC", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transfer scales fractional amount and strips trailing zeros`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "1500000"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                tokenDecimals = 6,
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("1.5 USDC", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transfer with null decimals keeps the raw integer in the display`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "1000000"]""",
+                json = json,
+                tokenSymbol = "USDC",
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("1000000 USDC", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transfer with hex amount scales correctly`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "0xf4240"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                tokenDecimals = 6,
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("1 USDC", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transfer with malformed amount falls back to the raw string`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "not-a-number"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                tokenDecimals = 6,
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("not-a-number", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `transfer with implausible decimals falls back to the raw integer`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "transfer(address,uint256)",
+                inputsJson = """["0xabc", "1000000"]""",
+                json = json,
+                tokenSymbol = "USDC",
+                tokenDecimals = 255,
+            )
+
+        val amount = assertNotNull(rows)[1]
+        assertEquals("1000000 USDC", (amount.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `unknown signature shape with arity mismatch still produces generic rows`() {
+        val rows =
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = """["0xabc"]""",
+                json = json,
+            )
+
+        assertNotNull(rows)
+        // Inputs underflowed by one; the generic fallback covers what is there + the missing slot
+        // so the row count is the larger of the two and the missing slot has empty value.
+        assertEquals(2, rows.size)
+    }
+
+    @Test
+    fun `blank inputs produce null`() {
+        assertNull(
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = "",
+                json = json,
+            )
+        )
+        assertNull(decodedFunctionParams(signature = "", inputsJson = "[]", json = json))
+        assertNull(
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = null,
+                json = json,
+            )
+        )
+    }
+
+    @Test
+    fun `malformed JSON produces null`() {
+        assertNull(
+            decodedFunctionParams(
+                signature = "approve(address,uint256)",
+                inputsJson = "not-json",
+                json = json,
+            )
+        )
+    }
+
+    @Test
+    fun `signature without closing paren produces null`() {
+        assertNull(
+            decodedFunctionParams(
+                signature = "approve(address,uint256",
+                inputsJson = "[]",
+                json = json,
+            )
+        )
+    }
+
+    @Test
+    fun `tuple parameters are kept as a single positional row in unknown-function fallback`() {
+        val rows =
+            decodedFunctionParams(
+                signature =
+                    "exactInputSingle((address,address,uint24,address,uint256,uint256,uint160))",
+                inputsJson = """[[ "0xa", "0xb", "500", "0xc", "1000", "100", "0" ]]""",
+                json = json,
+            )
+
+        assertNotNull(rows)
+        assertEquals(1, rows.size)
+        assertEquals(
+            "#1 ((address,address,uint24,address,uint256,uint256,uint160))",
+            (rows[0].label as UiText.DynamicString).text,
+        )
+    }
+
+    private fun assertResId(expected: Int, label: UiText) {
+        val actual = label as UiText.StringResource
+        assertEquals(expected, actual.resId)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.FourByteRepository
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -78,6 +79,7 @@ internal class VerifyTransactionViewModelTest {
     private lateinit var vaultRepository: VaultRepository
     private lateinit var addressBookRepository: AddressBookRepository
     private lateinit var fourByteRepository: FourByteRepository
+    private lateinit var tokenMetadataResolver: TokenMetadataResolver
     private val json: Json = Json
 
     /** Sets up mocks and test dispatcher before each test. */
@@ -97,6 +99,7 @@ internal class VerifyTransactionViewModelTest {
         vaultRepository = mockk(relaxed = true)
         addressBookRepository = mockk(relaxed = true)
         fourByteRepository = mockk(relaxed = true)
+        tokenMetadataResolver = mockk(relaxed = true)
         // Function-type-interface mocks need explicit return-type stubs; relaxed mode auto-stubs
         // to a generic Object that fails the implicit cast at the VM call site.
         coEvery { isVaultHasFastSignById(any()) } returns false
@@ -132,6 +135,7 @@ internal class VerifyTransactionViewModelTest {
             vaultRepository = vaultRepository,
             addressBookRepository = addressBookRepository,
             fourByteRepository = fourByteRepository,
+            tokenMetadataResolver = tokenMetadataResolver,
             json = json,
             ioDispatcher = testDispatcher,
         )

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
@@ -315,6 +315,50 @@ internal class VerifyTransactionViewModelTest {
             actual.token.token.ticker shouldBe "OM"
         }
 
+    /**
+     * Verifies the EVM decode pipeline populates the new rich-row UI fields once
+     * `enrichDecodedCall` is wired in: `decodedFunctionParams` carries the parsed labelled rows and
+     * `dstContractLabel` resolves through the static [KnownEvmContracts] registry. With the
+     * destination set to the Uniswap V2 Router on Ethereum, the label must come back as `Uniswap V2
+     * Router`.
+     */
+    @Test
+    fun `decoded function parameters and dst contract label populate from enrichDecodedCall`() =
+        runTest(testDispatcher) {
+            val spender = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
+            val memo =
+                "0x095ea7b3000000000000000000000000${spender.removePrefix("0x")}" +
+                    "0000000000000000000000000000000000000000000000000000000000000064"
+            val tx = mockk<Transaction>(relaxed = true)
+            // `Chain.Ethereum.standard` is already `TokenStandard.EVM` so the production code's
+            // `if (chain.standard == TokenStandard.EVM && !memo.isNullOrEmpty())` gate falls open
+            // on the real enum value — no need to stub `standard` separately.
+            every { tx.token } returns
+                mockk<Coin>(relaxed = true).apply { every { chain } returns Chain.Ethereum }
+            every { tx.memo } returns memo
+            // `dstAddress` is the Uniswap V2 Router on Ethereum so the registry hit fires.
+            every { tx.dstAddress } returns spender
+            coEvery { transactionRepository.getTransaction(TX_ID) } returns tx
+            coEvery { mapTransactionToUiModel(tx) } returns
+                TransactionDetailsUiModel(dstAddress = spender)
+            coEvery { fourByteRepository.decodeFunction(memo) } returns "approve(address,uint256)"
+            every {
+                fourByteRepository.decodeFunctionArgs("approve(address,uint256)", memo)
+            } returns "[\"$spender\",\"100\"]"
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val actual = vm.uiState.value.transaction
+            actual.functionSignature shouldBe "approve(address,uint256)"
+            actual.dstContractLabel shouldBe "Uniswap V2 Router"
+            actual.decodedFunctionParams.shouldNotBeNull()
+            actual.decodedFunctionParams!!.size shouldBe 2
+            // First row is the spender, copyable to clipboard.
+            actual.decodedFunctionParams!![0].copyableValue shouldBe spender
+            actual.decodedFunctionParams!![0].secondary shouldBe "Uniswap V2 Router"
+        }
+
     private companion object {
         const val VAULT_ID = "vault-1"
         const val TX_ID = "tx-1"

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
@@ -352,11 +352,11 @@ internal class VerifyTransactionViewModelTest {
             val actual = vm.uiState.value.transaction
             actual.functionSignature shouldBe "approve(address,uint256)"
             actual.dstContractLabel shouldBe "Uniswap V2 Router"
-            actual.decodedFunctionParams.shouldNotBeNull()
-            actual.decodedFunctionParams!!.size shouldBe 2
+            val decodedParams = actual.decodedFunctionParams.shouldNotBeNull()
+            decodedParams.size shouldBe 2
             // First row is the spender, copyable to clipboard.
-            actual.decodedFunctionParams!![0].copyableValue shouldBe spender
-            actual.decodedFunctionParams!![0].secondary shouldBe "Uniswap V2 Router"
+            decodedParams[0].copyableValue shouldBe spender
+            decodedParams[0].secondary shouldBe "Uniswap V2 Router"
         }
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KnownEvmContracts.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KnownEvmContracts.kt
@@ -1,0 +1,131 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.annotation.VisibleForTesting
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+
+/**
+ * Static lookup of well-known EVM contract addresses → human-readable labels.
+ *
+ * Consulted by the dApp verify and join-keysign screens so a recipient that resolves to a known DEX
+ * router renders as e.g. `Uniswap V3 Router` instead of a raw `0x68b3…fC45`. Coverage is limited to
+ * contracts whose addresses are stable across deployments and widely used by Vultisig users; new
+ * entries should only be added once an address has been re-verified against the protocol's
+ * canonical documentation.
+ *
+ * Addresses are stored in their canonical (`0x` + lowercase hex) form so lookups never depend on
+ * the casing of the wire address. Permit2 (`0x000000000022D473030F116dDEE9F6B43aC78BA3`) ships at
+ * the same address on every chain it supports, so it lives in a separate chain-agnostic table that
+ * the public [lookup] consults as a fallback before reporting "no match".
+ */
+object KnownEvmContracts {
+
+    /** Address → label, keyed by chain. Addresses are stored as `0x` + lowercase 40-char hex. */
+    private val perChain: Map<Chain, Map<String, String>> =
+        mapOf(
+            Chain.Ethereum to
+                mapOf(
+                    // Uniswap V2 (`UniswapV2Router02`)
+                    "0x7a250d5630b4cf539739df2c5dacb4c659f2488d" to "Uniswap V2 Router",
+                    // Uniswap V3
+                    "0xe592427a0aece92de3edee1f18e0157c05861564" to "Uniswap V3 Router",
+                    "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45" to "Uniswap V3 Router 2",
+                    // Uniswap Universal Router — V1 (deadline variant) and V2 (V1.2, default)
+                    "0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b" to "Uniswap Universal Router V1",
+                    "0x66a9893cc07d91d95644aedd05d03f95e1dba8af" to "Uniswap Universal Router V2",
+                    // 1inch Aggregation Router (v5 + v6 — both at canonical deployments)
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    // 0x Exchange Proxy
+                    "0xdef1c0ded9bec7f1a1670819833240f027b25eff" to "0x Exchange Proxy",
+                    // Aave V3 Pool
+                    "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2" to "Aave V3 Pool",
+                ),
+            Chain.BscChain to
+                mapOf(
+                    "0x10ed43c718714eb63d5aa57b78b54704e256024e" to "PancakeSwap V2 Router",
+                    "0x13f4ea83d0bd40e75c8222255bc855a974568dd4" to "PancakeSwap V3 Router",
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                ),
+            Chain.Polygon to
+                mapOf(
+                    "0xe592427a0aece92de3edee1f18e0157c05861564" to "Uniswap V3 Router",
+                    "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45" to "Uniswap V3 Router 2",
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    "0x794a61358d6845594f94dc1db02a252b5b4814ad" to "Aave V3 Pool",
+                ),
+            Chain.Arbitrum to
+                mapOf(
+                    "0xe592427a0aece92de3edee1f18e0157c05861564" to "Uniswap V3 Router",
+                    "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45" to "Uniswap V3 Router 2",
+                    "0x5e325eda8064b456f4781070c0738d849c824258" to "Uniswap Universal Router",
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    "0x794a61358d6845594f94dc1db02a252b5b4814ad" to "Aave V3 Pool",
+                ),
+            Chain.Optimism to
+                mapOf(
+                    "0xe592427a0aece92de3edee1f18e0157c05861564" to "Uniswap V3 Router",
+                    "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45" to "Uniswap V3 Router 2",
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    "0x794a61358d6845594f94dc1db02a252b5b4814ad" to "Aave V3 Pool",
+                ),
+            Chain.Base to
+                mapOf(
+                    "0x2626664c2603336e57b271c5c0b26f421741e481" to "Uniswap V3 Router 2",
+                    "0x6ff5693b99212da76ad316178a184ab56d299b43" to "Uniswap Universal Router",
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    "0xa238dd80c259a72e81d7e4664a9801593f98d1c5" to "Aave V3 Pool",
+                ),
+            Chain.Avalanche to
+                mapOf(
+                    "0x1111111254eeb25477b68fb85ed929f73a960582" to "1inch Router V5",
+                    "0x111111125421ca6dc452d289314280a0f8842a65" to "1inch Router V6",
+                    "0x794a61358d6845594f94dc1db02a252b5b4814ad" to "Aave V3 Pool",
+                ),
+        )
+
+    /**
+     * Contracts that share an identical deployment address across every chain they support.
+     * Consulted only after the chain-specific table returns no match so a chain-specific override
+     * (rare in practice) always wins.
+     */
+    private val chainAgnostic: Map<String, String> =
+        mapOf(
+            // Permit2 — Uniswap's signature-based approval router
+            "0x000000000022d473030f116ddee9f6b43ac78ba3" to "Uniswap Permit2",
+            // CowSwap settlement contract
+            "0x9008d19f58aabd9ed0d60971565aa8510560ab41" to "CoW Protocol",
+        )
+
+    /**
+     * Returns the human-readable label for [address] on [chain], or null when the contract is not
+     * in the registry. [address] is matched case-insensitively after normalising to `0x`-prefixed
+     * lowercase hex; whitespace and casing variants from the wire are tolerated. Non-EVM chains
+     * always return null — the registry only meaningfully maps Ethereum-style addresses, and
+     * silently matching a chain-agnostic entry like Permit2 on Solana would mislead the user.
+     */
+    fun lookup(chain: Chain, address: String): String? {
+        if (chain.standard != TokenStandard.EVM) return null
+        val key = normalizeAddress(address) ?: return null
+        return perChain[chain]?.get(key) ?: chainAgnostic[key]
+    }
+
+    private fun normalizeAddress(address: String): String? {
+        val trimmed = address.trim().takeIf { it.isNotEmpty() } ?: return null
+        val withPrefix = if (trimmed.startsWith("0x", ignoreCase = true)) trimmed else "0x$trimmed"
+        return withPrefix.lowercase()
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val tableForTesting: Map<Chain, Map<String, String>>
+        get() = perChain
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val chainAgnosticForTesting: Map<String, String>
+        get() = chainAgnostic
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolver.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolver.kt
@@ -1,0 +1,178 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.annotation.VisibleForTesting
+import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/** Symbol + decimals pair for an ERC-20-shaped contract. */
+data class TokenMetadata(val symbol: String, val decimals: Int)
+
+/**
+ * Caching resolver for unknown ERC-20 token metadata. Backs the verify and join-keysign screens
+ * when an ABI-decoded transaction references a token contract that no installed vault holds — for
+ * example a fresh stablecoin or LP token surfaced by a dApp.
+ *
+ * Resolution path:
+ * 1. Returns a cached entry when one is fresher than [ttl].
+ * 2. Coalesces concurrent calls for the same (chain, address) pair onto a single in-flight RPC so
+ *    that wiring this into multiple rows on the same screen costs one round-trip, not several.
+ * 3. Falls through to [TokenRepository.getEVMTokenByContract], which already executes the parallel
+ *    `symbol()` / `decimals()` eth_calls via [com.vultisig.wallet.data.api.EvmApi.findCustomToken].
+ *
+ * Failures (network error, non-ERC-20 contract, garbage response) are returned as `null` and never
+ * cached — a transient outage shouldn't poison the next 24 hours of lookups. The decimals upper
+ * bound rejects contracts claiming more than [MAX_DECIMALS] places; downstream display code
+ * computes `10 ^ decimals`, so a hostile or buggy contract returning e.g. 255 would chew CPU during
+ * render without this guard. 36 is well above any legitimate token (18 is the de-facto ceiling).
+ */
+@Singleton
+class TokenMetadataResolver
+@Inject
+constructor(
+    private val tokenRepository: TokenRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal constructor(
+        tokenRepository: TokenRepository,
+        ioDispatcher: CoroutineDispatcher,
+        clock: () -> Long,
+        ttl: Duration,
+    ) : this(tokenRepository, ioDispatcher) {
+        this.clock = clock
+        this.ttl = ttl
+    }
+
+    private var clock: () -> Long = { System.currentTimeMillis() }
+        private set
+
+    private var ttl: Duration = DEFAULT_TTL
+        private set
+
+    private val mutex = Mutex()
+    private val cache = mutableMapOf<String, CacheEntry>()
+    private val inFlight = mutableMapOf<String, CompletableDeferred<TokenMetadata?>>()
+
+    /**
+     * Resolves the symbol + decimals for the ERC-20 token at [contractAddress] on [chain]. Returns
+     * `null` when [chain] is not an EVM chain, when [contractAddress] is blank, when the RPC call
+     * fails, or when the response does not look like a valid ERC-20.
+     */
+    suspend fun resolve(chain: Chain, contractAddress: String): TokenMetadata? {
+        if (chain.standard != TokenStandard.EVM) return null
+        val key = cacheKey(chain, contractAddress) ?: return null
+
+        // Acquire either a fresh cache hit, a deferred to wait on, or a deferred to own. The lock
+        // is released before any suspending await/fetch so a slow RPC never blocks unrelated
+        // lookups.
+        val slot =
+            mutex.withLock {
+                cache[key]?.let { cached ->
+                    if (clock() - cached.fetchedAt < ttl.inWholeMilliseconds) {
+                        return cached.metadata
+                    }
+                }
+                val existing = inFlight[key]
+                if (existing != null) {
+                    Slot.Wait(existing)
+                } else {
+                    val owned = CompletableDeferred<TokenMetadata?>()
+                    inFlight[key] = owned
+                    Slot.Own(owned)
+                }
+            }
+
+        return when (slot) {
+            is Slot.Wait -> slot.deferred.await()
+            is Slot.Own -> runFetch(chain, contractAddress, key, slot.deferred)
+        }
+    }
+
+    private suspend fun runFetch(
+        chain: Chain,
+        contractAddress: String,
+        key: String,
+        owned: CompletableDeferred<TokenMetadata?>,
+    ): TokenMetadata? {
+        try {
+            val metadata = fetch(chain, contractAddress)
+            mutex.withLock {
+                inFlight.remove(key)
+                if (metadata != null) {
+                    cache[key] = CacheEntry(metadata = metadata, fetchedAt = clock())
+                }
+            }
+            owned.complete(metadata)
+            return metadata
+        } catch (e: CancellationException) {
+            mutex.withLock { inFlight.remove(key) }
+            owned.cancel(e)
+            throw e
+        } catch (t: Throwable) {
+            mutex.withLock { inFlight.remove(key) }
+            // Followers must not observe the failure as a thrown exception — completing with
+            // `null` (the standard "couldn't resolve" sentinel everywhere else in this resolver)
+            // keeps every awaiter on the same code path. The failure is also not cached, so a
+            // transient outage doesn't poison the next [ttl] window.
+            owned.complete(null)
+            Timber.w(t, "Token metadata fetch failed for %s on %s", contractAddress, chain.raw)
+            return null
+        }
+    }
+
+    private suspend fun fetch(chain: Chain, contractAddress: String): TokenMetadata? {
+        val coin =
+            withContext(ioDispatcher) {
+                tokenRepository.getEVMTokenByContract(chain.id, contractAddress)
+            } ?: return null
+        val symbol = coin.ticker.trim()
+        if (symbol.isEmpty()) return null
+        if (coin.decimal !in 0..MAX_DECIMALS) return null
+        return TokenMetadata(symbol = symbol, decimals = coin.decimal)
+    }
+
+    private fun cacheKey(chain: Chain, contractAddress: String): String? {
+        val trimmed = contractAddress.trim().takeIf { it.isNotEmpty() } ?: return null
+        return "${chain.raw}|${trimmed.lowercase()}"
+    }
+
+    private data class CacheEntry(val metadata: TokenMetadata, val fetchedAt: Long)
+
+    private sealed interface Slot {
+        val deferred: CompletableDeferred<TokenMetadata?>
+
+        data class Wait(override val deferred: CompletableDeferred<TokenMetadata?>) : Slot
+
+        data class Own(override val deferred: CompletableDeferred<TokenMetadata?>) : Slot
+    }
+
+    companion object {
+        /**
+         * Hard ceiling for a contract's reported `decimals()`. Any value above this is treated as a
+         * malicious or buggy response — downstream formatting computes `10 ^ decimals` and a value
+         * like 255 would chew CPU during render. 36 is well above every legitimate token (18 is the
+         * de-facto ceiling, USDC/USDT use 6).
+         */
+        const val MAX_DECIMALS: Int = 36
+
+        /**
+         * How long a successful resolution stays cached before the next on-screen access triggers a
+         * fresh RPC call. 24h matches iOS so the two platforms surface the same metadata for the
+         * same token within a single working session.
+         */
+        val DEFAULT_TTL: Duration = 24.hours
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolver.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolver.kt
@@ -121,14 +121,15 @@ constructor(
             mutex.withLock { inFlight.remove(key) }
             owned.cancel(e)
             throw e
-        } catch (t: Throwable) {
+        } catch (e: Exception) {
             mutex.withLock { inFlight.remove(key) }
             // Followers must not observe the failure as a thrown exception — completing with
             // `null` (the standard "couldn't resolve" sentinel everywhere else in this resolver)
             // keeps every awaiter on the same code path. The failure is also not cached, so a
-            // transient outage doesn't poison the next [ttl] window.
+            // transient outage doesn't poison the next [ttl] window. `Error` subclasses (OOM
+            // etc.) propagate intentionally — they aren't ours to swallow.
             owned.complete(null)
-            Timber.w(t, "Token metadata fetch failed for %s on %s", contractAddress, chain.raw)
+            Timber.w(e, "Token metadata fetch failed for %s on %s", contractAddress, chain.raw)
             return null
         }
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/KnownEvmContractsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/KnownEvmContractsTest.kt
@@ -1,0 +1,154 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class KnownEvmContractsTest {
+
+    @Test
+    fun `looks up Uniswap V2 Router on Ethereum`() {
+        assertEquals(
+            "Uniswap V2 Router",
+            KnownEvmContracts.lookup(Chain.Ethereum, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"),
+        )
+    }
+
+    @Test
+    fun `looks up PancakeSwap V2 Router on BSC`() {
+        assertEquals(
+            "PancakeSwap V2 Router",
+            KnownEvmContracts.lookup(Chain.BscChain, "0x10ED43C718714eb63d5aA57B78B54704E256024E"),
+        )
+    }
+
+    @Test
+    fun `address lookup is case-insensitive`() {
+        assertEquals(
+            "Uniswap V2 Router",
+            KnownEvmContracts.lookup(Chain.Ethereum, "0x7A250D5630B4CF539739DF2C5DACB4C659F2488D"),
+        )
+    }
+
+    @Test
+    fun `address lookup tolerates missing 0x prefix`() {
+        assertEquals(
+            "Uniswap V2 Router",
+            KnownEvmContracts.lookup(Chain.Ethereum, "7a250d5630b4cf539739df2c5dacb4c659f2488d"),
+        )
+    }
+
+    @Test
+    fun `unknown address on a known chain returns null`() {
+        assertNull(
+            KnownEvmContracts.lookup(Chain.Ethereum, "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead")
+        )
+    }
+
+    @Test
+    fun `chain-agnostic Permit2 resolves on every EVM chain in the registry`() {
+        val permit2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        val chains = KnownEvmContracts.tableForTesting.keys
+        for (chain in chains) {
+            assertEquals(
+                "Uniswap Permit2",
+                KnownEvmContracts.lookup(chain, permit2),
+                "Permit2 must resolve on $chain",
+            )
+        }
+    }
+
+    @Test
+    fun `chain-agnostic Permit2 resolves on EVM chains that have no chain-specific entries`() {
+        val permit2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        val unmappedEvmChains =
+            Chain.entries.filter {
+                it.standard == TokenStandard.EVM && it !in KnownEvmContracts.tableForTesting.keys
+            }
+        assertTrue(
+            unmappedEvmChains.isNotEmpty(),
+            "test assumes some EVM chains have no chain-specific entries",
+        )
+        for (chain in unmappedEvmChains) {
+            assertEquals(
+                "Uniswap Permit2",
+                KnownEvmContracts.lookup(chain, permit2),
+                "Permit2 must resolve on $chain",
+            )
+        }
+    }
+
+    @Test
+    fun `chain-agnostic CowSwap resolves`() {
+        assertEquals(
+            "CoW Protocol",
+            KnownEvmContracts.lookup(Chain.Ethereum, "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"),
+        )
+    }
+
+    @Test
+    fun `lookup on a non-EVM chain returns null even for an address that is in the table`() {
+        assertNull(
+            KnownEvmContracts.lookup(Chain.Solana, "0x7a250d5630b4cf539739df2c5dacb4c659f2488d")
+        )
+    }
+
+    @Test
+    fun `blank or whitespace-only addresses return null`() {
+        assertNull(KnownEvmContracts.lookup(Chain.Ethereum, ""))
+        assertNull(KnownEvmContracts.lookup(Chain.Ethereum, "   "))
+    }
+
+    @Test
+    fun `every registered chain is EVM`() {
+        for (chain in KnownEvmContracts.tableForTesting.keys) {
+            assertEquals(
+                TokenStandard.EVM,
+                chain.standard,
+                "$chain in registry must be an EVM chain",
+            )
+        }
+    }
+
+    @Test
+    fun `every registered address is normalised lowercase with 0x prefix`() {
+        val pattern = Regex("^0x[0-9a-f]{40}$")
+        for ((chain, entries) in KnownEvmContracts.tableForTesting) {
+            for (address in entries.keys) {
+                assertTrue(
+                    pattern.matches(address),
+                    "$chain entry '$address' must be lowercase 0x + 40 hex",
+                )
+            }
+        }
+        for (address in KnownEvmContracts.chainAgnosticForTesting.keys) {
+            assertTrue(
+                pattern.matches(address),
+                "chain-agnostic entry '$address' must be lowercase 0x + 40 hex",
+            )
+        }
+    }
+
+    @Test
+    fun `chain-specific entries take precedence over chain-agnostic ones`() {
+        // Sanity check: the chain-agnostic table doesn't accidentally overshadow a chain-specific
+        // entry. Any address present in both should resolve to the chain-specific label.
+        for ((chain, entries) in KnownEvmContracts.tableForTesting) {
+            for ((address, label) in entries) {
+                val resolved = KnownEvmContracts.lookup(chain, address)
+                assertNotNull(resolved)
+                if (KnownEvmContracts.chainAgnosticForTesting.containsKey(address)) {
+                    assertEquals(
+                        label,
+                        resolved,
+                        "$chain entry '$address' must override chain-agnostic",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolverTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenMetadataResolverTest.kt
@@ -1,0 +1,251 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class TokenMetadataResolverTest {
+
+    @Test
+    fun `resolve returns symbol and decimals from the underlying repository`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        val resolver = newResolver(repo)
+
+        val metadata = resolver.resolve(Chain.Ethereum, USDC)
+
+        assertEquals(TokenMetadata(symbol = "USDC", decimals = 6), metadata)
+        assertEquals(1, repo.calls.get())
+    }
+
+    @Test
+    fun `cached resolution does not hit the repository again`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        val resolver = newResolver(repo)
+
+        resolver.resolve(Chain.Ethereum, USDC)
+        resolver.resolve(Chain.Ethereum, USDC)
+        resolver.resolve(Chain.Ethereum, USDC.uppercase())
+
+        assertEquals(1, repo.calls.get())
+    }
+
+    @Test
+    fun `concurrent calls for the same key dedupe to a single fetch`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val repo = FakeTokenRepository(usdcOnEthereum(), gate = gate)
+        val resolver = newResolver(repo)
+
+        val a = async { resolver.resolve(Chain.Ethereum, USDC) }
+        val b = async { resolver.resolve(Chain.Ethereum, USDC) }
+        val c = async { resolver.resolve(Chain.Ethereum, USDC) }
+        advanceUntilIdle()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(TokenMetadata("USDC", 6), a.await())
+        assertEquals(TokenMetadata("USDC", 6), b.await())
+        assertEquals(TokenMetadata("USDC", 6), c.await())
+        assertEquals(1, repo.calls.get())
+    }
+
+    @Test
+    fun `failures are not cached and the next call retries`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        repo.nextThrowable = RuntimeException("rpc down")
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, USDC))
+        assertEquals(1, repo.calls.get())
+
+        val metadata = resolver.resolve(Chain.Ethereum, USDC)
+        assertEquals(TokenMetadata("USDC", 6), metadata)
+        assertEquals(2, repo.calls.get())
+    }
+
+    @Test
+    fun `null coin from the repository yields null metadata and is not cached`() = runTest {
+        val repo = FakeTokenRepository(coin = null)
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, USDC))
+        assertEquals(1, repo.calls.get())
+    }
+
+    @Test
+    fun `blank symbol is rejected`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum().copy(ticker = "   "))
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, USDC))
+    }
+
+    @Test
+    fun `decimals exceeding the ceiling are rejected`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum().copy(decimal = 255))
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, USDC))
+    }
+
+    @Test
+    fun `negative decimals are rejected`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum().copy(decimal = -1))
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, USDC))
+    }
+
+    @Test
+    fun `non-EVM chains return null without hitting the repository`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Solana, USDC))
+        assertEquals(0, repo.calls.get())
+    }
+
+    @Test
+    fun `blank contract address returns null without hitting the repository`() = runTest {
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        val resolver = newResolver(repo)
+
+        assertNull(resolver.resolve(Chain.Ethereum, ""))
+        assertNull(resolver.resolve(Chain.Ethereum, "   "))
+        assertEquals(0, repo.calls.get())
+    }
+
+    @Test
+    fun `cache key is chain-scoped so the same address on a different chain re-fetches`() =
+        runTest {
+            val repo = FakeTokenRepository(usdcOnEthereum())
+            val resolver = newResolver(repo)
+
+            val ethereum = resolver.resolve(Chain.Ethereum, USDC)
+            val arbitrum = resolver.resolve(Chain.Arbitrum, USDC)
+
+            assertEquals(2, repo.calls.get())
+            assertNotEquals(null, ethereum)
+            assertNotEquals(null, arbitrum)
+        }
+
+    @Test
+    fun `entries past the TTL trigger a refetch`() = runTest {
+        val now = AtomicInteger(0)
+        val repo = FakeTokenRepository(usdcOnEthereum())
+        val resolver =
+            TokenMetadataResolver(
+                tokenRepository = repo,
+                ioDispatcher = testDispatcher(),
+                clock = { now.get().toLong() },
+                ttl = 1.hours,
+            )
+
+        resolver.resolve(Chain.Ethereum, USDC)
+        assertEquals(1, repo.calls.get())
+
+        now.set((1.hours.inWholeMilliseconds + 1L).toInt())
+        resolver.resolve(Chain.Ethereum, USDC)
+        assertEquals(2, repo.calls.get())
+    }
+
+    @Test
+    fun `concurrent callers do not all observe the failure as a thrown exception`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val repo = FakeTokenRepository(coin = null, gate = gate)
+        repo.nextThrowable = RuntimeException("rpc died")
+        val resolver = newResolver(repo)
+
+        val results = mutableListOf<TokenMetadata?>()
+        repeat(3) { launch { results += resolver.resolve(Chain.Ethereum, USDC) } }
+        advanceUntilIdle()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(3, results.size)
+        results.forEach { assertNull(it) }
+    }
+
+    private fun TestScope.newResolver(repo: TokenRepository): TokenMetadataResolver =
+        TokenMetadataResolver(
+            tokenRepository = repo,
+            ioDispatcher = testDispatcher(),
+            clock = { 0L },
+            ttl = 24.hours,
+        )
+
+    private fun TestScope.testDispatcher(): CoroutineDispatcher =
+        StandardTestDispatcher(testScheduler)
+
+    private fun usdcOnEthereum(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "USDC",
+            logo = "",
+            address = "",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = USDC,
+            isNativeToken = false,
+        )
+
+    private companion object {
+        private const val USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    }
+
+    private class FakeTokenRepository(
+        private val coin: Coin?,
+        private val gate: CompletableDeferred<Unit>? = null,
+    ) : TokenRepository {
+        val calls = AtomicInteger(0)
+        var nextThrowable: Throwable? = null
+
+        override suspend fun getToken(tokenId: String): Coin? = error("unused")
+
+        override suspend fun getNativeToken(chainId: String): Coin = error("unused")
+
+        override suspend fun getEVMTokenByContract(
+            chainId: String,
+            contractAddress: String,
+        ): Coin? {
+            calls.incrementAndGet()
+            gate?.await()
+            nextThrowable?.let {
+                nextThrowable = null
+                throw it
+            }
+            return coin
+        }
+
+        override suspend fun getTokensWithBalance(
+            chain: Chain,
+            address: String,
+            enabledDenoms: Set<String>,
+        ): List<Coin> = error("unused")
+
+        override suspend fun getRefreshTokens(chain: Chain, vault: Vault): List<Coin> =
+            error("unused")
+
+        override val builtInTokens: Flow<List<Coin>> = emptyFlow()
+        override val nativeTokens: Flow<List<Coin>> = emptyFlow()
+    }
+}


### PR DESCRIPTION
Replaces the raw JSON dump of decoded function arguments in the dApp verify and join-keysign Transaction Details section with labelled per-function rows. Adds a chain-scoped known-contract registry, a caching on-chain ERC-20 metadata resolver, and a copy icon on every address row so the full hex stays accessible even though the visible string is middle-ellipsised.

Closes #4058.

## What changed

- New `data/.../repositories/KnownEvmContracts.kt` — address→label registry covering Uniswap V2/V3/Universal Router, 1inch v5/v6, 0x Exchange Proxy, PancakeSwap, Aave V3 Pool, plus chain-agnostic entries for Permit2 and CoW Protocol. Non-EVM chains short-circuit to null so Permit2's chain-agnostic entry doesn't accidentally fire on Solana.
- New `data/.../repositories/TokenMetadataResolver.kt` — caching/single-flight resolver around the existing `findCustomToken` RPC. 24h TTL, decimals validated to 0..36, failures never cached. The `runFetch` catch is scoped to `Exception` so `Error` subclasses propagate.
- New `app/.../ui/models/keysign/DecodedFunctionParams.kt` — parses an ABI signature + decoded inputs JSON into rows with semantic labels (`Spender`, `Recipient`, `Amount`, etc.) for known function shapes, with a positional `#N (type)` fallback for unknown signatures. Token decimals carry through so `transfer(addr, 1_000_000)` on USDC renders as `1 USDC`, not the raw integer.
- New `app/.../ui/models/keysign/DecodedCallEnrichment.kt` — shared helper that both `VerifyTransactionViewModel` and `JoinKeysignViewModel` call to populate the new `dstContractLabel` and `decodedFunctionParams` fields on `TransactionDetailsUiModel`.
- New `app/.../ui/screens/send/DecodedFunctionParamsRows.kt` — `@Composable` that renders the rows. Address-typed rows ship a `CopyIcon` so the user can recover the full hex even though the visible string is middle-ellipsised.
- `VerifySendScreen.kt` shows the rich rows inside the expandable details section (falls back to the existing raw JSON when the parser doesn't recognise the signature); the `To` row now resolves through `dstContractLabel`.
- Strings added to all 10 locale `strings.xml` files. Existing keys (`erc20_approval_spender`, `verify_transaction_to_title`, `verify_transaction_from_title`) are reused where the meaning aligns.

## Before / After

Collapsed verify card — same on both paths (the rich rows live behind the disclosure):

![collapsed](https://i.imgur.com/pUvh3j8.png)

Expanded Transaction Details:

| Before (raw JSON) | After (labelled rows + copy) |
|-------------------|------------------------------|
| ![before](https://i.imgur.com/AJtycvV.png) | ![after](https://i.imgur.com/LnkHMfs.png) |

## Testing

- `./gradlew :app:assembleDebug :app:testDebugUnitTest :data:testDebugUnitTest` — all green
- `./gradlew :app:lintDebug` — 0 errors
- New unit tests: `KnownEvmContractsTest`, `TokenMetadataResolverTest`, `DecodedFunctionParamsTest` (~70 cases total covering known + unknown signatures, single-flight, TTL boundary, decimals scaling, malformed input, copy-value mapping)
- Existing `VerifyTransactionViewModelTest` extended with an integration test covering `decodedFunctionParams` + `dstContractLabel`
- Manual capture on Pixel 9 Pro emulator via `PreviewActivity` — screenshots above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer Verify screens: decoded function parameters shown as labeled rows (owner/operator/spender, amount, deadline) with copy and warning affordances; destination contract names displayed when known; improved handling of expanded/collapsed details.

* **Improvements**
  * Better token metadata lookup so symbols and decimals appear in transaction details, improving amount formatting and unlimited-approval messaging.

* **Internationalization**
  * Added decoded-function UI strings for DE, ES, HR, IT, KO, NL, PT, RU, ZH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->