### PR TITLE
fix(swap): flip button resolves same-asset when src was auto-selected

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -665,8 +665,12 @@ constructor(
 
         resetQuoteState()
 
-        selectedSrcId.value = currentDstTokenId
-        selectedDstId.value = currentSrcTokenId
+        // Fall back to the raw ID when the resolved SendSrc hasn't loaded yet, so a race between
+        // the flip gesture and token resolution never silently clobbers both slots with null.
+        val newSrcId = currentDstTokenId ?: selectedDstId.value
+        val newDstId = currentSrcTokenId ?: selectedSrcId.value
+        selectedSrcId.value = newSrcId
+        selectedDstId.value = newDstId
 
         // collectSelectedTokens() observes the IDs above and resolves selectedSrc/selectedDst
         // synchronously under Main.immediate. A manual swap of those resolved StateFlows here

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -665,9 +665,8 @@ constructor(
 
         resetQuoteState()
 
-        val previousSrcId = selectedSrcId.value
-        selectedSrcId.value = selectedDstId.value
-        selectedDstId.value = previousSrcId
+        selectedSrcId.value = currentDstTokenId
+        selectedDstId.value = currentSrcTokenId
 
         // collectSelectedTokens() observes the IDs above and resolves selectedSrc/selectedDst
         // synchronously under Main.immediate. A manual swap of those resolved StateFlows here

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -572,6 +572,33 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
+    fun `flipSelectedTokens swaps correctly when dst was not explicitly set`() =
+        runTest(mainDispatcher) {
+            // BTC is first so the auto-selection of dst (dstTokenId=null) picks BTC;
+            // ETH is found by explicit srcTokenId. Mirrors the src=null test but in reverse.
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(btcAddress(), ethAddress()),
+                    srcTokenId = ETH_COIN.id,
+                    dstTokenId = null,
+                )
+            advanceUntilIdle()
+
+            val srcBefore = vm.uiState.value.selectedSrcToken?.model?.account?.token?.id
+            val dstBefore = vm.uiState.value.selectedDstToken?.model?.account?.token?.id
+            assertEquals(ETH_COIN.id, srcBefore)
+            assertEquals(BTC_COIN.id, dstBefore)
+
+            vm.flipSelectedTokens()
+            advanceUntilIdle()
+
+            val srcAfter = vm.uiState.value.selectedSrcToken?.model?.account?.token?.id
+            val dstAfter = vm.uiState.value.selectedDstToken?.model?.account?.token?.id
+            assertEquals(BTC_COIN.id, srcAfter, "src should now be BTC after flip")
+            assertEquals(ETH_COIN.id, dstAfter, "dst should now be ETH after flip")
+        }
+
+    @Test
     fun `flipSelectedTokens resets quote state`() =
         runTest(mainDispatcher) {
             val vm = createViewModelWithAddresses()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -543,6 +543,35 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
+    fun `flipSelectedTokens swaps correctly when src was not explicitly set`() =
+        runTest(mainDispatcher) {
+            // Reproduces issue #4581: srcTokenId is null (user navigated without pre-selecting
+            // a source), user then changes the destination, then taps switch. Before the fix,
+            // selectedSrcId stayed null after the flip so selectedDst resolved back to the old
+            // dst (BCH in the bug report), making both slots show the same asset.
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(ethAddress(), btcAddress()),
+                    srcTokenId = null,
+                    dstTokenId = BTC_COIN.id,
+                )
+            advanceUntilIdle()
+
+            val srcBefore = vm.uiState.value.selectedSrcToken?.model?.account?.token?.id
+            val dstBefore = vm.uiState.value.selectedDstToken?.model?.account?.token?.id
+            assertEquals(ETH_COIN.id, srcBefore)
+            assertEquals(BTC_COIN.id, dstBefore)
+
+            vm.flipSelectedTokens()
+            advanceUntilIdle()
+
+            val srcAfter = vm.uiState.value.selectedSrcToken?.model?.account?.token?.id
+            val dstAfter = vm.uiState.value.selectedDstToken?.model?.account?.token?.id
+            assertEquals(BTC_COIN.id, srcAfter, "src should now be BTC after flip")
+            assertEquals(ETH_COIN.id, dstAfter, "dst should now be ETH after flip")
+        }
+
+    @Test
     fun `flipSelectedTokens resets quote state`() =
         runTest(mainDispatcher) {
             val vm = createViewModelWithAddresses()


### PR DESCRIPTION
## Summary
- When navigating to swap without a pre-selected source token, `selectedSrcId` was `null`
- The old flip logic swapped the raw `selectedSrcId`/`selectedDstId` StateFlow values, leaving `selectedSrcId` still `null` after the flip
- The collection loop then resolved both src and dst to the previously selected destination, showing the same asset in both slots
- Fix: read the already-resolved token IDs from `selectedSrc`/`selectedDst` StateFlows before swapping, so concrete IDs are always written

## Issue
Closes #4581

## Test Plan
- [ ] New unit test `flipSelectedTokens swaps correctly when src was not explicitly set` covers the regression scenario
- [ ] Existing `flipSelectedTokens` tests still pass
- [ ] Lint passes (`./gradlew lint`) ✅
- [ ] Manual: open swap screen from a chain page (no pre-selected source), change destination, tap flip — src and dst should swap, not show the same asset

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token-swap flip behavior when the source token is unset so the flip reliably resolves both sides to the correct assets, using safe fallbacks to ensure the selected source and destination tokens are correct after flipping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->