### PR TITLE
feat(swap): SwapKit Bitcoin PSBT signer

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -473,10 +473,41 @@ constructor(
                                 )
                             }
 
-                            // Per-chain signers wire this branch as they ship; no quote source
-                            // emits SwapQuote.SwapKit yet.
-                            is SwapQuote.SwapKit ->
-                                error("No SwapKit signer wired for txType=${quote.data.txType}")
+                            is SwapQuote.SwapKit -> {
+                                // Only BTC PSBT is wired today; other SwapKit txTypes (TON / ADA /
+                                // SUI / TRON) land with their per-chain signers. SwapProviderTable
+                                // does not yet offer SwapKit on Bitcoin, so this branch is reached
+                                // only once enablement ships — guarded loudly until then.
+                                require(quote.data.txType == SWAPKIT_PSBT_TX_TYPE) {
+                                    "Unsupported SwapKit txType for swap: ${quote.data.txType}"
+                                }
+                                val specificAndUtxo =
+                                    swapGasCalculator.getSpecificAndUtxo(
+                                        srcToken = srcToken,
+                                        srcAddress = srcAddress,
+                                        gasFee = gasFee,
+                                    )
+                                RegularSwapTransaction(
+                                    id = UUID.randomUUID().toString(),
+                                    vaultId = vaultId,
+                                    srcToken = srcToken,
+                                    srcTokenValue = srcTokenValue,
+                                    dstToken = dstToken,
+                                    // SwapKit's source-chain deposit address — where the BTC the
+                                    // PSBT spends is sent. Signing is driven entirely by the PSBT
+                                    // bytes carried on the payload, not by this blockChainSpecific.
+                                    dstAddress = quote.data.targetAddress,
+                                    expectedDstTokenValue = dstTokenValue,
+                                    blockChainSpecific = specificAndUtxo,
+                                    estimatedFees = quote.fees,
+                                    gasFees = estimatedNetworkFeeTokenValue.value ?: gasFee,
+                                    memo = quote.data.memo,
+                                    isApprovalRequired = false,
+                                    gasFeeFiatValue =
+                                        estimatedNetworkFeeFiatValue.value ?: gasFeeFiatValue,
+                                    payload = SwapPayload.SwapKit(quote.data),
+                                )
+                            }
 
                             is SwapQuote.OneInch -> {
                                 val dstAddress = quote.data.tx.to
@@ -1229,6 +1260,9 @@ constructor(
 }
 
 private const val MAX_DISPLAY_DECIMALS = 8
+
+// SwapKit `meta.txType` for the only non-EVM SwapKit swap wired today (Bitcoin PSBT).
+private const val SWAPKIT_PSBT_TX_TYPE = "PSBT"
 
 internal fun BigDecimal.formatFlippedAmount(tokenDecimals: Int? = null): String =
     setScale(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
@@ -478,7 +479,7 @@ constructor(
                                 // SUI / TRON) land with their per-chain signers. SwapProviderTable
                                 // does not yet offer SwapKit on Bitcoin, so this branch is reached
                                 // only once enablement ships — guarded loudly until then.
-                                require(quote.data.txType == SWAPKIT_PSBT_TX_TYPE) {
+                                require(quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }
                                 val specificAndUtxo =
@@ -1260,9 +1261,6 @@ constructor(
 }
 
 private const val MAX_DISPLAY_DECIMALS = 8
-
-// SwapKit `meta.txType` for the only non-EVM SwapKit swap wired today (Bitcoin PSBT).
-private const val SWAPKIT_PSBT_TX_TYPE = "PSBT"
 
 internal fun BigDecimal.formatFlippedAmount(tokenDecimals: Int? = null): String =
     setScale(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -26,6 +26,8 @@ import wallet.core.jni.EthereumAbi
 
 object SigningHelper {
     private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
+    // SwapKit `meta.txType` for the Bitcoin PSBT signer dispatch.
+    private const val PSBT_TX_TYPE = "PSBT"
 
     @OptIn(ExperimentalStdlibApi::class)
     fun getKeysignMessages(messagePayload: CustomMessagePayload): List<String> {
@@ -92,6 +94,18 @@ object SigningHelper {
                                 .getPreSignedImageHash(swapPayload.data, payload, nonceAcc)
 
                     messages += message
+                }
+                is SwapPayload.SwapKit -> {
+                    require(swapPayload.data.txType == PSBT_TX_TYPE) {
+                        "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
+                    }
+                    messages +=
+                        SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                            .getPreSignedImageHash(
+                                psbtBytes = swapPayload.data.txPayload,
+                                targetAddress = swapPayload.data.targetAddress,
+                                fromAmount = swapPayload.data.fromAmount,
+                            )
                 }
                 else -> Unit
             }
@@ -273,6 +287,13 @@ object SigningHelper {
                             )
                 }
 
+                is SwapPayload.SwapKit -> {
+                    require(swapPayload.data.txType == PSBT_TX_TYPE) {
+                        "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
+                    }
+                    return SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                        .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                }
                 else -> {}
             }
         } else if (swapPayload is SwapPayload.MayaChain && !swapPayload.srcToken.isNativeToken) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.crypto.TonHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
@@ -26,8 +27,6 @@ import wallet.core.jni.EthereumAbi
 
 object SigningHelper {
     private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
-    // SwapKit `meta.txType` for the Bitcoin PSBT signer dispatch.
-    private const val PSBT_TX_TYPE = "PSBT"
 
     @OptIn(ExperimentalStdlibApi::class)
     fun getKeysignMessages(messagePayload: CustomMessagePayload): List<String> {
@@ -96,7 +95,7 @@ object SigningHelper {
                     messages += message
                 }
                 is SwapPayload.SwapKit -> {
-                    require(swapPayload.data.txType == PSBT_TX_TYPE) {
+                    require(swapPayload.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
                         "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
                     }
                     messages +=
@@ -288,7 +287,7 @@ object SigningHelper {
                 }
 
                 is SwapPayload.SwapKit -> {
-                    require(swapPayload.data.txType == PSBT_TX_TYPE) {
+                    require(swapPayload.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
                         "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
                     }
                     return SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
@@ -1,0 +1,424 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.utils.Numeric
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.security.MessageDigest
+import tss.KeysignResponse
+import vultisig.keysign.v1.BitcoinInput
+import vultisig.keysign.v1.BitcoinOutput
+import vultisig.keysign.v1.SignBitcoin
+import wallet.core.jni.BitcoinScript
+import wallet.core.jni.CoinType
+import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
+
+internal class SwapKitBtcSignerException(message: String) : Exception(message)
+
+/**
+ * Bridges SwapKit's pre-built BTC PSBT onto Android's existing structured-PSBT signing path. Ported
+ * from iOS' `SwapKitBTCSigner` + the compile half of `BitcoinPsbtSigner`. SwapKit's `/v3/swap`
+ * returns a base64 BIP-174 PSBT (already base64-decoded into `SwapKitSwapPayloadJson.txPayload`).
+ * We decode it into a [SignBitcoin], reuse [UtxoHelper]'s BIP-143 sighashes plus the vault +
+ * destination binding, and assemble the signed segwit transaction from the MPC signatures.
+ *
+ * Scope: P2WPKH + P2SH-P2WPKH inputs, SIGHASH_ALL only — matches [UtxoHelper.computeOurSighashes]
+ * and the SwapKit BTC providers observed (NEAR / GARDEN / FLASHNET), which place only the user's
+ * UTXOs in the inputs (every input is `is_ours`). PSBT framing primitives live in
+ * [SwapKitPsbtParser]; the BIP-144 unsigned-tx body parser stays here.
+ */
+internal class SwapKitBtcSigner(
+    private val vaultHexPublicKey: String,
+    private val vaultHexChainCode: String,
+) {
+    private val coinType = CoinType.BITCOIN
+    private val utxo = UtxoHelper(coinType, vaultHexPublicKey, vaultHexChainCode)
+
+    /**
+     * BIP-143 sighashes (sorted hex) for every `is_ours` input. Delegates to
+     * [UtxoHelper.getPreSignedImageHashFromSignBitcoin], pinning the non-change deposit to
+     * SwapKit's [targetAddress] and [fromAmount] and the change to the vault — a defense-in-depth
+     * binding that refuses to sign a PSBT whose outputs diverge from the quoted deposit.
+     */
+    fun getPreSignedImageHash(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        fromAmount: BigInteger,
+    ): List<String> {
+        val signBitcoin = decodeToSignBitcoin(psbtBytes)
+        return utxo.getPreSignedImageHashFromSignBitcoin(
+            signBitcoin = signBitcoin,
+            expectedToAddress = targetAddress,
+            expectedToAmount = fromAmount,
+        )
+    }
+
+    /** Assemble the signed segwit transaction from the SwapKit PSBT bytes + MPC signatures. */
+    fun getSignedTransaction(
+        psbtBytes: ByteArray,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val signBitcoin = decodeToSignBitcoin(psbtBytes)
+        return compileSignedTransaction(signBitcoin, signatures)
+    }
+
+    /**
+     * Decode a BIP-174 PSBT blob into the structured [SignBitcoin]. Every input is `is_ours=true`
+     * (SwapKit only puts the user's UTXOs in the inputs). An output is flagged `is_change=true` iff
+     * its scriptPubKey equals the vault's own lock script, so the reused binding in
+     * [UtxoHelper.getPreSignedImageHashFromSignBitcoin] treats the deposit as the payment and the
+     * vault output as change.
+     */
+    fun decodeToSignBitcoin(psbtBytes: ByteArray): SignBitcoin {
+        val vaultAddr = vaultAddress()
+        return decode(psbtBytes, vaultAddr, vaultLockScriptHex(vaultAddr))
+    }
+
+    /**
+     * Core decode. [vaultLockScriptHex] / [vaultAddress] drive `is_change` marking; pass both null
+     * to skip it (the resulting [SignBitcoin] is enough for the pure BIP-143 sighash path, which
+     * ignores outputs' change flags). Splitting the vault lookup out keeps the sighash transcoding
+     * testable without the WalletCore JNI.
+     */
+    internal fun decode(
+        psbtBytes: ByteArray,
+        vaultAddress: String?,
+        vaultLockScriptHex: String?,
+    ): SignBitcoin {
+        if (psbtBytes.isEmpty()) {
+            throw SwapKitBtcSignerException("SwapKit BTC payload has no PSBT bytes")
+        }
+        val header = SwapKitPsbtParser.parseFramingHeader(psbtBytes)
+        val parsedTx = parseUnsignedTx(header.unsignedTxBytes)
+        val cursor = header.cursor
+        val inputMaps = parsedTx.inputs.map { cursor.readMap() }
+        // Output maps are always parsed for spec compliance / forward-compat even though no field
+        // is
+        // currently read from them.
+        parsedTx.outputs.forEach { cursor.readMap() }
+
+        val inputs =
+            parsedTx.inputs.mapIndexed { index, txIn ->
+                makeBitcoinInput(inputMaps[index], index, txIn)
+            }
+        val outputs =
+            parsedTx.outputs.map { txOut ->
+                val scriptHex = Numeric.toHexStringNoPrefix(txOut.scriptPubKey)
+                val isChange =
+                    vaultLockScriptHex != null &&
+                        scriptHex.equals(vaultLockScriptHex, ignoreCase = true)
+                BitcoinOutput(
+                    amount = txOut.amount,
+                    address = if (isChange) vaultAddress.orEmpty() else "",
+                    scriptPubKey = scriptHex,
+                    isChange = isChange,
+                )
+            }
+        return SignBitcoin(
+            version = parsedTx.version.toUInt(),
+            locktime = parsedTx.locktime.toUInt(),
+            inputs = inputs,
+            outputs = outputs,
+        )
+    }
+
+    private fun makeBitcoinInput(
+        inputMap: Map<String, ByteArray>,
+        index: Int,
+        txIn: ParsedTxInput,
+    ): BitcoinInput {
+        val witnessUtxo =
+            inputMap[KEY_WITNESS_UTXO]
+                ?: throw SwapKitBtcSignerException(
+                    "SwapKit BTC PSBT input #$index is missing PSBT_IN_WITNESS_UTXO"
+                )
+        val (amount, scriptPubKey) = parseWitnessUtxo(witnessUtxo, index)
+        val (scriptType, redeemScript) = classifyScript(scriptPubKey, inputMap, index)
+        val sighashType =
+            inputMap[KEY_SIGHASH_TYPE]?.let { bytes ->
+                if (bytes.size != 4) {
+                    throw SwapKitBtcSignerException(
+                        "SwapKit BTC PSBT input #$index sighash-type record has ${bytes.size} " +
+                            "bytes, expected 4"
+                    )
+                }
+                ((bytes[0].toLong() and 0xFF) or
+                        ((bytes[1].toLong() and 0xFF) shl 8) or
+                        ((bytes[2].toLong() and 0xFF) shl 16) or
+                        ((bytes[3].toLong() and 0xFF) shl 24))
+                    .toUInt()
+            }
+        return BitcoinInput(
+            hash = txIn.prevTxIdDisplay,
+            index = txIn.prevIndex.toUInt(),
+            amount = amount,
+            scriptPubKey = Numeric.toHexStringNoPrefix(scriptPubKey),
+            scriptType = scriptType,
+            isOurs = true,
+            redeemScript = redeemScript,
+            sequence = txIn.sequence.toUInt(),
+            sighashType = sighashType,
+        )
+    }
+
+    /** WITNESS_UTXO value: 8-byte LE amount + varint-prefixed scriptPubKey. */
+    private fun parseWitnessUtxo(bytes: ByteArray, index: Int): Pair<Long, ByteArray> {
+        val cursor = PsbtCursor(bytes)
+        val amount = cursor.readUInt64LE()
+        val scriptLen = cursor.readCompactSize()
+        val script = cursor.readBytes(scriptLen.toInt())
+        if (!cursor.isAtEnd) {
+            throw SwapKitBtcSignerException(
+                "SwapKit BTC PSBT input #$index WITNESS_UTXO has trailing bytes"
+            )
+        }
+        return amount to script
+    }
+
+    /** Classify the input scriptPubKey. P2WPKH and (with a redeem script) P2SH-P2WPKH only. */
+    private fun classifyScript(
+        scriptPubKey: ByteArray,
+        inputMap: Map<String, ByteArray>,
+        index: Int,
+    ): Pair<String, String?> {
+        // P2WPKH: 0x00 0x14 <20-byte hash> (22 bytes).
+        if (
+            scriptPubKey.size == 22 &&
+                scriptPubKey[0] == 0x00.toByte() &&
+                scriptPubKey[1] == 0x14.toByte()
+        ) {
+            return "p2wpkh" to null
+        }
+        // P2SH: 0xa9 0x14 <20-byte hash> 0x87 (23 bytes); promotion to P2SH-P2WPKH needs the
+        // redeem.
+        if (
+            scriptPubKey.size == 23 &&
+                scriptPubKey[0] == 0xa9.toByte() &&
+                scriptPubKey[1] == 0x14.toByte() &&
+                scriptPubKey[22] == 0x87.toByte()
+        ) {
+            val redeem =
+                inputMap[KEY_REDEEM_SCRIPT]
+                    ?: throw SwapKitBtcSignerException(
+                        "SwapKit BTC PSBT P2SH input #$index missing redeem script"
+                    )
+            if (!(redeem.size == 22 && redeem[0] == 0x00.toByte() && redeem[1] == 0x14.toByte())) {
+                throw SwapKitBtcSignerException(
+                    "SwapKit BTC PSBT P2SH redeem script on input #$index is not P2SH-P2WPKH"
+                )
+            }
+            return "p2sh-p2wpkh" to Numeric.toHexStringNoPrefix(redeem)
+        }
+        throw SwapKitBtcSignerException(
+            "SwapKit BTC PSBT input #$index scriptPubKey is not P2WPKH or P2SH-P2WPKH: " +
+                Numeric.toHexStringNoPrefix(scriptPubKey)
+        )
+    }
+
+    private data class ParsedTxInput(
+        val prevTxIdDisplay: String,
+        val prevIndex: Long,
+        val sequence: Long,
+    )
+
+    private data class ParsedTxOutput(val amount: Long, val scriptPubKey: ByteArray)
+
+    private data class ParsedTx(
+        val version: Long,
+        val locktime: Long,
+        val inputs: List<ParsedTxInput>,
+        val outputs: List<ParsedTxOutput>,
+    )
+
+    /**
+     * Parse the legacy (non-witness) unsigned-tx body that BIP-174 stores under global key 0x00.
+     */
+    private fun parseUnsignedTx(data: ByteArray): ParsedTx {
+        val cursor = PsbtCursor(data)
+        val version = cursor.readUInt32LE()
+        val inputCount = cursor.readCompactSize()
+        val inputs =
+            (0L until inputCount).map {
+                val prevBytes = cursor.readBytes(32)
+                // Outpoint hash is internal (little-endian) on the wire; SignBitcoin/BIP-143 expect
+                // big-endian display order — reverse once here.
+                val prevTxIdDisplay = Numeric.toHexStringNoPrefix(prevBytes.reversedArray())
+                val prevIndex = cursor.readUInt32LE()
+                val scriptSigLen = cursor.readCompactSize()
+                cursor.readBytes(
+                    scriptSigLen.toInt()
+                ) // empty for unsigned txs; consume for correctness
+                val sequence = cursor.readUInt32LE()
+                ParsedTxInput(prevTxIdDisplay, prevIndex, sequence)
+            }
+        val outputCount = cursor.readCompactSize()
+        val outputs =
+            (0L until outputCount).map {
+                val amount = cursor.readUInt64LE()
+                val scriptLen = cursor.readCompactSize()
+                ParsedTxOutput(amount, cursor.readBytes(scriptLen.toInt()))
+            }
+        val locktime = cursor.readUInt32LE()
+        return ParsedTx(version, locktime, inputs, outputs)
+    }
+
+    private fun compileSignedTransaction(
+        signBitcoin: SignBitcoin,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val pubKeyBytes = derivedPublicKeyBytes()
+        val inputs = signBitcoin.inputs.filterNotNull()
+        // Recompute per-input sighashes in input order (is_ours only) so each maps to the MPC
+        // signature keyed by its sighash hex — the same matching UtxoHelper uses.
+        val sighashes = utxo.computeOurSighashes(signBitcoin)
+        val witnesses = Array(inputs.size) { emptyList<ByteArray>() }
+        var sighashIndex = 0
+        inputs.forEachIndexed { i, input ->
+            if (!input.isOurs) return@forEachIndexed
+            val sighash = sighashes[sighashIndex++]
+            val key = Numeric.toHexStringNoPrefix(sighash)
+            val derSignature =
+                signatures[key]?.derSignature
+                    ?: throw SwapKitBtcSignerException(
+                        "Missing signature for sighash ${key.take(16)}…"
+                    )
+            val sigPlusFlag =
+                Numeric.hexStringToByteArray(derSignature) + byteArrayOf(sighashFlagByte(input))
+            witnesses[i] = listOf(sigPlusFlag, pubKeyBytes)
+        }
+        val rawTx = serializeSegwitTransaction(signBitcoin, witnesses)
+        return SignedTransactionResult(
+            rawTransaction = Numeric.toHexStringNoPrefix(rawTx),
+            transactionHash = txid(signBitcoin),
+        )
+    }
+
+    private fun sighashFlagByte(input: BitcoinInput): Byte =
+        ((input.sighashType ?: SIGHASH_ALL).toInt() and 0xFF).toByte()
+
+    /** BIP-141 segwit serialization: marker+flag, scriptSig per input, witness stacks. */
+    private fun serializeSegwitTransaction(
+        signBitcoin: SignBitcoin,
+        witnesses: Array<List<ByteArray>>,
+    ): ByteArray {
+        val buf = ByteArrayOutputStream()
+        buf.write(uint32LE(signBitcoin.version.toInt()))
+        buf.write(0x00) // marker
+        buf.write(0x01) // flag
+        buf.write(serializeInputsAndOutputs(signBitcoin))
+        witnesses.forEach { stack ->
+            buf.write(varInt(stack.size.toLong()))
+            stack.forEach { item ->
+                buf.write(varInt(item.size.toLong()))
+                buf.write(item)
+            }
+        }
+        buf.write(uint32LE(signBitcoin.locktime.toInt()))
+        return buf.toByteArray()
+    }
+
+    /** Shared body (counts + per-input outpoint/scriptSig/sequence + per-output value/script). */
+    private fun serializeInputsAndOutputs(signBitcoin: SignBitcoin): ByteArray {
+        val inputs = signBitcoin.inputs.filterNotNull()
+        val outputs = signBitcoin.outputs.filterNotNull()
+        val buf = ByteArrayOutputStream()
+        buf.write(varInt(inputs.size.toLong()))
+        inputs.forEach { input ->
+            buf.write(serializeOutpoint(input.hash, input.index.toInt()))
+            val scriptSig = scriptSig(input)
+            buf.write(varInt(scriptSig.size.toLong()))
+            buf.write(scriptSig)
+            buf.write(uint32LE((input.sequence ?: 0xFFFFFFFFu).toInt()))
+        }
+        buf.write(varInt(outputs.size.toLong()))
+        outputs.forEach { output ->
+            buf.write(uint64LE(output.amount))
+            val script = Numeric.hexStringToByteArray(output.scriptPubKey)
+            buf.write(varInt(script.size.toLong()))
+            buf.write(script)
+        }
+        return buf.toByteArray()
+    }
+
+    /** Empty for native segwit; pushes the redeem script for P2SH-P2WPKH. */
+    private fun scriptSig(input: BitcoinInput): ByteArray {
+        if (input.scriptType.lowercase() != "p2sh-p2wpkh") return ByteArray(0)
+        val redeemHex =
+            input.redeemScript
+                ?: throw SwapKitBtcSignerException(
+                    "P2SH-P2WPKH input ${input.hash}:${input.index} missing redeem script"
+                )
+        val redeem = Numeric.hexStringToByteArray(redeemHex)
+        return byteArrayOf((redeem.size and 0xFF).toByte()) + redeem
+    }
+
+    /** txid = reverse(double-sha256(non-witness serialization)), Bitcoin display order. */
+    private fun txid(signBitcoin: SignBitcoin): String {
+        val buf = ByteArrayOutputStream()
+        buf.write(uint32LE(signBitcoin.version.toInt()))
+        buf.write(serializeInputsAndOutputs(signBitcoin))
+        buf.write(uint32LE(signBitcoin.locktime.toInt()))
+        return Numeric.toHexStringNoPrefix(sha256d(buf.toByteArray()).reversedArray())
+    }
+
+    private fun serializeOutpoint(prevTxIdDisplay: String, index: Int): ByteArray {
+        val buf = ByteArrayOutputStream()
+        buf.write(Numeric.hexStringToByteArray(prevTxIdDisplay).reversedArray())
+        buf.write(uint32LE(index))
+        return buf.toByteArray()
+    }
+
+    private fun derivedPublicKeyBytes(): ByteArray {
+        val derivedHex =
+            PublicKeyHelper.getDerivedPublicKey(
+                vaultHexPublicKey,
+                vaultHexChainCode,
+                coinType.derivationPath(),
+            )
+        val bytes = Numeric.hexStringToByteArray(derivedHex)
+        require(PublicKey.isValid(bytes, PublicKeyType.SECP256K1)) {
+            "Invalid derived vault public key for SwapKit BTC signing"
+        }
+        return bytes
+    }
+
+    private fun vaultAddress(): String {
+        val derivedHex =
+            PublicKeyHelper.getDerivedPublicKey(
+                vaultHexPublicKey,
+                vaultHexChainCode,
+                coinType.derivationPath(),
+            )
+        val publicKey = PublicKey(Numeric.hexStringToByteArray(derivedHex), PublicKeyType.SECP256K1)
+        return coinType.deriveAddressFromPublicKey(publicKey)
+    }
+
+    private fun vaultLockScriptHex(address: String): String =
+        Numeric.toHexStringNoPrefix(BitcoinScript.lockScriptForAddress(address, coinType).data())
+
+    private fun uint32LE(v: Int): ByteArray =
+        byteArrayOf(v.toByte(), (v ushr 8).toByte(), (v ushr 16).toByte(), (v ushr 24).toByte())
+
+    private fun uint64LE(v: Long): ByteArray = ByteArray(8) { i -> (v ushr (i * 8)).toByte() }
+
+    private fun varInt(v: Long): ByteArray =
+        when {
+            v < 0xFDL -> byteArrayOf(v.toByte())
+            v <= 0xFFFFL -> byteArrayOf(0xFDu.toByte(), v.toByte(), (v ushr 8).toByte())
+            v <= 0xFFFFFFFFL -> byteArrayOf(0xFEu.toByte()) + uint32LE(v.toInt())
+            else -> byteArrayOf(0xFFu.toByte()) + uint64LE(v)
+        }
+
+    private fun sha256d(data: ByteArray): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(digest.digest(data))
+    }
+
+    private companion object {
+        private const val SIGHASH_ALL: UInt = 1u
+        private const val KEY_WITNESS_UTXO = "01"
+        private const val KEY_SIGHASH_TYPE = "03"
+        private const val KEY_REDEEM_SCRIPT = "04"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
@@ -60,7 +60,11 @@ internal class SwapKitBtcSigner(
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
         val signBitcoin = decodeToSignBitcoin(psbtBytes)
-        return compileSignedTransaction(signBitcoin, signatures)
+        return compileSignedTransaction(
+            signBitcoin = signBitcoin,
+            pubKeyBytes = derivedPublicKeyBytes(),
+            derSignatureBySighash = signatures.mapValues { it.value.derSignature },
+        )
     }
 
     /**
@@ -136,19 +140,24 @@ internal class SwapKitBtcSigner(
         val (amount, scriptPubKey) = parseWitnessUtxo(witnessUtxo, index)
         val (scriptType, redeemScript) = classifyScript(scriptPubKey, inputMap, index)
         val sighashType =
-            inputMap[KEY_SIGHASH_TYPE]?.let { bytes ->
-                if (bytes.size != 4) {
-                    throw SwapKitBtcSignerException(
-                        "SwapKit BTC PSBT input #$index sighash-type record has ${bytes.size} " +
-                            "bytes, expected 4"
-                    )
+            inputMap[KEY_SIGHASH_TYPE]
+                ?.let { bytes ->
+                    if (bytes.size != 4) {
+                        throw SwapKitBtcSignerException(
+                            "SwapKit BTC PSBT input #$index sighash-type record has ${bytes.size} " +
+                                "bytes, expected 4"
+                        )
+                    }
+                    ((bytes[0].toLong() and 0xFF) or
+                            ((bytes[1].toLong() and 0xFF) shl 8) or
+                            ((bytes[2].toLong() and 0xFF) shl 16) or
+                            ((bytes[3].toLong() and 0xFF) shl 24))
+                        .toUInt()
                 }
-                ((bytes[0].toLong() and 0xFF) or
-                        ((bytes[1].toLong() and 0xFF) shl 8) or
-                        ((bytes[2].toLong() and 0xFF) shl 16) or
-                        ((bytes[3].toLong() and 0xFF) shl 24))
-                    .toUInt()
-            }
+                // An explicit sighash of 0 is the default (SIGHASH_ALL); drop to null so the
+                // downstream `?: SIGHASH_ALL` applies — matches iOS rather than rejecting the
+                // input.
+                ?.takeIf { it != 0u }
         return BitcoinInput(
             hash = txIn.prevTxIdDisplay,
             index = txIn.prevIndex.toUInt(),
@@ -271,11 +280,17 @@ internal class SwapKitBtcSigner(
         return ParsedTx(version, locktime, inputs, outputs)
     }
 
-    private fun compileSignedTransaction(
+    /**
+     * Assemble the signed segwit tx. [derSignatureBySighash] maps each sighash hex (the message the
+     * MPC engine signed) to its DER signature hex; [pubKeyBytes] is the derived vault pubkey placed
+     * in every witness. Takes plain bytes/strings (not the `compileOnly` TSS type) so the broadcast
+     * serialization can be pinned by a headless unit test.
+     */
+    internal fun compileSignedTransaction(
         signBitcoin: SignBitcoin,
-        signatures: Map<String, KeysignResponse>,
+        pubKeyBytes: ByteArray,
+        derSignatureBySighash: Map<String, String>,
     ): SignedTransactionResult {
-        val pubKeyBytes = derivedPublicKeyBytes()
         val inputs = signBitcoin.inputs.filterNotNull()
         // SwapKit puts only the user's UTXOs in the PSBT, so `decode` marks every input is_ours and
         // this holds by construction. Guard it anyway: a non-ours input would get an empty witness
@@ -293,7 +308,7 @@ internal class SwapKitBtcSigner(
             val sighash = sighashes[sighashIndex++]
             val key = Numeric.toHexStringNoPrefix(sighash)
             val derSignature =
-                signatures[key]?.derSignature
+                derSignatureBySighash[key]
                     ?: throw SwapKitBtcSignerException(
                         "Missing signature for sighash ${key.take(16)}…"
                     )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
@@ -70,7 +70,7 @@ internal class SwapKitBtcSigner(
      * [UtxoHelper.getPreSignedImageHashFromSignBitcoin] treats the deposit as the payment and the
      * vault output as change.
      */
-    fun decodeToSignBitcoin(psbtBytes: ByteArray): SignBitcoin {
+    internal fun decodeToSignBitcoin(psbtBytes: ByteArray): SignBitcoin {
         val vaultAddr = vaultAddress()
         return decode(psbtBytes, vaultAddr, vaultLockScriptHex(vaultAddr))
     }
@@ -167,7 +167,7 @@ internal class SwapKitBtcSigner(
         val cursor = PsbtCursor(bytes)
         val amount = cursor.readUInt64LE()
         val scriptLen = cursor.readCompactSize()
-        val script = cursor.readBytes(scriptLen.toInt())
+        val script = cursor.readBytes(cursor.asLength(scriptLen))
         if (!cursor.isAtEnd) {
             throw SwapKitBtcSignerException(
                 "SwapKit BTC PSBT input #$index WITNESS_UTXO has trailing bytes"
@@ -257,9 +257,17 @@ internal class SwapKitBtcSigner(
             (0L until outputCount).map {
                 val amount = cursor.readUInt64LE()
                 val scriptLen = cursor.readCompactSize()
-                ParsedTxOutput(amount, cursor.readBytes(scriptLen.toInt()))
+                ParsedTxOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
             }
         val locktime = cursor.readUInt32LE()
+        // The unsigned-tx body must consume exactly; trailing bytes mean a malformed serialization
+        // (e.g. a stray BIP-144 witness flag) whose dropped data would silently change what's
+        // signed.
+        if (!cursor.isAtEnd) {
+            throw SwapKitBtcSignerException(
+                "SwapKit BTC PSBT unsigned-tx body has ${data.size - cursor.offset} trailing bytes"
+            )
+        }
         return ParsedTx(version, locktime, inputs, outputs)
     }
 
@@ -269,6 +277,12 @@ internal class SwapKitBtcSigner(
     ): SignedTransactionResult {
         val pubKeyBytes = derivedPublicKeyBytes()
         val inputs = signBitcoin.inputs.filterNotNull()
+        // SwapKit puts only the user's UTXOs in the PSBT, so `decode` marks every input is_ours and
+        // this holds by construction. Guard it anyway: a non-ours input would get an empty witness
+        // (a non-final tx), so reject mixed-ownership PSBTs loudly rather than broadcast garbage.
+        require(inputs.all { it.isOurs }) {
+            "SwapKitBtcSigner expects every input to be is_ours; mixed-ownership PSBTs are unsupported"
+        }
         // Recompute per-input sighashes in input order (is_ours only) so each maps to the MPC
         // signature keyed by its sighash hex — the same matching UtxoHelper uses.
         val sighashes = utxo.computeOurSighashes(signBitcoin)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitPsbtParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitPsbtParser.kt
@@ -1,0 +1,143 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.utils.Numeric
+
+/**
+ * Shared BIP-174 PSBT framing primitives. Ported from iOS' `SwapKitPSBTParser`. Every SwapKit UTXO
+ * signer consumes the same byte-level envelope — magic prefix, global key/value map, per-input map,
+ * per-output map. Per-chain signers diverge only on the unsigned-tx body parser (which lives with
+ * the chain's serialization rules in the per-chain signer) and on script-type classification.
+ *
+ * Pure bytes: no crypto and no vault context. The unsigned-tx body (global key `0x00`) is exposed
+ * as raw bytes; the caller parses it because the serialization differs per chain (BIP-144 segwit
+ * for BTC, legacy for DOGE/BCH/DASH, Sapling-v4 for ZEC).
+ */
+internal class SwapKitPsbtException(message: String) : Exception(message)
+
+/**
+ * Framing header — magic consumed, globals map parsed, unsigned-tx bytes extracted. The cursor is
+ * left positioned at the first per-input map so the caller can stream the input/output maps once it
+ * knows the counts from the unsigned-tx body.
+ */
+internal class PsbtFramingHeader(
+    val cursor: PsbtCursor,
+    val globals: Map<String, ByteArray>,
+    val unsignedTxBytes: ByteArray,
+)
+
+internal object SwapKitPsbtParser {
+
+    // BIP-174 magic: 4-byte ASCII 'psbt' (0x70 0x73 0x62 0x74) + a single 0xff separator.
+    private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+
+    // PSBT_GLOBAL_UNSIGNED_TX key is the single byte 0x00.
+    private const val GLOBAL_UNSIGNED_TX_KEY = "00"
+
+    /**
+     * Read the framing header + globals and extract the mandatory `PSBT_GLOBAL_UNSIGNED_TX` value.
+     * The returned cursor is positioned at the first per-input map; the caller reads one map per
+     * input and one per output (counts come from the unsigned-tx body it parses itself).
+     */
+    fun parseFramingHeader(psbtBytes: ByteArray): PsbtFramingHeader {
+        if (psbtBytes.isEmpty()) throw SwapKitPsbtException("SwapKit PSBT payload is empty")
+        val cursor = PsbtCursor(psbtBytes)
+        cursor.expectMagic(MAGIC)
+        val globals = cursor.readMap()
+        val unsignedTx =
+            globals[GLOBAL_UNSIGNED_TX_KEY]
+                ?: throw SwapKitPsbtException(
+                    "SwapKit PSBT is missing the PSBT_GLOBAL_UNSIGNED_TX global record"
+                )
+        return PsbtFramingHeader(cursor, globals, unsignedTx)
+    }
+}
+
+/**
+ * Cursor into a PSBT byte stream implementing the BIP-174 wire helpers. Mutable offset; all readers
+ * throw [SwapKitPsbtException] on truncation/malformation so the per-chain signer wraps once.
+ */
+internal class PsbtCursor(private val data: ByteArray) {
+    var offset: Int = 0
+        private set
+
+    val isAtEnd: Boolean
+        get() = offset >= data.size
+
+    fun expectMagic(magic: ByteArray) {
+        if (data.size < magic.size)
+            throw SwapKitPsbtException("SwapKit PSBT magic bytes are invalid")
+        for (i in magic.indices) {
+            if (data[i] != magic[i]) {
+                throw SwapKitPsbtException("SwapKit PSBT magic bytes are invalid")
+            }
+        }
+        offset = magic.size
+    }
+
+    /**
+     * Read a BIP-174 key/value map up to its `0x00` terminator. Keys are hex-encoded so they can be
+     * looked up by content. BIP-174 mandates unique keys within a map; duplicates are malformed and
+     * rejected (a silent overwrite would let an adversarial upstream swap, e.g., a WITNESS_UTXO
+     * amount under the parser's nose).
+     */
+    fun readMap(): Map<String, ByteArray> {
+        val map = LinkedHashMap<String, ByteArray>()
+        while (true) {
+            val keyLen = readCompactSize()
+            if (keyLen == 0L) return map // 0x00 terminator
+            val key = readBytes(keyLen.toInt())
+            val valLen = readCompactSize()
+            val value = readBytes(valLen.toInt())
+            val keyHex = Numeric.toHexStringNoPrefix(key)
+            if (map.containsKey(keyHex)) {
+                throw SwapKitPsbtException("SwapKit PSBT is malformed: duplicate key 0x$keyHex")
+            }
+            map[keyHex] = value
+        }
+    }
+
+    fun readCompactSize(): Long =
+        when (val head = readByte().toInt() and 0xFF) {
+            0xff -> readUInt64LE()
+            0xfe -> readUInt32LE()
+            0xfd -> readUInt16LE().toLong()
+            else -> head.toLong()
+        }
+
+    fun readByte(): Byte {
+        if (offset >= data.size) throw SwapKitPsbtException("SwapKit PSBT is truncated")
+        return data[offset++]
+    }
+
+    fun readBytes(count: Int): ByteArray {
+        if (count < 0 || offset + count > data.size) {
+            throw SwapKitPsbtException("SwapKit PSBT is truncated")
+        }
+        val slice = data.copyOfRange(offset, offset + count)
+        offset += count
+        return slice
+    }
+
+    // Little-endian readers assembled byte-by-byte (no alignment assumptions).
+    fun readUInt16LE(): Int {
+        val b0 = readByte().toInt() and 0xFF
+        val b1 = readByte().toInt() and 0xFF
+        return b0 or (b1 shl 8)
+    }
+
+    fun readUInt32LE(): Long {
+        val b0 = readByte().toLong() and 0xFF
+        val b1 = readByte().toLong() and 0xFF
+        val b2 = readByte().toLong() and 0xFF
+        val b3 = readByte().toLong() and 0xFF
+        return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)
+    }
+
+    fun readUInt64LE(): Long {
+        var result = 0L
+        for (i in 0 until 8) {
+            result = result or ((readByte().toLong() and 0xFF) shl (i * 8))
+        }
+        return result
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitPsbtParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitPsbtParser.kt
@@ -85,9 +85,9 @@ internal class PsbtCursor(private val data: ByteArray) {
         while (true) {
             val keyLen = readCompactSize()
             if (keyLen == 0L) return map // 0x00 terminator
-            val key = readBytes(keyLen.toInt())
+            val key = readBytes(asLength(keyLen))
             val valLen = readCompactSize()
-            val value = readBytes(valLen.toInt())
+            val value = readBytes(asLength(valLen))
             val keyHex = Numeric.toHexStringNoPrefix(key)
             if (map.containsKey(keyHex)) {
                 throw SwapKitPsbtException("SwapKit PSBT is malformed: duplicate key 0x$keyHex")
@@ -116,6 +116,20 @@ internal class PsbtCursor(private val data: ByteArray) {
         val slice = data.copyOfRange(offset, offset + count)
         offset += count
         return slice
+    }
+
+    /**
+     * Narrow a compactSize/length to an [Int] for [readBytes], with a clear error instead of the
+     * silent wrap-to-negative `toInt()` would produce on a value ≥ 2^31 (which would then surface
+     * as a misleading "truncated").
+     */
+    fun asLength(value: Long): Int {
+        if (value > Int.MAX_VALUE) {
+            throw SwapKitPsbtException(
+                "SwapKit PSBT field length $value exceeds the supported limit"
+            )
+        }
+        return value.toInt()
     }
 
     // Little-endian readers assembled byte-by-byte (no alignment assumptions).

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -60,4 +60,9 @@ data class SwapKitSwapPayloadJson(
         result = 31 * result + swapId.hashCode()
         return result
     }
+
+    companion object {
+        /** `meta.txType` discriminator for the Bitcoin PSBT signing path. */
+        const val TX_TYPE_PSBT = "PSBT"
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import wallet.core.jni.BitcoinScript
 import wallet.core.jni.CoinType
+import wallet.core.jni.Hash
 import wallet.core.jni.PublicKey
 import wallet.core.jni.PublicKeyType
 
@@ -130,6 +131,104 @@ class SwapKitBtcSignerTest {
             ),
             hashes,
         )
+    }
+
+    @Test
+    fun `compileSignedTransaction - P2WPKH segwit framing is pinned byte-for-byte`() {
+        // Headless: serialization + witness assembly are pure (computeOurSighashes is pure for
+        // P2WPKH), so we feed a fixed PSBT + a fixed pubkey + a fake DER keyed by the sighash and
+        // assert the exact broadcast bytes — version, marker/flag, reversed outpoint, empty
+        // scriptSig, witness stack [der||sighashFlag, pubkey], and locktime.
+        val signer = SwapKitBtcSigner("", "")
+        val outScript = "0014" + "33".repeat(20)
+        val psbt =
+            encodePsbt(
+                inputs =
+                    listOf(
+                        TestIn(
+                            prevTxIdDisplay =
+                                "0000000000000000000000000000000000000000000000000000000000000001",
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            scriptHex = "0014" + "11".repeat(20),
+                        )
+                    ),
+                outputs = listOf(TestOut(amount = 99_000, scriptHex = outScript)),
+            )
+        val signBitcoin = signer.decode(psbt, vaultAddress = null, vaultLockScriptHex = null)
+        val sighash = UtxoHelper(CoinType.BITCOIN, "", "").computeOurSighashes(signBitcoin)[0]
+        val derHex = "abcdef"
+        val pubKeyHex = "02" + "bb".repeat(32)
+
+        val result =
+            signer.compileSignedTransaction(
+                signBitcoin = signBitcoin,
+                pubKeyBytes = Numeric.hexStringToByteArray(pubKeyHex),
+                derSignatureBySighash = mapOf(Numeric.toHexStringNoPrefix(sighash) to derHex),
+            )
+
+        val expected =
+            "02000000" + // version
+                "0001" + // segwit marker + flag
+                "01" + // input count
+                ("01" + "00".repeat(31)) + // outpoint txid (display order reversed)
+                "00000000" + // vout
+                "00" + // empty scriptSig
+                "ffffffff" + // sequence
+                "01" + // output count
+                "b882010000000000" + // 99_000 sats, 8-byte LE
+                "16" + // output script length (22)
+                outScript +
+                "02" + // witness stack item count
+                "04" +
+                (derHex + "01") + // der || SIGHASH_ALL flag
+                "21" +
+                pubKeyHex + // 33-byte pubkey
+                "00000000" // locktime
+        assertEquals(expected, result.rawTransaction)
+        assertEquals(64, result.transactionHash.length)
+    }
+
+    @Test
+    fun `compileSignedTransaction - P2SH-P2WPKH pushes the redeem script into scriptSig`() {
+        try {
+            val redeemHex = "0014" + "22".repeat(20)
+            val redeemHash160 = Hash.sha256RIPEMD(Numeric.hexStringToByteArray(redeemHex))
+            val scriptPubKey = "a914" + Numeric.toHexStringNoPrefix(redeemHash160) + "87"
+            val signer = SwapKitBtcSigner("", "")
+            val psbt =
+                encodePsbt(
+                    inputs =
+                        listOf(
+                            TestIn(
+                                prevTxIdDisplay =
+                                    "0000000000000000000000000000000000000000000000000000000000000001",
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                scriptHex = scriptPubKey,
+                                redeemScriptHex = redeemHex,
+                            )
+                        ),
+                    outputs = listOf(TestOut(amount = 99_000, scriptHex = "0014" + "33".repeat(20))),
+                )
+            val signBitcoin = signer.decode(psbt, null, null)
+            val sighash = UtxoHelper(CoinType.BITCOIN, "", "").computeOurSighashes(signBitcoin)[0]
+
+            val result =
+                signer.compileSignedTransaction(
+                    signBitcoin = signBitcoin,
+                    pubKeyBytes = Numeric.hexStringToByteArray("02" + "bb".repeat(32)),
+                    derSignatureBySighash = mapOf(Numeric.toHexStringNoPrefix(sighash) to "abcdef"),
+                )
+
+            // scriptSig is a single push of the 22-byte redeem script (0x16 length prefix).
+            assertTrue(result.rawTransaction.contains("16$redeemHex"))
+            assertTrue(result.rawTransaction.startsWith("020000000001"))
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
@@ -1,0 +1,312 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.utils.Numeric
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.util.Base64
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import wallet.core.jni.BitcoinScript
+import wallet.core.jni.CoinType
+import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
+
+/**
+ * Tests for [SwapKitBtcSigner] + [SwapKitPsbtParser].
+ *
+ * Framing tests are pure JVM (no WalletCore). Decode / sighash / compile tests need the WalletCore
+ * JNI (address derivation, HASH160, secp256k1) and skip gracefully when it is unavailable — the
+ * same pattern [UtxoHelperTest] uses.
+ *
+ * The golden decode + sighash vector is the real `v3-real-btc-all-swap` SwapKit fixture, with the
+ * BIP-143 sighashes pinned to the values the iOS port asserts — so any byte-level drift in the PSBT
+ * decode or sighash transcoding (varint, amount endianness, scriptCode) surfaces here.
+ */
+class SwapKitBtcSignerTest {
+
+    // A valid compressed secp256k1 pubkey; with an empty chain code PublicKeyHelper returns it
+    // as-is (no BIP32 derivation), so it stands in for a vault key in decode/binding tests.
+    private val vaultPubKeyHex =
+        "025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357"
+    private val recipientPubKeyHex =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+    @Test
+    fun `parseFramingHeader - rejects empty payload`() {
+        val e =
+            assertThrows(SwapKitPsbtException::class.java) {
+                SwapKitPsbtParser.parseFramingHeader(ByteArray(0))
+            }
+        assertTrue(e.message!!.contains("empty"))
+    }
+
+    @Test
+    fun `parseFramingHeader - rejects bad magic`() {
+        // 'psb' + wrong 4th byte.
+        val bad = byteArrayOf(0x70, 0x73, 0x62, 0x00, 0xff.toByte(), 0x00)
+        assertThrows(SwapKitPsbtException::class.java) { SwapKitPsbtParser.parseFramingHeader(bad) }
+    }
+
+    @Test
+    fun `parseFramingHeader - rejects truncated value`() {
+        val buf = ByteArrayOutputStream()
+        buf.write(MAGIC)
+        buf.write(0x01) // keyLen
+        buf.write(0x00) // key 0x00
+        buf.write(0x05) // valLen = 5
+        buf.write(byteArrayOf(0x01, 0x02)) // only 2 bytes present
+        assertThrows(SwapKitPsbtException::class.java) {
+            SwapKitPsbtParser.parseFramingHeader(buf.toByteArray())
+        }
+    }
+
+    @Test
+    fun `parseFramingHeader - rejects duplicate key in a map`() {
+        val buf = ByteArrayOutputStream()
+        buf.write(MAGIC)
+        // two records with the same key 0x00
+        buf.write(byteArrayOf(0x01, 0x00, 0x01, 0xAA.toByte()))
+        buf.write(byteArrayOf(0x01, 0x00, 0x01, 0xBB.toByte()))
+        buf.write(0x00)
+        val e =
+            assertThrows(SwapKitPsbtException::class.java) {
+                SwapKitPsbtParser.parseFramingHeader(buf.toByteArray())
+            }
+        assertTrue(e.message!!.contains("duplicate"))
+    }
+
+    @Test
+    fun `parseFramingHeader - rejects PSBT missing the unsigned-tx global`() {
+        val buf = ByteArrayOutputStream()
+        buf.write(MAGIC)
+        buf.write(0x00) // empty global map (immediate terminator) -> no key 0x00
+        val e =
+            assertThrows(SwapKitPsbtException::class.java) {
+                SwapKitPsbtParser.parseFramingHeader(buf.toByteArray())
+            }
+        assertTrue(e.message!!.contains("PSBT_GLOBAL_UNSIGNED_TX"))
+    }
+
+    @Test
+    fun `decode + sighashes - golden v3-real-btc-all-swap vector`() {
+        // Pure path: decode(..., null, null) skips the vault-address (JNI) is_change marking, which
+        // the BIP-143 sighash math ignores anyway — so this authoritative vector runs headlessly.
+        val signer = SwapKitBtcSigner("", "")
+        val psbt = Base64.getDecoder().decode(GOLDEN_BTC_PSBT_B64)
+        val signBitcoin = signer.decode(psbt, vaultAddress = null, vaultLockScriptHex = null)
+
+        assertEquals(2, signBitcoin.version.toInt())
+        assertEquals(0, signBitcoin.locktime.toInt())
+
+        val inputs = signBitcoin.inputs.filterNotNull()
+        assertEquals(4, inputs.size)
+        inputs.forEach { input ->
+            assertTrue(input.isOurs, "every SwapKit BTC input is the user's")
+            assertEquals("p2wpkh", input.scriptType)
+            assertEquals(0xFFFFFFFFL, input.sequence!!.toLong())
+        }
+
+        val outputs = signBitcoin.outputs.filterNotNull()
+        assertEquals(1, outputs.size)
+        assertEquals(12_466L, outputs[0].amount)
+        assertEquals("00147baaaca44c91115ae35dce3410f7395522f1c1aa", outputs[0].scriptPubKey)
+
+        // computeOurSighashes is pure (no JNI) for P2WPKH; pin the BIP-143 sighashes against the
+        // values the iOS SwapKitBTCSigner port asserts for this same fixture.
+        val hashes =
+            UtxoHelper(CoinType.BITCOIN, "", "")
+                .computeOurSighashes(signBitcoin)
+                .map { Numeric.toHexStringNoPrefix(it) }
+                .sorted()
+        assertEquals(
+            listOf(
+                "3725e1553bb43700c74d97edd361ed8538416b106e7f968e43023ac3f2e1e404",
+                "447a8a57d19fafa308c3ed817c76e4455b581c77d1b7eef03d85440100ba6b78",
+                "73935a24a8dd1df3fb5b6018d7f6d5ad95b3774ea55cbda87f62b6b28ee0f8ba",
+                "9a32077b87e4a99bf6942350eb88db33145a28cddb736fb3d2b736c89d7f92c7",
+            ),
+            hashes,
+        )
+    }
+
+    @Test
+    fun `getPreSignedImageHash - happy path binds deposit to targetAddress and change to vault`() {
+        try {
+            val vaultAddress = addressFor(vaultPubKeyHex)
+            val recipient = addressFor(recipientPubKeyHex)
+            val signer = SwapKitBtcSigner(vaultPubKeyHex, "")
+            val psbt =
+                encodePsbt(
+                    inputs =
+                        listOf(
+                            TestIn(
+                                prevTxIdDisplay =
+                                    "0000000000000000000000000000000000000000000000000000000000000001",
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                scriptHex = scriptHexFor(vaultAddress),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            TestOut(amount = 60_000, scriptHex = scriptHexFor(recipient)),
+                            TestOut(amount = 39_500, scriptHex = scriptHexFor(vaultAddress)),
+                        ),
+                )
+
+            val hashes =
+                signer.getPreSignedImageHash(
+                    psbtBytes = psbt,
+                    targetAddress = recipient,
+                    fromAmount = BigInteger.valueOf(60_000L),
+                )
+            assertEquals(1, hashes.size)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `getPreSignedImageHash - rejects when deposit amount diverges from fromAmount`() {
+        try {
+            val vaultAddress = addressFor(vaultPubKeyHex)
+            val recipient = addressFor(recipientPubKeyHex)
+            val signer = SwapKitBtcSigner(vaultPubKeyHex, "")
+            val psbt =
+                encodePsbt(
+                    inputs =
+                        listOf(
+                            TestIn(
+                                prevTxIdDisplay =
+                                    "0000000000000000000000000000000000000000000000000000000000000001",
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                scriptHex = scriptHexFor(vaultAddress),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            TestOut(amount = 50_000, scriptHex = scriptHexFor(recipient)),
+                            TestOut(amount = 49_500, scriptHex = scriptHexFor(vaultAddress)),
+                        ),
+                )
+            // Quote says 60_000 but the PSBT deposits 50_000 — must refuse.
+            assertThrows(IllegalArgumentException::class.java) {
+                signer.getPreSignedImageHash(
+                    psbtBytes = psbt,
+                    targetAddress = recipient,
+                    fromAmount = BigInteger.valueOf(60_000L),
+                )
+            }
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private data class TestIn(
+        val prevTxIdDisplay: String,
+        val vout: Long,
+        val sequence: Long,
+        val amount: Long,
+        val scriptHex: String,
+    )
+
+    private data class TestOut(val amount: Long, val scriptHex: String)
+
+    /** Minimal BIP-174 PSBT encoder: magic + global unsigned-tx + per-input WITNESS_UTXO maps. */
+    private fun encodePsbt(inputs: List<TestIn>, outputs: List<TestOut>): ByteArray {
+        val unsigned = ByteArrayOutputStream()
+        unsigned.write(le32(2)) // version
+        unsigned.write(varInt(inputs.size.toLong()))
+        inputs.forEach { input ->
+            unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
+            unsigned.write(le32(input.vout))
+            unsigned.write(0x00) // empty scriptSig
+            unsigned.write(le32(input.sequence))
+        }
+        unsigned.write(varInt(outputs.size.toLong()))
+        outputs.forEach { output ->
+            unsigned.write(le64(output.amount))
+            val script = Numeric.hexStringToByteArray(output.scriptHex)
+            unsigned.write(varInt(script.size.toLong()))
+            unsigned.write(script)
+        }
+        unsigned.write(le32(0)) // locktime
+
+        val psbt = ByteArrayOutputStream()
+        psbt.write(MAGIC)
+        // global map: key 0x00 -> unsigned tx
+        val unsignedBytes = unsigned.toByteArray()
+        psbt.write(byteArrayOf(0x01, 0x00)) // keyLen=1, key=0x00
+        psbt.write(varInt(unsignedBytes.size.toLong()))
+        psbt.write(unsignedBytes)
+        psbt.write(0x00) // global map terminator
+        // per-input maps: WITNESS_UTXO (key 0x01) = amount(8 LE) + varint(scriptLen) + script
+        inputs.forEach { input ->
+            val witnessUtxo = ByteArrayOutputStream()
+            witnessUtxo.write(le64(input.amount))
+            val script = Numeric.hexStringToByteArray(input.scriptHex)
+            witnessUtxo.write(varInt(script.size.toLong()))
+            witnessUtxo.write(script)
+            val wu = witnessUtxo.toByteArray()
+            psbt.write(byteArrayOf(0x01, 0x01)) // keyLen=1, key=0x01
+            psbt.write(varInt(wu.size.toLong()))
+            psbt.write(wu)
+            psbt.write(0x00) // input map terminator
+        }
+        // per-output maps: empty
+        outputs.forEach { psbt.write(0x00) }
+        return psbt.toByteArray()
+    }
+
+    private fun le32(v: Long): ByteArray =
+        byteArrayOf(v.toByte(), (v ushr 8).toByte(), (v ushr 16).toByte(), (v ushr 24).toByte())
+
+    private fun le64(v: Long): ByteArray = ByteArray(8) { i -> (v ushr (i * 8)).toByte() }
+
+    private fun varInt(v: Long): ByteArray =
+        when {
+            v < 0xFDL -> byteArrayOf(v.toByte())
+            v <= 0xFFFFL -> byteArrayOf(0xFDu.toByte(), v.toByte(), (v ushr 8).toByte())
+            else -> byteArrayOf(0xFEu.toByte()) + le32(v)
+        }
+
+    private fun addressFor(pubKeyHex: String): String =
+        CoinType.BITCOIN.deriveAddressFromPublicKey(
+            PublicKey(Numeric.hexStringToByteArray(pubKeyHex), PublicKeyType.SECP256K1)
+        )
+
+    private fun scriptHexFor(address: String): String =
+        Numeric.toHexStringNoPrefix(
+            BitcoinScript.lockScriptForAddress(address, CoinType.BITCOIN).data()
+        )
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+
+    private companion object {
+        private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+
+        // Real SwapKit `/v3/swap` PSBT for a NEAR-routed BTC->USDC swap (v3-real-btc-all-swap
+        // fixture): 4 P2WPKH inputs, 1 output (12,466 sats to the deposit address).
+        private const val GOLDEN_BTC_PSBT_B64 =
+            "cHNidP8BAM0CAAAABOVo0TThbPQnZPebtyukLPWJ8zTi8piPdXsze7QTpHekAQAAAAD/////NUFhS3D0" +
+                "dVeh3+xkFHoyu6G5vdtD2A3CtoeCcReEMz8AAAAAAP////81QWFLcPR1V6Hf7GQUejK7obm920PYDcK2" +
+                "h4JxF4QzPwEAAAAA/////+xBpwbhlGXBc6uhU3v4W6GemcLpliKrby7YspyY1eriAAAAAAD/////AbIw" +
+                "AAAAAAAAFgAUe6qspEyREVrjXc40EPc5VSLxwaoAAAAAAAEBH6EhAAAAAAAAFgAU3LjAij6CzvLoWWvp" +
+                "sWQSP91VrhsAAQEfeQcAAAAAAAAWABTcuMCKPoLO8uhZa+mxZBI/3VWuGwABAR+HBQAAAAAAABYAFNy4" +
+                "wIo+gs7y6Flr6bFkEj/dVa4bAAEBH+gDAAAAAAAAFgAU3LjAij6CzvLoWWvpsWQSP91VrhsAAA=="
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
@@ -208,12 +208,40 @@ class SwapKitBtcSignerTest {
         }
     }
 
+    @Test
+    fun `decode - classifies a P2SH-P2WPKH input and keeps its redeem script`() {
+        val redeem = "0014" + "22".repeat(20)
+        val signer = SwapKitBtcSigner("", "")
+        val psbt =
+            encodePsbt(
+                inputs =
+                    listOf(
+                        TestIn(
+                            prevTxIdDisplay =
+                                "0000000000000000000000000000000000000000000000000000000000000001",
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            scriptHex = "a914" + "11".repeat(20) + "87", // P2SH
+                            redeemScriptHex = redeem,
+                        )
+                    ),
+                outputs = listOf(TestOut(amount = 99_000, scriptHex = "0014" + "33".repeat(20))),
+            )
+
+        val input = signer.decode(psbt, null, null).inputs.filterNotNull().single()
+        assertEquals("p2sh-p2wpkh", input.scriptType)
+        assertEquals(redeem, input.redeemScript)
+        assertEquals(100_000L, input.amount)
+    }
+
     private data class TestIn(
         val prevTxIdDisplay: String,
         val vout: Long,
         val sequence: Long,
         val amount: Long,
         val scriptHex: String,
+        val redeemScriptHex: String? = null,
     )
 
     private data class TestOut(val amount: Long, val scriptHex: String)
@@ -257,6 +285,13 @@ class SwapKitBtcSignerTest {
             psbt.write(byteArrayOf(0x01, 0x01)) // keyLen=1, key=0x01
             psbt.write(varInt(wu.size.toLong()))
             psbt.write(wu)
+            input.redeemScriptHex?.let { redeemHex ->
+                // PSBT_IN_REDEEM_SCRIPT (key 0x04) for P2SH-P2WPKH inputs.
+                val redeem = Numeric.hexStringToByteArray(redeemHex)
+                psbt.write(byteArrayOf(0x01, 0x04)) // keyLen=1, key=0x04
+                psbt.write(varInt(redeem.size.toLong()))
+                psbt.write(redeem)
+            }
             psbt.write(0x00) // input map terminator
         }
         // per-output maps: empty

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
@@ -226,7 +226,7 @@ class SwapKitBtcSignerTest {
         inputs.forEach { input ->
             unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
             unsigned.write(le32(input.vout))
-            unsigned.write(0x00) // empty scriptSig
+            unsigned.write(varInt(0)) // empty scriptSig
             unsigned.write(le32(input.sequence))
         }
         unsigned.write(varInt(outputs.size.toLong()))


### PR DESCRIPTION
## Summary

Wires the **signing** side for SwapKit Bitcoin swaps. The quote + PSBT payload decode already landed on `feature/swapkit-btc`; that produced a fully-formed `SwapQuote.SwapKit` carrying the base64-decoded PSBT, but the signing side was unwired (`SwapFormViewModel` threw "No SwapKit signer wired" and `SigningHelper` no-oped on `SwapPayload.SwapKit`). This makes a SwapKit BTC swap signable (TSS) and broadcastable.

Mirrors the iOS `SwapKitBTCSigner`: a dedicated signer dispatched by `txType == "PSBT"`, separate from the existing dApp PSBT co-sign path (which deliberately skips broadcast). The swap deposit must broadcast, so the swap path keeps `keysignPayload.signBitcoin == null` and decodes the PSBT on the fly in the dispatch.

## What's in it

- **`SwapKitPsbtParser`** — BIP-174 framing cursor (magic, key/value maps, compactSize, little-endian readers; rejects truncation, bad magic, duplicate keys, missing unsigned-tx global). Pure bytes, no crypto.
- **`SwapKitBtcSigner`** — decodes the PSBT into the structured `SignBitcoin` (P2WPKH / P2SH-P2WPKH, `witness_utxo`, every input `is_ours`; an output is marked change when its scriptPubKey matches the vault lock script), then:
  - reuses `UtxoHelper.getPreSignedImageHashFromSignBitcoin` for the BIP-143 sighashes **and** its existing defense-in-depth binding — pinning the deposit to SwapKit's `targetAddress`/`fromAmount` and the change to the vault;
  - assembles the signed segwit transaction from the MPC signatures (ported from the iOS compile path).
- **`SigningHelper`** — dispatches `SwapPayload.SwapKit` (`txType == "PSBT"`) on both the pre-sign and compile paths; any other `txType` fails loudly.
- **`SwapFormViewModel`** — builds the keysign payload for a SwapKit BTC quote (deposit → `targetAddress`, fees from the quote) instead of erroring.

## Reuse

No new crypto where the repo already had it: the BIP-143 sighashes and the vault/destination binding come from the existing `UtxoHelper` structured-PSBT path. New code is limited to the PSBT byte parser, the decode → `SignBitcoin` transcode, the segwit compile, and the dispatch/UI wiring.

## Safety / scope

- **Inert in production.** `SwapProviderTable` still does not offer SwapKit on Bitcoin, so this path is reached only by unit tests. Enabling it for real BTC is a deliberate follow-up.
- P2WPKH (+ P2SH-P2WPKH) inputs only, SIGHASH_ALL only; anything else throws a typed error.

## Test plan

- [x] `SwapKitPsbtParser` framing edge cases (empty, bad magic, truncation, duplicate key, missing unsigned-tx global) — pure, run headlessly.
- [x] **Golden vector**: decode the real `v3-real-btc-all-swap` PSBT and assert the BIP-143 sighashes match the values the iOS port pins for the same fixture (runs headlessly; the only correctness-critical check).
- [x] Binding happy-path + a rejection (deposit amount diverging from the quote) — run where the WalletCore JNI is available.
- [x] `:data:testDebugUnitTest` green; ktfmt clean.
- [ ] **Requires on-device E2E** on a real BTC swap (compile + broadcast) and maintainer review before the `SwapProviderTable` entry is enabled. Not exercisable in unit tests (the TSS lib is `compileOnly`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for SwapKit exchange protocol, enabling PSBT (Partially Signed Bitcoin Transaction) handling for improved swap capabilities on non-EVM blockchains.
  * Enhanced transaction signing flow to support SwapKit-routed transactions with proper validation and fee calculation.

* **Tests**
  * Added comprehensive test suite validating PSBT parsing, transaction signing, and edge-case error handling for SwapKit integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Enablement blockers (before flipping the `SwapProviderTable` Bitcoin entry)

Surfaced in review — must be resolved with on-device validation before SwapKit is offered on Bitcoin:
- [ ] Source the displayed network fee from the decoded PSBT (`inputs − outputs`), not `getSpecificAndUtxo`'s coin-selection estimate; wire `utxoFeeData`/submit-guard for `SwapQuote.SwapKit` so the form is confirmable.
- [ ] Add a fail-closed sanity bound on the implicit miner fee once a sane threshold is established from real-route data.
- [ ] Validate the deposit/change binding against real NEAR / Garden / Flashnet PSBTs (with a change output present); the strict `sum(non-change) == fromAmount` + exact-match change detection may need loosening if a provider funds the deposit as `sellAmount − fee`.
