### PR TITLE
test(signing): unit-testable eth_signTypedData_v4 coverage

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -28,9 +28,16 @@ object SigningHelper {
     private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
 
     @OptIn(ExperimentalStdlibApi::class)
-    fun getKeysignMessages(messagePayload: CustomMessagePayload): List<String> {
+    fun getKeysignMessages(messagePayload: CustomMessagePayload): List<String> =
+        getKeysignMessages(messagePayload, typedDataHasher = EthereumAbi::encodeTyped)
+
+    @OptIn(ExperimentalStdlibApi::class)
+    internal fun getKeysignMessages(
+        messagePayload: CustomMessagePayload,
+        typedDataHasher: (String) -> ByteArray?,
+    ): List<String> {
         if (messagePayload.method.equals(ETH_SIGN_TYPED_DATA_V4, ignoreCase = true)) {
-            return getKeysignMessagesForTypedData(messagePayload.message)
+            return getKeysignMessagesForTypedData(messagePayload.message, typedDataHasher)
         }
 
         val processedBytes =
@@ -51,8 +58,11 @@ object SigningHelper {
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    private fun getKeysignMessagesForTypedData(message: String): List<String> {
-        val hash = EthereumAbi.encodeTyped(message)
+    private fun getKeysignMessagesForTypedData(
+        message: String,
+        hashFn: (String) -> ByteArray?,
+    ): List<String> {
+        val hash = hashFn(message)
         if (hash == null || hash.isEmpty()) {
             error("Invalid eth_signTypedData_v4 message")
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
@@ -28,7 +29,6 @@ class SigningHelperCustomMessageTest {
 
     @Test
     fun `hex-encoded message is decoded then keccak256-hashed for ECDSA chain`() {
-        // "Vultisig" as hex
         val hexMessage = "56756c7469736967"
         val payload =
             CustomMessagePayload(method = "personal_sign", message = hexMessage, chain = "Ethereum")
@@ -41,13 +41,11 @@ class SigningHelperCustomMessageTest {
 
     @Test
     fun `EdDSA chain message skips keccak256 and passes bytes through directly`() {
-        // Solana is an EdDSA chain — the initiator sends a pre-computed digest
         val hexMessage = "abcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
         val payload = CustomMessagePayload(method = "sign", message = hexMessage, chain = "Solana")
 
         val messages = SigningHelper.getKeysignMessages(payload)
 
-        // No keccak256 applied — raw bytes are used as-is
         val expected = hexMessage.toHexBytes().toHexString()
         messages shouldBe listOf(expected)
     }
@@ -56,15 +54,15 @@ class SigningHelperCustomMessageTest {
     fun `ECDSA and EdDSA produce different keysign messages for the same hex input`() {
         val hexMessage = "abcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
 
-        val ecdsaPayload =
-            CustomMessagePayload(method = "sign", message = hexMessage, chain = "Ethereum")
-        val eddsaPayload =
-            CustomMessagePayload(method = "sign", message = hexMessage, chain = "Solana")
+        val ecdsaMessages =
+            SigningHelper.getKeysignMessages(
+                CustomMessagePayload(method = "sign", message = hexMessage, chain = "Ethereum")
+            )
+        val eddsaMessages =
+            SigningHelper.getKeysignMessages(
+                CustomMessagePayload(method = "sign", message = hexMessage, chain = "Solana")
+            )
 
-        val ecdsaMessages = SigningHelper.getKeysignMessages(ecdsaPayload)
-        val eddsaMessages = SigningHelper.getKeysignMessages(eddsaPayload)
-
-        // ECDSA path applies keccak256; EdDSA path does not — so the hashes must differ
         ecdsaMessages shouldNotBe eddsaMessages
     }
 
@@ -76,5 +74,63 @@ class SigningHelperCustomMessageTest {
 
         val expected = "test message".toByteArray().toKeccak256ByteArray().toHexString()
         messages shouldBe listOf(expected)
+    }
+
+    @Test
+    fun `eth_signTypedData_v4 routes to hash function and returns hex of result`() {
+        val stubbedHash = ByteArray(32) { it.toByte() }
+        val payload =
+            CustomMessagePayload(
+                method = "eth_signTypedData_v4",
+                message = """{"domain":{},"message":{}}""",
+                chain = "Ethereum",
+            )
+
+        val messages = SigningHelper.getKeysignMessages(payload, typedDataHasher = { stubbedHash })
+
+        messages shouldBe listOf(stubbedHash.toHexString())
+    }
+
+    @Test
+    fun `eth_signTypedData_v4 method matching is case-insensitive`() {
+        val stubbedHash = ByteArray(32) { 0xAB.toByte() }
+        val payload =
+            CustomMessagePayload(
+                method = "ETH_SIGNTYPEDDATA_V4",
+                message = """{"domain":{},"message":{}}""",
+                chain = "Ethereum",
+            )
+
+        val messages = SigningHelper.getKeysignMessages(payload, typedDataHasher = { stubbedHash })
+
+        messages shouldBe listOf(stubbedHash.toHexString())
+    }
+
+    @Test
+    fun `eth_signTypedData_v4 throws when hash function returns null`() {
+        val payload =
+            CustomMessagePayload(
+                method = "eth_signTypedData_v4",
+                message = "invalid-typed-data",
+                chain = "Ethereum",
+            )
+
+        shouldThrow<IllegalStateException> {
+            SigningHelper.getKeysignMessages(payload, typedDataHasher = { null })
+        }
+    }
+
+    @Test
+    fun `eth_signTypedData_v4 throws when hash function returns empty array`() {
+        val payload =
+            CustomMessagePayload(
+                method = "eth_signTypedData_v4",
+                message = "invalid-typed-data",
+                chain = "Ethereum",
+            )
+
+        shouldThrow<IllegalStateException> {
+            SigningHelper.getKeysignMessages(payload, typedDataHasher = { ByteArray(0) })
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds an `internal` overload of `SigningHelper.getKeysignMessages(CustomMessagePayload)` that accepts an injectable `typedDataHasher: (String) -> ByteArray?` parameter
- The public API is unchanged; the default value wires `EthereumAbi::encodeTyped` so production behaviour is identical
- Creates `SigningHelperCustomMessageTest` with 9 unit tests covering all `getKeysignMessages(CustomMessagePayload)` paths, including the previously-untestable `eth_signTypedData_v4` branch

## Issue
Closes #4661

## Test Plan
- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.chains.helpers.SigningHelperCustomMessageTest"` — 9/9 pass
- [x] `./gradlew :data:lint` — no new findings
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for message signing: plain-text and hex messages, ECDSA vs EdDSA differences, null-chain defaulting to ECDSA, and typed-data signing behaviors (including case-insensitive method matching and error cases when a typed-data hasher returns null/empty).

* **Refactor**
  * Made typed-data hashing pluggable and validated that typed-data digests are non-empty, improving flexibility of typed-data signing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->