### PR TITLE
feat(verify): decode Uniswap Universal Router execute calls

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -1351,6 +1351,7 @@ private fun decodedUniversalRouterSendState(
             functionSignature = "execute(bytes,bytes[],uint256)",
             functionInputs = rawArgs,
             decodedFunctionParams = if (useUrRows) urRows else genericRows,
+            isUniversalRouterSwap = useUrRows,
             networkFeeFiatValue = "$2.41",
             networkFeeTokenValue = "0.000632 ETH",
         )

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -155,6 +155,12 @@ class PreviewActivity : ComponentActivity() {
                         VerifyDecodedSendPreview(expanded = true, useRichRows = false)
                     "decoded_function_verify_expanded_after" ->
                         VerifyDecodedSendPreview(expanded = true, useRichRows = true)
+                    "universal_router_verify_collapsed" ->
+                        VerifyUniversalRouterPreview(expanded = false)
+                    "universal_router_verify_before" ->
+                        VerifyUniversalRouterPreview(expanded = true, useUrRows = false)
+                    "universal_router_verify_after" ->
+                        VerifyUniversalRouterPreview(expanded = true, useUrRows = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1232,6 +1238,128 @@ private fun decodedApproveSendState(
                     recommendations = "",
                 )
             ),
+    )
+}
+
+/**
+ * Full-screen [VerifySendScreen] preview wired for #4059 PR screenshots. Renders the real verify
+ * card with a mocked decoded Uniswap Universal Router `execute(...)` call (V3_SWAP_EXACT_IN USDC →
+ * DAI). `useUrRows = false` reproduces the BEFORE state — the same call passed through Phase-2A's
+ * generic positional decoder that can't see inside `bytes[]`. `useUrRows = true` shows the AFTER
+ * state with the four labelled swap rows. Both renders share device, layout, and mock data so the
+ * PR diff is apples-to-apples.
+ */
+@Composable
+private fun VerifyUniversalRouterPreview(expanded: Boolean = true, useUrRows: Boolean = true) {
+    VerifySendScreen(
+        state = decodedUniversalRouterSendState(useUrRows),
+        isConsentsEnabled = false,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
+        initiallyExpandedDetails = expanded,
+    )
+}
+
+private fun decodedUniversalRouterSendState(
+    useUrRows: Boolean
+): com.vultisig.wallet.ui.models.VerifyTransactionUiModel {
+    val ethCoin = Coins.Ethereum.ETH
+    val urAddress = "0x66a9893cc07d91d95644aedd05d03f95e1dba8af"
+    val usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    val dai = "0x6b175474e89094c44da98b954eedeac495271d0f"
+    // Realistic V3_SWAP_EXACT_IN inputs blob — the same shape the 4byte path emits for a
+    // 1 USDC → 0.99 DAI Universal Router swap.
+    val v3SwapInput =
+        "0x" +
+            "0000000000000000000000001111111111111111111111111111111111111111" +
+            "00000000000000000000000000000000000000000000000000000000000f4240" +
+            "0000000000000000000000000000000000000000000000000dbd2fca82fa0000" +
+            "00000000000000000000000000000000000000000000000000000000000000a0" +
+            "0000000000000000000000000000000000000000000000000000000000000001" +
+            "0000000000000000000000000000000000000000000000000000000000000002" +
+            "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" +
+            "0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f"
+    val rawArgs = """["0x08",["$v3SwapInput"],"0"]"""
+    val urRows =
+        listOf(
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_from_token
+                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("USDC"),
+                copyableValue = usdc,
+                secondary = usdc,
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_amount_in
+                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("1 USDC"),
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_to_token
+                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("DAI"),
+                copyableValue = dai,
+                secondary = dai,
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label =
+                    com.vultisig.wallet.ui.utils.UiText.StringResource(
+                        com.vultisig.wallet.R.string.decoded_function_min_amount_out
+                    ),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("0.99 DAI"),
+            ),
+        )
+    val genericRows =
+        listOf(
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label = com.vultisig.wallet.ui.utils.UiText.DynamicString("#1 (bytes)"),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("0x08"),
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label = com.vultisig.wallet.ui.utils.UiText.DynamicString("#2 (bytes[])"),
+                value =
+                    com.vultisig.wallet.ui.utils.UiText.DynamicString(
+                        "[$v3SwapInput]".take(64) + "…"
+                    ),
+            ),
+            com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam(
+                label = com.vultisig.wallet.ui.utils.UiText.DynamicString("#3 (uint256)"),
+                value = com.vultisig.wallet.ui.utils.UiText.DynamicString("0"),
+            ),
+        )
+    val tx =
+        com.vultisig.wallet.ui.models.TransactionDetailsUiModel(
+            token = ValuedToken(token = ethCoin, value = "0", fiatValue = "$0.00"),
+            srcAddress = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+            srcVaultName = "Honeypot Vault DKLS",
+            dstAddress = urAddress,
+            dstContractLabel = "Uniswap Universal Router V2",
+            functionName = "Execute",
+            functionSignature = "execute(bytes,bytes[],uint256)",
+            functionInputs = rawArgs,
+            decodedFunctionParams = if (useUrRows) urRows else genericRows,
+            networkFeeFiatValue = "$2.41",
+            networkFeeTokenValue = "0.000632 ETH",
+        )
+    return com.vultisig.wallet.ui.models.VerifyTransactionUiModel(
+        transaction = tx,
+        consentAddress = false,
+        consentAmount = false,
+        hasFastSign = false,
+        txScanStatus = com.vultisig.wallet.ui.models.TransactionScanStatus.NotStarted,
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -108,6 +108,13 @@ internal data class TransactionDetailsUiModel(
      */
     val decodedFunctionParams: List<DecodedFunctionParam>? = null,
     /**
+     * True when the call decoded to an aggregate Uniswap Universal Router swap. The verify screen
+     * uses this to swap the toolbar title from "Send overview" to "Swap overview" and the card
+     * title from the raw `Execute` function name to "Swap" so the user sees real intent, not the
+     * router's `execute(...)` plumbing.
+     */
+    val isUniversalRouterSwap: Boolean = false,
+    /**
      * Resolved hero content for the dApp signing screens. Populated by [BuildHeroContentUseCase]
      * once the Blockaid simulation completes. When non-null, screens render this in place of the
      * function-name title or the native-amount `VsOverviewToken`. When null, screens fall back to
@@ -388,6 +395,7 @@ constructor(
                     approvalTokenTicker = decodedExtras.approvalTokenTicker,
                     dstContractLabel = decodedExtras.dstContractLabel,
                     decodedFunctionParams = decodedExtras.decodedFunctionParams,
+                    isUniversalRouterSwap = decodedExtras.isUniversalRouterSwap,
                 )
 
             _uiState.update { it.copy(transaction = namedUiModel) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.FourByteRepository
 import com.vultisig.wallet.data.repositories.PrettyJson
 import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -164,6 +165,7 @@ constructor(
     private val addressBookRepository: AddressBookRepository,
     private val fourByteRepository: FourByteRepository,
     private val tokenMetadataResolver: TokenMetadataResolver,
+    private val tokenRepository: TokenRepository,
     @param:PrettyJson private val json: Json,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -370,6 +372,7 @@ constructor(
                     isUnlimitedApproval = isUnlimitedApproval,
                     json = json,
                     tokenMetadataResolver = tokenMetadataResolver,
+                    nativeTokenLookup = { c -> nativeTokenOrNull(c.id) },
                 )
 
             val namedUiModel =
@@ -429,4 +432,20 @@ constructor(
             }
         }
     }
+
+    /**
+     * Fetches the chain's native coin for the Universal Router swap-intent decoder so a native-ETH
+     * leg renders the right ticker. Non-fatal — a failed RPC just means the row displays the bare
+     * zero address. [CancellationException] propagates so structured-concurrency cancellation isn't
+     * swallowed.
+     */
+    private suspend fun nativeTokenOrNull(chainId: String) =
+        try {
+            tokenRepository.getNativeToken(chainId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Timber.w(t, "Failed to resolve native token for %s", chainId)
+            null
+        }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -444,8 +444,8 @@ constructor(
             tokenRepository.getNativeToken(chainId)
         } catch (e: CancellationException) {
             throw e
-        } catch (t: Throwable) {
-            Timber.w(t, "Failed to resolve native token for %s", chainId)
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to resolve native token for %s", chainId)
             null
         }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
@@ -16,6 +16,7 @@ internal data class DecodedCallExtras(
     val decodedFunctionParams: List<DecodedFunctionParam>?,
     val dstContractLabel: String?,
     val approvalTokenTicker: String?,
+    val isUniversalRouterSwap: Boolean = false,
 )
 
 /**
@@ -109,6 +110,7 @@ internal suspend fun enrichDecodedCall(
         decodedFunctionParams = rows,
         dstContractLabel = dstContractLabel,
         approvalTokenTicker = approvalToken?.symbol,
+        isUniversalRouterSwap = urRows != null,
     )
 }
 
@@ -143,4 +145,4 @@ private suspend fun resolveApprovalToken(
     return ApprovalToken(symbol = resolved.symbol, decimals = resolved.decimals)
 }
 
-private val EMPTY = DecodedCallExtras(null, null, null)
+private val EMPTY = DecodedCallExtras(null, null, null, false)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/DecodedCallEnrichment.kt
@@ -1,9 +1,11 @@
 package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.KnownEvmContracts
 import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import com.vultisig.wallet.data.repositories.UniversalRouterDecoder
 import kotlinx.serialization.json.Json
 
 /**
@@ -53,6 +55,7 @@ internal suspend fun enrichDecodedCall(
     isUnlimitedApproval: Boolean,
     json: Json,
     tokenMetadataResolver: TokenMetadataResolver,
+    nativeTokenLookup: suspend (Chain) -> Coin? = { null },
 ): DecodedCallExtras {
     if (functionInfo == null) return EMPTY
 
@@ -70,16 +73,37 @@ internal suspend fun enrichDecodedCall(
 
     val dstContractLabel = KnownEvmContracts.lookup(chain, dstAddress)
 
+    // Universal Router execute(...) goes through a dedicated swap-intent decoder so the labelled
+    // rows render real swap context (from/to token + amounts) instead of the opaque positional
+    // fallback `decodedFunctionParams` would produce for `(bytes, bytes[], uint256)`. Gated on
+    // the destination being on the known-router allowlist so an unrelated `execute` overload on
+    // another contract never coincidentally gets framed as a swap.
+    val urRows =
+        if (
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature(signature) &&
+                dstContractLabel != null &&
+                isUniversalRouterLabel(dstContractLabel)
+        ) {
+            universalRouterSwapRows(
+                chain = chain,
+                intent = UniversalRouterDecoder.decode(functionInfo.inputs, json),
+                allVaults = allVaults,
+                tokenMetadataResolver = tokenMetadataResolver,
+                nativeTokenLookup = nativeTokenLookup,
+            )
+        } else null
+
     val rows =
-        decodedFunctionParams(
-            signature = signature,
-            inputsJson = functionInfo.inputs,
-            json = json,
-            tokenSymbol = approvalToken?.symbol,
-            tokenDecimals = approvalToken?.decimals,
-            contractLabel = { address -> KnownEvmContracts.lookup(chain, address) },
-            isUnlimitedApproval = isUnlimitedApproval,
-        )
+        urRows
+            ?: decodedFunctionParams(
+                signature = signature,
+                inputsJson = functionInfo.inputs,
+                json = json,
+                tokenSymbol = approvalToken?.symbol,
+                tokenDecimals = approvalToken?.decimals,
+                contractLabel = { address -> KnownEvmContracts.lookup(chain, address) },
+                isUnlimitedApproval = isUnlimitedApproval,
+            )
 
     return DecodedCallExtras(
         decodedFunctionParams = rows,
@@ -87,6 +111,15 @@ internal suspend fun enrichDecodedCall(
         approvalTokenTicker = approvalToken?.symbol,
     )
 }
+
+/**
+ * `true` when [label] points at a Universal Router entry in
+ * [com.vultisig.wallet.data.repositories.KnownEvmContracts]. Matching on the label rather than the
+ * full address keeps the allowlist in one place — adding a new UR deployment to the registry
+ * automatically enables decoding without touching this gate.
+ */
+private fun isUniversalRouterLabel(label: String): Boolean =
+    label.startsWith("Uniswap Universal Router", ignoreCase = true)
 
 private suspend fun resolveApprovalToken(
     chain: Chain,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1154,6 +1154,7 @@ constructor(
                             approvalTokenTicker = decodedExtras.approvalTokenTicker,
                             dstContractLabel = decodedExtras.dstContractLabel,
                             decodedFunctionParams = decodedExtras.decodedFunctionParams,
+                            isUniversalRouterSwap = decodedExtras.isUniversalRouterSwap,
                         )
                     transactionTypeUiModel = TransactionTypeUiModel.Send(namedTransactionUiModel)
                     transactionHistoryData = mapTransactionHistoryData(namedTransactionUiModel)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1138,6 +1138,7 @@ constructor(
                             isUnlimitedApproval = isUnlimitedApproval,
                             json = json,
                             tokenMetadataResolver = tokenMetadataResolver,
+                            nativeTokenLookup = { c -> nativeTokenOrNull(c.id) },
                         )
 
                     val namedTransactionUiModel =
@@ -1616,6 +1617,22 @@ constructor(
         } else {
             withContext(Dispatchers.IO) { feeServiceComposite.calculateFees(blockchainTransaction) }
                 .amount
+        }
+
+    /**
+     * Fetches the chain's native coin for the Universal Router swap-intent decoder so a native-ETH
+     * leg renders the right ticker. Non-fatal — a failed RPC just means the row displays the bare
+     * zero address. [CancellationException] propagates so structured-concurrency cancellation isn't
+     * swallowed.
+     */
+    private suspend fun nativeTokenOrNull(chainId: String) =
+        try {
+            tokenRepository.getNativeToken(chainId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Timber.w(t, "Failed to resolve native token for %s", chainId)
+            null
         }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1630,8 +1630,8 @@ constructor(
             tokenRepository.getNativeToken(chainId)
         } catch (e: CancellationException) {
             throw e
-        } catch (t: Throwable) {
-            Timber.w(t, "Failed to resolve native token for %s", chainId)
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to resolve native token for %s", chainId)
             null
         }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/UniversalRouterSwapRows.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/UniversalRouterSwapRows.kt
@@ -1,0 +1,145 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.TokenMetadata
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import com.vultisig.wallet.data.repositories.UniversalRouterDecoder
+import com.vultisig.wallet.data.repositories.UniversalRouterSwapIntent
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asUiText
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * Builds the labelled rows shown inside the verify-screen Transaction Details disclosure when the
+ * decoded contract call is a Uniswap Universal Router swap.
+ *
+ * Each swap surfaces four rows in the user's perspective:
+ * - **From Token** — `intent.fromToken`, ticker if resolved (native uses the chain's fee coin),
+ *   secondary row carries the contract address so the user can copy the full hex.
+ * - **Amount In** / **Max Amount In** — `intent.amountIn`, scaled by the fromToken decimals when
+ *   known. The label swaps to `Max Amount In` for exact-out so the user knows it's a ceiling.
+ * - **To Token** — same shape as the From row, for `intent.toToken`.
+ * - **Min Amount Out** / **Amount Out** — `intent.amountOutMin`, with the symmetric exact-out label
+ *   swap.
+ *
+ * Returns `null` when [intent] is absent — callers should then leave the generic Phase-2A rows in
+ * place. The function never throws; unresolved tokens fall back to the bare contract address with
+ * no symbol/decimals applied so the user still sees the on-chain truth.
+ */
+internal suspend fun universalRouterSwapRows(
+    chain: Chain,
+    intent: UniversalRouterSwapIntent?,
+    allVaults: List<Vault>,
+    tokenMetadataResolver: TokenMetadataResolver,
+    nativeTokenLookup: suspend (Chain) -> Coin? = { null },
+): List<DecodedFunctionParam>? {
+    if (intent == null) return null
+
+    val fromInfo =
+        resolveTokenInfo(
+            chain,
+            intent.fromToken,
+            allVaults,
+            tokenMetadataResolver,
+            nativeTokenLookup,
+        )
+    val toInfo =
+        resolveTokenInfo(chain, intent.toToken, allVaults, tokenMetadataResolver, nativeTokenLookup)
+
+    val amountInLabel =
+        if (intent.isExactOut) R.string.decoded_function_max_amount_in
+        else R.string.decoded_function_amount_in
+    val amountOutLabel =
+        if (intent.isExactOut) R.string.decoded_function_amount_out
+        else R.string.decoded_function_min_amount_out
+
+    return listOf(
+        tokenRow(R.string.decoded_function_from_token, intent.fromToken, fromInfo),
+        amountRow(amountInLabel, intent.amountIn, fromInfo),
+        tokenRow(R.string.decoded_function_to_token, intent.toToken, toInfo),
+        amountRow(amountOutLabel, intent.amountOutMin, toInfo),
+    )
+}
+
+private data class ResolvedTokenInfo(val symbol: String?, val decimals: Int?)
+
+private suspend fun resolveTokenInfo(
+    chain: Chain,
+    tokenAddress: String,
+    allVaults: List<Vault>,
+    tokenMetadataResolver: TokenMetadataResolver,
+    nativeTokenLookup: suspend (Chain) -> Coin?,
+): ResolvedTokenInfo {
+    if (tokenAddress.equals(UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS, ignoreCase = true)) {
+        val native = nativeTokenLookup(chain)
+        return ResolvedTokenInfo(symbol = native?.ticker, decimals = native?.decimal)
+    }
+    val vaultMatch =
+        allVaults
+            .asSequence()
+            .flatMap { it.coins.asSequence() }
+            .firstOrNull { coin ->
+                coin.chain == chain && coin.contractAddress.equals(tokenAddress, ignoreCase = true)
+            }
+    if (vaultMatch != null && vaultMatch.ticker.isNotBlank()) {
+        return ResolvedTokenInfo(symbol = vaultMatch.ticker, decimals = vaultMatch.decimal)
+    }
+    val resolved: TokenMetadata? = tokenMetadataResolver.resolve(chain, tokenAddress)
+    return ResolvedTokenInfo(symbol = resolved?.symbol, decimals = resolved?.decimals)
+}
+
+private fun tokenRow(
+    labelRes: Int,
+    address: String,
+    info: ResolvedTokenInfo,
+): DecodedFunctionParam {
+    val symbol = info.symbol?.takeIf { it.isNotBlank() }
+    val isNative = address.equals(UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS, ignoreCase = true)
+    return if (symbol != null) {
+        DecodedFunctionParam(
+            label = labelRes.asUiText(),
+            value = UiText.DynamicString(symbol),
+            // Suppress the zero-address noise for native — the symbol already conveys the chain
+            // coin and the address would just be 40 zeros.
+            copyableValue = address.takeUnless { isNative },
+            secondary = address.takeUnless { isNative },
+        )
+    } else {
+        DecodedFunctionParam(
+            label = labelRes.asUiText(),
+            value = UiText.DynamicString(address),
+            copyableValue = address.takeUnless { isNative },
+        )
+    }
+}
+
+private fun amountRow(
+    labelRes: Int,
+    rawAmount: BigInteger,
+    info: ResolvedTokenInfo,
+): DecodedFunctionParam {
+    val display = formatAmount(rawAmount, info.decimals)
+    val ticker = info.symbol?.takeIf { it.isNotBlank() }
+    val text = if (ticker != null) "$display $ticker" else display
+    return DecodedFunctionParam(label = labelRes.asUiText(), value = UiText.DynamicString(text))
+}
+
+/**
+ * Scales an ABI uint amount into the token's display units. Decimals outside `0..[MAX_DECIMALS]`
+ * fall back to the raw integer, mirroring
+ * [com.vultisig.wallet.data.repositories.TokenMetadataResolver]'s own ceiling so a hostile contract
+ * claiming `decimals() = 255` cannot make the verify screen render a million-character zero-padded
+ * string. Trailing zeros are stripped so the row shows `1` instead of `1.000000` for a clean
+ * whole-unit amount.
+ */
+private fun formatAmount(rawAmount: BigInteger, decimals: Int?): String {
+    if (decimals == null || decimals !in 0..MAX_DECIMALS) return rawAmount.toString()
+    if (decimals == 0) return rawAmount.toString()
+    return BigDecimal(rawAmount).movePointLeft(decimals).stripTrailingZeros().toPlainString()
+}
+
+private const val MAX_DECIMALS = 36

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -142,7 +142,15 @@ internal fun VerifySendScreen(
     initiallyExpandedDetails: Boolean = false,
 ) {
     V2Scaffold(
-        title = stringResource(R.string.verify_send_send_overview).takeIf { hasToolbar },
+        title =
+            stringResource(
+                    if (state.transaction.isUniversalRouterSwap) {
+                        R.string.verify_swap_swap_overview
+                    } else {
+                        R.string.verify_send_send_overview
+                    }
+                )
+                .takeIf { hasToolbar },
         onBackClick = onBackClick.takeIf { hasToolbar },
         bottomBar = {
             Column(
@@ -237,10 +245,18 @@ internal fun VerifySendScreen(
 
                     // Hero is the dApp signing source of truth — Blockaid simulation when
                     // resolved, function-name title when only the 4byte decode loaded, native
-                    // VsOverviewToken otherwise.
+                    // VsOverviewToken otherwise. For a decoded Universal Router swap we override
+                    // the raw `execute` function name with a localised "Swap" title so the user
+                    // sees real intent instead of the router's plumbing.
+                    val heroTitle =
+                        if (tx.isUniversalRouterSwap) {
+                            stringResource(R.string.decoded_function_swap_title)
+                        } else {
+                            tx.functionName
+                        }
                     TransactionHero(
                         heroContent = tx.heroContent,
-                        functionName = tx.functionName,
+                        functionName = heroTitle,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         VsOverviewToken(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1195,4 +1195,10 @@
     <string name="decoded_function_amount">Betrag</string>
     <string name="decoded_function_unlimited">Unbegrenzt</string>
     <string name="decoded_function_unlimited_amount">Unbegrenzt %1$s</string>
+    <string name="decoded_function_from_token">Quell-Token</string>
+    <string name="decoded_function_to_token">Ziel-Token</string>
+    <string name="decoded_function_amount_in">Eingangsbetrag</string>
+    <string name="decoded_function_max_amount_in">Max. Eingangsbetrag</string>
+    <string name="decoded_function_min_amount_out">Min. Ausgangsbetrag</string>
+    <string name="decoded_function_amount_out">Ausgangsbetrag</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1201,4 +1201,5 @@
     <string name="decoded_function_max_amount_in">Max. Eingangsbetrag</string>
     <string name="decoded_function_min_amount_out">Min. Ausgangsbetrag</string>
     <string name="decoded_function_amount_out">Ausgangsbetrag</string>
+    <string name="decoded_function_swap_title">Tausch</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1199,4 +1199,5 @@
     <string name="decoded_function_max_amount_in">Cantidad máxima de entrada</string>
     <string name="decoded_function_min_amount_out">Cantidad mínima de salida</string>
     <string name="decoded_function_amount_out">Cantidad de salida</string>
+    <string name="decoded_function_swap_title">Intercambio</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1193,4 +1193,10 @@
     <string name="decoded_function_amount">Cantidad</string>
     <string name="decoded_function_unlimited">Ilimitado</string>
     <string name="decoded_function_unlimited_amount">Ilimitado %1$s</string>
+    <string name="decoded_function_from_token">Token de origen</string>
+    <string name="decoded_function_to_token">Token de destino</string>
+    <string name="decoded_function_amount_in">Cantidad de entrada</string>
+    <string name="decoded_function_max_amount_in">Cantidad máxima de entrada</string>
+    <string name="decoded_function_min_amount_out">Cantidad mínima de salida</string>
+    <string name="decoded_function_amount_out">Cantidad de salida</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1209,4 +1209,5 @@
     <string name="decoded_function_max_amount_in">Maksimalni ulazni iznos</string>
     <string name="decoded_function_min_amount_out">Minimalni izlazni iznos</string>
     <string name="decoded_function_amount_out">Izlazni iznos</string>
+    <string name="decoded_function_swap_title">Zamjena</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1203,4 +1203,10 @@
     <string name="decoded_function_amount">Iznos</string>
     <string name="decoded_function_unlimited">Neograničeno</string>
     <string name="decoded_function_unlimited_amount">Neograničeno %1$s</string>
+    <string name="decoded_function_from_token">Polazni token</string>
+    <string name="decoded_function_to_token">Odredišni token</string>
+    <string name="decoded_function_amount_in">Ulazni iznos</string>
+    <string name="decoded_function_max_amount_in">Maksimalni ulazni iznos</string>
+    <string name="decoded_function_min_amount_out">Minimalni izlazni iznos</string>
+    <string name="decoded_function_amount_out">Izlazni iznos</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1196,4 +1196,10 @@
     <string name="decoded_function_amount">Quantità</string>
     <string name="decoded_function_unlimited">Illimitato</string>
     <string name="decoded_function_unlimited_amount">Illimitato %1$s</string>
+    <string name="decoded_function_from_token">Token di origine</string>
+    <string name="decoded_function_to_token">Token di destinazione</string>
+    <string name="decoded_function_amount_in">Importo in entrata</string>
+    <string name="decoded_function_max_amount_in">Importo massimo in entrata</string>
+    <string name="decoded_function_min_amount_out">Importo minimo in uscita</string>
+    <string name="decoded_function_amount_out">Importo in uscita</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1202,4 +1202,5 @@
     <string name="decoded_function_max_amount_in">Importo massimo in entrata</string>
     <string name="decoded_function_min_amount_out">Importo minimo in uscita</string>
     <string name="decoded_function_amount_out">Importo in uscita</string>
+    <string name="decoded_function_swap_title">Scambio</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1218,4 +1218,5 @@
     <string name="decoded_function_max_amount_in">최대 보내는 금액</string>
     <string name="decoded_function_min_amount_out">최소 받는 금액</string>
     <string name="decoded_function_amount_out">받는 금액</string>
+    <string name="decoded_function_swap_title">스왑</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1212,4 +1212,10 @@
     <string name="decoded_function_amount">금액</string>
     <string name="decoded_function_unlimited">무제한</string>
     <string name="decoded_function_unlimited_amount">무제한 %1$s</string>
+    <string name="decoded_function_from_token">보내는 토큰</string>
+    <string name="decoded_function_to_token">받는 토큰</string>
+    <string name="decoded_function_amount_in">보내는 금액</string>
+    <string name="decoded_function_max_amount_in">최대 보내는 금액</string>
+    <string name="decoded_function_min_amount_out">최소 받는 금액</string>
+    <string name="decoded_function_amount_out">받는 금액</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1187,4 +1187,10 @@
     <string name="decoded_function_amount">Bedrag</string>
     <string name="decoded_function_unlimited">Onbeperkt</string>
     <string name="decoded_function_unlimited_amount">Onbeperkt %1$s</string>
+    <string name="decoded_function_from_token">Bron-token</string>
+    <string name="decoded_function_to_token">Bestemmingstoken</string>
+    <string name="decoded_function_amount_in">Bedrag in</string>
+    <string name="decoded_function_max_amount_in">Max. bedrag in</string>
+    <string name="decoded_function_min_amount_out">Min. bedrag uit</string>
+    <string name="decoded_function_amount_out">Bedrag uit</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1193,4 +1193,5 @@
     <string name="decoded_function_max_amount_in">Max. bedrag in</string>
     <string name="decoded_function_min_amount_out">Min. bedrag uit</string>
     <string name="decoded_function_amount_out">Bedrag uit</string>
+    <string name="decoded_function_swap_title">Swap</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1197,4 +1197,5 @@
     <string name="decoded_function_max_amount_in">Valor máximo de entrada</string>
     <string name="decoded_function_min_amount_out">Valor mínimo de saída</string>
     <string name="decoded_function_amount_out">Valor de saída</string>
+    <string name="decoded_function_swap_title">Troca</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1191,4 +1191,10 @@
     <string name="decoded_function_amount">Montante</string>
     <string name="decoded_function_unlimited">Ilimitado</string>
     <string name="decoded_function_unlimited_amount">Ilimitado %1$s</string>
+    <string name="decoded_function_from_token">Token de origem</string>
+    <string name="decoded_function_to_token">Token de destino</string>
+    <string name="decoded_function_amount_in">Valor de entrada</string>
+    <string name="decoded_function_max_amount_in">Valor máximo de entrada</string>
+    <string name="decoded_function_min_amount_out">Valor mínimo de saída</string>
+    <string name="decoded_function_amount_out">Valor de saída</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1205,4 +1205,10 @@
     <string name="decoded_function_amount">Сумма</string>
     <string name="decoded_function_unlimited">Без ограничений</string>
     <string name="decoded_function_unlimited_amount">Без ограничений %1$s</string>
+    <string name="decoded_function_from_token">Исходный токен</string>
+    <string name="decoded_function_to_token">Целевой токен</string>
+    <string name="decoded_function_amount_in">Сумма ввода</string>
+    <string name="decoded_function_max_amount_in">Макс. сумма ввода</string>
+    <string name="decoded_function_min_amount_out">Мин. сумма получения</string>
+    <string name="decoded_function_amount_out">Сумма получения</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1211,4 +1211,5 @@
     <string name="decoded_function_max_amount_in">Макс. сумма ввода</string>
     <string name="decoded_function_min_amount_out">Мин. сумма получения</string>
     <string name="decoded_function_amount_out">Сумма получения</string>
+    <string name="decoded_function_swap_title">Обмен</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1518,4 +1518,10 @@
     <string name="decoded_function_amount">金额</string>
     <string name="decoded_function_unlimited">无限制</string>
     <string name="decoded_function_unlimited_amount">无限制 %1$s</string>
+    <string name="decoded_function_from_token">源代币</string>
+    <string name="decoded_function_to_token">目标代币</string>
+    <string name="decoded_function_amount_in">转入金额</string>
+    <string name="decoded_function_max_amount_in">最大转入金额</string>
+    <string name="decoded_function_min_amount_out">最小转出金额</string>
+    <string name="decoded_function_amount_out">转出金额</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1524,4 +1524,5 @@
     <string name="decoded_function_max_amount_in">最大转入金额</string>
     <string name="decoded_function_min_amount_out">最小转出金额</string>
     <string name="decoded_function_amount_out">转出金额</string>
+    <string name="decoded_function_swap_title">交换</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1250,4 +1250,5 @@
     <string name="decoded_function_max_amount_in">Max amount in</string>
     <string name="decoded_function_min_amount_out">Min amount out</string>
     <string name="decoded_function_amount_out">Amount out</string>
+    <string name="decoded_function_swap_title">Swap</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1244,4 +1244,10 @@
     <string name="decoded_function_amount">Amount</string>
     <string name="decoded_function_unlimited">Unlimited</string>
     <string name="decoded_function_unlimited_amount">Unlimited %1$s</string>
+    <string name="decoded_function_from_token">From token</string>
+    <string name="decoded_function_to_token">To token</string>
+    <string name="decoded_function_amount_in">Amount in</string>
+    <string name="decoded_function_max_amount_in">Max amount in</string>
+    <string name="decoded_function_min_amount_out">Min amount out</string>
+    <string name="decoded_function_amount_out">Amount out</string>
 </resources>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/UniversalRouterSwapRowsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/UniversalRouterSwapRowsTest.kt
@@ -1,0 +1,200 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.TokenMetadata
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import com.vultisig.wallet.data.repositories.UniversalRouterDecoder
+import com.vultisig.wallet.data.repositories.UniversalRouterSwapIntent
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class UniversalRouterSwapRowsTest {
+
+    private val tokenMetadataResolver: TokenMetadataResolver = mockk(relaxed = true)
+
+    private val ethCoin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "ethereum",
+            address = "",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun erc20(ticker: String, decimals: Int, contractAddress: String) =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = ticker,
+            logo = ticker.lowercase(),
+            address = "",
+            decimal = decimals,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contractAddress,
+            isNativeToken = false,
+        )
+
+    private val usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    private val daiContract = "0x6b175474e89094c44da98b954eedeac495271d0f"
+
+    private suspend fun buildRows(
+        intent: UniversalRouterSwapIntent?,
+        vaultCoins: List<Coin> = emptyList(),
+        nativeLookup: suspend (Chain) -> Coin? = { ethCoin },
+    ): List<DecodedFunctionParam>? =
+        universalRouterSwapRows(
+            chain = Chain.Ethereum,
+            intent = intent,
+            allVaults = listOf(Vault(id = "v", name = "vault", coins = vaultCoins)),
+            tokenMetadataResolver = tokenMetadataResolver,
+            nativeTokenLookup = nativeLookup,
+        )
+
+    @Test
+    fun `returns null when intent is null`() = runTest { assertNull(buildRows(intent = null)) }
+
+    @Test
+    fun `exact-in swap renders four labelled rows with from-to-amountIn-amountOut`() = runTest {
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = usdcContract,
+                toToken = daiContract,
+                amountIn = BigInteger.valueOf(1_000_000L),
+                amountOutMin = BigInteger("990000000000000000"),
+                isExactOut = false,
+            )
+        val usdc = erc20("USDC", 6, usdcContract)
+        val dai = erc20("DAI", 18, daiContract)
+
+        val rs = assertNotNull(buildRows(intent, vaultCoins = listOf(usdc, dai)))
+        assertEquals(4, rs.size)
+        assertResId(R.string.decoded_function_from_token, rs[0].label)
+        assertEquals("USDC", (rs[0].value as UiText.DynamicString).text)
+        assertEquals(usdcContract, rs[0].copyableValue)
+        assertEquals(usdcContract, rs[0].secondary)
+
+        assertResId(R.string.decoded_function_amount_in, rs[1].label)
+        assertEquals("1 USDC", (rs[1].value as UiText.DynamicString).text)
+
+        assertResId(R.string.decoded_function_to_token, rs[2].label)
+        assertEquals("DAI", (rs[2].value as UiText.DynamicString).text)
+
+        assertResId(R.string.decoded_function_min_amount_out, rs[3].label)
+        assertEquals("0.99 DAI", (rs[3].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `exact-out swap uses max-in and amount-out labels`() = runTest {
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = usdcContract,
+                toToken = daiContract,
+                amountIn = BigInteger.valueOf(2_000_000L),
+                amountOutMin = BigInteger("1000000000000000000"),
+                isExactOut = true,
+            )
+
+        val rs = assertNotNull(buildRows(intent))
+        assertResId(R.string.decoded_function_max_amount_in, rs[1].label)
+        assertResId(R.string.decoded_function_amount_out, rs[3].label)
+    }
+
+    @Test
+    fun `native ETH side renders the chain fee coin ticker and hides the zero address`() = runTest {
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS,
+                toToken = usdcContract,
+                amountIn = BigInteger("1000000000000000000"),
+                amountOutMin = BigInteger.valueOf(2_000_000L),
+                isExactOut = false,
+            )
+
+        val rs = assertNotNull(buildRows(intent))
+        val fromRow = rs[0]
+        assertEquals("ETH", (fromRow.value as UiText.DynamicString).text)
+        // Native row should not expose the 40-zero sentinel for copy / secondary.
+        assertNull(fromRow.copyableValue)
+        assertNull(fromRow.secondary)
+
+        val amountInRow = rs[1]
+        assertEquals("1 ETH", (amountInRow.value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `unknown ERC20 falls back to metadata resolver`() = runTest {
+        coEvery { tokenMetadataResolver.resolve(Chain.Ethereum, usdcContract) } returns
+            TokenMetadata(symbol = "USDC", decimals = 6)
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = usdcContract,
+                toToken = UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS,
+                amountIn = BigInteger.valueOf(1_500_000L),
+                amountOutMin = BigInteger("700000000000000000"),
+                isExactOut = false,
+            )
+
+        val rs = assertNotNull(buildRows(intent))
+        assertEquals("USDC", (rs[0].value as UiText.DynamicString).text)
+        // 1_500_000 / 10^6 = 1.5
+        assertEquals("1.5 USDC", (rs[1].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `unresolved token leaves bare address and raw amount`() = runTest {
+        coEvery { tokenMetadataResolver.resolve(Chain.Ethereum, usdcContract) } returns null
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = usdcContract,
+                toToken = UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS,
+                amountIn = BigInteger.valueOf(1_500_000L),
+                amountOutMin = BigInteger("700000000000000000"),
+                isExactOut = false,
+            )
+
+        val rs = assertNotNull(buildRows(intent))
+        // Falls back to the bare address (no symbol, no secondary).
+        assertEquals(usdcContract, (rs[0].value as UiText.DynamicString).text)
+        assertEquals(usdcContract, rs[0].copyableValue)
+        assertNull(rs[0].secondary)
+        // Raw integer because decimals are unknown.
+        assertEquals("1500000", (rs[1].value as UiText.DynamicString).text)
+    }
+
+    @Test
+    fun `swallows null native lookup gracefully`() = runTest {
+        val intent =
+            UniversalRouterSwapIntent(
+                fromToken = UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS,
+                toToken = usdcContract,
+                amountIn = BigInteger("1000000000000000000"),
+                amountOutMin = BigInteger.valueOf(2_000_000L),
+                isExactOut = false,
+            )
+        val rs = assertNotNull(buildRows(intent, nativeLookup = { null }))
+        // No ticker resolved — value is just the raw amount, label still the localised one.
+        assertEquals("1000000000000000000", (rs[1].value as UiText.DynamicString).text)
+    }
+
+    private fun assertResId(expected: Int, label: UiText) {
+        assertTrue(
+            label is UiText.StringResource && label.resId == expected,
+            "expected R.string $expected, got $label",
+        )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.FourByteRepository
 import com.vultisig.wallet.data.repositories.TokenMetadataResolver
+import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -80,6 +81,7 @@ internal class VerifyTransactionViewModelTest {
     private lateinit var addressBookRepository: AddressBookRepository
     private lateinit var fourByteRepository: FourByteRepository
     private lateinit var tokenMetadataResolver: TokenMetadataResolver
+    private lateinit var tokenRepository: TokenRepository
     private val json: Json = Json
 
     /** Sets up mocks and test dispatcher before each test. */
@@ -100,6 +102,7 @@ internal class VerifyTransactionViewModelTest {
         addressBookRepository = mockk(relaxed = true)
         fourByteRepository = mockk(relaxed = true)
         tokenMetadataResolver = mockk(relaxed = true)
+        tokenRepository = mockk(relaxed = true)
         // Function-type-interface mocks need explicit return-type stubs; relaxed mode auto-stubs
         // to a generic Object that fails the implicit cast at the VM call site.
         coEvery { isVaultHasFastSignById(any()) } returns false
@@ -136,6 +139,7 @@ internal class VerifyTransactionViewModelTest {
             addressBookRepository = addressBookRepository,
             fourByteRepository = fourByteRepository,
             tokenMetadataResolver = tokenMetadataResolver,
+            tokenRepository = tokenRepository,
             json = json,
             ioDispatcher = testDispatcher,
         )
@@ -357,6 +361,78 @@ internal class VerifyTransactionViewModelTest {
             // First row is the spender, copyable to clipboard.
             decodedParams[0].copyableValue shouldBe spender
             decodedParams[0].secondary shouldBe "Uniswap V2 Router"
+        }
+
+    /**
+     * Universal Router `execute(bytes,bytes[],uint256)` to the Ethereum UR V2 address: the decoder
+     * runs, resolves the from/to tokens, and replaces the generic positional rows with the labelled
+     * From token / Amount in / To token / Min amount out shape.
+     *
+     * `inputsJson` is built from a pre-encoded V2_SWAP_EXACT_IN input (recipient `0x11…11`,
+     * amountIn = 1_000_000, amountOutMin = 10^18, path = [USDC, DAI], payerIsUser = true) — kept
+     * inline rather than pulled from the data-module test encoder so this test stays inside
+     * `:app:test`.
+     */
+    @Test
+    fun `universal router execute populates swap-style rows when dst is a known router`() =
+        runTest(testDispatcher) {
+            val urAddress = "0x66a9893cc07d91d95644aedd05d03f95e1dba8af"
+            val usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            val dai = "0x6b175474e89094c44da98b954eedeac495271d0f"
+            val v2Input =
+                "0x" +
+                    "0000000000000000000000001111111111111111111111111111111111111111" +
+                    "00000000000000000000000000000000000000000000000000000000000f4240" +
+                    "0000000000000000000000000000000000000000000000000de0b6b3a7640000" +
+                    "00000000000000000000000000000000000000000000000000000000000000a0" +
+                    "0000000000000000000000000000000000000000000000000000000000000001" +
+                    "0000000000000000000000000000000000000000000000000000000000000002" +
+                    "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" +
+                    "0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f"
+            val inputsJson = """["0x08",["$v2Input"],"0"]"""
+            val memo = "0x3593564c"
+
+            val tx = mockk<Transaction>(relaxed = true)
+            every { tx.token } returns
+                mockk<Coin>(relaxed = true).apply { every { chain } returns Chain.Ethereum }
+            every { tx.memo } returns memo
+            every { tx.dstAddress } returns urAddress
+            coEvery { transactionRepository.getTransaction(TX_ID) } returns tx
+            coEvery { mapTransactionToUiModel(tx) } returns
+                TransactionDetailsUiModel(dstAddress = urAddress)
+            coEvery { fourByteRepository.decodeFunction(memo) } returns
+                "execute(bytes,bytes[],uint256)"
+            every {
+                fourByteRepository.decodeFunctionArgs("execute(bytes,bytes[],uint256)", memo)
+            } returns inputsJson
+            // Resolver returns USDC / DAI on chain metadata lookup (vault has neither here).
+            coEvery { tokenMetadataResolver.resolve(Chain.Ethereum, usdc) } returns
+                com.vultisig.wallet.data.repositories.TokenMetadata("USDC", 6)
+            coEvery { tokenMetadataResolver.resolve(Chain.Ethereum, dai) } returns
+                com.vultisig.wallet.data.repositories.TokenMetadata("DAI", 18)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val actual = vm.uiState.value.transaction
+            actual.dstContractLabel shouldBe "Uniswap Universal Router V2"
+            val rows = actual.decodedFunctionParams.shouldNotBeNull()
+            rows.size shouldBe 4
+            (rows[0].label as com.vultisig.wallet.ui.utils.UiText.StringResource).resId shouldBe
+                com.vultisig.wallet.R.string.decoded_function_from_token
+            (rows[0].value as com.vultisig.wallet.ui.utils.UiText.DynamicString).text shouldBe
+                "USDC"
+            (rows[1].label as com.vultisig.wallet.ui.utils.UiText.StringResource).resId shouldBe
+                com.vultisig.wallet.R.string.decoded_function_amount_in
+            (rows[1].value as com.vultisig.wallet.ui.utils.UiText.DynamicString).text shouldBe
+                "1 USDC"
+            (rows[2].label as com.vultisig.wallet.ui.utils.UiText.StringResource).resId shouldBe
+                com.vultisig.wallet.R.string.decoded_function_to_token
+            (rows[2].value as com.vultisig.wallet.ui.utils.UiText.DynamicString).text shouldBe "DAI"
+            (rows[3].label as com.vultisig.wallet.ui.utils.UiText.StringResource).resId shouldBe
+                com.vultisig.wallet.R.string.decoded_function_min_amount_out
+            (rows[3].value as com.vultisig.wallet.ui.utils.UiText.DynamicString).text shouldBe
+                "1 DAI"
         }
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoder.kt
@@ -82,6 +82,10 @@ object UniversalRouterDecoder {
     private const val V4_ACTION_SWAP_EXACT_OUT = 0x09
 
     private const val WORD = 32
+    private const val V3_PATH_TOKEN_BYTES = 20
+    private const val V3_PATH_FEE_BYTES = 3
+    private const val V3_PATH_HOP_BYTES = V3_PATH_TOKEN_BYTES + V3_PATH_FEE_BYTES
+    private const val V3_PATH_MIN_BYTES = V3_PATH_TOKEN_BYTES + V3_PATH_HOP_BYTES
 
     private val EXECUTE_SIGNATURES =
         setOf("execute(bytes,bytes[],uint256)", "execute(bytes,bytes[])")
@@ -269,9 +273,13 @@ object UniversalRouterDecoder {
         val amountB = readUint(input, 2 * WORD) ?: return null
         val pathOffset = readPositiveInt(input, 3 * WORD) ?: return null
         val pathBytes = readBytes(input, pathOffset) ?: return null
-        if (pathBytes.size < 20) return null
+        // V3 packs the path as token(20) || fee(3) || token(20) || fee(3) || … so the byte count
+        // is always 20 + 23 * hops. Truncated / misaligned blobs would otherwise let
+        // `readAddress(pathBytes.size - 20)` surface arbitrary trailing bytes as a token address.
+        if (pathBytes.size < V3_PATH_MIN_BYTES) return null
+        if ((pathBytes.size - V3_PATH_TOKEN_BYTES) % V3_PATH_HOP_BYTES != 0) return null
         val firstToken = readAddress(pathBytes, 0)
-        val lastToken = readAddress(pathBytes, pathBytes.size - 20)
+        val lastToken = readAddress(pathBytes, pathBytes.size - V3_PATH_TOKEN_BYTES)
         return if (isExactOut) {
             SwapEntry(
                 fromToken = lastToken,
@@ -417,9 +425,12 @@ object UniversalRouterDecoder {
         val out = mutableListOf<String>()
         for (i in 0 until length) {
             val pointer = readPositiveInt(data, elementsStart + i * WORD) ?: return null
-            val keyStart = elementsStart + pointer
-            if (data.size < keyStart + WORD) return null
-            out += readAddressWord(data, keyStart)
+            // Long math so a hostile `pointer` near Int.MAX_VALUE can't wrap negative — without
+            // this guard `readAddressWord` would happily read at the wrapped index and surface the
+            // zero-address sentinel, framing a malformed payload as a native-token swap.
+            val keyStart = elementsStart.toLong() + pointer.toLong()
+            if (keyStart < 0 || keyStart > data.size - WORD) return null
+            out += readAddressWord(data, keyStart.toInt())
         }
         return out
     }
@@ -507,7 +518,12 @@ object UniversalRouterDecoder {
         val out = mutableListOf<ByteArray>()
         for (i in 0 until length) {
             val pointer = readPositiveInt(data, elementsStart + i * WORD) ?: return null
-            out += readBytes(data, elementsStart + pointer) ?: return null
+            // Long math so a hostile `pointer` near Int.MAX_VALUE can't wrap negative when added
+            // to `elementsStart`. Bounded against `data.size - WORD` so the subsequent length read
+            // inside `readBytes` is in range.
+            val elementStart = elementsStart.toLong() + pointer.toLong()
+            if (elementStart < 0 || elementStart > data.size - WORD) return null
+            out += readBytes(data, elementStart.toInt()) ?: return null
         }
         return out
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoder.kt
@@ -1,0 +1,519 @@
+package com.vultisig.wallet.data.repositories
+
+import java.math.BigInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+
+/**
+ * Aggregate swap intent extracted from a Uniswap Universal Router `execute(...)` call.
+ *
+ * Addresses are stored as canonical `0x`-prefixed lowercase 40-char hex; native ETH is represented
+ * by [UniversalRouterDecoder.NATIVE_TOKEN_ADDRESS] (matching V4's Currency.unwrap convention) so
+ * callers should translate that sentinel to the chain's fee coin when displaying.
+ *
+ * The [amountIn] / [amountOutMin] semantics differ by direction:
+ * - Exact-in ([isExactOut] = false): [amountIn] is the user-supplied input, [amountOutMin] is the
+ *   floor on what they accepted.
+ * - Exact-out ([isExactOut] = true): [amountIn] is the upper bound the user authorized
+ *   (amountInMax), [amountOutMin] is the exact output the user is buying.
+ */
+data class UniversalRouterSwapIntent(
+    val fromToken: String,
+    val toToken: String,
+    val amountIn: BigInteger,
+    val amountOutMin: BigInteger,
+    val isExactOut: Boolean,
+)
+
+/**
+ * Decoder for Uniswap Universal Router `execute(bytes commands, bytes[] inputs, uint256 deadline)`
+ * (and the deadline-less overload) calldata.
+ *
+ * Phase 1's 4byte path resolves the outer signature and JSON-decodes the three arguments, but the
+ * useful information lives inside the `bytes[]` and is opaque to that path — the verify screen
+ * shows "Execute" with no swap context. This decoder walks the `commands` byte string, dispatches
+ * each command opcode to a per-shape input decoder (V2 / V3 / V4 in exact-in and exact-out
+ * variants, plus the WRAP_ETH / UNWRAP_WETH wrappers that frame native-ETH legs), and aggregates
+ * them into a single [UniversalRouterSwapIntent] for display.
+ *
+ * Returns `null` for inputs that are not a recognisable Universal Router execute call. Unknown
+ * opcodes inside an otherwise valid execute call are skipped rather than rejected — the router
+ * frequently bundles Permit2, sweep, and transfer commands around the actual swap.
+ *
+ * Aligned with the SDK reference (`@vultisig/core-chain/.../universalRouter/decode`) so swap intent
+ * stays consistent across Android, iOS, and the Extension when each platform's Blockaid simulation
+ * falls back to the local fallback path.
+ */
+object UniversalRouterDecoder {
+
+    /**
+     * Zero address — the V4 Currency convention for native ETH. Callers translate this to the
+     * chain's fee coin (ETH on Ethereum, MATIC on Polygon, …) when rendering.
+     */
+    const val NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+    /**
+     * Sentinel value sometimes passed as `amountIn` to mean "spend the router's full balance of the
+     * input token". Treated specially so a `WRAP_ETH` upstream wins over the sentinel.
+     */
+    private val CONTRACT_BALANCE_SENTINEL: BigInteger = BigInteger.ONE.shiftLeft(255)
+
+    /**
+     * The high bit (`0x80`) on a command byte is the "allow revert" flag. Only the lower 6 bits
+     * identify the opcode, so we mask before dispatching.
+     */
+    private const val COMMAND_TYPE_MASK = 0x3f
+
+    private const val V3_SWAP_EXACT_IN = 0x00
+    private const val V3_SWAP_EXACT_OUT = 0x01
+    private const val V2_SWAP_EXACT_IN = 0x08
+    private const val V2_SWAP_EXACT_OUT = 0x09
+    private const val WRAP_ETH = 0x0b
+    private const val UNWRAP_WETH = 0x0c
+    private const val V4_SWAP = 0x10
+
+    private const val V4_ACTION_SWAP_EXACT_IN_SINGLE = 0x06
+    private const val V4_ACTION_SWAP_EXACT_IN = 0x07
+    private const val V4_ACTION_SWAP_EXACT_OUT_SINGLE = 0x08
+    private const val V4_ACTION_SWAP_EXACT_OUT = 0x09
+
+    private const val WORD = 32
+
+    private val EXECUTE_SIGNATURES =
+        setOf("execute(bytes,bytes[],uint256)", "execute(bytes,bytes[])")
+
+    /**
+     * `true` when [signature] (as returned by `FourByteRepository.decodeFunction`) is one of the
+     * Universal Router execute overloads. Whitespace inside the signature is tolerated so a 4byte
+     * response with cosmetic spacing still matches.
+     */
+    fun isUniversalRouterExecuteSignature(signature: String?): Boolean {
+        if (signature.isNullOrBlank()) return false
+        return signature.replace("\\s+".toRegex(), "") in EXECUTE_SIGNATURES
+    }
+
+    /**
+     * Decode the pretty inputs JSON produced by [FourByteRepositoryImpl.decodeFunctionArgs] for a
+     * Universal Router execute call into an aggregate [UniversalRouterSwapIntent].
+     *
+     * The expected JSON shape is a top-level array whose first element is the `commands` byte
+     * string (lowercase `0x…` hex) and second element is the `inputs` array (each element another
+     * `0x…` hex string). A third `deadline` element may follow; it's ignored. Returns `null` when
+     * the JSON doesn't match that shape, when commands/inputs lengths disagree, or when no
+     * recognisable swap opcode is present.
+     */
+    fun decode(inputsJson: String?, json: Json): UniversalRouterSwapIntent? {
+        if (inputsJson.isNullOrBlank()) return null
+        val root = runCatching { json.parseToJsonElement(inputsJson).jsonArray }.getOrNull()
+        if (root == null || root.size < 2) return null
+        val commandsHex = root[0].asHexStringOrNull() ?: return null
+        val inputsArray = root[1] as? JsonArray ?: return null
+        val commands = decodeHex(commandsHex) ?: return null
+        if (commands.size != inputsArray.size) return null
+        val inputs = inputsArray.map { it.asHexStringOrNull()?.let(::decodeHex) ?: return null }
+        return aggregate(commands, inputs)
+    }
+
+    private fun aggregate(
+        commands: ByteArray,
+        inputs: List<ByteArray>,
+    ): UniversalRouterSwapIntent? {
+        val swaps = mutableListOf<SwapEntry>()
+        var wrapEthAmount: BigInteger? = null
+        var sawUnwrapWeth = false
+        var sawKnownCommand = false
+
+        for (i in commands.indices) {
+            val opcode = commands[i].toInt() and COMMAND_TYPE_MASK
+            val input = inputs[i]
+            when (opcode) {
+                V2_SWAP_EXACT_IN -> {
+                    sawKnownCommand = true
+                    decodeV2Swap(input, isExactOut = false)?.let(swaps::add)
+                }
+                V2_SWAP_EXACT_OUT -> {
+                    sawKnownCommand = true
+                    decodeV2Swap(input, isExactOut = true)?.let(swaps::add)
+                }
+                V3_SWAP_EXACT_IN -> {
+                    sawKnownCommand = true
+                    decodeV3Swap(input, isExactOut = false)?.let(swaps::add)
+                }
+                V3_SWAP_EXACT_OUT -> {
+                    sawKnownCommand = true
+                    decodeV3Swap(input, isExactOut = true)?.let(swaps::add)
+                }
+                WRAP_ETH -> {
+                    sawKnownCommand = true
+                    // Only the wrap that precedes the first swap matters for the user's input
+                    // side; later wraps are intermediate routing.
+                    if (swaps.isEmpty()) wrapEthAmount = decodeWrapEth(input)
+                }
+                UNWRAP_WETH -> {
+                    sawKnownCommand = true
+                    sawUnwrapWeth = true
+                }
+                V4_SWAP -> {
+                    sawKnownCommand = true
+                    decodeV4Swap(input)?.let(swaps::add)
+                }
+            // Anything else is intentionally skipped — Permit2, sweep, transfer, etc.
+            }
+        }
+
+        if (!sawKnownCommand || swaps.isEmpty()) return null
+
+        val first = swaps.first()
+        val last = swaps.last()
+
+        // Uniswap splits a single pair across multiple legs for better execution. Each leg is its
+        // own swap command but they share fromToken/toToken; reporting one leg's amounts would
+        // dramatically under-count the trade.
+        val isSplitRoute =
+            swaps.size > 1 &&
+                swaps.all { it.fromToken == first.fromToken && it.toToken == first.toToken }
+
+        var fromToken = first.fromToken
+        var toToken = if (isSplitRoute) first.toToken else last.toToken
+        var amountIn =
+            if (isSplitRoute) swaps.fold(BigInteger.ZERO) { acc, s -> acc.add(s.amountIn) }
+            else first.amountIn
+        val amountOutMin =
+            if (isSplitRoute) swaps.fold(BigInteger.ZERO) { acc, s -> acc.add(s.amountOutMin) }
+            else last.amountOutMin
+
+        wrapEthAmount?.let { wrap ->
+            fromToken = NATIVE_TOKEN_ADDRESS
+            // WRAP_ETH's amount is the user's total native input for the whole sequence. The first
+            // swap leg's amountIn/amountInMax only covers that leg (wrong for multi-hop or
+            // exact-out), so prefer the wrap amount unless it's the "use router balance" sentinel.
+            if (wrap != CONTRACT_BALANCE_SENTINEL || amountIn == CONTRACT_BALANCE_SENTINEL) {
+                amountIn = wrap
+            }
+        }
+
+        if (sawUnwrapWeth) {
+            // UNWRAP_WETH has two reasons that mean opposite things for the user-facing output:
+            //   1. Output conversion — the final swap lands in WETH and UNWRAP_WETH converts it to
+            //      native (ERC-20 → NATIVE).
+            //   2. Leftover refund — an exact-out flow wrapped too much ETH upfront and
+            //      UNWRAP_WETH refunds the unused remainder. The swap output is still the last
+            //      leg's ERC-20 toToken.
+            // Distinguish them: leftover refund only happens AFTER a WRAP_ETH, and only when the
+            // last swap's toToken is something other than the wrapped working asset (= first
+            // swap's fromToken). When the last swap's toToken matches the wrapped native, it's an
+            // output conversion back to native.
+            val isLeftoverRefund = wrapEthAmount != null && last.toToken != first.fromToken
+            if (!isLeftoverRefund) toToken = NATIVE_TOKEN_ADDRESS
+        }
+
+        return UniversalRouterSwapIntent(
+            fromToken = fromToken,
+            toToken = toToken,
+            amountIn = amountIn,
+            amountOutMin = amountOutMin,
+            isExactOut = last.isExactOut,
+        )
+    }
+
+    private data class SwapEntry(
+        val fromToken: String,
+        val toToken: String,
+        val amountIn: BigInteger,
+        val amountOutMin: BigInteger,
+        val isExactOut: Boolean,
+    )
+
+    // V2 input shape: (address recipient, uint256 amountA, uint256 amountB, address[] path, bool
+    // payerIsUser). For exact-in: amountA = amountIn, amountB = amountOutMin. For exact-out:
+    // amountA = amountOut, amountB = amountInMax.
+    private fun decodeV2Swap(input: ByteArray, isExactOut: Boolean): SwapEntry? {
+        if (input.size < 5 * WORD) return null
+        val amountA = readUint(input, WORD) ?: return null
+        val amountB = readUint(input, 2 * WORD) ?: return null
+        val pathOffset = readPositiveInt(input, 3 * WORD) ?: return null
+        val path = readAddressArray(input, pathOffset) ?: return null
+        if (path.size < 2) return null
+        val fromToken = path.first()
+        val toToken = path.last()
+        return if (isExactOut) {
+            SwapEntry(
+                fromToken,
+                toToken,
+                amountIn = amountB,
+                amountOutMin = amountA,
+                isExactOut = true,
+            )
+        } else {
+            SwapEntry(
+                fromToken,
+                toToken,
+                amountIn = amountA,
+                amountOutMin = amountB,
+                isExactOut = false,
+            )
+        }
+    }
+
+    // V3 input shape: (address recipient, uint256 amountA, uint256 amountB, bytes path, bool
+    // payerIsUser). V3 packs the path as tokenA(20) || fee(3) || tokenB(20) || fee(3) || ... For
+    // exact-in the path is in swap order; for exact-out it's reversed (tokenOut first), so we flip
+    // the endpoints to keep the user's perspective consistent.
+    private fun decodeV3Swap(input: ByteArray, isExactOut: Boolean): SwapEntry? {
+        if (input.size < 5 * WORD) return null
+        val amountA = readUint(input, WORD) ?: return null
+        val amountB = readUint(input, 2 * WORD) ?: return null
+        val pathOffset = readPositiveInt(input, 3 * WORD) ?: return null
+        val pathBytes = readBytes(input, pathOffset) ?: return null
+        if (pathBytes.size < 20) return null
+        val firstToken = readAddress(pathBytes, 0)
+        val lastToken = readAddress(pathBytes, pathBytes.size - 20)
+        return if (isExactOut) {
+            SwapEntry(
+                fromToken = lastToken,
+                toToken = firstToken,
+                amountIn = amountB,
+                amountOutMin = amountA,
+                isExactOut = true,
+            )
+        } else {
+            SwapEntry(
+                fromToken = firstToken,
+                toToken = lastToken,
+                amountIn = amountA,
+                amountOutMin = amountB,
+                isExactOut = false,
+            )
+        }
+    }
+
+    // WRAP_ETH input shape: (address recipient, uint256 amount).
+    private fun decodeWrapEth(input: ByteArray): BigInteger? {
+        if (input.size < 2 * WORD) return null
+        return readUint(input, WORD)
+    }
+
+    // V4_SWAP outer shape: (bytes actions, bytes[] params). First recognised swap action wins.
+    // V4 swaps emit one action per command in practice; Take-All / Settle-All actions surround
+    // it but don't change the aggregate intent.
+    private fun decodeV4Swap(input: ByteArray): SwapEntry? {
+        if (input.size < 2 * WORD) return null
+        val actionsOffset = readPositiveInt(input, 0) ?: return null
+        val paramsOffset = readPositiveInt(input, WORD) ?: return null
+        val actions = readBytes(input, actionsOffset) ?: return null
+        val params = readBytesArray(input, paramsOffset) ?: return null
+        if (actions.size != params.size) return null
+        for (i in actions.indices) {
+            val action = actions[i].toInt() and 0xff
+            val payload = params[i]
+            val entry =
+                when (action) {
+                    V4_ACTION_SWAP_EXACT_IN_SINGLE ->
+                        decodeV4SingleSwap(payload, isExactOut = false)
+                    V4_ACTION_SWAP_EXACT_OUT_SINGLE ->
+                        decodeV4SingleSwap(payload, isExactOut = true)
+                    V4_ACTION_SWAP_EXACT_IN -> decodeV4MultiSwap(payload, isExactOut = false)
+                    V4_ACTION_SWAP_EXACT_OUT -> decodeV4MultiSwap(payload, isExactOut = true)
+                    else -> null
+                }
+            if (entry != null) return entry
+        }
+        return null
+    }
+
+    /**
+     * V4 single-pool swap params, both directions:
+     * - Encoded as a single dynamic-tuple arg, so the payload starts with a 32-byte offset (= 32)
+     *   pointing at the tuple body.
+     * - Tuple body: `(PoolKey poolKey, bool zeroForOne, uint128 amount1, uint128 amount2, bytes
+     *   hookData)` where `PoolKey = (address currency0, address currency1, uint24 fee, int24
+     *   tickSpacing, address hooks)` is all static (5 words inline). For exact-in: `amount1 =
+     *   amountIn`, `amount2 = amountOutMinimum`. For exact-out: `amount1 = amountOut`, `amount2 =
+     *   amountInMaximum`.
+     */
+    private fun decodeV4SingleSwap(payload: ByteArray, isExactOut: Boolean): SwapEntry? {
+        if (payload.size < WORD) return null
+        val tupleStart = readPositiveInt(payload, 0) ?: return null
+        // poolKey (5 words) + zeroForOne (1) + amount1 (1) + amount2 (1) — we don't read past
+        // amount2 so we don't need room for the hookData offset.
+        if (payload.size < tupleStart + 8 * WORD) return null
+        val currency0 = readAddressWord(payload, tupleStart)
+        val currency1 = readAddressWord(payload, tupleStart + WORD)
+        val zeroForOne = readBoolWord(payload, tupleStart + 5 * WORD)
+        val amount1 = readUint(payload, tupleStart + 6 * WORD) ?: return null
+        val amount2 = readUint(payload, tupleStart + 7 * WORD) ?: return null
+        val fromToken = if (zeroForOne) currency0 else currency1
+        val toToken = if (zeroForOne) currency1 else currency0
+        return if (isExactOut) {
+            SwapEntry(
+                fromToken = fromToken,
+                toToken = toToken,
+                amountIn = amount2,
+                amountOutMin = amount1,
+                isExactOut = true,
+            )
+        } else {
+            SwapEntry(
+                fromToken = fromToken,
+                toToken = toToken,
+                amountIn = amount1,
+                amountOutMin = amount2,
+                isExactOut = false,
+            )
+        }
+    }
+
+    /**
+     * V4 multi-hop swap params, both directions:
+     * - Encoded as a single dynamic-tuple arg: 32-byte offset (= 32) + tuple body.
+     * - Tuple body: `(address currencyIn|Out, PathKey[] path, uint128 amount1, uint128 amount2)`
+     *   where `PathKey = (address intermediateCurrency, uint24 fee, int24 tickSpacing, address
+     *   hooks, bytes hookData)` is dynamic (has bytes). For exact-in: fromToken = currencyIn,
+     *   toToken = last(path).intermediateCurrency, amount1 = amountIn, amount2 = amountOutMinimum.
+     *   For exact-out: fromToken = first(path).intermediateCurrency, toToken = currencyOut, amount1
+     *   = amountOut, amount2 = amountInMaximum.
+     */
+    private fun decodeV4MultiSwap(payload: ByteArray, isExactOut: Boolean): SwapEntry? {
+        if (payload.size < WORD) return null
+        val tupleStart = readPositiveInt(payload, 0) ?: return null
+        if (payload.size < tupleStart + 4 * WORD) return null
+        val currency = readAddressWord(payload, tupleStart)
+        val pathOffsetRelative = readPositiveInt(payload, tupleStart + WORD) ?: return null
+        val pathKeys = readPathKeys(payload, tupleStart + pathOffsetRelative) ?: return null
+        if (pathKeys.isEmpty()) return null
+        val amount1 = readUint(payload, tupleStart + 2 * WORD) ?: return null
+        val amount2 = readUint(payload, tupleStart + 3 * WORD) ?: return null
+        return if (isExactOut) {
+            SwapEntry(
+                fromToken = pathKeys.first(),
+                toToken = currency,
+                amountIn = amount2,
+                amountOutMin = amount1,
+                isExactOut = true,
+            )
+        } else {
+            SwapEntry(
+                fromToken = currency,
+                toToken = pathKeys.last(),
+                amountIn = amount1,
+                amountOutMin = amount2,
+                isExactOut = false,
+            )
+        }
+    }
+
+    /**
+     * PathKey[] at [start]. Layout: 32-byte length, then N 32-byte offset pointers (each relative
+     * to the area after the length), then each PathKey's dynamic tuple body. We only care about the
+     * leading `intermediateCurrency` address so the rest of the PathKey is skipped.
+     */
+    private fun readPathKeys(data: ByteArray, start: Int): List<String>? {
+        val length = readPositiveInt(data, start) ?: return null
+        val elementsStart = start + WORD
+        val out = mutableListOf<String>()
+        for (i in 0 until length) {
+            val pointer = readPositiveInt(data, elementsStart + i * WORD) ?: return null
+            val keyStart = elementsStart + pointer
+            if (data.size < keyStart + WORD) return null
+            out += readAddressWord(data, keyStart)
+        }
+        return out
+    }
+
+    // ─── Low-level ABI byte reading (offsets are always in bytes) ────────────────
+
+    private fun decodeHex(hex: String): ByteArray? {
+        val cleaned = hex.removePrefix("0x").removePrefix("0X")
+        if (cleaned.length % 2 != 0) return null
+        if (cleaned.isEmpty()) return ByteArray(0)
+        val out = ByteArray(cleaned.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(cleaned[i * 2], 16)
+            val lo = Character.digit(cleaned[i * 2 + 1], 16)
+            if (hi < 0 || lo < 0) return null
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    /** Read a 32-byte unsigned big-endian integer at [offset]. Returns null if out of bounds. */
+    private fun readUint(data: ByteArray, offset: Int): BigInteger? {
+        if (offset < 0 || data.size < offset + WORD) return null
+        return BigInteger(1, data.copyOfRange(offset, offset + WORD))
+    }
+
+    /**
+     * Read a 32-byte uint at [offset] and convert to a non-negative `Int` for use as a byte offset
+     * into the payload. Returns null if the value would overflow `Int` or is negative.
+     */
+    private fun readPositiveInt(data: ByteArray, offset: Int): Int? {
+        val value = readUint(data, offset) ?: return null
+        if (value.signum() < 0 || value.bitLength() > 31) return null
+        return value.toInt()
+    }
+
+    /** Read an `address` packed in a 32-byte word at [offset] (last 20 bytes). */
+    private fun readAddressWord(data: ByteArray, offset: Int): String {
+        if (offset < 0 || data.size < offset + WORD) return NATIVE_TOKEN_ADDRESS
+        return readAddress(data, offset + 12)
+    }
+
+    /** Read a 20-byte address starting at the byte [offset], formatted as 0x-prefixed lowercase. */
+    private fun readAddress(data: ByteArray, offset: Int): String {
+        if (offset < 0 || data.size < offset + 20) return NATIVE_TOKEN_ADDRESS
+        val buf = StringBuilder(2 + 40)
+        buf.append("0x")
+        for (i in 0 until 20) {
+            val b = data[offset + i].toInt() and 0xff
+            buf.append(HEX_CHARS[b ushr 4])
+            buf.append(HEX_CHARS[b and 0x0f])
+        }
+        return buf.toString()
+    }
+
+    private fun readBoolWord(data: ByteArray, offset: Int): Boolean {
+        if (offset < 0 || data.size < offset + WORD) return false
+        // ABI encodes booleans as a full 32-byte word with the value in the last byte.
+        return data[offset + WORD - 1].toInt() != 0
+    }
+
+    /** Read dynamic `bytes` at [offset]: 32-byte length followed by the payload bytes. */
+    private fun readBytes(data: ByteArray, offset: Int): ByteArray? {
+        val length = readPositiveInt(data, offset) ?: return null
+        val start = offset + WORD
+        if (data.size < start + length) return null
+        return data.copyOfRange(start, start + length)
+    }
+
+    /** Read `address[]` at [offset]: 32-byte length followed by N word-padded addresses. */
+    private fun readAddressArray(data: ByteArray, offset: Int): List<String>? {
+        val length = readPositiveInt(data, offset) ?: return null
+        val start = offset + WORD
+        if (data.size < start + length * WORD) return null
+        return (0 until length).map { i -> readAddressWord(data, start + i * WORD) }
+    }
+
+    /**
+     * Read `bytes[]` at [offset]: 32-byte length, N 32-byte offset pointers (relative to the area
+     * after the length), then each element's `bytes` encoding (length + payload).
+     */
+    private fun readBytesArray(data: ByteArray, offset: Int): List<ByteArray>? {
+        val length = readPositiveInt(data, offset) ?: return null
+        val elementsStart = offset + WORD
+        val out = mutableListOf<ByteArray>()
+        for (i in 0 until length) {
+            val pointer = readPositiveInt(data, elementsStart + i * WORD) ?: return null
+            out += readBytes(data, elementsStart + pointer) ?: return null
+        }
+        return out
+    }
+
+    private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+    private fun JsonElement.asHexStringOrNull(): String? =
+        (this as? JsonPrimitive)?.contentOrNull?.takeIf { it.startsWith("0x", ignoreCase = true) }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UniversalRouterDecoderTest.kt
@@ -1,0 +1,588 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.PathKey
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.buildExecuteInputsJson
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.commandsFor
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV2Input
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV3Input
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV3Path
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV4MultiSwapParams
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV4SingleSwapParams
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeV4SwapInput
+import com.vultisig.wallet.data.repositories.UrAbiTestEncoder.encodeWrapEthInput
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+/**
+ * Ports the SDK reference test suite for the Universal Router decoder so swap intent stays in
+ * lockstep across Android, iOS, and the Extension when each platform's Blockaid simulation falls
+ * back to the local fallback path.
+ *
+ * The tests feed pre-decoded inputs JSON (the shape `FourByteRepository.decodeFunctionArgs` already
+ * produces for the outer `execute(bytes,bytes[],uint256)` call) so coverage runs on the JVM unit
+ * test target without pulling in Trust Wallet Core's JNI.
+ */
+internal class UniversalRouterDecoderTest {
+
+    private val json = Json
+
+    // ─── Constants ──────────────────────────────────────────────────────────────
+
+    private val WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    private val USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    private val DAI = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    private val RECIPIENT = "0x1111111111111111111111111111111111111111"
+    private val ZERO_ADDR = "0x0000000000000000000000000000000000000000"
+
+    // V4 command opcodes — duplicated here to keep tests independent of decoder internals.
+    private val V3_SWAP_EXACT_IN = 0x00
+    private val V3_SWAP_EXACT_OUT = 0x01
+    private val V2_SWAP_EXACT_IN = 0x08
+    private val V2_SWAP_EXACT_OUT = 0x09
+    private val WRAP_ETH = 0x0b
+    private val UNWRAP_WETH = 0x0c
+    private val V4_SWAP = 0x10
+
+    private val V4_ACTION_SWAP_EXACT_IN_SINGLE = 0x06
+    private val V4_ACTION_SWAP_EXACT_IN = 0x07
+    private val V4_ACTION_SWAP_EXACT_OUT_SINGLE = 0x08
+    private val V4_ACTION_SWAP_EXACT_OUT = 0x09
+
+    private val CONTRACT_BALANCE_SENTINEL: BigInteger = BigInteger.ONE.shiftLeft(255)
+
+    // ─── Null cases ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `returns null for blank inputs json`() {
+        assertNull(UniversalRouterDecoder.decode(null, json))
+        assertNull(UniversalRouterDecoder.decode("", json))
+        assertNull(UniversalRouterDecoder.decode("   ", json))
+    }
+
+    @Test
+    fun `returns null for malformed json`() {
+        assertNull(UniversalRouterDecoder.decode("not json", json))
+        assertNull(UniversalRouterDecoder.decode("{ }", json))
+        assertNull(UniversalRouterDecoder.decode("[]", json))
+        assertNull(UniversalRouterDecoder.decode("""["0x00"]""", json))
+    }
+
+    @Test
+    fun `returns null when commands and inputs lengths disagree`() {
+        val mismatched =
+            buildExecuteInputsJson(
+                commandsHex = "0x0008",
+                inputHexes = listOf("0x"),
+                deadline = null,
+            )
+        assertNull(UniversalRouterDecoder.decode(mismatched, json))
+    }
+
+    // ─── V2 ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `decodes a V2 exact-in swap (USDC -- DAI)`() {
+        val input =
+            encodeV2Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(1_000_000L),
+                amount2 = BigInteger("990000000000000000"),
+                path = listOf(USDC, DAI),
+                payerIsUser = true,
+            )
+        val inputsJson = buildExecuteInputsJson(commandsFor(V2_SWAP_EXACT_IN), listOf(input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(1_000_000L), intent.amountIn)
+        assertEquals(BigInteger("990000000000000000"), intent.amountOutMin)
+        assertEquals(false, intent.isExactOut)
+    }
+
+    @Test
+    fun `decodes a V2 exact-out swap (reports amountInMax as amountIn)`() {
+        // For exact-out, the encoded order is (amountOut, amountInMax); we report amountInMax as
+        // amountIn so the user sees what they could spend.
+        val input =
+            encodeV2Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger("5000000000000000000"),
+                amount2 = BigInteger.valueOf(2_000_000L),
+                path = listOf(USDC, DAI),
+                payerIsUser = true,
+            )
+        val inputsJson = buildExecuteInputsJson(commandsFor(V2_SWAP_EXACT_OUT), listOf(input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(2_000_000L), intent.amountIn)
+        assertEquals(BigInteger("5000000000000000000"), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    // ─── V3 ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `decodes a V3 exact-in multi-hop swap (USDC -- WETH -- DAI)`() {
+        val path = encodeV3Path(listOf(USDC, WETH, DAI), listOf(500, 3000))
+        val input =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(2_000_000L),
+                amount2 = BigInteger("1900000000000000000"),
+                path = path,
+                payerIsUser = true,
+            )
+        val inputsJson = buildExecuteInputsJson(commandsFor(V3_SWAP_EXACT_IN), listOf(input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(2_000_000L), intent.amountIn)
+        assertEquals(BigInteger("1900000000000000000"), intent.amountOutMin)
+    }
+
+    @Test
+    fun `decodes a V3 exact-out swap with reversed path`() {
+        // V3 encodes the path tokenOut→tokenIn for exact-out; decoder flips so the user sees their
+        // direction.
+        val reversedPath = encodeV3Path(listOf(DAI, USDC), listOf(500))
+        val input =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger("1000000000000000000"),
+                amount2 = BigInteger.valueOf(2_000_000L),
+                path = reversedPath,
+                payerIsUser = true,
+            )
+        val inputsJson = buildExecuteInputsJson(commandsFor(V3_SWAP_EXACT_OUT), listOf(input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(2_000_000L), intent.amountIn)
+        assertEquals(BigInteger("1000000000000000000"), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    // ─── WRAP_ETH / UNWRAP_WETH framing ─────────────────────────────────────────
+
+    @Test
+    fun `maps WRAP_ETH + V3 swap to native ETH as input`() {
+        val wrap = encodeWrapEthInput(RECIPIENT, BigInteger("1000000000000000000"))
+        val swap =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger("1000000000000000000"),
+                amount2 = BigInteger.valueOf(2_000_000_000L),
+                path = encodeV3Path(listOf(WETH, USDC), listOf(500)),
+                payerIsUser = false,
+            )
+        val inputsJson =
+            buildExecuteInputsJson(commandsFor(WRAP_ETH, V3_SWAP_EXACT_IN), listOf(wrap, swap))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(ZERO_ADDR, intent.fromToken)
+        assertEquals(USDC.lowercase(), intent.toToken)
+        assertEquals(BigInteger("1000000000000000000"), intent.amountIn)
+    }
+
+    @Test
+    fun `substitutes WRAP_ETH amount when swap uses CONTRACT_BALANCE sentinel`() {
+        val wrap = encodeWrapEthInput(RECIPIENT, BigInteger("5000000000000000000"))
+        val swap =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = CONTRACT_BALANCE_SENTINEL,
+                amount2 = BigInteger.ONE,
+                path = encodeV3Path(listOf(WETH, USDC), listOf(500)),
+                payerIsUser = false,
+            )
+        val inputsJson =
+            buildExecuteInputsJson(commandsFor(WRAP_ETH, V3_SWAP_EXACT_IN), listOf(wrap, swap))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(BigInteger("5000000000000000000"), intent.amountIn)
+    }
+
+    @Test
+    fun `ignores UNWRAP_WETH leftover refund after WRAP_ETH + exact-out swap`() {
+        // Native ETH → USDC exact-out: wrap the maximum input, run V3 exact-out (path reversed:
+        // USDC → WETH in calldata), then UNWRAP_WETH refunds the unused WETH. Output is USDC, not
+        // native.
+        val wrap = encodeWrapEthInput(RECIPIENT, BigInteger("2000000000000000000")) // max 2 ETH
+        val swap =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(5_000_000L), // amountOut = 5 USDC
+                amount2 = BigInteger("2000000000000000000"), // amountInMax = 2 WETH
+                path = encodeV3Path(listOf(USDC, WETH), listOf(500)), // exact-out path is reversed
+                payerIsUser = false,
+            )
+        val unwrap = encodeWrapEthInput(RECIPIENT, BigInteger.ZERO) // refund whatever's left
+        val inputsJson =
+            buildExecuteInputsJson(
+                commandsFor(WRAP_ETH, V3_SWAP_EXACT_OUT, UNWRAP_WETH),
+                listOf(wrap, swap, unwrap),
+            )
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(ZERO_ADDR, intent.fromToken)
+        assertEquals(USDC.lowercase(), intent.toToken)
+        // WRAP_ETH amount wins over the first-leg amountInMax.
+        assertEquals(BigInteger("2000000000000000000"), intent.amountIn)
+        assertEquals(BigInteger.valueOf(5_000_000L), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    @Test
+    fun `prefers WRAP_ETH amount over first-leg amountInMax for multi-hop exact-out`() {
+        // WRAP_ETH is the total user input; each V3 leg only carries its own per-leg
+        // amountInMax, so aggregating the first leg would under-report the spend.
+        val wrapAmount = BigInteger("5000000000000000000") // 5 ETH total
+        val wrap = encodeWrapEthInput(RECIPIENT, wrapAmount)
+        val leg1 =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(1_000_000L),
+                amount2 = BigInteger("3000000000000000000"), // leg-1 amountInMax: 3 WETH
+                path = encodeV3Path(listOf(USDC, WETH), listOf(500)),
+                payerIsUser = false,
+            )
+        val leg2 =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(2_000_000L),
+                amount2 = BigInteger("2000000000000000000"), // leg-2 amountInMax: 2 WETH
+                path = encodeV3Path(listOf(DAI, WETH), listOf(3000)),
+                payerIsUser = false,
+            )
+        val unwrap = encodeWrapEthInput(RECIPIENT, BigInteger.ZERO)
+        val inputsJson =
+            buildExecuteInputsJson(
+                commandsFor(WRAP_ETH, V3_SWAP_EXACT_OUT, V3_SWAP_EXACT_OUT, UNWRAP_WETH),
+                listOf(wrap, leg1, leg2, unwrap),
+            )
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(ZERO_ADDR, intent.fromToken)
+        // Last leg's toToken in V3 exact-out path-reversed encoding is DAI (path: DAI ← WETH), so
+        // the final aggregate output is DAI, not the WETH that UNWRAP_WETH refunds.
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(wrapAmount, intent.amountIn)
+    }
+
+    @Test
+    fun `maps V3 swap + UNWRAP_WETH to native ETH as output`() {
+        val swap =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(2_000_000L),
+                amount2 = BigInteger("100000000000000000"),
+                path = encodeV3Path(listOf(USDC, WETH), listOf(500)),
+                payerIsUser = true,
+            )
+        val unwrap = encodeWrapEthInput(RECIPIENT, BigInteger("100000000000000000"))
+        val inputsJson =
+            buildExecuteInputsJson(commandsFor(V3_SWAP_EXACT_IN, UNWRAP_WETH), listOf(swap, unwrap))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(ZERO_ADDR, intent.toToken)
+    }
+
+    // ─── Allow-revert masking ───────────────────────────────────────────────────
+
+    @Test
+    fun `ignores the allow-revert flag bit on command bytes`() {
+        val withRevertFlag = 0x80 or V2_SWAP_EXACT_IN
+        val input =
+            encodeV2Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(100L),
+                amount2 = BigInteger.valueOf(90L),
+                path = listOf(USDC, DAI),
+                payerIsUser = true,
+            )
+        val inputsJson = buildExecuteInputsJson(commandsFor(withRevertFlag), listOf(input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+    }
+
+    // ─── V4 ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `decodes a V4 single-pool exact-in swap`() {
+        val params =
+            encodeV4SingleSwapParams(
+                currency0 = DAI,
+                currency1 = USDC,
+                fee = 500,
+                tickSpacing = 10,
+                hooks = ZERO_ADDR,
+                zeroForOne = true, // spending currency0 = DAI
+                amount1 = BigInteger("1000000000000000000"),
+                amount2 = BigInteger.valueOf(900_000L),
+            )
+        val actions = byteArrayOf(V4_ACTION_SWAP_EXACT_IN_SINGLE.toByte())
+        val v4Input = encodeV4SwapInput(actions, listOf(params))
+        val inputsJson = buildExecuteInputsJson(commandsFor(V4_SWAP), listOf(v4Input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(DAI.lowercase(), intent.fromToken)
+        assertEquals(USDC.lowercase(), intent.toToken)
+        assertEquals(BigInteger("1000000000000000000"), intent.amountIn)
+        assertEquals(BigInteger.valueOf(900_000L), intent.amountOutMin)
+        assertEquals(false, intent.isExactOut)
+    }
+
+    @Test
+    fun `decodes a V4 single-pool exact-out swap with zeroForOne false`() {
+        val params =
+            encodeV4SingleSwapParams(
+                currency0 = DAI,
+                currency1 = USDC,
+                fee = 500,
+                tickSpacing = 10,
+                hooks = ZERO_ADDR,
+                zeroForOne = false, // spending currency1 = USDC
+                amount1 = BigInteger("1000000000000000000"), // amountOut
+                amount2 = BigInteger.valueOf(1_100_000L), // amountInMaximum
+            )
+        val actions = byteArrayOf(V4_ACTION_SWAP_EXACT_OUT_SINGLE.toByte())
+        val v4Input = encodeV4SwapInput(actions, listOf(params))
+        val inputsJson = buildExecuteInputsJson(commandsFor(V4_SWAP), listOf(v4Input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(1_100_000L), intent.amountIn)
+        assertEquals(BigInteger("1000000000000000000"), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    @Test
+    fun `decodes a V4 multi-hop exact-in swap`() {
+        val pathKeys =
+            listOf(
+                PathKey(
+                    intermediateCurrency = WETH,
+                    fee = 500,
+                    tickSpacing = 10,
+                    hooks = ZERO_ADDR,
+                ),
+                PathKey(intermediateCurrency = DAI, fee = 3000, tickSpacing = 60, hooks = ZERO_ADDR),
+            )
+        val params =
+            encodeV4MultiSwapParams(
+                currency = USDC,
+                path = pathKeys,
+                amount1 = BigInteger.valueOf(2_000_000L),
+                amount2 = BigInteger("1900000000000000000"),
+            )
+        val actions = byteArrayOf(V4_ACTION_SWAP_EXACT_IN.toByte())
+        val v4Input = encodeV4SwapInput(actions, listOf(params))
+        val inputsJson = buildExecuteInputsJson(commandsFor(V4_SWAP), listOf(v4Input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(2_000_000L), intent.amountIn)
+        assertEquals(BigInteger("1900000000000000000"), intent.amountOutMin)
+        assertEquals(false, intent.isExactOut)
+    }
+
+    @Test
+    fun `decodes a V4 multi-hop exact-out swap`() {
+        val pathKeys =
+            listOf(
+                PathKey(
+                    intermediateCurrency = USDC,
+                    fee = 500,
+                    tickSpacing = 10,
+                    hooks = ZERO_ADDR,
+                ),
+                PathKey(
+                    intermediateCurrency = WETH,
+                    fee = 3000,
+                    tickSpacing = 60,
+                    hooks = ZERO_ADDR,
+                ),
+            )
+        val params =
+            encodeV4MultiSwapParams(
+                currency = DAI,
+                path = pathKeys,
+                amount1 = BigInteger.valueOf(1_000_000L), // amountOut
+                amount2 = BigInteger("500000000000000000"), // amountInMaximum
+            )
+        val actions = byteArrayOf(V4_ACTION_SWAP_EXACT_OUT.toByte())
+        val v4Input = encodeV4SwapInput(actions, listOf(params))
+        val inputsJson = buildExecuteInputsJson(commandsFor(V4_SWAP), listOf(v4Input))
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger("500000000000000000"), intent.amountIn)
+        assertEquals(BigInteger.valueOf(1_000_000L), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    // ─── Split routes ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `sums amountIn and amountOutMin across split V3 exact-in legs`() {
+        val legA =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(600_000L),
+                amount2 = BigInteger("590000000000000000"),
+                path = encodeV3Path(listOf(USDC, DAI), listOf(500)),
+                payerIsUser = true,
+            )
+        val legB =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(400_000L),
+                amount2 = BigInteger("395000000000000000"),
+                path = encodeV3Path(listOf(USDC, DAI), listOf(3000)),
+                payerIsUser = true,
+            )
+        val inputsJson =
+            buildExecuteInputsJson(
+                commandsFor(V3_SWAP_EXACT_IN, V3_SWAP_EXACT_IN),
+                listOf(legA, legB),
+            )
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+        assertEquals(BigInteger.valueOf(1_000_000L), intent.amountIn)
+        assertEquals(BigInteger("985000000000000000"), intent.amountOutMin)
+    }
+
+    @Test
+    fun `sums split V3 exact-out legs under WRAP_ETH + UNWRAP_WETH refund`() {
+        val wrapAmount = BigInteger("2150000000000000")
+        val wrap = encodeWrapEthInput(RECIPIENT, wrapAmount)
+        fun mkLeg(amountOut: BigInteger, amountInMax: BigInteger) =
+            encodeV3Input(
+                recipient = RECIPIENT,
+                amount1 = amountOut,
+                amount2 = amountInMax,
+                path = encodeV3Path(listOf(USDC, WETH), listOf(500)),
+                payerIsUser = false,
+            )
+        val unwrap = encodeWrapEthInput(RECIPIENT, BigInteger.ZERO)
+        val inputsJson =
+            buildExecuteInputsJson(
+                commandsFor(
+                    WRAP_ETH,
+                    V3_SWAP_EXACT_OUT,
+                    V3_SWAP_EXACT_OUT,
+                    V3_SWAP_EXACT_OUT,
+                    UNWRAP_WETH,
+                ),
+                listOf(
+                    wrap,
+                    mkLeg(BigInteger.valueOf(500_000L), BigInteger("800000000000000")),
+                    mkLeg(BigInteger.valueOf(400_000L), BigInteger("700000000000000")),
+                    mkLeg(BigInteger.valueOf(300_000L), BigInteger("600000000000000")),
+                    unwrap,
+                ),
+            )
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(ZERO_ADDR, intent.fromToken)
+        assertEquals(USDC.lowercase(), intent.toToken)
+        // WRAP_ETH wins for amountIn (full authorized input).
+        assertEquals(wrapAmount, intent.amountIn)
+        // amountOutMin is the sum of the three legs' amountOut values.
+        assertEquals(BigInteger.valueOf(1_200_000L), intent.amountOutMin)
+        assertEquals(true, intent.isExactOut)
+    }
+
+    // ─── No recognised swap ─────────────────────────────────────────────────────
+
+    @Test
+    fun `returns null when execute carries only unsupported commands`() {
+        // 0x02 = PERMIT2_TRANSFER_FROM — not a swap, so the decoder reports no intent.
+        val anyPayload = "0x" + "00".repeat(96)
+        val inputsJson =
+            buildExecuteInputsJson(commandsHex = "0x02", inputHexes = listOf(anyPayload))
+        assertNull(UniversalRouterDecoder.decode(inputsJson, json))
+    }
+
+    @Test
+    fun `returns null when commands is empty`() {
+        val inputsJson = buildExecuteInputsJson(commandsHex = "0x", inputHexes = emptyList())
+        assertNull(UniversalRouterDecoder.decode(inputsJson, json))
+    }
+
+    // ─── Deadline-less overload ────────────────────────────────────────────────
+
+    @Test
+    fun `decodes deadline-less execute(bytes, bytes array) overload`() {
+        val input =
+            encodeV2Input(
+                recipient = RECIPIENT,
+                amount1 = BigInteger.valueOf(123L),
+                amount2 = BigInteger.valueOf(100L),
+                path = listOf(USDC, DAI),
+                payerIsUser = true,
+            )
+        val inputsJson =
+            buildExecuteInputsJson(commandsFor(V2_SWAP_EXACT_IN), listOf(input), deadline = null)
+
+        val intent = assertNotNull(UniversalRouterDecoder.decode(inputsJson, json))
+        assertEquals(USDC.lowercase(), intent.fromToken)
+        assertEquals(DAI.lowercase(), intent.toToken)
+    }
+
+    // ─── isUniversalRouterExecuteSignature ─────────────────────────────────────
+
+    @Test
+    fun `signature matcher accepts both UR overloads`() {
+        assertTrue(
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature(
+                "execute(bytes,bytes[],uint256)"
+            )
+        )
+        assertTrue(
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature("execute(bytes,bytes[])")
+        )
+    }
+
+    @Test
+    fun `signature matcher tolerates whitespace`() {
+        assertTrue(
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature(
+                "execute( bytes , bytes[] , uint256 )"
+            )
+        )
+    }
+
+    @Test
+    fun `signature matcher rejects other functions`() {
+        assertEquals(false, UniversalRouterDecoder.isUniversalRouterExecuteSignature(null))
+        assertEquals(false, UniversalRouterDecoder.isUniversalRouterExecuteSignature(""))
+        assertEquals(
+            false,
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature("approve(address,uint256)"),
+        )
+        // `execute` overload that doesn't match UR's signature should be rejected.
+        assertEquals(
+            false,
+            UniversalRouterDecoder.isUniversalRouterExecuteSignature("execute(uint256,bytes)"),
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UrAbiTestEncoder.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UrAbiTestEncoder.kt
@@ -1,0 +1,329 @@
+package com.vultisig.wallet.data.repositories
+
+import java.math.BigInteger
+
+/**
+ * Minimal ABI encoder for the V2 / V3 / V4 / WRAP_ETH input shapes consumed by
+ * [UniversalRouterDecoder]. Used only by tests to construct realistic Universal Router calldata
+ * fixtures. Mirrors what ethers' `AbiCoder.defaultAbiCoder().encode(...)` would emit for the
+ * specific tuples we exercise.
+ *
+ * Lives in the test source set; production code uses Trust Wallet Core's ABI codec instead.
+ */
+internal object UrAbiTestEncoder {
+
+    private const val WORD = 32
+
+    fun commandsFor(vararg opcodes: Int): String =
+        opcodes.joinToString(prefix = "0x", separator = "") { it.toString(16).padStart(2, '0') }
+
+    fun encodeV2Input(
+        recipient: String,
+        amount1: BigInteger,
+        amount2: BigInteger,
+        path: List<String>,
+        payerIsUser: Boolean,
+    ): String =
+        encodeHeadTail(
+            staticHeads =
+                listOf(
+                    0 to addressWord(recipient),
+                    1 to uintWord(amount1),
+                    2 to uintWord(amount2),
+                    4 to boolWord(payerIsUser),
+                ),
+            tails = listOf(3 to addressArrayBytes(path)),
+            slotCount = 5,
+        )
+
+    fun encodeV3Input(
+        recipient: String,
+        amount1: BigInteger,
+        amount2: BigInteger,
+        path: ByteArray,
+        payerIsUser: Boolean,
+    ): String =
+        encodeHeadTail(
+            staticHeads =
+                listOf(
+                    0 to addressWord(recipient),
+                    1 to uintWord(amount1),
+                    2 to uintWord(amount2),
+                    4 to boolWord(payerIsUser),
+                ),
+            tails = listOf(3 to bytesField(path)),
+            slotCount = 5,
+        )
+
+    fun encodeV3Path(tokens: List<String>, fees: List<Int>): ByteArray {
+        require(tokens.size == fees.size + 1) { "fees must be tokens.size - 1" }
+        var out = ByteArray(0)
+        for (i in fees.indices) {
+            out += address20(tokens[i])
+            // Solidity packs the fee as 3 big-endian bytes.
+            out += ((fees[i] ushr 16) and 0xff).toByte()
+            out += ((fees[i] ushr 8) and 0xff).toByte()
+            out += (fees[i] and 0xff).toByte()
+        }
+        out += address20(tokens.last())
+        return out
+    }
+
+    fun encodeWrapEthInput(recipient: String, amount: BigInteger): String =
+        toHex(addressWord(recipient) + uintWord(amount))
+
+    /**
+     * Encode the V4 single-pool action params (works for both exact-in and exact-out — the two
+     * uints carry the matching pair of values per direction).
+     */
+    fun encodeV4SingleSwapParams(
+        currency0: String,
+        currency1: String,
+        fee: Int,
+        tickSpacing: Int,
+        hooks: String,
+        zeroForOne: Boolean,
+        amount1: BigInteger,
+        amount2: BigInteger,
+        hookData: ByteArray = ByteArray(0),
+    ): String {
+        // Tuple body (head + dynamic bytes tail). Tuple is dynamic because of hookData.
+        val tupleHead =
+            addressWord(currency0) +
+                addressWord(currency1) +
+                uintWord(BigInteger.valueOf(fee.toLong())) +
+                intWord(BigInteger.valueOf(tickSpacing.toLong())) +
+                addressWord(hooks) +
+                boolWord(zeroForOne) +
+                uintWord(amount1) +
+                uintWord(amount2) +
+                // bytes hookData offset within tuple: 9 words = 288.
+                uintWord(BigInteger.valueOf(9L * WORD))
+        val tupleBody = tupleHead + bytesField(hookData)
+        // Single dynamic-tuple arg: 32-byte offset (= 32) + tuple body.
+        return toHex(uintWord(BigInteger.valueOf(WORD.toLong())) + tupleBody)
+    }
+
+    fun encodeV4MultiSwapParams(
+        currency: String,
+        path: List<PathKey>,
+        amount1: BigInteger,
+        amount2: BigInteger,
+    ): String {
+        // Tuple body: currency, PathKey[] offset, amount1, amount2, then PathKey[] data.
+        // PathKey[] starts after 4 tuple-head words (currency, pathOffset, amount1, amount2).
+        val pathOffsetWithinTuple = BigInteger.valueOf(4L * WORD)
+        val tupleBody =
+            addressWord(currency) +
+                uintWord(pathOffsetWithinTuple) +
+                uintWord(amount1) +
+                uintWord(amount2) +
+                pathKeyArrayBytes(path)
+        return toHex(uintWord(BigInteger.valueOf(WORD.toLong())) + tupleBody)
+    }
+
+    data class PathKey(
+        val intermediateCurrency: String,
+        val fee: Int,
+        val tickSpacing: Int,
+        val hooks: String,
+        val hookData: ByteArray = ByteArray(0),
+    )
+
+    fun encodeV4SwapInput(actions: ByteArray, paramHexes: List<String>): String {
+        val paramsBytes = paramHexes.map { hexToBytes(it) }
+        // (bytes actions, bytes[] params)
+        return encodeHeadTail(
+            staticHeads = emptyList(),
+            tails = listOf(0 to bytesField(actions), 1 to bytesArrayField(paramsBytes)),
+            slotCount = 2,
+        )
+    }
+
+    /**
+     * Build the JSON shape `FourByteRepository.decodeFunctionArgs` would emit for a Universal
+     * Router `execute(bytes,bytes[],uint256)` call, given the commands hex and per-input hex. Pass
+     * `deadline = null` for the deadline-less overload.
+     */
+    fun buildExecuteInputsJson(
+        commandsHex: String,
+        inputHexes: List<String>,
+        deadline: BigInteger? = BigInteger.ZERO,
+    ): String = buildString {
+        append('[')
+        append('"').append(commandsHex).append('"')
+        append(',')
+        append('[')
+        inputHexes.forEachIndexed { i, hex ->
+            if (i > 0) append(',')
+            append('"').append(hex).append('"')
+        }
+        append(']')
+        if (deadline != null) {
+            append(',')
+            append('"').append(deadline.toString()).append('"')
+        }
+        append(']')
+    }
+
+    // ─── Primitives ──────────────────────────────────────────────────────────────
+
+    private fun addressWord(address: String): ByteArray {
+        val padded = ByteArray(WORD)
+        System.arraycopy(address20(address), 0, padded, 12, 20)
+        return padded
+    }
+
+    private fun uintWord(value: BigInteger): ByteArray = toWord(value)
+
+    private fun intWord(value: BigInteger): ByteArray {
+        if (value.signum() >= 0) return toWord(value)
+        // Two's complement 32-byte representation for negative ints.
+        val twos = BigInteger.ONE.shiftLeft(WORD * 8).add(value)
+        return toWord(twos)
+    }
+
+    private fun boolWord(flag: Boolean): ByteArray =
+        ByteArray(WORD).also { if (flag) it[WORD - 1] = 1 }
+
+    private fun toWord(value: BigInteger): ByteArray {
+        require(value.signum() >= 0) { "expected unsigned for uint word" }
+        val raw = value.toByteArray()
+        // BigInteger.toByteArray() may include a leading sign byte; strip it if present.
+        val stripped =
+            if (raw.size > WORD && raw[0] == 0.toByte()) raw.copyOfRange(1, raw.size) else raw
+        require(stripped.size <= WORD) { "value too large for 32-byte word" }
+        val padded = ByteArray(WORD)
+        System.arraycopy(stripped, 0, padded, WORD - stripped.size, stripped.size)
+        return padded
+    }
+
+    private fun address20(address: String): ByteArray {
+        val cleaned = address.removePrefix("0x").removePrefix("0X")
+        require(cleaned.length == 40) { "address must be 20 bytes (40 hex chars)" }
+        return hexToBytes("0x$cleaned")
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val cleaned = hex.removePrefix("0x").removePrefix("0X")
+        require(cleaned.length % 2 == 0) { "odd-length hex" }
+        val out = ByteArray(cleaned.length / 2)
+        for (i in out.indices) {
+            out[i] =
+                ((Character.digit(cleaned[i * 2], 16) shl 4) or
+                        Character.digit(cleaned[i * 2 + 1], 16))
+                    .toByte()
+        }
+        return out
+    }
+
+    private fun bytesField(payload: ByteArray): ByteArray =
+        toWord(BigInteger.valueOf(payload.size.toLong())) + padTo32(payload)
+
+    private fun addressArrayBytes(addresses: List<String>): ByteArray {
+        var out = toWord(BigInteger.valueOf(addresses.size.toLong()))
+        for (addr in addresses) out += addressWord(addr)
+        return out
+    }
+
+    private fun bytesArrayField(elements: List<ByteArray>): ByteArray {
+        val lengthWord = toWord(BigInteger.valueOf(elements.size.toLong()))
+        if (elements.isEmpty()) return lengthWord
+        // length || k offset pointers (relative to area after length) || each bytes data
+        val encodedElements = elements.map { bytesField(it) }
+        val pointersSize = elements.size * WORD
+        var cursor = pointersSize
+        var head = ByteArray(0)
+        for (encoded in encodedElements) {
+            head += toWord(BigInteger.valueOf(cursor.toLong()))
+            cursor += encoded.size
+        }
+        var tail = ByteArray(0)
+        for (elem in encodedElements) tail += elem
+        return lengthWord + head + tail
+    }
+
+    private fun pathKeyArrayBytes(keys: List<PathKey>): ByteArray {
+        val lengthWord = toWord(BigInteger.valueOf(keys.size.toLong()))
+        // Each PathKey is dynamic (has bytes hookData). Layout: length || head pointers || tails.
+        val encodedKeys = keys.map { encodePathKey(it) }
+        val pointersSize = keys.size * WORD
+        var cursor = pointersSize
+        var head = ByteArray(0)
+        for (encoded in encodedKeys) {
+            head += toWord(BigInteger.valueOf(cursor.toLong()))
+            cursor += encoded.size
+        }
+        var tail = ByteArray(0)
+        for (data in encodedKeys) tail += data
+        return lengthWord + head + tail
+    }
+
+    private fun encodePathKey(pk: PathKey): ByteArray {
+        // PathKey is `(address intermediateCurrency, uint24 fee, int24 tickSpacing, address hooks,
+        // bytes hookData)`. Dynamic due to hookData. Head: 5 inline words + bytes offset.
+        val head =
+            addressWord(pk.intermediateCurrency) +
+                uintWord(BigInteger.valueOf(pk.fee.toLong())) +
+                intWord(BigInteger.valueOf(pk.tickSpacing.toLong())) +
+                addressWord(pk.hooks) +
+                // bytes offset within this PathKey: 5 head words after = 5 * 32 = 160.
+                uintWord(BigInteger.valueOf(5L * WORD))
+        return head + bytesField(pk.hookData)
+    }
+
+    private fun padTo32(data: ByteArray): ByteArray {
+        val remainder = data.size % WORD
+        if (remainder == 0) return data
+        return data + ByteArray(WORD - remainder)
+    }
+
+    /**
+     * Standard ABI head-tail encoding. [staticHeads] supplies inline 32-byte head words at the
+     * given slot indices; [tails] is one `(slotIndex, dynamicTailBytes)` per dynamic arg ordered by
+     * slot index. Slots not in either list are left as 32 zero bytes.
+     */
+    private fun encodeHeadTail(
+        staticHeads: List<Pair<Int, ByteArray>>,
+        tails: List<Pair<Int, ByteArray>>,
+        slotCount: Int,
+    ): String {
+        val staticBySlot = staticHeads.toMap()
+        val tailBySlot = tails.toMap()
+        val headSize = slotCount * WORD
+        val offsets = mutableMapOf<Int, Int>()
+        var cursor = headSize
+        for ((slot, encoded) in tails) {
+            offsets[slot] = cursor
+            cursor += encoded.size
+        }
+        var encoded = ByteArray(0)
+        for (slot in 0 until slotCount) {
+            encoded +=
+                when {
+                    staticBySlot.containsKey(slot) -> {
+                        val word = staticBySlot.getValue(slot)
+                        require(word.size == WORD) { "static head slot $slot must be 32 bytes" }
+                        word
+                    }
+                    tailBySlot.containsKey(slot) ->
+                        toWord(BigInteger.valueOf(checkNotNull(offsets[slot]).toLong()))
+                    else -> ByteArray(WORD)
+                }
+        }
+        for ((_, tail) in tails) encoded += tail
+        return toHex(encoded)
+    }
+
+    private fun toHex(data: ByteArray): String {
+        val chars = "0123456789abcdef".toCharArray()
+        val sb = StringBuilder(2 + data.size * 2)
+        sb.append("0x")
+        for (b in data) {
+            val v = b.toInt() and 0xff
+            sb.append(chars[v ushr 4])
+            sb.append(chars[v and 0x0f])
+        }
+        return sb.toString()
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UrAbiTestEncoder.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/UrAbiTestEncoder.kt
@@ -206,13 +206,13 @@ internal object UrAbiTestEncoder {
 
     private fun hexToBytes(hex: String): ByteArray {
         val cleaned = hex.removePrefix("0x").removePrefix("0X")
-        require(cleaned.length % 2 == 0) { "odd-length hex" }
+        require(cleaned.length % 2 == 0) { "odd-length hex: $hex" }
         val out = ByteArray(cleaned.length / 2)
         for (i in out.indices) {
-            out[i] =
-                ((Character.digit(cleaned[i * 2], 16) shl 4) or
-                        Character.digit(cleaned[i * 2 + 1], 16))
-                    .toByte()
+            val hi = Character.digit(cleaned[i * 2], 16)
+            val lo = Character.digit(cleaned[i * 2 + 1], 16)
+            require(hi >= 0 && lo >= 0) { "invalid hex fixture: $hex" }
+            out[i] = ((hi shl 4) or lo).toByte()
         }
         return out
     }


### PR DESCRIPTION
## Summary

Walks the `commands` byte string inside a Uniswap Universal Router `execute(bytes,bytes[],uint256)` (and the deadline-less overload) so the dApp verify and join-keysign screens can show the actual swap — from token, to token, amounts — instead of an opaque "Execute" row. Mirrors the SDK reference (`@vultisig/core-chain/.../universalRouter/decode`) and the Windows wiring (vultisig/vultisig-windows#3797) so swap intent stays consistent across platforms.

V2 / V3 / V4 swaps in both exact-in and exact-out variants are decoded; WRAP_ETH and UNWRAP_WETH framing maps a leg to native ETH; split routes across identical pairs aggregate so the user sees their full trade; unknown opcodes (Permit2, sweep, transfer …) are skipped instead of failing the whole decode. Native ETH resolves to the chain's fee coin; unresolved ERC-20s fall through to `TokenMetadataResolver`'s 24h cached on-chain `symbol()` / `decimals()` lookup. Gated on the destination being on the `KnownEvmContracts` Universal Router allowlist so an unrelated `execute` overload on another contract never gets framed as a swap.

A successful decode also promotes the surface itself: the toolbar switches from "Send overview" to "Swap overview" (existing string) and the card hero swaps the raw `Execute` function name for a localised "Swap" so the user sees real intent, not router plumbing.

Closes #4059.

## Screenshots

Pixel 9 Pro emulator render via `PreviewActivity`. Collapsed entry-point shows the toolbar reading "Swap overview" and the destination labelled `Uniswap Universal Router V2`; BEFORE expands to the generic positional decode (Phase 2A's `#1 (bytes)`, `#2 (bytes[])`, `#3 (uint256)` fallback rows the router would land in without this PR); AFTER swaps in the four labelled rows from this PR and the localised "Swap" hero title.

Collapsed entry-point:

![collapsed](https://i.imgur.com/UNWDlRg.png)

| Before (generic positional rows) | After (labelled swap rows + Swap title) |
| --- | --- |
| ![before](https://i.imgur.com/58NlH3P.png) | ![after](https://i.imgur.com/sV8uJif.png) |

## Testing

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — all green (25 new decoder cases, 7 new row-builder cases, 1 new verify-VM integration case)
- `./gradlew :app:assembleDebug` — green
- `./gradlew :app:lintDebug` — 0 new errors

## Notes

- Both initiator (`VerifyTransactionViewModel`) and co-signer (`JoinKeysignViewModel`) paths share `enrichDecodedCall` so co-sign sees the same labelled rows and swap title. The native-coin lookup propagates `CancellationException` and logs all other failures, falling back to the raw zero-address row.
- New `decoded_function_from_token` / `_to_token` / `_amount_in` / `_max_amount_in` / `_min_amount_out` / `_amount_out` / `_swap_title` strings landed in all 10 locale files with locale-appropriate phrasing.
- Adding a new chain's Universal Router only needs the deployment address in `KnownEvmContracts`; the decoder gate keys on the label prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and display Uniswap Universal Router swaps in transaction verification with dedicated four-row swap details and a full-screen preview.

* **UX Enhancements**
  * Best-effort native-token symbol lookup for clearer tickers and cleaner native-token display; verify screen title and hero text now reflect decoded swap intent.

* **Tests**
  * Extensive unit tests covering Universal Router decoding and swap-row rendering.

* **Localization**
  * Added swap-related label translations in multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->