### PR TITLE
feat(swap): SwapKit BTC/PSBT quote+payload decode (part 1)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -641,8 +641,12 @@ constructor(
                         ),
                     )
                 val evmResult =
-                    (result as? SwapQuoteResult.Evm)
-                        ?: error("SwapKitQuoteSource must return SwapQuoteResult.Evm")
+                    when (result) {
+                        // Non-EVM SwapKit (Phase 2: BTC/PSBT) arrives as a fully-formed
+                        // SwapQuote.SwapKit on the Native result — cache it directly.
+                        is SwapQuoteResult.Native -> return@getCachedQuoteOrFetch result.quote
+                        is SwapQuoteResult.Evm -> result
+                    }
                 val apiQuote = evmResult.data
                 val expectedDstValue =
                     TokenValue(
@@ -687,7 +691,12 @@ constructor(
         // Read the sub-provider off the returned quote (not a hoisted var): a cache HIT skips the
         // fetch lambda, so a transient var would be null and the label would silently collapse from
         // "via CHAINFLIP" back to the generic "SwapKit" when the form re-opens within the TTL.
-        val resolvedSubProvider = (swapQuote as? SwapQuote.OneInch)?.subProvider
+        val resolvedSubProvider =
+            when (swapQuote) {
+                is SwapQuote.OneInch -> swapQuote.subProvider
+                is SwapQuote.SwapKit -> swapQuote.subProvider
+                else -> null
+            }
         val providerLabel =
             if (resolvedSubProvider.isNullOrBlank()) R.string.swap_for_provider_swapkit.asUiText()
             else formatSwapKitProviderLabel(resolvedSubProvider).asUiText()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -3,25 +3,36 @@
 package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
 import com.vultisig.wallet.data.usecases.ConvertTokenToToken
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.SearchTokenUseCase
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class SwapQuoteManagerTest {
@@ -82,4 +93,78 @@ internal class SwapQuoteManagerTest {
 
         assertIs<SwapException.TimeOut>(deferred.await().exceptionOrNull())
     }
+
+    @Test
+    fun `fetchQuote keeps the SwapKit sub-provider label across a cache hit (Native path)`() =
+        runTest {
+            // Pins the SwapQuoteResult.Native arm + the `is SwapQuote.SwapKit -> subProvider`
+            // label:
+            // a non-EVM SwapKit quote must surface "SwapKit (NEAR)", and that must survive a cache
+            // hit (second fetch skips the lambda) rather than collapse to the generic "SwapKit".
+            val btc = coin(Chain.Bitcoin, "BTC", address = "bc1qsrc", decimals = 8)
+            val eth = coin(Chain.Ethereum, "ETH", address = "0xdst", decimals = 18)
+            val swapKitQuote =
+                SwapQuote.SwapKit(
+                    expectedDstValue = TokenValue(BigInteger.ONE, eth),
+                    fees = TokenValue(BigInteger.valueOf(400), btc),
+                    expiredAt = Clock.System.now().plus(5.minutes),
+                    data = mockk(relaxed = true),
+                    subProvider = "NEAR",
+                )
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) } returns
+                SwapQuoteResult.Native(swapKitQuote)
+            // Relaxed mockk returns Object for these fun-type mappers; give them real return types
+            // so the SwapKit (null-rawFees) fiat-formatting path doesn't ClassCastException.
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, "USD")
+            every { mapTokenValueToDecimalUiString(any()) } returns "0"
+
+            val manager = createManager()
+            val first =
+                manager.fetchQuote(
+                    SwapProvider.SWAPKIT,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    btc,
+                    eth,
+                    BigInteger.ONE,
+                    TokenValue(BigInteger.ONE, btc),
+                    AppCurrency.USD,
+                    null,
+                    null,
+                    BigDecimal.ONE,
+                )
+            val second =
+                manager.fetchQuote(
+                    SwapProvider.SWAPKIT,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    btc,
+                    eth,
+                    BigInteger.ONE,
+                    TokenValue(BigInteger.ONE, btc),
+                    AppCurrency.USD,
+                    null,
+                    null,
+                    BigDecimal.ONE,
+                )
+
+            assertEquals(UiText.DynamicString("SwapKit (NEAR)"), first.providerUiText)
+            assertEquals(UiText.DynamicString("SwapKit (NEAR)"), second.providerUiText)
+            // Second call is a cache hit (same pair/amount/addresses) — the lambda is skipped.
+            coVerify(exactly = 1) { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) }
+        }
+
+    private fun coin(chain: Chain, ticker: String, address: String, decimals: Int) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = address,
+            decimal = decimals,
+            hexPublicKey = "pub",
+            priceProviderID = ticker.lowercase(),
+            contractAddress = "",
+            isNativeToken = true,
+        )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
@@ -30,6 +30,10 @@ data class SwapKitSwapResponseJson(
     @SerialName("meta") val meta: SwapKitTxMeta,
     @SerialName("targetAddress") val targetAddress: String? = null,
     @SerialName("expectedBuyAmount") val expectedBuyAmount: String? = null,
+    // Source-chain fee breakdown on the executed route. The `type == "inbound"` entry is the
+    // canonical deposit cost; read it from here (not the /v3/quote route) so a repriced fee on the
+    // refreshed /v3/swap reply stays fresh. Mirrors iOS' SwapKitSwapResponse.fees.
+    @SerialName("fees") val fees: List<SwapKitFee> = emptyList(),
     @SerialName("providers") val providers: List<String> = emptyList(),
     @SerialName("error") val error: String? = null,
     @SerialName("message") val message: String? = null,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -415,8 +415,17 @@ constructor(
         val base64 =
             (element as? JsonPrimitive)?.takeIf { it.isString }?.content
                 ?: throw SwapKitError.Decoding("SwapKit non-EVM tx is not a base64 string")
-        return runCatching { Base64.getDecoder().decode(base64) }
-            .getOrElse { throw SwapKitError.Decoding("SwapKit non-EVM tx is not valid base64", it) }
+        val decoded =
+            runCatching { Base64.getDecoder().decode(base64) }
+                .getOrElse {
+                    throw SwapKitError.Decoding("SwapKit non-EVM tx is not valid base64", it)
+                }
+        // An empty (or whitespace-only) base64 decodes to zero bytes — refuse it rather than stage
+        // an unsignable empty payload that would only surface as a failure at sign time.
+        if (decoded.isEmpty()) {
+            throw SwapKitError.Decoding("SwapKit non-EVM tx payload is empty")
+        }
+        return decoded
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -12,13 +12,18 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
 import com.vultisig.wallet.data.models.TokenValue
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.util.Base64
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -140,19 +145,38 @@ constructor(
         //  specific quote. The DTO already carries it; the persistence wiring lands with the
         //  tx-history Phase D work.
 
-        // SwapQuoteResult.Evm is the envelope for both EVM and Solana SwapKit txTypes — Solana
-        // signers pull the base64 blob from `tx.data`, matching how JupiterQuoteSource already
-        // stages a Solana swap. The Evm-typed result is intentional, not a copy-paste.
-        return SwapQuoteResult.Evm(
-            data = buildEvmQuoteFromSwapKit(swapResponse, request.srcToken, request.dstToken, best),
-            // Sub-provider tag (Chainflip / NEAR Intents / Garden / Flashnet) — surfaced on the
-            // verify screen so the user can reason about ETA and debug routing. Prefer
-            // `swapResponse.providers[0]` (the swap call's authoritative routing) and fall back
-            // to `meta.subProvider` for forward compat.
-            subProvider =
-                swapResponse.providers.firstOrNull()?.takeIf { it.isNotBlank() }
-                    ?: swapResponse.meta.subProvider?.takeIf { it.isNotBlank() },
-        )
+        // Sub-provider tag (Chainflip / NEAR Intents / Garden / Flashnet) — surfaced on the verify
+        // screen so the user can reason about ETA and debug routing. Prefer
+        // `swapResponse.providers[0]`
+        // (the swap call's authoritative routing) and fall back to `meta.subProvider` for forward
+        // compat.
+        val subProvider =
+            swapResponse.providers.firstOrNull()?.takeIf { it.isNotBlank() }
+                ?: swapResponse.meta.subProvider?.takeIf { it.isNotBlank() }
+
+        // EVM + Solana ride the EVMSwapQuoteJson envelope (Solana signers pull the base64 blob from
+        // `tx.data`, matching how JupiterQuoteSource stages a Solana swap). PSBT (Bitcoin) and the
+        // other non-EVM txTypes can't fit that shape, so they surface as a fully-formed
+        // SwapQuote.SwapKit on the Native result for a per-chain signer to consume.
+        return when (txTypeOf(swapResponse)) {
+            TxKind.EVM,
+            TxKind.SOLANA ->
+                SwapQuoteResult.Evm(
+                    data =
+                        buildEvmQuoteFromSwapKit(
+                            swapResponse,
+                            request.srcToken,
+                            request.dstToken,
+                            best,
+                        ),
+                    subProvider = subProvider,
+                )
+            TxKind.PSBT ->
+                SwapQuoteResult.Native(
+                    buildSwapKitNativeQuote(swapResponse, request, best, subProvider)
+                )
+            TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(swapResponse.meta.txType)
+        }
     }
 
     /**
@@ -213,12 +237,14 @@ constructor(
     }
 
     /**
-     * Native-coin decimals for a SwapKit Phase-1 chain. EVM chains use 18; Solana uses 9. Only
-     * reached for chains [chainPrefix] already maps (the caller returns early otherwise).
+     * Native gas-coin decimals for a SwapKit source chain. EVM chains use 18, Solana 9, Bitcoin 8.
+     * The inbound fee is always denominated in the source chain's native coin, so it is scaled by
+     * these — not the sell token's decimals. Only reached for chains [chainPrefix] already maps.
      */
     private fun nativeDecimals(chain: Chain): Int =
         when (chain) {
             Chain.Solana -> 9
+            Chain.Bitcoin -> 8
             else -> 18
         }
 
@@ -326,8 +352,71 @@ constructor(
                         ),
                 )
             }
