### PR TITLE
feat(swap): SwapKit TON support

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,13 +475,13 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT and TRON (TronWeb object) are wired; the remaining
-                                // SwapKit txTypes (TON / ADA / SUI) land with their per-chain
-                                // signers. Guarded loudly so an un-wired txType can't reach
-                                // signing.
+                                // BTC PSBT, TRON (TronWeb object) and TON (native transfer) are
+                                // wired; remaining SwapKit txTypes (ADA / SUI) land with their
+                                // per-chain signers. Guarded so an un-wired txType can't sign.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TON
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitTonTransfer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitTonTransfer.kt
@@ -1,0 +1,17 @@
+package com.vultisig.wallet.data.api.models.quotes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One element of SwapKit's TON `tx` array (`POST /v3/swap` with `meta.txType == "TON"`). [amount]
+ * is raw nano-TON (decimal string, 1e9 = 1 TON), never human-readable TON units. SwapKit emits a
+ * single-element array today; the list shape is preserved so a future multi-output route decodes
+ * cleanly. Field order matches iOS' `SwapKitTonTransfer` so the canonical JSON re-encoding is
+ * byte-identical across platforms.
+ */
+@Serializable
+data class SwapKitTonTransfer(
+    @SerialName("address") val address: String,
+    @SerialName("amount") val amount: String,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -117,6 +117,11 @@ object SigningHelper {
                             SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                                 SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
+                            // TON SwapKit is a plain native transfer to the deposit address. The
+                            // KeysignPayload already carries toAddress / toAmount / Ton specifics.
+                            // It reuses the native TonHelper path (no signTon, matching iOS).
+                            SwapKitSwapPayloadJson.TX_TYPE_TON ->
+                                TonHelper.getPreSignedImageHash(payload)
                             else ->
                                 error(
                                     "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
@@ -311,6 +316,14 @@ object SigningHelper {
                         SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                             SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        // TON SwapKit reuses the native TonHelper path (EdDSA), signing the deposit
+                        // transfer off the KeysignPayload's toAddress / toAmount — matching iOS.
+                        SwapKitSwapPayloadJson.TX_TYPE_TON ->
+                            TonHelper.getSignedTransaction(
+                                vaultHexPublicKey = eddsaKey,
+                                payload = keysignPayload,
+                                signatures = signatures,
+                            )
                         else ->
                             error(
                                 "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -198,6 +198,7 @@ val Chain.isSwapSupported: Boolean
                 Chain.ZkSync,
                 Chain.Zcash,
                 Chain.Tron,
+                Chain.Ton,
                 Chain.Hyperliquid,
             )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -71,5 +71,15 @@ data class SwapKitSwapPayloadJson(
          * hashes `raw_data_hex` and re-assembles the broadcast envelope. Mirrors iOS' `"TRON"`.
          */
         const val TX_TYPE_TRON = "TRON"
+
+        /**
+         * `meta.txType` discriminator for the TON signing path. SwapKit returns `tx` as a
+         * `[{address, amount}]` array (raw nano-TON amounts) JSON-encoded into [txPayload]. A TON
+         * SwapKit swap is a plain native transfer to the deposit [targetAddress] — routing is by
+         * the deposit address itself (Chainflip / NEAR), no memo — so signing reuses the existing
+         * [com.vultisig.wallet.data.crypto.TonHelper] native path off `toAddress` / `toAmount`
+         * rather than a dedicated signer. Mirrors iOS' `"TON"`.
+         */
+        const val TX_TYPE_TON = "TON"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSolanaTx
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTonTransfer
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -25,6 +26,7 @@ import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -54,9 +56,10 @@ import timber.log.Timber
  *    backstopped with the L1-sized default, which would over-estimate L2 fees by multiples.
  *
  * Non-EVM/non-Solana `txType`s surface as a fully-formed [SwapQuote.SwapKit] for a per-chain signer
- * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]) and
- * TRON (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]) are wired
- * today. The remaining types (TON, SUI, CARDANO, RIPPLE, …) still surface as
+ * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]), TRON
+ * (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]) and TON
+ * (transfer array, signed via the native [com.vultisig.wallet.data.crypto.TonHelper] path) are
+ * wired today. The remaining types (SUI, CARDANO, RIPPLE, …) still surface as
  * [SwapKitError.UnsupportedTxType] so the picker falls back to another provider rather than signing
  * garbage, until their signers land. `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are
  * aliased; SwapKit flipped them once before.
@@ -157,10 +160,10 @@ constructor(
             swapResponse.providers.firstOrNull()?.takeIf { it.isNotBlank() }
                 ?: swapResponse.meta.subProvider?.takeIf { it.isNotBlank() }
 
-        // EVM + Solana ride the EVMSwapQuoteJson envelope (Solana signers pull the base64 blob from
-        // `tx.data`, matching how JupiterQuoteSource stages a Solana swap). PSBT (Bitcoin) and the
-        // other non-EVM txTypes can't fit that shape, so they surface as a fully-formed
-        // SwapQuote.SwapKit on the Native result for a per-chain signer to consume.
+        // EVM + Solana ride the EVMSwapQuoteJson envelope (Solana signers pull the base64 blob
+        // from `tx.data`, matching how JupiterQuoteSource stages a Solana swap). PSBT (Bitcoin),
+        // TRON and TON can't fit that shape, so they surface as a fully-formed SwapQuote.SwapKit
+        // on the Native result for a per-chain signer to consume.
         return when (txTypeOf(swapResponse)) {
             TxKind.EVM,
             TxKind.SOLANA ->
@@ -175,7 +178,8 @@ constructor(
                     subProvider = subProvider,
                 )
             TxKind.PSBT,
-            TxKind.TRON ->
+            TxKind.TRON,
+            TxKind.TON ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -259,7 +263,8 @@ constructor(
      */
     private fun nativeDecimals(chain: Chain): Int =
         when (chain) {
-            Chain.Solana -> 9
+            Chain.Solana,
+            Chain.Ton -> 9
             Chain.Bitcoin -> 8
             Chain.Tron -> 6
             else -> 18
@@ -369,21 +374,23 @@ constructor(
                         ),
                 )
             }
-            // PSBT/TRON are dispatched to buildSwapKitNativeQuote before reaching here; the arm
+            // PSBT/TRON/TON are dispatched to buildSwapKitNativeQuote before reaching here; the arm
             // keeps the `when` exhaustive and refuses anything that slips through.
             TxKind.PSBT,
             TxKind.TRON,
+            TxKind.TON,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
 
     /**
-     * Wrap a non-EVM SwapKit route (Phase 2: Bitcoin / PSBT) into a fully-formed
-     * [SwapQuote.SwapKit] for a per-chain signer to consume. The unsigned-tx bytes (base64 PSBT)
-     * land in [SwapKitSwapPayloadJson.txPayload]; the inbound fee is the source chain's native-unit
-     * deposit cost (same surface as the EVM/Solana path). The signing side is wired separately —
-     * until it (and the provider table) enable SwapKit on these chains, this path isn't reached in
-     * production; it's exercised by unit tests so the data contract is pinned ahead of the signer.
+     * Wrap a non-EVM SwapKit route (Bitcoin PSBT, TRON object, TON transfer array) into a
+     * fully-formed [SwapQuote.SwapKit] for a per-chain signer to consume. The unsigned-tx bytes
+     * land in [SwapKitSwapPayloadJson.txPayload] ([encodeNativeTxPayload]); the inbound fee is the
+     * source chain's native-unit deposit cost (same surface as the EVM/Solana path).
+     * [targetAddress] is the source-chain deposit address — for TON it doubles as the native
+     * transfer destination ([com.vultisig.wallet.data.crypto.TonHelper] signs off `toAddress` /
+     * `toAmount`).
      */
     private fun buildSwapKitNativeQuote(
         response: SwapKitSwapResponseJson,
@@ -434,6 +441,9 @@ constructor(
      * - TRON → a TronWeb-shaped JSON object (`{txID, raw_data, raw_data_hex, …}`). We UTF-8 encode
      *   the object verbatim so the cosigning peer reconstructs it and [SwapKitTronSigner] can pull
      *   `raw_data_hex`. Matches iOS' `buildSwapKitTronPayload`.
+     * - TON → a `[{address, amount}]` transfer array. We decode, validate every amount is an
+     *   integer (so a malformed transfer is rejected at quote time, not keysign), then re-encode
+     *   the validated transfers canonically. Matches iOS' `buildSwapKitTonPayload` byte-for-byte.
      */
     private fun encodeNativeTxPayload(response: SwapKitSwapResponseJson): ByteArray =
         when (txTypeOf(response)) {
@@ -452,7 +462,33 @@ constructor(
                     ?: throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
                 json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
             }
+            TxKind.TON -> {
+                val transfers = decodeTonTransfers(response.tx)
+                if (transfers.isEmpty()) {
+                    throw SwapKitError.Decoding("SwapKit TON tx is an empty transfer array")
+                }
+                // Reject any non-integer amount up front (nano-TON is an integer) so a malformed
+                // transfer falls back to another provider here rather than failing at keysign.
+                transfers.forEachIndexed { index, transfer ->
+                    transfer.amount.toBigIntegerOrNull()
+                        ?: throw SwapKitError.Decoding(
+                            "SwapKit TON transfer[$index] amount is not an integer: ${transfer.amount}"
+                        )
+                }
+                json.encodeToString(transfers).encodeToByteArray()
+            }
             else -> decodeBinaryTx(response.tx)
+        }
+
+    /**
+     * Decode SwapKit's TON `tx` (`[{address, amount}]`) into [SwapKitTonTransfer]s, wrapping any
+     * shape mismatch as [SwapKitError.Decoding] so the picker can fall back to another provider.
+     */
+    private fun decodeTonTransfers(element: JsonElement): List<SwapKitTonTransfer> =
+        try {
+            json.decodeFromJsonElement<List<SwapKitTonTransfer>>(element)
+        } catch (e: Exception) {
+            throw SwapKitError.Decoding("Failed to decode SwapKit TON transfer array", cause = e)
         }
 
     /**
@@ -489,6 +525,7 @@ constructor(
             "serialized_base64" -> TxKind.SOLANA
             "psbt" -> TxKind.PSBT
             "tron" -> TxKind.TRON
+            "ton" -> TxKind.TON
             else -> TxKind.UNSUPPORTED
         }
 
@@ -523,6 +560,7 @@ constructor(
         SOLANA,
         PSBT,
         TRON,
+        TON,
         UNSUPPORTED,
     }
 
@@ -583,6 +621,7 @@ constructor(
             Chain.Solana -> "SOL"
             Chain.Bitcoin -> "BTC"
             Chain.Tron -> "TRON"
+            Chain.Ton -> "TON"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -130,13 +130,17 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             // raw_data_hex). Mirrors iOS' `.tron → [.thorchain, .swapkit]`.
             Chain.Tron -> setOf(SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
 
+            // SwapKit TON routes are a plain native deposit transfer signed via TonHelper. TON has
+            // no native Thor/Maya route on Android, so it is SwapKit-only. Mirrors iOS'
+            // `.ton → [.swapkit]`.
+            Chain.Ton -> setOf(SwapProvider.SWAPKIT)
+
             Chain.Hyperliquid -> setOf(SwapProvider.LIFI)
 
             Chain.Polkadot,
             Chain.Bittensor,
             Chain.Dydx,
             Chain.Sui,
-            Chain.Ton,
             Chain.Osmosis,
             Chain.Terra,
             Chain.TerraClassic,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -7,10 +7,12 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteResponseJson
 import com.vultisig.wallet.data.api.models.quotes.SwapKitRoute
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTonTransfer
 import com.vultisig.wallet.data.api.models.quotes.SwapKitTxMeta
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
 import io.mockk.coEvery
@@ -24,7 +26,9 @@ import java.util.Base64
 import java.util.Locale
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -504,9 +508,8 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch throws UnsupportedTxType for a still-unwired non-EVM txType`() = runTest {
-        // PSBT (Bitcoin) and TRON are now wired to a Native SwapQuote.SwapKit; the remaining
-        // non-EVM
-        // txTypes (TON/SUI/CARDANO/RIPPLE) still have no signer, so they surface as
+        // PSBT (Bitcoin), TRON and TON are now wired to a Native SwapQuote.SwapKit; the remaining
+        // non-EVM txTypes (SUI/CARDANO/RIPPLE) still have no signer, so they surface as
         // UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -945,6 +948,154 @@ internal class SwapKitQuoteSourceTest {
         }
     }
 
