### PR TITLE
feat(swap): SwapKit task 2/5 — quote source + Phase 1 EVM/Solana wiring

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -43,7 +43,10 @@ constructor(
                 SwapProvider.LIFI -> from.dstToken
 
                 SwapProvider.ONEINCH,
-                SwapProvider.KYBER -> tokenRepository.getNativeToken(from.srcToken.chain.id)
+                SwapProvider.KYBER,
+                // SwapKit (Phase 1 EVM/Solana) pays the inbound fee in the source chain's native
+                // gas token — same shape as 1inch/Kyber, not the LiFi destination-side model.
+                SwapProvider.SWAPKIT -> tokenRepository.getNativeToken(from.srcToken.chain.id)
 
                 SwapProvider.JUPITER -> from.srcToken
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -145,6 +145,18 @@ constructor(
                         vultBPSDiscount,
                         srcNativeToken,
                     )
+
+                SwapProvider.SWAPKIT ->
+                    fetchSwapKitQuote(
+                        src,
+                        dst,
+                        srcToken,
+                        dstToken,
+                        srcTokenValue,
+                        tokenValue,
+                        vultBPSDiscount,
+                        srcNativeToken,
+                    )
             }
 
         val feeCoin =
@@ -152,6 +164,11 @@ constructor(
                 SwapProvider.MAYA,
                 SwapProvider.THORCHAIN,
                 SwapProvider.LIFI -> dstToken
+                // SwapKit's inbound (source-chain) fee is denominated in the source's native gas
+                // token — mirrors 1inch / Kyber / Jupiter rather than the LiFi destination-side
+                // integrator-fee model. Per-leg fee parsing from response.fees[] lands with the
+                // tier-discount affiliate work in a later task.
+                SwapProvider.SWAPKIT -> srcNativeToken
                 else -> srcNativeToken
             }
 
@@ -551,6 +568,63 @@ constructor(
                 R.string.swap_for_provider_jupiter.asUiText()
             }
         return swapQuote to providerText