+            // PSBT is dispatched to buildSwapKitNativeQuote before reaching here; the arm keeps the
+            // `when` exhaustive and refuses anything that slips through.
+            TxKind.PSBT,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
+    }
+
+    /**
+     * Wrap a non-EVM SwapKit route (Phase 2: Bitcoin / PSBT) into a fully-formed
+     * [SwapQuote.SwapKit] for a per-chain signer to consume. The unsigned-tx bytes (base64 PSBT)
+     * land in [SwapKitSwapPayloadJson.txPayload]; the inbound fee is the source chain's native-unit
+     * deposit cost (same surface as the EVM/Solana path). The signing side is wired separately —
+     * until it (and the provider table) enable SwapKit on these chains, this path isn't reached in
+     * production; it's exercised by unit tests so the data contract is pinned ahead of the signer.
+     */
+    private fun buildSwapKitNativeQuote(
+        response: SwapKitSwapResponseJson,
+        request: SwapQuoteRequest,
+        route: SwapKitRoute,
+        subProvider: String?,
+    ): SwapQuote.SwapKit {
+        val srcToken = request.srcToken
+        val dstToken = request.dstToken
+        val toAmountDecimal =
+            response.expectedBuyAmount?.let { runCatching { BigDecimal(it) }.getOrNull() }
+                ?: throw SwapKitError.MalformedAmount(raw = response.expectedBuyAmount.orEmpty())
+        val payload =
+            SwapKitSwapPayloadJson(
+                fromCoin = srcToken,
+                toCoin = dstToken,
+                fromAmount = request.tokenValue.value,
+                toAmountDecimal = toAmountDecimal,
+                txType = response.meta.txType,
+                txPayload = decodeBinaryTx(response.tx),
+                targetAddress = response.targetAddress.orEmpty(),
+                memo = null,
+                subProvider = subProvider.orEmpty(),
+                swapId = response.swapId.orEmpty(),
+            )
+        return SwapQuote.SwapKit(
+            expectedDstValue =
+                TokenValue(
+                    toAmountDecimal.movePointRight(dstToken.decimal).toBigInteger(),
+                    dstToken,
+                ),
+            // Source-chain native deposit fee (BTC 8dp), same surface as the EVM/Solana inbound
+            // fee.
+            fees = TokenValue(inboundFeeRawUnits(srcToken, route), srcToken),
+            expiredAt = Clock.System.now() + expiredAfter,
+            data = payload,
+            subProvider = subProvider,
+        )
+    }
+
+    /**
+     * Decode a base64 unsigned-tx blob (PSBT today; PTB / CBOR as more chains land) from `tx` into
+     * raw bytes for [SwapKitSwapPayloadJson.txPayload]. V3 ships these as a top-level base64
+     * [JsonPrimitive].
+     */
+    private fun decodeBinaryTx(element: JsonElement): ByteArray {
+        val base64 =
+            (element as? JsonPrimitive)?.takeIf { it.isString }?.content
+                ?: throw SwapKitError.Decoding("SwapKit non-EVM tx is not a base64 string")
+        return runCatching { Base64.getDecoder().decode(base64) }
+            .getOrElse { throw SwapKitError.Decoding("SwapKit non-EVM tx is not valid base64", it) }
     }
 
     /**
@@ -340,6 +429,7 @@ constructor(
             "evm" -> TxKind.EVM
             "solana",
             "serialized_base64" -> TxKind.SOLANA
+            "psbt" -> TxKind.PSBT
             else -> TxKind.UNSUPPORTED
         }
 
@@ -372,6 +462,7 @@ constructor(
     private enum class TxKind {
         EVM,
         SOLANA,
+        PSBT,
         UNSUPPORTED,
     }
 
@@ -423,6 +514,7 @@ constructor(
             Chain.Base -> "BASE"
             Chain.Polygon -> "POL"
             Chain.Solana -> "SOL"
+            Chain.Bitcoin -> "BTC"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.api.errors.SwapKitError
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.SwapKitEvmTx
+import com.vultisig.wallet.data.api.models.quotes.SwapKitFee
 import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSolanaTx
@@ -163,18 +164,11 @@ constructor(
             TxKind.SOLANA ->
                 SwapQuoteResult.Evm(
                     data =
-                        buildEvmQuoteFromSwapKit(
-                            swapResponse,
-                            request.srcToken,
-                            request.dstToken,
-                            best,
-                        ),
+                        buildEvmQuoteFromSwapKit(swapResponse, request.srcToken, request.dstToken),
                     subProvider = subProvider,
                 )
             TxKind.PSBT ->
-                SwapQuoteResult.Native(
-                    buildSwapKitNativeQuote(swapResponse, request, best, subProvider)
-                )
+                SwapQuoteResult.Native(buildSwapKitNativeQuote(swapResponse, request, subProvider))
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(swapResponse.meta.txType)
         }
     }
@@ -212,17 +206,19 @@ constructor(
     }
 
     /**
-     * Extract the source-chain inbound fee from `route.fees[]` — the canonical SwapKit-attributed
-     * cost of executing the deposit on the source chain. Mirrors iOS' `SwapKitService.inboundFee`
-     * so the displayed Network Fee reconciles against the actual on-chain debit (especially on
-     * Solana and cross-chain Chainflip / NEAR routes where the EVM gas envelope would otherwise
-     * read zero). Returns `0` when the entry is absent so the UI surfaces "—" rather than blocking
-     * the quote.
+     * Extract the source-chain inbound fee from the `/v3/swap` response's `fees[]` — the canonical
+     * SwapKit-attributed cost of executing the deposit on the source chain. Read from the swap
+     * response (not the `/v3/quote` route) so a fee SwapKit reprices on the refreshed `/v3/swap`
+     * reply stays fresh, matching iOS' `SwapKitService.inboundFee(from response)`. Mirrors iOS so
+     * the displayed Network Fee reconciles against the actual on-chain debit (especially on Solana
+     * and cross-chain Chainflip / NEAR routes where the EVM gas envelope would otherwise read
+     * zero). Returns `0` when the entry is absent so the UI surfaces "—" rather than blocking the
+     * quote.
      */
