### PR TITLE
feat(swap): SwapKit non-EVM payload foundation — proto round-trip + sealed-class plumbing

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -617,9 +617,6 @@ constructor(
                         is SwapPayload.EVM ->
                             swapProviderFromWireId(swapPayload.data.provider)?.getSwapProviderId()
                                 ?: swapPayload.data.provider
-                        // Verbatim sub-provider (CHAINFLIP / NEAR / GARDEN / …) — matches iOS'
-                        // SwapPayload.providerName so the joining peer sees the same routing
-                        // context the initiator saw at quote time.
                         is SwapPayload.SwapKit ->
                             formatSwapKitProviderLabel(swapPayload.data.subProvider)
                     }
@@ -865,12 +862,8 @@ constructor(
                     }
 
                     is SwapPayload.SwapKit -> {
-                        // Non-EVM SwapKit routes (TON / PSBT / SUI / Cardano / TRON). The
-                        // initiator's per-leg fee surface lived on route.fees[] and isn't
-                        // re-fetched at join time — display zero provider fee here and rely on
-                        // the network gas estimate for the verify row. The signing path itself
-                        // reads payload.swapPayload (cross-device wire shape, proto field 26)
-                        // plus chain-specific dispatch (e.g. payload.signTon for TON).
+                        // Zero provider fee — the initiator's per-leg `fees[]` isn't re-fetched
+                        // at join time; the network gas estimate carries the cost.
                         val swapTransactionUiModel =
                             buildSwapUiModel(
                                 srcToken = srcToken,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -87,6 +87,7 @@ import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
+import com.vultisig.wallet.ui.models.swap.formatSwapKitSubProvider
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -616,6 +617,16 @@ constructor(
                         is SwapPayload.EVM ->
                             swapProviderFromWireId(swapPayload.data.provider)?.getSwapProviderId()
                                 ?: swapPayload.data.provider
+                        // Surface the SwapKit sub-provider (Chainflip / NEAR / Garden / Flashnet)
+                        // in the join-flow verify row when present so the joining peer sees the
+                        // same routing context the initiator saw at quote time.
+                        is SwapPayload.SwapKit -> {
+                            val baseLabel = SwapProvider.SWAPKIT.getSwapProviderId()
+                            swapPayload.data.subProvider
+                                .takeIf { it.isNotBlank() }
+                                ?.let { "$baseLabel (${formatSwapKitSubProvider(it)})" }
+                                ?: baseLabel
+                        }
                     }
 
                 when (swapPayload) {
@@ -844,6 +855,37 @@ constructor(
                                 provider = provider,
                                 providerFee = quote.fees,
                                 providerFeeToken = dstToken,
+                                currency = currency,
+                            )
+                        transactionTypeUiModel = TransactionTypeUiModel.Swap(swapTransactionUiModel)
+                        transactionHistoryData =
+                            mapSwapTransactionToHistoryData(swapTransactionUiModel)
+                        verifyUiModel.value =
+                            VerifyUiModel.Swap(
+                                VerifySwapUiModel(
+                                    tx = swapTransactionUiModel,
+                                    vaultName = vaultName,
+                                )
+                            )
+                    }
+
+                    is SwapPayload.SwapKit -> {
+                        // Non-EVM SwapKit routes (TON / PSBT / SUI / Cardano / TRON). The
+                        // initiator's per-leg fee surface lived on route.fees[] and isn't
+                        // re-fetched at join time — display zero provider fee here and rely on
+                        // the network gas estimate for the verify row. The signing path itself
+                        // reads payload.swapPayload (cross-device wire shape, proto field 26)
+                        // plus chain-specific dispatch (e.g. payload.signTon for TON).
+                        val swapTransactionUiModel =
+                            buildSwapUiModel(
+                                srcToken = srcToken,
+                                srcTokenValue = srcTokenValue,
+                                dstToken = dstToken,
+                                dstTokenValue = dstTokenValue,
+                                estimatedNetworkGasFee = estimatedNetworkGasFee,
+                                provider = provider,
+                                providerFee = TokenValue(value = BigInteger.ZERO, token = srcToken),
+                                providerFeeToken = srcToken,
                                 currency = currency,
                             )
                         transactionTypeUiModel = TransactionTypeUiModel.Swap(swapTransactionUiModel)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -87,7 +87,7 @@ import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
-import com.vultisig.wallet.ui.models.swap.formatSwapKitSubProvider
+import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -617,16 +617,11 @@ constructor(
                         is SwapPayload.EVM ->
                             swapProviderFromWireId(swapPayload.data.provider)?.getSwapProviderId()
                                 ?: swapPayload.data.provider
-                        // Surface the SwapKit sub-provider (Chainflip / NEAR / Garden / Flashnet)
-                        // in the join-flow verify row when present so the joining peer sees the
-                        // same routing context the initiator saw at quote time.
-                        is SwapPayload.SwapKit -> {
-                            val baseLabel = SwapProvider.SWAPKIT.getSwapProviderId()
-                            swapPayload.data.subProvider
-                                .takeIf { it.isNotBlank() }
-                                ?.let { "$baseLabel (${formatSwapKitSubProvider(it)})" }
-                                ?: baseLabel
-                        }
+                        // Verbatim sub-provider (CHAINFLIP / NEAR / GARDEN / …) — matches iOS'
+                        // SwapPayload.providerName so the joining peer sees the same routing
+                        // context the initiator saw at quote time.
+                        is SwapPayload.SwapKit ->
+                            formatSwapKitProviderLabel(swapPayload.data.subProvider)
                     }
 
                 when (swapPayload) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -34,6 +34,10 @@ constructor(
                 is SwapPayload.EVM ->
                     SwapProvider.entries.find { it.getSwapProviderId() == payload.data.provider }
                         ?: error("Unknown EVM provider: ${payload.data.provider}")
+                // Non-EVM SwapKit routes (TON / BTC PSBT / SUI / Cardano / TRON / ZEC) all carry
+                // SwapProvider.SWAPKIT — sub-provider disambiguation (Chainflip / NEAR / Garden)
+                // lives on the payload's data.subProvider but isn't a SwapProvider enum value.
+                is SwapPayload.SwapKit -> SwapProvider.SWAPKIT
             }
 
         val tokenValue =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -34,9 +34,6 @@ constructor(
                 is SwapPayload.EVM ->
                     SwapProvider.entries.find { it.getSwapProviderId() == payload.data.provider }
                         ?: error("Unknown EVM provider: ${payload.data.provider}")
-                // Non-EVM SwapKit routes (TON / BTC PSBT / SUI / Cardano / TRON / ZEC) all carry
-                // SwapProvider.SWAPKIT — sub-provider disambiguation (Chainflip / NEAR / Garden)
-                // lives on the payload's data.subProvider but isn't a SwapProvider enum value.
                 is SwapPayload.SwapKit -> SwapProvider.SWAPKIT
             }
 
@@ -48,8 +45,6 @@ constructor(
 
                 SwapProvider.ONEINCH,
                 SwapProvider.KYBER,
-                // SwapKit (Phase 1 EVM/Solana) pays the inbound fee in the source chain's native
-                // gas token — same shape as 1inch/Kyber, not the LiFi destination-side model.
                 SwapProvider.SWAPKIT -> tokenRepository.getNativeToken(from.srcToken.chain.id)
 
                 SwapProvider.JUPITER -> from.srcToken

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -472,6 +472,19 @@ constructor(
                                 )
                             }
 
+                            // Non-EVM SwapKit quotes (TON / PSBT / SUI / Cardano / TRON / ZEC)
+                            // can't reach this branch yet — no SwapQuoteSource emits
+                            // SwapQuote.SwapKit in this PR, the wiring lands per-chain with each
+                            // signer's PR. The branch exists here purely to satisfy the
+                            // exhaustive when so the foundation can compile without forcing a
+                            // half-finished per-chain build path.
+                            is SwapQuote.SwapKit ->
+                                error(
+                                    "SwapQuote.SwapKit reached SwapFormViewModel build path " +
+                                        "before its chain-specific signer was wired " +
+                                        "(txType=${quote.data.txType})"
+                                )
+
                             is SwapQuote.OneInch -> {
                                 val dstAddress = quote.data.tx.to
                                 val specificAndUtxo =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -472,18 +472,10 @@ constructor(
                                 )
                             }
 
-                            // Non-EVM SwapKit quotes (TON / PSBT / SUI / Cardano / TRON / ZEC)
-                            // can't reach this branch yet — no SwapQuoteSource emits
-                            // SwapQuote.SwapKit in this PR, the wiring lands per-chain with each
-                            // signer's PR. The branch exists here purely to satisfy the
-                            // exhaustive when so the foundation can compile without forcing a
-                            // half-finished per-chain build path.
+                            // Per-chain signers wire this branch as they ship; no quote source
+                            // emits SwapQuote.SwapKit yet.
                             is SwapQuote.SwapKit ->
-                                error(
-                                    "SwapQuote.SwapKit reached SwapFormViewModel build path " +
-                                        "before its chain-specific signer was wired " +
-                                        "(txType=${quote.data.txType})"
-                                )
+                                error("No SwapKit signer wired for txType=${quote.data.txType}")
 
                             is SwapQuote.OneInch -> {
                                 val dstAddress = quote.data.tx.to

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
@@ -1,0 +1,16 @@
+package com.vultisig.wallet.ui.models.swap
+
+/**
+ * Render a SwapKit sub-provider id (`CHAINFLIP`, `near_intents`, `flashnet`) into a display label
+ * fragment used in `SwapKit (<sub-provider>)` UI strings. Replaces `_` / `-` with spaces and
+ * title-cases each token so `near_intents` → `Near Intents`; brand names already in mixed/upper
+ * case are left intact (`CHAINFLIP` → `Chainflip` — first letter only is canonicalised).
+ *
+ * Lives at app-module scope because both [SwapQuoteManager.fetchSwapKitQuote] (initiator path) and
+ * [com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel] (peer-side verify row) display the
+ * sub-provider, and both rely on the same canonicalisation for visual consistency.
+ */
+internal fun formatSwapKitSubProvider(raw: String): String =
+    raw.split('_', '-').joinToString(" ") { token ->
+        token.replaceFirstChar { ch -> if (ch.isLowerCase()) ch.titlecase() else ch.toString() }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
@@ -1,16 +1,17 @@
 package com.vultisig.wallet.ui.models.swap
 
 /**
- * Render a SwapKit sub-provider id (`CHAINFLIP`, `near_intents`, `flashnet`) into a display label
- * fragment used in `SwapKit (<sub-provider>)` UI strings. Replaces `_` / `-` with spaces and
- * title-cases each token so `near_intents` → `Near Intents`; brand names already in mixed/upper
- * case are left intact (`CHAINFLIP` → `Chainflip` — first letter only is canonicalised).
+ * Build the SwapKit provider label shown on verify rows and history entries: `SwapKit` when no
+ * sub-provider is known, `SwapKit (<sub-provider>)` otherwise. The sub-provider token is rendered
+ * **verbatim** from the wire value (`CHAINFLIP`, `NEAR`, `GARDEN`, …) to match iOS'
+ * `SwapPayload.providerName` (`SwapPayload.swift:101`), `SwapQuote.displayName`
+ * (`SwapQuote.swift:89`), and `TransactionHistoryRecorder.recordSwap`
+ * (`TransactionHistoryRecorder.swift:202`) — all three iOS call sites embed the raw
+ * `payload.subProvider` directly so cross-platform users see the same label.
  *
  * Lives at app-module scope because both [SwapQuoteManager.fetchSwapKitQuote] (initiator path) and
- * [com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel] (peer-side verify row) display the
- * sub-provider, and both rely on the same canonicalisation for visual consistency.
+ * [com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel] (peer-side verify row) render the
+ * label, and they must agree byte-for-byte.
  */
-internal fun formatSwapKitSubProvider(raw: String): String =
-    raw.split('_', '-').joinToString(" ") { token ->
-        token.replaceFirstChar { ch -> if (ch.isLowerCase()) ch.titlecase() else ch.toString() }
-    }
+internal fun formatSwapKitProviderLabel(subProvider: String?): String =
+    if (subProvider.isNullOrBlank()) "SwapKit" else "SwapKit ($subProvider)"

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapKitDisplay.kt
@@ -1,17 +1,8 @@
 package com.vultisig.wallet.ui.models.swap
 
 /**
- * Build the SwapKit provider label shown on verify rows and history entries: `SwapKit` when no
- * sub-provider is known, `SwapKit (<sub-provider>)` otherwise. The sub-provider token is rendered
- * **verbatim** from the wire value (`CHAINFLIP`, `NEAR`, `GARDEN`, …) to match iOS'
- * `SwapPayload.providerName` (`SwapPayload.swift:101`), `SwapQuote.displayName`
- * (`SwapQuote.swift:89`), and `TransactionHistoryRecorder.recordSwap`
- * (`TransactionHistoryRecorder.swift:202`) — all three iOS call sites embed the raw
- * `payload.subProvider` directly so cross-platform users see the same label.
- *
- * Lives at app-module scope because both [SwapQuoteManager.fetchSwapKitQuote] (initiator path) and
- * [com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel] (peer-side verify row) render the
- * label, and they must agree byte-for-byte.
+ * `SwapKit` or `SwapKit (<sub-provider>)`. The sub-provider is rendered verbatim from the wire so
+ * the label matches what iOS shows for the same payload — `CHAINFLIP` / `NEAR` / `GARDEN`.
  */
 internal fun formatSwapKitProviderLabel(subProvider: String?): String =
     if (subProvider.isNullOrBlank()) "SwapKit" else "SwapKit ($subProvider)"

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -644,20 +644,10 @@ constructor(
         val providerLabel =
             resolvedSubProvider
                 ?.takeIf { it.isNotBlank() }
-                ?.let { sub -> "SwapKit (${formatSubProvider(sub)})".asUiText() }
+                ?.let { sub -> "SwapKit (${formatSwapKitSubProvider(sub)})".asUiText() }
                 ?: R.string.swap_for_provider_swapkit.asUiText()
         return swapQuote to providerLabel
     }
-
-    /**
-     * Render a SwapKit sub-provider id (`CHAINFLIP`, `near_intents`, `flashnet`) into a display
-     * label. Replaces underscores with spaces and title-cases each token so `near_intents` → `Near
-     * Intents`; brand names already in mixed/upper case are left alone.
-     */
-    private fun formatSubProvider(raw: String): String =
-        raw.split('_', '-').joinToString(" ") { token ->
-            token.replaceFirstChar { ch -> if (ch.isLowerCase()) ch.titlecase() else ch.toString() }
-        }
 
     private suspend fun resolveSwapFee(
         swapFeeTokenContract: String,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -165,10 +165,8 @@ constructor(
                 SwapProvider.MAYA,
                 SwapProvider.THORCHAIN,
                 SwapProvider.LIFI -> dstToken
-                // SwapKit's inbound (source-chain) fee is denominated in the source's native gas
-                // token — mirrors 1inch / Kyber / Jupiter rather than the LiFi destination-side
-                // integrator-fee model. SwapKitQuoteSource already pulls the inbound amount out of
-                // route.fees[] and stages it on tx.swapFee (raw units) for resolveSwapFee below.
+                // SwapKit inbound fee is source-native (like 1inch/Kyber/Jupiter, not LiFi's
+                // destination-side integrator model).
                 SwapProvider.SWAPKIT -> srcNativeToken
                 else -> srcNativeToken
             }
@@ -614,13 +612,10 @@ constructor(
                                 ),
                         token = dstToken,
                     )
-                // SwapKit's canonical source-chain fee is the `fees[]` entry with type=="inbound"
-                // for the source chain — the source layer already extracts that and stages it on
-                // `tx.swapFee` (raw units in source-native) with `swapFeeTokenContract = ""`. The
-                // empty-contract branch of resolveSwapFee returns the fallback in srcNativeToken,
-                // so pass the parsed swapFee as the fallback (mirrors Kyber's call at line 435
-                // which passes gasFees) — otherwise the source-extracted inbound fee is silently
-                // discarded and the verify screen renders $0 Network Fee.
+                // The source layer stages the inbound fee on tx.swapFee with an empty token
+                // contract; resolveSwapFee's empty-contract branch returns the fallback. Pass the
+                // parsed swapFee as fallback so an empty contract doesn't discard the fee and
+                // render $0 Network Fee.
                 val swapKitInboundFee = apiQuote.tx.swapFee.toBigIntegerOrNull() ?: BigInteger.ZERO
                 val (feeAmount, feeCoin) =
                     resolveSwapFee(
@@ -641,9 +636,6 @@ constructor(
                     provider = SwapProvider.SWAPKIT.getSwapProviderId(),
                 )
             }
-        // Verbatim sub-provider in the label — matches iOS' SwapPayload.providerName /
-        // SwapQuote.displayName so cross-platform users see the same `SwapKit (CHAINFLIP)` /
-        // `SwapKit (NEAR)` string.
         val providerLabel =
             if (resolvedSubProvider.isNullOrBlank()) R.string.swap_for_provider_swapkit.asUiText()
             else formatSwapKitProviderLabel(resolvedSubProvider).asUiText()
@@ -776,8 +768,7 @@ constructor(
 
     companion object {
         private const val KYBER_AFFILIATE_FEE_BPS = 50
-        // Mirrors iOS' SwapKit milestone: 50 bps base affiliate, discounted by the user's
-        // vultTierDiscount, clamped to SwapKit's documented 0..1000 bps (0..10%) range.
+        /** Base bps before tier discount; clamped to SwapKit's documented 0..1000 range. */
         private const val SWAPKIT_AFFILIATE_FEE_BPS = 50
         private const val NATIVE_TOKEN_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         private const val QUOTE_FETCH_TIMEOUT_MS = 15_000L

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -641,11 +641,12 @@ constructor(
                     provider = SwapProvider.SWAPKIT.getSwapProviderId(),
                 )
             }
+        // Verbatim sub-provider in the label — matches iOS' SwapPayload.providerName /
+        // SwapQuote.displayName so cross-platform users see the same `SwapKit (CHAINFLIP)` /
+        // `SwapKit (NEAR)` string.
         val providerLabel =
-            resolvedSubProvider
-                ?.takeIf { it.isNotBlank() }
-                ?.let { sub -> "SwapKit (${formatSwapKitSubProvider(sub)})".asUiText() }
-                ?: R.string.swap_for_provider_swapkit.asUiText()
+            if (resolvedSubProvider.isNullOrBlank()) R.string.swap_for_provider_swapkit.asUiText()
+            else formatSwapKitProviderLabel(resolvedSubProvider).asUiText()
         return swapQuote to providerLabel
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -95,9 +95,8 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                             SwapPayload.MayaChain(it.toThorChainSwapPayload())
                         }
 
-                    // SwapKit non-EVM-shaped routes (BTC PSBT / TON / ADA / TRON / SUI / ZEC /
-                    // …). Proto field 26 (commondata #86). EVM/Solana SwapKit routes round-trip
-                    // via `oneinchSwapPayload` above with `provider="swapkit"` discriminator.
+                    // EVM/Solana SwapKit round-trip via `oneinchSwapPayload` above with
+                    // `provider="swapkit"`; this branch is for non-EVM shapes only.
                     from.swapkitSwapPayload != null ->
                         from.swapkitSwapPayload.let { it ->
                             SwapPayload.SwapKit(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.DAppMetadata
@@ -92,6 +93,28 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                     from.mayachainSwapPayload != null ->
                         from.mayachainSwapPayload.let {
                             SwapPayload.MayaChain(it.toThorChainSwapPayload())
+                        }
+
+                    // SwapKit non-EVM-shaped routes (BTC PSBT / TON / ADA / TRON / SUI / ZEC /
+                    // …). Proto field 26 (commondata #86). EVM/Solana SwapKit routes round-trip
+                    // via `oneinchSwapPayload` above with `provider="swapkit"` discriminator.
+                    from.swapkitSwapPayload != null ->
+                        from.swapkitSwapPayload.let { it ->
+                            SwapPayload.SwapKit(
+                                SwapKitSwapPayloadJson(
+                                    fromCoin = requireNotNull(it.fromCoin).toCoin(),
+                                    toCoin = requireNotNull(it.toCoin).toCoin(),
+                                    fromAmount = BigInteger(it.fromAmount),
+                                    toAmountDecimal = BigDecimal(it.toAmountDecimal),
+                                    txType = it.txType,
+                                    txPayload = it.txPayload,
+                                    targetAddress = it.targetAddress,
+                                    inboundAddress = it.inboundAddress,
+                                    memo = it.memo,
+                                    subProvider = it.subProvider,
+                                    swapId = it.swapId,
+                                )
+                            )
                         }
 
                     else -> null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -231,6 +231,27 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         provider = from.provider,
                     )
                 } else null,
+            // SwapKit non-EVM-shaped routes (BTC PSBT, TON transfer array, ADA CBOR, TRON
+            // TronWeb object, SUI PTB, ZEC Sapling, etc.) — proto field 26 added via commondata
+            // PR #86. EVM and Solana SwapKit routes ride oneinchSwapPayload above with
+            // provider="swapkit", so this branch is non-empty only for non-EVM tx types.
+            swapkitSwapPayload =
+                if (swapPayload is SwapPayload.SwapKit) {
+                    val from = swapPayload.data
+                    vultisig.keysign.v1.SwapKitSwapPayload(
+                        fromCoin = from.fromCoin.toCoinProto(),
+                        toCoin = from.toCoin.toCoinProto(),
+                        fromAmount = from.fromAmount.toString(),
+                        toAmountDecimal = from.toAmountDecimal.toPlainString(),
+                        txType = from.txType,
+                        txPayload = from.txPayload,
+                        targetAddress = from.targetAddress,
+                        inboundAddress = from.inboundAddress,
+                        memo = from.memo,
+                        subProvider = from.subProvider,
+                        swapId = from.swapId,
+                    )
+                } else null,
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,
             erc20ApprovePayload =
                 if (approvePayload is ERC20ApprovePayload) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -231,10 +231,8 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         provider = from.provider,
                     )
                 } else null,
-            // SwapKit non-EVM-shaped routes (BTC PSBT, TON transfer array, ADA CBOR, TRON
-            // TronWeb object, SUI PTB, ZEC Sapling, etc.) — proto field 26 added via commondata
-            // PR #86. EVM and Solana SwapKit routes ride oneinchSwapPayload above with
-            // provider="swapkit", so this branch is non-empty only for non-EVM tx types.
+            // EVM/Solana SwapKit ride oneinchSwapPayload above with provider="swapkit"; this
+            // carries non-EVM shapes only.
             swapkitSwapPayload =
                 if (swapPayload is SwapPayload.SwapKit) {
                     val from = swapPayload.data

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -4,76 +4,31 @@ import java.math.BigDecimal
 import java.math.BigInteger
 
 /**
- * Kotlin-side mirror of `vultisig.keysign.v1.SwapKitSwapPayload` (proto field 26 in the
- * `KeysignPayload.swap_payload` oneof, landed via commondata #86). Carries SwapKit-routed swaps
- * whose wire shape doesn't fit [EVMSwapPayloadJson] — Phase 2 ships BTC PSBT here; later phases add
- * TON / TRON / SUI / Cardano.
- *
- * The flexibility lives in [txPayload] (raw bytes, opaque to commondata) and [txType] (a string
- * discriminator the keysign-side dispatcher uses to pick the right per-chain signer). New SwapKit
- * chains land without a proto bump — just a new [txType] value plus a per-chain signer on each
- * client. Peers that don't recognise a [txType] MUST fall through to an "unsupported provider" UI
- * rather than crash decode.
+ * SwapKit-routed swap whose wire shape doesn't fit [EVMSwapPayloadJson] — BTC PSBT, TON transfer
+ * array, ADA CBOR, TRON object, SUI PTB. [txType] is the discriminator the signing-side dispatcher
+ * uses to pick the per-chain signer. Peers that don't recognise a [txType] MUST fall through to an
+ * "unsupported provider" UI rather than crash.
  */
 data class SwapKitSwapPayloadJson(
     val fromCoin: Coin,
     val toCoin: Coin,
     val fromAmount: BigInteger,
     val toAmountDecimal: BigDecimal,
-
-    /**
-     * SwapKit's `meta.txType` verbatim. Drives the peer-side dispatcher:
-     * - `"PSBT"` — [txPayload] is the base64-decoded BTC PSBT (BIP-174 SegWit).
-     * - `"PSBT_DOGE"` / `"PSBT_BCH"` / `"PSBT_DASH"` / `"PSBT_ZEC"` — legacy / Sapling variants.
-     * - `"TRON"` — [txPayload] is UTF-8 bytes of the canonical JSON of the TronWeb tx.
-     * - `"TON"` — [txPayload] is UTF-8 bytes of the canonical JSON of the transfer array.
-     * - `"SUI"` — [txPayload] is the base64-decoded Sui PTB.
-     * - `"CARDANO"` — [txPayload] is empty; routing via [targetAddress] + [fromAmount].
-     * - `"CARDANO_PREBUILT"` — [txPayload] is the raw CBOR transaction envelope.
-     */
+    /** `meta.txType` verbatim — `PSBT`, `TON`, `SUI`, `CARDANO`, `CARDANO_PREBUILT`, `TRON`, … */
     val txType: String,
-
-    /**
-     * Raw unsigned-transaction bytes returned by `POST /v3/swap`. Bytes (not string) so binary
-     * payloads (PSBT, PTB, CBOR) round-trip via protobuf without re-encoding. Object-shaped
-     * payloads (TRON, TON) are JSON-encoded on the initiator and decoded on the peer.
-     */
+    /** Unsigned-tx bytes; binary for PSBT/PTB/CBOR, UTF-8 canonical JSON for TON/TRON. */
     val txPayload: ByteArray,
-
-    /**
-     * Deposit address on the source chain. For PSBT this duplicates info also encoded inside
-     * [txPayload]; for deposit-only chains (Cardano) this is the only routing info available.
-     */
+    /** Source-chain deposit address. For deposit-only chains (Cardano) the only routing info. */
     val targetAddress: String,
-
-    /**
-     * THORChain-style inbound vault address. Populated only for routes that go through TC-style
-     * inbound monitoring. Rare in SwapKit since we filter THORChain/Maya client-side; kept for
-     * forward compatibility.
-     */
+    /** THORChain-style inbound vault — rare since we filter Thor/Maya client-side. */
     val inboundAddress: String? = null,
-
-    /**
-     * Optional memo. SwapKit V3 returned null for every chain observed; kept for forward compat.
-     */
     val memo: String? = null,
-
-    /**
-     * Sub-provider tag for the verify screen (`"CHAINFLIP"`, `"NEAR"`, `"GARDEN"`, `"FLASHNET"`,
-     * `"HARBOR"`). Verbatim from `route.providers[0]` in the `/v3/quote` response.
-     */
+    /** Sub-protocol tag from `route.providers[0]` — `CHAINFLIP`, `NEAR`, `GARDEN`, … */
     val subProvider: String = "",
-
-    /**
-     * SwapKit swap identifier — persisted for tracking and analytics. Does not participate in
-     * signing. NOT accepted by `POST /track` — tracking still keys off the broadcast hash + source
-     * chain id.
-     */
+    /** Persisted for analytics; not accepted by `/track` (keys off broadcast hash + chain id). */
     val swapId: String = "",
 ) {
-    // Data class auto-generates equals/hashCode/copy, but the default equals on ByteArray uses
-    // reference equality. Override so two payloads with identical bytes compare equal — matters
-    // for tests pinning round-trip behaviour and for the no-op write detection in caches.
+    // Override equals/hashCode so the ByteArray field compares by content (default is reference).
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -1,0 +1,108 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * Kotlin-side mirror of `vultisig.keysign.v1.SwapKitSwapPayload` (proto field 26 in the
+ * `KeysignPayload.swap_payload` oneof, landed via commondata #86). Carries SwapKit-routed swaps
+ * whose wire shape doesn't fit [EVMSwapPayloadJson] — Phase 2 ships BTC PSBT here; later phases add
+ * TON / TRON / SUI / Cardano.
+ *
+ * The flexibility lives in [txPayload] (raw bytes, opaque to commondata) and [txType] (a string
+ * discriminator the keysign-side dispatcher uses to pick the right per-chain signer). New SwapKit
+ * chains land without a proto bump — just a new [txType] value plus a per-chain signer on each
+ * client. Peers that don't recognise a [txType] MUST fall through to an "unsupported provider" UI
+ * rather than crash decode.
+ */
+data class SwapKitSwapPayloadJson(
+    val fromCoin: Coin,
+    val toCoin: Coin,
+    val fromAmount: BigInteger,
+    val toAmountDecimal: BigDecimal,
+
+    /**
+     * SwapKit's `meta.txType` verbatim. Drives the peer-side dispatcher:
+     * - `"PSBT"` — [txPayload] is the base64-decoded BTC PSBT (BIP-174 SegWit).
+     * - `"PSBT_DOGE"` / `"PSBT_BCH"` / `"PSBT_DASH"` / `"PSBT_ZEC"` — legacy / Sapling variants.
+     * - `"TRON"` — [txPayload] is UTF-8 bytes of the canonical JSON of the TronWeb tx.
+     * - `"TON"` — [txPayload] is UTF-8 bytes of the canonical JSON of the transfer array.
+     * - `"SUI"` — [txPayload] is the base64-decoded Sui PTB.
+     * - `"CARDANO"` — [txPayload] is empty; routing via [targetAddress] + [fromAmount].
+     * - `"CARDANO_PREBUILT"` — [txPayload] is the raw CBOR transaction envelope.
+     */
+    val txType: String,
+
+    /**
+     * Raw unsigned-transaction bytes returned by `POST /v3/swap`. Bytes (not string) so binary
+     * payloads (PSBT, PTB, CBOR) round-trip via protobuf without re-encoding. Object-shaped
+     * payloads (TRON, TON) are JSON-encoded on the initiator and decoded on the peer.
+     */
+    val txPayload: ByteArray,
+
+    /**
+     * Deposit address on the source chain. For PSBT this duplicates info also encoded inside
+     * [txPayload]; for deposit-only chains (Cardano) this is the only routing info available.
+     */
+    val targetAddress: String,
+
+    /**
+     * THORChain-style inbound vault address. Populated only for routes that go through TC-style
+     * inbound monitoring. Rare in SwapKit since we filter THORChain/Maya client-side; kept for
+     * forward compatibility.
+     */
+    val inboundAddress: String? = null,
+
+    /**
+     * Optional memo. SwapKit V3 returned null for every chain observed; kept for forward compat.
+     */
+    val memo: String? = null,
+
+    /**
+     * Sub-provider tag for the verify screen (`"CHAINFLIP"`, `"NEAR"`, `"GARDEN"`, `"FLASHNET"`,
+     * `"HARBOR"`). Verbatim from `route.providers[0]` in the `/v3/quote` response.
+     */
+    val subProvider: String = "",
+
+    /**
+     * SwapKit swap identifier — persisted for tracking and analytics. Does not participate in
+     * signing. NOT accepted by `POST /track` — tracking still keys off the broadcast hash + source
+     * chain id.
+     */
+    val swapId: String = "",
+) {
+    // Data class auto-generates equals/hashCode/copy, but the default equals on ByteArray uses
+    // reference equality. Override so two payloads with identical bytes compare equal — matters
+    // for tests pinning round-trip behaviour and for the no-op write detection in caches.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SwapKitSwapPayloadJson
+        return fromCoin == other.fromCoin &&
+            toCoin == other.toCoin &&
+            fromAmount == other.fromAmount &&
+            toAmountDecimal.compareTo(other.toAmountDecimal) == 0 &&
+            txType == other.txType &&
+            txPayload.contentEquals(other.txPayload) &&
+            targetAddress == other.targetAddress &&
+            inboundAddress == other.inboundAddress &&
+            memo == other.memo &&
+            subProvider == other.subProvider &&
+            swapId == other.swapId
+    }
+
+    override fun hashCode(): Int {
+        var result = fromCoin.hashCode()
+        result = 31 * result + toCoin.hashCode()
+        result = 31 * result + fromAmount.hashCode()
+        result = 31 * result + toAmountDecimal.stripTrailingZeros().hashCode()
+        result = 31 * result + txType.hashCode()
+        result = 31 * result + txPayload.contentHashCode()
+        result = 31 * result + targetAddress.hashCode()
+        result = 31 * result + (inboundAddress?.hashCode() ?: 0)
+        result = 31 * result + (memo?.hashCode() ?: 0)
+        result = 31 * result + subProvider.hashCode()
+        result = 31 * result + swapId.hashCode()
+        return result
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -35,6 +35,21 @@ sealed class SwapQuote {
         val data: THORChainSwapQuote,
     ) : SwapQuote()
 
+    /**
+     * SwapKit non-EVM-shaped quote — carries a fully-formed [SwapKitSwapPayloadJson] (the same
+     * shape that round-trips via proto field 26). Phase 2+ consumers (TON / BTC PSBT / ADA / TRON /
+     * SUI / ZEC signers) read the payload directly when building the KeysignPayload; no EVM-style
+     * `tx` envelope to interpret. [subProvider] surfaces the route's downstream protocol
+     * (Chainflip, NEAR Intents, Garden, …) for the verify-row label.
+     */
+    data class SwapKit(
+        override val expectedDstValue: TokenValue,
+        override val fees: TokenValue,
+        override val expiredAt: Instant,
+        val data: SwapKitSwapPayloadJson,
+        val subProvider: String?,
+    ) : SwapQuote()
+
     companion object {
         val expiredAfter = 1.minutes
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -36,11 +36,9 @@ sealed class SwapQuote {
     ) : SwapQuote()
 
     /**
-     * SwapKit non-EVM-shaped quote — carries a fully-formed [SwapKitSwapPayloadJson] (the same
-     * shape that round-trips via proto field 26). Phase 2+ consumers (TON / BTC PSBT / ADA / TRON /
-     * SUI / ZEC signers) read the payload directly when building the KeysignPayload; no EVM-style
-     * `tx` envelope to interpret. [subProvider] surfaces the route's downstream protocol
-     * (Chainflip, NEAR Intents, Garden, …) for the verify-row label.
+     * SwapKit non-EVM quote (BTC / TON / ADA / TRON / SUI / ZEC). Carries a fully-formed
+     * [SwapKitSwapPayloadJson]; per-chain signers read it directly. [subProvider] drives the
+     * verify-row label.
      */
     data class SwapKit(
         override val expectedDstValue: TokenValue,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
@@ -72,12 +72,8 @@ sealed class SwapPayload {
     }
 
     /**
-     * SwapKit-routed swaps whose wire shape doesn't fit [EVM] / [EVMSwapPayloadJson]. EVM and
-     * Solana SwapKit routes continue to ride [EVM] (their /v3/swap shape matches OneInchQuote 1:1
-     * and stays typed at the proto layer with `provider = "swapkit"`). This variant carries the
-     * non-EVM shapes that round-trip via the `swapkit_swap_payload` proto field 26: BTC PSBT, TON
-     * transfer arrays, ADA CBOR, TRON TronWeb objects, SUI PTB, ZEC Sapling-v4 PSBT, etc. The
-     * per-chain dispatcher reads [SwapKitSwapPayloadJson.txType] to pick the right signer.
+     * SwapKit routes whose wire shape doesn't fit [EVM]. EVM and Solana SwapKit still ride [EVM]
+     * with `provider = "swapkit"`; this carries BTC PSBT / TON / ADA / TRON / SUI / ZEC.
      */
     data class SwapKit(val data: SwapKitSwapPayloadJson) : SwapPayload() {
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/SwapPayload.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.models.payload
 
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EVMSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenValue
 
@@ -52,6 +53,33 @@ sealed class SwapPayload {
     }
 
     data class EVM(val data: EVMSwapPayloadJson) : SwapPayload() {
+
+        override val srcToken: Coin
+            get() = data.fromCoin
+
+        override val dstToken: Coin
+            get() = data.toCoin
+
+        override val srcTokenValue: TokenValue
+            get() = TokenValue(value = data.fromAmount, token = srcToken)
+
+        override val dstTokenValue: TokenValue
+            get() =
+                TokenValue(
+                    value = data.toAmountDecimal.movePointRight(dstToken.decimal).toBigInteger(),
+                    token = dstToken,
+                )
+    }
+
+    /**
+     * SwapKit-routed swaps whose wire shape doesn't fit [EVM] / [EVMSwapPayloadJson]. EVM and
+     * Solana SwapKit routes continue to ride [EVM] (their /v3/swap shape matches OneInchQuote 1:1
+     * and stays typed at the proto layer with `provider = "swapkit"`). This variant carries the
+     * non-EVM shapes that round-trip via the `swapkit_swap_payload` proto field 26: BTC PSBT, TON
+     * transfer arrays, ADA CBOR, TRON TronWeb objects, SUI PTB, ZEC Sapling-v4 PSBT, etc. The
+     * per-chain dispatcher reads [SwapKitSwapPayloadJson.txType] to pick the right signer.
+     */
+    data class SwapKit(val data: SwapKitSwapPayloadJson) : SwapPayload() {
 
         override val srcToken: Coin
             get() = data.fromCoin

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -39,11 +39,24 @@ sealed class SwapQuoteResult {
      */
     data class Evm(val data: EVMSwapQuoteJson, val subProvider: String? = null) : SwapQuoteResult()
 
+    /**
+     * SwapKit non-EVM-shaped quote envelope. EVM and Solana SwapKit routes stay on [Evm] (their
+     * /v3/swap shape matches OneInch's 1:1); BTC PSBT / TON / ADA / TRON / SUI / ZEC route shapes
+     * flow through here so the payload builder can stash the bytes on a [SwapPayload.SwapKit] for
+     * cross-device proto round-trip via `swapkitSwapPayload` field 26.
+     */
+    data class SwapKit(val quote: com.vultisig.wallet.data.models.SwapQuote.SwapKit) :
+        SwapQuoteResult()
+
     fun expectNative(provider: SwapProvider): SwapQuote =
         when (this) {
             is Native -> quote
             is Evm ->
                 throw SwapException.UnkownSwapError("Expected Native quote for $provider, got Evm")
+            is SwapKit ->
+                throw SwapException.UnkownSwapError(
+                    "Expected Native quote for $provider, got SwapKit"
+                )
         }
 
     fun expectEvm(provider: SwapProvider): EVMSwapQuoteJson =
@@ -51,6 +64,8 @@ sealed class SwapQuoteResult {
             is Evm -> data
             is Native ->
                 throw SwapException.UnkownSwapError("Expected Evm quote for $provider, got Native")
+            is SwapKit ->
+                throw SwapException.UnkownSwapError("Expected Evm quote for $provider, got SwapKit")
         }
 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -32,19 +32,12 @@ sealed class SwapQuoteResult {
     data class Native(val quote: SwapQuote) : SwapQuoteResult()
 
     /**
-     * EVM-shaped quote envelope. [subProvider] is the route's sub-provider tag when an aggregator
-     * routes through a downstream protocol (e.g. SwapKit → Chainflip / NEAR Intents / Garden /
-     * Flashnet); `null` for direct aggregators (1inch, Kyber, LiFi, Jupiter). The UI label uses it
-     * to disambiguate the verify screen.
+     * EVM-shaped envelope. [subProvider] disambiguates SwapKit's downstream protocol (Chainflip /
+     * NEAR / Garden); `null` for direct aggregators (1inch, Kyber, LiFi, Jupiter).
      */
     data class Evm(val data: EVMSwapQuoteJson, val subProvider: String? = null) : SwapQuoteResult()
 
-    /**
-     * SwapKit non-EVM-shaped quote envelope. EVM and Solana SwapKit routes stay on [Evm] (their
-     * /v3/swap shape matches OneInch's 1:1); BTC PSBT / TON / ADA / TRON / SUI / ZEC route shapes
-     * flow through here so the payload builder can stash the bytes on a [SwapPayload.SwapKit] for
-     * cross-device proto round-trip via `swapkitSwapPayload` field 26.
-     */
+    /** SwapKit non-EVM routes (BTC / TON / ADA / TRON / SUI / ZEC). EVM/Solana stay on [Evm]. */
     data class SwapKit(val quote: com.vultisig.wallet.data.models.SwapQuote.SwapKit) :
         SwapQuoteResult()
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
@@ -9,7 +9,7 @@ import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import vultisig.keysign.v1.SwapKitSwapPayload as SwapKitSwapPayloadProto
@@ -232,8 +232,10 @@ class KeysignPayloadProtoMapperSwapKitTest {
 
         assertEquals(a, b)
         assertEquals(a.hashCode(), b.hashCode())
-        assertNotNull(c) // not equal — different bytes
-        assert(a != c)
+        // assertNotEquals (not Kotlin's `assert(...)`) — the language-level `assert` is a no-op
+        // when the JVM is run without `-ea`, which silently disarms the check on Gradle's default
+        // test classpath. JUnit's assertion always runs.
+        assertNotEquals(a, c)
     }
 
     // ---- helpers ----

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
@@ -17,10 +17,9 @@ import vultisig.keysign.v1.THORChainSpecific
 import vultisig.keysign.v1.TransactionType
 
 /**
- * Pins the proto round-trip for [SwapPayload.SwapKit] via `swapkitSwapPayload` field 26
- * (commondata #86). Both directions must preserve every field — the cosigning peer reconstructs the
- * same payload bytes the initiator built. Bytes (`txPayload`) and decimal string round-trips are
- * the load-bearing checks; getting either wrong silently breaks cross-device cosigning.
+ * Pins the [SwapPayload.SwapKit] proto round-trip in both directions. Bytes (`txPayload`) and
+ * decimal-string round-trips are the load-bearing checks — getting either wrong silently breaks
+ * cross-device cosigning.
  */
 class KeysignPayloadProtoMapperSwapKitTest {
 
@@ -96,7 +95,7 @@ class KeysignPayloadProtoMapperSwapKitTest {
     }
 
     @Test
-    fun `outbound mapper writes swapkitSwapPayload onto field 26 with every field intact`() {
+    fun `outbound mapper writes swapkitSwapPayload with every field intact`() {
         val txPayloadBytes = byteArrayOf(0x70, 0x73, 0x62, 0x74) // "psbt" magic
         val domain =
             mapper

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
@@ -1,0 +1,317 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.proto.v1.CoinProto
+import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SwapKitSwapPayload as SwapKitSwapPayloadProto
+import vultisig.keysign.v1.THORChainSpecific
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * Pins the proto round-trip for [SwapPayload.SwapKit] via `swapkitSwapPayload` field 26
+ * (commondata #86). Both directions must preserve every field — the cosigning peer reconstructs the
+ * same payload bytes the initiator built. Bytes (`txPayload`) and decimal string round-trips are
+ * the load-bearing checks; getting either wrong silently breaks cross-device cosigning.
+ */
+class KeysignPayloadProtoMapperSwapKitTest {
+
+    private val mapper = KeysignPayloadProtoMapperImpl()
+    private val outboundMapper = PayloadToProtoMapperImpl()
+
+    @Test
+    fun `inbound mapper decodes swapkitSwapPayload into SwapPayload SwapKit with every field intact`() {
+        val txPayloadBytes = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0xFF.toByte(), 0x00, 0x7F)
+        val proto =
+            basePayload(
+                swapkitSwapPayload =
+                    SwapKitSwapPayloadProto(
+                        fromCoin = TON_COIN,
+                        toCoin = ETH_COIN,
+                        fromAmount = "1000000000",
+                        toAmountDecimal = "0.0125",
+                        txType = "TON",
+                        txPayload = txPayloadBytes,
+                        targetAddress = "EQAbc123",
+                        inboundAddress = "thor1inbound",
+                        memo = "memo-1",
+                        subProvider = "CHAINFLIP",
+                        swapId = "swap-uuid-1",
+                    )
+            )
+
+        val result = mapper.invoke(proto)
+        val swapKit = assertInstanceOf(SwapPayload.SwapKit::class.java, result.swapPayload)
+        val data = swapKit.data
+
+        assertEquals("TON", data.fromCoin.ticker)
+        assertEquals("ETH", data.toCoin.ticker)
+        assertEquals(BigInteger("1000000000"), data.fromAmount)
+        assertEquals(0, BigDecimal("0.0125").compareTo(data.toAmountDecimal))
+        assertEquals("TON", data.txType)
+        assertArrayEquals(txPayloadBytes, data.txPayload)
+        assertEquals("EQAbc123", data.targetAddress)
+        assertEquals("thor1inbound", data.inboundAddress)
+        assertEquals("memo-1", data.memo)
+        assertEquals("CHAINFLIP", data.subProvider)
+        assertEquals("swap-uuid-1", data.swapId)
+    }
+
+    @Test
+    fun `inbound mapper tolerates absent optional fields on swapkitSwapPayload`() {
+        // inboundAddress and memo are proto3 `optional` — peers MUST handle them being absent
+        // (Cardano deposit-only / Phase 1 EVM observed in iOS spike) without throwing.
+        val proto =
+            basePayload(
+                swapkitSwapPayload =
+                    SwapKitSwapPayloadProto(
+                        fromCoin = TON_COIN,
+                        toCoin = ETH_COIN,
+                        fromAmount = "1000",
+                        toAmountDecimal = "0",
+                        txType = "CARDANO",
+                        txPayload = byteArrayOf(),
+                        targetAddress = "addr1deposit",
+                        inboundAddress = null,
+                        memo = null,
+                        subProvider = "",
+                        swapId = "",
+                    )
+            )
+
+        val result = mapper.invoke(proto)
+        val data = assertInstanceOf(SwapPayload.SwapKit::class.java, result.swapPayload).data
+
+        assertNull(data.inboundAddress)
+        assertNull(data.memo)
+        assertEquals(0, data.txPayload.size)
+    }
+
+    @Test
+    fun `outbound mapper writes swapkitSwapPayload onto field 26 with every field intact`() {
+        val txPayloadBytes = byteArrayOf(0x70, 0x73, 0x62, 0x74) // "psbt" magic
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(
+                    swapPayload =
+                        SwapPayload.SwapKit(
+                            SwapKitSwapPayloadJson(
+                                fromCoin = tonDomainCoin(),
+                                toCoin = ethDomainCoin(),
+                                fromAmount = BigInteger("5000000000"),
+                                toAmountDecimal = BigDecimal("0.001"),
+                                txType = "PSBT",
+                                txPayload = txPayloadBytes,
+                                targetAddress = "bc1qdeposit",
+                                inboundAddress = null,
+                                memo = "tag-7",
+                                subProvider = "CHAINFLIP",
+                                swapId = "psbt-swap-1",
+                            )
+                        )
+                )
+
+        val outbound = requireNotNull(outboundMapper.invoke(domain))
+        val proto = requireNotNull(outbound.swapkitSwapPayload)
+
+        assertEquals("TON", proto.fromCoin?.ticker)
+        assertEquals("ETH", proto.toCoin?.ticker)
+        assertEquals("5000000000", proto.fromAmount)
+        assertEquals("0.001", proto.toAmountDecimal)
+        assertEquals("PSBT", proto.txType)
+        assertArrayEquals(txPayloadBytes, proto.txPayload)
+        assertEquals("bc1qdeposit", proto.targetAddress)
+        assertNull(proto.inboundAddress)
+        assertEquals("tag-7", proto.memo)
+        assertEquals("CHAINFLIP", proto.subProvider)
+        assertEquals("psbt-swap-1", proto.swapId)
+
+        // Sibling oneof fields must stay null — proto.swap_payload is a oneof and the generated
+        // init {} require() enforces only one entry. A leaky outbound writer would crash here.
+        assertNull(outbound.oneinchSwapPayload)
+        assertNull(outbound.thorchainSwapPayload)
+        assertNull(outbound.mayachainSwapPayload)
+    }
+
+    @Test
+    fun `outbound mapper writes null swapkitSwapPayload when domain has no swap payload`() {
+        val domain = mapper.invoke(basePayload())
+        val outbound = requireNotNull(outboundMapper.invoke(domain))
+        assertNull(outbound.swapkitSwapPayload)
+    }
+
+    @Test
+    fun `proto round-trip preserves SwapPayload SwapKit byte-for-byte across inbound and outbound`() {
+        val txPayloadBytes =
+            byteArrayOf(0x00, 0x01, 0x02, 0x03, 0xFE.toByte(), 0xFF.toByte(), 0x42, 0x7F)
+        val inboundProto =
+            basePayload(
+                swapkitSwapPayload =
+                    SwapKitSwapPayloadProto(
+                        fromCoin = TON_COIN,
+                        toCoin = ETH_COIN,
+                        fromAmount = "987654321",
+                        toAmountDecimal = "12345.6789",
+                        txType = "PSBT_BCH",
+                        txPayload = txPayloadBytes,
+                        targetAddress = "bitcoincash:qpdeposit",
+                        inboundAddress = "thor1inbound",
+                        memo = "round-trip-memo",
+                        subProvider = "NEAR",
+                        swapId = "rt-swap-99",
+                    )
+            )
+
+        val domain = mapper.invoke(inboundProto)
+        val outbound = requireNotNull(outboundMapper.invoke(domain))
+        val roundTripped = requireNotNull(outbound.swapkitSwapPayload)
+
+        // Every field on the proto must match the original — protobuf bytes round-trip is the
+        // contract cross-device cosigning relies on.
+        assertEquals(inboundProto.swapkitSwapPayload?.fromCoin, roundTripped.fromCoin)
+        assertEquals(inboundProto.swapkitSwapPayload?.toCoin, roundTripped.toCoin)
+        assertEquals(inboundProto.swapkitSwapPayload?.fromAmount, roundTripped.fromAmount)
+        assertEquals(inboundProto.swapkitSwapPayload?.toAmountDecimal, roundTripped.toAmountDecimal)
+        assertEquals(inboundProto.swapkitSwapPayload?.txType, roundTripped.txType)
+        assertArrayEquals(inboundProto.swapkitSwapPayload?.txPayload, roundTripped.txPayload)
+        assertEquals(inboundProto.swapkitSwapPayload?.targetAddress, roundTripped.targetAddress)
+        assertEquals(inboundProto.swapkitSwapPayload?.inboundAddress, roundTripped.inboundAddress)
+        assertEquals(inboundProto.swapkitSwapPayload?.memo, roundTripped.memo)
+        assertEquals(inboundProto.swapkitSwapPayload?.subProvider, roundTripped.subProvider)
+        assertEquals(inboundProto.swapkitSwapPayload?.swapId, roundTripped.swapId)
+    }
+
+    @Test
+    fun `SwapPayload SwapKit exposes src and dst token values derived from the inner data`() {
+        val data =
+            SwapKitSwapPayloadJson(
+                fromCoin = tonDomainCoin(),
+                toCoin = ethDomainCoin(),
+                fromAmount = BigInteger("1000000000"),
+                toAmountDecimal = BigDecimal("0.0125"),
+                txType = "TON",
+                txPayload = byteArrayOf(),
+                targetAddress = "EQAbc",
+            )
+        val payload = SwapPayload.SwapKit(data)
+
+        assertEquals(data.fromCoin, payload.srcToken)
+        assertEquals(data.toCoin, payload.dstToken)
+        assertEquals(BigInteger("1000000000"), payload.srcTokenValue.value)
+        // dstTokenValue scales toAmountDecimal by dst decimals (ETH = 18) → 0.0125 * 1e18 raw wei.
+        assertEquals(BigInteger("12500000000000000"), payload.dstTokenValue.value)
+    }
+
+    @Test
+    fun `SwapKitSwapPayloadJson equals and hashCode compare ByteArray by content`() {
+        val a =
+            SwapKitSwapPayloadJson(
+                fromCoin = tonDomainCoin(),
+                toCoin = ethDomainCoin(),
+                fromAmount = BigInteger.TEN,
+                toAmountDecimal = BigDecimal("0.001"),
+                txType = "TON",
+                txPayload = byteArrayOf(1, 2, 3),
+                targetAddress = "addr",
+            )
+        val b =
+            a.copy(
+                // Distinct array instance with identical content.
+                txPayload = byteArrayOf(1, 2, 3)
+            )
+        val c = a.copy(txPayload = byteArrayOf(1, 2, 4))
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotNull(c) // not equal — different bytes
+        assert(a != c)
+    }
+
+    // ---- helpers ----
+
+    private fun tonDomainCoin() =
+        com.vultisig.wallet.data.models.Coin(
+            chain = com.vultisig.wallet.data.models.Chain.Ton,
+            ticker = "TON",
+            logo = "",
+            address = "EQAuser",
+            decimal = 9,
+            hexPublicKey = "pubkey",
+            priceProviderID = "the-open-network",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun ethDomainCoin() =
+        com.vultisig.wallet.data.models.Coin(
+            chain = com.vultisig.wallet.data.models.Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xuser",
+            decimal = 18,
+            hexPublicKey = "pubkey",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun basePayload(
+        coin: CoinProto = TON_COIN,
+        swapkitSwapPayload: SwapKitSwapPayloadProto? = null,
+    ) =
+        KeysignPayloadProto(
+            coin = coin,
+            toAddress = "EQAdest",
+            toAmount = "1000",
+            vaultPublicKeyEcdsa = "pubkey",
+            vaultLocalPartyId = "party-1",
+            thorchainSpecific =
+                THORChainSpecific(
+                    accountNumber = 1uL,
+                    sequence = 0uL,
+                    fee = 2_000_000uL,
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            swapkitSwapPayload = swapkitSwapPayload,
+        )
+
+    companion object {
+        // CoinProto.chain must round-trip via Chain.fromRaw / Chain.raw — use the canonical
+        // mixed-case "Ton" rather than the SwapKit wire-format "TON" so equals works after the
+        // domain-Coin → proto-Coin round trip.
+        private val TON_COIN =
+            CoinProto(
+                chain = "Ton",
+                ticker = "TON",
+                address = "EQAuser",
+                contractAddress = "",
+                decimals = 9,
+                priceProviderId = "the-open-network",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+        private val ETH_COIN =
+            CoinProto(
+                chain = "Ethereum",
+                ticker = "ETH",
+                address = "0xuser",
+                contractAddress = "",
+                decimals = 18,
+                priceProviderId = "ethereum",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Lays the type-system and proto plumbing for SwapKit's **non-EVM-shaped routes** (BTC PSBT, TON transfer array, ADA CBOR, TRON TronWeb object, SUI PTB, ZEC Sapling, etc.). EVM and Solana SwapKit routes still ride the existing `oneinchSwapPayload` field with `provider="swapkit"` — only chains whose `/v3/swap` wire shape doesn't fit `OneInchQuote` 1:1 land here.

**No `SwapQuoteSource` emits the new types yet** — this PR is purely additive. Each per-chain signer plugs on top in a follow-up PR with ~200–500 lines of chain-specific decoding + signing wiring. The first consumer (TON) is on a follow-up branch.

This is the Android port of the proto landed in commondata #86 (pinned via my prior PR #4621).

### What lands

**New types**
- `SwapKitSwapPayloadJson` — Kotlin mirror of `vultisig.keysign.v1.SwapKitSwapPayload` (proto field 26). Overrides `equals`/`hashCode` so `ByteArray` fields (`txPayload`) compare by content.
- `SwapPayload.SwapKit` — new sealed-class variant exposing the same `srcToken` / `dstToken` / `srcTokenValue` / `dstTokenValue` surface as the existing variants.
- `SwapQuote.SwapKit` + `SwapQuoteResult.SwapKit` — quote-side envelopes carrying the payload + sub-provider tag.

**Proto round-trip**
- `PayloadToProtoMapper` writes `SwapPayload.SwapKit` → `swapkitSwapPayload` field on the outbound side.
- `KeysignPayloadProtoMapper` reads `swapkitSwapPayload` → `SwapPayload.SwapKit` on the inbound side. Optional `inboundAddress` + `memo` tolerated as null.

**Exhaustive-when callers updated**
- `SwapTransactionToUiModelMapper` — `SwapPayload.SwapKit` resolves to `SwapProvider.SWAPKIT`.
- `JoinKeysignViewModel` — join-flow uses sub-provider in the verify-row label (`SwapKit (Chainflip)`) and zero provider fee (network gas estimate carries the cost).
- `SwapFormViewModel` — `SwapQuote.SwapKit` branch `error()`s with a clear *signer not yet wired* message. No source reaches it in this PR.
- `SwapQuoteResult.expectNative` / `expectEvm` throw typed `UnknownSwapError` for SwapKit results.

**Shared util**
- `SwapKitDisplay.formatSwapKitSubProvider` — extracted so initiator + peer render identically.

### Deliberately out of scope (follow-ups)
- TON signer (next PR): `SwapKitTonTransfer` decoder, `Chain.Ton` table entry, `signTon` population so existing `TonHelper` picks it up unchanged.
- Per-chain signers: BTC PSBT, SUI PTB, ADA CBOR, TRON, DOGE/BCH/DASH, ZEC Sapling.
- `/v3/swap` tx-history → `/track` polling.

## Test plan
- [x] `./gradlew :data:test :app:testDebugUnitTest` — green
- [x] `./gradlew ktfmtCheck` — green
- [x] `./gradlew :app:lintDebug` — green
- [x] 7 new tests in `KeysignPayloadProtoMapperSwapKitTest` (round-trip preserves payload byte-for-byte; optional fields tolerated; sibling oneofs stay null; `ByteArray` equals; getters derive correctly)

## Checklist
- [x] Self-review
- [x] No new warnings
- [x] Tests included

## Agent Metadata
- **Agent**: Claude Code (Opus 4.7, 1M context)
- **Issue**: foundation for vultisig-android#4589 — non-EVM SwapKit signer phases
- **Confidence**: high for proto round-trip + sealed-class plumbing
- **Needs human review for**: \`JoinKeysignViewModel\` zero-fee display decision; whether \`SwapFormViewModel.SwapQuote.SwapKit\` should error or no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SwapKit routing support for non‑EVM chains and improved provider label display for clearer routing info.
  * Swap transaction flow now includes dedicated handling for SwapKit quotes so swaps and history show consistent provider and fee presentation.

* **Tests**
  * Added comprehensive tests validating SwapKit payload mapping, serialization, and equality/hash semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->