### PR TITLE
fix(swap): preserve full token precision for MAX/percentage buttons

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -759,9 +759,9 @@ constructor(
         val amount =
             TokenValue.createDecimal(maxUsableTokenAmount, srcTokenValue.decimals)
                 .multiply(percentage.toBigDecimal())
-                .setScale(6, RoundingMode.DOWN)
+                .formatFlippedAmount(srcTokenValue.decimals)
 
-        srcAmountState.setTextAndPlaceCursorAtEnd(amount.toString())
+        srcAmountState.setTextAndPlaceCursorAtEnd(amount)
     }
 
     fun loadData(vaultId: String, chainId: String?, srcTokenId: String?, dstTokenId: String?) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -539,6 +539,31 @@ internal class SwapFormViewModelTest {
             )
         }
 
+    @Test
+    fun `selectSrcPercentage preserves full token precision beyond 6 decimals`() =
+        runTest(mainDispatcher) {
+            // 0.00553297 BTC — more than 6 significant decimals. BTC src avoids the Ethereum
+            // gas-fee mock subtraction (chain mismatch), so at 100% the inserted amount equals
+            // the balance and must keep all 8 decimals rather than truncating to 6.
+            val btcPreciseBalance =
+                Address(
+                    chain = Chain.Bitcoin,
+                    address = "bc1qbtcaddress",
+                    accounts = listOf(createAccount(BTC_COIN, BigInteger("553297"))),
+                )
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(btcPreciseBalance, ethAddress()),
+                    srcTokenId = BTC_COIN.id,
+                    dstTokenId = ETH_COIN.id,
+                )
+            advanceUntilIdle()
+
+            vm.selectSrcPercentage(1.0f)
+
+            assertEquals("0.00553297", vm.srcAmountState.text.toString())
+        }
+
     // endregion
 
     // region flipSelectedTokens


### PR DESCRIPTION
## Summary
- Swap MAX / 25% / 50% / 75% buttons truncated the inserted "From" amount to 6 decimals, so high-precision / low-value tokens lost trailing decimals and the full balance couldn't be swapped (e.g. `0.00553297` became `0.005532`).
- Root cause: `SwapFormViewModel.selectSrcPercentage()` used a hardcoded `.setScale(6, RoundingMode.DOWN)`.
- Fix: scale by the token's own `decimals` via the existing `formatFlippedAmount()` helper (capped at `MAX_DISPLAY_DECIMALS` = 8 and trailing zeros stripped), making the percentage handler consistent with the flipped-amount formatter already used on the same screen.

Closes #4668

## Test plan
- [x] Added `selectSrcPercentage preserves full token precision beyond 6 decimals` — asserts `0.00553297 BTC` at 100% stays intact instead of truncating to `0.005532`.
- [x] `./gradlew :app:testDebugUnitTest --tests "*.SwapFormViewModelTest"` — 77 tests, 0 failures.
- [ ] Manual: on Swap, pick a token with a balance having >6 decimals, tap MAX, confirm the full precision is inserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the swap form to preserve full token precision when selecting percentage amounts. Previously, values were truncated to 6 decimals; now the complete precision is retained for accurate swap calculations.

* **Tests**
  * Added test coverage verifying precision is maintained for tokens with more than 6 decimal places during percentage-based amount selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->