-    private fun inboundFeeRawUnits(srcToken: Coin, route: SwapKitRoute): BigInteger {
+    private fun inboundFeeRawUnits(srcToken: Coin, fees: List<SwapKitFee>): BigInteger {
         val prefix = chainPrefix(srcToken.chain) ?: return BigInteger.ZERO
         val inbound =
-            route.fees.firstOrNull { fee ->
+            fees.firstOrNull { fee ->
                 fee.type?.equals("inbound", ignoreCase = true) == true && fee.chain == prefix
             } ?: return BigInteger.ZERO
         val amount =
@@ -261,7 +257,6 @@ constructor(
         response: SwapKitSwapResponseJson,
         srcToken: Coin,
         dstToken: Coin,
-        route: SwapKitRoute,
     ): EVMSwapQuoteJson {
         // SwapKit V3 reports `expectedBuyAmount` as a human-readable decimal string ("42.5"
         // USDC) per the docs. Every other Android quote source (1inch / Kyber / LiFi / Jupiter)
@@ -274,7 +269,7 @@ constructor(
         // is SwapKitService.inboundFee). Embedded in `swapFee` with `swapFeeTokenContract = ""`
         // (the native-coin sentinel resolveSwapFee recognises) so the consumer reads it the same
         // way Kyber/Jupiter quote sources surface their per-leg fees.
-        val inboundFee = inboundFeeRawUnits(srcToken, route).toString()
+        val inboundFee = inboundFeeRawUnits(srcToken, response.fees).toString()
         return when (txTypeOf(response)) {
             TxKind.EVM -> {
                 val evm = decode<SwapKitEvmTx>(response.tx, "evm")
@@ -370,14 +365,16 @@ constructor(
     private fun buildSwapKitNativeQuote(
         response: SwapKitSwapResponseJson,
         request: SwapQuoteRequest,
-        route: SwapKitRoute,
         subProvider: String?,
     ): SwapQuote.SwapKit {
         val srcToken = request.srcToken
         val dstToken = request.dstToken
-        val toAmountDecimal =
-            response.expectedBuyAmount?.let { runCatching { BigDecimal(it) }.getOrNull() }
-                ?: throw SwapKitError.MalformedAmount(raw = response.expectedBuyAmount.orEmpty())
+        val toAmountDecimal = parseExpectedBuyAmount(response.expectedBuyAmount)
+        // Deposit-only chains (Cardano / XRP) route entirely on `targetAddress`, so a blank value
+        // would stage an unspendable quote — refuse it rather than emit a quote that can't settle.
+        val targetAddress =
+            response.targetAddress?.takeIf { it.isNotBlank() }
+                ?: throw SwapKitError.Decoding("SwapKit non-EVM response missing targetAddress")
         val payload =
             SwapKitSwapPayloadJson(
                 fromCoin = srcToken,
@@ -386,7 +383,7 @@ constructor(
                 toAmountDecimal = toAmountDecimal,
                 txType = response.meta.txType,
                 txPayload = decodeBinaryTx(response.tx),
-                targetAddress = response.targetAddress.orEmpty(),
+                targetAddress = targetAddress,
                 memo = null,
                 subProvider = subProvider.orEmpty(),
                 swapId = response.swapId.orEmpty(),
@@ -399,7 +396,7 @@ constructor(
                 ),
             // Source-chain native deposit fee (BTC 8dp), same surface as the EVM/Solana inbound
             // fee.
-            fees = TokenValue(inboundFeeRawUnits(srcToken, route), srcToken),
+            fees = TokenValue(inboundFeeRawUnits(srcToken, response.fees), srcToken),
             expiredAt = Clock.System.now() + expiredAfter,
             data = payload,
             subProvider = subProvider,
@@ -481,15 +478,22 @@ constructor(
      * [SwapKitError.MalformedAmount] when the upstream value is missing or unparseable so the user
      * sees the typed "Invalid amount" message instead of a generic "Could not parse response".
      */
-    private fun scaleDecimalToRawUnits(decimalString: String?, decimals: Int): String {
-        val parsed =
-            decimalString?.let { runCatching { BigDecimal(it) }.getOrNull() }
-                // `raw` is surfaced to the user via `swapkit_error_malformed_amount`; pass empty
-                // for the null case so the developer-only `(missing)` sentinel never leaks into
-                // the form error. The UI maps blank raw onto the generic decoding copy.
-                ?: throw SwapKitError.MalformedAmount(raw = decimalString.orEmpty())
-        return parsed.movePointRight(decimals).toBigInteger().toString()
-    }
+    private fun scaleDecimalToRawUnits(decimalString: String?, decimals: Int): String =
+        parseExpectedBuyAmount(decimalString).movePointRight(decimals).toBigInteger().toString()
+
+    /**
+     * Parse SwapKit's human-readable `expectedBuyAmount` (decimal string, e.g. "42.5") into a
+     * [BigDecimal], or throw [SwapKitError.MalformedAmount] when it's missing/unparseable so the
+     * user sees the typed "Invalid amount" message. Shared by the EVM/Solana raw-units scaling
+     * ([scaleDecimalToRawUnits]) and the native-quote builder so the parse lives in one place.
+     */
+    private fun parseExpectedBuyAmount(decimalString: String?): BigDecimal =
+        decimalString?.let { runCatching { BigDecimal(it) }.getOrNull() }
+            // `raw` is surfaced to the user via `swapkit_error_malformed_amount`; pass empty for
+            // the
+            // null case so the developer-only `(missing)` sentinel never leaks into the form error.
+            // The UI maps blank raw onto the generic decoding copy.
+            ?: throw SwapKitError.MalformedAmount(raw = decimalString.orEmpty())
 
     /**
      * SwapKit asset identifier: `CHAIN.TICKER` or `CHAIN.TICKER-CONTRACT` for ERC-20-style tokens.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -18,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import java.math.BigInteger
+import java.util.Base64
 import java.util.Locale
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -479,16 +481,18 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
-    fun `fetch throws UnsupportedTxType for non-EVM, non-Solana txType`() = runTest {
+    fun `fetch throws UnsupportedTxType for a still-unwired non-EVM txType`() = runTest {
+        // PSBT (Bitcoin) is now wired to a Native SwapQuote.SwapKit; the remaining non-EVM txTypes
+        // (TRON/TON/SUI/CARDANO/RIPPLE) still have no signer, so they surface as UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
-                routes = listOf(route(routeId = "r-psbt", providers = listOf("CHAINFLIP")))
+                routes = listOf(route(routeId = "r-tron", providers = listOf("CHAINFLIP")))
             )
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 tx = JsonObject(emptyMap()),
-                meta = SwapKitTxMeta(txType = "PSBT"),
+                meta = SwapKitTxMeta(txType = "TRON"),
                 expectedBuyAmount = "1",
             )
 
@@ -711,6 +715,57 @@ internal class SwapKitQuoteSourceTest {
         }
     }
 
+    @Test
+    fun `fetch decodes a Bitcoin PSBT route into a Native SwapQuote SwapKit payload`() = runTest {
+        // Phase 2 foundation: a non-EVM (PSBT) route surfaces as SwapQuoteResult.Native wrapping a
+        // fully-formed SwapQuote.SwapKit — the base64 PSBT is decoded into txPayload bytes, and the
+        // inbound BTC fee scales by 8 native decimals. (Signer is wired separately.)
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val psbtBytes = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0x01, 0x02) // "psbt" magic + bytes
+        val base64 = Base64.getEncoder().encodeToString(psbtBytes)
+        val btc = btcCoin()
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(
+                            routeId = "r-btc",
+                            providers = listOf("NEAR"),
+                            expectedBuy = "385.24",
+                            fees =
+                                listOf(
+                                    SwapKitFee(type = "inbound", chain = "BTC", amount = "0.000004")
+                                ),
+                        )
+                    )
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "btc-swap-1",
+                tx = JsonPrimitive(base64),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+                targetAddress = "bc1ptarget",
+                expectedBuyAmount = "385.24",
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = btc, dstToken = ethCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+
+        assertEquals("NEAR", quote.subProvider)
+        assertEquals("PSBT", quote.data.txType)
+        assertTrue(psbtBytes.contentEquals(quote.data.txPayload))
+        assertEquals("bc1ptarget", quote.data.targetAddress)
+        assertEquals("btc-swap-1", quote.data.swapId)
+        assertEquals("NEAR", quote.data.subProvider)
+        assertEquals(btc, quote.data.fromCoin)
+        // 0.000004 BTC inbound fee scaled by 8 native decimals = 400 sats (not 0.000004 × 10^18).
+        assertEquals(BigInteger("400"), quote.fees.value)
+        assertEquals("BTC", quote.fees.unit)
+        assertEquals(8, quote.fees.decimals)
+    }
+
     // ---- helpers ----
 
     private fun request(
@@ -796,6 +851,19 @@ internal class SwapKitQuoteSourceTest {
             decimal = 9,
             hexPublicKey = "pub",
             priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun btcCoin() =
+        Coin(
+            chain = Chain.Bitcoin,
+            ticker = "BTC",
+            logo = "",
+            address = "bc1qsender",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = "bitcoin",
             contractAddress = "",
             isNativeToken = true,
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.Base64
 import java.util.Locale
@@ -388,28 +389,19 @@ internal class SwapKitQuoteSourceTest {
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
                 routes =
-                    listOf(
-                        route(
-                            routeId = "r-sol",
-                            providers = listOf("NEAR"),
-                            expectedBuy = "9",
-                            fees =
-                                listOf(
-                                    SwapKitFee(
-                                        type = "inbound",
-                                        chain = "SOL",
-                                        amount = "0.000005",
-                                    ),
-                                    SwapKitFee(type = "outbound", chain = "ETH", amount = "0.0001"),
-                                ),
-                        )
-                    )
+                    listOf(route(routeId = "r-sol", providers = listOf("NEAR"), expectedBuy = "9"))
             )
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 tx = JsonPrimitive("BASE64"),
                 meta = SwapKitTxMeta(txType = "SOLANA"),
                 expectedBuyAmount = "9",
+                // Inbound fee comes from the /v3/swap response (fresh), not the /v3/quote route.
+                fees =
+                    listOf(
+                        SwapKitFee(type = "inbound", chain = "SOL", amount = "0.000005"),
+                        SwapKitFee(type = "outbound", chain = "ETH", amount = "0.0001"),
+                    ),
             )
 
         val result = source().fetch(request(srcToken = solanaCoin())) as SwapQuoteResult.Evm
@@ -432,18 +424,13 @@ internal class SwapKitQuoteSourceTest {
                                 routeId = "r",
                                 providers = listOf("CHAINFLIP"),
                                 expectedBuy = "42",
-                                fees =
-                                    listOf(
-                                        SwapKitFee(
-                                            type = "outbound",
-                                            chain = "ETH",
-                                            amount = "0.01",
-                                        )
-                                    ),
                             )
                         )
                 )
-            coEvery { api.swap(any()) } returns evmSwapResponse()
+            coEvery { api.swap(any()) } returns
+                evmSwapResponse(
+                    fees = listOf(SwapKitFee(type = "outbound", chain = "ETH", amount = "0.01"))
+                )
 
             val result = source().fetch(request()) as SwapQuoteResult.Evm
 
@@ -651,22 +638,20 @@ internal class SwapKitQuoteSourceTest {
                 SwapKitQuoteResponseJson(
                     routes =
                         listOf(
-                            route(
-                                routeId = "r",
-                                providers = listOf("ONEINCH"),
-                                expectedBuy = "1",
-                                fees =
-                                    listOf(
-                                        SwapKitFee(
-                                            type = "inbound",
-                                            chain = "ETH",
-                                            amount = "0.00001165876952721",
-                                        )
-                                    ),
+                            route(routeId = "r", providers = listOf("ONEINCH"), expectedBuy = "1")
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                evmSwapResponse(
+                    fees =
+                        listOf(
+                            SwapKitFee(
+                                type = "inbound",
+                                chain = "ETH",
+                                amount = "0.00001165876952721",
                             )
                         )
                 )
-            coEvery { api.swap(any()) } returns evmSwapResponse()
 
             val result = source().fetch(request(srcToken = usdc)) as SwapQuoteResult.Evm
 
@@ -728,15 +713,7 @@ internal class SwapKitQuoteSourceTest {
             SwapKitQuoteResponseJson(
                 routes =
                     listOf(
-                        route(
-                            routeId = "r-btc",
-                            providers = listOf("NEAR"),
-                            expectedBuy = "385.24",
-                            fees =
-                                listOf(
-                                    SwapKitFee(type = "inbound", chain = "BTC", amount = "0.000004")
-                                ),
-                        )
+                        route(routeId = "r-btc", providers = listOf("NEAR"), expectedBuy = "385.24")
                     )
             )
         coEvery { api.swap(any()) } returns
@@ -746,6 +723,8 @@ internal class SwapKitQuoteSourceTest {
                 meta = SwapKitTxMeta(txType = "PSBT"),
                 targetAddress = "bc1ptarget",
                 expectedBuyAmount = "385.24",
+                // Inbound fee comes from the /v3/swap response, not the /v3/quote route.
+                fees = listOf(SwapKitFee(type = "inbound", chain = "BTC", amount = "0.000004")),
                 providers = listOf("NEAR"),
             )
 
@@ -760,6 +739,12 @@ internal class SwapKitQuoteSourceTest {
         assertEquals("btc-swap-1", quote.data.swapId)
         assertEquals("NEAR", quote.data.subProvider)
         assertEquals(btc, quote.data.fromCoin)
+        // The fragile scaling line: expectedDstValue + payload amounts must use the right decimals.
+        assertEquals(ethCoin(), quote.data.toCoin)
+        assertEquals(BigInteger.ONE, quote.data.fromAmount)
+        assertEquals(0, BigDecimal("385.24").compareTo(quote.data.toAmountDecimal))
+        // 385.24 ETH (dst, 18 dp) = 385.24 × 10^18.
+        assertEquals(BigInteger("385240000000000000000"), quote.expectedDstValue.value)
         // 0.000004 BTC inbound fee scaled by 8 native decimals = 400 sats (not 0.000004 × 10^18).
         assertEquals(BigInteger("400"), quote.fees.value)
         assertEquals("BTC", quote.fees.unit)
@@ -823,18 +808,8 @@ internal class SwapKitQuoteSourceTest {
             affiliateBps = affiliateBps,
         )
 
-    private fun route(
-        routeId: String,
-        providers: List<String>,
-        expectedBuy: String? = "1",
-        fees: List<SwapKitFee> = emptyList(),
-    ) =
-        SwapKitRoute(
-            routeId = routeId,
-            providers = providers,
-            expectedBuyAmount = expectedBuy,
-            fees = fees,
-        )
+    private fun route(routeId: String, providers: List<String>, expectedBuy: String? = "1") =
+        SwapKitRoute(routeId = routeId, providers = providers, expectedBuyAmount = expectedBuy)
 
     private fun evmSwapResponse(
         gas: String? = "200000",
@@ -847,6 +822,7 @@ internal class SwapKitQuoteSourceTest {
         providers: List<String> = listOf("CHAINFLIP"),
         metaSubProvider: String? = null,
         approvalAddress: String? = null,
+        fees: List<SwapKitFee> = emptyList(),
     ) =
         SwapKitSwapResponseJson(
             swapId = "swap-id",
@@ -866,6 +842,7 @@ internal class SwapKitQuoteSourceTest {
                     approvalAddress = approvalAddress,
                 ),
             expectedBuyAmount = expectedBuy,
+            fees = fees,
             providers = providers,
         )
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -766,6 +766,46 @@ internal class SwapKitQuoteSourceTest {
         assertEquals(8, quote.fees.decimals)
     }
 
+    @Test
+    fun `fetch throws Decoding when the PSBT tx is not valid base64`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-btc", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive("!!!not-base64!!!"),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+                targetAddress = "bc1ptarget",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> {
+            source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+        }
+    }
+
+    @Test
+    fun `fetch throws Decoding when the PSBT tx decodes to an empty payload`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-btc", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive(""),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+                targetAddress = "bc1ptarget",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> {
+            source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+        }
+    }
+
     // ---- helpers ----
 
     private fun request(


### PR DESCRIPTION
Part 1 of SwapKit **BTC/PSBT** support (non-EVM Phase 2, epic #4589), targeting the **`feature/swapkit-btc`** integration branch — `main` only gets BTC via the final integration PR once the feature is complete. This PR is the **quote/payload decode** half; the signer (#4666) and the `SwapProviderTable` BTC gate land on the same branch next.

## What this does (tested, inert in prod)
Teaches `SwapKitQuoteSource` to decode a BTC `PSBT` route instead of refusing it:
- `chainPrefix` maps `Bitcoin → "BTC"`; `nativeDecimals(Bitcoin) = 8` so the inbound BTC deposit fee scales correctly.
- New `TxKind.PSBT`: the `/v3/swap` response is decoded into a fully-formed `SwapQuote.SwapKit` (base64 PSBT → `SwapKitSwapPayloadJson.txPayload` bytes, `targetAddress`, `toAmountDecimal`, `subProvider`, `swapId`) and returned on `SwapQuoteResult.Native` — the seam a per-chain signer consumes.
- `SwapQuoteManager.fetchSwapKitQuote` handles the `Native(SwapQuote.SwapKit)` result and reads the sub-provider label off it.

`SwapProviderTable` does not offer SwapKit on Bitcoin, so this path is only exercised by the new unit tests until the signer + table entry land — no behaviour change for users.

## Follow-up on this branch — the PSBT signer (#4666)
Signing moves real BTC and needs on-device testing + the BTC-keysign owner's review, so it lands next on this feature branch. Android has a Bitcoin PSBT path, but it consumes Vultisig's own `SignBitcoin` proto (dApp co-signing), **not** a raw BIP-174 PSBT, and rejects P2TR inputs. Two approaches — maintainer call:
- **A — rebuild as a deposit:** build our own BTC send of the input amount to `targetAddress`, reusing the `UtxoHelper` path (like Thor/Maya BTC swaps). Low new-code risk; assumes SwapKit BTC routes are deposit-based.
- **B — sign SwapKit's BIP-174 PSBT:** parse the base64 PSBT into `SignBitcoin` form and sign it (iOS-faithful). Net-new PSBT parsing + taproot handling.

Lean is **B** for iOS parity; owner's call with on-device testing.

## Test plan
- Unit tests pin the PSBT decode, native-decimal fee (400 sats), payload fields, and the malformed/empty base64 failure modes. `:data` + `:app` swap suites green; ktfmt clean.
- End-to-end keysign/broadcast is covered by the signer follow-up (#4666).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for native Bitcoin swap transactions.

* **Improvements**
  * More robust swap quote handling across EVM, Solana and native routes.
  * Improved swap provider label resolution across different quote sources.
  * Corrected native fee scaling and unit handling for Bitcoin.

* **Tests**
  * Added tests covering Bitcoin PSBT routes and error cases for invalid PSBT payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->