### PR TITLE
fix(keysign): bound toToken logo size to prevent Rive OOM crash

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -51,6 +51,14 @@ import timber.log.Timber
 private const val RIVE_PROGRESS_PROPERTY = "progessPercentage" // typo in riv_keysign.riv
 private const val RIVE_TO_TOKEN_IMAGE_PROPERTY = "toToken"
 
+// The toToken logo only occupies a small slot in the animation, so cap the rasterized size.
+// Rive decodes the bytes we hand it via ImageDecoder.decodeToBitmap, which copies the image into
+// an IntArray (width * height ints) on the Java heap. A drawable with large/abnormal intrinsic
+// bounds would balloon that allocation past the heap limit and throw an OutOfMemoryError — which
+// Rive's native decode path does not catch (it only catches Exception), so it aborts the whole
+// process. Bounding the size keeps that allocation tiny and well within the heap.
+private const val RIVE_TO_TOKEN_IMAGE_MAX_PX = 256
+
 @Composable
 internal fun KeysignView(
     state: KeysignState,
@@ -203,10 +211,17 @@ private fun KeysignRiveProgress(progress: Float, @DrawableRes coinLogoRes: Int?)
     )
 }
 
-/** Rasterizes a (vector or raster) drawable resource to PNG bytes for Rive ImageAsset binding. */
+/**
+ * Rasterizes a (vector or raster) drawable resource to PNG bytes for Rive ImageAsset binding.
+ *
+ * The rasterized size is bounded by [RIVE_TO_TOKEN_IMAGE_MAX_PX] (aspect ratio preserved) so the
+ * image we hand to Rive can never produce an oversized decode allocation — see the constant for why
+ * an unbounded size crashes the process.
+ */
 private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): ByteArray? {
     val drawable = AppCompatResources.getDrawable(context, resId) ?: return null
-    val bitmap = drawable.toBitmap()
+    val (width, height) = boundedLogoSize(drawable.intrinsicWidth, drawable.intrinsicHeight)
+    val bitmap = drawable.toBitmap(width = width, height = height, config = Bitmap.Config.ARGB_8888)
     return try {
         ByteArrayOutputStream().use { stream ->
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
@@ -215,6 +230,25 @@ private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): Byte
     } finally {
         bitmap.recycle()
     }
+}
+
+/**
+ * Returns a (width, height) bounded by [RIVE_TO_TOKEN_IMAGE_MAX_PX], preserving aspect ratio. Falls
+ * back to a square of the max size when intrinsic bounds are missing (vector drawables can report
+ * -1) or already within the bound only the down-scale path applies.
+ */
+private fun boundedLogoSize(intrinsicWidth: Int, intrinsicHeight: Int): Pair<Int, Int> {
+    if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
+        return RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX
+    }
+    val largest = maxOf(intrinsicWidth, intrinsicHeight)
+    if (largest <= RIVE_TO_TOKEN_IMAGE_MAX_PX) {
+        return intrinsicWidth to intrinsicHeight
+    }
+    val scale = RIVE_TO_TOKEN_IMAGE_MAX_PX.toFloat() / largest
+    val width = (intrinsicWidth * scale).toInt().coerceAtLeast(1)
+    val height = (intrinsicHeight * scale).toInt().coerceAtLeast(1)
+    return width to height
 }
 
 @Preview

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.keysign
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.annotation.DrawableRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -57,7 +58,7 @@ private const val RIVE_TO_TOKEN_IMAGE_PROPERTY = "toToken"
 // bounds would balloon that allocation past the heap limit and throw an OutOfMemoryError — which
 // Rive's native decode path does not catch (it only catches Exception), so it aborts the whole
 // process. Bounding the size keeps that allocation tiny and well within the heap.
-private const val RIVE_TO_TOKEN_IMAGE_MAX_PX = 256
+internal const val RIVE_TO_TOKEN_IMAGE_MAX_PX = 256
 
 @Composable
 internal fun KeysignView(
@@ -245,7 +246,8 @@ private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): Byte
  * back to a square of the max size when intrinsic bounds are missing (vector drawables can report
  * -1) or already within the bound only the down-scale path applies.
  */
