### PR TITLE
feat(swap): SwapKit SUI signing support

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,13 +475,14 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT and TRON (TronWeb object) are wired; the remaining
-                                // SwapKit txTypes (TON / ADA / SUI) land with their per-chain
+                                // BTC PSBT, TRON (TronWeb object), and SUI (PTB) are wired; the
+                                // remaining SwapKit txTypes (TON / ADA) land with their per-chain
                                 // signers. Guarded loudly so an un-wired txType can't reach
                                 // signing.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -117,6 +117,9 @@ object SigningHelper {
                             SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                                 SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
+                            SwapKitSwapPayloadJson.TX_TYPE_SUI ->
+                                SwapKitSuiSigner(eddsaKey)
+                                    .getPreSignedImageHash(swapPayload.data.txPayload)
                             else ->
                                 error(
                                     "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
@@ -310,6 +313,9 @@ object SigningHelper {
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
                         SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                             SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
+                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        SwapKitSwapPayloadJson.TX_TYPE_SUI ->
+                            SwapKitSuiSigner(eddsaKey)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
                         else ->
                             error(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
@@ -1,0 +1,106 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.tss.getSignature
+import java.util.Base64
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import tss.KeysignResponse
+import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
+
+internal class SwapKitSuiSignerException(message: String) : Exception(message)
+
+/**
+ * Signs SwapKit's pre-built Sui programmable transaction block (PTB). Ported from iOS'
+ * `SwapKitSuiSigner`. WalletCore's `Sui.SigningInput` only models structured `Pay` / `PaySui` flows
+ * — it can't take a serialized PTB and produce a sighash — so we compute Sui's signing digest
+ * ourselves, feed it to the MPC engine, then assemble the submit-format signature envelope around
+ * the resulting Ed25519 signature (the same hash-and-sign pattern the QBTC claim path uses).
+ *
+ * Sui signing intent (from the Sui spec):
+ * ```
+ *   intent_message = [scope=0 (TransactionData), version=0 (V0), app=0 (Sui)] || bcs(transaction_data)
+ *   digest         = blake2b_32(intent_message)
+ * ```
+ *
+ * SwapKit returns the BCS-serialized transaction data as a base64 string, base64-decoded into
+ * [SwapKitSwapPayloadJson.txPayload] by `SwapKitQuoteSource`. We prepend the three intent-prefix
+ * bytes and hash with Blake2b-32 (Bouncy Castle, identical to WalletCore's `Hash.blake2b(_, 32)` —
+ * keeps the digest path JNI-free and unit-testable). The submit-format envelope is `[flag=0x00
+ * ed25519, sig (64 bytes), pubkey (32 bytes)]`, base64-encoded — this is the `signatures[0]`
+ * argument to `sui_executeTransactionBlock`; the `tx_bytes` argument is the same base64 PTB SwapKit
+ * handed us, passed verbatim ([SignedTransactionResult.rawTransaction]).
+ */
+internal class SwapKitSuiSigner(private val vaultHexPublicKey: String) {
+
+    /**
+     * Sui signing digest = `blake2b_32(intent_prefix || ptb)`. A single-element list because every
+     * Sui transaction signs exactly one digest; hex-encoded to match the keysign message-hash
+     * convention.
+     */
+    fun getPreSignedImageHash(ptbBytes: ByteArray): List<String> =
+        listOf(digest(ptbBytes).toHexString())
+
+    /**
+     * Assemble the Sui submit-format signed transaction. [rawTransaction][SignedTransactionResult]
+     * is the base64 PTB (passed verbatim to the RPC); [signature][SignedTransactionResult] is the
+     * base64 Ed25519 envelope. The transaction hash stays empty — Sui's canonical tx digest only
+     * resolves after the RPC accepts the submission (same convention as [SuiHelper]).
+     */
+    fun getSignedTransaction(
+        ptbBytes: ByteArray,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val pubKeyData = vaultHexPublicKey.hexToByteArray()
+        val publicKey = PublicKey(pubKeyData, PublicKeyType.ED25519)
+
+        val digest = digest(ptbBytes)
+        val key = digest.toHexString()
+        val signature =
+            signatures[key]?.getSignature()
+                ?: throw SwapKitSuiSignerException(
+                    "Missing signature for Sui digest ${key.take(16)}…"
+                )
+        if (!publicKey.verify(signature, digest)) {
+            throw SwapKitSuiSignerException("SwapKit Sui signature verification failed")
+        }
+
+        // Envelope: [flag=0x00 ed25519] + sig (64 bytes) + pubkey (32 bytes).
+        val envelope = byteArrayOf(ED25519_SCHEME_FLAG) + signature + pubKeyData
+        return SignedTransactionResult(
+            rawTransaction = Base64.getEncoder().encodeToString(ptbBytes),
+            transactionHash = "",
+            signature = Base64.getEncoder().encodeToString(envelope),
+        )
+    }
+
+    /**
+     * Sui signing digest = Blake2b-32 of `intent_prefix || ptb_bytes`. The PTB bytes are hashed
+     * verbatim — SwapKit hands us already-BCS-serialized transaction data, which is exactly what
+     * the intent message wraps. Exposed (internal) so a unit test can pin the digest without JNI.
+     */
+    internal fun digest(ptbBytes: ByteArray): ByteArray {
+        if (ptbBytes.isEmpty()) {
+            throw SwapKitSuiSignerException("SwapKit Sui payload is empty")
+        }
+        val message = INTENT_PREFIX + ptbBytes
+        val blake = Blake2bDigest(256)
+        blake.update(message, 0, message.size)
+        val out = ByteArray(blake.digestSize)
+        blake.doFinal(out, 0)
+        return out
+    }
+
+    private companion object {
+        /**
+         * Sui transaction-data intent prefix: scope=0 (TransactionData), version=0 (V0), app=0
+         * (Sui).
+         */
+        private val INTENT_PREFIX = byteArrayOf(0x00, 0x00, 0x00)
+
+        /** Ed25519 signature-scheme flag in Sui's signature envelope. */
+        private const val ED25519_SCHEME_FLAG: Byte = 0x00
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
@@ -82,9 +82,7 @@ internal class SwapKitSuiSigner(private val vaultHexPublicKey: String) {
      * the intent message wraps. Exposed (internal) so a unit test can pin the digest without JNI.
      */
     internal fun digest(ptbBytes: ByteArray): ByteArray {
-        if (ptbBytes.isEmpty()) {
-            throw SwapKitSuiSignerException("SwapKit Sui payload is empty")
-        }
+        require(ptbBytes.isNotEmpty()) { "SwapKit Sui payload is empty" }
         val message = INTENT_PREFIX + ptbBytes
         val blake = Blake2bDigest(256)
         blake.update(message, 0, message.size)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -198,6 +198,7 @@ val Chain.isSwapSupported: Boolean
                 Chain.ZkSync,
                 Chain.Zcash,
                 Chain.Tron,
+                Chain.Sui,
                 Chain.Hyperliquid,
             )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -71,5 +71,13 @@ data class SwapKitSwapPayloadJson(
          * hashes `raw_data_hex` and re-assembles the broadcast envelope. Mirrors iOS' `"TRON"`.
          */
         const val TX_TYPE_TRON = "TRON"
+
+        /**
+         * `meta.txType` discriminator for the Sui signing path. SwapKit returns a base64-encoded
+         * pre-built programmable transaction block (PTB), base64-decoded into [txPayload]; the
+         * signer hashes `intent_prefix || ptb` with Blake2b-32 and wraps the Ed25519 signature in
+         * Sui's submit envelope. Mirrors iOS' `"SUI"`.
+         */
+        const val TX_TYPE_SUI = "SUI"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -54,12 +54,13 @@ import timber.log.Timber
  *    backstopped with the L1-sized default, which would over-estimate L2 fees by multiples.
  *
  * Non-EVM/non-Solana `txType`s surface as a fully-formed [SwapQuote.SwapKit] for a per-chain signer
- * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]) and
- * TRON (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]) are wired
- * today. The remaining types (TON, SUI, CARDANO, RIPPLE, …) still surface as
- * [SwapKitError.UnsupportedTxType] so the picker falls back to another provider rather than signing
- * garbage, until their signers land. `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are
- * aliased; SwapKit flipped them once before.
+ * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]), TRON
+ * (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]), and SUI
+ * (base64 PTB, via [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner]) are wired today. The
+ * remaining types (TON, CARDANO, RIPPLE, …) still surface as [SwapKitError.UnsupportedTxType] so
+ * the picker falls back to another provider rather than signing garbage, until their signers land.
+ * `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once
+ * before.
  */
 internal class SwapKitQuoteSource
 @Inject
@@ -175,7 +176,8 @@ constructor(
                     subProvider = subProvider,
                 )
             TxKind.PSBT,
-            TxKind.TRON ->
+            TxKind.TRON,
+            TxKind.SUI ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -260,6 +262,7 @@ constructor(
     private fun nativeDecimals(chain: Chain): Int =
         when (chain) {
             Chain.Solana -> 9
+            Chain.Sui -> 9
             Chain.Bitcoin -> 8
             Chain.Tron -> 6
             else -> 18
@@ -369,10 +372,11 @@ constructor(
                         ),
                 )
             }
-            // PSBT/TRON are dispatched to buildSwapKitNativeQuote before reaching here; the arm
+            // PSBT/TRON/SUI are dispatched to buildSwapKitNativeQuote before reaching here; the arm
             // keeps the `when` exhaustive and refuses anything that slips through.
             TxKind.PSBT,
             TxKind.TRON,
+            TxKind.SUI,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
@@ -489,6 +493,7 @@ constructor(
             "serialized_base64" -> TxKind.SOLANA
             "psbt" -> TxKind.PSBT
             "tron" -> TxKind.TRON
+            "sui" -> TxKind.SUI
             else -> TxKind.UNSUPPORTED
         }
 
@@ -523,6 +528,7 @@ constructor(
         SOLANA,
         PSBT,
         TRON,
+        SUI,
         UNSUPPORTED,
     }
 
@@ -583,6 +589,7 @@ constructor(
             Chain.Solana -> "SOL"
             Chain.Bitcoin -> "BTC"
             Chain.Tron -> "TRON"
+            Chain.Sui -> "SUI"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -132,10 +132,13 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
 
             Chain.Hyperliquid -> setOf(SwapProvider.LIFI)
 
+            // SwapKit SUI routes are signed by SwapKitSuiSigner (Blake2b-32 of the intent-prefixed
+            // PTB, Ed25519 envelope). Mirrors iOS' `.sui → [.swapkit]`.
+            Chain.Sui -> setOf(SwapProvider.SWAPKIT)
+
             Chain.Polkadot,
             Chain.Bittensor,
             Chain.Dydx,
-            Chain.Sui,
             Chain.Ton,
             Chain.Osmosis,
             Chain.Terra,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSignerTest.kt
@@ -1,0 +1,63 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [SwapKitSuiSigner]'s pure (no-JNI) surface: the Blake2b-32 signing digest and the
+ * single-entry pre-signed hash. Sui's digest is `blake2b_32([0x00,0x00,0x00] || ptb)` — the intent
+ * prefix (scope/version/app) prepended to SwapKit's BCS-serialized PTB. The expected value is
+ * recomputed here with an independent Blake2b so a drift in the prefix bytes or hashing surfaces.
+ *
+ * Ed25519 signature verification + envelope assembly need the WalletCore JNI and are exercised by
+ * the iOS port + integration, mirroring the headless framing tests in [SwapKitBtcSignerTest].
+ */
+class SwapKitSuiSignerTest {
+
+    // The vault key is only read in the JNI-dependent signing path, not by digest().
+    private val signer = SwapKitSuiSigner(vaultHexPublicKey = "")
+
+    private fun blake2b32(data: ByteArray): ByteArray {
+        val d = Blake2bDigest(256)
+        d.update(data, 0, data.size)
+        return ByteArray(d.digestSize).also { d.doFinal(it, 0) }
+    }
+
+    @Test
+    fun `digest is blake2b-32 of the intent-prefixed PTB`() {
+        val ptb = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+        val expected = blake2b32(byteArrayOf(0x00, 0x00, 0x00) + ptb)
+
+        val actual = signer.digest(ptb)
+
+        assertEquals(32, actual.size, "Sui digest is Blake2b-32")
+        assertArrayEquals(expected, actual)
+    }
+
+    @Test
+    fun `digest depends on the intent prefix`() {
+        val ptb = byteArrayOf(0x0a, 0x0b, 0x0c)
+        // Hashing the bare PTB (no intent prefix) must NOT match — the prefix is part of the signed
+        // message, so dropping it would produce a signature the Sui RPC rejects.
+        assertNotEquals(blake2b32(ptb).toHexString(), signer.digest(ptb).toHexString())
+    }
+
+    @Test
+    fun `pre-signed image hash is a single entry equal to the digest`() {
+        val ptb = byteArrayOf(0x11, 0x22, 0x33)
+        val hashes = signer.getPreSignedImageHash(ptb)
+        assertEquals(1, hashes.size)
+        assertEquals(signer.digest(ptb).toHexString(), hashes[0])
+    }
+
+    @Test
+    fun `empty payload is rejected`() {
+        assertThrows(SwapKitSuiSignerException::class.java) { signer.digest(ByteArray(0)) }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSignerTest.kt
@@ -58,6 +58,7 @@ class SwapKitSuiSignerTest {
 
     @Test
     fun `empty payload is rejected`() {
-        assertThrows(SwapKitSuiSignerException::class.java) { signer.digest(ByteArray(0)) }
+        // Empty PTB is an input precondition → IllegalArgumentException via require().
+        assertThrows(IllegalArgumentException::class.java) { signer.digest(ByteArray(0)) }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
@@ -134,10 +134,11 @@ class SwapQuoteRepositoryTest {
 
     @Test
     fun `unsupported chain returns null`() {
-        val sui1 = coin(Chain.Sui, "SUI")
-        val sui2 = coin(Chain.Sui, "USDC", contractAddress = "0xabc")
+        // Sui now routes through SwapKit; Polkadot remains a no-swap chain.
+        val dot1 = coin(Chain.Polkadot, "DOT")
+        val dot2 = coin(Chain.Polkadot, "DOT")
 
-        val providers = providerTable.eligibleProvidersFor(sui1, sui2)
+        val providers = providerTable.eligibleProvidersFor(dot1, dot2)
 
         assertTrue(providers.isEmpty())
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -504,19 +504,18 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch throws UnsupportedTxType for a still-unwired non-EVM txType`() = runTest {
-        // PSBT (Bitcoin) and TRON are now wired to a Native SwapQuote.SwapKit; the remaining
-        // non-EVM
-        // txTypes (TON/SUI/CARDANO/RIPPLE) still have no signer, so they surface as
+        // PSBT (Bitcoin), TRON, and SUI are now wired to a Native SwapQuote.SwapKit; the remaining
+        // non-EVM txTypes (TON/CARDANO/RIPPLE) still have no signer, so they surface as
         // UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
             SwapKitQuoteResponseJson(
-                routes = listOf(route(routeId = "r-sui", providers = listOf("CHAINFLIP")))
+                routes = listOf(route(routeId = "r-ton", providers = listOf("CHAINFLIP")))
             )
         coEvery { api.swap(any()) } returns
             SwapKitSwapResponseJson(
                 tx = JsonObject(emptyMap()),
-                meta = SwapKitTxMeta(txType = "SUI"),
+                meta = SwapKitTxMeta(txType = "TON"),
                 expectedBuyAmount = "1",
             )
 
@@ -844,6 +843,50 @@ internal class SwapKitQuoteSourceTest {
         }
 
     @Test
+    fun `fetch decodes a SUI route into a Native SwapQuote SwapKit payload`() = runTest {
+        // SUI's tx is a base64 pre-built PTB (same wire shape as PSBT) → decoded into txPayload
+        // bytes. The inbound SUI fee scales by 9 native decimals, not the source token's decimals.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val ptbBytes = byteArrayOf(0x00, 0x00, 0x02, 0x11, 0x22, 0x33)
+        val base64 = Base64.getEncoder().encodeToString(ptbBytes)
+        val sui = suiCoin()
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(routeId = "r-sui", providers = listOf("NEAR"), expectedBuy = "10.3")
+                    )
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "sui-swap-1",
+                tx = JsonPrimitive(base64),
+                meta = SwapKitTxMeta(txType = "SUI"),
+                targetAddress =
+                    "0x6e894db314206472c3290beaf2b78107fac89154308327206a5c7751c9700d98",
+                expectedBuyAmount = "10.3",
+                fees = listOf(SwapKitFee(type = "inbound", chain = "SUI", amount = "0.0015")),
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = sui, dstToken = ethCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+
+        assertEquals("SUI", quote.data.txType)
+        assertTrue(ptbBytes.contentEquals(quote.data.txPayload))
+        assertEquals(
+            "0x6e894db314206472c3290beaf2b78107fac89154308327206a5c7751c9700d98",
+            quote.data.targetAddress,
+        )
+        assertEquals("sui-swap-1", quote.data.swapId)
+        assertEquals(sui, quote.data.fromCoin)
+        // 0.0015 SUI inbound fee scaled by 9 native decimals = 1_500_000 MIST.
+        assertEquals(BigInteger("1500000"), quote.fees.value)
+        assertEquals("SUI", quote.fees.unit)
+    }
+
+    @Test
     fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -1060,5 +1103,18 @@ internal class SwapKitQuoteSourceTest {
             priceProviderID = "tether",
             contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
             isNativeToken = false,
+        )
+
+    private fun suiCoin() =
+        Coin(
+            chain = Chain.Sui,
+            ticker = "SUI",
+            logo = "",
+            address = "0x6e894db314206472c3290beaf2b78107fac89154308327206a5c7751c9700d98",
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "sui",
+            contractAddress = "",
+            isNativeToken = true,
         )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -41,6 +41,7 @@ internal class SwapProviderTableTest {
                 coin(Chain.Bitcoin, "BTC", isNative = true), // BTC PSBT route
                 coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
                 coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
+                coin(Chain.Sui, "SUI", isNative = true), // SUI PTB route
             )
 
         swapKitCoins.forEach { c ->
@@ -71,7 +72,6 @@ internal class SwapProviderTableTest {
                 coin(Chain.Ripple, "XRP", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
                 coin(Chain.Ton, "TON", isNative = true),
-                coin(Chain.Sui, "SUI", isNative = true),
                 coin(Chain.Cardano, "ADA", isNative = true),
                 coin(Chain.Polkadot, "DOT", isNative = true),
             )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.repositories.swap
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.isSwapSupported
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -80,6 +81,20 @@ internal class SwapProviderTableTest {
             assertFalse(
                 SwapProvider.SWAPKIT in table.providersFor(c),
                 "Did not expect SWAPKIT for ${c.chain}/${c.ticker} but got ${table.providersFor(c)}",
+            )
+        }
+    }
+
+    @Test
+    fun `SwapKit-wired chains are marked swap-supported so the Swap action button shows`() {
+        // ChainTokensViewModel.canSwap reads Chain.isSwapSupported to show the Swap button on the
+        // account screen. A chain can offer SWAPKIT in the provider table yet stay invisible to the
+        // user if it is missing from isSwapSupported — the Sui regression that hid the button while
+        // iOS showed it. Pin every SwapKit-wired native chain here.
+        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui).forEach { chain ->
+            assertTrue(
+                chain.isSwapSupported,
+                "$chain offers SWAPKIT but is not marked isSwapSupported — Swap button would hide",
             )
         }
     }


### PR DESCRIPTION
## Summary

Wires SwapKit's **SUI** swap path end-to-end on Android, mirroring the iOS implementation. Builds on the BTC PSBT and TRON signers already on `main`; previously SUI surfaced as `UnsupportedTxType`.

SwapKit's `/v3/swap` returns a base64-encoded pre-built Sui **programmable transaction block (PTB)**. WalletCore's `Sui.SigningInput` only models structured `Pay`/`PaySui` flows and can't take a serialized PTB and produce a sighash, so the signer computes Sui's signing digest itself:

```
intent_message = [scope=0 (TransactionData), version=0 (V0), app=0 (Sui)] || bcs(transaction_data)
digest         = blake2b_32(intent_message)
```

feeds that digest to the MPC engine, and assembles Sui's submit-format envelope `[flag=0x00 ed25519, sig(64), pubkey(32)]` around the Ed25519 signature. The `tx_bytes` argument to `sui_executeTransactionBlock` is the same base64 PTB SwapKit handed us, passed verbatim.

## Changes

- **`SwapKitSuiSigner`** (new): the Blake2b-32 signing digest, single-entry pre-signed hash, and the Ed25519 submit-format envelope with signature verification against the vault key. The digest uses Bouncy Castle `Blake2bDigest(256)` (identical output to WalletCore's `Hash.blake2b(_, 32)`) so the digest path is JNI-free and unit-testable.
- **`SwapKitSwapPayloadJson`**: added `TX_TYPE_SUI` discriminator.
- **`SigningHelper`**: SUI arm in both the pre-sign and signed-tx dispatch, signing with the vault's **EdDSA** key (vs ECDSA for BTC/TRON).
- **`SwapKitQuoteSource`**: SUI added to the tx-kind dispatch, `chainPrefix(Sui) → "SUI"`, native decimals `9`; the base64 PTB rides the existing binary-tx native-quote path.
- **`SwapProviderTable`**: `Chain.Sui` now offers `SWAPKIT` (mirrors iOS `.sui → [swapkit]`).
- **`SwapFormViewModel`**: the SwapKit gate accepts SUI.

## Test plan

- New `SwapKitSuiSignerTest`: digest pinned against an independently-computed Blake2b-32, proven to depend on the intent prefix, single-entry pre-sign hash, empty-payload rejection.
- New `SwapKitQuoteSourceTest` case: a SUI route decodes into a Native `SwapQuote.SwapKit` with the base64 PTB in `txPayload` and the inbound SUI fee scaled by 9 native decimals.
- Updated existing tests that used SUI as the "unsupported" example (`SwapProviderTableTest`, `SwapQuoteRepositoryTest`, and the unwired-txType `SwapKitQuoteSourceTest` case now uses TON).
- `./gradlew :data:testDebugUnitTest` green; `:data` + `:app` `compileDebugKotlin` green.

## Notes

- Ed25519 signature verification needs the WalletCore JNI, so the headless unit tests cover the digest logic; the verify + envelope path is exercised by the iOS port + integration (same constraint as the BTC/TRON signers).
- On-device E2E of a real SUI swap (sign + broadcast) is still pending, as with the BTC/TRON paths.
- Remaining iOS parity gaps after this: TON, ADA (+ legacy-P2PKH UTXO chains and XRP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

## SwapKit Sui routing — live investigation

Queried the live SwapKit API (via the `api.vultisig.com/swapkit-a` proxy) to verify Sui support end to end.

**Configured support (`/providers` + `/tokens`):**
- Providers covering Sui: **NEAR Intents** and **MAYAN** (both cross-chain).
- Sui tokens in the catalog: `SUI.SUI`, `SUI.USDC` (NEAR); plus via MAYAN `SUI.xBTC`, `SUI.LBTC`, `SUI.WETH`, `SUI.wUSDT`, `SUI.FDUSD`, `SUI.sbETH`, `SUI.sbUSDT`, `SUI.HaSUI`, `SUI.vSUI`, `SUI.AFSUI`, `SUI.WAL`, `SUI.BUCK`, `SUI.NAVX`, `SUI.XAUM`, `SUI.FUD`. MAYAN identifies native Sui as `SUI.SUI-0x2::sui::SUI`; NEAR as plain `SUI.SUI`.

**Live routability (`POST /v3/quote`):** every Sui pair currently returns `noRoutesFound` — both directions, with addresses, varied amounts, and both native-Sui identifier forms:

| Pair | Result |
|---|---|
| `SUI.SUI → ETH.ETH` / `ETH.USDC` / `SOL.SOL` | ✗ noRoutesFound |
| `SOL.SOL → SUI.SUI` | ✗ noRoutesFound |
| `SUI.SUI → SUI.USDC` (intra-chain) | ✗ noRoutesFound |

Control pairs on the same endpoint confirm the engine + request format are fine:

| Control pair | Result |
|---|---|
| `ETH.ETH → SOL.SOL` | ✓ 2 routes (CHAINFLIP, NEAR) |
| `SOL.SOL → ETH.ETH` | ✓ 2 routes |
| `ETH.ETH → BTC.BTC` | ✓ 4 routes |

**Conclusion:** this is an upstream/provider-liquidity state, **not an Android bug**. SwapKit lists Sui (providers + token catalog) but its routers (NEAR Intents / MAYAN) return zero live Sui routes right now; iOS hits the same backend and would get the same result today (its SUI fixture is a recorded historical response). The wiring in this PR is correct — the `SUI.SUI` identifier matches the catalog/iOS exactly, the Swap button now shows, and `noRoutesFound` maps to the correct "no route available" UI. The `SwapKitSuiSigner` path can only be exercised end-to-end once SwapKit re-enables live Sui routing (same dormant-until-liquid posture as the merged BTC/TRON signers).


## Summary by CodeRabbit

* **New Features**
  * Added Sui support for native swaps via SwapKit, including signing, submission envelope handling, fee scaling, and Swap action visibility for Sui.

* **Tests**
  * Added unit tests covering Sui transaction digest, pre-signed image hash, signature handling, and end-to-end Sui swap decoding and provider routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
