### PR TITLE
feat(swap): SwapKit TRON signing support

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,11 +475,14 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // Only BTC PSBT is wired today; other SwapKit txTypes (TON / ADA /
-                                // SUI / TRON) land with their per-chain signers. SwapProviderTable
-                                // does not yet offer SwapKit on Bitcoin, so this branch is reached
-                                // only once enablement ships — guarded loudly until then.
-                                require(quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
+                                // BTC PSBT and TRON (TronWeb object) are wired; the remaining
+                                // SwapKit txTypes (TON / ADA / SUI) land with their per-chain
+                                // signers. Guarded loudly so an un-wired txType can't reach
+                                // signing.
+                                require(
+                                    quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON
+                                ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }
                                 val specificAndUtxo =
@@ -494,9 +497,9 @@ constructor(
                                     srcToken = srcToken,
                                     srcTokenValue = srcTokenValue,
                                     dstToken = dstToken,
-                                    // SwapKit's source-chain deposit address — where the BTC the
-                                    // PSBT spends is sent. Signing is driven entirely by the PSBT
-                                    // bytes carried on the payload, not by this blockChainSpecific.
+                                    // SwapKit's source-chain deposit address. Signing is driven
+                                    // entirely by the payload bytes (PSBT / TronWeb object), not by
+                                    // this blockChainSpecific.
                                     dstAddress = quote.data.targetAddress,
                                     expectedDstTokenValue = dstTokenValue,
                                     blockChainSpecific = specificAndUtxo,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -105,16 +105,23 @@ object SigningHelper {
                     messages += message
                 }
                 is SwapPayload.SwapKit -> {
-                    require(swapPayload.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
-                        "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
-                    }
                     messages +=
-                        SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
-                            .getPreSignedImageHash(
-                                psbtBytes = swapPayload.data.txPayload,
-                                targetAddress = swapPayload.data.targetAddress,
-                                fromAmount = swapPayload.data.fromAmount,
-                            )
+                        when (swapPayload.data.txType) {
+                            SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
+                                SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                                    .getPreSignedImageHash(
+                                        psbtBytes = swapPayload.data.txPayload,
+                                        targetAddress = swapPayload.data.targetAddress,
+                                        fromAmount = swapPayload.data.fromAmount,
+                                    )
+                            SwapKitSwapPayloadJson.TX_TYPE_TRON ->
+                                SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
+                                    .getPreSignedImageHash(swapPayload.data.txPayload)
+                            else ->
+                                error(
+                                    "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
+                                )
+                        }
                 }
                 else -> Unit
             }
@@ -297,11 +304,18 @@ object SigningHelper {
                 }
 
                 is SwapPayload.SwapKit -> {
-                    require(swapPayload.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT) {
-                        "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
+                    return when (swapPayload.data.txType) {
+                        SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
+                            SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        SwapKitSwapPayloadJson.TX_TYPE_TRON ->
+                            SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
+                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        else ->
+                            error(
+                                "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
+                            )
                     }
-                    return SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
-                        .getSignedTransaction(swapPayload.data.txPayload, signatures)
                 }
                 else -> {}
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSigner.kt
@@ -1,0 +1,184 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
+import com.vultisig.wallet.data.utils.Numeric
+import java.security.MessageDigest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import timber.log.Timber
+import tss.KeysignResponse
+import wallet.core.jni.CoinType
+import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
+
+internal class SwapKitTronSignerException(message: String) : Exception(message)
+
+/**
+ * Bridges SwapKit's pre-built TRON transaction onto Android's signing path. Ported from iOS'
+ * `SwapKitTronSigner`. SwapKit's `/v3/swap` returns a TronWeb-shaped object (`{txID, raw_data
+ * {...}, raw_data_hex, visible?}`) which the quote source JSON-encodes verbatim into
+ * [SwapKitSwapPayloadJson.txPayload].
+ *
+ * The canonical Tron signing input is `sha256(raw_data_bytes)` — which is also the `txID` — so we
+ * hash SwapKit's `raw_data_hex` directly (option B in iOS' consolidated-signing plan) rather than
+ * round-tripping `raw_data` back through a `Tron.SigningInput` proto. Trusting the pre-built
+ * `raw_data_hex` keeps the surface area small (no need to reimplement every `contract.type` SwapKit
+ * might emit — `TriggerSmartContract`, `TransferContract`, …) and gives the cosigning peer
+ * identical bytes to verify against. The signed broadcast envelope is the original object with the
+ * 65-byte `r||s||v` signature appended as `signature: [hex]`, which is exactly what
+ * [com.vultisig.wallet.data.api.TronApi.broadcastTransaction] posts to
+ * `/wallet/broadcasttransaction`.
+ *
+ * Trade-off: SwapKit bakes its own `fee_limit` (typically 10 TRX for TRC-20 routes) into
+ * `raw_data_hex` and we don't second-guess it; a tight limit is logged so an OUT_OF_ENERGY revert
+ * is traceable in support logs, but it doesn't fail the sign.
+ */
+internal class SwapKitTronSigner(
+    private val vaultHexPublicKey: String,
+    private val vaultHexChainCode: String,
+) {
+    private val coinType = CoinType.TRON
+
+    /**
+     * Tron signing digest = `sha256(raw_data_bytes)`, hex-encoded to match the keysign message-hash
+     * convention. Single hash per transaction.
+     */
+    fun getPreSignedImageHash(txPayload: ByteArray): List<String> =
+        listOf(Numeric.toHexStringNoPrefix(digest(txPayload)))
+
+    /**
+     * Assemble the broadcast-format TronWeb envelope from SwapKit's pre-built object plus the MPC
+     * ECDSA signature. Verifies the signature against the derived vault key before re-encoding so a
+     * wrong-key cosignature can't be broadcast.
+     */
+    fun getSignedTransaction(
+        txPayload: ByteArray,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val digest = digest(txPayload)
+        val key = Numeric.toHexStringNoPrefix(digest)
+        val signature =
+            signatures[key]?.getSignatureWithRecoveryID()
+                ?: throw SwapKitTronSignerException(
+                    "Missing signature for Tron digest ${key.take(16)}…"
+                )
+        // Tron broadcast expects a 65-byte r||s||v signature; getSignatureWithRecoveryID yields
+        // exactly that.
+        if (signature.size != 65) {
+            throw SwapKitTronSignerException(
+                "Tron signature must be 65 bytes (r||s||v); got ${signature.size}"
+            )
+        }
+        val publicKey = derivedPublicKey()
+        if (!publicKey.verify(signature, digest)) {
+            throw SwapKitTronSignerException("SwapKit TRON signature verification failed")
+        }
+
+        logTightFeeLimit(txPayload)
+
+        return SignedTransactionResult(
+            rawTransaction =
+                makeBroadcastEnvelope(txPayload, Numeric.toHexStringNoPrefix(signature)),
+            transactionHash = key,
+        )
+    }
+
+    /**
+     * Tron signing digest = `sha256(raw_data_bytes)`. Exposed (internal) so a unit test can pin the
+     * digest to SwapKit's reported `txID` (Tron's txID is exactly this digest) without the
+     * WalletCore JNI.
+     */
+    internal fun digest(txPayload: ByteArray): ByteArray {
+        val rawDataHex = parseRawDataHex(txPayload)
+        val rawDataBytes =
+            runCatching { Numeric.hexStringToByteArray(rawDataHex) }
+                .getOrElse {
+                    throw SwapKitTronSignerException("SwapKit TRON raw_data_hex is not valid hex")
+                }
+        if (rawDataBytes.isEmpty()) {
+            throw SwapKitTronSignerException("SwapKit TRON raw_data_hex is empty")
+        }
+        return sha256(rawDataBytes)
+    }
+
+    /**
+     * Re-encode the original TronWeb object with `signature: [hex]` appended. Preserves the
+     * existing fields verbatim so the cosigning peer broadcasts the same canonical object — only
+     * the signature is added.
+     */
+    internal fun makeBroadcastEnvelope(txPayload: ByteArray, signatureHex: String): String {
+        val obj = parsePayloadObject(txPayload)
+        val merged =
+            JsonObject(obj + ("signature" to JsonArray(listOf(JsonPrimitive(signatureHex)))))
+        return json.encodeToString(JsonObject.serializer(), merged)
+    }
+
+    private fun parsePayloadObject(txPayload: ByteArray): JsonObject {
+        if (txPayload.isEmpty()) {
+            throw SwapKitTronSignerException("SwapKit TRON payload is empty")
+        }
+        val element =
+            runCatching { json.parseToJsonElement(txPayload.decodeToString()) }
+                .getOrElse {
+                    throw SwapKitTronSignerException("SwapKit TRON payload is not valid JSON")
+                }
+        return element as? JsonObject
+            ?: throw SwapKitTronSignerException("SwapKit TRON payload is not a JSON object")
+    }
+
+    private fun parseRawDataHex(txPayload: ByteArray): String =
+        parsePayloadObject(txPayload)["raw_data_hex"]
+            ?.jsonPrimitive
+            ?.takeIf { it.isString }
+            ?.content
+            ?: throw SwapKitTronSignerException("SwapKit TRON payload is missing raw_data_hex")
+
+    /**
+     * Surface a suspiciously low `raw_data.fee_limit` (< 20 TRX) so post-mortem logs catch an
+     * OUT_OF_ENERGY revert. Best-effort only: a parse miss is silently ignored — the fee_limit is
+     * SwapKit's to pick and never blocks the sign. Mirrors iOS' warning.
+     */
+    private fun logTightFeeLimit(txPayload: ByteArray) {
+        val feeLimit =
+            runCatching {
+                    parsePayloadObject(txPayload)["raw_data"]
+                        ?.let { it as? JsonObject }
+                        ?.get("fee_limit")
+                        ?.jsonPrimitive
+                        ?.content
+                        ?.toLongOrNull()
+                }
+                .getOrNull() ?: return
+        if (feeLimit in 1 until TIGHT_FEE_LIMIT_SUN) {
+            Timber.w("SwapKit TRON fee_limit looks tight: %d sun", feeLimit)
+        }
+    }
+
+    private fun derivedPublicKey(): PublicKey {
+        val derivedHex =
+            PublicKeyHelper.getDerivedPublicKey(
+                vaultHexPublicKey,
+                vaultHexChainCode,
+                coinType.derivationPath(),
+            )
+        return PublicKey(Numeric.hexStringToByteArray(derivedHex), PublicKeyType.SECP256K1)
+            .uncompressed()
+    }
+
+    private fun sha256(data: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest(data)
+
+    private companion object {
+        /**
+         * 20 TRX in sun — SwapKit TRC-20 routes typically set 10 TRX, so below this is worth a log.
+         */
+        private const val TIGHT_FEE_LIMIT_SUN = 20_000_000L
+        private val json = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -64,5 +64,12 @@ data class SwapKitSwapPayloadJson(
     companion object {
         /** `meta.txType` discriminator for the Bitcoin PSBT signing path. */
         const val TX_TYPE_PSBT = "PSBT"
+
+        /**
+         * `meta.txType` discriminator for the TRON signing path. SwapKit returns a TronWeb-shaped
+         * object (`txID` / `raw_data` / `raw_data_hex`) JSON-encoded into [txPayload]; the signer
+         * hashes `raw_data_hex` and re-assembles the broadcast envelope. Mirrors iOS' `"TRON"`.
+         */
+        const val TX_TYPE_TRON = "TRON"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -441,9 +441,15 @@ constructor(
                 val obj =
                     response.tx as? JsonObject
                         ?: throw SwapKitError.Decoding("SwapKit TRON tx is not a JSON object")
-                if ("raw_data_hex" !in obj) {
-                    throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
-                }
+                // Validate raw_data_hex is a non-blank string here (not just present) so a null /
+                // non-string / empty value is rejected in the decoding path — letting quote
+                // selection fall back to another provider — instead of surfacing only at keysign in
+                // SwapKitTronSigner.
+                (obj["raw_data_hex"] as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.content
+                    ?.takeIf { it.isNotBlank() }
+                    ?: throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
                 json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
             }
             else -> decodeBinaryTx(response.tx)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -53,11 +53,13 @@ import timber.log.Timber
  *    reads zero. EVM routes that omit `tx.gas` are refused (`SwapKitError.Decoding`) rather than
  *    backstopped with the L1-sized default, which would over-estimate L2 fees by multiples.
  *
- * Non-EVM/non-Solana `txType`s (PSBT, TRON, TON, SUI, CARDANO, RIPPLE, …) are out of scope for
- * Phase 1 — they require per-chain signers and the dedicated `SwapKitSwapPayload` proto, which land
- * in subsequent task batches. Such responses surface as [SwapKitError.UnsupportedTxType] so the
- * picker falls back to another provider rather than signing garbage. `SOLANA` and the legacy
- * `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once before.
+ * Non-EVM/non-Solana `txType`s surface as a fully-formed [SwapQuote.SwapKit] for a per-chain signer
+ * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]) and
+ * TRON (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]) are wired
+ * today. The remaining types (TON, SUI, CARDANO, RIPPLE, …) still surface as
+ * [SwapKitError.UnsupportedTxType] so the picker falls back to another provider rather than signing
+ * garbage, until their signers land. `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are
+ * aliased; SwapKit flipped them once before.
  */
 internal class SwapKitQuoteSource
 @Inject
@@ -172,7 +174,8 @@ constructor(
                         ),
                     subProvider = subProvider,
                 )
-            TxKind.PSBT ->
+            TxKind.PSBT,
+            TxKind.TRON ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -258,6 +261,7 @@ constructor(
         when (chain) {
             Chain.Solana -> 9
             Chain.Bitcoin -> 8
+            Chain.Tron -> 6
             else -> 18
         }
 
@@ -365,9 +369,10 @@ constructor(
                         ),
                 )
             }
-            // PSBT is dispatched to buildSwapKitNativeQuote before reaching here; the arm keeps the
-            // `when` exhaustive and refuses anything that slips through.
+            // PSBT/TRON are dispatched to buildSwapKitNativeQuote before reaching here; the arm
+            // keeps the `when` exhaustive and refuses anything that slips through.
             TxKind.PSBT,
+            TxKind.TRON,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
@@ -401,7 +406,7 @@ constructor(
                 fromAmount = request.tokenValue.value,
                 toAmountDecimal = toAmountDecimal,
                 txType = response.meta.txType,
-                txPayload = decodeBinaryTx(response.tx),
+                txPayload = encodeNativeTxPayload(response),
                 targetAddress = targetAddress,
                 memo = null,
                 subProvider = subProvider.orEmpty(),
@@ -421,6 +426,28 @@ constructor(
             subProvider = subProvider,
         )
     }
+
+    /**
+     * Encode `tx` into the raw [SwapKitSwapPayloadJson.txPayload] bytes the per-chain signer
+     * consumes. The wire shape depends on `meta.txType`:
+     * - PSBT → a top-level base64 string ([decodeBinaryTx]).
+     * - TRON → a TronWeb-shaped JSON object (`{txID, raw_data, raw_data_hex, …}`). We UTF-8 encode
+     *   the object verbatim so the cosigning peer reconstructs it and [SwapKitTronSigner] can pull
+     *   `raw_data_hex`. Matches iOS' `buildSwapKitTronPayload`.
+     */
+    private fun encodeNativeTxPayload(response: SwapKitSwapResponseJson): ByteArray =
+        when (txTypeOf(response)) {
+            TxKind.TRON -> {
+                val obj =
+                    response.tx as? JsonObject
+                        ?: throw SwapKitError.Decoding("SwapKit TRON tx is not a JSON object")
+                if ("raw_data_hex" !in obj) {
+                    throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
+                }
+                json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
+            }
+            else -> decodeBinaryTx(response.tx)
+        }
 
     /**
      * Decode a base64 unsigned-tx blob (PSBT today; PTB / CBOR as more chains land) from `tx` into
@@ -455,6 +482,7 @@ constructor(
             "solana",
             "serialized_base64" -> TxKind.SOLANA
             "psbt" -> TxKind.PSBT
+            "tron" -> TxKind.TRON
             else -> TxKind.UNSUPPORTED
         }
 
@@ -488,6 +516,7 @@ constructor(
         EVM,
         SOLANA,
         PSBT,
+        TRON,
         UNSUPPORTED,
     }
 
@@ -547,6 +576,7 @@ constructor(
             Chain.Polygon -> "POL"
             Chain.Solana -> "SOL"
             Chain.Bitcoin -> "BTC"
+            Chain.Tron -> "TRON"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -124,8 +124,11 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                     )
                 else setOf(SwapProvider.JUPITER, SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
-            Chain.Ripple,
-            Chain.Tron -> setOf(SwapProvider.THORCHAIN)
+            Chain.Ripple -> setOf(SwapProvider.THORCHAIN)
+
+            // SwapKit TRON routes are signed by SwapKitTronSigner (TronWeb object → sha256 of
+            // raw_data_hex). Mirrors iOS' `.tron → [.thorchain, .swapkit]`.
+            Chain.Tron -> setOf(SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
 
             Chain.Hyperliquid -> setOf(SwapProvider.LIFI)
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSignerTest.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.utils.Numeric
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [SwapKitTronSigner]'s pure (no-JNI) surface: the signing digest, the single-entry
+ * pre-signed hash, and the broadcast-envelope assembly.
+ *
+ * The golden vector is the real `v3-tron-final-swap-fresh` SwapKit fixture (a TRC-20 USDT→USDC
+ * route via NEAR). Tron's `txID` IS `sha256(raw_data_bytes)`, and SwapKit reports both — so pinning
+ * the digest to the fixture's `txID` catches any drift in how `raw_data_hex` is decoded and hashed.
+ * Signature verification needs the WalletCore JNI (secp256k1) and is covered by the iOS port +
+ * integration; these tests stay headless like the framing half of [SwapKitBtcSignerTest].
+ */
+class SwapKitTronSignerTest {
+
+    private val signer = SwapKitTronSigner(vaultHexPublicKey = "", vaultHexChainCode = "")
+
+    private fun payloadBytes(rawDataHex: String, txId: String = TX_ID): ByteArray =
+        """{"visible":true,"txID":"$txId","raw_data_hex":"$rawDataHex"}""".encodeToByteArray()
+
+    @Test
+    fun `digest equals sha256 of raw_data_hex and matches txID`() {
+        val digestHex = Numeric.toHexStringNoPrefix(signer.digest(payloadBytes(RAW_DATA_HEX)))
+        assertEquals(
+            TX_ID,
+            digestHex,
+            "Tron signing digest must equal sha256(raw_data_bytes) == txID",
+        )
+    }
+
+    @Test
+    fun `pre-signed image hash is a single entry equal to the digest`() {
+        val hashes = signer.getPreSignedImageHash(payloadBytes(RAW_DATA_HEX))
+        assertEquals(1, hashes.size)
+        assertEquals(TX_ID, hashes[0])
+    }
+
+    @Test
+    fun `malformed JSON payload is rejected`() {
+        assertThrows(SwapKitTronSignerException::class.java) {
+            signer.digest("not json".encodeToByteArray())
+        }
+    }
+
+    @Test
+    fun `missing raw_data_hex is rejected`() {
+        assertThrows(SwapKitTronSignerException::class.java) {
+            signer.digest("""{"txID":"$TX_ID","visible":true}""".encodeToByteArray())
+        }
+    }
+
+    @Test
+    fun `empty payload is rejected`() {
+        assertThrows(SwapKitTronSignerException::class.java) { signer.digest(ByteArray(0)) }
+    }
+
+    @Test
+    fun `broadcast envelope appends the signature and preserves the original fields`() {
+        val signatureHex = "aa".repeat(65)
+        val envelope = signer.makeBroadcastEnvelope(payloadBytes(RAW_DATA_HEX), signatureHex)
+        val obj = Json.parseToJsonElement(envelope) as JsonObject
+
+        // signature appended as a single-element hex array (TronWeb broadcast shape).
+        val sig = obj["signature"]!!.jsonArray
+        assertEquals(1, sig.size)
+        assertEquals(signatureHex, sig[0].jsonPrimitive.content)
+        // Original canonical fields survive verbatim so the cosigning peer broadcasts the same tx.
+        assertEquals(TX_ID, obj["txID"]!!.jsonPrimitive.content)
+        assertEquals(RAW_DATA_HEX, obj["raw_data_hex"]!!.jsonPrimitive.content)
+        assertTrue(obj["visible"]!!.jsonPrimitive.content.toBoolean())
+    }
+
+    private companion object {
+        // Real SwapKit `v3-tron-final-swap-fresh` fixture: TRC-20 USDT transfer via
+        // TriggerSmartContract.
+        private const val RAW_DATA_HEX =
+            "0a028975220898cc46b34632500840b8e093aee4335aae01081f12a9010a31747970652e676f6f676c65" +
+                "617069732e636f6d2f70726f746f636f6c2e54726967676572536d617274436f6e747261637412740a" +
+                "154170082243784dcdf3042034e7b044d6d342a91360121541a614f803b6fd780986a42c78ec9c7f77e" +
+                "6ded13c2244a9059cbb000000000000000000000000cd606df761d75d06a716ef7af816b0a553306f5a" +
+                "0000000000000000000000000000000000000000000000000000000002faf08070b0ca81aee43390018" +
+                "0ade204"
+        private const val TX_ID = "90788bbae2f83d278b5f13a9b39e26a294d9319bf7ea8bb69b8dbf32b1c61133"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitTronSignerTest.kt
@@ -70,13 +70,26 @@ class SwapKitTronSignerTest {
         val obj = Json.parseToJsonElement(envelope) as JsonObject
 
         // signature appended as a single-element hex array (TronWeb broadcast shape).
-        val sig = obj["signature"]!!.jsonArray
+        val sig = requireNotNull(obj["signature"]) { "signature field is missing" }.jsonArray
         assertEquals(1, sig.size)
         assertEquals(signatureHex, sig[0].jsonPrimitive.content)
         // Original canonical fields survive verbatim so the cosigning peer broadcasts the same tx.
-        assertEquals(TX_ID, obj["txID"]!!.jsonPrimitive.content)
-        assertEquals(RAW_DATA_HEX, obj["raw_data_hex"]!!.jsonPrimitive.content)
-        assertTrue(obj["visible"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(
+            TX_ID,
+            requireNotNull(obj["txID"]) { "txID field is missing" }.jsonPrimitive.content,
+        )
+        assertEquals(
+            RAW_DATA_HEX,
+            requireNotNull(obj["raw_data_hex"]) { "raw_data_hex field is missing" }
+                .jsonPrimitive
+                .content,
+        )
+        assertTrue(
+            requireNotNull(obj["visible"]) { "visible field is missing" }
+                .jsonPrimitive
+                .content
+                .toBoolean()
+        )
     }
 
     private companion object {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -503,17 +504,19 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch throws UnsupportedTxType for a still-unwired non-EVM txType`() = runTest {
-        // PSBT (Bitcoin) is now wired to a Native SwapQuote.SwapKit; the remaining non-EVM txTypes
-        // (TRON/TON/SUI/CARDANO/RIPPLE) still have no signer, so they surface as UnsupportedTxType.
+        // PSBT (Bitcoin) and TRON are now wired to a Native SwapQuote.SwapKit; the remaining
+        // non-EVM
+        // txTypes (TON/SUI/CARDANO/RIPPLE) still have no signer, so they surface as
+        // UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
-                routes = listOf(route(routeId = "r-tron", providers = listOf("CHAINFLIP")))
+                routes = listOf(route(routeId = "r-sui", providers = listOf("CHAINFLIP")))
             )
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 tx = JsonObject(emptyMap()),
-                meta = SwapKitTxMeta(txType = "TRON"),
+                meta = SwapKitTxMeta(txType = "SUI"),
                 expectedBuyAmount = "1",
             )
 
@@ -786,6 +789,76 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch decodes a TRON route into a Native SwapQuote SwapKit with the TronWeb object as txPayload`() =
+        runTest {
+            // TRON's tx is a TronWeb-shaped JSON object (not base64) — the source UTF-8 encodes it
+            // verbatim into txPayload so SwapKitTronSigner can pull raw_data_hex. The inbound TRX
+            // fee scales by 6 native decimals.
+            every { config.isFeatureEnabled } returns flowOf(true)
+            val tronTx = buildJsonObject {
+                put("visible", JsonPrimitive(true))
+                put("txID", JsonPrimitive("90788bbae2f83d278b5f13a9b39e26a294d9319bf"))
+                put("raw_data_hex", JsonPrimitive("0a0289752208deadbeef"))
+            }
+            val tron = tronCoin()
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r-tron",
+                                providers = listOf("NEAR"),
+                                expectedBuy = "49.634251",
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                SwapKitSwapResponseJson(
+                    swapId = "tron-swap-1",
+                    tx = tronTx,
+                    meta = SwapKitTxMeta(txType = "TRON"),
+                    targetAddress = "TUh93RjWWSxikbHA2U31pnYJYaP3zL45z5",
+                    expectedBuyAmount = "49.634251",
+                    fees = listOf(SwapKitFee(type = "inbound", chain = "TRON", amount = "13.3735")),
+                    providers = listOf("NEAR"),
+                )
+
+            val result =
+                source().fetch(request(srcToken = tron, dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+            val quote = result.quote as SwapQuote.SwapKit
+
+            assertEquals("TRON", quote.data.txType)
+            assertEquals("TUh93RjWWSxikbHA2U31pnYJYaP3zL45z5", quote.data.targetAddress)
+            assertEquals("tron-swap-1", quote.data.swapId)
+            // txPayload is the UTF-8 JSON object — round-trips back to the same raw_data_hex.
+            val decoded =
+                Json.parseToJsonElement(quote.data.txPayload.decodeToString()) as JsonObject
+            assertEquals("0a0289752208deadbeef", decoded["raw_data_hex"]!!.jsonPrimitive.content)
+            // 13.3735 TRX inbound fee scaled by 6 native decimals = 13_373_500 sun.
+            assertEquals(BigInteger("13373500"), quote.fees.value)
+            assertEquals("USDT", quote.fees.unit)
+        }
+
+    @Test
+    fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-tron", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive("not-an-object"),
+                meta = SwapKitTxMeta(txType = "TRON"),
+                targetAddress = "Ttarget",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = tronCoin())) }
+    }
+
+    @Test
     fun `fetch throws Decoding when the PSBT tx is not valid base64`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -951,5 +1024,18 @@ internal class SwapKitQuoteSourceTest {
             priceProviderID = "bitcoin",
             contractAddress = "",
             isNativeToken = true,
+        )
+
+    private fun tronCoin() =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "USDT",
+            logo = "",
+            address = "TLBaRhANQoJFTqre9Nf1mjuwNWjCJeYqUL",
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "tether",
+            contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            isNativeToken = false,
         )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -800,7 +800,9 @@ internal class SwapKitQuoteSourceTest {
                 put("txID", JsonPrimitive("90788bbae2f83d278b5f13a9b39e26a294d9319bf"))
                 put("raw_data_hex", JsonPrimitive("0a0289752208deadbeef"))
             }
-            val tron = tronCoin()
+            // decimal = 18 (not the chain's native 6) so a regression that scaled the inbound fee
+            // by srcToken.decimal instead of TRON's native 6 decimals would fail this assertion.
+            val tron = tronCoin().copy(decimal = 18)
             coEvery { api.quote(any()) } returns
                 SwapKitQuoteResponseJson(
                     routes =
@@ -834,7 +836,8 @@ internal class SwapKitQuoteSourceTest {
             // txPayload is the UTF-8 JSON object — round-trips back to the same raw_data_hex.
             val decoded =
                 Json.parseToJsonElement(quote.data.txPayload.decodeToString()) as JsonObject
-            assertEquals("0a0289752208deadbeef", decoded["raw_data_hex"]!!.jsonPrimitive.content)
+            val rawDataHex = decoded["raw_data_hex"]?.jsonPrimitive?.content
+            assertEquals("0a0289752208deadbeef", rawDataHex)
             // 13.3735 TRX inbound fee scaled by 6 native decimals = 13_373_500 sun.
             assertEquals(BigInteger("13373500"), quote.fees.value)
             assertEquals("USDT", quote.fees.unit)
@@ -850,6 +853,26 @@ internal class SwapKitQuoteSourceTest {
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 tx = JsonPrimitive("not-an-object"),
+                meta = SwapKitTxMeta(txType = "TRON"),
+                targetAddress = "Ttarget",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = tronCoin())) }
+    }
+
+    @Test
+    fun `fetch throws Decoding when the TRON tx has a blank raw_data_hex`() = runTest {
+        // A present-but-empty raw_data_hex must be rejected at quote time (not deferred to keysign)
+        // so route selection can fall back cleanly.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-tron", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = buildJsonObject { put("raw_data_hex", JsonPrimitive("")) },
                 meta = SwapKitTxMeta(txType = "TRON"),
                 targetAddress = "Ttarget",
                 expectedBuyAmount = "1",

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -39,6 +39,8 @@ internal class SwapProviderTableTest {
                 coin(Chain.Solana, "SOL", isNative = true),
                 coin(Chain.Solana, "USDC", isNative = false),
                 coin(Chain.Bitcoin, "BTC", isNative = true), // BTC PSBT route
+                coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
+                coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
             )
 
         swapKitCoins.forEach { c ->
@@ -67,7 +69,6 @@ internal class SwapProviderTableTest {
                 coin(Chain.MayaChain, "CACAO", isNative = true),
                 coin(Chain.Zcash, "ZEC", isNative = true),
                 coin(Chain.Ripple, "XRP", isNative = true),
-                coin(Chain.Tron, "TRX", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
                 coin(Chain.Ton, "TON", isNative = true),
                 coin(Chain.Sui, "SUI", isNative = true),


### PR DESCRIPTION
## Summary

Wires SwapKit's **TRON** swap path end-to-end on Android, mirroring the iOS implementation. Previously Android's SwapKit support covered EVM + Solana + Bitcoin PSBT only; TRON (and the other non-EVM txTypes) surfaced as `UnsupportedTxType`.

SwapKit's `/v3/swap` returns a TronWeb-shaped JSON **object** (`{txID, raw_data, raw_data_hex, …}`) rather than a base64 blob. The canonical Tron signing input is `sha256(raw_data_bytes)` — which is also Tron's `txID` — so the signer hashes the pre-built `raw_data_hex` directly and re-assembles the broadcast envelope by appending the 65-byte `r||s||v` signature as `signature:[hex]`. This keeps the surface small (no per-`contract.type` `SigningInput` reconstruction) and gives the cosigning peer identical bytes to verify. `TronApi.broadcastTransaction` posts that envelope verbatim.

### Transaction hash
https://tronscan.org/#/transaction/e0865bfd91e5707cb5b3bebe58c7a0844d3e58229cbfa5d5cc3c2c11a0b30d76

## Changes

- **`SwapKitTronSigner`** (new): signing digest, single-entry pre-signed hash, and signed-broadcast-envelope assembly with signature verification against the derived vault key.
- **`SwapKitSwapPayloadJson`**: added `TX_TYPE_TRON` discriminator.
- **`SigningHelper`**: the PSBT-only `require` gate in both the pre-sign and signed-tx paths is now a `when(txType)` dispatch (PSBT → `SwapKitBtcSigner`, TRON → `SwapKitTronSigner`).
- **`SwapKitQuoteSource`**: TRON added to the tx-kind dispatch, `chainPrefix(Tron) → "TRON"`, native decimals `6`, and a JSON-object `txPayload` encoder (TRON's `tx` is an object, not a base64 string).
- **`SwapProviderTable`**: `Chain.Tron` now offers `SWAPKIT` alongside `THORCHAIN` (mirrors iOS `.tron → [thorchain, swapkit]`).
- **`SwapFormViewModel`**: the SwapKit gate accepts PSBT or TRON.

## Test plan

- New `SwapKitTronSignerTest`: digest pinned to the real `v3-tron-final-swap-fresh` fixture's reported `txID`, single-entry pre-sign hash, envelope appends signature + preserves fields, and rejects malformed / empty / missing-`raw_data_hex` payloads.
- New `SwapKitQuoteSourceTest` cases: TRON route decodes into a Native `SwapQuote.SwapKit` with the TronWeb object round-tripped into `txPayload` and the inbound TRX fee scaled by 6 native decimals; a non-object TRON `tx` throws `Decoding`.
- Updated existing tests that encoded "TRON unsupported" (`SwapProviderTableTest`, the unwired-txType `SwapKitQuoteSourceTest` case now uses SUI).
- `./gradlew :data:testDebugUnitTest` green; `./gradlew :app:compileDebugKotlin` green.

## Notes

- secp256k1 signature verification needs the WalletCore JNI, so the headless unit tests cover the digest + envelope logic; the verify path is exercised by the iOS port + integration (same constraint as the existing BTC PSBT signer).
- On-device E2E of a real TRON swap (compile + broadcast) is still pending, as with the BTC path.
- Remaining iOS parity gaps after this: TON, ADA, SUI (+ legacy-P2PKH UTXO chains and XRP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TRON support for SwapKit swaps: TRX and TRC-20 assets can route through SwapKit.
  * Implemented TRON-specific signing and broadcast handling so TRON transactions can be prepared and submitted.

* **Bug Fixes / Improvements**
  * Expanded transaction type handling to accept both PSBT and TRON payloads; preserved original payload fields during processing.
  * Adjusted native fee scaling and chain mapping for TRON.

* **Tests**
  * Added unit tests covering TRON signing, payload parsing, and quote decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->