### PR TITLE
fix: replace .body<T>() with bodyOrThrow<T>() in API layer (#3865)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.models.cosmos.PolkadotQueryInfoResponseJson
 import com.vultisig.wallet.data.api.utils.postRpc
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -125,7 +126,10 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
                 id = 1,
             )
         val response = httpClient.post(BITTENSOR_RPC_URL) { setBody(payload) }
-        val responseContent = response.bodyOrThrow<PolkadotBroadcastTransactionJson>()
+        // Read the RPC body regardless of HTTP status: the relay may surface "Already Imported"
+        // with a non-2xx status, and the duplicate rebroadcast from a second signing device must
+        // still resolve to null rather than throw.
+        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
         if (responseContent.error != null) {
             if (responseContent.error.message?.contains("Already Imported") == true) {
                 return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -8,8 +8,8 @@ import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetNonceJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetRunTimeVersionJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotQueryInfoResponseJson
 import com.vultisig.wallet.data.api.utils.postRpc
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -125,7 +125,7 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
                 id = 1,
             )
         val response = httpClient.post(BITTENSOR_RPC_URL) { setBody(payload) }
-        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
+        val responseContent = response.bodyOrThrow<PolkadotBroadcastTransactionJson>()
         if (responseContent.error != null) {
             if (responseContent.error.message?.contains("Already Imported") == true) {
                 return null
@@ -174,7 +174,7 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
         val hash = if (txHash.startsWith("0x")) txHash else "0x$txHash"
         val response = httpClient.get("${TAOSTATS_PROXY_URL}/v1?hash=$hash")
         if (response.status == HttpStatusCode.NotFound) return null
-        return response.body<TaostatsExtrinsicResponse>().data?.firstOrNull()
+        return response.bodyOrThrow<TaostatsExtrinsicResponse>().data?.firstOrNull()
     }
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BlockChairApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BlockChairApi.kt
@@ -8,8 +8,8 @@ import com.vultisig.wallet.data.api.models.TransactionHashDataJson
 import com.vultisig.wallet.data.api.models.TransactionHashRequestBodyJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.utils.UTXOStatusResponseSerializer
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -63,7 +63,7 @@ constructor(
                 ) {
                     header("Content-Type", "application/json")
                 }
-            val responseData = response.body<BlockChairInfoJson>()
+            val responseData = response.bodyOrThrow<BlockChairInfoJson>()
             Timber.d("response data: $responseData")
             return responseData.data[address]
         } catch (e: Exception) {
@@ -78,7 +78,7 @@ constructor(
             httpClient.get("$BASE_URL/${getChainName(chain)}/stats") {
                 header("Content-Type", "application/json")
             }
-        return response.body<SuggestedTransactionFeeDataJson>().data.value
+        return response.bodyOrThrow<SuggestedTransactionFeeDataJson>().data.value
     }
 
     suspend fun broadcastTransactionMempool(signedTransaction: String): String {
@@ -120,7 +120,7 @@ constructor(
                     error("fail to broadcast transaction: $errorBody")
                 }
 
-                return response.body<TransactionHashDataJson>().data.value
+                return response.bodyOrThrow<TransactionHashDataJson>().data.value
             }
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.models.cardano.CardanoUtxoResponseJson
 import com.vultisig.wallet.data.api.models.cardano.OgmiosTransactionResponse
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.payload.UtxoInfo
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -19,6 +20,7 @@ import io.ktor.http.path
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import timber.log.Timber
@@ -36,9 +38,12 @@ interface CardanoApi {
 }
 
 internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpClient) : CardanoApi {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
     private val url: String = "https://api.koios.rest"
     private val apiV1Path: String = "api/v1"
-    private val url2 = "https://api.vultisig.com"
     private val ogmiosUrl = "https://api.vultisig.com/ada/"
 
     override suspend fun getBalance(coin: Coin): BigInteger {
@@ -69,7 +74,7 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
             }
 
         return try {
-            response.body<List<CardanoUtxoResponseJson>>().toUtxos()
+            response.bodyOrThrow<List<CardanoUtxoResponseJson>>().toUtxos()
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e("Error in Cardano getUTXOs : ${e.message}")
@@ -103,7 +108,7 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
 
             when (response.status) {
                 HttpStatusCode.OK -> {
-                    val ogmiosResponse = response.body<OgmiosTransactionResponse>()
+                    val ogmiosResponse = response.bodyOrThrow<OgmiosTransactionResponse>()
 
                     ogmiosResponse.result?.transaction?.id
                         ?: run {
@@ -114,7 +119,8 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
                 }
 
                 HttpStatusCode.BadRequest -> {
-                    val ogmiosError = response.body<OgmiosTransactionResponse>()
+                    val ogmiosError =
+                        json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
                     ogmiosError.error?.data?.unknownOutputReferences?.firstOrNull()?.transaction?.id
                         ?: run {
                             val errorMessage = ogmiosError.error?.message ?: "Unknown error"
@@ -134,40 +140,6 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
             error("Failed to broadcast transaction : ${t.message}")
         }
     }
-
-    /* override suspend fun broadcastTransaction(
-        chain: String, signedTransaction: String,
-    ): String? {
-        return try {
-            val response = httpClient.post(url2) {
-                url {
-                    path(
-                        "blockchair",
-                        "cardano",
-                        "push",
-                        "transaction"
-                    )
-                }
-                setBody(CardanoTransactionHashRequestBodyJson(signedTransaction))
-            }
-
-            if (response.status != HttpStatusCode.OK) {
-                val responseString = response.body<String>()
-                if (responseString.contains("BadInputsUTxO") || responseString.contains("timed out")) {
-                    Timber.d("Cardano transaction already broadcast")
-                    return null
-                }
-                Timber.d("Failed to broadcast transaction: $responseString")
-                error("Failed to broadcast transaction: $responseString")
-            }
-
-            val cardanoBroadcastResponse: CardanoBroadcastResponseJson = response.body()
-            cardanoBroadcastResponse.data.transactionHash
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            error("Failed to broadcast transaction: ${e.message}")
-        }
-    } */
 
     private suspend fun getCurrentSlot(): ULong {
         val response = httpClient.get(url) { url { path(apiV1Path, "tip") } }
@@ -193,6 +165,6 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
                 url { path(apiV1Path, "tx_status") }
                 setBody(requestBody)
             }
-        return response.body<List<CardanoTxStatusResponseJson>>().firstOrNull()
+        return response.bodyOrThrow<List<CardanoTxStatusResponseJson>>().firstOrNull()
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -10,7 +10,6 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -37,11 +36,9 @@ interface CardanoApi {
     suspend fun broadcastTransaction(chain: String, signedTransaction: String): String?
 }
 
-internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpClient) : CardanoApi {
-    private val json = Json {
-        ignoreUnknownKeys = true
-        explicitNulls = false
-    }
+internal class CardanoApiImpl
+@Inject
+constructor(private val httpClient: HttpClient, private val json: Json) : CardanoApi {
     private val url: String = "https://api.koios.rest"
     private val apiV1Path: String = "api/v1"
     private val ogmiosUrl = "https://api.vultisig.com/ada/"
@@ -55,7 +52,7 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
                 setBody(requestBody)
             }
         return try {
-            val balances: List<CardanoBalanceResponseJson> = response.body()
+            val balances = response.bodyOrThrow<List<CardanoBalanceResponseJson>>()
             val balanceString = balances.firstOrNull()?.balance ?: "0"
             BigInteger(balanceString)
         } catch (e: Exception) {
@@ -149,7 +146,7 @@ internal class CardanoApiImpl @Inject constructor(private val httpClient: HttpCl
             Timber.d("Failed to parse slot from response: $responseString")
             error("Failed to parse slot from response: $responseString")
         }
-        val cardanoSlotResponse: List<CardanoSlotResponseJson> = response.body()
+        val cardanoSlotResponse = response.bodyOrThrow<List<CardanoSlotResponseJson>>()
         return cardanoSlotResponse.firstOrNull()?.absSlot?.toULong() ?: 0UL
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.utils.CosmosThorChainResponseSerializer
 import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -94,7 +93,7 @@ internal class CosmosApiImp(
 ) : CosmosApi {
     override suspend fun getBalance(address: String): List<CosmosBalance> {
         val response = httpClient.get("$rpcEndpoint/cosmos/bank/v1beta1/balances/$address")
-        val resp = response.body<CosmosBalanceResponse>()
+        val resp = response.bodyOrThrow<CosmosBalanceResponse>()
         return resp.balances ?: emptyList()
     }
 
@@ -145,7 +144,7 @@ internal class CosmosApiImp(
             amount =
                 httpClient
                     .get("$rpcEndpoint/cosmwasm/wasm/v1/contract/$contractAddress/smart/$payload")
-                    .body<JsonObject>()["data"]
+                    .bodyOrThrow<JsonObject>()["data"]
                     ?.jsonObject
                     ?.get("balance")
                     ?.jsonPrimitive
@@ -159,7 +158,7 @@ internal class CosmosApiImp(
         val hash = contractAddress.removePrefix("ibc/")
         return httpClient
             .get("$rpcEndpoint/ibc/apps/transfer/v1/denom_traces/$hash")
-            .body<CosmosIbcDenomTraceJson>()
+            .bodyOrThrow<CosmosIbcDenomTraceJson>()
             .denomTrace!!
     }
 
@@ -188,7 +187,7 @@ internal class CosmosApiImp(
     override suspend fun getLatestBlock(): String {
         return httpClient
             .get("$rpcEndpoint/cosmos/base/tendermint/v1beta1/blocks/latest")
-            .body<JsonObject>()
+            .bodyOrThrow<JsonObject>()
             .jsonObject["block"]
             ?.jsonObject
             ?.get("header")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/DashApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/DashApi.kt
@@ -4,8 +4,8 @@ import com.vultisig.wallet.data.api.models.DashAddressParam
 import com.vultisig.wallet.data.api.models.DashRpcRequest
 import com.vultisig.wallet.data.api.models.DashRpcResponse
 import com.vultisig.wallet.data.models.payload.UtxoInfo
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import javax.inject.Inject
@@ -31,7 +31,7 @@ internal class DashApiImpl @Inject constructor(private val httpClient: HttpClien
                         )
                     )
                 }
-                .body<DashRpcResponse>()
+                .bodyOrThrow<DashRpcResponse>()
 
         if (rpcResponse.error != null) {
             error("Dash RPC error: ${rpcResponse.error.message}")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/FeatureFlagApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/FeatureFlagApi.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.FeatureFlagJson
 import com.vultisig.wallet.data.api.utils.throwIfUnsuccessful
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import javax.inject.Inject
 
@@ -18,5 +18,5 @@ internal class FeatureFlagApiImpl @Inject constructor(private val http: HttpClie
         http
             .get("https://api.vultisig.com/feature/release.json")
             .throwIfUnsuccessful()
-            .body<FeatureFlagJson>()
+            .bodyOrThrow<FeatureFlagJson>()
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/FourByteApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/FourByteApi.kt
@@ -1,8 +1,8 @@
 package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.FourByteResponseJson
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import javax.inject.Inject
 
@@ -17,6 +17,6 @@ internal class FourByteApiImpl @Inject constructor(private val httpClient: HttpC
             httpClient.get(
                 "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=${hash}&ordering=created_at"
             )
-        return response.body<FourByteResponseJson>().list.firstOrNull()?.textSignature
+        return response.bodyOrThrow<FourByteResponseJson>().list.firstOrNull()?.textSignature
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
@@ -6,9 +6,9 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.oneInchChainId
 import com.vultisig.wallet.data.utils.LiFiSwapQuoteResponseSerializer
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import javax.inject.Inject
@@ -93,7 +93,7 @@ constructor(
                 }
             }
         return try {
-            json.decodeFromString(liFiSwapQuoteResponseSerializer, response.body<String>())
+            json.decodeFromString(liFiSwapQuoteResponseSerializer, response.bodyAsText())
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             LiFiSwapQuoteDeserialized.Error(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.chains.helpers.THORChainSwaps.Companion.MAYA_STR
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -162,7 +161,7 @@ constructor(
             ) {
                 header(xClientID, xClientIDValue)
             }
-        val resp = response.body<CosmosBalanceResponse>()
+        val resp = response.bodyOrThrow<CosmosBalanceResponse>()
         return resp.balances ?: emptyList()
     }
 
@@ -173,7 +172,7 @@ constructor(
                     .get("https://midgard.mayachain.info") {
                         url { path("v2", "cacaopool", address) }
                     }
-                    .body<List<MayaChainDepositCacaoResponse>>()
+                    .bodyOrThrow<List<MayaChainDepositCacaoResponse>>()
             request.firstOrNull()?.cacaoDeposit
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
@@ -213,7 +212,7 @@ constructor(
                     )
                 )
             }
-            val responseRawString = response.body<String>()
+            val responseRawString = response.bodyOrThrow<String>()
             return json.decodeFromString(
                 thorChainSwapQuoteResponseJsonSerializer,
                 responseRawString,
@@ -231,7 +230,7 @@ constructor(
             httpClient.get("https://mayanode.mayachain.info/auth/accounts/$address") {
                 header(xClientID, xClientIDValue)
             }
-        val responseBody = response.body<THORChainAccountResultJson>()
+        val responseBody = response.bodyOrThrow<THORChainAccountResultJson>()
         Timber.d("getAccountNumber: $responseBody")
         return responseBody.result?.value ?: error("Field value is not found in the response")
     }
@@ -261,7 +260,7 @@ constructor(
     override suspend fun getLatestBlock(): MayaLatestBlockInfoResponse {
         try {
             val response = httpClient.get("https://mayanode.mayachain.info/blocks/latest")
-            val responseBody = response.body<MayaLatestBlockInfoResponse>()
+            val responseBody = response.bodyOrThrow<MayaLatestBlockInfoResponse>()
             Timber.d("getLatestBlock: $responseBody")
             return responseBody
         } catch (e: Exception) {
@@ -276,7 +275,7 @@ constructor(
             val response =
                 httpClient.get("https://mayanode.mayachain.info/mayachain/cacao_provider/$address")
 
-            val body = response.body<CacaoProviderResponse>()
+            val body = response.bodyOrThrow<CacaoProviderResponse>()
             Timber.d("getCacaoProvider: $body")
             return body
         } catch (e: Exception) {
@@ -289,7 +288,7 @@ constructor(
     override suspend fun getMayaConstants(): Map<String, Long> {
         try {
             val response = httpClient.get("https://mayanode.mayachain.info/mayachain/mimir")
-            val body = response.body<Map<String, Long>>()
+            val body = response.bodyOrThrow<Map<String, Long>>()
             Timber.d("getMayaConstants: $body")
             return body
         } catch (e: Exception) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -12,7 +12,6 @@ import com.vultisig.wallet.data.api.models.cosmos.PolkadotQueryInfoResponseJson
 import com.vultisig.wallet.data.api.utils.postRpc
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import java.math.BigInteger
@@ -94,7 +93,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
                 id = 1,
             )
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        return response.body<PolkadotGetNonceJson>().result
+        return response.bodyOrThrow<PolkadotGetNonceJson>().result
     }
 
     override suspend fun getBlockHash(isGenesis: Boolean): String {
@@ -106,7 +105,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
                 id = 1,
             )
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        return response.body<PolkadotGetBlockHashJson>().result
+        return response.bodyOrThrow<PolkadotGetBlockHashJson>().result
     }
 
     override suspend fun getGenesisBlockHash(): String {
@@ -122,7 +121,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
                 id = 1,
             )
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        val rpcResp = response.body<PolkadotGetRunTimeVersionJson>()
+        val rpcResp = response.bodyOrThrow<PolkadotGetRunTimeVersionJson>()
         val specVersion = rpcResp.result.specVersion
         val transactionVersion = rpcResp.result.transactionVersion
         return Pair(specVersion, transactionVersion)
@@ -138,7 +137,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
             )
 
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        val responseContent = response.body<PolkadotGetBlockHeaderJson>()
+        val responseContent = response.bodyOrThrow<PolkadotGetBlockHeaderJson>()
         val number = responseContent.result.number
         return BigInteger(number.drop(2), 16)
     }
@@ -152,7 +151,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
                 id = 1,
             )
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
+        val responseContent = response.bodyOrThrow<PolkadotBroadcastTransactionJson>()
         if (responseContent.error != null) {
             if (responseContent.error.code == 1012 || responseContent.error.code == 1013) {
                 return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.api.models.cosmos.PolkadotQueryInfoResponseJson
 import com.vultisig.wallet.data.api.utils.postRpc
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import java.math.BigInteger
@@ -151,7 +152,10 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
                 id = 1,
             )
         val response = httpClient.post(POLKADOT_API_URL) { setBody(payload) }
-        val responseContent = response.bodyOrThrow<PolkadotBroadcastTransactionJson>()
+        // Read the RPC body regardless of HTTP status: nodes may surface the idempotent
+        // "already in pool" errors (1012/1013) with a non-2xx status, and the duplicate
+        // rebroadcast from a second signing device must still resolve to null rather than throw.
+        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
         if (responseContent.error != null) {
             if (responseContent.error.code == 1012 || responseContent.error.code == 1013) {
                 return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -6,7 +6,6 @@ import com.vultisig.wallet.data.api.models.RpcPayload
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import java.math.BigInteger
@@ -43,7 +42,7 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
                 )
             val response = http.post(BASE_XRP_CLUSTER) { setBody(payload) }
 
-            val rpcResp = response.body<RippleBroadcastResponseResponseJson>()
+            val rpcResp = response.bodyOrThrow<RippleBroadcastResponseResponseJson>()
 
             val resultMessage = rpcResp.result.engineResultMessage
 
@@ -132,7 +131,7 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
                         },
                 )
             val response = http.post(BASE_XRP_CLUSTER) { setBody(payload) }
-            response.body<RippleAccountInfoResponseJson>()
+            response.bodyOrThrow<RippleAccountInfoResponseJson>()
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e("Error in fetchTokenAccountsByOwner: ${e.message}")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RouterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RouterApi.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.utils.throwIfUnsuccessful
 import com.vultisig.wallet.data.common.sha256
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -19,7 +19,10 @@ interface RouterApi {
 
 internal class RouterApiImp @Inject constructor(private val httpClient: HttpClient) : RouterApi {
     override suspend fun getPayload(serverURL: String, hash: String): String {
-        return httpClient.get("$serverURL/payload/$hash").throwIfUnsuccessful().body<String>()
+        return httpClient
+            .get("$serverURL/payload/$hash")
+            .throwIfUnsuccessful()
+            .bodyOrThrow<String>()
     }
 
     override suspend fun uploadPayload(serverURL: String, payload: String): String {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.api.utils.HttpException
 import com.vultisig.wallet.data.api.utils.throwIfUnsuccessful
 import com.vultisig.wallet.data.mediator.Message
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -77,7 +78,10 @@ internal class SessionApiImpl
 constructor(private val json: Json, private val httpClient: HttpClient) : SessionApi {
     override suspend fun checkCommittee(serverUrl: String, sessionId: String): List<String> {
         return withRelayRetry {
-            httpClient.get("$serverUrl/start/$sessionId").throwIfUnsuccessful().body<List<String>>()
+            httpClient
+                .get("$serverUrl/start/$sessionId")
+                .throwIfUnsuccessful()
+                .bodyOrThrow<List<String>>()
         }
     }
 
@@ -120,11 +124,14 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
         return httpClient
             .get("$serverUrl/complete/$sessionId")
             .throwIfUnsuccessful()
-            .body<List<String>>()
+            .bodyOrThrow<List<String>>()
     }
 
     override suspend fun getParticipants(serverUrl: String, sessionId: String): List<String> {
-        return httpClient.get("$serverUrl/$sessionId").throwIfUnsuccessful().body<List<String>>()
+        return httpClient
+            .get("$serverUrl/$sessionId")
+            .throwIfUnsuccessful()
+            .bodyOrThrow<List<String>>()
     }
 
     override suspend fun sendTssMessage(serverUrl: String, messageId: String?, message: Message) {
@@ -150,7 +157,7 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
                     messageId?.let { header(MESSAGE_ID_HEADER_TITLE, it) }
                 }
                 .throwIfUnsuccessful()
-                .body<List<Message>>()
+                .bodyOrThrow<List<Message>>()
         }
 
     override suspend fun deleteTssMessage(
@@ -187,7 +194,7 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
         return httpClient
             .get(serverUrl) { header(MESSAGE_ID_HEADER_TITLE, messageId) }
             .throwIfUnsuccessful()
-            .body<tss.KeysignResponse>()
+            .bodyOrThrow<tss.KeysignResponse>()
     }
 
     override suspend fun getSetupMessage(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -100,7 +100,7 @@ constructor(
                     id = 1,
                 )
             val response = httpClient.post(rpcEndpoint) { setBody(payload) }
-            val rpcResp = response.body<SolanaBalanceJson>()
+            val rpcResp = response.bodyOrThrow<SolanaBalanceJson>()
             Timber.tag("solanaApiImp").d(response.toString())
 
             if (rpcResp.error != null) {
@@ -141,7 +141,7 @@ constructor(
         val response = httpClient.post(rpcEndpoint) { setBody(payload) }
         val responseContent = response.bodyAsText()
         Timber.tag("solanaApiImp").d(responseContent)
-        val rpcResp = response.body<RecentBlockHashResponseJson>()
+        val rpcResp = response.bodyOrThrow<RecentBlockHashResponseJson>()
         if (rpcResp.error != null) {
             Timber.tag("solanaApiImp").d("get recent blockhash  error: ${rpcResp.error}")
             return ""
@@ -188,7 +188,7 @@ constructor(
                 )
             val response = httpClient.post(rpcEndpoint) { setBody(requestBody) }
             val responseRawString = response.bodyAsText()
-            val result = response.body<BroadcastTransactionRespJson>()
+            val result = response.bodyOrThrow<BroadcastTransactionRespJson>()
             result.error?.let { error ->
                 Timber.tag("SolanaApiImp").d("Error broadcasting transaction: $responseRawString")
                 error(error["message"].toString())
@@ -229,7 +229,7 @@ constructor(
                     try {
                         httpClient
                             .get(splTokensInfoEndpoint2) { parameter("query", token) }
-                            .body<List<SplTokenInfo>>()
+                            .bodyOrThrow<List<SplTokenInfo>>()
                             .firstOrNull()
                     } catch (e: Exception) {
                         if (e is kotlinx.coroutines.CancellationException) throw e
@@ -260,7 +260,7 @@ constructor(
 
                 listOf(response, responseToken2022)
                     .awaitAll()
-                    .mapNotNull { it.body<SplResponseJson>().result?.accounts }
+                    .mapNotNull { it.bodyOrThrow<SplResponseJson>().result?.accounts }
                     .flatten()
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
@@ -299,7 +299,7 @@ constructor(
             val response = httpClient.post(rpcEndpoint) { setBody(payload) }
             val responseContent = response.bodyAsText()
             Timber.d(responseContent)
-            val rpcResp = response.body<SplAmountRpcResponseJson>()
+            val rpcResp = response.bodyOrThrow<SplAmountRpcResponseJson>()
 
             if (rpcResp.error != null) {
                 Timber.d("get spl token amount error: ${rpcResp.error}")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -71,7 +70,7 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
                     contentType(ContentType.Application.Json)
                     setBody(tx)
                 }
-            val response = httpResponse.body<TronBroadcastTxResponseJson>()
+            val response = httpResponse.bodyOrThrow<TronBroadcastTxResponseJson>()
             if (response.code == NOT_ENOUGH_EFFECTIVE_CONNECTION_ERROR_CODE) {
                 Timber.d("Tron broadcast NOT_ENOUGH_EFFECTIVE_CONNECTION, attempt %d", attempt + 1)
                 if (attempt < MAX_BROADCAST_RETRIES - 1) {
@@ -89,7 +88,7 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
     override suspend fun getSpecific() =
         httpClient
             .post(tronGrid) { url { path("tron", "wallet", "getnowblock") } }
-            .body<TronSpecificBlockJson>()
+            .bodyOrThrow<TronSpecificBlockJson>()
 
     override suspend fun getTriggerConstantContractFee(
         ownerAddressBase58: String,
@@ -126,7 +125,7 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
     override suspend fun getBalance(coin: Coin): BigInteger {
         try {
             val response = httpClient.get("$tronGrid/v1/accounts/${coin.address}")
-            val content = response.body<TronBalanceResponseJson>()
+            val content = response.bodyOrThrow<TronBalanceResponseJson>()
             val account = content.tronBalanceResponseData.firstOrNull() ?: return BigInteger.ZERO
 
             return if (coin.isNativeToken) {
@@ -182,7 +181,7 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
                     url { path("tron", "walletsolidity", "gettransactionbyid") }
                     setBody(mapOf("value" to txHash))
                 }
-                .body<TronTransactionStatusResponse?>()
+                .bodyOrThrow<TronTransactionStatusResponse?>()
                 ?.takeIf { it.txId != null }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoBroadcastDataResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoBroadcastDataResponseJson.kt
@@ -1,9 +1,0 @@
-package com.vultisig.wallet.data.api.models.cardano
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class CardanoBroadcastDataResponseJson(
-    @SerialName("transaction_hash") val transactionHash: String
-)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoBroadcastResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoBroadcastResponseJson.kt
@@ -1,9 +1,0 @@
-package com.vultisig.wallet.data.api.models.cardano
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class CardanoBroadcastResponseJson(
-    @SerialName("data") val data: CardanoBroadcastDataResponseJson
-)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoTransactionHashRequestBodyJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoTransactionHashRequestBodyJson.kt
@@ -1,7 +1,0 @@
-package com.vultisig.wallet.data.api.models.cardano
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class CardanoTransactionHashRequestBodyJson(@SerialName("data") val data: String)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/KyberApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/KyberApi.kt
@@ -10,7 +10,6 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.utils.KyberSwapQuoteResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
@@ -95,7 +94,7 @@ constructor(
             if (!response.status.isSuccess()) {
                 val errorResponse =
                     runCatching {
-                            json.decodeFromString<KyberSwapErrorResponse>(response.body<String>())
+                            json.decodeFromString<KyberSwapErrorResponse>(response.bodyAsText())
                         }
                         .getOrNull()
                 return KyberSwapQuoteDeserialized.Error(
@@ -108,7 +107,7 @@ constructor(
 
             return json.decodeFromString(
                 kyberSwapQuoteResponseJsonSerializer,
-                response.body<String>(),
+                response.bodyOrThrow<String>(),
             )
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
@@ -13,6 +13,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import java.math.BigInteger
 import javax.inject.Inject
@@ -86,7 +87,10 @@ constructor(
                 listOf(swapResponseAsync, quoteResponseAsync).awaitAll().also { responses ->
                     responses.forEach { response ->
                         if (!response.status.isSuccess()) {
-                            val resp = response.body<OneInchSwapQuoteErrorResponse>()
+                            val resp =
+                                json.decodeFromString<OneInchSwapQuoteErrorResponse>(
+                                    response.bodyAsText()
+                                )
                             return@coroutineScope EVMSwapQuoteDeserialized.Error(
                                 error = resp.description
                             )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
@@ -9,7 +9,6 @@ import com.vultisig.wallet.data.models.oneInchChainId
 import com.vultisig.wallet.data.utils.OneInchSwapQuoteResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -22,6 +21,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 
 interface OneInchApi {
@@ -101,8 +101,8 @@ constructor(
             json.decodeFromJsonElement(
                 oneInchSwapQuoteResponseJsonSerializer,
                 buildJsonObject {
-                    put("swap", swapResponse.body())
-                    put("quote", quoteResponse.body())
+                    put("swap", swapResponse.bodyOrThrow<JsonElement>())
+                    put("quote", quoteResponse.bodyOrThrow<JsonElement>())
                 },
             )
         } catch (e: Exception) {
@@ -137,7 +137,7 @@ constructor(
     override suspend fun getTokens(chain: Chain): OneInchTokensJson =
         httpClient
             .get("https://api.vultisig.com/1inch/swap/v6.1/${chain.oneInchChainId()}/tokens")
-            .body()
+            .bodyOrThrow<OneInchTokensJson>()
 
     override suspend fun getContractsWithBalance(chain: Chain, address: String): List<String> {
         val response =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -19,8 +20,13 @@ import org.junit.jupiter.api.Test
  */
 class CardanoApiBroadcastTest {
 
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
     private fun newApi(status: HttpStatusCode, body: String): CardanoApi =
-        CardanoApiImpl(httpClient = MockHttpClient.respondingWith(status, body))
+        CardanoApiImpl(httpClient = MockHttpClient.respondingWith(status, body), json = json)
 
     @Test
     fun `broadcastTransaction returns transaction id on success`() = runTest {


### PR DESCRIPTION
## Summary

Closes #3865. Swaps raw `.body<T>()` for `.bodyOrThrow<T>()` on success-path reads across the API layer so HTTP errors are wrapped consistently (per the two-layer error-handling architecture in `docs/network-error-handling.md`).

This is the second half of a two-PR, test-first flow. The characterization tests landed first in #4629 (now merged); this PR applies the production swap and those same tests stay green.

## Changes

- Success-path reads in 17 API files now use `bodyOrThrow<T>()` instead of `body<T>()`.
- Error-parsing branches that read **non-2xx** bodies are intentionally left **not** using `bodyOrThrow` (it throws on non-2xx, which would break their error handling):
  - `KyberApi` / `LiFiChainApi`: read via `bodyAsText()`. LiFi has no `isSuccess` guard and relies on its serializer to surface the body's error `message`, so it must not throw on non-2xx.
  - `OneInchApi` / `CardanoApi` BadRequest branch: `json.decodeFromString(bodyAsText())`.
- `CardanoApi` gains a private `Json` for the BadRequest decode (constructor unchanged). Also removed a dead commented-out `broadcastTransaction` block and its orphaned `url2` field.

## Test plan

- `grep '\.body<' data/.../api/` → 0 remaining usages.
- All 16 characterization classes from #4629 pass against the refactored code: **69 tests, 0 failures** via `./gradlew :data:testDebugUnitTest`.
- `./gradlew :data:ktfmtCheckMain` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened HTTP response parsing and error handling across many blockchain and swap integrations to reduce silent failures and improve reliability.
* **Bug Fixes**
  * Made parsing stricter so malformed or unexpected responses surface as errors rather than silently producing nulls.
* **Tests**
  * Updated tests to align with the new JSON parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->