### PR TITLE
perf(balances): stream per-chain balances, cached snapshot first

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -48,8 +48,10 @@ import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.VaultI
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.pushNotificationErrorUiText
 import com.vultisig.wallet.ui.utils.textAsFlow
+import com.vultisig.wallet.ui.utils.throttleLatest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -405,8 +407,15 @@ constructor(
             viewModelScope.safeLaunch {
                 combine(
                         accountsRepository
-                            .loadAddresses(vaultId)
-                            .map { it.sortByAccountsTotalFiatValue() }
+                            .loadAddressBalances(vaultId)
+                            // Leading debounce: coalesce the burst of per-chain updates so the rows
+                            // settle once per window instead of reordering on every chain arrival
+                            // (matches the leading debounce iOS added in #4337).
+                            .throttleLatest(BALANCE_RENDER_WINDOW) { it.isComplete }
+                            // Keep the pull-to-refresh spinner up until every chain has resolved,
+                            // matching iOS/Windows, instead of clearing it on the cached snapshot.
+                            .onEach { if (it.isComplete) updateRefreshing(false) }
+                            .map { it.addresses.sortByAccountsTotalFiatValue() }
                             .catch {
                                 updateRefreshing(false)
                                 Timber.e(it)
@@ -498,7 +507,6 @@ constructor(
                 )
             }
         }
-        updateRefreshing(false)
 
         Timber.d("Update updateUiStateFromList: %s", "$this")
     }
@@ -704,5 +712,9 @@ constructor(
 
     companion object {
         internal const val REFRESH_CHAIN_DATA = "refresh_chain_data"
+
+        // Window for coalescing per-chain balance updates so rows settle once per window instead
+        // of reordering on every chain arrival; matches the leading debounce iOS uses (#4337).
+        private val BALANCE_RENDER_WINDOW = 250.milliseconds
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -282,7 +282,7 @@ constructor(
     fun refreshData() {
         val vaultId = vaultId ?: return
         updateRefreshing(true)
-        loadAccounts(vaultId, true)
+        loadAccounts(vaultId)
     }
 
     fun send() {
@@ -399,13 +399,13 @@ constructor(
             }
     }
 
-    private fun loadAccounts(vaultId: String, isRefresh: Boolean = false) {
+    private fun loadAccounts(vaultId: String) {
         loadAccountsJob?.cancel()
         loadAccountsJob =
             viewModelScope.safeLaunch {
                 combine(
                         accountsRepository
-                            .loadAddresses(vaultId, isRefresh)
+                            .loadAddresses(vaultId)
                             .map { it.sortByAccountsTotalFiatValue() }
                             .catch {
                                 updateRefreshing(false)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
@@ -142,7 +142,7 @@ internal class AccountsLoader(
                 )
             }
         accountsRepository
-            .loadAddresses(vaultId, isRefresh = false)
+            .loadAddresses(vaultId)
             .map { addrs -> addrs.flatMap { it.accounts } }
             .collect { accountsLoaded ->
                 publishCircleUsdc(
@@ -211,7 +211,7 @@ internal class AccountsLoader(
         val cachedDetails =
             stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.ThorChain.RUJI.id)
         accountsRepository
-            .loadAddresses(vaultId, isRefresh = false)
+            .loadAddresses(vaultId)
             .map { addrs -> addrs.flatMap { it.accounts } }
             .collect { accountsLoaded ->
                 publishRewards(accountsLoaded, cachedDetails?.rewards, generation)

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/ThrottleLatest.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/ThrottleLatest.kt
@@ -1,0 +1,35 @@
+package com.vultisig.wallet.ui.utils
+
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Leading throttle: emits the first value immediately, then at most one value per [window], always
+ * passing through any value for which [isTerminal] is true so the final state is never dropped (the
+ * snapshots are cumulative, so a dropped intermediate is superseded by the next one that gets
+ * through).
+ *
+ * Mirrors the leading debounce iOS applies to balance updates (#4337) so rows settle once per
+ * window instead of reordering on every per-chain emission.
+ *
+ * [timeSource] is injectable so tests can drive the window deterministically; production uses a
+ * monotonic wall clock rather than the coroutine scheduler so the window reflects real elapsed time
+ * regardless of how fast upstream emits.
+ */
+internal fun <T> Flow<T>.throttleLatest(
+    window: Duration,
+    timeSource: TimeSource = TimeSource.Monotonic,
+    isTerminal: (T) -> Boolean = { false },
+): Flow<T> = flow {
+    var lastEmit: TimeMark? = null
+    collect { value ->
+        val previous = lastEmit
+        if (isTerminal(value) || previous == null || previous.elapsedNow() >= window) {
+            lastEmit = timeSource.markNow()
+            emit(value)
+        }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.AddressBalancesUpdate
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
@@ -50,6 +51,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.math.BigDecimal
 import java.math.BigInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -212,26 +214,28 @@ internal class VaultAccountsViewModelTest {
             vm.uiState.value.cryptoConnectionType shouldBe CryptoConnectionType.Wallet
         }
 
-    /** Verifies refreshData re-invokes accountsRepository with isRefresh=true. */
+    /**
+     * Verifies refreshData re-triggers a balance reload via accountsRepository.loadAddressBalances.
+     */
     @Test
-    fun `refreshData re-invokes accountsRepository with isRefresh true`() =
+    fun `refreshData re-invokes loadAddressBalances`() =
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
 
             val vm = createViewModel()
             advanceUntilIdle()
-            // Drop any loadAddresses calls made during init; only count the refresh call.
+            // Drop any loadAddressBalances calls made during init; only count the refresh call.
             clearMocks(accountsRepository, answers = false)
 
             vm.refreshData()
             advanceUntilIdle()
 
-            verify(exactly = 1) { accountsRepository.loadAddresses("vault-1") }
+            verify(exactly = 1) { accountsRepository.loadAddressBalances("vault-1") }
         }
 
     /**
-     * Verifies refreshData drives `loadAddresses` to completion via the .catch block when the
+     * Verifies refreshData drives the balance load to completion via the .catch block when the
      * underlying flow throws, leaving `isRefreshing` cleared. The verify guards against a no-op
      * implementation passing the assertion vacuously (default `isRefreshing` is already false).
      */
@@ -240,7 +244,7 @@ internal class VaultAccountsViewModelTest {
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1") } returns
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
                 flow { throw RuntimeException("Balance load failed") }
 
             val vm = createViewModel()
@@ -252,16 +256,67 @@ internal class VaultAccountsViewModelTest {
             advanceUntilIdle()
 
             vm.uiState.value.isRefreshing.shouldBeFalse()
-            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1") }
+            verify(atLeast = 1) { accountsRepository.loadAddressBalances("vault-1") }
         }
 
     /**
-     * Verifies that when `accountsRepository.loadAddresses` emits a non-empty list of `Address`
-     * during init, the mapped `AccountUiModel`s appear in `uiState.accounts` and preserve the
-     * underlying address/chain identity from the source `Address`.
+     * Verifies the pull-to-refresh spinner stays up until the whole refresh completes (matching
+     * iOS/Windows) rather than clearing on the cached snapshot that loadAddressBalances emits
+     * first. The spinner must remain while only the cached (isComplete = false) emission has been
+     * seen, and clear only once the terminal (isComplete = true) emission arrives.
      */
     @Test
-    fun `accounts from loadAddresses are surfaced in uiState`() =
+    fun `refresh spinner stays up until load completes`() =
+        runTest(testDispatcher) {
+            val address = buildTestAddress(chain = Chain.Ethereum, address = "0xabc")
+            val completeGate = CompletableDeferred<Unit>()
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flow {
+                    emit(AddressBalancesUpdate(listOf(address), isComplete = false))
+                    completeGate.await()
+                    emit(AddressBalancesUpdate(listOf(address), isComplete = true))
+                }
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            // Stub the mappers so rendering the cached snapshot succeeds; an unstubbed mapper would
+            // throw and trip the .catch in loadAccounts, clearing the spinner for the wrong reason.
+            coEvery { addressToUiModelMapper(any()) } returns
+                AccountUiModel(
+                    model = address,
+                    chainName = Chain.Ethereum.raw,
+                    logo = 0,
+                    address = address.address,
+                    nativeTokenAmount = "1.0",
+                    fiatAmount = "$10.00",
+                    assetsSize = address.accounts.size,
+                    nativeTokenTicker = "ETH",
+                )
+            coEvery { fiatValueToStringMapper(any(), any()) } returns "$10.00"
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.refreshData()
+            advanceUntilIdle()
+
+            // Only the cached snapshot has been emitted; the network balances are still loading,
+            // so the spinner must still be up.
+            vm.uiState.value.isRefreshing.shouldBeTrue()
+
+            completeGate.complete(Unit)
+            advanceUntilIdle()
+
+            // Terminal emission arrived — the refresh is done and the spinner clears.
+            vm.uiState.value.isRefreshing.shouldBeFalse()
+        }
+
+    /**
+     * Verifies that when `accountsRepository.loadAddressBalances` emits a non-empty list of
+     * `Address` during init, the mapped `AccountUiModel`s appear in `uiState.accounts` and preserve
+     * the underlying address/chain identity from the source `Address`.
+     */
+    @Test
+    fun `accounts from loadAddressBalances are surfaced in uiState`() =
         runTest(testDispatcher) {
             val testAddress = buildTestAddress(chain = Chain.Ethereum, address = "0xabc")
             val mappedUiModel =
@@ -278,8 +333,8 @@ internal class VaultAccountsViewModelTest {
 
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1") } returns
-                flowOf(listOf(testAddress))
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flowOf(AddressBalancesUpdate(listOf(testAddress), isComplete = true))
             coEvery { addressToUiModelMapper(any()) } returns mappedUiModel
             coEvery { fiatValueToStringMapper(any(), any()) } returns "$10.00"
 
@@ -296,19 +351,19 @@ internal class VaultAccountsViewModelTest {
         }
 
     /**
-     * Verifies that an exception thrown by `accountsRepository.loadAddresses` during the init load
-     * path is caught (via the `.catch` block in `loadAccounts`) so the ViewModel does not crash,
-     * `accounts` stays empty, and `isRefreshing` remains cleared. Per-chain failures are already
-     * swallowed inside `AccountsRepositoryImpl`, so the only externally observable error channel
-     * from a flow consumer's perspective is a whole-flow throwable; this test exercises that
-     * pathway from the init side (mirrors the refresh-side test above).
+     * Verifies that an exception thrown by `accountsRepository.loadAddressBalances` during the init
+     * load path is caught (via the `.catch` block in `loadAccounts`) so the ViewModel does not
+     * crash, `accounts` stays empty, and `isRefreshing` remains cleared. Per-chain failures are
+     * already swallowed inside `AccountsRepositoryImpl`, so the only externally observable error
+     * channel from a flow consumer's perspective is a whole-flow throwable; this test exercises
+     * that pathway from the init side (mirrors the refresh-side test above).
      */
     @Test
-    fun `init load swallows loadAddresses failure without crashing`() =
+    fun `init load swallows loadAddressBalances failure without crashing`() =
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1") } returns
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
                 flow { throw RuntimeException("Per-chain balance load failed") }
 
             val vm = createViewModel()
@@ -318,7 +373,7 @@ internal class VaultAccountsViewModelTest {
             // populated with stale or partial data.
             vm.uiState.value.isRefreshing.shouldBeFalse()
             vm.uiState.value.accounts.isEmpty().shouldBeTrue()
-            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1") }
+            verify(atLeast = 1) { accountsRepository.loadAddressBalances("vault-1") }
         }
 
     /** Verifies dismissBuyVultBanner persists the dismissed flag. */

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -227,7 +227,7 @@ internal class VaultAccountsViewModelTest {
             vm.refreshData()
             advanceUntilIdle()
 
-            verify(exactly = 1) { accountsRepository.loadAddresses("vault-1", true) }
+            verify(exactly = 1) { accountsRepository.loadAddresses("vault-1") }
         }
 
     /**
@@ -240,7 +240,7 @@ internal class VaultAccountsViewModelTest {
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1", true) } returns
+            every { accountsRepository.loadAddresses("vault-1") } returns
                 flow { throw RuntimeException("Balance load failed") }
 
             val vm = createViewModel()
@@ -252,7 +252,7 @@ internal class VaultAccountsViewModelTest {
             advanceUntilIdle()
 
             vm.uiState.value.isRefreshing.shouldBeFalse()
-            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1", true) }
+            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1") }
         }
 
     /**
@@ -278,7 +278,7 @@ internal class VaultAccountsViewModelTest {
 
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1", any()) } returns
+            every { accountsRepository.loadAddresses("vault-1") } returns
                 flowOf(listOf(testAddress))
             coEvery { addressToUiModelMapper(any()) } returns mappedUiModel
             coEvery { fiatValueToStringMapper(any(), any()) } returns "$10.00"
@@ -308,7 +308,7 @@ internal class VaultAccountsViewModelTest {
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { accountsRepository.loadAddresses("vault-1", any()) } returns
+            every { accountsRepository.loadAddresses("vault-1") } returns
                 flow { throw RuntimeException("Per-chain balance load failed") }
 
             val vm = createViewModel()
@@ -318,7 +318,7 @@ internal class VaultAccountsViewModelTest {
             // populated with stale or partial data.
             vm.uiState.value.isRefreshing.shouldBeFalse()
             vm.uiState.value.accounts.isEmpty().shouldBeTrue()
-            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1", any()) }
+            verify(atLeast = 1) { accountsRepository.loadAddresses("vault-1") }
         }
 
     /** Verifies dismissBuyVultBanner persists the dismissed flag. */

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -251,12 +251,14 @@ internal class VaultAccountsViewModelTest {
             advanceUntilIdle()
             // Sanity: init must not leave the spinner running.
             vm.uiState.value.isRefreshing.shouldBeFalse()
+            // Drop any loadAddressBalances calls made during init; only count the refresh call.
+            clearMocks(accountsRepository, answers = false)
 
             vm.refreshData()
             advanceUntilIdle()
 
             vm.uiState.value.isRefreshing.shouldBeFalse()
-            verify(atLeast = 1) { accountsRepository.loadAddressBalances("vault-1") }
+            verify(exactly = 1) { accountsRepository.loadAddressBalances("vault-1") }
         }
 
     /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
@@ -120,7 +120,7 @@ internal class AccountsLoaderTest {
             advanceUntilIdle()
 
             assertEquals(listOf(tcyAccount), loadedAccounts)
-            coVerify(exactly = 0) { accountsRepository.loadAddresses(any(), any()) }
+            coVerify(exactly = 0) { accountsRepository.loadAddresses(any()) }
         }
 
     @Test
@@ -154,7 +154,7 @@ internal class AccountsLoaderTest {
             defiType = DeFiNavActions.WITHDRAW_RUJI
             val runeAccount = thorAccount(Coins.ThorChain.RUNE.copy(address = "thor1"))
             val rujiAccount = thorAccount(Coins.ThorChain.RUJI.copy(address = "thor1"))
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
                         Address(
@@ -190,7 +190,7 @@ internal class AccountsLoaderTest {
             defiType = DeFiNavActions.WITHDRAW_RUJI
             val runeAccount = thorAccount(Coins.ThorChain.RUNE)
             val rujiAccount = thorAccount(Coins.ThorChain.RUJI)
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
                         Address(
@@ -221,8 +221,7 @@ internal class AccountsLoaderTest {
         runTest(mainDispatcher) {
             defiType = DeFiNavActions.WITHDRAW_RUJI
             // No RUNE account in the vault — publishRewards short-circuits to empty.
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
-                flowOf(emptyList())
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns flowOf(emptyList())
             val loader = build(backgroundScope)
 
             // Pre-existing state from a prior nav action — must not leak through.
@@ -249,7 +248,7 @@ internal class AccountsLoaderTest {
             // yield() between emissions gives the accountsState subscriber a chance to
             // observe the cached snapshot — without it StateFlow conflates the two writes
             // and the test only sees the final hydrated value.
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flow {
                     emit(
                         listOf(
@@ -303,7 +302,7 @@ internal class AccountsLoaderTest {
             defiType = DeFiNavActions.WITHDRAW_RUJI
             val runeAccount = thorAccount(Coins.ThorChain.RUNE.copy(address = "thor1"))
             val rujiAccount = thorAccount(Coins.ThorChain.RUJI.copy(address = "thor1"))
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flow {
                     emit(
                         listOf(
@@ -352,7 +351,7 @@ internal class AccountsLoaderTest {
             defiType = DeFiNavActions.WITHDRAW_USDC_CIRCLE
             mscaAddress = null
             val ethAccount = ethAccount()
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
                         Address(
@@ -382,7 +381,7 @@ internal class AccountsLoaderTest {
             defiType = DeFiNavActions.WITHDRAW_USDC_CIRCLE
             mscaAddress = "0xMSCA"
             val ethAccount = ethAccount()
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
                         Address(
@@ -412,8 +411,7 @@ internal class AccountsLoaderTest {
             // No ETH account in the vault → falling back to a zero-address ETH placeholder
             // would silently produce a USDC token with no address bound, which breaks any
             // later submit. The loader must publish empty instead.
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
-                flowOf(emptyList())
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns flowOf(emptyList())
             val loader = build(backgroundScope)
 
             accountsState.value = AccountsLoadState.Loaded(listOf(ethAccount())) // sentinel
@@ -433,7 +431,7 @@ internal class AccountsLoaderTest {
             val hydratedEth =
                 cachedEth.copy(tokenValue = TokenValue(BigInteger("123456789"), Coins.Ethereum.ETH))
             // yield() between emissions — see WITHDRAW_RUJI dual-emission test.
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flow {
                     emit(
                         listOf(
@@ -488,7 +486,7 @@ internal class AccountsLoaderTest {
             val cachedEth = ethAccount()
             val hydratedEth =
                 cachedEth.copy(tokenValue = TokenValue(BigInteger("42"), Coins.Ethereum.ETH))
-            every { accountsRepository.loadAddresses(VAULT_ID, isRefresh = false) } returns
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flow {
                     emit(
                         listOf(

--- a/app/src/test/java/com/vultisig/wallet/ui/utils/ThrottleLatestTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/utils/ThrottleLatestTest.kt
@@ -1,0 +1,47 @@
+package com.vultisig.wallet.ui.utils
+
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TestTimeSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ThrottleLatestTest {
+
+    @Test
+    fun `emits the leading value immediately and drops values within the window`() = runTest {
+        val time = TestTimeSource()
+        val source = flow {
+            emit(1) // leading edge -> emitted
+            emit(2) // same instant, within window -> dropped
+            time += 300.milliseconds
+            emit(3) // window elapsed -> emitted
+            emit(4) // same instant, within window -> dropped
+        }
+
+        val result = source.throttleLatest(window = 250.milliseconds, timeSource = time).toList()
+
+        assertEquals(listOf(1, 3), result)
+    }
+
+    @Test
+    fun `always passes terminal values even within the window`() = runTest {
+        val time = TestTimeSource()
+        val source = flow {
+            emit(1 to false) // leading edge -> emitted
+            emit(2 to false) // within window -> dropped
+            emit(3 to true) // terminal -> emitted despite the window
+        }
+
+        val result =
+            source
+                .throttleLatest(window = 250.milliseconds, timeSource = time) { it.second }
+                .toList()
+
+        assertEquals(listOf(1 to false, 3 to true), result)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.supervisorScope
 import timber.log.Timber
 
 interface AccountsRepository {
-    fun loadAddresses(vaultId: String, isRefresh: Boolean = false): Flow<List<Address>>
+    fun loadAddresses(vaultId: String): Flow<List<Address>>
 
     fun loadCachedAddresses(vaultId: String): Flow<List<Address>>
 
@@ -69,16 +69,17 @@ constructor(
     private fun getVaultAsFlow(vaultId: String): Flow<Vault> =
         vaultRepository.getAsFlow(vaultId).filterNotNull()
 
-    override fun loadAddresses(vaultId: String, isRefresh: Boolean): Flow<List<Address>> =
+    override fun loadAddresses(vaultId: String): Flow<List<Address>> =
         buildCacheAddresses(vaultId).flatMapLatest { (vaultCoins, addresses) ->
             channelFlow {
                 supervisorScope {
                     val loadPrices = async { tokenPriceRepository.refresh(vaultCoins) }
 
-                    if (!isRefresh) {
-                        addresses.fetchAccountFromDb()
-                        send(addresses)
-                    }
+                    // Always emit the last-known DB snapshot first so the UI shows cached
+                    // balances immediately instead of empty rows — including on refresh
+                    // (e.g. right after adding a chain).
+                    addresses.fetchAccountFromDb()
+                    send(addresses.toList())
 
                     addresses
                         .mapIndexed { index, account ->
@@ -109,6 +110,11 @@ constructor(
                                     }
 
                                     addresses[index] = account.copy(accounts = newAccounts)
+                                    // Stream each chain's balance as soon as it resolves rather
+                                    // than waiting for every chain to finish, matching iOS/Windows.
+                                    // Emit a snapshot copy because other chains may still be
+                                    // mutating the backing list in parallel.
+                                    send(addresses.toList())
                                 } catch (e: Exception) {
                                     if (e is kotlinx.coroutines.CancellationException) throw e
                                     Timber.e(e)
@@ -117,7 +123,7 @@ constructor(
                             }
                         }
                         .awaitAll()
-                    send(addresses)
+                    send(addresses.toList())
                 }
                 awaitClose()
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -37,8 +38,23 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.supervisorScope
 import timber.log.Timber
 
+/**
+ * Progressive result of a balance load: [addresses] is the latest snapshot and [isComplete] is true
+ * only on the terminal emission, once every chain has resolved (or failed). Lets callers that care
+ * about the load lifecycle — e.g. the pull-to-refresh spinner — know when the refresh is done,
+ * which a plain `Flow<List<Address>>` cannot express because the stream stays open.
+ */
+data class AddressBalancesUpdate(val addresses: List<Address>, val isComplete: Boolean)
+
 interface AccountsRepository {
     fun loadAddresses(vaultId: String): Flow<List<Address>>
+
+    /**
+     * Same per-chain streaming load as [loadAddresses] but each emission also carries whether the
+     * whole load has finished. [loadAddresses] is implemented on top of this, dropping the terminal
+     * completion emission since it only repeats the last snapshot.
+     */
+    fun loadAddressBalances(vaultId: String): Flow<AddressBalancesUpdate>
 
     fun loadCachedAddresses(vaultId: String): Flow<List<Address>>
 
@@ -69,7 +85,13 @@ constructor(
     private fun getVaultAsFlow(vaultId: String): Flow<Vault> =
         vaultRepository.getAsFlow(vaultId).filterNotNull()
 
+    // Drop the terminal completion emission for plain List consumers: it only repeats the last
+    // per-chain snapshot, so re-rendering it would be redundant. Lifecycle-aware callers use
+    // loadAddressBalances instead.
     override fun loadAddresses(vaultId: String): Flow<List<Address>> =
+        loadAddressBalances(vaultId).filter { !it.isComplete }.map { it.addresses }
+
+    override fun loadAddressBalances(vaultId: String): Flow<AddressBalancesUpdate> =
         buildCacheAddresses(vaultId).flatMapLatest { (vaultCoins, addresses) ->
             channelFlow {
                 supervisorScope {
@@ -79,7 +101,7 @@ constructor(
                     // balances immediately instead of empty rows — including on refresh
                     // (e.g. right after adding a chain).
                     addresses.fetchAccountFromDb()
-                    send(addresses.toList())
+                    send(AddressBalancesUpdate(addresses.toList(), isComplete = false))
 
                     addresses
                         .mapIndexed { index, account ->
@@ -111,10 +133,16 @@ constructor(
 
                                     addresses[index] = account.copy(accounts = newAccounts)
                                     // Stream each chain's balance as soon as it resolves rather
-                                    // than waiting for every chain to finish, matching iOS/Windows.
-                                    // Emit a snapshot copy because other chains may still be
-                                    // mutating the backing list in parallel.
-                                    send(addresses.toList())
+                                    // than waiting for every chain to finish (Windows streams the
+                                    // same way; iOS instead batches all balances and applies them
+                                    // at once). Emit a snapshot copy because other chains may still
+                                    // be mutating the backing list in parallel.
+                                    send(
+                                        AddressBalancesUpdate(
+                                            addresses.toList(),
+                                            isComplete = false,
+                                        )
+                                    )
                                 } catch (e: Exception) {
                                     if (e is kotlinx.coroutines.CancellationException) throw e
                                     Timber.e(e)
@@ -123,7 +151,10 @@ constructor(
                             }
                         }
                         .awaitAll()
-                    send(addresses.toList())
+
+                    // Terminal emission: every chain has resolved (or failed). Carries the final
+                    // snapshot and flags completion so the UI can stop the refresh spinner.
+                    send(AddressBalancesUpdate(addresses.toList(), isComplete = true))
                 }
                 awaitClose()
             }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -120,6 +120,14 @@ internal class AccountsRepositoryImplTest {
             streamedEth.value(Chain.Solana),
             "SOL should still show its cached value while its network call is in flight",
         )
+        // Exactly two emissions while SOL is gated — the cached snapshot and ETH's streamed update.
+        // A batched implementation would only have emitted the cached snapshot at this point, so
+        // the count, not just the presence of ETH_NETWORK, pins down the streaming behaviour.
+        assertEquals(
+            2,
+            emissions.size,
+            "expected cached + ETH-streamed emissions before SOL resolves",
+        )
 
         solanaGate.complete(Unit)
         advanceUntilIdle()
@@ -128,6 +136,72 @@ internal class AccountsRepositoryImplTest {
         assertEquals(ETH_NETWORK, finalEmission.value(Chain.Ethereum))
         assertEquals(SOL_NETWORK, finalEmission.value(Chain.Solana))
         job.cancel()
+    }
+
+    @Test
+    fun `loadAddressBalances marks completion only after every chain resolves`() = runTest {
+        val eth = Coins.Ethereum.ETH.copy(address = ETH_ADDRESS)
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(eth, sol)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = sol))
+
+        every { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
+            flowOf(balance(amount = ETH_NETWORK, coin = eth))
+        val solanaGate = CompletableDeferred<Unit>()
+        every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            gatedBalance(solanaGate, amount = SOL_NETWORK, coin = sol)
+
+        val emissions = mutableListOf<AddressBalancesUpdate>()
+        val job = launch { repository.loadAddressBalances(VAULT_ID).collect(emissions::add) }
+
+        advanceUntilIdle()
+        // While SOL is still in flight the load is not done, so nothing is marked complete.
+        assertTrue(
+            emissions.none { it.isComplete },
+            "load must not report completion while a chain is still pending",
+        )
+
+        solanaGate.complete(Unit)
+        advanceUntilIdle()
+
+        // Exactly one terminal emission, it is the last, and it carries every network balance.
+        assertEquals(1, emissions.count { it.isComplete })
+        val terminal = emissions.last()
+        assertTrue(terminal.isComplete)
+        assertEquals(ETH_NETWORK, terminal.addresses.value(Chain.Ethereum))
+        assertEquals(SOL_NETWORK, terminal.addresses.value(Chain.Solana))
+        job.cancel()
+    }
+
+    @Test
+    fun `loadAddresses drops the redundant terminal completion emission`() = runTest {
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(sol)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = sol))
+        every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            flowOf(balance(amount = NETWORK, coin = sol))
+
+        val listEmissions = mutableListOf<List<Address>>()
+        val balanceEmissions = mutableListOf<AddressBalancesUpdate>()
+        val listJob = launch { repository.loadAddresses(VAULT_ID).collect(listEmissions::add) }
+        val balanceJob = launch {
+            repository.loadAddressBalances(VAULT_ID).collect(balanceEmissions::add)
+        }
+
+        advanceUntilIdle()
+
+        // loadAddressBalances ends with a terminal completion emission that just repeats the last
+        // snapshot; loadAddresses filters it out, so it emits exactly one fewer time while still
+        // surfacing the final network balance.
+        assertTrue(balanceEmissions.any { it.isComplete })
+        assertEquals(balanceEmissions.size - 1, listEmissions.size)
+        assertEquals(NETWORK, listEmissions.last().solValue())
+        listJob.cancel()
+        balanceJob.cancel()
     }
 
     private fun stubVault(vararg coins: Coin) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -1,0 +1,181 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.mappers.ChainAndTokensToAddressMapperImpl
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenBalance
+import com.vultisig.wallet.data.models.TokenBalanceAndPrice
+import com.vultisig.wallet.data.models.TokenBalanceWrapped
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class AccountsRepositoryImplTest {
+
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var balanceRepository: BalanceRepository
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var splTokenRepository: SplTokenRepository
+    private lateinit var repository: AccountsRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        vaultRepository = mockk()
+        balanceRepository = mockk()
+        tokenPriceRepository = mockk()
+        splTokenRepository = mockk(relaxed = true)
+        repository =
+            AccountsRepositoryImpl(
+                vaultRepository = vaultRepository,
+                balanceRepository = balanceRepository,
+                tokenPriceRepository = tokenPriceRepository,
+                chainAndTokensToAddressMapper = ChainAndTokensToAddressMapperImpl(),
+                splTokenRepository = splTokenRepository,
+            )
+    }
+
+    @Test
+    fun `emits cached DB snapshot before network balances`() = runTest {
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(sol)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+
+        // Cached DB balance present for SOL.
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = sol))
+
+        // Network balance is gated so it cannot win the race against the cached emit.
+        val networkGate = CompletableDeferred<Unit>()
+        every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            gatedBalance(networkGate, amount = NETWORK, coin = sol)
+
+        val emissions = mutableListOf<List<Address>>()
+        val job = launch { repository.loadAddresses(VAULT_ID).collect(emissions::add) }
+
+        advanceUntilIdle()
+
+        // With the network call still blocked, the only thing the UI has seen is the cached row —
+        // proving the early DB snapshot is always emitted first.
+        assertTrue(emissions.isNotEmpty(), "expected a cached emission before the network returned")
+        assertEquals(CACHED, emissions.first().solValue())
+
+        networkGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(NETWORK, emissions.last().solValue())
+        job.cancel()
+    }
+
+    @Test
+    fun `streams each chain as it resolves without waiting for the slowest chain`() = runTest {
+        val eth = Coins.Ethereum.ETH.copy(address = ETH_ADDRESS)
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(eth, sol)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = sol))
+
+        // ETH resolves immediately; SOL is gated (simulating a slow chain).
+        every { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
+            flowOf(balance(amount = ETH_NETWORK, coin = eth))
+        val solanaGate = CompletableDeferred<Unit>()
+        every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            gatedBalance(solanaGate, amount = SOL_NETWORK, coin = sol)
+
+        val emissions = mutableListOf<List<Address>>()
+        val job = launch { repository.loadAddresses(VAULT_ID).collect(emissions::add) }
+
+        advanceUntilIdle()
+
+        // ETH's balance must surface while SOL is still pending — the whole point of per-chain
+        // streaming. Before the fix, no emission carried ETH's network value until SOL also
+        // finished.
+        val streamedEth = emissions.firstOrNull { it.value(Chain.Ethereum) == ETH_NETWORK }
+        assertNotNull(streamedEth, "ETH balance should stream before the slow SOL chain resolves")
+        assertEquals(
+            CACHED,
+            streamedEth.value(Chain.Solana),
+            "SOL should still show its cached value while its network call is in flight",
+        )
+
+        solanaGate.complete(Unit)
+        advanceUntilIdle()
+
+        val finalEmission = emissions.last()
+        assertEquals(ETH_NETWORK, finalEmission.value(Chain.Ethereum))
+        assertEquals(SOL_NETWORK, finalEmission.value(Chain.Solana))
+        job.cancel()
+    }
+
+    private fun stubVault(vararg coins: Coin) {
+        val vault = Vault(id = VAULT_ID, name = "Test Vault", coins = coins.toList())
+        every { vaultRepository.getAsFlow(VAULT_ID) } returns flowOf(vault)
+    }
+
+    private fun wrapped(amount: Long, coin: Coin) =
+        TokenBalanceWrapped(
+            tokenBalance = tokenBalance(amount, coin),
+            address = coin.address,
+            coinId = coin.id,
+        )
+
+    private fun balance(amount: Long, coin: Coin) =
+        TokenBalanceAndPrice(
+            tokenBalance = tokenBalance(amount, coin),
+            price = FiatValue(BigDecimal.ONE, USD),
+        )
+
+    private fun gatedBalance(
+        gate: CompletableDeferred<Unit>,
+        amount: Long,
+        coin: Coin,
+    ): Flow<TokenBalanceAndPrice> = flow {
+        gate.await()
+        emit(balance(amount, coin))
+    }
+
+    private fun tokenBalance(amount: Long, coin: Coin) =
+        TokenBalance(
+            tokenValue = TokenValue(BigInteger.valueOf(amount), coin.ticker, coin.decimal),
+            fiatValue = FiatValue(BigDecimal.valueOf(amount), USD),
+        )
+
+    private fun List<Address>.value(chain: Chain): Long? =
+        firstOrNull { it.chain == chain }?.accounts?.firstOrNull()?.tokenValue?.value?.toLong()
+
+    private fun List<Address>.solValue(): Long? = value(Chain.Solana)
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+        const val USD = "USD"
+        const val ETH_ADDRESS = "0xeth"
+        const val SOL_ADDRESS = "sol-addr"
+        const val CACHED = 5L
+        const val NETWORK = 10L
+        const val ETH_NETWORK = 100L
+        const val SOL_NETWORK = 200L
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the slow first-fetch reported in #4562 (Solana balance row stays empty far longer on Android than iOS/Windows).

`AccountsRepository.loadAddresses` batched every chain's balance into a **single** emit after `awaitAll()`, so a fast chain stayed empty until the **slowest** chain on the vault returned. The early DB-cache emit was also gated behind `if (!isRefresh)`, so right after adding a chain (`isRefresh = true`) the UI showed empty rows instead of the last-known balances.

## Changes

- **Stream per chain** — emit each chain's balance as soon as it resolves, instead of one emit after all chains finish. Uses a `toList()` snapshot since chains mutate the backing list in parallel. (issue priority #1)
- **Always emit the cached DB snapshot first** — dropped the `if (!isRefresh)` gate, so the last-known balances render immediately, including on refresh. (issue priority #3)
- **Removed the now-dead `isRefresh` parameter** from the plural `loadAddresses` and its call sites (`VaultAccountsViewModel`, `AccountsLoader`). It still lives on `loadDeFiAddresses`/`loadAddress`, which genuinely use it.
- Added `AccountsRepositoryImplTest` (cached-first + per-chain streaming).

## Deferred follow-ups (called out in the issue)

Not in this PR — larger/riskier, warrant separate review:
- #2 decouple balance from the global price refresh (needs balance-then-fiat re-emit)
- #4 Solana 30-day token-account/ATA cache
- #5 TLS pre-warm to `api.vultisig.com`

## Test plan

- [x] `:data:testDebugUnitTest` — new `AccountsRepositoryImplTest` (2 tests) green
- [x] `:app:testDebugUnitTest` — `VaultAccountsViewModelTest`, `AccountsLoaderTest` green
- [x] ktfmt applied
- [ ] Manual: add Solana to a multi-chain vault, confirm SOL balance appears as soon as its RPC returns rather than after every chain

Closes #4562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Account loading now surfaces cached accounts immediately and progressively updates per-chain balances, keeping the refresh spinner active until final completion.
* **New Features**
  * Added a throttling operator to coalesce rapid balance updates while guaranteeing final updates are delivered.
* **Tests**
  * Extended tests covering progressive balance streaming, spinner behavior during refresh, and throttling semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->