### PR TITLE
fix(crash): content-based keys in TokenSelectionList grouped grid (#4540)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
@@ -158,7 +158,9 @@ internal fun <T> TokenSelectionList(
 
                             itemsIndexed(
                                 items,
-                                key = { itemIndex, _ -> "$groupIndex-$itemIndex" },
+                                key = { _, item ->
+                                    "${title ?: "group$groupIndex"}-${item.hashCode()}"
+                                },
                             ) { _, item ->
                                 GridItem(
                                     uiModel = mapper(item),


### PR DESCRIPTION
Fixes #4540

## Problem
`TokenSelectionList.kt` renders a grouped grid in a single `LazyVerticalGrid`. The `itemsIndexed` call used index-based keys:

```kotlin
key = { itemIndex, _ -> "$groupIndex-$itemIndex" }
```

Under mid-measurement mutation (e.g., on lower-end Android 14 devices like TECNO Spark Go 1), index-based keys can collide across groups and become stale, which surfaces as `IllegalArgumentException` in `LayoutNodeSubcompositionsState.subcompose` — the same crash family as #4066, #4388, #4427.

This is the call-site change that PR #4434's description claimed to make, but the actual merged commit did not touch this file.

## Fix
Switch to content-based keys derived from the group title and item hash:

```kotlin
key = { _, item ->
    "${title ?: "group$groupIndex"}-${item.hashCode()}"
}
```

## Test plan
- [ ] Open token-selection bottom sheet (e.g., Send → select asset → grouped grid view) and verify list renders without crash
- [ ] Scroll through grouped sections; ensure no scroll-position glitch when groups update
- [ ] Run on Android 14 emulator to confirm no regression
- [ ] Monitor Android Vitals after release for the `IllegalArgumentException` family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token selection list rendering and recomposition behavior to improve list performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->