+    @Test
+    fun `fetch decodes a TON route into a Native SwapQuote SwapKit with the transfer array as txPayload`() =
+        runTest {
+            // TON's tx is a [{address, amount}] array of raw nano-TON. The source validates every
+            // amount and re-encodes the canonical array into txPayload; the deposit address is
+            // targetAddress and the on-chain debit is the user's send amount (fromAmount), matching
+            // iOS. Signing reuses the native TonHelper path. The inbound TON fee scales by 9
+            // native decimals.
+            every { config.isFeatureEnabled } returns flowOf(true)
+            val ton = tonCoin()
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r-ton",
+                                providers = listOf("CHAINFLIP"),
+                                expectedBuy = "385.24",
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                tonSwapResponse(
+                    transfers = listOf("EQvault" to "5000000000"),
+                    expectedBuy = "385.24",
+                    fees = listOf(SwapKitFee(type = "inbound", chain = "TON", amount = "0.05")),
+                )
+
+            val result =
+                source()
+                    .fetch(
+                        request(
+                            srcToken = ton,
+                            dstToken = ethCoin(),
+                            tokenValue = TokenValue(BigInteger("5000000000"), ton),
+                        )
+                    ) as SwapQuoteResult.Native
+            val quote = result.quote as SwapQuote.SwapKit
+
+            assertEquals("CHAINFLIP", quote.subProvider)
+            assertEquals(SwapKitSwapPayloadJson.TX_TYPE_TON, quote.data.txType)
+            assertEquals("EQvault", quote.data.targetAddress)
+            assertEquals("ton-swap-1", quote.data.swapId)
+            assertEquals(ton, quote.data.fromCoin)
+            assertEquals(ethCoin(), quote.data.toCoin)
+            // fromAmount is the user's send amount (iOS' fromAmountInCoin), not echoed from tx.
+            assertEquals(BigInteger("5000000000"), quote.data.fromAmount)
+            // txPayload is the canonical transfer array — round-trips to the same address + amount.
+            val decoded =
+                Json { ignoreUnknownKeys = true }
+                    .decodeFromString<List<SwapKitTonTransfer>>(
+                        quote.data.txPayload.decodeToString()
+                    )
+            assertEquals(1, decoded.size)
+            assertEquals("EQvault", decoded[0].address)
+            assertEquals("5000000000", decoded[0].amount)
+            // 385.24 ETH (dst, 18 dp) = 385.24 × 10^18.
+            assertEquals(BigInteger("385240000000000000000"), quote.expectedDstValue.value)
+            // 0.05 TON inbound fee scaled by 9 native decimals = 50_000_000 nanoTON.
+            assertEquals(BigInteger("50000000"), quote.fees.value)
+            assertEquals("TON", quote.fees.unit)
+            assertEquals(9, quote.fees.decimals)
+        }
+
+    @Test
+    fun `fetch carries multiple TON transfers verbatim in the canonical txPayload bytes`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            val ton = tonCoin()
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes = listOf(route(routeId = "r", providers = listOf("CHAINFLIP")))
+                )
+            coEvery { api.swap(any()) } returns
+                tonSwapResponse(
+                    transfers = listOf("EQvault1" to "500000000", "EQvault2" to "500000000")
+                )
+
+            val result =
+                source().fetch(request(srcToken = ton, dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+            val quote = result.quote as SwapQuote.SwapKit
+
+            // The leading transfer address is the deposit target; the full set is kept in
+            // txPayload.
+            assertEquals("EQvault1", quote.data.targetAddress)
+            val decoded =
+                Json { ignoreUnknownKeys = true }
+                    .decodeFromString<List<SwapKitTonTransfer>>(
+                        quote.data.txPayload.decodeToString()
+                    )
+            assertEquals(2, decoded.size)
+            assertEquals("EQvault2", decoded[1].address)
+            assertEquals("500000000", decoded[1].amount)
+        }
+
+    @Test
+    fun `fetch throws Decoding when a TON transfer amount is not an integer`() = runTest {
+        // A non-integer nano-TON amount must be rejected at quote time so route selection falls
+        // back
+        // cleanly instead of failing at keysign. Covers every transfer, not just the first.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns
+            tonSwapResponse(transfers = listOf("EQvault" to "1000000000", "EQvault2" to "1.5"))
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = tonCoin())) }
+    }
+
+    @Test
+    fun `fetch throws Decoding when the TON tx is an empty transfer array`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonArray(emptyList()),
+                meta = SwapKitTxMeta(txType = "TON"),
+                targetAddress = "EQvault",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = tonCoin())) }
+    }
+
+    @Test
+    fun `fetch throws Decoding when the TON tx is not a transfer array`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonObject(emptyMap()),
+                meta = SwapKitTxMeta(txType = "TON"),
+                targetAddress = "EQvault",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = tonCoin())) }
+    }
+
     // ---- helpers ----
 
     private fun request(
@@ -1010,6 +1161,32 @@ internal class SwapKitQuoteSourceTest {
             providers = providers,
         )
 
+    private fun tonSwapResponse(
+        transfers: List<Pair<String, String>>,
+        swapId: String? = "ton-swap-1",
+        targetAddress: String? = transfers.firstOrNull()?.first,
+        expectedBuy: String? = "1",
+        providers: List<String> = listOf("CHAINFLIP"),
+        fees: List<SwapKitFee> = emptyList(),
+    ) =
+        SwapKitSwapResponseJson(
+            swapId = swapId,
+            tx =
+                JsonArray(
+                    transfers.map { (address, amount) ->
+                        buildJsonObject {
+                            put("address", JsonPrimitive(address))
+                            put("amount", JsonPrimitive(amount))
+                        }
+                    }
+                ),
+            meta = SwapKitTxMeta(txType = "TON"),
+            targetAddress = targetAddress,
+            expectedBuyAmount = expectedBuy,
+            fees = fees,
+            providers = providers,
+        )
+
     private fun ethCoin() =
         Coin(
             chain = Chain.Ethereum,
@@ -1060,5 +1237,18 @@ internal class SwapKitQuoteSourceTest {
             priceProviderID = "tether",
             contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
             isNativeToken = false,
+        )
+
+    private fun tonCoin() =
+        Coin(
+            chain = Chain.Ton,
+            ticker = "TON",
+            logo = "",
+            address = "EQsender",
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "the-open-network",
+            contractAddress = "",
+            isNativeToken = true,
         )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -41,6 +41,7 @@ internal class SwapProviderTableTest {
                 coin(Chain.Bitcoin, "BTC", isNative = true), // BTC PSBT route
                 coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
                 coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
+                coin(Chain.Ton, "TON", isNative = true), // TON native deposit route
             )
 
         swapKitCoins.forEach { c ->
@@ -70,7 +71,6 @@ internal class SwapProviderTableTest {
                 coin(Chain.Zcash, "ZEC", isNative = true),
                 coin(Chain.Ripple, "XRP", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
-                coin(Chain.Ton, "TON", isNative = true),
                 coin(Chain.Sui, "SUI", isNative = true),
                 coin(Chain.Cardano, "ADA", isNative = true),
                 coin(Chain.Polkadot, "DOT", isNative = true),


### PR DESCRIPTION
## Description

Adds SwapKit swap support for TON, matching iOS/Windows. The SwapKit foundation already merged, so this is the TON-specific wiring on top — quote, sign, and broadcast.

SwapKit returns a TON swap as a `[{address, amount}]` array (nano-TON): a plain native deposit to the SwapKit address. Signing reuses the existing `TonHelper` native path off the payload's `toAddress`/`toAmount` (no `signTon`, same as iOS), and broadcast goes through the existing TON path.

- `Chain.isSwapSupported` + `SwapProviderTable`: TON → SwapKit-only (no native Thor/Maya route)
- `SwapKitQuoteSource`: decode and validate the TON transfer array; `TON` asset prefix, 9 decimals
- `SigningHelper`: route `TX_TYPE_TON` to `TonHelper`
- `SwapFormViewModel`: allow TON through the SwapKit guard

Supersedes #4636

Testing: `:data:testDebugUnitTest`, `:app:testDebugUnitTest --tests "*Swap*"`, `:app:lintDebug`, ktfmt — green.


## Testing

### Tx hashes

ETH -> TON
https://etherscan.io/tx/0xd690bc02a632118071eeae865d254afd110c41eea3c4dc9bd0e437594fd02bcb

TON -> SOL
https://tonviewer.com/transaction/f5055c427af3a0112f959d09200bd87fbb992e8f8e2fc46855e0b490af4f9470

### Screenshots
<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/ed0eb54f-967c-4b6d-8cc8-b006deb95cce" />

<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/a2ff48e1-e9b3-490e-9089-923c482e129a" />

<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/3b292188-118c-4854-a863-c8c38f8f8a7b" />

<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/fd4c5850-b745-4e53-a68b-28ff0cf1e722" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native TON (The Open Network) support in swaps: TON routes, transaction encoding, signing, and quote handling; TON pairs are now offered by the swap provider.

* **Tests**
  * Added end-to-end and negative tests covering TON swap decoding, payload validation, provider routing, and fee/amount scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->