### PR TITLE
fix(swap): clear stale network fee when switching From asset to UTXO chain

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -726,8 +726,9 @@ constructor(
         val maxUsableTokenAmount =
             srcTokenValue.value -
                 swapFee -
-                (estimatedNetworkFeeTokenValue.value?.value?.takeIf { srcToken.isNativeToken }
-                    ?: BigInteger.ZERO)
+                (estimatedNetworkFeeTokenValue.value?.value?.takeIf {
+                    srcToken.isNativeToken && gasFeeChain.value == srcToken.chain
+                } ?: BigInteger.ZERO)
 
         if (maxUsableTokenAmount <= BigInteger.ZERO) {
             srcAmountState.setTextAndPlaceCursorAtEnd("0")
@@ -831,6 +832,7 @@ constructor(
                         // can compute the correct UTXO plan fee.
                         estimatedNetworkFeeTokenValue.value = null
                         estimatedNetworkFeeFiatValue.value = null
+                        uiState.update { it.copy(networkFee = "", networkFeeFiat = "") }
                         // The plan-fee block in calculateFees() may have already run
                         // with a stale or null gasFeeChain and skipped via its chain guard,
                         // leaving the form fee blank; re-fire so it can compute with the byte

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -825,7 +825,13 @@ constructor(
                         }
                     } else if (previousChain != chain) {
                         // UTXO non-Cardano + chain transitioned (initial selection or token
-                        // switch). The plan-fee block in calculateFees() may have already run
+                        // switch). Clear any stale fee from the previous chain immediately so
+                        // selectSrcPercentage() doesn't subtract a cross-chain fee value
+                        // (e.g. ETH wei subtracted from ZEC satoshis) before calculateFees()
+                        // can compute the correct UTXO plan fee.
+                        estimatedNetworkFeeTokenValue.value = null
+                        estimatedNetworkFeeFiatValue.value = null
+                        // The plan-fee block in calculateFees() may have already run
                         // with a stale or null gasFeeChain and skipped via its chain guard,
                         // leaving the form fee blank; re-fire so it can compute with the byte
                         // fee for this chain.

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -513,6 +513,32 @@ internal class SwapFormViewModelTest {
             assertEquals("0", vm.srcAmountState.text.toString())
         }
 
+    @Test
+    fun `selectSrcPercentage does not subtract stale cross-chain fee`() =
+        runTest(mainDispatcher) {
+            // The default setUp mock returns chain=Ethereum for any calculateGasFee call.
+            // With BTC as src, gasFeeChain ends up as Ethereum while srcToken.chain is Bitcoin
+            // — identical to the real bug (switching from ETH→ZEC leaves a huge wei fee value
+            // that, if subtracted from satoshis, makes maxUsableTokenAmount negative).
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(btcAddressLargeBalance(), ethAddress()),
+                    srcTokenId = BTC_COIN.id,
+                    dstTokenId = ETH_COIN.id,
+                )
+            advanceUntilIdle()
+            // estimatedNetworkFeeTokenValue = 1e15 (ETH wei from the Ethereum gas mock),
+            // gasFeeChain = Ethereum, srcToken.chain = Bitcoin.
+
+            vm.selectSrcPercentage(1.0f)
+
+            val amountText = vm.srcAmountState.text.toString()
+            assertTrue(
+                amountText.isNotEmpty() && amountText.toDoubleOrNull()?.let { it > 0 } == true,
+                "selectSrcPercentage subtracted a stale cross-chain fee: $amountText",
+            )
+        }
+
     // endregion
 
     // region flipSelectedTokens


### PR DESCRIPTION
## Summary
- When switching the swap source from a non-UTXO chain (e.g. Zksync ETH) to a UTXO chain (e.g. ZEC), the old `estimatedNetworkFeeTokenValue` was never cleared
- Tapping a percentage button then subtracted that stale cross-chain fee (ETH in wei, ~10^13) from the new chain's balance (ZEC in satoshis, ~10^7), making `maxUsableTokenAmount` negative and triggering a false "Insufficient balance" error
- Fix: clear `estimatedNetworkFeeTokenValue` and `estimatedNetworkFeeFiatValue` in `calculateGas()` whenever the source chain transitions to a UTXO chain, before the UTXO plan fee is recomputed

## Issue
Closes #4582

## Test Plan
- [ ] Start a swap with Zksync ETH as the From asset
- [ ] Switch From to Zcash (ZEC) with a non-zero balance
- [ ] Tap a percentage button (25% / 50% / 75%) — it should populate the amount field correctly, not show an insufficient balance error
- [ ] Verify the swap quote is fetched after the amount is set
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When switching chains during a swap, estimated network fee and fiat values are cleared and refreshed so users no longer see stale or incorrect fee/fiat estimates.
  * Source-percentage selection no longer subtracts an unrelated cross-chain gas fee; fees are applied only when the source token is native and the fee chain matches the token's chain.

* **Tests**
  * Added a regression test ensuring source-percentage selection doesn't apply stale cross-chain fees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->