### PR TITLE
Transaction complete: hide empty To row

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -247,9 +247,8 @@ private fun SwapTransactionDetail(swapTransaction: SwapTransactionUiModel) {
 private fun TransactionDetail(transaction: TransactionDetailsUiModel?) {
     if (transaction != null) {
 
-        UiHorizontalDivider()
-
         if (transaction.dstAddress.isNotBlank()) {
+            UiHorizontalDivider()
             AddressField(
                 title = stringResource(R.string.verify_transaction_to_title),
                 address = transaction.dstAddress,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -249,10 +249,12 @@ private fun TransactionDetail(transaction: TransactionDetailsUiModel?) {
 
         UiHorizontalDivider()
 
-        AddressField(
-            title = stringResource(R.string.verify_transaction_to_title),
-            address = transaction.dstAddress,
-        )
+        if (transaction.dstAddress.isNotBlank()) {
+            AddressField(
+                title = stringResource(R.string.verify_transaction_to_title),
+                address = transaction.dstAddress,
+            )
+        }
 
         if (!transaction.memo.isNullOrEmpty())
             OtherField(


### PR DESCRIPTION
## Summary
- Hide the Transaction Complete `To` address row when the destination address is blank to avoid rendering an empty field.

## Issue
Closes #4527

## Test Plan
- [x] Lint passes (`./gradlew lint`)
- [x] Unit tests pass (`./gradlew :app:testDebugUnitTest`)
- [ ] Manual: complete a tx with blank destination address; verify `To` row is hidden
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction details view no longer shows an empty destination section. Empty destination address and its divider are hidden, resulting in a cleaner, more concise transaction summary and improved readability when destination information is not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->