### PR TITLE
ci: parallelize Android CI and trim build to debug-only

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,17 +18,82 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
-      - name: set up JDK 21
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: gradle
-      
-      - name: git submodule update
-        run: git submodule update --init --recursive
-      
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Only assemble the debug variant and run debug unit tests.
+      # Avoids the release R8/minify pass and the duplicate release unit-test
+      # run that `./gradlew build` would otherwise perform.
+      - name: Build debug + run unit tests
+        env:
+          TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
+          TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
+        run: ./gradlew assembleDebug testDebugUnitTest --parallel --build-cache
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run lint
+        env:
+          TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
+          TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
+        run: ./gradlew lintDebug --parallel --build-cache
+
+      - name: Archive code analysis reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Lint-Reports
+          path: |
+            app/build/reports/lint-results-debug.html
+            app/build/intermediates/lint_intermediate_text_report/debug/lintReportDebug/lint-results-debug.txt
+
+  instrumented-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -36,17 +101,10 @@ jobs:
       - name: Free disk space
         run: |
           echo "Freeing disk space..."
-          sudo rm -rf /usr/share/dotnet || true                    
-          sudo rm -rf /usr/local/lib/nodejs || true  
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/nodejs || true
           sudo apt-get clean
           df -h
-
-      # Build and run unit tests
-      - name: Build and run unit tests
-        env:
-          TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
-          TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
-        run: ./gradlew build --parallel --build-cache --no-daemon
 
       # Enable KVM for better emulator performance
       - name: Enable KVM
@@ -88,13 +146,3 @@ jobs:
           script: |
             # Run ALL instrumented tests
             ./gradlew app:connectedDebugAndroidTest --stacktrace
-
-      # Archive lint reports
-      - name: Archive code analysis reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Lint-Reports
-          path: |
-            app/build/reports/lint-results-debug.html
-            app/build/intermediates/lint_intermediate_text_report/debug/lintReportDebug/lint-results-debug.txt

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -66,7 +66,10 @@ jobs:
         env:
           TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
           TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
-        run: ./gradlew lintDebug --parallel --build-cache
+        # Cap the daemon heap so the lintAnalyzeDebug worker JVM (which inherits
+        # these args) plus the daemon both fit in the runner's memory. The 4 GB
+        # default doubles up across daemon + worker and OOMs.
+        run: ./gradlew lintDebug --build-cache -Dorg.gradle.jvmargs="-Xmx2g -Dfile.encoding=UTF-8"
 
       - name: Archive code analysis reports
         if: always()

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          # These jobs only read the repo (build/lint/test); they never push.
+          # Don't persist the auth token in git config to reduce attack surface.
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -49,6 +52,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          # These jobs only read the repo (build/lint/test); they never push.
+          # Don't persist the auth token in git config to reduce attack surface.
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -87,6 +93,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          # These jobs only read the repo (build/lint/test); they never push.
+          # Don't persist the auth token in git config to reduce attack surface.
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -147,5 +156,5 @@ jobs:
           disable-animations: true
           disable-spellchecker: true
           script: |
-            # Run ALL instrumented tests
+            # Run debug instrumented tests (connectedDebugAndroidTest)
             ./gradlew app:connectedDebugAndroidTest --stacktrace


### PR DESCRIPTION
## Summary

Reduces the ~20 min Android CI wall-clock time by parallelizing jobs and cutting wasted work.

- **Split one sequential job into three parallel jobs** — `build-and-test`, `lint`, `instrumented-tests`. Wall-clock is now `max()` of the three instead of their sum.
- **Replace `./gradlew build` with `assembleDebug testDebugUnitTest`** — skips the release R8/minify pass and the duplicate release unit-test run that this workflow never used. Lint moved to its own `lintDebug` job.
- **Switch caching to `gradle/actions/setup-gradle@v4`** — proper Gradle build-cache restore (read-only on PRs, writes from `main`), replacing the weaker `cache: gradle` on setup-java.
- Folded submodule checkout into `actions/checkout` (`submodules: recursive`).

No change to `gradle.properties` (parallel/caching/daemon already enabled) and the project already uses KSP, so no annotation-processor lever was available.

## Trade-off

The release variant is no longer assembled by this workflow (it was only built and discarded). If release verification is wanted as a safety net, a non-blocking `assembleRelease` job can be added.

## Test plan

- [ ] CI runs green on this PR (build-and-test, lint, instrumented-tests jobs all pass)
- [ ] Confirm wall-clock time is reduced vs. the previous single-job run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Android CI: faster, more focused build, lint, and instrumented-test runs; improved handling of repository submodules; reduced unnecessary steps and tuned test/lint execution and artifact uploads to speed checks without affecting app functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->