### PR TITLE
fix(bittensor): correct tao-tx status proxy path so TAO sends confirm (#4565)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -172,7 +172,7 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
 
     override suspend fun getTxStatus(txHash: String): TaostatsExtrinsicData? {
         val hash = if (txHash.startsWith("0x")) txHash else "0x$txHash"
-        val response = httpClient.get("${TAOSTATS_PROXY_URL}/extrinsic/v1?hash=$hash")
+        val response = httpClient.get("${TAOSTATS_PROXY_URL}/v1?hash=$hash")
         if (response.status == HttpStatusCode.NotFound) return null
         return response.body<TaostatsExtrinsicResponse>().data?.firstOrNull()
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiTest.kt
@@ -63,6 +63,75 @@ class BittensorApiTest {
         assertNull(api.getTxStatus("0xabc"))
     }
 
+    @Test
+    fun `getTxStatus hits the tao-tx v1 proxy path with the hash query`() = runBlocking {
+        lateinit var requestedUrl: String
+        val api =
+            bittensorApi(
+                MockEngine { request ->
+                    requestedUrl = request.url.toString()
+                    respond(
+                        content = """{"data":[]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        api.getTxStatus("0xabc")
+        assertEquals("https://api.vultisig.com/tao-tx/v1?hash=0xabc", requestedUrl)
+    }
+
+    @Test
+    fun `getTxStatus parses the live proxy payload shape and ignores extra fields`() = runBlocking {
+        val api =
+            bittensorApi(
+                MockEngine {
+                    respond(
+                        content =
+                            """
+                            {
+                              "pagination": {"current_page": 1, "per_page": 50, "total_items": 1},
+                              "data": [{
+                                "timestamp": "2026-05-24T10:36:48Z",
+                                "block_number": 8253395,
+                                "hash": "0x75c804b9",
+                                "id": "8253395-0009",
+                                "index": 9,
+                                "success": true,
+                                "error": null
+                              }]
+                            }
+                            """
+                                .trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val result = api.getTxStatus("0x75c804b9")
+
+        assertEquals(true, result?.success)
+        assertEquals(8253395, result?.blockNumber)
+    }
+
+    @Test
+    fun `getTxStatus surfaces success false for a failed extrinsic`() = runBlocking {
+        val api =
+            bittensorApi(
+                MockEngine {
+                    respond(
+                        content = """{"data":[{"success":false,"block_number":8253395}]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        assertEquals(false, api.getTxStatus("0xabc")?.success)
+    }
+
     private fun bittensorApi(engine: MockEngine): BittensorApi =
         BittensorApiImp(
             HttpClient(engine) {


### PR DESCRIPTION
## Summary

Fixes #4565 — TAO (Bittensor) sends were stuck on **"In progress…"** in transaction history forever and never flipped to **Successful**, even after the tx confirmed on-chain.

### Root cause
The status check called the wrong proxy path:

| | Path | Result on a confirmed hash |
|---|---|---|
| Android (before) | `https://api.vultisig.com/tao-tx/**extrinsic**/v1?hash=…` | **404** (route doesn't exist) |
| iOS | `https://api.vultisig.com/tao-tx/v1?hash=…` | **200** + `{ success, block_number }` |

`/tao-tx/extrinsic/v1` is not a route on the proxy, so it returned **404 for every hash**. `BittensorStatusProvider` maps that 404 → `Pending`, so the history poller kept polling indefinitely and the entry never confirmed. (The earlier #4292 "404 = not yet indexed, keep polling" handling was masking the wrong URL.)

### Fix
One-line path correction in `BittensorApi.getTxStatus`: `/tao-tx/extrinsic/v1` → `/tao-tx/v1`, matching iOS.

### Verified against the live proxy
- Confirmed extrinsics (real, finalized, pulled from the chain) return **`200`** with `success`/`block_number` and the matching `hash` on `/tao-tx/v1`, while `/tao-tx/extrinsic/v1` returns `404`.
- An unknown / not-yet-indexed hash returns **`200`** with an empty `data` array → still `Pending` (polling continues cleanly; the existing 404 guard is kept as defensive).
- A successful extrinsic reports `success: true` → `Confirmed`; a failed one reports `success: false` → `Failed`.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.BittensorApiTest"` — passes (6 tests).
- [x] Added a **regression test** asserting the request URL is exactly `…/tao-tx/v1?hash=…` (no existing test checked the path — which is how the wrong path slipped through).
- [x] Added a test parsing the **real proxy payload shape** (with `pagination` + extra fields) and a `success: false` case.
- [x] `./gradlew :data:ktfmtCheck` — passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the transaction status lookup endpoint to properly query the proxy service.

* **Tests**
  * Added comprehensive unit tests validating transaction status retrieval and response parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->