### PR TITLE
fix(deposit): empty-state for Withdraw Secured Asset with no assets (#4607)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -177,6 +177,7 @@ internal data class DepositFormUiModel(
     val unstakeUnlocksInText: UiText? = null,
     val rewardsAmount: String? = null,
     val availableSecuredAssets: List<TokenWithdrawSecureAsset> = emptyList(),
+    val securedAssetsLoaded: Boolean = false,
     val selectedSecuredAsset: TokenWithdrawSecureAsset =
         availableSecuredAssets.firstOrNull() ?: TokenWithdrawSecureAsset.EMPTY,
     val bondableAssets: List<String> = emptyList(),
@@ -1107,16 +1108,15 @@ constructor(
                         tokenValue = it.tokenValue,
                     )
                 }
-        if (availableSecuredAssets.isNotEmpty()) {
-            val selectedSecuredAsset = availableSecuredAssets.first()
-            val balance = selectedSecuredAsset.tokenValue?.let(mapTokenValueToStringWithUnit)
-            _state.update {
-                it.copy(
-                    availableSecuredAssets = availableSecuredAssets,
-                    selectedSecuredAsset = selectedSecuredAsset,
-                    balance = balance?.asUiText() ?: UiText.Empty,
-                )
-            }
+        val selectedSecuredAsset = availableSecuredAssets.firstOrNull()
+        val balance = selectedSecuredAsset?.tokenValue?.let(mapTokenValueToStringWithUnit)
+        _state.update {
+            it.copy(
+                availableSecuredAssets = availableSecuredAssets,
+                securedAssetsLoaded = true,
+                selectedSecuredAsset = selectedSecuredAsset ?: TokenWithdrawSecureAsset.EMPTY,
+                balance = balance?.asUiText() ?: UiText.Empty,
+            )
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
@@ -553,6 +553,12 @@ internal fun DepositFormScreen(
                                 onLostFocus = onTokenAmountLostFocus,
                                 error = state.tokenAmountError,
                             )
+                        } else if (state.securedAssetsLoaded) {
+                            Text(
+                                text = stringResource(R.string.deposit_no_secured_assets),
+                                style = Theme.brockmann.body.s.regular,
+                                color = Theme.v2.colors.text.tertiary,
+                            )
                         }
                     }
                 }
@@ -573,7 +579,9 @@ internal fun DepositFormScreen(
                         state.isWhitelistFailed ||
                         state.nodeAddressError != null ||
                         state.dstAddressError != null ||
-                        state.thorAddressError != null
+                        state.thorAddressError != null ||
+                        (state.depositOption == DepositOption.WithdrawSecuredAsset &&
+                            state.availableSecuredAssets.isEmpty())
                 )
                     VsButtonState.Disabled
                 else VsButtonState.Enabled,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -947,6 +947,7 @@
     <string name="address_auto_filled">%1$s Adresse (automatisch ausgefüllt)</string>
     <string name="generated_memo">Generierte Notiz:</string>
     <string name="amount_to_withdraw">Auszuzahlender Betrag (Guthaben: %1$s)</string>
+    <string name="deposit_no_secured_assets">Sie haben in diesem Tresor keine gesicherten Assets zum Abheben</string>
     <string name="mint_secured_asset_secure">Gesichertes Asset erstellen (SECURE+)</string>
     <string name="target_asset">Zielvermögen: %1$s-%2$s</string>
     <string name="thor_address">THORChain-Adresse</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -945,6 +945,7 @@
     <string name="address_auto_filled">Dirección de %1$s (autocompletada)</string>
     <string name="generated_memo">Memo generado:</string>
     <string name="amount_to_withdraw">Cantidad a retirar (Saldo: %1$s)</string>
+    <string name="deposit_no_secured_assets">No tienes activos garantizados para retirar en esta bóveda</string>
     <string name="mint_secured_asset_secure">Acuñar activo garantizado (SECURE+)</string>
     <string name="target_asset">Activo objetivo: %1$s-%2$s</string>
     <string name="thor_address">Dirección de Thor</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -950,6 +950,7 @@
     <string name="address_auto_filled">%1$s Adresa (automatski popunjeno)</string>
     <string name="generated_memo">Generirani dopis:</string>
     <string name="amount_to_withdraw">Iznos za isplatu (Stanje: %1$s)</string>
+    <string name="deposit_no_secured_assets">Nemate osiguranu imovinu za povlačenje iz ovog trezora</string>
     <string name="mint_secured_asset_secure">Osigurana imovina Mint (SECURE+)</string>
     <string name="target_asset">Ciljana imovina: %1$s-%2$s</string>
     <string name="thor_address">THORChain adresa</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -945,6 +945,7 @@
     <string name="address_auto_filled">Indirizzo %1$s (compilato automaticamente)</string>
     <string name="generated_memo">Memo generata:</string>
     <string name="amount_to_withdraw">Importo da prelevare (Saldo: %1$s)</string>
+    <string name="deposit_no_secured_assets">Non hai asset garantiti da prelevare in questo vault</string>
     <string name="mint_secured_asset_secure">Asset garantito Mint (SECURE+)</string>
     <string name="target_asset">Risorsa di destinazione: %1$s-%2$s</string>
     <string name="thor_address">Indirizzo THORChain</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -978,6 +978,7 @@
     <string name="address_auto_filled">%1$s 주소 (자동 입력)</string>
     <string name="generated_memo">생성된 메모:</string>
     <string name="amount_to_withdraw">출금 금액 (잔액: %1$s)</string>
