### PR TITLE
fix(peer-discovery): show "X/4+" for 4+ device vaults

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -99,6 +99,7 @@ data class PeerDiscoveryUiModel(
     val selectedDevices: List<String> = emptyList(),
     val minimumDevices: Int = MIN_KEYGEN_DEVICES,
     val minimumDevicesDisplayed: Int = MIN_KEYGEN_DEVICES,
+    val allowsMoreDevices: Boolean = false,
     val showQrHelpModal: Boolean = false,
     val showDevicesHint: Boolean = true,
     val connectingToServer: ConnectingToServerUiModel? = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignPeerDiscovery.kt
@@ -155,6 +155,7 @@ internal fun KeysignPeerDiscovery(
                     selectedDevices = selectionState.filter { it != vault.localPartyID },
                     minimumDevices = minimumDevices,
                     minimumDevicesDisplayed = minimumDevices,
+                    allowsMoreDevices = vault.signers.size > minimumDevices,
                     showQrHelpModal = false,
                     showDevicesHint = false,
                     connectingToServer = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -277,7 +277,7 @@ internal fun PeerDiscoveryScreen(
                         Text(
                             text =
                                 stringResource(
-                                    if (state.minimumDevicesDisplayed >= 4)
+                                    if (state.allowsMoreDevices)
                                         R.string.peer_discovery_devices_n_of_n_plus
                                     else R.string.peer_discovery_devices_n_of_n,
                                     selectedDevicesSize,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -277,7 +277,9 @@ internal fun PeerDiscoveryScreen(
                         Text(
                             text =
                                 stringResource(
-                                    R.string.peer_discovery_devices_n_of_n,
+                                    if (state.minimumDevicesDisplayed >= 4)
+                                        R.string.peer_discovery_devices_n_of_n_plus
+                                    else R.string.peer_discovery_devices_n_of_n,
                                     selectedDevicesSize,
                                     state.minimumDevicesDisplayed,
                                 ),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -812,6 +812,7 @@
     <string name="peer_discovery_topbar_title">QR-Code scannen</string>
     <string name="peer_discovery_waiting_for_devices_action">Geräte werden angefordert…</string>
     <string name="peer_discovery_devices_n_of_n">Geräte (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Geräte (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">An %s gesendet.</string>
     <string name="vault_backup_screen_donot_receive_email">Keine E-Mail erhalten?</string>
     <string name="onboarding_desc_page_5_part_2">separat in einem</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -810,6 +810,7 @@
     <string name="peer_discovery_topbar_title">Escanear código QR</string>
     <string name="peer_discovery_waiting_for_devices_action">Esperando dispositivos…</string>
     <string name="peer_discovery_devices_n_of_n">Dispositivos (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Dispositivos (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Enviado a %s.</string>
     <string name="vault_backup_screen_donot_receive_email">¿No recibiste un correo?</string>
     <string name="onboarding_desc_page_5_part_2">por separado en un</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -815,6 +815,7 @@
     <string name="peer_discovery_topbar_title">Skenirajte QR</string>
     <string name="peer_discovery_waiting_for_devices_action">Čekanje na uređaje…</string>
     <string name="peer_discovery_devices_n_of_n">Uređaji (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Uređaji (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Poslano na %s.</string>
     <string name="vault_backup_screen_donot_receive_email">Niste primili e-poštu?</string>
     <string name="onboarding_desc_page_5_part_2">odvojeno u</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -810,6 +810,7 @@
     <string name="peer_discovery_topbar_title">Scansiona il codice QR</string>
     <string name="peer_discovery_waiting_for_devices_action">In attesa dei dispositivi…</string>
     <string name="peer_discovery_devices_n_of_n">Dispositivi (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Dispositivi (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Inviato a %s.</string>
     <string name="vault_backup_screen_donot_receive_email">Non hai ricevuto un\'email?</string>
     <string name="onboarding_desc_page_5_part_2">separatamente in un</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -519,6 +519,7 @@
     <string name="peer_discovery_scan_with_n_device">%1$s 기기로 스캔</string>
     <string name="peer_discovery_waiting_for_devices_action">기기 대기 중…</string>
     <string name="peer_discovery_devices_n_of_n">기기 (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">기기 (%1$s/%2$s+)</string>
     <string name="scan_qr_code_modal_annotation">다른 기기에서 앱을 열고 \'QR 코드 스캔\'을 탭하여 연결하세요.</string>
     <string name="scan_qr_code_modal_next">스캔 시작</string>
     <string name="scan_qr_code_modal_scan_the">다른 기기에서 QR을 스캔하세요</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -807,6 +807,7 @@
     <string name="peer_discovery_topbar_title">QR scannen</string>
     <string name="peer_discovery_waiting_for_devices_action">Wachten op apparaten…</string>
     <string name="peer_discovery_devices_n_of_n">Apparaten (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Apparaten (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Verzonden naar %s.</string>
     <string name="vault_backup_screen_donot_receive_email">Geen email ontvangen?</string>
     <string name="onboarding_desc_page_5_part_2">Afzonderlijk in een</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -809,6 +809,7 @@
     <string name="peer_discovery_topbar_title">Leia o QR Code</string>
     <string name="peer_discovery_waiting_for_devices_action">Aguarda dispositivos…</string>
     <string name="peer_discovery_devices_n_of_n">Dispositivos (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Dispositivos (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Enviado para %s.</string>
     <string name="vault_backup_screen_donot_receive_email">Não recebeu um email?</string>
     <string name="onboarding_desc_page_5_part_2">separadamente num</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -815,6 +815,7 @@
     <string name="peer_discovery_topbar_title">Сканируйте QR-код</string>
     <string name="peer_discovery_waiting_for_devices_action">Ожидание устройств…</string>
     <string name="peer_discovery_devices_n_of_n">Устройства (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Устройства (%1$s/%2$s+)</string>
     <string name="vault_backup_screen_email_sent_to">Отправлено %s.</string>
     <string name="vault_backup_screen_donot_receive_email">Не получили письмо?</string>
     <string name="onboarding_desc_page_5_part_2">отдельно в</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1143,6 +1143,7 @@
     <string name="peer_discovery_topbar_title">扫描二维码</string>
     <string name="peer_discovery_waiting_for_devices_action">正在等待设备……</string>
     <string name="peer_discovery_devices_n_of_n">设备（%1$s/%2$s）</string>
+    <string name="peer_discovery_devices_n_of_n_plus">设备（%1$s/%2$s+）</string>
     <string name="onboarding_desc_page_5_part_2">单独发送</string>
     <string name="onboarding_desc_page_5_part_3">其他位置</string>
     <string name="scan_qr_code_modal_annotation">在另一台设备上打开应用并点击“扫描二维码”进行连接。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -527,6 +527,7 @@
     <string name="peer_discovery_scan_with_n_device">Scan with %1$s device</string>
     <string name="peer_discovery_waiting_for_devices_action">Waiting for devices to connect…</string>
     <string name="peer_discovery_devices_n_of_n">Devices (%1$s/%2$s)</string>
+    <string name="peer_discovery_devices_n_of_n_plus">Devices (%1$s/%2$s+)</string>
     <string name="scan_qr_code_modal_annotation">On your other device, open the app and tap \"Scan QR\" to connect it.</string>
     <string name="scan_qr_code_modal_next">Start scanning</string>
     <string name="scan_qr_code_modal_scan_the">Scan the QR on your other devices</string>


### PR DESCRIPTION
## Summary
- Adds `peer_discovery_devices_n_of_n_plus` string (`Devices (%1$s/%2$s+)`) to all 10 locale files
- `PeerDiscoveryScreen` now selects the `+` variant when `minimumDevicesDisplayed >= 4`, keeping the existing format for 2-of-2 and 3-of-3 vaults unchanged

## Issue
Closes #4553

## Test Plan
- [x] On a 4-device vault, peer-discovery screen shows `Devices (1/4+)` and increments correctly: `2/4+`, `3/4+`, `4/4+`
- [x] On a 2-device vault, peer-discovery screen still shows `Devices (1/2)` (no `+`)
- [x] On a 3-device vault, peer-discovery screen still shows `Devices (1/3)` (no `+`)
- [x] Lint passes (`./gradlew lint`) ✅
- [x] Debug build succeeds (`./gradlew assembleDebug`) ✅

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer discovery now shows an "N of N+" device-count variant when additional devices can be added, improving visibility of device status.

* **Internationalization**
  * Added translations for the "N of N+" device-count label in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->