-private fun boundedLogoSize(intrinsicWidth: Int, intrinsicHeight: Int): Pair<Int, Int> {
+@VisibleForTesting
+internal fun boundedLogoSize(intrinsicWidth: Int, intrinsicHeight: Int): Pair<Int, Int> {
     if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
         return RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -221,14 +221,22 @@ private fun KeysignRiveProgress(progress: Float, @DrawableRes coinLogoRes: Int?)
 private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): ByteArray? {
     val drawable = AppCompatResources.getDrawable(context, resId) ?: return null
     val (width, height) = boundedLogoSize(drawable.intrinsicWidth, drawable.intrinsicHeight)
-    val bitmap = drawable.toBitmap(width = width, height = height, config = Bitmap.Config.ARGB_8888)
     return try {
-        ByteArrayOutputStream().use { stream ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-            stream.toByteArray()
+        val bitmap =
+            drawable.toBitmap(width = width, height = height, config = Bitmap.Config.ARGB_8888)
+        try {
+            ByteArrayOutputStream().use { stream ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                stream.toByteArray()
+            }
+        } finally {
+            bitmap.recycle()
         }
-    } finally {
-        bitmap.recycle()
+    } catch (e: Exception) {
+        // toBitmap()/compress()/toByteArray() can throw; the caller treats null as "no logo" and
+        // logs it. Never let this escape into the LaunchedEffect coroutine and crash the screen.
+        Timber.e(e, "Failed to encode coin logo res %d as PNG", resId)
+        null
     }
 }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
@@ -1,0 +1,54 @@
+package com.vultisig.wallet.ui.screens.keysign
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for [boundedLogoSize], the guard that prevents the keysign Rive animation from
+ * being handed an oversized "toToken" logo. Rive decodes the image into an `IntArray(width *
+ * height)` on the Java heap, so an unbounded logo could throw an uncatchable `OutOfMemoryError` and
+ * abort the process. These tests pin the invariant that no dimension ever exceeds
+ * [RIVE_TO_TOKEN_IMAGE_MAX_PX].
+ */
+class KeysignLogoSizeTest {
+
+    @Test
+    fun `oversized square logo is clamped to the max dimension`() {
+        // The dimensions that crashed the process in the wild (~462MB IntArray).
+        boundedLogoSize(10752, 10752) shouldBe
+            (RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX)
+    }
+
+    @Test
+    fun `oversized logo is clamped while preserving aspect ratio`() {
+        // 1024x512 -> scale 256/1024 = 0.25 -> 256x128
+        boundedLogoSize(1024, 512) shouldBe (256 to 128)
+    }
+
+    @Test
+    fun `logo within the bound is passed through unchanged`() {
+        boundedLogoSize(96, 96) shouldBe (96 to 96)
+        boundedLogoSize(100, 40) shouldBe (100 to 40)
+    }
+
+    @Test
+    fun `logo exactly at the bound is unchanged`() {
+        boundedLogoSize(RIVE_TO_TOKEN_IMAGE_MAX_PX, RIVE_TO_TOKEN_IMAGE_MAX_PX) shouldBe
+            (RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX)
+    }
+
+    @Test
+    fun `missing intrinsic bounds fall back to a max-size square`() {
+        // Vector drawables can report -1 for intrinsic width and height.
+        boundedLogoSize(-1, -1) shouldBe (RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX)
+        boundedLogoSize(0, 0) shouldBe (RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX)
+        boundedLogoSize(256, 0) shouldBe (RIVE_TO_TOKEN_IMAGE_MAX_PX to RIVE_TO_TOKEN_IMAGE_MAX_PX)
+    }
+
+    @Test
+    fun `extreme aspect ratio never collapses a dimension to zero`() {
+        val (width, height) = boundedLogoSize(100_000, 1)
+        width shouldBe RIVE_TO_TOKEN_IMAGE_MAX_PX
+        height shouldBe 1 // coerced up from 0
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
@@ -26,6 +26,12 @@ class KeysignLogoSizeTest {
     }
 
     @Test
+    fun `oversized logo is clamped while preserving aspect ratio when height exceeds width`() {
+        // 512x1024 -> scale 256/1024 = 0.25 -> 128x256
+        boundedLogoSize(512, 1024) shouldBe (128 to 256)
+    }
+
+    @Test
     fun `logo within the bound is passed through unchanged`() {
         boundedLogoSize(96, 96) shouldBe (96 to 96)
         boundedLogoSize(100, 40) shouldBe (100 to 40)


### PR DESCRIPTION
## Problem

The app crashes hard (SIGABRT, whole process killed) during keysign — reproducible while signing a swap. The native abort is on the **Rive CmdServer** thread:

```
java.lang.OutOfMemoryError: Failed to allocate a 462422040 byte allocation ... growth limit 201326592
    app.rive.runtime.kotlin.core.ImageDecoder.decodeToBitmap(ImageDecoder.kt:25)
...
JNI DETECTED ERROR IN APPLICATION: JNI NewStringUTF called with pending exception java.lang.OutOfMemoryError
runtime.cc: Runtime aborting...
Fatal signal 6 (SIGABRT) in tid (Rive CmdServer)
```

## Root cause

Introduced by #4677 (toToken image binding). `KeysignRiveProgress` rasterizes the signing coin's logo via `encodeDrawableAsPng` and hands the PNG to Rive (`ImageAsset.fromBytes` → `setImage("toToken", …)`).

`encodeDrawableAsPng` called `drawable.toBitmap()` with **no size bound**, so the bitmap took the drawable's intrinsic dimensions. Rive then decodes those bytes through `ImageDecoder.decodeToBitmap`, which does:

```kotlin
val pixels = IntArray(offset + width * height)   // ImageDecoder.kt:24 — Java heap
```

`462422040 / 4 ≈ 115.6M ints ≈ 10752×10752`. The decoded bitmap itself lives in **native** memory (so the decode succeeds), but this `IntArray` of `width*height` ints is allocated on the **Java heap** (192 MB growth limit) → `OutOfMemoryError`.

The kicker: Rive's decode wraps the body in `catch (e: Exception)`, but `OutOfMemoryError` is an `Error`, **not** an `Exception` — so it escapes. It becomes a pending JNI exception, Rive's native logging path then calls `NewStringUTF` with that exception pending, and ART's CheckJNI aborts the whole process. We can't fix the `.aar`, so we must never hand Rive an oversized image.

## Fix

Bound the rasterized logo to **256 px** (aspect ratio preserved) in `encodeDrawableAsPng` before encoding. The toToken slot in the animation is small, so 256 px is plenty, and the `IntArray` Rive allocates is now ~256 KB regardless of the drawable's intrinsic bounds. Also:
- handle missing intrinsic bounds (vector drawables can report `-1`),
- pin the config to `ARGB_8888`.

## Test plan
- [x] `:app:compileDebugKotlin` passes; ktfmt clean
- [x] Ran keysign on the emulator — signing animation renders the coin logo and no longer crashes (verified on-device)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum token logo size and preserved aspect ratio on the keysign screen to avoid oversized images.

* **Performance**
  * Improved image rasterization and encoding to reduce peak memory usage and stabilize rendering.

* **Stability**
  * Added safe error handling for image processing to prevent crashes and return a safe fallback.

* **Tests**
  * Added regression tests for logo sizing, clamping, aspect-ratio handling, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->