### PR TITLE
fix(peer-discovery): remove obsolete device-count hint banner

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -100,7 +100,6 @@ data class PeerDiscoveryUiModel(
     val minimumDevices: Int = MIN_KEYGEN_DEVICES,
     val minimumDevicesDisplayed: Int = MIN_KEYGEN_DEVICES,
     val showQrHelpModal: Boolean = false,
-    val showDevicesHint: Boolean = true,
     val connectingToServer: ConnectingToServerUiModel? = null,
     val error: ErrorUiModel? = null,
     val warning: ErrorUiModel? = null,
@@ -250,10 +249,6 @@ constructor(
         val shareBitmap = createQrCodeSharingBitmap(qr, info)
 
         activity.share(shareBitmap, shareFileName(vaultName, vaultName.sha256(), ShareType.KEYGEN))
-    }
-
-    fun closeDevicesHint() {
-        state.update { it.copy(showDevicesHint = false) }
     }
 
     fun switchMode() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
@@ -156,7 +156,6 @@ internal fun KeysignPeerDiscovery(
                     minimumDevices = minimumDevices,
                     minimumDevicesDisplayed = minimumDevices,
                     showQrHelpModal = false,
-                    showDevicesHint = false,
                     connectingToServer = null,
                     error = null,
                     enableNotification = uiModel.enableNotification,
@@ -166,7 +165,6 @@ internal fun KeysignPeerDiscovery(
             showHelp = false,
             onHelpClick = {},
             onShareQrClick = { sharedViewModel.shareQRCode(activity) },
-            onCloseHintClick = {},
             onDismissQrHelpModal = {},
             onSwitchModeClick = {
                 viewModel.changeNetworkPromptOption(
@@ -203,7 +201,6 @@ private fun KeysignPeerDiscoveryPreview() {
                 minimumDevices = 2,
                 minimumDevicesDisplayed = 2,
                 showQrHelpModal = false,
-                showDevicesHint = false,
                 connectingToServer = null,
                 error = null,
                 enableNotification = true,
@@ -212,7 +209,6 @@ private fun KeysignPeerDiscoveryPreview() {
         showHelp = false,
         onHelpClick = {},
         onShareQrClick = {},
-        onCloseHintClick = {},
         onDismissQrHelpModal = {},
         onSwitchModeClick = {},
         onDeviceClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -67,8 +67,6 @@ import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.ShowQrHelperBottomSheet
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.banners.Banner
-import com.vultisig.wallet.ui.components.banners.BannerVariant
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.clickOnce
@@ -151,7 +149,6 @@ internal fun KeygenPeerDiscoveryScreen(model: KeygenPeerDiscoveryViewModel = hil
                 onBackClick = model::back,
                 onHelpClick = { uriHandler.openUri(VsAuxiliaryLinks.CREATE_VAULT) },
                 onShareQrClick = { model.shareQr(context) },
-                onCloseHintClick = model::closeDevicesHint,
                 onSwitchModeClick = model::switchMode,
                 onDeviceClick = model::selectDevice,
                 onNextClick = model::next,
@@ -168,7 +165,6 @@ internal fun PeerDiscoveryScreen(
     onBackClick: () -> Unit,
     onHelpClick: () -> Unit,
     onShareQrClick: () -> Unit,
-    onCloseHintClick: () -> Unit,
     onSwitchModeClick: () -> Unit,
     onDeviceClick: (ParticipantName) -> Unit,
     onResendNotification: () -> Unit,
@@ -246,21 +242,6 @@ internal fun PeerDiscoveryScreen(
                             },
                         devicesSize = devicesSize,
                     )
-
-                    AnimatedVisibility(visible = state.showDevicesHint) {
-                        Column {
-                            Banner(
-                                text =
-                                    stringResource(
-                                        R.string.peer_discovery_recommended_devices_hint
-                                    ),
-                                variant = BannerVariant.Info,
-                                onCloseClick = onCloseHintClick,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                            UiSpacer(16.dp)
-                        }
-                    }
 
                     AnimatedVisibility(visible = state.network == NetworkOption.Local) {
                         Column {
@@ -787,7 +768,6 @@ private fun PeerDiscoveryScreenPreview() {
         onBackClick = {},
         onHelpClick = {},
         onShareQrClick = {},
-        onCloseHintClick = {},
         onSwitchModeClick = {},
         onDeviceClick = {},
         onNextClick = {},

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -859,7 +859,6 @@
     <string name="fast_vault_password_screen_hint">Dies geschieht, weil das Passwort zur lokalen Verschlüsselung der Sicherungsdatei verwendet wird, ähnlich wie bei der Festplattenverschlüsselung. Im nächsten Schritt können Sie einen Hinweis hinzufügen.</string>
     <string name="fast_vault_password_screen_hint_title">Weitere Informationen</string>
     <string name="peer_discovery_local_mode_hint">Sie befinden sich im lokalen Modus.</string>
-    <string name="peer_discovery_recommended_devices_hint">QR-Code mit einem anderen Gerät scannen. Einrichtung mit 3 Geräten empfohlen, 2 Geräte reichen aus.</string>
     <string name="review_vault_devices_title">Vault-Geräte überprüfen</string>
     <string name="review_vault_devices_description">Stellen Sie sicher, dass dies die richtigen Geräte sind, die Sie hinzugefügt haben:</string>
     <string name="review_vault_devices_looks_good">Sieht gut aus</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -857,7 +857,6 @@
     <string name="fast_vault_password_screen_hint">Esto ocurre porque la contraseña se usa para cifrar localmente el archivo de copia de seguridad, de forma similar a como se cifra un disco duro. En el siguiente paso, tiene la opción de añadir una pista.</string>
     <string name="fast_vault_password_screen_hint_title">Más información</string>
     <string name="peer_discovery_local_mode_hint">Estás en modo local</string>
-    <string name="peer_discovery_recommended_devices_hint">Escanear código QR con otro dispositivo. Se recomienda configurar 3 dispositivos, pero con 2 es suficiente.</string>
     <string name="review_vault_devices_title">Revisar los dispositivos del vault</string>
     <string name="review_vault_devices_description">Asegúrate de que estos son los dispositivos correctos que has añadido:</string>
     <string name="review_vault_devices_looks_good">Se ve bien</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -862,7 +862,6 @@
     <string name="fast_vault_password_screen_hint">To se događa jer se lozinka koristi za lokalno šifriranje datoteke sigurnosne kopije, slično kao što se šifrira tvrdi disk. U sljedećem koraku imate mogućnost dodati podsjetnik.</string>
     <string name="fast_vault_password_screen_hint_title">Više informacija</string>
     <string name="peer_discovery_local_mode_hint">U lokalnom ste načinu rada</string>
-    <string name="peer_discovery_recommended_devices_hint">Skenirajte QR s drugim uređajem. Preporučuje se postavljanje s 3 uređaja, 2 su dovoljna.</string>
     <string name="review_vault_devices_title">Pregledaj uređaje trezora</string>
     <string name="review_vault_devices_description">Provjerite jesu li ovo ispravni uređaji koje ste dodali:</string>
     <string name="review_vault_devices_looks_good">Izgleda dobro</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -857,7 +857,6 @@
     <string name="fast_vault_password_screen_hint">Ciò si verifica perché la password viene utilizzata per crittografare localmente il file di backup, in modo simile a come viene crittografato un disco rigido. Nel passaggio successivo, è possibile aggiungere un suggerimento.</string>
     <string name="fast_vault_password_screen_hint_title">Ulteriori informazioni</string>
     <string name="peer_discovery_local_mode_hint">Sei in modalità locale</string>
-    <string name="peer_discovery_recommended_devices_hint">Scansiona il codice QR con un altro dispositivo. Si consiglia la configurazione a 3 dispositivi, 2 sono sufficienti.</string>
     <string name="review_vault_devices_title">Controlla i dispositivi del vault</string>
     <string name="review_vault_devices_description">Assicurati che questi siano i dispositivi corretti che hai aggiunto:</string>
     <string name="review_vault_devices_looks_good">Sembra corretto</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -551,7 +551,6 @@
     <string name="peer_discovery_switch_network_mode_switch_to_local">로컬 모드로 전환</string>
     <string name="peer_discovery_switch_network_mode_switch_to_internet">인터넷 모드로 전환</string>
     <string name="peer_discovery_local_mode_hint">로컬 모드입니다</string>
-    <string name="peer_discovery_recommended_devices_hint">다른 기기로 QR을 스캔하세요. 3기기 설정을 권장하며, 2기기도 충분합니다.</string>
     <string name="fast_vault_name_screen_title">볼트 이름 지정</string>
     <string name="fast_vault_name_screen_desc">볼트 이름은 나중에 설정에서 변경할 수 있습니다</string>
     <string name="enter_email_screen_title">이메일 입력</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -854,7 +854,6 @@
     <string name="fast_vault_password_screen_hint">Dit gebeurt omdat het wachtwoord wordt gebruikt om het back-upbestand lokaal te versleutelen, vergelijkbaar met hoe een harde schijf wordt versleuteld. In de volgende stap kunt u een hint toevoegen.</string>
     <string name="fast_vault_password_screen_hint_title">Meer informatie</string>
     <string name="peer_discovery_local_mode_hint">Je bevindt je in de lokale modus.</string>
-    <string name="peer_discovery_recommended_devices_hint">Scan QR met een ander apparaat. Installatie van 3 apparaten aanbevolen, 2 is voldoende.</string>
     <string name="review_vault_devices_title">Controleer je kluis-apparaten</string>
     <string name="review_vault_devices_description">Zorg ervoor dat dit de juiste apparaten zijn die je hebt toegevoegd:</string>
     <string name="review_vault_devices_looks_good">Ziet er goed uit</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -856,7 +856,6 @@
     <string name="fast_vault_password_screen_hint">Isto porque a palavra-passe é utilizada para encriptar localmente o ficheiro de cópia de segurança, de forma semelhante à encriptação de um disco rígido. No passo seguinte, tem a opção de adicionar uma dica.</string>
     <string name="fast_vault_password_screen_hint_title">Mais informações</string>
     <string name="peer_discovery_local_mode_hint">Está no modo local</string>
-    <string name="peer_discovery_recommended_devices_hint">Leia o QR Code com outro dispositivo. Recomenda-se a configuração com 3 dispositivos, mas 2 são suficientes.</string>
     <string name="review_vault_devices_title">Revise os dispositivos do cofre</string>
     <string name="review_vault_devices_description">Certifique-se de que estes são os dispositivos corretos que adicionou:</string>
     <string name="review_vault_devices_looks_good">Parece correto</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -862,7 +862,6 @@
     <string name="fast_vault_password_screen_hint">Это происходит потому, что пароль используется для локального шифрования файла резервной копии, аналогично шифрованию жёсткого диска. На следующем шаге вы можете добавить подсказку.</string>
     <string name="fast_vault_password_screen_hint_title">Подробнее</string>
     <string name="peer_discovery_local_mode_hint">Вы работаете в локальном режиме</string>
-    <string name="peer_discovery_recommended_devices_hint">Сканируйте QR-код другим устройством. Рекомендуется настройка с тремя устройствами, двух достаточно.</string>
     <string name="review_vault_devices_title">Проверьте устройства хранилища</string>
     <string name="review_vault_devices_description">Убедитесь, что это правильные устройства, которые вы добавили:</string>
     <string name="review_vault_devices_looks_good">Выглядит хорошо</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1188,7 +1188,6 @@
     <string name="fast_vault_password_screen_hint">这是因为密码用于对备份文件进行本地加密，类似于硬盘的加密方式。下一步，您可以选择添加密码提示。</string>
     <string name="fast_vault_password_screen_hint_title">更多信息</string>
     <string name="peer_discovery_local_mode_hint">您处于本地模式</string>
-    <string name="peer_discovery_recommended_devices_hint">使用其他设备扫描二维码。建议设置 3 台设备，2 台也足够。</string>
     <string name="review_vault_devices_title">检查您的保险库设备</string>
     <string name="review_vault_devices_description">请确认这些是您添加的正确设备:</string>
     <string name="review_vault_devices_looks_good">看起来不错</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -559,7 +559,6 @@
     <string name="peer_discovery_switch_network_mode_switch_to_local">Switch to local mode</string>
     <string name="peer_discovery_switch_network_mode_switch_to_internet">Switch back to internet mode</string>
     <string name="peer_discovery_local_mode_hint">You’re in local mode</string>
-    <string name="peer_discovery_recommended_devices_hint">Scan QR with other device. 3-device setup recommended, 2 is sufficient.</string>
     <string name="fast_vault_name_screen_title">Name your vault</string>
     <string name="fast_vault_name_screen_desc">You can always rename your vault later in the settings</string>
     <string name="enter_email_screen_title">Enter your email</string>


### PR DESCRIPTION
## Summary
- Removes the \"3-device setup recommended, 2 is sufficient\" info banner from the peer-discovery screen
- Banner is now contradictory since users already committed to a device count on the preceding screen
- Deletes `showDevicesHint` state field and `closeDevicesHint()` handler from `KeygenPeerDiscoveryViewModel`
- Removes `onCloseHintClick` parameter from `PeerDiscoveryScreen` composable and its call sites in both `KeygenPeerDiscoveryScreen` and `KeysignPeerDiscovery`
- Removes `peer_discovery_recommended_devices_hint` string from all 10 locale files

## Issue
Closes #4554

## Test Plan
- [x] Navigate to vault setup → Secure → select any device count → proceed to peer-discovery screen; confirm no hint banner appears
- [x] Lint passes (`./gradlew lint`) ✅
- [x] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Interface**
  * Removed the dismissible "recommended devices" hint and its close action from the peer discovery screen.
  * Updated peer discovery messaging: replaced/adjusted the previous recommended-devices hint with a local-mode hint or removed it across multiple locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->