### PR TITLE
fix(keygen): auto-start 2/2 and 3/3 peer discovery, hide Next button

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -80,7 +80,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -99,6 +101,7 @@ data class PeerDiscoveryUiModel(
     val selectedDevices: List<String> = emptyList(),
     val minimumDevices: Int = MIN_KEYGEN_DEVICES,
     val minimumDevicesDisplayed: Int = MIN_KEYGEN_DEVICES,
+    val deviceCount: Int? = null,
     val allowsMoreDevices: Boolean = false,
     val showQrHelpModal: Boolean = false,
     val connectingToServer: ConnectingToServerUiModel? = null,
@@ -150,6 +153,7 @@ constructor(
             PeerDiscoveryUiModel(
                 minimumDevices = args?.deviceCount ?: MIN_KEYGEN_DEVICES,
                 minimumDevicesDisplayed = args?.deviceCount ?: MIN_KEYGEN_DEVICES,
+                deviceCount = args?.deviceCount,
                 enableNotification = false,
             )
         )
@@ -192,11 +196,40 @@ constructor(
 
     private var serverUrl: String = VULTISIG_RELAY_URL
 
+    private var hasAutoStartedKeygen: Boolean = false
+
     init {
         if (args == null) {
             viewModelScope.launch { navigator.navigate(Destination.Back) }
         } else {
             loadData()
+            observeAutoStartKeygen()
+        }
+    }
+
+    /**
+     * Auto-kicks off keygen for 2/2 and 3/3 secure-vault flows so the initiator does not have to
+     * tap Next once the deterministic peer threshold has been met. Mirrors the Windows
+     * `AutoStartKeygen` component. Skipped for Fast Vault, which already auto-fires from
+     * [startVultiServerConnection] when the server peer is discovered — double-firing would launch
+     * two concurrent session-start attempts.
+     */
+    private fun observeAutoStartKeygen() {
+        val args = args ?: return
+        val targetDeviceCount = args.deviceCount ?: return
+        if (targetDeviceCount > 3) return
+        if (!email.isNullOrBlank() && !password.isNullOrBlank()) return
+
+        viewModelScope.launch {
+            state
+                .map { it.selectedDevices.size }
+                .distinctUntilChanged()
+                .collect { selectedSize ->
+                    if (!hasAutoStartedKeygen && selectedSize + 1 == targetDeviceCount) {
+                        hasAutoStartedKeygen = true
+                        next()
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -80,7 +80,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -196,8 +195,6 @@ constructor(
 
     private var serverUrl: String = VULTISIG_RELAY_URL
 
-    private var hasAutoStartedKeygen: Boolean = false
-
     init {
         if (args == null) {
             viewModelScope.launch { navigator.navigate(Destination.Back) }
@@ -217,19 +214,12 @@ constructor(
     private fun observeAutoStartKeygen() {
         val args = args ?: return
         val targetDeviceCount = args.deviceCount ?: return
-        if (targetDeviceCount > 3) return
+        if (targetDeviceCount !in 2..3) return
         if (!email.isNullOrBlank() && !password.isNullOrBlank()) return
 
         viewModelScope.launch {
-            state
-                .map { it.selectedDevices.size }
-                .distinctUntilChanged()
-                .collect { selectedSize ->
-                    if (!hasAutoStartedKeygen && selectedSize + 1 == targetDeviceCount) {
-                        hasAutoStartedKeygen = true
-                        next()
-                    }
-                }
+            state.map { it.selectedDevices.size }.first { it == targetDeviceCount - 1 }
+            next()
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -200,15 +200,22 @@ internal fun PeerDiscoveryScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.padding(vertical = 12.dp, horizontal = 24.dp),
             ) {
-                VsButton(
-                    label =
-                        if (hasEnoughDevices)
-                            stringResource(R.string.peer_discovery_action_next_title)
-                        else stringResource(R.string.peer_discovery_waiting_for_devices_action),
-                    state = if (hasEnoughDevices) VsButtonState.Enabled else VsButtonState.Disabled,
-                    onClick = onNextClick,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                // 2/2 and 3/3 vaults auto-start keygen once the peer threshold is met (see
+                // KeygenPeerDiscoveryViewModel.observeAutoStartKeygen), so the Next button is
+                // hidden entirely. For 4+ device vaults the initiator still picks which peers
+                // to commit, so the button stays visible.
+                if (state.deviceCount == null || state.deviceCount > 3) {
+                    VsButton(
+                        label =
+                            if (hasEnoughDevices)
+                                stringResource(R.string.peer_discovery_action_next_title)
+                            else stringResource(R.string.peer_discovery_waiting_for_devices_action),
+                        state =
+                            if (hasEnoughDevices) VsButtonState.Enabled else VsButtonState.Disabled,
+                        onClick = onNextClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
 
                 Text(
                     text =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModelTest.kt
@@ -113,12 +113,18 @@ internal class KeygenPeerDiscoveryViewModelTest {
         unmockkObject(Utils)
     }
 
-    private fun stubRoute(deviceCount: Int? = null) {
+    private fun stubRoute(
+        deviceCount: Int? = null,
+        email: String? = null,
+        password: String? = null,
+    ) {
         every { any<SavedStateHandle>().toRoute<Route.Keygen.PeerDiscovery>() } returns
             Route.Keygen.PeerDiscovery(
                 action = TssAction.KEYGEN,
                 vaultName = "Test Vault",
                 deviceCount = deviceCount,
+                email = email,
+                password = password,
             )
     }
 
@@ -403,5 +409,76 @@ internal class KeygenPeerDiscoveryViewModelTest {
 
         // navigate(Back) called exactly once (from init), not a second time from tryAgain
         coVerify(exactly = 1) { navigator.navigate(Destination.Back) }
+    }
+
+    // --- Auto-kickoff tests (issue #4552) ---
+
+    @Test
+    fun `auto-start fires for 2-of-2 secure vault when first peer is selected`() {
+        stubRoute(deviceCount = 2)
+        val vm = createViewModel()
+
+        vm.selectDevice("peer-1")
+
+        coVerify(exactly = 1) { sessionApi.startWithCommittee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto-start fires for 3-of-3 secure vault when both peers are selected`() {
+        stubRoute(deviceCount = 3)
+        val vm = createViewModel()
+
+        vm.selectDevice("peer-1")
+        // Threshold not yet reached — should not fire
+        coVerify(exactly = 0) { sessionApi.startWithCommittee(any(), any(), any()) }
+
+        vm.selectDevice("peer-2")
+        coVerify(exactly = 1) { sessionApi.startWithCommittee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto-start does not fire for 4-of-4 secure vault`() {
+        stubRoute(deviceCount = 4)
+        val vm = createViewModel()
+
+        simulateAutoDiscovery(vm, listOf("d1", "d2", "d3"))
+        // 4-device flow keeps manual Next; the auto-start collector must not fire.
+        coVerify(exactly = 0) { sessionApi.startWithCommittee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto-start does not fire for Fast Vault even at 2-of-2 threshold`() {
+        // Fast Vault has its own auto-kickoff via startVultiServerConnection; the new collector
+        // must skip this path or two concurrent next() calls would race.
+        stubRoute(deviceCount = 2, email = "user@example.com", password = "secret")
+        val vm = createViewModel()
+
+        vm.selectDevice("server-peer")
+
+        coVerify(exactly = 0) { sessionApi.startWithCommittee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto-start does not fire when deviceCount is null`() {
+        // ReShare and similar flows pass deviceCount=null; never auto-start.
+        stubRoute(deviceCount = null)
+        val vm = createViewModel()
+
+        vm.selectDevice("peer-1")
+
+        coVerify(exactly = 0) { sessionApi.startWithCommittee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto-start fires only once even when selection fluctuates around threshold`() {
+        stubRoute(deviceCount = 3)
+        val vm = createViewModel()
+
+        vm.selectDevice("peer-1")
+        vm.selectDevice("peer-2") // threshold met → fires once
+        vm.selectDevice("peer-1") // deselect → size drops back to 1
+        vm.selectDevice("peer-1") // reselect → size back to 2
+
+        coVerify(exactly = 1) { sessionApi.startWithCommittee(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
Closes #4552

## Summary
- On the Keygen peer-discovery screen, 2/2 and 3/3 secure vault flows required the initiator to manually tap **Next** even though the device threshold is deterministic and no selection decision remains.
- This PR adds an auto-kickoff collector in `KeygenPeerDiscoveryViewModel` that fires `next()` exactly once when `args.deviceCount` is set, ≤ 3, and the local device + selected peers reach the target. The collector is skipped for Fast Vault (`email` + `password` set), which already auto-fires from `startVultiServerConnection` — guarding against a double session-start race.
- In `PeerDiscoveryScreen`, the `VsButton` is wrapped in `if (state.deviceCount == null || state.deviceCount > 3)` so 2/2 and 3/3 layouts hide the button entirely (freeing space for the device list and QR), while 4+ device vaults and `deviceCount == null` flows (ReShare, Migrate) keep manual control.
- Mirrors the Windows reference implementation (`AutoStartKeygen.tsx`, `SecureVaultPeerDiscoveryScreen.tsx`).

## Test plan
- [x] `./gradlew assembleDebug` — passes
- [x] `:app:testDebugUnitTest` for `KeygenPeerDiscoveryViewModelTest` and `KeygenPeerDiscoveryViewModelReshareTest` — passes (6 new auto-kickoff cases: 2/2 fires, 3/3 fires only at threshold, 4/4 no-fire, Fast Vault no-fire, `deviceCount == null` no-fire, idempotent under selection fluctuation)
- [ ] Setup new vault → Secure → 2-device: keygen auto-starts when 2nd device joins, no Next tap
- [ ] Setup new vault → Secure → 3-device: keygen auto-starts when 3rd device joins, no Next tap
- [ ] Setup new vault → Secure → 4-device (3-of-4): Next button remains and keygen does not auto-start
- [ ] Fast Vault 2-device flow still completes via the existing server-discovery auto-fire (no double session start)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-starts key generation when the required number of devices is selected for eligible secure vaults (2- or 3-device setups), with safeguards to skip auto-start when email/password are provided.

* **Improvements**
  * The "Next" button is hidden during eligible auto-start scenarios to streamline the flow.

* **Tests**
  * Added tests covering auto-kickoff behavior, thresholds, exclusions, and single-trigger guarantees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->