### PR TITLE
fix(onboarding): tablet layout — center content on midline (#4450)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -16,7 +16,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,6 +44,7 @@ import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.services.VultisigFirebaseMessagingService
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 import com.vultisig.wallet.ui.theme.v2.V2.colors
+import com.vultisig.wallet.ui.utils.LocalWindowSizeClass
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -94,31 +98,38 @@ class MainActivity : AppCompatActivity() {
         observePreventScreenshots()
 
         setContent {
-            OnBoardingComposeTheme {
-                val screen by mainViewModel.startDestination.collectAsStateWithLifecycle()
+            @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+            val windowSizeClass = calculateWindowSizeClass(this)
+            CompositionLocalProvider(LocalWindowSizeClass provides windowSizeClass) {
+                OnBoardingComposeTheme {
+                    val screen by mainViewModel.startDestination.collectAsStateWithLifecycle()
 
-                val navController = rememberNavController()
+                    val navController = rememberNavController()
 
-                val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
-                var showSplash by remember { mutableStateOf(true) }
+                    val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
+                    var showSplash by remember { mutableStateOf(true) }
 
-                if (showSplash) {
-                    AnimatedSplash(isLoading = isLoading, onSplashComplete = { showSplash = false })
-                } else {
-                    var isNavigationReady by remember { mutableStateOf(false) }
+                    if (showSplash) {
+                        AnimatedSplash(
+                            isLoading = isLoading,
+                            onSplashComplete = { showSplash = false },
+                        )
+                    } else {
+                        var isNavigationReady by remember { mutableStateOf(false) }
 
-                    if (isNavigationReady) {
-                        CheckDeeplink(mainViewModel::openUri)
+                        if (isNavigationReady) {
+                            CheckDeeplink(mainViewModel::openUri)
+                        }
+
+                        CheckUpdates()
+
+                        MainActivityContent(
+                            navController = navController,
+                            mainViewModel = mainViewModel,
+                            startDestination = screen,
+                            onNavigationReady = { isNavigationReady = true },
+                        )
                     }
-
-                    CheckUpdates()
-
-                    MainActivityContent(
-                        navController = navController,
-                        mainViewModel = mainViewModel,
-                        startDestination = screen,
-                        onNavigationReady = { isNavigationReady = true },
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/ChooseVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/ChooseVaultScreen.kt
@@ -65,6 +65,7 @@ import com.vultisig.wallet.ui.models.keygen.ChooseVaultViewModel
 import com.vultisig.wallet.ui.models.keygen.SelectVaultTypeUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultType
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
 import com.vultisig.wallet.ui.utils.asString
@@ -328,6 +329,18 @@ private fun TextAndIcon(
 @Preview
 @Composable
 internal fun SelectVaultTypeScreenPreview() {
+    ChooseVaultScreen(
+        state = SelectVaultTypeUiModel(vaultType = VaultType.Secure),
+        onTabClick = {},
+        onStartClick = {},
+        onBackClick = {},
+        onHelpClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun SelectVaultTypeScreenTabletPreview() {
     ChooseVaultScreen(
         state = SelectVaultTypeUiModel(vaultType = VaultType.Secure),
         onTabClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/ChooseVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/ChooseVaultScreen.kt
@@ -64,6 +64,7 @@ import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.keygen.ChooseVaultViewModel
 import com.vultisig.wallet.ui.models.keygen.SelectVaultTypeUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultType
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
 import com.vultisig.wallet.ui.utils.asString
@@ -97,191 +98,195 @@ private fun ChooseVaultScreen(
         onBackClick = onBackClick,
         title = stringResource(R.string.select_vault_type_choose_setup),
     ) {
-        Column(horizontalAlignment = CenterHorizontally) {
-            val isSecureTypeSelected = state.vaultType is VaultType.Secure
+        OnboardingResponsiveContainer {
+            Column(horizontalAlignment = CenterHorizontally) {
+                val isSecureTypeSelected = state.vaultType is VaultType.Secure
 
-            val fadeAnimation = remember { Animatable(0f) }
-            val scaleAnimation = remember { Animatable(0.5f) }
+                val fadeAnimation = remember { Animatable(0f) }
+                val scaleAnimation = remember { Animatable(0.5f) }
 
-            LaunchedEffect(Unit) {
-                launch { startFadeAnimation(fadeAnimation) }
-                startScaleAnimation(scaleAnimation)
-            }
-
-            RiveAnimation(
-                animation = R.raw.riv_choose_vault,
-                modifier = Modifier.padding(vertical = 24.dp, horizontal = 12.dp).weight(1f),
-                alignment = TOP_CENTER,
-                onInit = { rive: RiveAnimationView -> state.animate(rive) },
-            )
-
-            Column(
-                Modifier.graphicsLayer {
-                    this.transformOrigin = TransformOrigin.Center.copy(pivotFractionY = 1f)
-                    this.alpha = fadeAnimation.value
-                    this.scaleX = scaleAnimation.value
-                    this.scaleY = scaleAnimation.value
+                LaunchedEffect(Unit) {
+                    launch { startFadeAnimation(fadeAnimation) }
+                    startScaleAnimation(scaleAnimation)
                 }
-            ) {
-                LookaheadScope {
-                    Box(
-                        modifier =
-                            Modifier.height(intrinsicSize = IntrinsicSize.Min)
-                                .clip(CircleShape)
-                                .background(Theme.v2.colors.backgrounds.tertiary_2)
-                                .padding(6.dp)
-                    ) {
+
+                RiveAnimation(
+                    animation = R.raw.riv_choose_vault,
+                    modifier = Modifier.padding(vertical = 24.dp, horizontal = 12.dp).weight(1f),
+                    alignment = TOP_CENTER,
+                    onInit = { rive: RiveAnimationView -> state.animate(rive) },
+                )
+
+                Column(
+                    Modifier.graphicsLayer {
+                        this.transformOrigin = TransformOrigin.Center.copy(pivotFractionY = 1f)
+                        this.alpha = fadeAnimation.value
+                        this.scaleX = scaleAnimation.value
+                        this.scaleY = scaleAnimation.value
+                    }
+                ) {
+                    LookaheadScope {
                         Box(
-                            modifier = Modifier.fillMaxWidth().fillMaxHeight(),
-                            contentAlignment =
-                                if (isSecureTypeSelected) Alignment.TopEnd else Alignment.TopStart,
+                            modifier =
+                                Modifier.height(intrinsicSize = IntrinsicSize.Min)
+                                    .clip(CircleShape)
+                                    .background(Theme.v2.colors.backgrounds.tertiary_2)
+                                    .padding(6.dp)
                         ) {
                             Box(
-                                modifier =
-                                    Modifier.animatePlacementInScope(this@LookaheadScope)
-                                        .clip(CircleShape)
-                                        .background(Theme.v2.colors.backgrounds.primary)
-                                        .fillMaxHeight()
-                                        .fillMaxWidth(0.5f)
-                            )
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceAround,
-                        ) {
-                            Row(
-                                modifier =
-                                    Modifier.weight(1f)
-                                        .clip(CircleShape)
-                                        .clickable { onTabClick(VaultType.Fast) }
-                                        .padding(16.dp)
-                                        .wrapContentWidth(CenterHorizontally)
-                                        .testTag("ChooseVaultScreen.selectFastVault")
+                                modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                                contentAlignment =
+                                    if (isSecureTypeSelected) Alignment.TopEnd
+                                    else Alignment.TopStart,
                             ) {
-                                val brushGradient = Theme.v2.colors.gradients.primary
-                                val iconModifier =
-                                    if (!isSecureTypeSelected) {
-                                        Modifier.graphicsLayer(
-                                                compositingStrategy = CompositingStrategy.Offscreen
-                                            )
-                                            .drawWithCache {
-                                                onDrawWithContent {
-                                                    drawContent()
-                                                    drawRect(
-                                                        brushGradient,
-                                                        blendMode = BlendMode.SrcAtop,
-                                                    )
-                                                }
-                                            }
-                                    } else {
-                                        Modifier
-                                    }
-                                Icon(
-                                    modifier = iconModifier,
-                                    painter = painterResource(R.drawable.thunder),
-                                    contentDescription =
-                                        stringResource(R.string.select_vault_type_fast),
-                                    tint = Theme.v2.colors.text.primary,
-                                )
-                                UiSpacer(8.dp)
-                                Text(
-                                    text = stringResource(R.string.select_vault_type_fast),
-                                    color = Theme.v2.colors.text.primary,
-                                    style = Theme.brockmann.body.s.medium,
+                                Box(
+                                    modifier =
+                                        Modifier.animatePlacementInScope(this@LookaheadScope)
+                                            .clip(CircleShape)
+                                            .background(Theme.v2.colors.backgrounds.primary)
+                                            .fillMaxHeight()
+                                            .fillMaxWidth(0.5f)
                                 )
                             }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceAround,
+                            ) {
+                                Row(
+                                    modifier =
+                                        Modifier.weight(1f)
+                                            .clip(CircleShape)
+                                            .clickable { onTabClick(VaultType.Fast) }
+                                            .padding(16.dp)
+                                            .wrapContentWidth(CenterHorizontally)
+                                            .testTag("ChooseVaultScreen.selectFastVault")
+                                ) {
+                                    val brushGradient = Theme.v2.colors.gradients.primary
+                                    val iconModifier =
+                                        if (!isSecureTypeSelected) {
+                                            Modifier.graphicsLayer(
+                                                    compositingStrategy =
+                                                        CompositingStrategy.Offscreen
+                                                )
+                                                .drawWithCache {
+                                                    onDrawWithContent {
+                                                        drawContent()
+                                                        drawRect(
+                                                            brushGradient,
+                                                            blendMode = BlendMode.SrcAtop,
+                                                        )
+                                                    }
+                                                }
+                                        } else {
+                                            Modifier
+                                        }
+                                    Icon(
+                                        modifier = iconModifier,
+                                        painter = painterResource(R.drawable.thunder),
+                                        contentDescription =
+                                            stringResource(R.string.select_vault_type_fast),
+                                        tint = Theme.v2.colors.text.primary,
+                                    )
+                                    UiSpacer(8.dp)
+                                    Text(
+                                        text = stringResource(R.string.select_vault_type_fast),
+                                        color = Theme.v2.colors.text.primary,
+                                        style = Theme.brockmann.body.s.medium,
+                                    )
+                                }
 
-                            TextAndIcon(
-                                text = stringResource(R.string.select_vault_type_secure),
-                                icon = painterResource(R.drawable.ic_shield),
-                                tint =
-                                    if (isSecureTypeSelected) Theme.v2.colors.alerts.success
-                                    else Theme.v2.colors.text.primary,
-                                contentDescription =
-                                    stringResource(R.string.select_vault_type_secure),
-                                modifier =
-                                    Modifier.weight(1f)
-                                        .clip(CircleShape)
-                                        .clickable { onTabClick(VaultType.Secure) }
-                                        .padding(16.dp)
-                                        .wrapContentWidth(CenterHorizontally),
-                            )
+                                TextAndIcon(
+                                    text = stringResource(R.string.select_vault_type_secure),
+                                    icon = painterResource(R.drawable.ic_shield),
+                                    tint =
+                                        if (isSecureTypeSelected) Theme.v2.colors.alerts.success
+                                        else Theme.v2.colors.text.primary,
+                                    contentDescription =
+                                        stringResource(R.string.select_vault_type_secure),
+                                    modifier =
+                                        Modifier.weight(1f)
+                                            .clip(CircleShape)
+                                            .clickable { onTabClick(VaultType.Secure) }
+                                            .padding(16.dp)
+                                            .wrapContentWidth(CenterHorizontally),
+                                )
+                            }
                         }
+                    }
+
+                    UiSpacer(16.dp)
+                    val borderColor = Theme.v2.colors.border.normal
+                    Column(
+                        Modifier.fillMaxWidth()
+                            .clip(RoundedCornerShape(15.dp))
+                            .border(
+                                width = 1.dp,
+                                color = borderColor,
+                                shape = RoundedCornerShape(15.dp),
+                            )
+                            .background(Theme.v2.colors.backgrounds.tertiary_2),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Text(
+                            text =
+                                buildAnnotatedString {
+                                    withStyle(
+                                        style = SpanStyle(brush = Theme.v2.colors.gradients.primary)
+                                    ) {
+                                        append(state.vaultType.title.asString())
+                                    }
+                                },
+                            color = Theme.v2.colors.alerts.success,
+                            style = Theme.brockmann.headings.subtitle,
+                            modifier =
+                                Modifier.background(Theme.v2.colors.backgrounds.tertiary_2)
+                                    .fillMaxWidth()
+                                    .background(color = Theme.v2.colors.backgrounds.primary)
+                                    .drawBehind {
+                                        drawLine(
+                                            color = borderColor,
+                                            start = Offset(0f, size.height),
+                                            end = Offset(size.width, size.height),
+                                            strokeWidth = 5f,
+                                            pathEffect =
+                                                PathEffect.dashPathEffect(floatArrayOf(10f, 10f)),
+                                        )
+                                    }
+                                    .padding(16.dp),
+                            textAlign = TextAlign.Center,
+                        )
+
+                        TextAndIcon(
+                            text = state.vaultType.desc1.asString(),
+                            icon = painterResource(R.drawable.check),
+                            tint = Theme.v2.colors.alerts.success,
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                        )
+                        TextAndIcon(
+                            text = state.vaultType.desc2.asString(),
+                            icon = painterResource(R.drawable.check),
+                            tint = Theme.v2.colors.alerts.success,
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                        )
+                        TextAndIcon(
+                            text = state.vaultType.desc3.asString(),
+                            icon = painterResource(R.drawable.check),
+                            tint = Theme.v2.colors.alerts.success,
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                        )
+
+                        UiSpacer(8.dp)
                     }
                 }
 
-                UiSpacer(16.dp)
-                val borderColor = Theme.v2.colors.border.normal
-                Column(
-                    Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(15.dp))
-                        .border(
-                            width = 1.dp,
-                            color = borderColor,
-                            shape = RoundedCornerShape(15.dp),
-                        )
-                        .background(Theme.v2.colors.backgrounds.tertiary_2),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        text =
-                            buildAnnotatedString {
-                                withStyle(
-                                    style = SpanStyle(brush = Theme.v2.colors.gradients.primary)
-                                ) {
-                                    append(state.vaultType.title.asString())
-                                }
-                            },
-                        color = Theme.v2.colors.alerts.success,
-                        style = Theme.brockmann.headings.subtitle,
-                        modifier =
-                            Modifier.background(Theme.v2.colors.backgrounds.tertiary_2)
-                                .fillMaxWidth()
-                                .background(color = Theme.v2.colors.backgrounds.primary)
-                                .drawBehind {
-                                    drawLine(
-                                        color = borderColor,
-                                        start = Offset(0f, size.height),
-                                        end = Offset(size.width, size.height),
-                                        strokeWidth = 5f,
-                                        pathEffect =
-                                            PathEffect.dashPathEffect(floatArrayOf(10f, 10f)),
-                                    )
-                                }
-                                .padding(16.dp),
-                        textAlign = TextAlign.Center,
-                    )
-
-                    TextAndIcon(
-                        text = state.vaultType.desc1.asString(),
-                        icon = painterResource(R.drawable.check),
-                        tint = Theme.v2.colors.alerts.success,
-                        modifier = Modifier.padding(horizontal = 20.dp),
-                    )
-                    TextAndIcon(
-                        text = state.vaultType.desc2.asString(),
-                        icon = painterResource(R.drawable.check),
-                        tint = Theme.v2.colors.alerts.success,
-                        modifier = Modifier.padding(horizontal = 20.dp),
-                    )
-                    TextAndIcon(
-                        text = state.vaultType.desc3.asString(),
-                        icon = painterResource(R.drawable.check),
-                        tint = Theme.v2.colors.alerts.success,
-                        modifier = Modifier.padding(horizontal = 20.dp),
-                    )
-
-                    UiSpacer(8.dp)
-                }
+                UiSpacer(24.dp)
+                VsButton(
+                    onClick = onStartClick,
+                    label = stringResource(id = R.string.select_vault_type_next),
+                    modifier = Modifier.fillMaxWidth().testTag("ChooseVaultScreen.continue"),
+                )
+                UiSpacer(32.dp)
             }
-
-            UiSpacer(24.dp)
-            VsButton(
-                onClick = onStartClick,
-                label = stringResource(id = R.string.select_vault_type_next),
-                modifier = Modifier.fillMaxWidth().testTag("ChooseVaultScreen.continue"),
-            )
-            UiSpacer(32.dp)
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultEmailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultEmailScreen.kt
@@ -35,6 +35,8 @@ import com.vultisig.wallet.ui.components.referral.AddReferralHeaderButton
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.keygen.FastVaultEmailState
 import com.vultisig.wallet.ui.models.keygen.FastVaultEmailViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -77,49 +79,53 @@ private fun FastVaultEmailScreen(
         onBackClick = onBackClick,
         actions = { AddReferralHeaderButton(hasReferral = hasReferral, onClick = onReferralClick) },
         bottomBar = {
-            VsButton(
-                label = stringResource(R.string.enter_email_screen_next),
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 24.dp)
-                        .testTag("FastVaultEmailScreen.next"),
-                onClick = onNextClick,
-                state =
-                    if (state.innerState == VsTextInputFieldInnerState.Success)
-                        VsButtonState.Enabled
-                    else VsButtonState.Disabled,
-            )
+            OnboardingResponsiveBottomBar {
+                VsButton(
+                    label = stringResource(R.string.enter_email_screen_next),
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 24.dp)
+                            .testTag("FastVaultEmailScreen.next"),
+                    onClick = onNextClick,
+                    state =
+                        if (state.innerState == VsTextInputFieldInnerState.Success)
+                            VsButtonState.Enabled
+                        else VsButtonState.Disabled,
+                )
+            }
         },
     ) {
-        Column {
-            val focusRequester = remember { FocusRequester() }
-            LaunchedEffect(Unit) { focusRequester.requestFocus() }
-            Text(
-                text = stringResource(R.string.enter_email_screen_title),
-                style = Theme.brockmann.headings.largeTitle,
-                color = Theme.v2.colors.text.primary,
-            )
-            UiSpacer(16.dp)
-            Text(
-                text = stringResource(R.string.enter_email_screen_desc),
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.tertiary,
-            )
-            VsTextInputField(
-                textFieldState = textFieldState,
-                innerState = state.innerState,
-                hint = stringResource(R.string.enter_email_screen_hint),
-                trailingIcon = R.drawable.close_circle,
-                onTrailingIconClick = onClearClick,
-                footNote = state.errorMessage.asString(),
-                focusRequester = focusRequester,
-                imeAction = ImeAction.Go,
-                onKeyboardAction = { onNextClick() },
-                modifier =
-                    Modifier.fillMaxSize()
-                        .wrapContentHeight()
-                        .testTag("FastVaultEmailScreen.emailField"),
-            )
+        OnboardingResponsiveContainer {
+            Column {
+                val focusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                Text(
+                    text = stringResource(R.string.enter_email_screen_title),
+                    style = Theme.brockmann.headings.largeTitle,
+                    color = Theme.v2.colors.text.primary,
+                )
+                UiSpacer(16.dp)
+                Text(
+                    text = stringResource(R.string.enter_email_screen_desc),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                VsTextInputField(
+                    textFieldState = textFieldState,
+                    innerState = state.innerState,
+                    hint = stringResource(R.string.enter_email_screen_hint),
+                    trailingIcon = R.drawable.close_circle,
+                    onTrailingIconClick = onClearClick,
+                    footNote = state.errorMessage.asString(),
+                    focusRequester = focusRequester,
+                    imeAction = ImeAction.Go,
+                    onKeyboardAction = { onNextClick() },
+                    modifier =
+                        Modifier.fillMaxSize()
+                            .wrapContentHeight()
+                            .testTag("FastVaultEmailScreen.emailField"),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultEmailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultEmailScreen.kt
@@ -37,6 +37,7 @@ import com.vultisig.wallet.ui.models.keygen.FastVaultEmailState
 import com.vultisig.wallet.ui.models.keygen.FastVaultEmailViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -133,6 +134,18 @@ private fun FastVaultEmailScreen(
 @Preview
 @Composable
 private fun FastVaultEmailScreenPreview() {
+    FastVaultEmailScreen(
+        state = FastVaultEmailState(),
+        textFieldState = rememberTextFieldState(),
+        onNextClick = {},
+        onClearClick = {},
+        onBackClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun FastVaultEmailScreenTabletPreview() {
     FastVaultEmailScreen(
         state = FastVaultEmailState(),
         textFieldState = rememberTextFieldState(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordHintScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordHintScreen.kt
@@ -33,6 +33,7 @@ import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordHintUiModel
 import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordHintViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -127,6 +128,18 @@ private fun FastVaultPasswordHintScreen(
 @Preview
 @Composable
 private fun FastVaultPasswordHintScreenPreview() {
+    FastVaultPasswordHintScreen(
+        state = FastVaultPasswordHintUiModel(),
+        textFieldState = rememberTextFieldState(),
+        onNextClick = {},
+        onBackClick = {},
+        onSkipClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun FastVaultPasswordHintScreenTabletPreview() {
     FastVaultPasswordHintScreen(
         state = FastVaultPasswordHintUiModel(),
         textFieldState = rememberTextFieldState(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordHintScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordHintScreen.kt
@@ -31,6 +31,8 @@ import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldType
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordHintUiModel
 import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordHintViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -61,59 +63,63 @@ private fun FastVaultPasswordHintScreen(
         title = null,
         onBackClick = onBackClick,
         bottomBar = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
-            ) {
-                VsButton(
-                    label = stringResource(R.string.fast_vault_password_hint_skip),
-                    onClick = onSkipClick,
-                    variant = VsButtonVariant.Secondary,
-                    modifier = Modifier.weight(1f).testTag("FastVaultPasswordHintScreen.skip"),
-                )
+            OnboardingResponsiveBottomBar {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+                ) {
+                    VsButton(
+                        label = stringResource(R.string.fast_vault_password_hint_skip),
+                        onClick = onSkipClick,
+                        variant = VsButtonVariant.Secondary,
+                        modifier = Modifier.weight(1f).testTag("FastVaultPasswordHintScreen.skip"),
+                    )
 
-                VsButton(
-                    label = stringResource(R.string.fast_vault_password_hint_next),
-                    state =
-                        if (state.isNextAvailable) VsButtonState.Enabled
-                        else VsButtonState.Disabled,
-                    onClick = {
-                        keyboardController?.hide()
-                        onNextClick()
-                    },
-                    modifier = Modifier.weight(1f),
-                )
+                    VsButton(
+                        label = stringResource(R.string.fast_vault_password_hint_next),
+                        state =
+                            if (state.isNextAvailable) VsButtonState.Enabled
+                            else VsButtonState.Disabled,
+                        onClick = {
+                            keyboardController?.hide()
+                            onNextClick()
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
             }
         },
     ) {
         val focusRequester = remember { FocusRequester() }
         LaunchedEffect(Unit) { focusRequester.requestFocus() }
-        Column {
-            Text(
-                text = stringResource(R.string.fast_vault_password_hint_screen_title),
-                style = Theme.brockmann.headings.largeTitle,
-                color = Theme.v2.colors.text.primary,
-            )
-            UiSpacer(16.dp)
-            Text(
-                text = stringResource(R.string.fast_vault_password_hint_screen_desc),
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.tertiary,
-            )
-            VsTextInputField(
-                textFieldState = textFieldState,
-                hint = stringResource(R.string.fast_vault_password_hint_screen_hint),
-                footNote = state.errorMessage?.asString(),
-                trailingIcon = R.drawable.ic_question_mark,
-                focusRequester = focusRequester,
-                type = VsTextInputFieldType.MultiLine(5),
-                imeAction = ImeAction.Go,
-                onKeyboardAction = {
-                    keyboardController?.hide()
-                    onNextClick()
-                },
-                modifier = Modifier.padding(top = 16.dp),
-            )
+        OnboardingResponsiveContainer {
+            Column {
+                Text(
+                    text = stringResource(R.string.fast_vault_password_hint_screen_title),
+                    style = Theme.brockmann.headings.largeTitle,
+                    color = Theme.v2.colors.text.primary,
+                )
+                UiSpacer(16.dp)
+                Text(
+                    text = stringResource(R.string.fast_vault_password_hint_screen_desc),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                VsTextInputField(
+                    textFieldState = textFieldState,
+                    hint = stringResource(R.string.fast_vault_password_hint_screen_hint),
+                    footNote = state.errorMessage?.asString(),
+                    trailingIcon = R.drawable.ic_question_mark,
+                    focusRequester = focusRequester,
+                    type = VsTextInputFieldType.MultiLine(5),
+                    imeAction = ImeAction.Go,
+                    onKeyboardAction = {
+                        keyboardController?.hide()
+                        onNextClick()
+                    },
+                    modifier = Modifier.padding(top = 16.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
@@ -55,6 +55,8 @@ import com.vultisig.wallet.ui.components.v2.utils.roundToPx
 import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordUiModel
 import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordViewModel
 import com.vultisig.wallet.ui.screens.swap.components.HintBox
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
@@ -111,136 +113,142 @@ internal fun FastVaultPasswordScreen(
         onBackClick = onBackClick,
         actions = { AddReferralHeaderButton(hasReferral = hasReferral, onClick = onReferralClick) },
         content = {
-            Column {
-                Text(
-                    text = title,
-                    style = Theme.brockmann.headings.largeTitle,
-                    color = Theme.v2.colors.text.primary,
-                )
-                UiSpacer(16.dp)
-
-                val descText = stringResource(R.string.password_extra_layer)
-                val descHighlight = stringResource(R.string.password_extra_layer_highlight)
-                val descAnnotated = buildAnnotatedString {
-                    val start = descText.indexOf(descHighlight)
-                    if (start >= 0) {
-                        append(descText.substring(0, start))
-                        withStyle(
-                            SpanStyle(
-                                color = Theme.v2.colors.text.primary,
-                                fontWeight = FontWeight.Bold,
-                            )
-                        ) {
-                            append(descHighlight)
-                        }
-                        append(descText.substring(start + descHighlight.length))
-                    } else {
-                        append(descText)
-                    }
-                }
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier =
-                        Modifier.fillMaxWidth().onGloballyPositioned { position ->
-                            hintBoxOffset =
-                                position.boundsInParent().bottom.toInt() + topbarHeight -
-                                    defaultVerticalPadding
-                        },
-                ) {
+            OnboardingResponsiveContainer {
+                Column {
                     Text(
-                        text = descAnnotated,
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.weight(1f, fill = false),
+                        text = title,
+                        style = Theme.brockmann.headings.largeTitle,
+                        color = Theme.v2.colors.text.primary,
                     )
-                    UiSpacer(size = 4.dp)
-                    UiIcon(
-                        drawableResId = R.drawable.circleinfo,
-                        size = 16.dp,
-                        tint = Theme.v2.colors.text.tertiary,
-                        onClick = onShowMoreInfo,
-                    )
-                }
+                    UiSpacer(16.dp)
 
-                UiSpacer(16.dp)
-
-                Column(modifier = Modifier.fillMaxSize()) {
-                    WarningCard(onShowMoreInfo = onShowMoreInfo, modifier = Modifier)
-
-                    UiSpacer(8.dp)
-
-                    Column(
-                        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-                        verticalArrangement =
-                            Arrangement.spacedBy(10.dp, Alignment.CenterVertically),
+                    val descText = stringResource(R.string.password_extra_layer)
+                    val descHighlight = stringResource(R.string.password_extra_layer_highlight)
+                    val descAnnotated = buildAnnotatedString {
+                        val start = descText.indexOf(descHighlight)
+                        if (start >= 0) {
+                            append(descText.substring(0, start))
+                            withStyle(
+                                SpanStyle(
+                                    color = Theme.v2.colors.text.primary,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            ) {
+                                append(descHighlight)
+                            }
+                            append(descText.substring(start + descHighlight.length))
+                        } else {
+                            append(descText)
+                        }
+                    }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier =
+                            Modifier.fillMaxWidth().onGloballyPositioned { position ->
+                                hintBoxOffset =
+                                    position.boundsInParent().bottom.toInt() + topbarHeight -
+                                        defaultVerticalPadding
+                            },
                     ) {
-                        val focusRequester = remember { FocusRequester() }
-
-                        LaunchedEffect(Unit) { focusRequester.requestFocus() }
-
-                        VsTextInputField(
-                            textFieldState = passwordTextFieldState,
-                            hint =
-                                stringResource(R.string.fast_vault_password_screen_password_hint),
-                            trailingIcon = R.drawable.ic_question_mark,
-                            type =
-                                VsTextInputFieldType.Password(
-                                    isVisible = state.isPasswordVisible,
-                                    onVisibilityClick = onTogglePasswordVisibilityClick,
-                                ),
-                            focusRequester = focusRequester,
-                            imeAction = ImeAction.Next,
-                            modifier = Modifier.testTag("FastVaultPasswordScreen.passwordField"),
+                        Text(
+                            text = descAnnotated,
+                            style = Theme.brockmann.body.s.medium,
+                            color = Theme.v2.colors.text.tertiary,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.weight(1f, fill = false),
                         )
-
-                        VsTextInputField(
-                            textFieldState = confirmPasswordTextFieldState,
-                            trailingIcon = R.drawable.ic_question_mark,
-                            hint =
-                                stringResource(
-                                    R.string.fast_vault_password_screen_reenter_password_hint
-                                ),
-                            type =
-                                VsTextInputFieldType.Password(
-                                    isVisible = state.isConfirmPasswordVisible,
-                                    onVisibilityClick = onToggleConfirmPasswordVisibilityClick,
-                                ),
-                            innerState = state.innerState,
-                            footNote = (state.errorMessage ?: UiText.Empty).asString(),
-                            imeAction =
-                                if (state.isNextButtonEnabled) ImeAction.Go else ImeAction.None,
-                            onKeyboardAction = { onNextClick() },
-                            modifier =
-                                Modifier.testTag("FastVaultPasswordScreen.confirmPasswordField"),
+                        UiSpacer(size = 4.dp)
+                        UiIcon(
+                            drawableResId = R.drawable.circleinfo,
+                            size = 16.dp,
+                            tint = Theme.v2.colors.text.tertiary,
+                            onClick = onShowMoreInfo,
                         )
                     }
-                }
-            }
 
-            HintBox(
-                title = stringResource(R.string.fast_vault_password_screen_hint_title),
-                message = stringResource(R.string.fast_vault_password_screen_hint),
-                offset = IntOffset(x = 0, y = hintBoxOffset),
-                pointerAlignment = Alignment.End,
-                onDismissClick = onHideMoreInfo,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                isVisible = state.isMoreInfoVisible,
-            )
+                    UiSpacer(16.dp)
+
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        WarningCard(onShowMoreInfo = onShowMoreInfo, modifier = Modifier)
+
+                        UiSpacer(8.dp)
+
+                        Column(
+                            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+                            verticalArrangement =
+                                Arrangement.spacedBy(10.dp, Alignment.CenterVertically),
+                        ) {
+                            val focusRequester = remember { FocusRequester() }
+
+                            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+                            VsTextInputField(
+                                textFieldState = passwordTextFieldState,
+                                hint =
+                                    stringResource(
+                                        R.string.fast_vault_password_screen_password_hint
+                                    ),
+                                trailingIcon = R.drawable.ic_question_mark,
+                                type =
+                                    VsTextInputFieldType.Password(
+                                        isVisible = state.isPasswordVisible,
+                                        onVisibilityClick = onTogglePasswordVisibilityClick,
+                                    ),
+                                focusRequester = focusRequester,
+                                imeAction = ImeAction.Next,
+                                modifier = Modifier.testTag("FastVaultPasswordScreen.passwordField"),
+                            )
+
+                            VsTextInputField(
+                                textFieldState = confirmPasswordTextFieldState,
+                                trailingIcon = R.drawable.ic_question_mark,
+                                hint =
+                                    stringResource(
+                                        R.string.fast_vault_password_screen_reenter_password_hint
+                                    ),
+                                type =
+                                    VsTextInputFieldType.Password(
+                                        isVisible = state.isConfirmPasswordVisible,
+                                        onVisibilityClick = onToggleConfirmPasswordVisibilityClick,
+                                    ),
+                                innerState = state.innerState,
+                                footNote = (state.errorMessage ?: UiText.Empty).asString(),
+                                imeAction =
+                                    if (state.isNextButtonEnabled) ImeAction.Go else ImeAction.None,
+                                onKeyboardAction = { onNextClick() },
+                                modifier =
+                                    Modifier.testTag("FastVaultPasswordScreen.confirmPasswordField"),
+                            )
+                        }
+                    }
+                }
+
+                HintBox(
+                    title = stringResource(R.string.fast_vault_password_screen_hint_title),
+                    message = stringResource(R.string.fast_vault_password_screen_hint),
+                    offset = IntOffset(x = 0, y = hintBoxOffset),
+                    pointerAlignment = Alignment.End,
+                    onDismissClick = onHideMoreInfo,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    isVisible = state.isMoreInfoVisible,
+                )
+            }
         },
         bottomBar = {
-            VsButton(
-                label = stringResource(R.string.fast_vault_password_screen_next),
-                state =
-                    if (state.isNextButtonEnabled) VsButtonState.Enabled
-                    else VsButtonState.Disabled,
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 24.dp)
-                        .testTag("FastVaultPasswordScreen.next"),
-                onClick = onNextClick,
-            )
+            OnboardingResponsiveBottomBar {
+                VsButton(
+                    label = stringResource(R.string.fast_vault_password_screen_next),
+                    state =
+                        if (state.isNextButtonEnabled) VsButtonState.Enabled
+                        else VsButtonState.Disabled,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 24.dp)
+                            .testTag("FastVaultPasswordScreen.next"),
+                    onClick = onNextClick,
+                )
+            }
         },
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
@@ -57,6 +57,7 @@ import com.vultisig.wallet.ui.models.keygen.FastVaultPasswordViewModel
 import com.vultisig.wallet.ui.screens.swap.components.HintBox
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
@@ -282,6 +283,23 @@ private fun WarningCard(modifier: Modifier, onShowMoreInfo: () -> Unit) {
 @Composable
 @Preview
 private fun FastVaultPasswordScreenPreview() {
+    FastVaultPasswordScreen(
+        state = FastVaultPasswordUiModel(isMoreInfoVisible = true),
+        passwordTextFieldState = rememberTextFieldState(),
+        confirmPasswordTextFieldState = rememberTextFieldState(),
+        title = stringResource(R.string.fast_vault_password_screen_title),
+        onNextClick = {},
+        onBackClick = {},
+        onShowMoreInfo = {},
+        onHideMoreInfo = {},
+        onToggleConfirmPasswordVisibilityClick = {},
+        onTogglePasswordVisibilityClick = {},
+    )
+}
+
+@Composable
+@TabletPreview
+private fun FastVaultPasswordScreenTabletPreview() {
     FastVaultPasswordScreen(
         state = FastVaultPasswordUiModel(isMoreInfoVisible = true),
         passwordTextFieldState = rememberTextFieldState(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenUiModel
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -66,41 +67,42 @@ internal fun JoinKeygenScreen(model: JoinKeygenViewModel = hiltViewModel()) {
 
 @Composable
 private fun JoinKeygenScreen(state: JoinKeygenUiModel) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier =
-            Modifier.fillMaxSize()
-                .background(color = Theme.v2.colors.backgrounds.primary)
-                .padding(all = 36.dp),
+    OnboardingResponsiveContainer(
+        modifier = Modifier.background(color = Theme.v2.colors.backgrounds.primary)
     ) {
-        Text(
-            text = stringResource(R.string.join_key_gen_waiting_for_other_devices_to_join),
-            style = Theme.brockmann.headings.title1,
-            color = Theme.v2.colors.text.primary,
-            textAlign = TextAlign.Center,
-        )
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxSize().padding(all = 36.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.join_key_gen_waiting_for_other_devices_to_join),
+                style = Theme.brockmann.headings.title1,
+                color = Theme.v2.colors.text.primary,
+                textAlign = TextAlign.Center,
+            )
 
-        UiSpacer(12.dp)
+            UiSpacer(12.dp)
 
-        Text(
-            text = stringResource(R.string.join_key_gen_your_vault_will_start_generating),
-            style = Theme.brockmann.body.s.medium,
-            color = Theme.v2.colors.text.tertiary,
-            textAlign = TextAlign.Center,
-        )
+            Text(
+                text = stringResource(R.string.join_key_gen_your_vault_will_start_generating),
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.tertiary,
+                textAlign = TextAlign.Center,
+            )
 
-        UiSpacer(36.dp)
+            UiSpacer(36.dp)
 
-        RiveAnimation(
-            animation = R.raw.riv_connecting_with_server,
-            modifier = Modifier.size(24.dp),
-            onInit = {
-                if (state.isSuccess) {
-                    it.fireState("State Machine 1", "Succes")
-                }
-            },
-        )
+            RiveAnimation(
+                animation = R.raw.riv_connecting_with_server,
+                modifier = Modifier.size(24.dp),
+                onInit = {
+                    if (state.isSuccess) {
+                        it.fireState("State Machine 1", "Succes")
+                    }
+                },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenUiModel
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -109,5 +110,11 @@ private fun JoinKeygenScreen(state: JoinKeygenUiModel) {
 @Preview
 @Composable
 private fun JoinKeygenScreenPreview() {
+    JoinKeygenScreen(state = JoinKeygenUiModel())
+}
+
+@TabletPreview
+@Composable
+private fun JoinKeygenScreenTabletPreview() {
     JoinKeygenScreen(state = JoinKeygenUiModel())
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
@@ -55,6 +55,7 @@ import com.vultisig.wallet.ui.models.keygen.KeygenStepUiModel
 import com.vultisig.wallet.ui.models.keygen.KeygenUiModel
 import com.vultisig.wallet.ui.models.keygen.KeygenViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
@@ -222,54 +223,54 @@ private fun LoadingStageItem(text: String, isLoading: Boolean, modifier: Modifie
 
 @Composable
 private fun Success() {
-
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
+    OnboardingResponsiveContainer(
+        modifier = Modifier.background(Theme.v2.colors.backgrounds.primary)
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            RiveAnimation(
-                animation = R.raw.riv_vault_created,
-                modifier = Modifier.fillMaxWidth().weight(1f),
-            )
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                RiveAnimation(
+                    animation = R.raw.riv_vault_created,
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                )
 
-            var isSuccessVisible by remember { mutableStateOf(false) }
+                var isSuccessVisible by remember { mutableStateOf(false) }
 
-            LaunchedEffect(Unit) { isSuccessVisible = true }
+                LaunchedEffect(Unit) { isSuccessVisible = true }
 
-            AnimatedVisibility(
-                visible = isSuccessVisible,
-                enter =
-                    fadeIn(tween(SUCCESS_ENTER_DURATION_MS)) +
-                        slideInVertically(tween(SUCCESS_ENTER_DURATION_MS)) +
-                        scaleIn(tween(SUCCESS_ENTER_DURATION_MS)),
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    val successText = buildAnnotatedString {
-                        append(stringResource(R.string.keygen_vault_created_success_part_1))
-                        appendLine(" ")
-                        withStyle(SpanStyle(brush = Theme.v2.colors.gradients.primary)) {
-                            append(stringResource(R.string.vault_created_success_part_2))
+                AnimatedVisibility(
+                    visible = isSuccessVisible,
+                    enter =
+                        fadeIn(tween(SUCCESS_ENTER_DURATION_MS)) +
+                            slideInVertically(tween(SUCCESS_ENTER_DURATION_MS)) +
+                            scaleIn(tween(SUCCESS_ENTER_DURATION_MS)),
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        val successText = buildAnnotatedString {
+                            append(stringResource(R.string.keygen_vault_created_success_part_1))
+                            appendLine(" ")
+                            withStyle(SpanStyle(brush = Theme.v2.colors.gradients.primary)) {
+                                append(stringResource(R.string.vault_created_success_part_2))
+                            }
                         }
+
+                        Text(
+                            text = successText,
+                            style = Theme.brockmann.headings.title1,
+                            color = Theme.v2.colors.text.primary,
+                            textAlign = TextAlign.Center,
+                        )
+
+                        UiSpacer(12.dp)
+
+                        RiveAnimation(
+                            animation = R.raw.riv_connecting_with_server,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
-
-                    Text(
-                        text = successText,
-                        style = Theme.brockmann.headings.title1,
-                        color = Theme.v2.colors.text.primary,
-                        textAlign = TextAlign.Center,
-                    )
-
-                    UiSpacer(12.dp)
-
-                    RiveAnimation(
-                        animation = R.raw.riv_connecting_with_server,
-                        modifier = Modifier.size(24.dp),
-                    )
                 }
-            }
 
-            UiSpacer(60.dp)
+                UiSpacer(60.dp)
+            }
         }
     }
 }
@@ -279,6 +280,28 @@ private const val SUCCESS_ENTER_DURATION_MS = 375
 @Preview
 @Composable
 private fun KeygenScreenPreview() {
+    KeygenScreen(
+        state =
+            KeygenUiModel(
+                steps =
+                    listOf(
+                        KeygenStepUiModel(
+                            UiText.StringResource(R.string.keygen_step_preparing_vault),
+                            isLoading = true,
+                        ),
+                        KeygenStepUiModel(
+                            UiText.StringResource(R.string.keygen_step_generating_ecdsa),
+                            isLoading = false,
+                        ),
+                    )
+            ),
+        onTryAgainClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun KeygenScreenTabletPreview() {
     KeygenScreen(
         state =
             KeygenUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
@@ -54,6 +54,7 @@ import com.vultisig.wallet.ui.models.keygen.KeygenState
 import com.vultisig.wallet.ui.models.keygen.KeygenStepUiModel
 import com.vultisig.wallet.ui.models.keygen.KeygenUiModel
 import com.vultisig.wallet.ui.models.keygen.KeygenViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
@@ -105,48 +106,54 @@ private fun KeygenScreen(state: KeygenUiModel, onTryAgainClick: () -> Unit) {
         applyScaffoldPaddings = false,
         topBar = {},
         content = {
-            Column(verticalArrangement = Arrangement.Center, modifier = Modifier.fillMaxSize()) {
-                val error = state.error
-                if (error == null) {
+            OnboardingResponsiveContainer {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    val error = state.error
+                    if (error == null) {
 
-                    val riveFile =
-                        rememberRiveResourceFile(resId = R.raw.riv_keygen).value ?: return@Column
-                    val vmi =
-                        rememberViewModelInstance(
+                        val riveFile =
+                            rememberRiveResourceFile(resId = R.raw.riv_keygen).value
+                                ?: return@Column
+                        val vmi =
+                            rememberViewModelInstance(
+                                file = riveFile,
+                                source = ViewModelSource.Named("ViewModel").defaultInstance(),
+                            )
+
+                        LaunchedEffect(Unit) { vmi.setBoolean("Connected", true) }
+
+                        val animatedValue by
+                            animateFloatAsState(
+                                targetValue = state.progress.times(100),
+                                animationSpec = tween(durationMillis = 300),
+                                label = "riv_progress_animation",
+                            )
+
+                        LaunchedEffect(animatedValue) {
+                            vmi.setNumber("progessPercentage", animatedValue)
+                        }
+
+                        RiveAnimation(
                             file = riveFile,
-                            source = ViewModelSource.Named("ViewModel").defaultInstance(),
+                            viewModelInstance = vmi,
+                            modifier = Modifier.fillMaxSize(),
+                            fit = Fit.Cover(),
                         )
-
-                    LaunchedEffect(Unit) { vmi.setBoolean("Connected", true) }
-
-                    val animatedValue by
-                        animateFloatAsState(
-                            targetValue = state.progress.times(100),
-                            animationSpec = tween(durationMillis = 300),
-                            label = "riv_progress_animation",
+                    } else {
+                        ErrorView(
+                            title = error.title.asString(),
+                            description = error.description.asString(),
+                            modifier = Modifier.fillMaxWidth(),
+                            buttonUiModel =
+                                ErrorViewButtonUiModel(
+                                    text = stringResource(R.string.try_again),
+                                    onClick = onTryAgainClick,
+                                ),
                         )
-
-                    LaunchedEffect(animatedValue) {
-                        vmi.setNumber("progessPercentage", animatedValue)
                     }
-
-                    RiveAnimation(
-                        file = riveFile,
-                        viewModelInstance = vmi,
-                        modifier = Modifier.fillMaxSize(),
-                        fit = Fit.Cover(),
-                    )
-                } else {
-                    ErrorView(
-                        title = error.title.asString(),
-                        description = error.description.asString(),
-                        modifier = Modifier.fillMaxWidth(),
-                        buttonUiModel =
-                            ErrorViewButtonUiModel(
-                                text = stringResource(R.string.try_again),
-                                onClick = onTryAgainClick,
-                            ),
-                    )
                 }
             }
         },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/NameVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/NameVaultScreen.kt
@@ -36,6 +36,7 @@ import com.vultisig.wallet.ui.models.keygen.NameVaultUiModel
 import com.vultisig.wallet.ui.models.keygen.NameVaultViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -130,6 +131,18 @@ private fun NameVaultScreen(
 @Preview
 @Composable
 private fun FastVaultNameScreenPreview() {
+    NameVaultScreen(
+        state = NameVaultUiModel(),
+        textFieldState = rememberTextFieldState(),
+        onNextClick = {},
+        onClearClick = {},
+        onBackClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun FastVaultNameScreenTabletPreview() {
     NameVaultScreen(
         state = NameVaultUiModel(),
         textFieldState = rememberTextFieldState(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/NameVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/NameVaultScreen.kt
@@ -34,6 +34,8 @@ import com.vultisig.wallet.ui.components.referral.AddReferralHeaderButton
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.keygen.NameVaultUiModel
 import com.vultisig.wallet.ui.models.keygen.NameVaultViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -77,44 +79,50 @@ private fun NameVaultScreen(
         onBackClick = onBackClick,
         actions = { AddReferralHeaderButton(hasReferral = hasReferral, onClick = onReferralClick) },
         bottomBar = {
-            VsButton(
-                label = stringResource(R.string.fast_vault_name_screen_next),
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 24.dp)
-                        .testTag("NameVaultScreen.continue"),
-                state =
-                    if (state.isNextButtonEnabled) VsButtonState.Enabled
-                    else VsButtonState.Disabled,
-                onClick = onNextClick,
-            )
+            OnboardingResponsiveBottomBar {
+                VsButton(
+                    label = stringResource(R.string.fast_vault_name_screen_next),
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 24.dp)
+                            .testTag("NameVaultScreen.continue"),
+                    state =
+                        if (state.isNextButtonEnabled) VsButtonState.Enabled
+                        else VsButtonState.Disabled,
+                    onClick = onNextClick,
+                )
+            }
         },
     ) {
         val focusRequester = remember { FocusRequester() }
         LaunchedEffect(Unit) { focusRequester.requestFocus() }
-        Column {
-            Text(
-                text = stringResource(R.string.fast_vault_name_screen_title),
-                style = Theme.brockmann.headings.largeTitle,
-                color = Theme.v2.colors.text.primary,
-            )
-            UiSpacer(16.dp)
-            Text(
-                text = stringResource(R.string.fast_vault_name_screen_desc),
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.tertiary,
-            )
-            VsTextInputField(
-                textFieldState = textFieldState,
-                trailingIcon = R.drawable.close_circle,
-                onTrailingIconClick = onClearClick,
-                focusRequester = focusRequester,
-                footNote = state.errorMessage?.asString(),
-                imeAction = ImeAction.Go,
-                onKeyboardAction = { onNextClick() },
-                modifier =
-                    Modifier.fillMaxSize().wrapContentHeight().testTag("NameVaultScreen.nameField"),
-            )
+        OnboardingResponsiveContainer {
+            Column {
+                Text(
+                    text = stringResource(R.string.fast_vault_name_screen_title),
+                    style = Theme.brockmann.headings.largeTitle,
+                    color = Theme.v2.colors.text.primary,
+                )
+                UiSpacer(16.dp)
+                Text(
+                    text = stringResource(R.string.fast_vault_name_screen_desc),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                VsTextInputField(
+                    textFieldState = textFieldState,
+                    trailingIcon = R.drawable.close_circle,
+                    onTrailingIconClick = onClearClick,
+                    focusRequester = focusRequester,
+                    footNote = state.errorMessage?.asString(),
+                    imeAction = ImeAction.Go,
+                    onKeyboardAction = { onNextClick() },
+                    modifier =
+                        Modifier.fillMaxSize()
+                            .wrapContentHeight()
+                            .testTag("NameVaultScreen.nameField"),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
@@ -48,6 +48,7 @@ import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.keygen.StartViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.startScreenAnimations
 
@@ -314,6 +315,19 @@ private fun ChooseImportTypeBottomSheetContentPreview() {
 @Preview
 @Composable
 private fun StartScreenPreview() {
+    StartScreen(
+        hasBackButton = true,
+        onCreateNewVaultClick = {},
+        onScanQrCodeClick = {},
+        onImportVaultClick = {},
+        onImportSeedphraseClick = {},
+        onBackClick = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun StartScreenTabletPreview() {
     StartScreen(
         hasBackButton = true,
         onCreateNewVaultClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
@@ -47,6 +47,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.keygen.StartViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.startScreenAnimations
 
@@ -85,92 +86,98 @@ private fun StartScreen(
     }
 
     V3Scaffold(onBackClick = if (hasBackButton) onBackClick else null) {
-        Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = CenterHorizontally) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = CenterHorizontally,
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.logo),
-                    contentDescription = "vultisig",
-                    modifier = Modifier.width(74.5.dp).scale(logoScale.value),
-                )
-                UiSpacer(12.dp)
-                Text(
-                    text = stringResource(R.string.create_new_vault_screen_vultisig),
-                    color = Theme.v2.colors.text.primary,
-                    style = Theme.brockmann.headings.title1,
-                )
-            }
+        OnboardingResponsiveContainer {
+            Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = CenterHorizontally) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = CenterHorizontally,
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.logo),
+                        contentDescription = "vultisig",
+                        modifier = Modifier.width(74.5.dp).scale(logoScale.value),
+                    )
+                    UiSpacer(12.dp)
+                    Text(
+                        text = stringResource(R.string.create_new_vault_screen_vultisig),
+                        color = Theme.v2.colors.text.primary,
+                        style = Theme.brockmann.headings.title1,
+                    )
+                }
 
-            Row {
-                VsButton(
-                    variant = VsButtonVariant.Secondary,
-                    onClick = onScanQrCodeClick,
-                    modifier = Modifier.weight(1f).startScreenAnimations(delay = 350),
-                    content = {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            if (!hasVaults) {
-                                UiIcon(drawableResId = R.drawable.scan_qr, size = 16.dp)
+                Row {
+                    VsButton(
+                        variant = VsButtonVariant.Secondary,
+                        onClick = onScanQrCodeClick,
+                        modifier = Modifier.weight(1f).startScreenAnimations(delay = 350),
+                        content = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                if (!hasVaults) {
+                                    UiIcon(drawableResId = R.drawable.scan_qr, size = 16.dp)
 
-                                UiSpacer(size = 6.dp)
-                            }
+                                    UiSpacer(size = 6.dp)
+                                }
 
-                            Text(
-                                text = stringResource(R.string.home_screen_scan_qr_code),
-                                style = Theme.brockmann.button.medium.medium,
-                                color = Theme.v2.colors.text.button.primary,
-                            )
-                        }
-                    },
-                )
-                UiSpacer(size = 8.dp)
-
-                VsButton(
-                    variant = VsButtonVariant.Secondary,
-                    onClick = { isChooseImportTypeBottomSheetVisible = true },
-                    modifier = Modifier.weight(1f).startScreenAnimations(delay = 450),
-                    content = {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.Center,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            val icon = if (hasVaults.not()) R.drawable.import_vault else null
-
-                            icon?.let { iconRes ->
-                                UiIcon(drawableResId = iconRes, size = 20.dp, modifier = Modifier)
-                                UiSpacer(6.dp)
-                            }
-
-                            Text(
-                                text = stringResource(R.string.import_seedphrase_import_button),
-                                style = Theme.brockmann.button.medium.medium,
-                                color = Theme.v2.colors.variables.textPrimary,
-                                modifier = Modifier.alignByBaseline(),
-                            )
-                            if (hasVaults)
-                                NewBadge(
-                                    modifier = Modifier.offset(x = 10.dp),
-                                    starSize = 8.dp,
-                                    fontStyle = Theme.brockmann.supplementary.captionSmall,
+                                Text(
+                                    text = stringResource(R.string.home_screen_scan_qr_code),
+                                    style = Theme.brockmann.button.medium.medium,
+                                    color = Theme.v2.colors.text.button.primary,
                                 )
-                        }
-                    },
+                            }
+                        },
+                    )
+                    UiSpacer(size = 8.dp)
+
+                    VsButton(
+                        variant = VsButtonVariant.Secondary,
+                        onClick = { isChooseImportTypeBottomSheetVisible = true },
+                        modifier = Modifier.weight(1f).startScreenAnimations(delay = 450),
+                        content = {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                val icon = if (hasVaults.not()) R.drawable.import_vault else null
+
+                                icon?.let { iconRes ->
+                                    UiIcon(
+                                        drawableResId = iconRes,
+                                        size = 20.dp,
+                                        modifier = Modifier,
+                                    )
+                                    UiSpacer(6.dp)
+                                }
+
+                                Text(
+                                    text = stringResource(R.string.import_seedphrase_import_button),
+                                    style = Theme.brockmann.button.medium.medium,
+                                    color = Theme.v2.colors.variables.textPrimary,
+                                    modifier = Modifier.alignByBaseline(),
+                                )
+                                if (hasVaults)
+                                    NewBadge(
+                                        modifier = Modifier.offset(x = 10.dp),
+                                        starSize = 8.dp,
+                                        fontStyle = Theme.brockmann.supplementary.captionSmall,
+                                    )
+                            }
+                        },
+                    )
+                }
+
+                UiSpacer(size = 16.dp)
+
+                VsButton(
+                    label = stringResource(R.string.referral_onboarding_get_started),
+                    modifier =
+                        Modifier.startScreenAnimations(delay = 100)
+                            .fillMaxWidth()
+                            .testTag("StartScreen.createNewVault"),
+                    onClick = onCreateNewVaultClick,
                 )
             }
-
-            UiSpacer(size = 16.dp)
-
-            VsButton(
-                label = stringResource(R.string.referral_onboarding_get_started),
-                modifier =
-                    Modifier.startScreenAnimations(delay = 100)
-                        .fillMaxWidth()
-                        .testTag("StartScreen.createNewVault"),
-                onClick = onCreateNewVaultClick,
-            )
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -1,7 +1,6 @@
 package com.vultisig.wallet.ui.screens.v3.onboarding
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,6 +37,8 @@ import com.vultisig.wallet.ui.components.rive.rememberRiveResourceFile
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.v3.onboarding.ChooseDeviceCountUiEvent
 import com.vultisig.wallet.ui.models.v3.onboarding.ChooseDeviceCountViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
@@ -71,7 +72,7 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                 val a11yDescription =
                     stringResource(R.string.choose_device_count_a11y_description, deviceCountLabel)
 
-                Box(Modifier.fillMaxSize()) {
+                OnboardingResponsiveContainer {
                     RiveAnimation(
                         file = riveFile,
                         viewModelInstance = vmi,
@@ -118,5 +119,11 @@ private fun Tip() {
 @Preview
 @Composable
 private fun ChooseDeviceCountScreenPreview() {
+    ChooseDeviceCountScreen(onEvent = {})
+}
+
+@TabletPreview
+@Composable
+private fun ChooseDeviceCountScreenTabletPreview() {
     ChooseDeviceCountScreen(onEvent = {})
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ChooseDeviceCountScreen.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.screens.v3.onboarding
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,7 +38,7 @@ import com.vultisig.wallet.ui.components.rive.rememberRiveResourceFile
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.v3.onboarding.ChooseDeviceCountUiEvent
 import com.vultisig.wallet.ui.models.v3.onboarding.ChooseDeviceCountViewModel
-import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -72,7 +73,7 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                 val a11yDescription =
                     stringResource(R.string.choose_device_count_a11y_description, deviceCountLabel)
 
-                OnboardingResponsiveContainer {
+                Box(modifier = Modifier.fillMaxSize()) {
                     RiveAnimation(
                         file = riveFile,
                         viewModelInstance = vmi,
@@ -83,15 +84,19 @@ private fun ChooseDeviceCountScreen(onEvent: (ChooseDeviceCountUiEvent) -> Unit)
                                 liveRegion = LiveRegionMode.Polite
                             },
                     )
-                    Column(modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
-                        Tip()
-                        UiSpacer(size = 16.dp)
-                        VsButton(
-                            label = stringResource(R.string.referral_onboarding_get_started),
-                            modifier = Modifier.fillMaxWidth(),
-                            variant = VsButtonVariant.CTA,
-                            onClick = { onEvent(ChooseDeviceCountUiEvent.Next) },
-                        )
+                    OnboardingResponsiveBottomBar(
+                        modifier = Modifier.align(Alignment.BottomCenter)
+                    ) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Tip()
+                            UiSpacer(size = 16.dp)
+                            VsButton(
+                                label = stringResource(R.string.referral_onboarding_get_started),
+                                modifier = Modifier.fillMaxWidth(),
+                                variant = VsButtonVariant.CTA,
+                                onClick = { onEvent(ChooseDeviceCountUiEvent.Next) },
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
@@ -63,6 +63,8 @@ import com.vultisig.wallet.ui.models.v3.onboarding.EnterVaultInfoViewModel
 import com.vultisig.wallet.ui.models.v3.onboarding.StepState
 import com.vultisig.wallet.ui.models.v3.onboarding.StepType
 import com.vultisig.wallet.ui.screens.swap.components.HintBox
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -114,146 +116,148 @@ internal fun EnterVaultInfoScreen(
         onBackClick = { onEvent(EnterVaultInfoEvent.Back) },
         actions = { AddReferralHeaderButton(hasReferral = hasReferral, onClick = onReferralClick) },
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            VaultInfoSteps(stepsState = uiState.stepAndStates)
-            UiSpacer(size = 32.dp)
-            Text(
-                text = uiState.activeStep.title.asString(),
-                style = Theme.brockmann.headings.title2,
-                color = Theme.v2.colors.text.primary,
-            )
-            UiSpacer(size = 12.dp)
-            val infoIconId = "info_icon"
-            val descText = uiState.activeStep.description.asString()
-            val descHighlight = uiState.activeStep.descriptionHighlight?.asString()
-            val baseAnnotated =
-                highlightedText(
-                    mainText = descText,
-                    highlightedWords = listOfNotNull(descHighlight),
-                    mainTextStyle = Theme.brockmann.body.s.medium,
-                    mainTextColor = Theme.v2.colors.text.tertiary,
-                    highlightTextStyle =
-                        Theme.brockmann.body.s.medium.copy(fontWeight = FontWeight.Bold),
-                    highlightTextColor = Theme.v2.colors.neutrals.n50,
+        OnboardingResponsiveContainer {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                VaultInfoSteps(stepsState = uiState.stepAndStates)
+                UiSpacer(size = 32.dp)
+                Text(
+                    text = uiState.activeStep.title.asString(),
+                    style = Theme.brockmann.headings.title2,
+                    color = Theme.v2.colors.text.primary,
                 )
-            val descAnnotated =
-                if (uiState.activeStep.showInfoIcon) {
-                    buildAnnotatedString {
-                        append(baseAnnotated)
-                        append(" ")
-                        appendInlineContent(infoIconId, "[i]")
-                    }
-                } else {
-                    baseAnnotated
-                }
-            Text(
-                text = descAnnotated,
-                color = Theme.v2.colors.text.tertiary,
-                style = Theme.brockmann.body.s.medium,
-                textAlign = TextAlign.Center,
-                inlineContent =
-                    if (uiState.activeStep.showInfoIcon)
-                        mapOf(
-                            infoIconId to
-                                InlineTextContent(
-                                    placeholder =
-                                        Placeholder(
-                                            width = 16.sp,
-                                            height = 16.sp,
-                                            placeholderVerticalAlign =
-                                                PlaceholderVerticalAlign.Center,
-                                        )
-                                ) {
-                                    UiIcon(
-                                        drawableResId = R.drawable.circleinfo,
-                                        size = 16.dp,
-                                        tint = Theme.v2.colors.text.tertiary,
-                                        onClick = { onEvent(EnterVaultInfoEvent.ShowMoreInfo) },
-                                    )
-                                }
-                        )
-                    else emptyMap(),
-                modifier =
-                    Modifier.onGloballyPositioned { position ->
-                        hintBoxOffset =
-                            position.boundsInParent().bottom.toInt() + scaffoldVerticalPadding
-                    },
-            )
-            UiSpacer(size = 24.dp)
-
-            VsTextInputField(
-                textFieldState = uiState.inputTextFieldState,
-                trailingIcon = R.drawable.close_circle,
-                innerState = uiState.innerState,
-                type =
-                    if (uiState.activeStep.isPassword) {
-                        VsTextInputFieldType.Password(
-                            isVisible = uiState.isPasswordVisible,
-                            onVisibilityClick = {
-                                onEvent(EnterVaultInfoEvent.TogglePasswordVisibility)
-                            },
-                        )
+                UiSpacer(size = 12.dp)
+                val infoIconId = "info_icon"
+                val descText = uiState.activeStep.description.asString()
+                val descHighlight = uiState.activeStep.descriptionHighlight?.asString()
+                val baseAnnotated =
+                    highlightedText(
+                        mainText = descText,
+                        highlightedWords = listOfNotNull(descHighlight),
+                        mainTextStyle = Theme.brockmann.body.s.medium,
+                        mainTextColor = Theme.v2.colors.text.tertiary,
+                        highlightTextStyle =
+                            Theme.brockmann.body.s.medium.copy(fontWeight = FontWeight.Bold),
+                        highlightTextColor = Theme.v2.colors.neutrals.n50,
+                    )
+                val descAnnotated =
+                    if (uiState.activeStep.showInfoIcon) {
+                        buildAnnotatedString {
+                            append(baseAnnotated)
+                            append(" ")
+                            appendInlineContent(infoIconId, "[i]")
+                        }
                     } else {
-                        VsTextInputFieldType.Text
-                    },
-                onTrailingIconClick = { onEvent(EnterVaultInfoEvent.ClearInput) },
-                footNote = uiState.errorMessage?.asString(),
-                imeAction = ImeAction.Go,
-                onKeyboardAction = {
-                    if (canProceed) {
-                        onEvent(EnterVaultInfoEvent.Next)
+                        baseAnnotated
                     }
-                },
-                hint = uiState.textFieldHint.asString(),
-            )
+                Text(
+                    text = descAnnotated,
+                    color = Theme.v2.colors.text.tertiary,
+                    style = Theme.brockmann.body.s.medium,
+                    textAlign = TextAlign.Center,
+                    inlineContent =
+                        if (uiState.activeStep.showInfoIcon)
+                            mapOf(
+                                infoIconId to
+                                    InlineTextContent(
+                                        placeholder =
+                                            Placeholder(
+                                                width = 16.sp,
+                                                height = 16.sp,
+                                                placeholderVerticalAlign =
+                                                    PlaceholderVerticalAlign.Center,
+                                            )
+                                    ) {
+                                        UiIcon(
+                                            drawableResId = R.drawable.circleinfo,
+                                            size = 16.dp,
+                                            tint = Theme.v2.colors.text.tertiary,
+                                            onClick = { onEvent(EnterVaultInfoEvent.ShowMoreInfo) },
+                                        )
+                                    }
+                            )
+                        else emptyMap(),
+                    modifier =
+                        Modifier.onGloballyPositioned { position ->
+                            hintBoxOffset =
+                                position.boundsInParent().bottom.toInt() + scaffoldVerticalPadding
+                        },
+                )
+                UiSpacer(size = 24.dp)
 
-            if (uiState.activeStep.isPassword) {
-                UiSpacer(size = 8.dp)
                 VsTextInputField(
-                    textFieldState = uiState.confirmPasswordTextFieldState,
-                    type =
-                        VsTextInputFieldType.Password(
-                            isVisible = uiState.isConfirmPasswordVisible,
-                            onVisibilityClick = {
-                                onEvent(EnterVaultInfoEvent.ToggleConfirmPasswordVisibility)
-                            },
-                        ),
+                    textFieldState = uiState.inputTextFieldState,
                     trailingIcon = R.drawable.close_circle,
                     innerState = uiState.innerState,
-                    onTrailingIconClick = { onEvent(EnterVaultInfoEvent.ClearConfirmInput) },
+                    type =
+                        if (uiState.activeStep.isPassword) {
+                            VsTextInputFieldType.Password(
+                                isVisible = uiState.isPasswordVisible,
+                                onVisibilityClick = {
+                                    onEvent(EnterVaultInfoEvent.TogglePasswordVisibility)
+                                },
+                            )
+                        } else {
+                            VsTextInputFieldType.Text
+                        },
+                    onTrailingIconClick = { onEvent(EnterVaultInfoEvent.ClearInput) },
+                    footNote = uiState.errorMessage?.asString(),
                     imeAction = ImeAction.Go,
                     onKeyboardAction = {
-                        if (uiState.isNextButtonEnabled) {
+                        if (canProceed) {
                             onEvent(EnterVaultInfoEvent.Next)
                         }
                     },
-                    hint = uiState.confirmPasswordTextFieldHint.asString(),
+                    hint = uiState.textFieldHint.asString(),
                 )
+
+                if (uiState.activeStep.isPassword) {
+                    UiSpacer(size = 8.dp)
+                    VsTextInputField(
+                        textFieldState = uiState.confirmPasswordTextFieldState,
+                        type =
+                            VsTextInputFieldType.Password(
+                                isVisible = uiState.isConfirmPasswordVisible,
+                                onVisibilityClick = {
+                                    onEvent(EnterVaultInfoEvent.ToggleConfirmPasswordVisibility)
+                                },
+                            ),
+                        trailingIcon = R.drawable.close_circle,
+                        innerState = uiState.innerState,
+                        onTrailingIconClick = { onEvent(EnterVaultInfoEvent.ClearConfirmInput) },
+                        imeAction = ImeAction.Go,
+                        onKeyboardAction = {
+                            if (uiState.isNextButtonEnabled) {
+                                onEvent(EnterVaultInfoEvent.Next)
+                            }
+                        },
+                        hint = uiState.confirmPasswordTextFieldHint.asString(),
+                    )
+                }
+
+                UiSpacer(weight = 1f)
+                VsButton(
+                    label = stringResource(R.string.enter_email_screen_next),
+                    modifier = Modifier.fillMaxWidth(),
+                    state = if (canProceed) VsButtonState.Enabled else VsButtonState.Disabled,
+                ) {
+                    onEvent(EnterVaultInfoEvent.Next)
+                }
             }
 
-            UiSpacer(weight = 1f)
-            VsButton(
-                label = stringResource(R.string.enter_email_screen_next),
-                modifier = Modifier.fillMaxWidth(),
-                state = if (canProceed) VsButtonState.Enabled else VsButtonState.Disabled,
-            ) {
-                onEvent(EnterVaultInfoEvent.Next)
-            }
+            HintBox(
+                message = stringResource(R.string.fast_vault_password_screen_hint),
+                offset = IntOffset(x = 0, y = hintBoxOffset),
+                pointerAlignment = Alignment.End,
+                onDismissClick = { onEvent(EnterVaultInfoEvent.HideMoreInfo) },
+                modifier = Modifier.padding(horizontal = 16.dp),
+                isVisible = uiState.isMoreInfoVisible,
+                textColor = Theme.v2.colors.text.inverse,
+                textStyle = Theme.satoshi.price.bodyS,
+            )
         }
-
-        HintBox(
-            message = stringResource(R.string.fast_vault_password_screen_hint),
-            offset = IntOffset(x = 0, y = hintBoxOffset),
-            pointerAlignment = Alignment.End,
-            onDismissClick = { onEvent(EnterVaultInfoEvent.HideMoreInfo) },
-            modifier = Modifier.padding(horizontal = 16.dp),
-            isVisible = uiState.isMoreInfoVisible,
-            textColor = Theme.v2.colors.text.inverse,
-            textStyle = Theme.satoshi.price.bodyS,
-        )
     }
 }
 
@@ -348,6 +352,25 @@ private fun ServerVaultExistsWarningDialog(onContinue: () -> Unit, onDismiss: ()
 @Preview
 @Composable
 private fun EnterVaultInfoScreenPreview() {
+    EnterVaultInfoScreen(
+        uiState =
+            EnterVaultInfoUiState(
+                stepAndStates =
+                    mapOf(
+                        StepType.Name to StepState.Done,
+                        StepType.Email to StepState.Done,
+                        StepType.Password to StepState.InProgress,
+                    ),
+                activeStep = StepType.Password,
+                isMoreInfoVisible = true,
+            ),
+        onEvent = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun EnterVaultInfoScreenTabletPreview() {
     EnterVaultInfoScreen(
         uiState =
             EnterVaultInfoUiState(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/EnterVaultInfoScreen.kt
@@ -229,7 +229,7 @@ internal fun EnterVaultInfoScreen(
                         onTrailingIconClick = { onEvent(EnterVaultInfoEvent.ClearConfirmInput) },
                         imeAction = ImeAction.Go,
                         onKeyboardAction = {
-                            if (uiState.isNextButtonEnabled) {
+                            if (canProceed) {
                                 onEvent(EnterVaultInfoEvent.Next)
                             }
                         },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ReviewVaultDevicesScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ReviewVaultDevicesScreen.kt
@@ -35,6 +35,9 @@ import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesEvent
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
@@ -51,77 +54,87 @@ private fun ReviewVaultDevicesScreen(
     V3Scaffold(
         onBackClick = { onEvent(ReviewVaultDevicesEvent.Back) },
         bottomBar = {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier =
-                    Modifier.fillMaxWidth().padding(horizontal = V3Scaffold.PADDING_HORIZONTAL),
-            ) {
-                VsButton(
-                    label = stringResource(R.string.review_vault_devices_looks_good),
-                    variant = VsButtonVariant.CTA,
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = { onEvent(ReviewVaultDevicesEvent.LooksGood) },
-                )
-
-                UiSpacer(size = 20.dp)
-
-                Text(
-                    text = stringResource(R.string.review_vault_devices_something_wrong),
-                    style = Theme.brockmann.body.s.medium,
-                    color = Theme.v2.colors.text.secondary,
+            OnboardingResponsiveBottomBar {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                     modifier =
-                        Modifier.clickable { onEvent(ReviewVaultDevicesEvent.SomethingsWrong) },
-                )
+                        Modifier.fillMaxWidth().padding(horizontal = V3Scaffold.PADDING_HORIZONTAL),
+                ) {
+                    VsButton(
+                        label = stringResource(R.string.review_vault_devices_looks_good),
+                        variant = VsButtonVariant.CTA,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { onEvent(ReviewVaultDevicesEvent.LooksGood) },
+                    )
 
-                UiSpacer(size = 12.dp)
+                    UiSpacer(size = 20.dp)
+
+                    Text(
+                        text = stringResource(R.string.review_vault_devices_something_wrong),
+                        style = Theme.brockmann.body.s.medium,
+                        color = Theme.v2.colors.text.secondary,
+                        modifier =
+                            Modifier.clickable { onEvent(ReviewVaultDevicesEvent.SomethingsWrong) },
+                    )
+
+                    UiSpacer(size = 12.dp)
+                }
             }
         },
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            RiveAnimation(animation = R.raw.riv_review_devices, modifier = Modifier.fillMaxWidth())
+        OnboardingResponsiveContainer {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                RiveAnimation(
+                    animation = R.raw.riv_review_devices,
+                    modifier = Modifier.fillMaxWidth(),
+                )
 
-            UiSpacer(size = 30.dp)
+                UiSpacer(size = 30.dp)
 
-            Text(
-                text = stringResource(R.string.review_vault_devices_title),
-                style = Theme.brockmann.headings.title2,
-                color = Theme.v2.colors.text.primary,
-                textAlign = TextAlign.Center,
-            )
+                Text(
+                    text = stringResource(R.string.review_vault_devices_title),
+                    style = Theme.brockmann.headings.title2,
+                    color = Theme.v2.colors.text.primary,
+                    textAlign = TextAlign.Center,
+                )
 
-            UiSpacer(size = 12.dp)
+                UiSpacer(size = 12.dp)
 
-            Text(
-                text = stringResource(R.string.review_vault_devices_description),
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.tertiary,
-                textAlign = TextAlign.Center,
-                modifier =
-                    Modifier.fillMaxWidth().padding(horizontal = V3Scaffold.PADDING_HORIZONTAL),
-            )
+                Text(
+                    text = stringResource(R.string.review_vault_devices_description),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                    textAlign = TextAlign.Center,
+                    modifier =
+                        Modifier.fillMaxWidth().padding(horizontal = V3Scaffold.PADDING_HORIZONTAL),
+                )
 
-            UiSpacer(size = 32.dp)
+                UiSpacer(size = 32.dp)
 
-            // Uniqueness of device strings is guaranteed by
-            // ReviewVaultDevicesViewModel.uniqueDevices.
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                itemsIndexed(uiState.devices, key = { _, device -> device }) { index, device ->
-                    VaultDeviceItem(
-                        label =
-                            if (device.equals(uiState.localPartyId, ignoreCase = true)) {
+                // Uniqueness of device strings is guaranteed by
+                // ReviewVaultDevicesViewModel.uniqueDevices.
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    itemsIndexed(uiState.devices, key = { _, device -> device }) { index, device ->
+                        VaultDeviceItem(
+                            label =
+                                if (device.equals(uiState.localPartyId, ignoreCase = true)) {
+                                    stringResource(
+                                        R.string.review_vault_devices_this_device_label,
+                                        device,
+                                    )
+                                } else {
+                                    device
+                                },
+                            subtitle =
                                 stringResource(
-                                    R.string.review_vault_devices_this_device_label,
-                                    device,
-                                )
-                            } else {
-                                device
-                            },
-                        subtitle =
-                            stringResource(R.string.review_vault_devices_device_index, index + 1),
-                    )
+                                    R.string.review_vault_devices_device_index,
+                                    index + 1,
+                                ),
+                        )
+                    }
                 }
             }
         }
@@ -173,6 +186,19 @@ private fun VaultDeviceItem(label: String, subtitle: String, modifier: Modifier 
 @Preview
 @Composable
 private fun ReviewVaultDevicesScreenPreview() {
+    ReviewVaultDevicesScreen(
+        uiState =
+            ReviewVaultDevicesUiState(
+                localPartyId = "iPhone",
+                devices = listOf("iPhone", "Extension", "MacBook"),
+            ),
+        onEvent = {},
+    )
+}
+
+@TabletPreview
+@Composable
+private fun ReviewVaultDevicesScreenTabletPreview() {
     ReviewVaultDevicesScreen(
         uiState =
             ReviewVaultDevicesUiState(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,7 +71,10 @@ private fun SetupVaultInfoScreen(
 
                     UiSpacer(size = 14.dp)
 
-                    SetupVaultRive(animationRes = uiState.rive)
+                    SetupVaultRive(
+                        animationRes = uiState.rive,
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    )
 
                     UiSpacer(size = 33.dp)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
@@ -23,9 +23,12 @@ import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.v3.onboarding.SetupVaultInfoEvent
 import com.vultisig.wallet.ui.models.v3.onboarding.SetupVaultInfoUiState
 import com.vultisig.wallet.ui.models.v3.onboarding.SetupVaultInfoViewModel
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveBottomBar
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.SetupVaultGuideItem
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.SetupVaultHeader
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.SetupVaultRive
+import com.vultisig.wallet.ui.screens.v3.onboarding.components.TabletPreview
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -45,55 +48,61 @@ private fun SetupVaultInfoScreen(
         onBackClick = { onEvent(SetupVaultInfoEvent.Back) },
         applyDefaultPaddings = false,
         content = {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.padding(horizontal = V3Scaffold.PADDING_HORIZONTAL)) {
-                    UiSpacer(size = 20.dp)
-                    Text(
-                        text = stringResource(R.string.vault_setup_your_vault_setup),
-                        color = Theme.v2.colors.neutrals.n50,
-                        style = Theme.brockmann.headings.title2,
-                    )
-                    UiSpacer(size = 20.dp)
+            OnboardingResponsiveContainer {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = V3Scaffold.PADDING_HORIZONTAL)
+                    ) {
+                        UiSpacer(size = 20.dp)
+                        Text(
+                            text = stringResource(R.string.vault_setup_your_vault_setup),
+                            color = Theme.v2.colors.neutrals.n50,
+                            style = Theme.brockmann.headings.title2,
+                        )
+                        UiSpacer(size = 20.dp)
 
-                    SetupVaultHeader(
-                        logo = uiState.headerLogo,
-                        title = uiState.title.asString(),
-                        subTitle = uiState.subTitle.asString(),
-                    )
-                }
+                        SetupVaultHeader(
+                            logo = uiState.headerLogo,
+                            title = uiState.title.asString(),
+                            subTitle = uiState.subTitle.asString(),
+                        )
+                    }
 
-                UiSpacer(size = 14.dp)
+                    UiSpacer(size = 14.dp)
 
-                SetupVaultRive(animationRes = uiState.rive)
+                    SetupVaultRive(animationRes = uiState.rive)
 
-                UiSpacer(size = 33.dp)
+                    UiSpacer(size = 33.dp)
 
-                Column(
-                    modifier =
-                        Modifier.padding(
-                                horizontal = V3Scaffold.PADDING_HORIZONTAL,
-                                vertical = V3Scaffold.PADDING_VERTICAL,
-                            )
-                            .verticalScroll(rememberScrollState())
-                ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                        uiState.tips.forEach { (logo, title, subTitle) ->
-                            SetupVaultGuideItem(
-                                logo = logo,
-                                title = title.asString(),
-                                subTitle = subTitle.asString(),
-                            )
+                    Column(
+                        modifier =
+                            Modifier.padding(
+                                    horizontal = V3Scaffold.PADDING_HORIZONTAL,
+                                    vertical = V3Scaffold.PADDING_VERTICAL,
+                                )
+                                .verticalScroll(rememberScrollState())
+                    ) {
+                        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                            uiState.tips.forEach { (logo, title, subTitle) ->
+                                SetupVaultGuideItem(
+                                    logo = logo,
+                                    title = title.asString(),
+                                    subTitle = subTitle.asString(),
+                                )
+                            }
                         }
                     }
                 }
             }
         },
         bottomBar = {
-            VsButton(
-                label = stringResource(R.string.key_import_device_count_get_started),
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onEvent(SetupVaultInfoEvent.Next) },
-            )
+            OnboardingResponsiveBottomBar {
+                VsButton(
+                    label = stringResource(R.string.key_import_device_count_get_started),
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onEvent(SetupVaultInfoEvent.Next) },
+                )
+            }
         },
     )
 }
@@ -101,5 +110,11 @@ private fun SetupVaultInfoScreen(
 @Composable
 @Preview
 private fun SetupVaultInfoScreenPreview() {
+    SetupVaultInfoScreen(uiState = SetupVaultInfoUiState(), onEvent = {})
+}
+
+@Composable
+@TabletPreview
+private fun SetupVaultInfoScreenTabletPreview() {
     SetupVaultInfoScreen(uiState = SetupVaultInfoUiState(), onEvent = {})
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingPreviews.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingPreviews.kt
@@ -1,0 +1,10 @@
+package com.vultisig.wallet.ui.screens.v3.onboarding.components
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "Tablet portrait",
+    device = "spec:width=800dp,height=1280dp,dpi=240",
+    showBackground = true,
+)
+annotation class TabletPreview

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingResponsiveContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingResponsiveContainer.kt
@@ -1,0 +1,62 @@
+package com.vultisig.wallet.ui.screens.v3.onboarding.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.utils.rememberWindowWidthSizeClass
+
+@Composable
+internal fun OnboardingResponsiveContainer(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    if (isCompactWidth()) {
+        Box(modifier = modifier.fillMaxSize(), content = content)
+    } else {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    modifier
+                        .widthIn(max = OnboardingDefaults.MaxContentWidth)
+                        .heightIn(max = OnboardingDefaults.MaxContentHeight)
+                        .fillMaxSize(),
+                content = content,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun OnboardingResponsiveBottomBar(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    if (isCompactWidth()) {
+        Box(modifier = modifier.fillMaxWidth(), content = content)
+    } else {
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    modifier.widthIn(max = OnboardingDefaults.MaxContentWidth).fillMaxWidth(),
+                content = content,
+            )
+        }
+    }
+}
+
+@Composable
+private fun isCompactWidth(): Boolean =
+    rememberWindowWidthSizeClass() == WindowWidthSizeClass.Compact
+
+internal object OnboardingDefaults {
+    val MaxContentWidth = 480.dp
+    val MaxContentHeight = 900.dp
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingResponsiveContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/OnboardingResponsiveContainer.kt
@@ -10,24 +10,23 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.ui.utils.rememberWindowWidthSizeClass
 
 @Composable
 internal fun OnboardingResponsiveContainer(
     modifier: Modifier = Modifier,
+    maxWidth: Dp = OnboardingDefaults.MaxContentWidth,
+    maxHeight: Dp = OnboardingDefaults.MaxContentHeight,
     content: @Composable BoxScope.() -> Unit,
 ) {
     if (isCompactWidth()) {
         Box(modifier = modifier.fillMaxSize(), content = content)
     } else {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Box(
-                modifier =
-                    modifier
-                        .widthIn(max = OnboardingDefaults.MaxContentWidth)
-                        .heightIn(max = OnboardingDefaults.MaxContentHeight)
-                        .fillMaxSize(),
+                modifier = Modifier.widthIn(max = maxWidth).heightIn(max = maxHeight).fillMaxSize(),
                 content = content,
             )
         }
@@ -37,17 +36,14 @@ internal fun OnboardingResponsiveContainer(
 @Composable
 internal fun OnboardingResponsiveBottomBar(
     modifier: Modifier = Modifier,
+    maxWidth: Dp = OnboardingDefaults.MaxContentWidth,
     content: @Composable BoxScope.() -> Unit,
 ) {
     if (isCompactWidth()) {
         Box(modifier = modifier.fillMaxWidth(), content = content)
     } else {
-        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-            Box(
-                modifier =
-                    modifier.widthIn(max = OnboardingDefaults.MaxContentWidth).fillMaxWidth(),
-                content = content,
-            )
+        Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            Box(modifier = Modifier.widthIn(max = maxWidth).fillMaxWidth(), content = content)
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultRive.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultRive.kt
@@ -1,7 +1,9 @@
 package com.vultisig.wallet.ui.screens.v3.onboarding.components
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -11,10 +13,19 @@ import com.vultisig.wallet.ui.components.rive.RiveAnimation
 
 @Composable
 fun SetupVaultRive(animationRes: Int, modifier: Modifier = Modifier) {
-    Box(modifier = modifier.size(width = 350.dp, height = 240.dp)) {
+    Box(
+        modifier =
+            modifier
+                .widthIn(max = SETUP_VAULT_RIVE_MAX_WIDTH)
+                .fillMaxWidth()
+                .aspectRatio(SETUP_VAULT_RIVE_RATIO)
+    ) {
         RiveAnimation(animation = animationRes)
     }
 }
+
+private val SETUP_VAULT_RIVE_MAX_WIDTH = 350.dp
+private const val SETUP_VAULT_RIVE_RATIO = 350f / 240f
 
 @Preview
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/LocalWindowSizeClass.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/LocalWindowSizeClass.kt
@@ -1,0 +1,25 @@
+package com.vultisig.wallet.ui.utils
+
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.dp
+
+val LocalWindowSizeClass = staticCompositionLocalOf<WindowSizeClass?> { null }
+
+@Composable
+fun rememberWindowWidthSizeClass(): WindowWidthSizeClass {
+    val provided = LocalWindowSizeClass.current
+    if (provided != null) return provided.widthSizeClass
+
+    val widthPx = LocalWindowInfo.current.containerSize.width
+    val widthDp = with(LocalDensity.current) { widthPx.toDp() }
+    return when {
+        widthDp < 600.dp -> WindowWidthSizeClass.Compact
+        widthDp < 840.dp -> WindowWidthSizeClass.Medium
+        else -> WindowWidthSizeClass.Expanded
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4450. Onboarding rendered with phone-sized content clustered in the upper-mid of the screen on Galaxy Tab class devices, leaving large empty space below.

- Wired up `WindowSizeClass` via `LocalWindowInfo.current.containerSize` (with a `LocalWindowSizeClass` provider in `MainActivity` and a preview-safe fallback in `rememberWindowWidthSizeClass()`).
- New `OnboardingResponsiveContainer` / `OnboardingResponsiveBottomBar`: on compact (phone) they are pass-throughs; on medium/expanded they cap content to 480dp × 900dp and center both horizontally and vertically — content sits on the visual midline with equal empty padding above and below.
- Applied to the full onboarding chain: v3 onboarding (4 screens) + `ChooseVault`, `Start`, `NameVault`, `FastVaultEmail`, `FastVaultPassword`, `FastVaultPasswordHint`, `JoinKeygen`, `Keygen`. `SetupVaultRive`'s hardcoded 350×240 was rewritten as `widthIn(max=350.dp).fillMaxWidth().aspectRatio(350/240)` so the illustration scales fluidly without overflowing.

Skipped intentionally: `FastVaultVerificationScreen` (bottom sheet, already width-constrained by Material); `PeerDiscoveryScreen` (shared with keysign); `VaultConfirmation` / `BackupVault` / `KeyImport*` (out of the issue's cited surface).

Landscape branching from the issue is N/A — `MainActivity` locks the app to `SCREEN_ORIENTATION_PORTRAIT`.

## Test plan

- [ ] Open the Compose preview pane on each modified screen and verify both phone `@Preview` and the new `@TabletPreview` (Galaxy Tab portrait, 800×1280dp) render without orphan-cluster effect.
- [ ] Run on a phone emulator: confirm onboarding flow is unchanged (compact passthrough).
- [ ] Run on a Galaxy Tab class emulator (or a Pixel Tablet AVD): confirm content sits centered on the midline, with phone-width form/CTA and equal empty padding above/below.
- [ ] Walk the full create-vault flow on both form factors: Start → ChooseVault → ChooseDeviceCount → SetupVaultInfo → EnterVaultInfo → keygen → ReviewVaultDevices.
- [ ] Walk the Fast Vault flow on both form factors: NameVault → FastVaultEmail → FastVaultPassword → FastVaultPasswordHint → keygen.
- [ ] Confirm `JoinKeygenScreen` (device pairing wait) renders cleanly on tablet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now responds to device/window size with global window-size awareness and tablet-optimized previews.
* **Refactor**
  * Onboarding screens and CTAs were restructured to center and constrain content on larger displays.
  * Animations and visual components now use adaptive sizing to preserve aspect ratio and respect max widths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->