+    }
+
+    private suspend fun fetchSwapKitQuote(
+        src: SendSrc,
+        dst: SendSrc,
+        srcToken: Coin,
+        dstToken: Coin,
+        srcTokenValue: BigInteger,
+        tokenValue: TokenValue,
+        vultBPSDiscount: Int?,
+        srcNativeToken: Coin,
+    ): Pair<SwapQuote, UiText> {
+        val swapQuote =
+            getCachedQuoteOrFetch(srcToken.id, dstToken.id, srcTokenValue, SwapProvider.SWAPKIT) {
+                val apiQuote =
+                    swapQuoteRepository
+                        .getQuote(
+                            SwapProvider.SWAPKIT,
+                            SwapQuoteRequest(
+                                srcToken = srcToken,
+                                dstToken = dstToken,
+                                tokenValue = tokenValue,
+                                srcAddress = src.address.address,
+                                dstAddress = dst.address.address,
+                                // Tier-discounted affiliate fee lands in its own follow-up task —
+                                // matches iOS's max(0, min(1000, 50 - vultTierDiscount)) formula.
+                                // For now pass zero so the proxy applies its dashboard-configured
+                                // default rather than a stale client override.
+                                affiliateBps = 0,
+                                bpsDiscount = vultBPSDiscount ?: 0,
+                            ),
+                        )
+                        .expectEvm(SwapProvider.SWAPKIT)
+                val expectedDstValue =
+                    TokenValue(
+                        value = apiQuote.dstAmount.toBigIntegerOrNull() ?: BigInteger.ZERO,
+                        token = dstToken,
+                    )
+                // SwapKit doesn't return a typed swapFee inside the EVM tx envelope (the
+                // response-level fees[] array carries the per-leg breakdown — surfaced as part of
+                // the affiliate-fee task). Use the gas envelope as the inbound-side fee estimate,
+                // matching the 1inch/Kyber gas-only pattern.
+                val gasUnits =
+                    apiQuote.tx.gas.takeIf { it != 0L } ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
+                val gasFees =
+                    (apiQuote.tx.gasPrice.toBigIntegerOrNull() ?: BigInteger.ZERO) *
+                        gasUnits.toBigInteger()
+                val tokenFees = TokenValue(value = gasFees, token = srcNativeToken)
+                SwapQuote.OneInch(
+                    expectedDstValue = expectedDstValue,
+                    fees = tokenFees,
+                    data = apiQuote,
+                    expiredAt = Clock.System.now() + expiredAfter,
+                    provider = SwapProvider.SWAPKIT.getSwapProviderId(),
+                )
+            }
+        return swapQuote to R.string.swap_for_provider_swapkit.asUiText()
     }
 
     private suspend fun resolveSwapFee(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -616,15 +616,18 @@ constructor(
                     )
                 // SwapKit's canonical source-chain fee is the `fees[]` entry with type=="inbound"
                 // for the source chain — the source layer already extracts that and stages it on
-                // `tx.swapFee` (raw units) with `swapFeeTokenContract = ""` (native sentinel). The
-                // resolveSwapFee helper falls back to srcNativeToken on the empty-contract case,
-                // matching how Kyber and Jupiter surface their per-leg fees.
+                // `tx.swapFee` (raw units in source-native) with `swapFeeTokenContract = ""`. The
+                // empty-contract branch of resolveSwapFee returns the fallback in srcNativeToken,
+                // so pass the parsed swapFee as the fallback (mirrors Kyber's call at line 435
+                // which passes gasFees) — otherwise the source-extracted inbound fee is silently
+                // discarded and the verify screen renders $0 Network Fee.
+                val swapKitInboundFee = apiQuote.tx.swapFee.toBigIntegerOrNull() ?: BigInteger.ZERO
                 val (feeAmount, feeCoin) =
                     resolveSwapFee(
                         apiQuote.tx.swapFeeTokenContract,
                         apiQuote.tx.swapFee,
                         srcNativeToken,
-                        BigInteger.ZERO,
+                        swapKitInboundFee,
                     )
                 val tokenFees = TokenValue(value = feeAmount, token = feeCoin)
                 SwapQuote.OneInch(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
 import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import com.vultisig.wallet.data.usecases.ConvertTokenToToken
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
@@ -166,8 +167,8 @@ constructor(
                 SwapProvider.LIFI -> dstToken
                 // SwapKit's inbound (source-chain) fee is denominated in the source's native gas
                 // token — mirrors 1inch / Kyber / Jupiter rather than the LiFi destination-side
-                // integrator-fee model. Per-leg fee parsing from response.fees[] lands with the
-                // tier-discount affiliate work in a later task.
+                // integrator-fee model. SwapKitQuoteSource already pulls the inbound amount out of
+                // route.fees[] and stages it on tx.swapFee (raw units) for resolveSwapFee below.
                 SwapProvider.SWAPKIT -> srcNativeToken
                 else -> srcNativeToken
             }
@@ -580,56 +581,80 @@ constructor(
         vultBPSDiscount: Int?,
         srcNativeToken: Coin,
     ): Pair<SwapQuote, UiText> {
+        // iOS' SwapKit tier-discount formula at this milestone:
+        //   max(0, min(1000, 50 - vultTierDiscount))
+        // 50 bps base affiliate, clamped to 0..1000 (SwapKit's documented 0..10% range).
+        val affiliateBps = (SWAPKIT_AFFILIATE_FEE_BPS - (vultBPSDiscount ?: 0)).coerceIn(0, 1000)
+        var resolvedSubProvider: String? = null
         val swapQuote =
             getCachedQuoteOrFetch(srcToken.id, dstToken.id, srcTokenValue, SwapProvider.SWAPKIT) {
-                val apiQuote =
-                    swapQuoteRepository
-                        .getQuote(
-                            SwapProvider.SWAPKIT,
-                            SwapQuoteRequest(
-                                srcToken = srcToken,
-                                dstToken = dstToken,
-                                tokenValue = tokenValue,
-                                srcAddress = src.address.address,
-                                dstAddress = dst.address.address,
-                                // Tier-discounted affiliate fee lands in its own follow-up task —
-                                // matches iOS's max(0, min(1000, 50 - vultTierDiscount)) formula.
-                                // For now pass zero so the proxy applies its dashboard-configured
-                                // default rather than a stale client override.
-                                affiliateBps = 0,
-                                bpsDiscount = vultBPSDiscount ?: 0,
-                            ),
-                        )
-                        .expectEvm(SwapProvider.SWAPKIT)
+                val result =
+                    swapQuoteRepository.getQuote(
+                        SwapProvider.SWAPKIT,
+                        SwapQuoteRequest(
+                            srcToken = srcToken,
+                            dstToken = dstToken,
+                            tokenValue = tokenValue,
+                            srcAddress = src.address.address,
+                            dstAddress = dst.address.address,
+                            affiliateBps = affiliateBps,
+                        ),
+                    )
+                val evmResult =
+                    (result as? SwapQuoteResult.Evm)
+                        ?: error("SwapKitQuoteSource must return SwapQuoteResult.Evm")
+                resolvedSubProvider = evmResult.subProvider
+                val apiQuote = evmResult.data
                 val expectedDstValue =
                     TokenValue(
-                        value = apiQuote.dstAmount.toBigIntegerOrNull() ?: BigInteger.ZERO,
+                        value =
+                            apiQuote.dstAmount.toBigIntegerOrNull()
+                                ?: error(
+                                    "Malformed SwapKit dstAmount (raw units expected): ${apiQuote.dstAmount}"
+                                ),
                         token = dstToken,
                     )
-                // SwapKit doesn't return a typed swapFee inside the EVM tx envelope (the
-                // response-level fees[] array carries the per-leg breakdown — surfaced as part of
-                // the affiliate-fee task). Use the gas envelope as the inbound-side fee estimate,
-                // matching the 1inch/Kyber gas-only pattern.
-                val gasUnits =
-                    apiQuote.tx.gas.takeIf { it != 0L } ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
-                // Parse gasPrice through BigDecimal so a decimal-string upstream (e.g. "20.5"
-                // — valid JSON, invalid BigInteger) truncates to integer wei rather than silently
-                // falling back to ZERO. A zero gas fee would make SwapKit look free in the ranking
-                // pass and could let the EVM signer broadcast an underpriced tx.
-                val gasFees =
-                    (apiQuote.tx.gasPrice.toBigDecimalOrNull()?.toBigInteger() ?: BigInteger.ZERO) *
-                        gasUnits.toBigInteger()
-                val tokenFees = TokenValue(value = gasFees, token = srcNativeToken)
+                // SwapKit's canonical source-chain fee is the `fees[]` entry with type=="inbound"
+                // for the source chain — the source layer already extracts that and stages it on
+                // `tx.swapFee` (raw units) with `swapFeeTokenContract = ""` (native sentinel). The
+                // resolveSwapFee helper falls back to srcNativeToken on the empty-contract case,
+                // matching how Kyber and Jupiter surface their per-leg fees.
+                val (feeAmount, feeCoin) =
+                    resolveSwapFee(
+                        apiQuote.tx.swapFeeTokenContract,
+                        apiQuote.tx.swapFee,
+                        srcNativeToken,
+                        BigInteger.ZERO,
+                    )
+                val tokenFees = TokenValue(value = feeAmount, token = feeCoin)
                 SwapQuote.OneInch(
                     expectedDstValue = expectedDstValue,
                     fees = tokenFees,
                     data = apiQuote,
                     expiredAt = Clock.System.now() + expiredAfter,
+                    // `provider` is the proto-serialized discriminator used by
+                    // SwapTransactionToUiModelMapper to map back onto SwapProvider.SWAPKIT —
+                    // keep it as the canonical id. The sub-provider drives the UI label below.
                     provider = SwapProvider.SWAPKIT.getSwapProviderId(),
                 )
             }
-        return swapQuote to R.string.swap_for_provider_swapkit.asUiText()
+        val providerLabel =
+            resolvedSubProvider
+                ?.takeIf { it.isNotBlank() }
+                ?.let { sub -> "SwapKit (${formatSubProvider(sub)})".asUiText() }
+                ?: R.string.swap_for_provider_swapkit.asUiText()
+        return swapQuote to providerLabel
     }
+
+    /**
+     * Render a SwapKit sub-provider id (`CHAINFLIP`, `near_intents`, `flashnet`) into a display
+     * label. Replaces underscores with spaces and title-cases each token so `near_intents` → `Near
+     * Intents`; brand names already in mixed/upper case are left alone.
+     */
+    private fun formatSubProvider(raw: String): String =
+        raw.split('_', '-').joinToString(" ") { token ->
+            token.replaceFirstChar { ch -> if (ch.isLowerCase()) ch.titlecase() else ch.toString() }
+        }
 
     private suspend fun resolveSwapFee(
         swapFeeTokenContract: String,
@@ -757,6 +782,9 @@ constructor(
 
     companion object {
         private const val KYBER_AFFILIATE_FEE_BPS = 50
+        // Mirrors iOS' SwapKit milestone: 50 bps base affiliate, discounted by the user's
+        // vultTierDiscount, clamped to SwapKit's documented 0..1000 bps (0..10%) range.
+        private const val SWAPKIT_AFFILIATE_FEE_BPS = 50
         private const val NATIVE_TOKEN_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         private const val QUOTE_FETCH_TIMEOUT_MS = 15_000L
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -612,8 +612,12 @@ constructor(
                 // matching the 1inch/Kyber gas-only pattern.
                 val gasUnits =
                     apiQuote.tx.gas.takeIf { it != 0L } ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
+                // Parse gasPrice through BigDecimal so a decimal-string upstream (e.g. "20.5"
+                // — valid JSON, invalid BigInteger) truncates to integer wei rather than silently
+                // falling back to ZERO. A zero gas fee would make SwapKit look free in the ranking
+                // pass and could let the EVM signer broadcast an underpriced tx.
                 val gasFees =
-                    (apiQuote.tx.gasPrice.toBigIntegerOrNull() ?: BigInteger.ZERO) *
+                    (apiQuote.tx.gasPrice.toBigDecimalOrNull()?.toBigInteger() ?: BigInteger.ZERO) *
                         gasUnits.toBigInteger()
                 val tokenFees = TokenValue(value = gasFees, token = srcNativeToken)
                 SwapQuote.OneInch(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,7 @@
     <string name="swap_for_provider_kyber" translatable="false">Kyber</string>
     <string name="swap_for_provider_li_fi" translatable="false">LI.FI</string>
     <string name="swap_for_provider_jupiter" translatable="false">Jupiter</string>
+    <string name="swap_for_provider_swapkit" translatable="false">SwapKit</string>
     <string name="backup_password_screen_title">Backup</string>
     <string name="import_file_screen_password_error">Incorrect password, try again</string>
     <string name="add_vault_save">Save</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapProvider.kt
@@ -6,6 +6,7 @@ enum class SwapProvider {
     LIFI,
     MAYA,
     ONEINCH,
+    SWAPKIT,
     THORCHAIN,
 }
 
@@ -16,6 +17,7 @@ fun SwapProvider.getSwapProviderId(): String {
         SwapProvider.LIFI -> "LI.FI"
         SwapProvider.MAYA -> "MayaChain"
         SwapProvider.ONEINCH -> "1Inch"
+        SwapProvider.SWAPKIT -> "SwapKit"
         SwapProvider.THORCHAIN -> "THORChain"
     }
 }
@@ -30,5 +32,6 @@ fun swapProviderFromWireId(wireId: String): SwapProvider? =
         "kyber",
         "kyberswap" -> SwapProvider.KYBER
         "jupiter" -> SwapProvider.JUPITER
+        "swapkit" -> SwapProvider.SWAPKIT
         else -> null
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.data.repositories.swap.SwapKitConfig
 import com.vultisig.wallet.data.repositories.swap.SwapKitConfigImpl
 import com.vultisig.wallet.data.repositories.swap.SwapKitProviderCache
 import com.vultisig.wallet.data.repositories.swap.SwapKitProviderCacheImpl
+import com.vultisig.wallet.data.repositories.swap.SwapKitQuoteSource
 import com.vultisig.wallet.data.repositories.swap.SwapProviderKey
 import com.vultisig.wallet.data.repositories.swap.SwapProviderTable
 import com.vultisig.wallet.data.repositories.swap.SwapProviderTableImpl
@@ -210,6 +211,12 @@ internal interface RepositoriesModule {
     @SwapProviderKey(SwapProvider.KYBER)
     @Reusable
     fun bindKyberQuoteSource(impl: KyberQuoteSource): SwapQuoteSource
+
+    @Binds
+    @IntoMap
+    @SwapProviderKey(SwapProvider.SWAPKIT)
+    @Reusable
+    fun bindSwapKitQuoteSource(impl: SwapKitQuoteSource): SwapQuoteSource
 
     @Binds
     @Singleton

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -1,0 +1,274 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import com.vultisig.wallet.data.api.errors.SwapKitError
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitEvmTx
+import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
+import com.vultisig.wallet.data.api.models.quotes.SwapKitSolanaTx
+import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
+import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
+import com.vultisig.wallet.data.chains.helpers.EvmHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import java.math.BigDecimal
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import timber.log.Timber
+
+/**
+ * SwapKit V3 quote source. Mirrors iOS' `SwapKitService.fetchBestRoute` + `buildSwapTx`:
+ * 1. Guard on the user's `SwapKitConfig` opt-in flag and the cached `/providers` enablement for
+ *    both source and destination chains — fails closed so a flag-off / cold-cache call never
+ *    reaches the proxy.
+ * 2. Call `POST /v3/quote`, drop multi-hop routes and any route whose sub-provider is THORChain or
+ *    Maya (Vultisig pays those affiliates directly via the existing integrations — routing through
+ *    SwapKit would stack a second affiliate fee on top).
+ * 3. Rank the survivors by `expectedBuyAmount` (string-decimal, higher wins) and pick the best.
+ * 4. Call `POST /v3/swap` with the chosen `routeId` to materialise the unsigned tx, then wrap the
+ *    EVM-shaped or Solana-shaped payload into the existing [EVMSwapQuoteJson] envelope so the rest
+ *    of the swap pipeline (signing, broadcast, proto round-trip via `oneinchSwapPayload`) needs no
+ *    changes for Phase 1.
+ *
+ * Non-EVM/non-Solana `txType`s (PSBT, TRON, TON, SUI, CARDANO, RIPPLE, …) are out of scope for
+ * Phase 1 — they require per-chain signers and the dedicated `SwapKitSwapPayload` proto, which land
+ * in subsequent task batches. Such responses surface as [SwapKitError.UnsupportedTxType] so the
+ * picker falls back to another provider rather than signing garbage.
+ */
+internal class SwapKitQuoteSource
+@Inject
+constructor(
+    private val api: SwapKitApi,
+    private val config: SwapKitConfig,
+    private val providerCache: SwapKitProviderCache,
+    private val json: Json,
+) : SwapQuoteSource {
+
+    override suspend fun fetch(request: SwapQuoteRequest): SwapQuoteResult {
+        return try {
+            fetchInternal(request)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: SwapKitError) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "SwapKit quote fetch failed")
+            throw SwapKitError.Network(
+                message = e.message ?: "SwapKit quote fetch failed",
+                cause = e,
+            )
+        }
+    }
+
+    private suspend fun fetchInternal(request: SwapQuoteRequest): SwapQuoteResult {
+        // Feature-flag kill switch (Advanced Settings → SwapKit). Defaults to off — short-circuits
+        // before any /quote network I/O so the proxy stays cold until the user opts in.
+        if (!config.isFeatureEnabled.first()) {
+            throw SwapKitError.NoRoutes("SwapKit feature flag disabled")
+        }
+
+        // Provider-cache gate — both ends must be enabled in the cached /providers snapshot.
+        // Fails closed: when the cache can't be hydrated isEnabled returns false, so we skip
+        // SwapKit and let another provider take the route rather than firing a /quote that we
+        // already expect to fail.
+        if (!providerCache.isEnabled(request.srcToken.chain)) {
+            throw SwapKitError.NoRoutes(
+                "SwapKit not enabled for source chain ${request.srcToken.chain.raw}"
+            )
+        }
+        if (!providerCache.isEnabled(request.dstToken.chain)) {
+            throw SwapKitError.NoRoutes(
+                "SwapKit not enabled for destination chain ${request.dstToken.chain.raw}"
+            )
+        }
+
+        val quoteResponse =
+            api.quote(
+                SwapKitQuoteRequest(
+                    sellAsset = assetIdentifier(request.srcToken),
+                    buyAsset = assetIdentifier(request.dstToken),
+                    // SwapKit interprets sellAmount as the human-readable decimal amount of the
+                    // source asset (e.g. "0.0086" BNB), NOT raw base units. Sending the wei value
+                    // makes the upstream read it as ~8.6 quadrillion BNB and every provider
+                    // returns noRoutesFound. Match iOS' formatSellAmount: strip trailing zeros so
+                    // "1.0000" → "1" and avoid any locale-introduced separators.
+                    sellAmount = formatSellAmount(request.tokenValue),
+                    sourceAddress = request.srcAddress.ifBlank { null },
+                    destinationAddress = request.dstAddress.ifBlank { null },
+                    affiliateFee = request.affiliateBps,
+                )
+            )
+
+        val best =
+            pickBestRoute(quoteResponse.routes)
+                ?: throw SwapKitError.NoRoutes(
+                    "No SwapKit route survived single-hop + Thor/Maya filter"
+                )
+
+        val routeId =
+            best.routeId
+                ?: throw SwapKitError.NoRoutes(
+                    "SwapKit route has no routeId — cannot call /v3/swap"
+                )
+
+        val swapResponse =
+            api.swap(
+                SwapKitSwapRequest(
+                    routeId = routeId,
+                    sourceAddress = request.srcToken.address,
+                    destinationAddress = request.dstToken.address,
+                )
+            )
+
+        return SwapQuoteResult.Evm(buildEvmQuoteFromSwapKit(swapResponse))
+    }
+
+    /**
+     * Drop multi-hop (>1 sub-provider) and routes whose primary sub-provider is THORChain or Maya —
+     * Vultisig pays those affiliates directly via its existing native integrations, so routing them
+     * through SwapKit would stack a second affiliate fee.
+     */
+    private fun pickBestRoute(routes: List<SwapKitRoute>): SwapKitRoute? {
+        val filtered =
+            routes.filter { route ->
+                if (route.providers.size != 1) return@filter false
+                val primary = route.primaryProviderId
+                primary !in FILTERED_PROVIDERS
+            }
+        if (filtered.isEmpty()) return null
+
+        return filtered
+            .mapNotNull { route ->
+                val amount =
+                    route.expectedBuyAmount?.let { runCatching { BigDecimal(it) }.getOrNull() }
+                amount?.let { route to it }
+            }
+            .maxByOrNull { it.second }
+            ?.first
+    }
+
+    /**
+     * Wrap the SwapKit `/v3/swap` response into the EVM-shaped [EVMSwapQuoteJson] envelope used by
+     * the existing pipeline. The `tx` blob's wire shape varies by `meta.txType`:
+     * - "evm" → decode as [SwapKitEvmTx], fields map 1:1 to [OneInchSwapTxJson]
+     * - "solana" → decode as [SwapKitSolanaTx], stash the base64 swap blob in `data` like
+     *   [com.vultisig.wallet.data.repositories.swap.JupiterQuoteSource] does so the downstream
+     *   Solana signer can pull it the same way it pulls a Jupiter tx today Anything else
+     *   (PSBT/TRON/TON/…) is out of scope until the per-chain signers ship.
+     */
+    private fun buildEvmQuoteFromSwapKit(response: SwapKitSwapResponseJson): EVMSwapQuoteJson {
+        val txType = response.meta.type
+        return when (txType) {
+            SwapKitTxMeta.TYPE_EVM -> {
+                val evm = decode<SwapKitEvmTx>(response.tx, "evm")
+                val gas =
+                    evm.gas?.toLongOrNull()?.takeIf { it > 0 }
+                        ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
+                EVMSwapQuoteJson(
+                    dstAmount = response.expectedBuyAmount.orEmpty(),
+                    tx =
+                        OneInchSwapTxJson(
+                            from = evm.from.orEmpty(),
+                            to = evm.to,
+                            data = evm.data,
+                            gas = gas,
+                            value = evm.value,
+                            gasPrice = evm.gasPrice.orEmpty(),
+                            // Per-leg swap fees on SwapKit are surfaced via the response-level
+                            // `fees[]` array (type=="inbound"|"outbound"|"affiliate"|…). Phase 1
+                            // does not parse those out here — gas math lands via the standard EVM
+                            // path and the inbound-fee surfacing belongs with the tier-discount
+                            // affiliate work in a later task.
+                            swapFee = "0",
+                            swapFeeTokenContract = "",
+                        ),
+                )
+            }
+            SwapKitTxMeta.TYPE_SOLANA -> {
+                val solana = decode<SwapKitSolanaTx>(response.tx, "solana")
+                val base64 =
+                    solana.swapTransaction
+                        ?: solana.message
+                        ?: throw SwapKitError.Decoding(
+                            "SwapKit Solana tx missing both swapTransaction and message"
+                        )
+                EVMSwapQuoteJson(
+                    dstAmount = response.expectedBuyAmount.orEmpty(),
+                    tx =
+                        OneInchSwapTxJson(
+                            // Solana signers don't read from/to/gas/value/gasPrice off the
+                            // OneInchSwapTxJson envelope — they consume the base64 blob in `data`,
+                            // matching how JupiterQuoteSource already stages the Jupiter swap.
+                            from = "",
+                            to = "",
+                            data = base64,
+                            gas = 0,
+                            value = "0",
+                            gasPrice = "0",
+                            swapFee = "0",
+                            swapFeeTokenContract = "",
+                        ),
+                )
+            }
+            else -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
+        }
+    }
+
+    /**
+     * SwapKit asset identifier: `CHAIN.TICKER` or `CHAIN.TICKER-CONTRACT` for ERC-20-style tokens.
+     */
+    private fun assetIdentifier(coin: Coin): String {
+        val prefix = chainPrefix(coin.chain) ?: coin.ticker
+        val ticker = coin.ticker
+        return if (coin.isNativeToken || coin.contractAddress.isBlank()) {
+            "$prefix.$ticker"
+        } else {
+            "$prefix.$ticker-${coin.contractAddress}"
+        }
+    }
+
+    private fun chainPrefix(chain: Chain): String? =
+        when (chain) {
+            Chain.Ethereum -> "ETH"
+            Chain.BscChain -> "BSC"
+            Chain.Avalanche -> "AVAX"
+            Chain.Arbitrum -> "ARB"
+            Chain.Optimism -> "OP"
+            Chain.Base -> "BASE"
+            Chain.Polygon -> "POL"
+            Chain.Solana -> "SOL"
+            else -> null
+        }
+
+    private inline fun <reified T> decode(element: JsonElement, label: String): T =
+        try {
+            json.decodeFromJsonElement<T>(element)
+        } catch (e: Exception) {
+            throw SwapKitError.Decoding(
+                message = "Failed to decode SwapKit $label tx payload",
+                cause = e,
+            )
+        }
+
+    private companion object {
+        /** Sub-provider ids (lower-cased) filtered out of `/v3/quote` results client-side. */
+        private val FILTERED_PROVIDERS: Set<String> =
+            setOf("thorchain", "thorchain-streaming", "mayachain", "maya")
+
+        /**
+         * Render [TokenValue] as a dot-separated decimal string suitable for
+         * [SwapKitQuoteRequest.sellAmount]. Strips trailing zeros so "1.0000" → "1" — matches the
+         * iOS POSIX formatter behaviour and the wire samples in the SwapKit V3 spec.
+         */
+        private fun formatSellAmount(tokenValue: TokenValue): String =
+            tokenValue.decimal.stripTrailingZeros().toPlainString()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -127,7 +127,14 @@ constructor(
                     destinationAddress = request.dstToken.address,
                 )
             )
+        // TODO(swapkit /track polling, later task): persist swapResponse.swapId on the resulting
+        //  SwapTransaction so /track lookups can correlate cross-chain settlement back to this
+        //  specific quote. The DTO already carries it; the persistence wiring lands with the
+        //  tx-history Phase D work.
 
+        // SwapQuoteResult.Evm is the envelope for both EVM and Solana SwapKit txTypes — Solana
+        // signers pull the base64 blob from `tx.data`, matching how JupiterQuoteSource already
+        // stages a Solana swap. The Evm-typed result is intentional, not a copy-paste.
         return SwapQuoteResult.Evm(buildEvmQuoteFromSwapKit(swapResponse, request.dstToken))
     }
 
@@ -140,7 +147,12 @@ constructor(
         val filtered =
             routes.filter { route ->
                 if (route.providers.size != 1) return@filter false
-                val primary = route.primaryProviderId
+                // SwapKitRoute.primaryProviderId already lower-cases the wire value, but
+                // .lowercase() again here is a deliberate belt-and-braces: if a future change
+                // to the DTO ever drops the normalization, the filter still excludes Thor/Maya
+                // sub-providers rather than silently letting them through (which would stack a
+                // second affiliate fee on top of Vultisig's native Thor/Maya integrations).
+                val primary = route.primaryProviderId.lowercase()
                 primary !in FILTERED_PROVIDERS
             }
         if (filtered.isEmpty()) return null
@@ -175,6 +187,10 @@ constructor(
         // so the contract stays uniform — otherwise "42.5" becomes ZERO and "2500" becomes 6
         // orders of magnitude smaller than the actual receive amount.
         val rawDstAmount = scaleDecimalToRawUnits(response.expectedBuyAmount, dstToken.decimal)
+        // `meta.type` is the lowercase canonical txType (computed by SwapKitTxMeta from `txType`),
+        // matched against TYPE_EVM / TYPE_SOLANA. `meta.txType` (raw upstream casing) is used only
+        // in the UnsupportedTxType message so diagnostics surface the wire value verbatim — e.g.
+        // "PSBT" not "psbt" — without affecting dispatch.
         val txType = response.meta.type
         return when (txType) {
             SwapKitTxMeta.TYPE_EVM -> {
@@ -251,7 +267,16 @@ constructor(
      * SwapKit asset identifier: `CHAIN.TICKER` or `CHAIN.TICKER-CONTRACT` for ERC-20-style tokens.
      */
     private fun assetIdentifier(coin: Coin): String {
-        val prefix = chainPrefix(coin.chain) ?: coin.ticker
+        // The provider-cache gate upstream of this call should already block any chain we don't
+        // have a SwapKit prefix mapping for. Throwing NoRoutes here (rather than falling back to
+        // `coin.ticker`) is defense-in-depth: a future cache change that enables a chain we
+        // haven't mapped would otherwise mint a garbage identifier (e.g. `ETH.ETH` for ZkSync.ETH)
+        // and surface as `helpers_invalid_asset_identifier` 500s from the proxy.
+        val prefix =
+            chainPrefix(coin.chain)
+                ?: throw SwapKitError.NoRoutes(
+                    "SwapKit asset identifier missing chain prefix for ${coin.chain.raw}"
+                )
         val ticker = coin.ticker
         return if (coin.isNativeToken || coin.contractAddress.isBlank()) {
             "$prefix.$ticker"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -9,46 +9,54 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSolanaTx
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
-import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
-import com.vultisig.wallet.data.chains.helpers.EvmHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import java.math.BigDecimal
+import java.math.BigInteger
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
 import timber.log.Timber
 
 /**
  * SwapKit V3 quote source. Mirrors iOS' `SwapKitService.fetchBestRoute` + `buildSwapTx`:
- * 1. Guard on the user's `SwapKitConfig` opt-in flag and the cached `/providers` enablement for
- *    both source and destination chains — fails closed so a flag-off / cold-cache call never
- *    reaches the proxy.
+ * 1. Short-circuit on the user's `SwapKitConfig` opt-in flag (default off) before any network I/O.
+ *    No cache gate beyond that — iOS' `SwapKitProviderCache` returns `true` on cache-miss and lets
+ *    `/v3/quote` surface unsupported chains via `noRoutesFound`; the Android source matches that
+ *    fail-open semantics so a single bad-network app launch doesn't hide SwapKit until refresh.
  * 2. Call `POST /v3/quote`, drop multi-hop routes and any route whose sub-provider is THORChain or
  *    Maya (Vultisig pays those affiliates directly via the existing integrations — routing through
- *    SwapKit would stack a second affiliate fee on top).
+ *    SwapKit would stack a second affiliate fee on top). Filter uses the wire-format provider ids
+ *    (`thorchain`, `thorchain_streaming`, `mayachain`, `mayachain_streaming`) so streaming variants
+ *    don't slip through.
  * 3. Rank the survivors by `expectedBuyAmount` (string-decimal, higher wins) and pick the best.
  * 4. Call `POST /v3/swap` with the chosen `routeId` to materialise the unsigned tx, then wrap the
  *    EVM-shaped or Solana-shaped payload into the existing [EVMSwapQuoteJson] envelope so the rest
  *    of the swap pipeline (signing, broadcast, proto round-trip via `oneinchSwapPayload`) needs no
- *    changes for Phase 1.
+ *    changes for Phase 1. The route's `fees[]` entry with `type=="inbound"` for the source chain
+ *    becomes `tx.swapFee` (raw native units) so the displayed Network Fee reconciles against the
+ *    actual on-chain debit — especially on Solana / Chainflip / NEAR where the EVM gas envelope
+ *    reads zero. EVM routes that omit `tx.gas` are refused (`SwapKitError.Decoding`) rather than
+ *    backstopped with the L1-sized default, which would over-estimate L2 fees by multiples.
  *
  * Non-EVM/non-Solana `txType`s (PSBT, TRON, TON, SUI, CARDANO, RIPPLE, …) are out of scope for
  * Phase 1 — they require per-chain signers and the dedicated `SwapKitSwapPayload` proto, which land
  * in subsequent task batches. Such responses surface as [SwapKitError.UnsupportedTxType] so the
- * picker falls back to another provider rather than signing garbage.
+ * picker falls back to another provider rather than signing garbage. `SOLANA` and the legacy
+ * `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once before.
  */
 internal class SwapKitQuoteSource
 @Inject
 constructor(
     private val api: SwapKitApi,
     private val config: SwapKitConfig,
-    private val providerCache: SwapKitProviderCache,
     private val json: Json,
 ) : SwapQuoteSource {
 
@@ -75,20 +83,12 @@ constructor(
             throw SwapKitError.NoRoutes("SwapKit feature flag disabled")
         }
 
-        // Provider-cache gate — both ends must be enabled in the cached /providers snapshot.
-        // Fails closed: when the cache can't be hydrated isEnabled returns false, so we skip
-        // SwapKit and let another provider take the route rather than firing a /quote that we
-        // already expect to fail.
-        if (!providerCache.isEnabled(request.srcToken.chain)) {
-            throw SwapKitError.NoRoutes(
-                "SwapKit not enabled for source chain ${request.srcToken.chain.raw}"
-            )
-        }
-        if (!providerCache.isEnabled(request.dstToken.chain)) {
-            throw SwapKitError.NoRoutes(
-                "SwapKit not enabled for destination chain ${request.dstToken.chain.raw}"
-            )
-        }
+        // No provider-cache gate here on purpose. iOS' SwapKitProviderCache returns `true` on a
+        // cache-miss and lets `/v3/quote` surface the real error so a single bad-network app
+        // launch doesn't silently hide SwapKit until the next refresh. Android's cache currently
+        // returns `false` on cache-miss (fail-closed), which would diverge. Letting `/v3/quote`
+        // be the authority — it returns a clear `noRoutesFound` for unsupported chains — keeps
+        // the user opt-in and the swap picker behaviour aligned with iOS.
 
         val quoteResponse =
             api.quote(
@@ -135,7 +135,16 @@ constructor(
         // SwapQuoteResult.Evm is the envelope for both EVM and Solana SwapKit txTypes — Solana
         // signers pull the base64 blob from `tx.data`, matching how JupiterQuoteSource already
         // stages a Solana swap. The Evm-typed result is intentional, not a copy-paste.
-        return SwapQuoteResult.Evm(buildEvmQuoteFromSwapKit(swapResponse, request.dstToken))
+        return SwapQuoteResult.Evm(
+            data = buildEvmQuoteFromSwapKit(swapResponse, request.srcToken, request.dstToken, best),
+            // Sub-provider tag (Chainflip / NEAR Intents / Garden / Flashnet) — surfaced on the
+            // verify screen so the user can reason about ETA and debug routing. Prefer
+            // `swapResponse.providers[0]` (the swap call's authoritative routing) and fall back
+            // to `meta.subProvider` for forward compat.
+            subProvider =
+                swapResponse.providers.firstOrNull()?.takeIf { it.isNotBlank() }
+                    ?: swapResponse.meta.subProvider?.takeIf { it.isNotBlank() },
+        )
     }
 
     /**
@@ -168,6 +177,26 @@ constructor(
     }
 
     /**
+     * Extract the source-chain inbound fee from `route.fees[]` — the canonical SwapKit-attributed
+     * cost of executing the deposit on the source chain. Mirrors iOS' `SwapKitService.inboundFee`
+     * so the displayed Network Fee reconciles against the actual on-chain debit (especially on
+     * Solana and cross-chain Chainflip / NEAR routes where the EVM gas envelope would otherwise
+     * read zero). Returns `0` when the entry is absent so the UI surfaces "—" rather than blocking
+     * the quote.
+     */
+    private fun inboundFeeRawUnits(srcToken: Coin, route: SwapKitRoute): BigInteger {
+        val prefix = chainPrefix(srcToken.chain) ?: return BigInteger.ZERO
+        val inbound =
+            route.fees.firstOrNull { fee ->
+                fee.type?.equals("inbound", ignoreCase = true) == true && fee.chain == prefix
+            } ?: return BigInteger.ZERO
+        val amount =
+            inbound.amount?.let { runCatching { BigDecimal(it) }.getOrNull() }
+                ?: return BigInteger.ZERO
+        return amount.movePointRight(srcToken.decimal).toBigInteger()
+    }
+
+    /**
      * Wrap the SwapKit `/v3/swap` response into the EVM-shaped [EVMSwapQuoteJson] envelope used by
      * the existing pipeline. The `tx` blob's wire shape varies by `meta.txType`:
      * - "evm" → decode as [SwapKitEvmTx], fields map 1:1 to [OneInchSwapTxJson]
@@ -178,7 +207,9 @@ constructor(
      */
     private fun buildEvmQuoteFromSwapKit(
         response: SwapKitSwapResponseJson,
+        srcToken: Coin,
         dstToken: Coin,
+        route: SwapKitRoute,
     ): EVMSwapQuoteJson {
         // SwapKit V3 reports `expectedBuyAmount` as a human-readable decimal string ("42.5"
         // USDC) per the docs. Every other Android quote source (1inch / Kyber / LiFi / Jupiter)
@@ -187,17 +218,24 @@ constructor(
         // so the contract stays uniform — otherwise "42.5" becomes ZERO and "2500" becomes 6
         // orders of magnitude smaller than the actual receive amount.
         val rawDstAmount = scaleDecimalToRawUnits(response.expectedBuyAmount, dstToken.decimal)
-        // `meta.type` is the lowercase canonical txType (computed by SwapKitTxMeta from `txType`),
-        // matched against TYPE_EVM / TYPE_SOLANA. `meta.txType` (raw upstream casing) is used only
-        // in the UnsupportedTxType message so diagnostics surface the wire value verbatim — e.g.
-        // "PSBT" not "psbt" — without affecting dispatch.
-        val txType = response.meta.type
-        return when (txType) {
-            SwapKitTxMeta.TYPE_EVM -> {
+        // Inbound fee in source-chain native units — canonical SwapKit fee surface (iOS' equivalent
+        // is SwapKitService.inboundFee). Embedded in `swapFee` with `swapFeeTokenContract = ""`
+        // (the native-coin sentinel resolveSwapFee recognises) so the consumer reads it the same
+        // way Kyber/Jupiter quote sources surface their per-leg fees.
+        val inboundFee = inboundFeeRawUnits(srcToken, route).toString()
+        return when (txTypeOf(response)) {
+            TxKind.EVM -> {
                 val evm = decode<SwapKitEvmTx>(response.tx, "evm")
+                // Refuse routes that omit `tx.gas`. Falling back to a hardcoded L1-sized constant
+                // (e.g. 600_000) over-estimates by multiples on Arbitrum / Optimism / Base / BSC /
+                // Polygon / Avalanche and produces a misleading Network Fee on the verify screen.
+                // Throwing Decoding here lets the picker drop SwapKit and rank another aggregator
+                // rather than ship a wrong number.
                 val gas =
                     evm.gas?.toLongOrNull()?.takeIf { it > 0 }
-                        ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
+                        ?: throw SwapKitError.Decoding(
+                            "SwapKit EVM tx missing gas estimate (got ${evm.gas}); refusing route"
+                        )
                 EVMSwapQuoteJson(
                     dstAmount = rawDstAmount,
                     tx =
@@ -208,24 +246,16 @@ constructor(
                             gas = gas,
                             value = evm.value,
                             gasPrice = evm.gasPrice.orEmpty(),
-                            // Per-leg swap fees on SwapKit are surfaced via the response-level
-                            // `fees[]` array (type=="inbound"|"outbound"|"affiliate"|…). Phase 1
-                            // does not parse those out here — gas math lands via the standard EVM
-                            // path and the inbound-fee surfacing belongs with the tier-discount
-                            // affiliate work in a later task.
-                            swapFee = "0",
+                            swapFee = inboundFee,
                             swapFeeTokenContract = "",
                         ),
                 )
             }
-            SwapKitTxMeta.TYPE_SOLANA -> {
-                val solana = decode<SwapKitSolanaTx>(response.tx, "solana")
-                val base64 =
-                    solana.swapTransaction
-                        ?: solana.message
-                        ?: throw SwapKitError.Decoding(
-                            "SwapKit Solana tx missing both swapTransaction and message"
-                        )
+            TxKind.SOLANA -> {
+                // SwapKit V3 returns the Solana `tx` as a bare base64 String (`JsonPrimitive`),
+                // not an object with `swapTransaction`/`message` — those nested fields are a
+                // transitional v2-era shape. Accept both with `JsonPrimitive` taking precedence.
+                val base64 = solanaBase64(response.tx)
                 EVMSwapQuoteJson(
                     dstAmount = rawDstAmount,
                     tx =
@@ -239,13 +269,58 @@ constructor(
                             gas = 0,
                             value = "0",
                             gasPrice = "0",
-                            swapFee = "0",
+                            swapFee = inboundFee,
                             swapFeeTokenContract = "",
                         ),
                 )
             }
-            else -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
+            TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
+    }
+
+    /**
+     * Map SwapKit's `meta.txType` (raw upstream casing) onto the internal dispatch kind. Accepts
+     * both `SOLANA` and `SERIALIZED_BASE64` for the Solana branch — SwapKit flipped that
+     * discriminator once before (per iOS commit `382b28f5f`), so the source is permissive.
+     */
+    private fun txTypeOf(response: SwapKitSwapResponseJson): TxKind =
+        when (response.meta.type) {
+            "evm" -> TxKind.EVM
+            "solana",
+            "serialized_base64" -> TxKind.SOLANA
+            else -> TxKind.UNSUPPORTED
+        }
+
+    /**
+     * Pull the Solana base64 swap blob out of `tx`. V3 ships it as a top-level [JsonPrimitive];
+     * fall back to the legacy [SwapKitSolanaTx] object shape so a transitional response (or a test
+     * fixture using either form) is decoded safely.
+     */
+    private fun solanaBase64(element: JsonElement): String {
+        (element as? JsonPrimitive)
+            ?.takeIf { it.isString }
+            ?.content
+            ?.let {
+                return it
+            }
+        if (element is JsonObject) {
+            val nested = decode<SwapKitSolanaTx>(element, "solana")
+            nested.swapTransaction?.let {
+                return it
+            }
+            nested.message?.let {
+                return it
+            }
+        }
+        throw SwapKitError.Decoding(
+            "SwapKit Solana tx is neither a base64 string nor a known object shape"
+        )
+    }
+
+    private enum class TxKind {
+        EVM,
+        SOLANA,
+        UNSUPPORTED,
     }
 
     /**
@@ -309,9 +384,15 @@ constructor(
         }
 
     private companion object {
-        /** Sub-provider ids (lower-cased) filtered out of `/v3/quote` results client-side. */
+        /**
+         * Sub-provider ids (lower-cased, underscored — matches the wire format of SwapKit's
+         * `/providers` and `route.providers[]` entries: `THORCHAIN`, `THORCHAIN_STREAMING`,
+         * `MAYACHAIN`, `MAYACHAIN_STREAMING`). Earlier dashed / 4-letter variants (`maya`,
+         * `thorchain-streaming`) silently let the streaming sub-providers through, which would
+         * stack a SwapKit affiliate fee on top of Vultisig's native Thor/Maya integrations.
+         */
         private val FILTERED_PROVIDERS: Set<String> =
-            setOf("thorchain", "thorchain-streaming", "mayachain", "maya")
+            setOf("thorchain", "thorchain_streaming", "mayachain", "mayachain_streaming")
 
         /**
          * Render [TokenValue] as a dot-separated decimal string suitable for

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -128,7 +128,7 @@ constructor(
                 )
             )
 
-        return SwapQuoteResult.Evm(buildEvmQuoteFromSwapKit(swapResponse))
+        return SwapQuoteResult.Evm(buildEvmQuoteFromSwapKit(swapResponse, request.dstToken))
     }
 
     /**
@@ -164,7 +164,17 @@ constructor(
      *   Solana signer can pull it the same way it pulls a Jupiter tx today Anything else
      *   (PSBT/TRON/TON/…) is out of scope until the per-chain signers ship.
      */
-    private fun buildEvmQuoteFromSwapKit(response: SwapKitSwapResponseJson): EVMSwapQuoteJson {
+    private fun buildEvmQuoteFromSwapKit(
+        response: SwapKitSwapResponseJson,
+        dstToken: Coin,
+    ): EVMSwapQuoteJson {
+        // SwapKit V3 reports `expectedBuyAmount` as a human-readable decimal string ("42.5"
+        // USDC) per the docs. Every other Android quote source (1inch / Kyber / LiFi / Jupiter)
+        // stores `EVMSwapQuoteJson.dstAmount` as a raw-units integer string, and the consumer
+        // (`SwapQuoteManager`) parses it back with `toBigIntegerOrNull`. Scale at this boundary
+        // so the contract stays uniform — otherwise "42.5" becomes ZERO and "2500" becomes 6
+        // orders of magnitude smaller than the actual receive amount.
+        val rawDstAmount = scaleDecimalToRawUnits(response.expectedBuyAmount, dstToken.decimal)
         val txType = response.meta.type
         return when (txType) {
             SwapKitTxMeta.TYPE_EVM -> {
@@ -173,7 +183,7 @@ constructor(
                     evm.gas?.toLongOrNull()?.takeIf { it > 0 }
                         ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
                 EVMSwapQuoteJson(
-                    dstAmount = response.expectedBuyAmount.orEmpty(),
+                    dstAmount = rawDstAmount,
                     tx =
                         OneInchSwapTxJson(
                             from = evm.from.orEmpty(),
@@ -201,7 +211,7 @@ constructor(
                             "SwapKit Solana tx missing both swapTransaction and message"
                         )
                 EVMSwapQuoteJson(
-                    dstAmount = response.expectedBuyAmount.orEmpty(),
+                    dstAmount = rawDstAmount,
                     tx =
                         OneInchSwapTxJson(
                             // Solana signers don't read from/to/gas/value/gasPrice off the
@@ -220,6 +230,21 @@ constructor(
             }
             else -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
+    }
+
+    /**
+     * Convert SwapKit's human-readable `expectedBuyAmount` (decimal string, e.g. "42.5") into the
+     * raw-units integer string the rest of the swap pipeline expects. Throws
+     * [SwapKitError.Decoding] when the upstream value is missing or unparseable so a malformed
+     * payload surfaces explicitly rather than masking as a zero quote.
+     */
+    private fun scaleDecimalToRawUnits(decimalString: String?, decimals: Int): String {
+        val parsed =
+            decimalString?.let { runCatching { BigDecimal(it) }.getOrNull() }
+                ?: throw SwapKitError.Decoding(
+                    "SwapKit expectedBuyAmount missing or not a decimal: $decimalString"
+                )
+        return parsed.movePointRight(decimals).toBigInteger().toString()
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -55,9 +55,16 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             "DAI",
         )
 
-    private val evmAggregators = setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.KYBER)
+    private val evmAggregators =
+        setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.KYBER, SwapProvider.SWAPKIT)
     private val thorchainPlusEvmAggregators =
-        setOf(SwapProvider.THORCHAIN, SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.KYBER)
+        setOf(
+            SwapProvider.THORCHAIN,
+            SwapProvider.ONEINCH,
+            SwapProvider.LIFI,
+            SwapProvider.KYBER,
+            SwapProvider.SWAPKIT,
+        )
 
     /** Providers that only quote same-chain swaps; filtered out for cross-chain pairs. */
     private val sameChainOnly = setOf(SwapProvider.ONEINCH, SwapProvider.KYBER)
@@ -78,11 +85,13 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                 if (ticker in thorAvaxTokens) thorchainPlusEvmAggregators else evmAggregators
 
             Chain.Base ->
-                if (ticker in thorBaseTokens) setOf(SwapProvider.LIFI, SwapProvider.THORCHAIN)
-                else setOf(SwapProvider.LIFI)
+                if (ticker in thorBaseTokens)
+                    setOf(SwapProvider.LIFI, SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
+                else setOf(SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
             Chain.Optimism,
-            Chain.Polygon,
+            Chain.Polygon -> setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.SWAPKIT)
+
             Chain.ZkSync -> setOf(SwapProvider.ONEINCH, SwapProvider.LIFI)
 
             Chain.Mantle -> setOf(SwapProvider.LIFI, SwapProvider.KYBER)
@@ -98,16 +107,22 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             Chain.Zcash -> setOf(SwapProvider.MAYA)
 
             Chain.Arbitrum ->
-                if (ticker in mayaArbTokens) setOf(SwapProvider.LIFI, SwapProvider.MAYA)
-                else setOf(SwapProvider.LIFI)
+                if (ticker in mayaArbTokens)
+                    setOf(SwapProvider.LIFI, SwapProvider.MAYA, SwapProvider.SWAPKIT)
+                else setOf(SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
             Chain.Blast,
             Chain.CronosChain -> setOf(SwapProvider.LIFI)
 
             Chain.Solana ->
                 if (coin.isNativeToken)
-                    setOf(SwapProvider.THORCHAIN, SwapProvider.JUPITER, SwapProvider.LIFI)
-                else setOf(SwapProvider.JUPITER, SwapProvider.LIFI)
+                    setOf(
+                        SwapProvider.THORCHAIN,
+                        SwapProvider.JUPITER,
+                        SwapProvider.LIFI,
+                        SwapProvider.SWAPKIT,
+                    )
+                else setOf(SwapProvider.JUPITER, SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
             Chain.Ripple,
             Chain.Tron -> setOf(SwapProvider.THORCHAIN)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -158,6 +158,12 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
     private fun ethereumProviders(ticker: String): Set<SwapProvider> {
         val isThor = ticker in thorEthTokens
         val isMaya = ticker in mayaEthTokens
+        // SwapKit is included in every Ethereum branch: the per-token-pair eligibility is
+        // negotiated downstream at `/v3/quote` time (and gated by the SwapKit feature flag +
+        // provider cache inside SwapKitQuoteSource), so the table only needs to surface SwapKit
+        // wherever the existing EVM aggregators show up. Without this, ETH/USDC/USDT and the
+        // other Thor/Maya-eligible Ethereum tokens silently lose SwapKit as a candidate even
+        // though the cache enables Ethereum.
         return when {
             isThor && isMaya ->
                 setOf(
@@ -165,6 +171,7 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                     SwapProvider.ONEINCH,
                     SwapProvider.LIFI,
                     SwapProvider.KYBER,
+                    SwapProvider.SWAPKIT,
                     SwapProvider.MAYA,
                 )
 
@@ -174,6 +181,7 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                     SwapProvider.ONEINCH,
                     SwapProvider.LIFI,
                     SwapProvider.KYBER,
+                    SwapProvider.SWAPKIT,
                 )
 
             isMaya ->
@@ -182,6 +190,7 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                     SwapProvider.LIFI,
                     SwapProvider.MAYA,
                     SwapProvider.KYBER,
+                    SwapProvider.SWAPKIT,
                 )
 
             else -> evmAggregators

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -31,7 +31,13 @@ data class SwapQuoteRequest(
 sealed class SwapQuoteResult {
     data class Native(val quote: SwapQuote) : SwapQuoteResult()
 
-    data class Evm(val data: EVMSwapQuoteJson) : SwapQuoteResult()
+    /**
+     * EVM-shaped quote envelope. [subProvider] is the route's sub-provider tag when an aggregator
+     * routes through a downstream protocol (e.g. SwapKit → Chainflip / NEAR Intents / Garden /
+     * Flashnet); `null` for direct aggregators (1inch, Kyber, LiFi, Jupiter). The UI label uses it
+     * to disambiguate the verify screen.
+     */
+    data class Evm(val data: EVMSwapQuoteJson, val subProvider: String? = null) : SwapQuoteResult()
 
     fun expectNative(provider: SwapProvider): SwapQuote =
         when (this) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -366,6 +366,20 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch throws NoRoutes when source chain has no SwapKit prefix mapping`() = runTest {
+        // Defense-in-depth: even if the provider cache somehow enables a chain we haven't mapped
+        // a SwapKit prefix for, assetIdentifier should surface NoRoutes rather than minting a
+        // garbage "TICKER.TICKER" identifier that the proxy rejects with
+        // helpers_invalid_asset_identifier. Drive the path by stubbing cache.isEnabled true while
+        // using a chain (Hyperliquid) that isn't in the Phase 1 prefix map.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        val unmapped = ethCoin().copy(chain = Chain.Hyperliquid)
+
+        assertThrows<SwapKitError.NoRoutes> { source().fetch(request(srcToken = unmapped)) }
+    }
+
+    @Test
     fun `fetch wraps unexpected exceptions as SwapKitError Network preserving the cause`() =
         runTest {
             every { config.isFeatureEnabled } returns flowOf(true)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.repositories.swap
 
 import com.vultisig.wallet.data.api.errors.SwapKitError
+import com.vultisig.wallet.data.api.models.quotes.SwapKitFee
 import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteResponseJson
 import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
@@ -8,7 +9,6 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
 import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
-import com.vultisig.wallet.data.chains.helpers.EvmHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
@@ -25,25 +25,26 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 /**
- * Pins the SwapKit quote-source contract: feature-flag and provider-cache gates short-circuit
- * before network I/O, multi-hop / THORChain / Maya routes are filtered client-side, ranking picks
- * the highest [SwapKitRoute.expectedBuyAmount], and Phase 1 EVM/Solana `meta.txType` responses are
- * unwrapped into [com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson]. Anything else
- * surfaces as a typed [SwapKitError] so the swap picker can fall back to another aggregator.
+ * Pins the SwapKit quote-source contract: feature-flag gating, multi-hop / THORChain / Maya
+ * filtering with the wire-format provider ids, ranking by [SwapKitRoute.expectedBuyAmount], Solana
+ * base64-as-JsonPrimitive decoding (+ legacy object fallback), `SERIALIZED_BASE64` txType aliasing,
+ * refusal of EVM routes missing `tx.gas`, inbound-fee extraction from `route.fees[]`, sub-provider
+ * passthrough into [SwapQuoteResult.Evm.subProvider], and exception wrapping. No provider-cache
+ * gate — `/v3/quote` is the authority on unsupported chains (mirrors iOS' fail-open cache).
  */
 internal class SwapKitQuoteSourceTest {
 
     private val api: SwapKitApi = mockk()
-    private val cache: SwapKitProviderCache = mockk()
     private val config: SwapKitConfig = mockk()
     private val json = Json { ignoreUnknownKeys = true }
 
-    private fun source(): SwapKitQuoteSource = SwapKitQuoteSource(api, config, cache, json)
+    private fun source(): SwapKitQuoteSource = SwapKitQuoteSource(api, config, json)
 
     @Test
     fun `fetch throws NoRoutes when feature flag is disabled`() = runTest {
@@ -54,34 +55,12 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
-    fun `fetch throws NoRoutes when source chain is not enabled in cache`() = runTest {
-        every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(Chain.Ethereum) } returns false
-
-        val error = assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
-        assertTrue(error.message?.contains("source") == true)
-    }
-
-    @Test
-    fun `fetch throws NoRoutes when destination chain is not enabled in cache`() = runTest {
-        every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(Chain.Ethereum) } returns true
-        coEvery { cache.isEnabled(Chain.Base) } returns false
-
-        val error =
-            assertThrows<SwapKitError.NoRoutes> { source().fetch(request(dstToken = baseCoin())) }
-        assertTrue(error.message?.contains("destination") == true)
-    }
-
-    @Test
     fun `fetch filters out multi-hop and Thor and Maya routes then picks highest expected amount`() =
         runTest {
             every { config.isFeatureEnabled } returns flowOf(true)
-            coEvery { cache.isEnabled(any()) } returns true
 
-            val quoteRequest = slot<SwapKitQuoteRequest>()
             val swapRequest = slot<SwapKitSwapRequest>()
-            coEvery { api.quote(capture(quoteRequest)) } returns
+            coEvery { api.quote(any()) } returns
                 SwapKitQuoteResponseJson(
                     routes =
                         listOf(
@@ -91,9 +70,19 @@ internal class SwapKitQuoteSourceTest {
                                 expectedBuy = "200",
                             ),
                             route(
+                                routeId = "skip-thor-streaming",
+                                providers = listOf("THORCHAIN_STREAMING"),
+                                expectedBuy = "250",
+                            ),
+                            route(
                                 routeId = "skip-maya",
                                 providers = listOf("MAYACHAIN"),
                                 expectedBuy = "300",
+                            ),
+                            route(
+                                routeId = "skip-maya-streaming",
+                                providers = listOf("MAYACHAIN_STREAMING"),
+                                expectedBuy = "400",
                             ),
                             route(
                                 routeId = "skip-multihop",
@@ -120,26 +109,33 @@ internal class SwapKitQuoteSourceTest {
         }
 
     @Test
-    fun `fetch throws NoRoutes when every route is filtered out`() = runTest {
-        every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
-        coEvery { api.quote(any()) } returns
-            SwapKitQuoteResponseJson(
-                routes =
-                    listOf(
-                        route(routeId = "thor", providers = listOf("THORCHAIN")),
-                        route(routeId = "maya", providers = listOf("MAYA")),
-                        route(routeId = "multi", providers = listOf("CHAINFLIP", "NEAR")),
-                    )
-            )
+    fun `fetch throws NoRoutes when every route is filtered out including streaming variants`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(routeId = "thor", providers = listOf("THORCHAIN")),
+                            route(
+                                routeId = "thor-streaming",
+                                providers = listOf("THORCHAIN_STREAMING"),
+                            ),
+                            route(routeId = "maya", providers = listOf("MAYACHAIN")),
+                            route(
+                                routeId = "maya-streaming",
+                                providers = listOf("MAYACHAIN_STREAMING"),
+                            ),
+                            route(routeId = "multi", providers = listOf("CHAINFLIP", "NEAR")),
+                        )
+                )
 
-        assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
-    }
+            assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
+        }
 
     @Test
-    fun `fetch maps EVM tx response into EVMSwapQuoteJson with gas defaults`() = runTest {
+    fun `fetch maps EVM tx response and surfaces sub-provider from swap response`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
@@ -151,37 +147,51 @@ internal class SwapKitQuoteSourceTest {
                         )
                     )
             )
-        // gas omitted in EVM tx — fetcher must fall back to the project's default swap gas unit so
-        // the downstream EVM signer never broadcasts a 0-gas transaction.
         coEvery { api.swap(any()) } returns
             evmSwapResponse(
-                gas = null,
+                gas = "200000",
                 gasPrice = "20",
                 from = "0xfrom",
                 to = "0xto",
                 data = "0xdeadbeef",
                 value = "1",
                 expectedBuy = "42",
+                providers = listOf("CHAINFLIP"),
             )
 
         val result = source().fetch(request()) as SwapQuoteResult.Evm
 
-        // dstToken is the default solanaCoin (9 decimals). SwapKit returns the decimal "42",
-        // and the source scales it to raw units so the downstream pipeline (which expects
-        // BigInteger-as-string) gets 42 * 10^9.
         assertEquals("42000000000", result.data.dstAmount)
         assertEquals("0xfrom", result.data.tx.from)
         assertEquals("0xto", result.data.tx.to)
         assertEquals("0xdeadbeef", result.data.tx.data)
         assertEquals("1", result.data.tx.value)
         assertEquals("20", result.data.tx.gasPrice)
-        assertEquals(EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT, result.data.tx.gas)
+        assertEquals(200000L, result.data.tx.gas)
+        assertEquals("CHAINFLIP", result.subProvider)
     }
 
     @Test
-    fun `fetch maps Solana tx response into EVMSwapQuoteJson with base64 in data`() = runTest {
+    fun `fetch refuses EVM route when tx_gas is missing`() = runTest {
+        // Hard-coding a 600k L1 default would over-estimate Network Fee on L2s by multiples.
+        // Refuse the route and let the picker rank another aggregator with a real gas estimate.
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse(gas = null)
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request()) }
+    }
+
+    @Test
+    fun `fetch decodes Solana base64 from JsonPrimitive at the tx root`() = runTest {
+        // SwapKit V3 returns the Solana tx as a bare base64 string on `tx`, not an object with
+        // swapTransaction/message. The legacy wrapper-object decoder masked this bug in earlier
+        // tests; this case pins the V3 wire shape explicitly.
+        every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
@@ -190,54 +200,137 @@ internal class SwapKitQuoteSourceTest {
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 swapId = "swap-1",
-                tx = buildJsonObject { put("swapTransaction", JsonPrimitive("BASE64SOLANA")) },
+                tx = JsonPrimitive("BASE64SOLANA"),
+                meta = SwapKitTxMeta(txType = "SOLANA"),
+                expectedBuyAmount = "9",
+                providers = listOf("NEAR"),
+            )
+
+        val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+        assertEquals("BASE64SOLANA", result.data.tx.data)
+        assertEquals("9000000000", result.data.dstAmount)
+        assertEquals("NEAR", result.subProvider)
+    }
+
+    @Test
+    fun `fetch decodes legacy Solana object shape with swapTransaction field`() = runTest {
+        // Transitional wire shape — SwapKit flipped this once before. Source stays permissive.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r-sol", providers = listOf("NEAR"), expectedBuy = "9"))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = buildJsonObject { put("swapTransaction", JsonPrimitive("BASE64LEGACY")) },
                 meta = SwapKitTxMeta(txType = "SOLANA"),
                 expectedBuyAmount = "9",
             )
 
         val result = source().fetch(request()) as SwapQuoteResult.Evm
 
-        assertEquals("BASE64SOLANA", result.data.tx.data)
-        // 9 SOL (9 decimals) scaled to raw lamports.
-        assertEquals("9000000000", result.data.dstAmount)
+        assertEquals("BASE64LEGACY", result.data.tx.data)
     }
 
     @Test
-    fun `fetch scales fractional expectedBuyAmount into raw destination units`() = runTest {
-        // Regression: SwapKit returns expectedBuyAmount as a human-readable decimal string
-        // ("42.5" USDC, "0.0086" ETH), but EVMSwapQuoteJson.dstAmount is consumed downstream as a
-        // BigInteger-as-string (raw units). Without scaling, "42.5".toBigIntegerOrNull() returns
-        // null and the consumer silently treats the receive amount as zero; "2500" would be
-        // interpreted as 0.0025 USDC instead of 2500 USDC. Both failure modes mislead the user.
+    fun `fetch accepts SERIALIZED_BASE64 txType as Solana`() = runTest {
+        // SwapKit upstream has flipped the Solana discriminator between SOLANA and
+        // SERIALIZED_BASE64 before (per iOS commit 382b28f5f). Both must dispatch to the Solana
+        // decoder; otherwise every real Solana route lands on UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r-sol", providers = listOf("NEAR"), expectedBuy = "9"))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive("BASE64SERIAL"),
+                meta = SwapKitTxMeta(txType = "SERIALIZED_BASE64"),
+                expectedBuyAmount = "9",
+            )
+
+        val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+        assertEquals("BASE64SERIAL", result.data.tx.data)
+    }
+
+    @Test
+    fun `fetch surfaces inbound fee from route fees list in raw source-chain units`() = runTest {
+        // Canonical SwapKit source-chain fee — iOS surfaces this via SwapKitService.inboundFee.
+        // Without parsing fees[], Solana routes display $0 Network Fee while real Chainflip /
+        // NEAR routes debit a real source-chain charge.
+        every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
                     listOf(
-                        route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "42.5")
+                        route(
+                            routeId = "r-sol",
+                            providers = listOf("NEAR"),
+                            expectedBuy = "9",
+                            fees =
+                                listOf(
+                                    SwapKitFee(
+                                        type = "inbound",
+                                        chain = "SOL",
+                                        amount = "0.000005",
+                                    ),
+                                    SwapKitFee(type = "outbound", chain = "ETH", amount = "0.0001"),
+                                ),
+                        )
                     )
             )
-        coEvery { api.swap(any()) } returns evmSwapResponse(expectedBuy = "42.5")
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive("BASE64"),
+                meta = SwapKitTxMeta(txType = "SOLANA"),
+                expectedBuyAmount = "9",
+            )
 
-        val usdc =
-            ethCoin()
-                .copy(
-                    ticker = "USDC",
-                    isNativeToken = false,
-                    contractAddress = "0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-                    decimal = 6,
-                )
-        val result = source().fetch(request(dstToken = usdc)) as SwapQuoteResult.Evm
+        val result = source().fetch(request(srcToken = solanaCoin())) as SwapQuoteResult.Evm
 
-        // 42.5 USDC × 10^6 = 42_500_000 raw units.
-        assertEquals("42500000", result.data.dstAmount)
+        // 0.000005 SOL * 10^9 = 5000 raw lamports. Embedded in tx.swapFee with an empty
+        // tokenContract so resolveSwapFee falls back to srcNativeToken (SOL).
+        assertEquals("5000", result.data.tx.swapFee)
+        assertEquals("", result.data.tx.swapFeeTokenContract)
     }
+
+    @Test
+    fun `fetch zero inbound fee when fees list lacks an inbound entry for the source chain`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r",
+                                providers = listOf("CHAINFLIP"),
+                                expectedBuy = "42",
+                                fees =
+                                    listOf(
+                                        SwapKitFee(
+                                            type = "outbound",
+                                            chain = "ETH",
+                                            amount = "0.01",
+                                        )
+                                    ),
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns evmSwapResponse()
+
+            val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+            assertEquals("0", result.data.tx.swapFee)
+        }
 
     @Test
     fun `fetch throws Decoding when expectedBuyAmount is missing`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
@@ -251,7 +344,6 @@ internal class SwapKitQuoteSourceTest {
     @Test
     fun `fetch throws Decoding when expectedBuyAmount is not a decimal`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
@@ -265,7 +357,6 @@ internal class SwapKitQuoteSourceTest {
     @Test
     fun `fetch throws UnsupportedTxType for non-EVM, non-Solana txType`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes = listOf(route(routeId = "r-psbt", providers = listOf("CHAINFLIP")))
@@ -283,7 +374,6 @@ internal class SwapKitQuoteSourceTest {
     @Test
     fun `fetch sends decimal sellAmount and dotted CHAIN-TICKER asset identifiers`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
 
         val captured = slot<SwapKitQuoteRequest>()
         coEvery { api.quote(capture(captured)) } returns
@@ -293,7 +383,6 @@ internal class SwapKitQuoteSourceTest {
             )
         coEvery { api.swap(any()) } returns evmSwapResponse()
 
-        // 0.0086 ETH = 8_600_000_000_000_000 wei (18 decimals).
         val src = ethCoin().copy(isNativeToken = true)
         source()
             .fetch(
@@ -304,15 +393,12 @@ internal class SwapKitQuoteSourceTest {
             )
 
         assertEquals("ETH.ETH", captured.captured.sellAsset)
-        // Trailing-zero stripping verifies the formatter — bug-prone if the wei → decimal
-        // conversion accidentally keeps full precision and SwapKit reads it as a larger number.
         assertEquals("0.0086", captured.captured.sellAmount)
     }
 
     @Test
     fun `fetch encodes ERC-20 token asset as CHAIN-TICKER-CONTRACT`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
 
         val captured = slot<SwapKitQuoteRequest>()
         coEvery { api.quote(capture(captured)) } returns
@@ -348,7 +434,6 @@ internal class SwapKitQuoteSourceTest {
     @Test
     fun `fetch passes affiliateBps from the request through to the SwapKit quote call`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
 
         val captured = slot<SwapKitQuoteRequest>()
         coEvery { api.quote(capture(captured)) } returns
@@ -367,23 +452,51 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch throws NoRoutes when source chain has no SwapKit prefix mapping`() = runTest {
-        // Defense-in-depth: even if the provider cache somehow enables a chain we haven't mapped
-        // a SwapKit prefix for, assetIdentifier should surface NoRoutes rather than minting a
-        // garbage "TICKER.TICKER" identifier that the proxy rejects with
-        // helpers_invalid_asset_identifier. Drive the path by stubbing cache.isEnabled true while
-        // using a chain (Hyperliquid) that isn't in the Phase 1 prefix map.
         every { config.isFeatureEnabled } returns flowOf(true)
-        coEvery { cache.isEnabled(any()) } returns true
         val unmapped = ethCoin().copy(chain = Chain.Hyperliquid)
 
         assertThrows<SwapKitError.NoRoutes> { source().fetch(request(srcToken = unmapped)) }
     }
 
     @Test
+    fun `fetch falls back to meta_subProvider when providers list is empty`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns
+            evmSwapResponse(providers = emptyList(), metaSubProvider = "GARDEN")
+
+        val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+        assertEquals("GARDEN", result.subProvider)
+    }
+
+    @Test
+    fun `fetch leaves subProvider null when neither providers list nor meta subProvider are present`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1")
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                evmSwapResponse(providers = emptyList(), metaSubProvider = null)
+
+            val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+            assertNull(result.subProvider)
+        }
+
+    @Test
     fun `fetch wraps unexpected exceptions as SwapKitError Network preserving the cause`() =
         runTest {
             every { config.isFeatureEnabled } returns flowOf(true)
-            coEvery { cache.isEnabled(any()) } returns true
             val boom = RuntimeException("DNS failure")
             coEvery { api.quote(any()) } throws boom
 
@@ -408,8 +521,18 @@ internal class SwapKitQuoteSourceTest {
             affiliateBps = affiliateBps,
         )
 
-    private fun route(routeId: String, providers: List<String>, expectedBuy: String? = "1") =
-        SwapKitRoute(routeId = routeId, providers = providers, expectedBuyAmount = expectedBuy)
+    private fun route(
+        routeId: String,
+        providers: List<String>,
+        expectedBuy: String? = "1",
+        fees: List<SwapKitFee> = emptyList(),
+    ) =
+        SwapKitRoute(
+            routeId = routeId,
+            providers = providers,
+            expectedBuyAmount = expectedBuy,
+            fees = fees,
+        )
 
     private fun evmSwapResponse(
         gas: String? = "200000",
@@ -419,6 +542,8 @@ internal class SwapKitQuoteSourceTest {
         data: String = "0xdata",
         value: String = "0",
         expectedBuy: String? = "1",
+        providers: List<String> = listOf("CHAINFLIP"),
+        metaSubProvider: String? = null,
     ) =
         SwapKitSwapResponseJson(
             swapId = "swap-id",
@@ -431,8 +556,9 @@ internal class SwapKitQuoteSourceTest {
                     gas?.let { put("gas", JsonPrimitive(it)) }
                     gasPrice?.let { put("gasPrice", JsonPrimitive(it)) }
                 },
-            meta = SwapKitTxMeta(txType = "EVM"),
+            meta = SwapKitTxMeta(txType = "EVM", subProvider = metaSubProvider),
             expectedBuyAmount = expectedBuy,
+            providers = providers,
         )
 
     private fun ethCoin() =
@@ -447,8 +573,6 @@ internal class SwapKitQuoteSourceTest {
             contractAddress = "",
             isNativeToken = true,
         )
-
-    private fun baseCoin() = ethCoin().copy(chain = Chain.Base)
 
     private fun solanaCoin() =
         Coin(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -50,7 +50,7 @@ internal class SwapKitQuoteSourceTest {
         every { config.isFeatureEnabled } returns flowOf(false)
 
         val error = assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
-        assertTrue(error.message!!.contains("flag", ignoreCase = true))
+        assertTrue(error.message?.contains("flag", ignoreCase = true) == true)
     }
 
     @Test
@@ -59,7 +59,7 @@ internal class SwapKitQuoteSourceTest {
         coEvery { cache.isEnabled(Chain.Ethereum) } returns false
 
         val error = assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
-        assertTrue(error.message!!.contains("source"))
+        assertTrue(error.message?.contains("source") == true)
     }
 
     @Test
@@ -70,7 +70,7 @@ internal class SwapKitQuoteSourceTest {
 
         val error =
             assertThrows<SwapKitError.NoRoutes> { source().fetch(request(dstToken = baseCoin())) }
-        assertTrue(error.message!!.contains("destination"))
+        assertTrue(error.message?.contains("destination") == true)
     }
 
     @Test
@@ -166,7 +166,10 @@ internal class SwapKitQuoteSourceTest {
 
         val result = source().fetch(request()) as SwapQuoteResult.Evm
 
-        assertEquals("42", result.data.dstAmount)
+        // dstToken is the default solanaCoin (9 decimals). SwapKit returns the decimal "42",
+        // and the source scales it to raw units so the downstream pipeline (which expects
+        // BigInteger-as-string) gets 42 * 10^9.
+        assertEquals("42000000000", result.data.dstAmount)
         assertEquals("0xfrom", result.data.tx.from)
         assertEquals("0xto", result.data.tx.to)
         assertEquals("0xdeadbeef", result.data.tx.data)
@@ -195,7 +198,68 @@ internal class SwapKitQuoteSourceTest {
         val result = source().fetch(request()) as SwapQuoteResult.Evm
 
         assertEquals("BASE64SOLANA", result.data.tx.data)
-        assertEquals("9", result.data.dstAmount)
+        // 9 SOL (9 decimals) scaled to raw lamports.
+        assertEquals("9000000000", result.data.dstAmount)
+    }
+
+    @Test
+    fun `fetch scales fractional expectedBuyAmount into raw destination units`() = runTest {
+        // Regression: SwapKit returns expectedBuyAmount as a human-readable decimal string
+        // ("42.5" USDC, "0.0086" ETH), but EVMSwapQuoteJson.dstAmount is consumed downstream as a
+        // BigInteger-as-string (raw units). Without scaling, "42.5".toBigIntegerOrNull() returns
+        // null and the consumer silently treats the receive amount as zero; "2500" would be
+        // interpreted as 0.0025 USDC instead of 2500 USDC. Both failure modes mislead the user.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "42.5")
+                    )
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse(expectedBuy = "42.5")
+
+        val usdc =
+            ethCoin()
+                .copy(
+                    ticker = "USDC",
+                    isNativeToken = false,
+                    contractAddress = "0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    decimal = 6,
+                )
+        val result = source().fetch(request(dstToken = usdc)) as SwapQuoteResult.Evm
+
+        // 42.5 USDC × 10^6 = 42_500_000 raw units.
+        assertEquals("42500000", result.data.dstAmount)
+    }
+
+    @Test
+    fun `fetch throws Decoding when expectedBuyAmount is missing`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse(expectedBuy = null)
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request()) }
+    }
+
+    @Test
+    fun `fetch throws Decoding when expectedBuyAmount is not a decimal`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse(expectedBuy = "not-a-number")
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request()) }
     }
 
     @Test
@@ -210,6 +274,7 @@ internal class SwapKitQuoteSourceTest {
             SwapKitSwapResponseJson(
                 tx = JsonObject(emptyMap()),
                 meta = SwapKitTxMeta(txType = "PSBT"),
+                expectedBuyAmount = "1",
             )
 
         assertThrows<SwapKitError.UnsupportedTxType> { source().fetch(request()) }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -1,0 +1,386 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import com.vultisig.wallet.data.api.errors.SwapKitError
+import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
+import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
+import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
+import com.vultisig.wallet.data.chains.helpers.EvmHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.math.BigInteger
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Pins the SwapKit quote-source contract: feature-flag and provider-cache gates short-circuit
+ * before network I/O, multi-hop / THORChain / Maya routes are filtered client-side, ranking picks
+ * the highest [SwapKitRoute.expectedBuyAmount], and Phase 1 EVM/Solana `meta.txType` responses are
+ * unwrapped into [com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson]. Anything else
+ * surfaces as a typed [SwapKitError] so the swap picker can fall back to another aggregator.
+ */
+internal class SwapKitQuoteSourceTest {
+
+    private val api: SwapKitApi = mockk()
+    private val cache: SwapKitProviderCache = mockk()
+    private val config: SwapKitConfig = mockk()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun source(): SwapKitQuoteSource = SwapKitQuoteSource(api, config, cache, json)
+
+    @Test
+    fun `fetch throws NoRoutes when feature flag is disabled`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(false)
+
+        val error = assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
+        assertTrue(error.message!!.contains("flag", ignoreCase = true))
+    }
+
+    @Test
+    fun `fetch throws NoRoutes when source chain is not enabled in cache`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(Chain.Ethereum) } returns false
+
+        val error = assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
+        assertTrue(error.message!!.contains("source"))
+    }
+
+    @Test
+    fun `fetch throws NoRoutes when destination chain is not enabled in cache`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(Chain.Ethereum) } returns true
+        coEvery { cache.isEnabled(Chain.Base) } returns false
+
+        val error =
+            assertThrows<SwapKitError.NoRoutes> { source().fetch(request(dstToken = baseCoin())) }
+        assertTrue(error.message!!.contains("destination"))
+    }
+
+    @Test
+    fun `fetch filters out multi-hop and Thor and Maya routes then picks highest expected amount`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { cache.isEnabled(any()) } returns true
+
+            val quoteRequest = slot<SwapKitQuoteRequest>()
+            val swapRequest = slot<SwapKitSwapRequest>()
+            coEvery { api.quote(capture(quoteRequest)) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "skip-thor",
+                                providers = listOf("THORCHAIN"),
+                                expectedBuy = "200",
+                            ),
+                            route(
+                                routeId = "skip-maya",
+                                providers = listOf("MAYACHAIN"),
+                                expectedBuy = "300",
+                            ),
+                            route(
+                                routeId = "skip-multihop",
+                                providers = listOf("CHAINFLIP", "NEAR"),
+                                expectedBuy = "500",
+                            ),
+                            route(
+                                routeId = "loser",
+                                providers = listOf("NEAR"),
+                                expectedBuy = "10",
+                            ),
+                            route(
+                                routeId = "winner",
+                                providers = listOf("CHAINFLIP"),
+                                expectedBuy = "100",
+                            ),
+                        )
+                )
+            coEvery { api.swap(capture(swapRequest)) } returns evmSwapResponse()
+
+            source().fetch(request())
+
+            assertEquals("winner", swapRequest.captured.routeId)
+        }
+
+    @Test
+    fun `fetch throws NoRoutes when every route is filtered out`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(routeId = "thor", providers = listOf("THORCHAIN")),
+                        route(routeId = "maya", providers = listOf("MAYA")),
+                        route(routeId = "multi", providers = listOf("CHAINFLIP", "NEAR")),
+                    )
+            )
+
+        assertThrows<SwapKitError.NoRoutes> { source().fetch(request()) }
+    }
+
+    @Test
+    fun `fetch maps EVM tx response into EVMSwapQuoteJson with gas defaults`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(
+                            routeId = "r-evm",
+                            providers = listOf("CHAINFLIP"),
+                            expectedBuy = "42",
+                        )
+                    )
+            )
+        // gas omitted in EVM tx — fetcher must fall back to the project's default swap gas unit so
+        // the downstream EVM signer never broadcasts a 0-gas transaction.
+        coEvery { api.swap(any()) } returns
+            evmSwapResponse(
+                gas = null,
+                gasPrice = "20",
+                from = "0xfrom",
+                to = "0xto",
+                data = "0xdeadbeef",
+                value = "1",
+                expectedBuy = "42",
+            )
+
+        val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+        assertEquals("42", result.data.dstAmount)
+        assertEquals("0xfrom", result.data.tx.from)
+        assertEquals("0xto", result.data.tx.to)
+        assertEquals("0xdeadbeef", result.data.tx.data)
+        assertEquals("1", result.data.tx.value)
+        assertEquals("20", result.data.tx.gasPrice)
+        assertEquals(EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT, result.data.tx.gas)
+    }
+
+    @Test
+    fun `fetch maps Solana tx response into EVMSwapQuoteJson with base64 in data`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r-sol", providers = listOf("NEAR"), expectedBuy = "9"))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "swap-1",
+                tx = buildJsonObject { put("swapTransaction", JsonPrimitive("BASE64SOLANA")) },
+                meta = SwapKitTxMeta(txType = "SOLANA"),
+                expectedBuyAmount = "9",
+            )
+
+        val result = source().fetch(request()) as SwapQuoteResult.Evm
+
+        assertEquals("BASE64SOLANA", result.data.tx.data)
+        assertEquals("9", result.data.dstAmount)
+    }
+
+    @Test
+    fun `fetch throws UnsupportedTxType for non-EVM, non-Solana txType`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-psbt", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonObject(emptyMap()),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+            )
+
+        assertThrows<SwapKitError.UnsupportedTxType> { source().fetch(request()) }
+    }
+
+    @Test
+    fun `fetch sends decimal sellAmount and dotted CHAIN-TICKER asset identifiers`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+
+        val captured = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(captured)) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        // 0.0086 ETH = 8_600_000_000_000_000 wei (18 decimals).
+        val src = ethCoin().copy(isNativeToken = true)
+        source()
+            .fetch(
+                request(
+                    srcToken = src,
+                    tokenValue = TokenValue(value = BigInteger("8600000000000000"), token = src),
+                )
+            )
+
+        assertEquals("ETH.ETH", captured.captured.sellAsset)
+        // Trailing-zero stripping verifies the formatter — bug-prone if the wei → decimal
+        // conversion accidentally keeps full precision and SwapKit reads it as a larger number.
+        assertEquals("0.0086", captured.captured.sellAmount)
+    }
+
+    @Test
+    fun `fetch encodes ERC-20 token asset as CHAIN-TICKER-CONTRACT`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+
+        val captured = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(captured)) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        val usdc =
+            ethCoin()
+                .copy(
+                    ticker = "USDC",
+                    isNativeToken = false,
+                    contractAddress = "0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    decimal = 6,
+                )
+        source()
+            .fetch(
+                request(
+                    srcToken = usdc,
+                    tokenValue = TokenValue(value = BigInteger("10000000"), token = usdc),
+                )
+            )
+
+        assertEquals(
+            "ETH.USDC-0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            captured.captured.sellAsset,
+        )
+        assertEquals("10", captured.captured.sellAmount)
+    }
+
+    @Test
+    fun `fetch passes affiliateBps from the request through to the SwapKit quote call`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { cache.isEnabled(any()) } returns true
+
+        val captured = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(captured)) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        source().fetch(request(affiliateBps = 25))
+
+        assertEquals(25, captured.captured.affiliateFee)
+        coVerify(exactly = 1) { api.quote(any()) }
+        coVerify(exactly = 1) { api.swap(any()) }
+    }
+
+    @Test
+    fun `fetch wraps unexpected exceptions as SwapKitError Network preserving the cause`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { cache.isEnabled(any()) } returns true
+            val boom = RuntimeException("DNS failure")
+            coEvery { api.quote(any()) } throws boom
+
+            val error = assertThrows<SwapKitError.Network> { source().fetch(request()) }
+            assertEquals(boom, error.cause)
+        }
+
+    // ---- helpers ----
+
+    private fun request(
+        srcToken: Coin = ethCoin(),
+        dstToken: Coin = solanaCoin(),
+        tokenValue: TokenValue = TokenValue(value = BigInteger.ONE, token = srcToken),
+        affiliateBps: Int = 0,
+    ) =
+        SwapQuoteRequest(
+            srcToken = srcToken,
+            dstToken = dstToken,
+            tokenValue = tokenValue,
+            srcAddress = "0xsrc",
+            dstAddress = "0xdst",
+            affiliateBps = affiliateBps,
+        )
+
+    private fun route(routeId: String, providers: List<String>, expectedBuy: String? = "1") =
+        SwapKitRoute(routeId = routeId, providers = providers, expectedBuyAmount = expectedBuy)
+
+    private fun evmSwapResponse(
+        gas: String? = "200000",
+        gasPrice: String? = "10",
+        from: String? = "0xfrom",
+        to: String = "0xto",
+        data: String = "0xdata",
+        value: String = "0",
+        expectedBuy: String? = "1",
+    ) =
+        SwapKitSwapResponseJson(
+            swapId = "swap-id",
+            tx =
+                buildJsonObject {
+                    from?.let { put("from", JsonPrimitive(it)) }
+                    put("to", JsonPrimitive(to))
+                    put("data", JsonPrimitive(data))
+                    put("value", JsonPrimitive(value))
+                    gas?.let { put("gas", JsonPrimitive(it)) }
+                    gasPrice?.let { put("gasPrice", JsonPrimitive(it)) }
+                },
+            meta = SwapKitTxMeta(txType = "EVM"),
+            expectedBuyAmount = expectedBuy,
+        )
+
+    private fun ethCoin() =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xsrc",
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "eth",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun baseCoin() = ethCoin().copy(chain = Chain.Base)
+
+    private fun solanaCoin() =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "",
+            address = "soldest",
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+}


### PR DESCRIPTION
## Summary

Task 2/5 of the SwapKit Android port — ports the iOS [#4394](https://github.com/vultisig/vultisig-ios/pull/4394) `SwapKitService` + Phase 1 wiring on top of #4619's client/cache/config foundation. **Base is `feature/swapkit`, not `main`** — diff is purely additive against task 1/5.

### What's in
- `SwapKitQuoteSource` — feature-flag + provider-cache gates, `/v3/quote` + `/v3/swap` two-step orchestrator, multi-hop / THORChain / Maya client-side filtering (Vultisig pays those affiliates directly via the existing native integrations, so routing through SwapKit would stack a second affiliate fee), rank-by-`expectedBuyAmount` picker, EVM/Solana `meta.txType` unwrap into the existing `EVMSwapQuoteJson` envelope.
- `SwapProvider.SWAPKIT` enum + display id + wire-id parsing. Phase 1 EVM/Solana routes ride the existing `oneinchSwapPayload` proto with `provider="swapkit"` as the discriminator (matches iOS — `SwapPayload.swift` comment: *"EVM and Solana SwapKit swaps still ride .generic since their wire shape matches OneInchSwapPayload 1:1"*).
- `SwapProviderTable` lists SwapKit alongside the existing EVM aggregators on ETH / BSC / AVAX / ARB / BASE / OP / POL plus Solana.
- `SwapQuoteManager` dispatch + a `swap_for_provider_swapkit` brand string (translatable=false, matches the other provider entries).
- Hilt `@IntoMap` binding for `SwapKitQuoteSource` in `RepositoriesModule`.

### What's deliberately out of scope (later tasks)
- Non-EVM signers (BTC PSBT, TRON, TON, SUI, ADA, DOGE/BCH/DASH/ZEC, XRP)
- `/track` polling + tx-history status
- Universal coin picker via `/v3/tokens`
- Tier-discounted affiliate fee (formula `max(0, min(1000, 50 - vultTierDiscount))`)
- `SwapKitSwapPayload` proto + the `SwapPayload.SwapKit` Kotlin variant — only needed once non-EVM signing lands. **No commondata bump in this PR.**

### Overlap with #4619
None. PR #4619 introduced `SwapKitApi`, the three DTO files, `SwapKitError`, `SwapKitConfig`, `SwapKitProviderCache`, their Hilt bindings, the settings toggle and locale strings; this PR **consumes** that surface and adds the quote source layered on top. The only shared file is `RepositoriesModule.kt` (each PR adds its own bindings — no line-level conflict because my branch is based on `feature/swapkit`).

## Which feature is affected?
- [x] Swap — adds SwapKit as a candidate aggregator (gated behind the existing default-off feature flag and the `/providers` cache)

## Verification
- [x] `./gradlew :data:compileDebugKotlin :app:compileDebugKotlin` — green
- [x] `./gradlew :data:test :app:testDebugUnitTest` — green
- [x] `./gradlew ktfmtCheck` — green
- [x] `./gradlew :app:lintDebug` — green
- [x] 12 new `SwapKitQuoteSourceTest` cases pin: feature-flag + cache gates, multi-hop / Thor / Maya filtering, ranking by `expectedBuyAmount`, asset-identifier formatting (`CHAIN.TICKER` / `CHAIN.TICKER-CONTRACT`, dotted decimal `sellAmount`, trailing-zero stripping so "1.0000" → "1"), EVM tx unwrap with gas defaults, Solana base64 in `data` field, `UnsupportedTxType` for non-Phase-1 `meta.txType`, exception → `SwapKitError.Network` wrapping with cause preservation, and `affiliateBps` passthrough.

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works

## Agent Metadata
- **Agent**: Claude Code (Opus 4.7, 1M context)
- **Issue**: parity port of vultisig-ios#4394 (Phase 1 quote-source slice)
- **Confidence**: medium-high — Phase 1 EVM/Solana parity verified by tests; live route fetch needs flag-on smoke test by a maintainer with proxy credentials
- **Needs human review for**: SwapKit quote-source contract assumptions (especially `formatSellAmount` decimals and the `expectedBuyAmount` ranking), Hilt graph layout, and the `SwapProviderTable` decision to include SwapKit unconditionally for in-cache chains (vs. gating at the table level too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SwapKit as a new swap provider for token exchanges
  * SwapKit support enabled across multiple blockchain networks including EVM chains and Solana

* **Tests**
  * Added comprehensive test coverage for SwapKit quote sourcing and transaction handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->