### PR TITLE
fix(keygen): block destructive fast-vault overwrite on seedphrase import (#4535)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/v3/onboarding/EnterVaultInfoViewModel.kt
@@ -534,14 +534,7 @@ constructor(
 
     fun dismissServerVaultWarning() {
         uiState.update { it.copy(showServerVaultExistsWarning = false) }
-    }
-
-    fun continueWithServerVaultWarning() {
-        uiState.update { it.copy(showServerVaultExistsWarning = false) }
-        val name = nameTextFieldState.text.toString()
-        val email = emailTextFieldState.text.toString()
-        val password = passwordTextFieldState.text.toString()
-        viewModelScope.launch { navigateToPeerDiscovery(name, email, password) }
+        viewModelScope.launch { navigator.back() }
     }
 
     private fun isNameValid(): Boolean {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
@@ -80,10 +80,7 @@ internal fun EnterVaultInfoScreen(viewModel: EnterVaultInfoViewModel = hiltViewM
     )
 
     if (uiState.showServerVaultExistsWarning) {
-        ServerVaultExistsWarningDialog(
-            onContinue = viewModel::continueWithServerVaultWarning,
-            onDismiss = viewModel::dismissServerVaultWarning,
-        )
+        ServerVaultExistsWarningDialog(onDismiss = viewModel::dismissServerVaultWarning)
     }
 
     if (showReferralSheet) {
@@ -306,7 +303,7 @@ fun StepIcon(type: StepType, state: StepState) {
 }
 
 @Composable
-private fun ServerVaultExistsWarningDialog(onContinue: () -> Unit, onDismiss: () -> Unit) {
+private fun ServerVaultExistsWarningDialog(onDismiss: () -> Unit) {
     AlertDialog(
         containerColor = Theme.v2.colors.backgrounds.secondary,
         onDismissRequest = onDismiss,
@@ -325,15 +322,6 @@ private fun ServerVaultExistsWarningDialog(onContinue: () -> Unit, onDismiss: ()
             )
         },
         confirmButton = {
-            TextButton(onClick = onContinue) {
-                Text(
-                    text = stringResource(R.string.name_vault_server_exists_warning_continue),
-                    color = Theme.v2.colors.neutrals.n100,
-                    style = Theme.montserrat.body3,
-                )
-            }
-        },
-        dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(
                     text = stringResource(R.string.name_vault_server_exists_warning_back),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -703,8 +703,7 @@
     <string name="send_form_enter_memo">Memo eingeben</string>
     <string name="name_vault_vault_with_this_name_already_exists">Ein Tresor mit diesem Namen ist bereits vorhanden.</string>
     <string name="name_vault_server_exists_warning_title">Schneller Tresor existiert bereits</string>
-    <string name="name_vault_server_exists_warning_message">Ein schneller Tresor mit dieser Seed-Phrase existiert bereits auf dem Server. Das Erstellen eines neuen schnellen Tresors ersetzt die Serverfreigabe und macht den bestehenden Tresor unbrauchbar. Erwägen Sie stattdessen einen sicheren Tresor.</string>
-    <string name="name_vault_server_exists_warning_continue">Weiter</string>
+    <string name="name_vault_server_exists_warning_message">Ein schneller Tresor für diese Seed-Phrase existiert bereits auf dem Server. Gehen Sie zurück und stellen Sie den bestehenden Tresor wieder her, oder wählen Sie einen sicheren Tresor für ein neues MPC-Setup.</string>
     <string name="name_vault_server_exists_warning_back">Zurück</string>
     <string name="referral_create_status">Status</string>
     <string name="referral_create_unknown">Unbekannt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -701,8 +701,7 @@
     <string name="send_form_enter_memo">Ingresar Memo</string>
     <string name="name_vault_vault_with_this_name_already_exists">Ya existe una bóveda con este nombre.</string>
     <string name="name_vault_server_exists_warning_title">La bóveda rápida ya existe</string>
-    <string name="name_vault_server_exists_warning_message">Ya existe una bóveda rápida con esta frase semilla en el servidor. Crear una nueva bóveda rápida reemplazará el recurso compartido del servidor y hará que la bóveda existente quede inutilizable. Considere usar una bóveda segura en su lugar.</string>
-    <string name="name_vault_server_exists_warning_continue">Continuar</string>
+    <string name="name_vault_server_exists_warning_message">Ya existe una bóveda rápida para esta frase semilla en el servidor. Vuelva y recupere la bóveda existente, o elija bóveda segura para una nueva configuración MPC.</string>
     <string name="name_vault_server_exists_warning_back">Volver</string>
     <string name="referral_create_status">Estado</string>
     <string name="referral_create_unknown">Desconocido</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -704,8 +704,7 @@
     <string name="send_form_enter_memo">Unesi memo</string>
     <string name="name_vault_vault_with_this_name_already_exists">Trezor s ovim nazivom već postoji</string>
     <string name="name_vault_server_exists_warning_title">Brzi trezor već postoji</string>
-    <string name="name_vault_server_exists_warning_message">Brzi trezor s ovom frazom za oporavak već postoji na serveru. Stvaranje novog brzog trezora zamijenit će serverski udio i učiniti postojeći trezor neupotrebljivim. Razmotrite korištenje sigurnog trezora umjesto toga.</string>
-    <string name="name_vault_server_exists_warning_continue">Nastavi</string>
+    <string name="name_vault_server_exists_warning_message">Brzi trezor za ovu frazu za oporavak već postoji na serveru. Vratite se i obnovite postojeći trezor ili odaberite sigurni trezor za novo MPC postavljanje.</string>
     <string name="name_vault_server_exists_warning_back">Nazad</string>
     <string name="referral_create_status">Status</string>
     <string name="referral_create_unknown">Nepoznato</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -701,8 +701,7 @@
     <string name="send_form_enter_memo">Inserisci Memo</string>
     <string name="name_vault_vault_with_this_name_already_exists">Esiste già un Vault con questo nome</string>
     <string name="name_vault_server_exists_warning_title">Il vault veloce esiste già</string>
-    <string name="name_vault_server_exists_warning_message">Un vault veloce con questa frase seed esiste già sul server. La creazione di un nuovo vault veloce sostituirà la condivisione del server e renderà inutilizzabile il vault esistente. Considera invece l\'utilizzo di un vault sicuro.</string>
-    <string name="name_vault_server_exists_warning_continue">Continua</string>
+    <string name="name_vault_server_exists_warning_message">Un vault veloce per questa frase seed esiste già sul server. Torna indietro e ripristina il vault esistente, oppure scegli vault sicuro per una nuova configurazione MPC.</string>
     <string name="name_vault_server_exists_warning_back">Indietro</string>
     <string name="referral_create_status">Stato</string>
     <string name="referral_create_unknown">Sconosciuto</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -889,8 +889,7 @@
     <string name="migration_password_enter_your_password_to_unlock">서버 공유를 잠금 해제하고 업그레이드를 시작하려면 비밀번호를 입력하세요</string>
     <string name="name_vault_vault_with_this_name_already_exists">이 이름의 볼트가 이미 존재합니다</string>
     <string name="name_vault_server_exists_warning_title">빠른 볼트가 이미 존재합니다</string>
-    <string name="name_vault_server_exists_warning_message">이 시드 구문을 사용하는 빠른 볼트가 이미 서버에 존재합니다. 새로운 빠른 볼트를 생성하면 서버 공유가 대체되어 기존 볼트를 사용할 수 없게 됩니다. 대신 보안 볼트 사용을 고려하세요.</string>
-    <string name="name_vault_server_exists_warning_continue">계속</string>
+    <string name="name_vault_server_exists_warning_message">이 시드 구문에 대한 빠른 볼트가 이미 서버에 존재합니다. 뒤로 가서 기존 볼트를 복구하거나, 새 MPC 설정을 위해 보안 볼트를 선택하세요.</string>
     <string name="name_vault_server_exists_warning_back">뒤로</string>
     <string name="referral_create_status">상태</string>
     <string name="referral_create_unknown">알 수 없음</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -698,8 +698,7 @@
     <string name="send_form_enter_memo">Memo invoeren</string>
     <string name="name_vault_vault_with_this_name_already_exists">Er bestaat al een kluis met deze naam</string>
     <string name="name_vault_server_exists_warning_title">Snelle kluis bestaat al</string>
-    <string name="name_vault_server_exists_warning_message">Er bestaat al een snelle kluis met deze herstelzin op de server. Het aanmaken van een nieuwe snelle kluis vervangt de servershare en maakt de bestaande kluis onbruikbaar. Overweeg in plaats daarvan een beveiligde kluis te gebruiken.</string>
-    <string name="name_vault_server_exists_warning_continue">Doorgaan</string>
+    <string name="name_vault_server_exists_warning_message">Er bestaat al een snelle kluis voor deze herstelzin op de server. Ga terug en herstel de bestaande kluis, of kies beveiligde kluis voor een nieuwe MPC-installatie.</string>
     <string name="name_vault_server_exists_warning_back">Terug</string>
     <string name="referral_create_status">Status</string>
     <string name="referral_create_unknown">Onbekend</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -700,8 +700,7 @@
     <string name="send_form_enter_memo">Inserir memorando</string>
     <string name="name_vault_vault_with_this_name_already_exists">O cofre com este nome já existe.</string>
     <string name="name_vault_server_exists_warning_title">O cofre rápido já existe</string>
-    <string name="name_vault_server_exists_warning_message">Já existe um cofre rápido com esta frase-semente no servidor. Criar um novo cofre rápido substituirá a partilha do servidor e tornará o cofre existente inutilizável. Considere usar um cofre seguro em vez disso.</string>
-    <string name="name_vault_server_exists_warning_continue">Continuar</string>
+    <string name="name_vault_server_exists_warning_message">Já existe um cofre rápido para esta frase-semente no servidor. Volte e recupere o cofre existente, ou escolha cofre seguro para uma nova configuração MPC.</string>
     <string name="name_vault_server_exists_warning_back">Voltar</string>
     <string name="referral_create_status">Status</string>
     <string name="referral_create_unknown">Desconhecido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -702,8 +702,7 @@
     <string name="send_form_enter_memo">Ввести Memo</string>
     <string name="name_vault_vault_with_this_name_already_exists">Хранилище с таким именем уже существует.</string>
     <string name="name_vault_server_exists_warning_title">Быстрое хранилище уже существует</string>
-    <string name="name_vault_server_exists_warning_message">Быстрое хранилище с этой сид-фразой уже существует на сервере. Создание нового быстрого хранилища заменит общий доступ к серверу и сделает существующее хранилище непригодным для использования. Рассмотрите возможность использования безопасного хранилища.</string>
-    <string name="name_vault_server_exists_warning_continue">Продолжить</string>
+    <string name="name_vault_server_exists_warning_message">Быстрое хранилище для этой сид-фразы уже существует на сервере. Вернитесь и восстановите существующее хранилище или выберите безопасное хранилище для новой настройки MPC.</string>
     <string name="name_vault_server_exists_warning_back">Назад</string>
     <string name="referral_create_status">Статус</string>
     <string name="referral_create_unknown">Неизвестно</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -896,8 +896,7 @@
     <!-- Vault Names -->
     <string name="name_vault_vault_with_this_name_already_exists">已存在此名称的保险库</string>
     <string name="name_vault_server_exists_warning_title">快速保险库已存在</string>
-    <string name="name_vault_server_exists_warning_message">使用此助记词的快速保险库已存在于服务器上。创建新的快速保险库将替换服务器份额，并使现有保险库无法使用。请考虑使用安全保险库。</string>
-    <string name="name_vault_server_exists_warning_continue">继续</string>
+    <string name="name_vault_server_exists_warning_message">此助记词的快速保险库已存在于服务器上。请返回并恢复现有保险库，或选择安全保险库进行新的 MPC 设置。</string>
     <string name="name_vault_server_exists_warning_back">返回</string>
 
     <!-- Errors -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -910,8 +910,7 @@
     <string name="migration_password_enter_your_password_to_unlock">Enter your password to unlock your Server Share and start the upgrade</string>
     <string name="name_vault_vault_with_this_name_already_exists">Vault with this name already exists</string>
     <string name="name_vault_server_exists_warning_title">Fast vault already exists</string>
-    <string name="name_vault_server_exists_warning_message">A fast vault with this seed phrase already exists on the server. Creating a new fast vault will replace the server share and make the existing vault unusable. Consider using a secure vault instead.</string>
-    <string name="name_vault_server_exists_warning_continue">Continue</string>
+    <string name="name_vault_server_exists_warning_message">A fast vault for this seed phrase already exists on the server. Go back and recover the existing vault, or choose Secure Vault for a new MPC setup.</string>
     <string name="name_vault_server_exists_warning_back">Back</string>
     <string name="referral_create_status">Status</string>
     <string name="referral_create_unknown">Unknown</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keygen/EnterVaultInfoViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keygen/EnterVaultInfoViewModelTest.kt
@@ -135,31 +135,17 @@ internal class EnterVaultInfoViewModelTest {
             vm.uiState.value.isPasswordVisible.shouldBeFalse()
         }
 
-    /** Verifies dismissServerVaultWarning clears showServerVaultExistsWarning. */
+    /** Verifies dismissServerVaultWarning clears the flag and navigates back. */
     @Test
-    fun `dismissServerVaultWarning clears showServerVaultExistsWarning`() =
+    fun `dismissServerVaultWarning clears flag and navigates back`() =
         runTest(testDispatcher) {
             val vm = createViewModel()
             vm.uiState.update { it.copy(showServerVaultExistsWarning = true) }
             vm.uiState.value.showServerVaultExistsWarning.shouldBeTrue()
             vm.dismissServerVaultWarning()
-            vm.uiState.value.showServerVaultExistsWarning.shouldBeFalse()
-        }
-
-    /**
-     * Verifies continueWithServerVaultWarning clears the warning flag and routes to peer discovery.
-     */
-    @Test
-    fun `continueWithServerVaultWarning navigates to PeerDiscovery and clears warning`() =
-        runTest(testDispatcher) {
-            every { any<SavedStateHandle>().toRoute<Route.EnterVaultInfo>() } returns
-                Route.EnterVaultInfo(count = 1, tssAction = TssAction.KeyImport)
-            val vm = createViewModel()
-            vm.uiState.update { it.copy(showServerVaultExistsWarning = true) }
-            vm.continueWithServerVaultWarning()
             advanceUntilIdle()
             vm.uiState.value.showServerVaultExistsWarning.shouldBeFalse()
-            coVerify { navigator.route(any<Route.Keygen.PeerDiscovery>()) }
+            coVerify { navigator.navigate(Destination.Back) }
         }
 
     /** Verifies Back event from Name step navigates back. */


### PR DESCRIPTION
## Summary

Closes #4535 (Option A — Negate).

When a user imports a seedphrase and chooses Fast Vault, the app checks whether a fast vault already exists on the server for that seedphrase. Previously the dialog offered a **Continue** button that silently overwrote the server share and made the existing vault unusable. This PR removes that path entirely.

- `ServerVaultExistsWarningDialog` now has a single Back button (no Continue).
- `dismissServerVaultWarning()` clears the flag **and** navigates back so the user lands on the vault-type select screen, where they can choose Secure Vault or go back further to recover the existing vault.
- Updated copy in all 10 locales to non-destructive guidance: _"A fast vault for this seed phrase already exists on the server. Go back and recover the existing vault, or choose Secure Vault for a new MPC setup."_
- Removed the now-unused `name_vault_server_exists_warning_continue` string from every locale.
- Updated the corresponding ViewModel unit test.

## Out of scope

- iOS parity — needs a separate ticket per the issue.
- Option B (N shares per seedphrase) — requires server schema + billing changes and is a cross-platform decision.
- Moving the check one screen earlier (to the seedphrase entry screen) — the path is still blocked, just one screen later; the destructive default is gone either way.

## Test plan

- [ ] Import a seedphrase that already has a fast vault on the server → pick Fast Vault → expect the dialog with only a Back button. Tapping Back returns to the vault-type select screen.
- [ ] Import a seedphrase with no existing fast vault on the server → pick Fast Vault → expect the existing happy path (no dialog).
- [ ] Secure Vault path is unaffected.
- [ ] Verify all 10 locales render the new message without truncation.
- [ ] `./gradlew :app:testDebugUnitTest --tests "*EnterVaultInfoViewModelTest*"` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the server vault exists warning behavior to require users to dismiss and navigate back instead of proceeding with the warning.
  * Updated warning message across all supported languages to clarify recovery options when a fast vault already exists on the server for the given seed phrase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->