+    <string name="deposit_no_secured_assets">이 볼트에는 출금할 보안 자산이 없습니다</string>
     <string name="mint_secured_asset_secure">보안 자산 민트 (SECURE+)</string>
     <string name="target_asset">대상 자산: %1$s-%2$s</string>
     <string name="thor_address">Thor 주소</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -942,6 +942,7 @@
     <string name="address_auto_filled">Adres %1$s (automatisch ingevuld)</string>
     <string name="generated_memo">Memo gegenereerd:</string>
     <string name="amount_to_withdraw">Bedrag om op te nemen (Saldo: %1$s)</string>
+    <string name="deposit_no_secured_assets">Je hebt geen gedekte activa om op te nemen in deze kluis</string>
     <string name="mint_secured_asset_secure">Mint Gedekte activa (SECURE+)</string>
     <string name="target_asset">Doelactiva: %1$s-%2$s</string>
     <string name="thor_address">THORChain-adres</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -944,6 +944,7 @@
     <string name="address_auto_filled">Endereço %1$s (preenchido automaticamente)</string>
     <string name="generated_memo">Memorando gerado:</string>
     <string name="amount_to_withdraw">Valor a levantar (Saldo: %1$s)</string>
+    <string name="deposit_no_secured_assets">Não tens ativos garantidos para levantar neste cofre</string>
     <string name="mint_secured_asset_secure">Ativo garantido Mint (SECURE+)</string>
     <string name="target_asset">Ativo alvo: %1$s-%2$s</string>
     <string name="thor_address">Endereço THORChain</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -950,6 +950,7 @@
     <string name="address_auto_filled">Адрес %1$s (заполняется автоматически)</string>
     <string name="generated_memo">Сгенерированное примечание:</string>
     <string name="amount_to_withdraw">Сумма для снятия (Баланс: %1$s)</string>
+    <string name="deposit_no_secured_assets">В этом хранилище нет обеспеченных активов для вывода</string>
     <string name="mint_secured_asset_secure">Чеканка обеспеченного актива (SECURE+)</string>
     <string name="target_asset">Целевой актив: %1$s-%2$s</string>
     <string name="thor_address">Адрес THORChain</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1276,6 +1276,7 @@
     <string name="address_auto_filled">%1$s 地址（自动填写）</string>
     <string name="generated_memo">生成的备注：</string>
     <string name="amount_to_withdraw">提款金额（余额：%1$s）</string>
+    <string name="deposit_no_secured_assets">此保险库中没有可提取的担保资产</string>
     <string name="mint_secured_asset_secure">铸造担保资产（SECURE+）</string>
     <string name="target_asset">目标资产：%1$s-%2$s</string>
     <string name="thor_address">Thor 地址</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="generated_memo">Generated Memo:</string>
     <string name="secure" translatable="false">SECURE+:%1$s</string>
     <string name="amount_to_withdraw">Amount to Withdraw (Balance: %1$s)</string>
+    <string name="deposit_no_secured_assets">You don\'t have any secured assets to withdraw from this vault</string>
     <string name="mint_secured_asset_secure">Mint Secured Asset (SECURE+)</string>
     <string name="target_asset">Target Asset: %1$s-%2$s</string>
     <string name="thor_address">Thor Address</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -467,4 +467,33 @@ internal class DepositFormViewModelTest {
                 (errorText as UiText.FormattedText).resId,
             )
         }
+
+    @Test
+    fun `WithdrawSecuredAsset with no secured assets marks loaded with empty list`() = runTest {
+        val vm = buildViewModel()
+        coEvery { accountsRepository.loadAddress("vault1", Chain.ThorChain) } returns
+            flowOf(
+                Address(
+                    chain = Chain.ThorChain,
+                    address = "thor1somevalidaddress",
+                    accounts =
+                        listOf(
+                            Account(
+                                token = Coins.ThorChain.RUNE,
+                                tokenValue = null,
+                                fiatValue = null,
+                                price = null,
+                            )
+                        ),
+                )
+            )
+
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+        vm.selectDepositOption(DepositOption.WithdrawSecuredAsset)
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.securedAssetsLoaded)
+        assertTrue(vm.state.value.availableSecuredAssets.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4607.

On the THORChain Function Signature screen, selecting **Withdraw Secured Asset** in a vault that holds no secured assets rendered an empty form (no asset selector, no amount field) but left **Continue** enabled. Tapping Continue surfaced a misleading error: *"Amount must be a positive number"* — even though there was no amount field to fill in.

This implements the issue's **preferred** behavior:
- Shows an inline empty-state message (*"You don't have any secured assets to withdraw from this vault"*) when the vault has no eligible secured assets.
- Disables the **Continue** button in that case, so the misleading downstream amount-validation error can no longer be triggered.

## Changes

- **`DepositFormViewModel`** — added `securedAssetsLoaded` to the UI model and made `handleWithdrawSecuredAsset` always update state (including the empty case), so the screen can distinguish "still loading" from "loaded, none available".
- **`DepositFormScreen`** — renders the empty-state text when loaded + empty; disables Continue when `WithdrawSecuredAsset && availableSecuredAssets.isEmpty()`.
- **Strings** — added `deposit_no_secured_assets` to `values/strings.xml` and all 9 locale files, matching each locale's existing secured-asset / vault / withdraw terminology.
- **Tests** — added a unit test covering the no-secured-assets case.

## Test plan

- [x] `:app:testDebugUnitTest --tests DepositFormViewModelTest` passes (incl. new test)
- [x] ktfmt formatting applied
- [ ] Manual: open a vault with no secured assets → Functions → THORChain → Withdraw Secured Asset → empty-state shown, Continue disabled
- [ ] Manual: vault with secured assets still shows the selector + amount field and Continue works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling when no secured assets are available for withdrawal. Users now see a clear message in this scenario, and the continue button is appropriately disabled.

* **Localization**
  * Added translations for the empty secured assets message across 11 languages (German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, Chinese, and English).

* **Tests**
  * Added test coverage for the scenario where no secured assets are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->