### PR TITLE
fix(swap): clear loading state when quote times out

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -290,7 +290,17 @@ constructor(
         val successes = results.mapNotNull { it.getOrNull() }
         if (successes.isEmpty()) {
             val failures = results.mapNotNull { it.exceptionOrNull() }
-            throw failures.firstOrNull { it is SwapException } ?: failures.first()
+            val firstSwapException = failures.firstOrNull { it is SwapException }
+            if (firstSwapException != null) throw firstSwapException
+            val firstFailure = failures.first()
+            // TimeoutCancellationException is a CancellationException — re-throwing it would
+            // propagate coroutine cancellation and leave the UI stuck in a loading state.
+            // Convert it to a SwapException so the error handler in calculateFees() can
+            // clear the loading state and show a user-facing message.
+            if (firstFailure is TimeoutCancellationException) {
+                throw SwapException.TimeOut(firstFailure.message ?: "Quote fetch timed out")
+            }
+            throw firstFailure
         }
 
         // Rank on estimatedDstFiat alone — this represents the destination amount

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -290,17 +290,11 @@ constructor(
         val successes = results.mapNotNull { it.getOrNull() }
         if (successes.isEmpty()) {
             val failures = results.mapNotNull { it.exceptionOrNull() }
-            val firstSwapException = failures.firstOrNull { it is SwapException }
-            if (firstSwapException != null) throw firstSwapException
-            val firstFailure = failures.first()
-            // TimeoutCancellationException is a CancellationException — re-throwing it would
-            // propagate coroutine cancellation and leave the UI stuck in a loading state.
-            // Convert it to a SwapException so the error handler in calculateFees() can
-            // clear the loading state and show a user-facing message.
-            if (firstFailure is TimeoutCancellationException) {
-                throw SwapException.TimeOut(firstFailure.message ?: "Quote fetch timed out")
-            }
-            throw firstFailure
+            failures.firstOrNull { it is SwapException }?.let { throw it }
+            failures
+                .firstOrNull { it is TimeoutCancellationException }
+                ?.let { throw SwapException.TimeOut(it.message.orEmpty()) }
+            throw failures.first()
         }
 
         // Rank on estimatedDstFiat alone — this represents the destination amount

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -1,0 +1,85 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenToToken
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.data.usecases.SearchTokenUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertIs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class SwapQuoteManagerTest {
+
+    private val swapQuoteRepository: SwapQuoteRepository = mockk(relaxed = true)
+    private val tokenRepository: TokenRepository = mockk(relaxed = true)
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk(relaxed = true)
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper =
+        mockk(relaxed = true)
+    private val fiatValueToString: FiatValueToStringMapper = mockk(relaxed = true)
+    private val searchToken: SearchTokenUseCase = mockk(relaxed = true)
+    private val convertTokenToTokenUseCase: ConvertTokenToToken = mockk(relaxed = true)
+
+    private fun createManager() =
+        SwapQuoteManager(
+            swapQuoteRepository = swapQuoteRepository,
+            tokenRepository = tokenRepository,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            fiatValueToString = fiatValueToString,
+            searchToken = searchToken,
+            convertTokenToTokenUseCase = convertTokenToTokenUseCase,
+        )
+
+    @Test
+    fun `fetchBestQuote converts all-timeout failures to SwapException_TimeOut`() = runTest {
+        coEvery { tokenRepository.getNativeToken(any()) } coAnswers
+            {
+                delay(Long.MAX_VALUE)
+                error("unreachable")
+            }
+
+        val manager = createManager()
+        val deferred = async {
+            runCatching {
+                manager.fetchBestQuote(
+                    candidates =
+                        listOf(
+                            QuoteCandidate(
+                                provider = SwapProvider.THORCHAIN,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            )
+                        ),
+                    src = mockk(relaxed = true),
+                    dst = mockk(relaxed = true),
+                    srcToken = mockk(relaxed = true),
+                    dstToken = mockk(relaxed = true),
+                    srcTokenValue = BigInteger.ONE,
+                    tokenValue = mockk(relaxed = true),
+                    currency = AppCurrency.USD,
+                    amount = BigDecimal.ONE,
+                )
+            }
+        }
+
+        advanceTimeBy(15_001L)
+
+        assertIs<SwapException.TimeOut>(deferred.await().exceptionOrNull())
+    }
+}


### PR DESCRIPTION
## Summary

- When all swap quote providers time out, `fetchBestQuote` rethrows the `TimeoutCancellationException` collected from the inner `withTimeout`
- `TimeoutCancellationException` is a `CancellationException`, so the catch block in `calculateFees()` re-throws it instead of routing it to `resetQuoteState()`
- This leaves `isLoading = true` forever — the screen shows a loading spinner indefinitely with no error, retry option, or way to proceed
- Fix: convert `TimeoutCancellationException` → `SwapException.TimeOut` in `fetchBestQuote` so the `catch (e: SwapException)` handler in `calculateFees()` can clear the loading state and show "Swap request timed out. Please try again"

## Issue

Closes #4583

## Test Plan

- [ ] Set From = BCH, To = LTC, enter an amount and wait for quote to load — screen should now show a timeout error message instead of spinning forever
- [ ] Confirm other swap pairs (ETH → USDC etc.) still load quotes normally
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error selection when all swap quote attempts fail: prioritizes specific swap errors and converts pure timeouts into a clear timeout error.

* **Tests**
  * Added a test to verify that multiple timeout failures are reported as a single timeout error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->