### PR TITLE
fix: THORChain Bond verify screen title + padding mismatch (#4606)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositScreen.kt
@@ -84,7 +84,7 @@ internal fun DepositScreen(
             title = defaultTitle
         }
         SendDst.VerifyTransaction.staticRoute -> {
-            title = stringResource(R.string.verify_transaction_screen_title)
+            title = stringResource(R.string.verify_deposit_function_overview)
         }
         else -> {
             title = defaultTitle

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -125,7 +125,7 @@ internal fun VerifyDepositScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier =
                     Modifier.padding(contentPadding)
-                        .padding(all = 16.dp)
+                        .padding(horizontal = if (hasToolbar) 16.dp else 0.dp, vertical = 16.dp)
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState()),
             ) {
@@ -309,7 +309,9 @@ internal fun VerifyDepositScreen(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp),
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(horizontal = if (hasToolbar) 24.dp else 8.dp, vertical = 12.dp),
             ) {
                 if (state.hasFastSign) {
                     Text(


### PR DESCRIPTION
## Summary
- Fixes the initiator showing \"Verify\" instead of \"Function overview\" on the THORChain Bond verify step — now matches the joiner
- Fixes the initiator's content card having double horizontal padding (32dp) vs the joiner's correct 16dp — caused by the outer `V2Scaffold` in `DepositScreen` (16dp) stacking with the inner `VerifyDepositScreen` padding (16dp)
- Adjusts bottom bar button padding similarly so the sign button aligns with the joiner (outer 16dp + inner 8dp = 24dp total, same as joiner's explicit 24dp)

## Root Cause
`DepositScreen` wraps its entire nav host in a `V2Scaffold` that applies `16dp` horizontal padding. When `VerifyDepositScreen` is rendered inside it (initiator path, `hasToolbar = false`), its own `padding(all = 16.dp)` stacks on top → 32dp total. The joiner path calls `VerifyDepositScreen(hasToolbar = true)` as the root scaffold, so it only sees the screen's own 16dp.

## Fix
1. `DepositScreen.kt`: use `verify_deposit_function_overview` ("Function overview") instead of `verify_transaction_screen_title` ("Verify") for the deposit verify route title
2. `VerifyDepositScreen.kt`: when `hasToolbar = false`, set content horizontal padding to `0.dp` (outer scaffold provides 16dp) and bottom bar horizontal padding to `8.dp` (outer 16dp + 8dp = 24dp)

## Issue
Closes #4606

## Test Plan
- [x] On the initiator device, start a THORChain BOND transaction and reach the verify step — title should now read "Function overview"
- [x] Compare the content card width on initiator vs joiner — addresses should truncate identically
- [x] Memo wraps the same way on both devices
- [x] Joiner layout is unchanged (all padding values unchanged when `hasToolbar = true`)
- [x] Lint passes (`./gradlew lint`) ✅
- [x] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated deposit verification screen title for improved clarity and consistency
  * Enhanced layout spacing to dynamically adjust padding based on interface element presence, improving overall responsiveness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->