### PR TITLE
feat(swap): SwapKit XRP signer (Payment + destination tag) (#4701)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,14 +475,15 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT, TRON (TronWeb object), and SUI (PTB) are wired; the
-                                // remaining SwapKit txTypes (TON / ADA) land with their per-chain
-                                // signers. Guarded loudly so an un-wired txType can't reach
-                                // signing.
+                                // BTC PSBT, TRON (TronWeb object), SUI (PTB), and XRP (deposit-only
+                                // native Payment) are wired; the remaining SwapKit txTypes (TON /
+                                // ADA) land with their per-chain signers. Guarded loudly so an
+                                // un-wired txType can't reach signing.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI ||
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_XRP
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
@@ -4,6 +4,7 @@ import java.util.Locale
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 
 /**
  * Body sent to `POST /v3/swap`. Per the SwapKit V3 docs the caller picks a route by [routeId] and
@@ -26,7 +27,9 @@ data class SwapKitSwapRequest(
 @Serializable
 data class SwapKitSwapResponseJson(
     @SerialName("swapId") val swapId: String? = null,
-    @SerialName("tx") val tx: JsonElement,
+    // Defaults to [JsonNull] so deposit-only routes (XRP) that omit `tx` still decode — the body is
+    // only read by the EVM/Solana/PSBT/TRON/SUI paths, which always carry it.
+    @SerialName("tx") val tx: JsonElement = JsonNull,
     @SerialName("meta") val meta: SwapKitTxMeta,
     @SerialName("targetAddress") val targetAddress: String? = null,
     @SerialName("expectedBuyAmount") val expectedBuyAmount: String? = null,
@@ -35,6 +38,12 @@ data class SwapKitSwapResponseJson(
     // refreshed /v3/swap reply stays fresh. Mirrors iOS' SwapKitSwapResponse.fees.
     @SerialName("fees") val fees: List<SwapKitFee> = emptyList(),
     @SerialName("providers") val providers: List<String> = emptyList(),
+    // XRP destination tag. SwapKit surfaces it (rarely) as a numeric or string-encoded value at the
+    // top level; kept as a raw [JsonElement] and parsed defensively so a number-vs-string wire flip
+    // doesn't break decoding. Resolution order (highest first): top-level → [SwapKitTxMeta] →
+    // `?dt=`/`|` suffix on [targetAddress]. Mirrors iOS'
+    // SwapKitSwapResponse.resolvedDestinationTag.
+    @SerialName("destinationTag") val destinationTag: JsonElement? = null,
     @SerialName("error") val error: String? = null,
     @SerialName("message") val message: String? = null,
 )
@@ -53,6 +62,9 @@ data class SwapKitTxMeta(
     // Null for native-source / non-EVM routes that need no approval. Mirrors iOS, which derives
     // the spender as `meta.approvalAddress`.
     @SerialName("approvalAddress") val approvalAddress: String? = null,
+    // XRP destination tag carried in meta (beats the address suffix, loses to the top-level field).
+    // Raw [JsonElement] for the same number-or-string defensiveness as the top-level field.
+    @SerialName("destinationTag") val destinationTag: JsonElement? = null,
 ) {
     /**
      * Lower-cased txType used to dispatch onto an EVM or Solana signer. Computed once at

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -120,6 +120,15 @@ object SigningHelper {
                             SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                                 SwapKitSuiSigner(eddsaKey)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
+                            // XRP is deposit-only: no SwapKit signer. SwapPayloadBuilder already
+                            // pointed the KeysignPayload's toAddress / toAmount / memo at the
+                            // deposit r-address, amount, and destination tag, so we reuse the
+                            // native
+                            // RippleHelper path (which turns a numeric memo into the
+                            // destinationTag).
+                            // Matches iOS, which lets XRP fall through to the per-chain helper.
+                            SwapKitSwapPayloadJson.TX_TYPE_XRP ->
+                                RippleHelper.getPreSignedImageHash(payload)
                             else ->
                                 error(
                                     "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
@@ -317,6 +326,13 @@ object SigningHelper {
                         SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                             SwapKitSuiSigner(eddsaKey)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        // XRP deposit-only: rebuild + sign a plain XRP Payment off the
+                        // KeysignPayload (toAddress / toAmount / memo) via the native RippleHelper.
+                        SwapKitSwapPayloadJson.TX_TYPE_XRP ->
+                            RippleHelper.getSignedTransaction(
+                                keysignPayload = keysignPayload,
+                                signatures = signatures,
+                            )
                         else ->
                             error(
                                 "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -79,5 +79,14 @@ data class SwapKitSwapPayloadJson(
          * Sui's submit envelope. Mirrors iOS' `"SUI"`.
          */
         const val TX_TYPE_SUI = "SUI"
+
+        /**
+         * `meta.txType` discriminator for the XRP (Ripple) deposit-only path. SwapKit returns no
+         * transaction body — only a deposit r-address (and optional destination tag). [txPayload]
+         * is empty; the cosigning peer rebuilds a plain XRP Payment to [targetAddress] for
+         * [fromAmount] via the existing `RippleHelper`, attaching the destination tag carried in
+         * [memo]. Mirrors iOS' `"XRP"`.
+         */
+        const val TX_TYPE_XRP = "XRP"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -56,11 +56,13 @@ import timber.log.Timber
  * Non-EVM/non-Solana `txType`s surface as a fully-formed [SwapQuote.SwapKit] for a per-chain signer
  * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]), TRON
  * (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]), and SUI
- * (base64 PTB, via [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner]) are wired today. The
- * remaining types (TON, CARDANO, RIPPLE, …) still surface as [SwapKitError.UnsupportedTxType] so
- * the picker falls back to another provider rather than signing garbage, until their signers land.
- * `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once
- * before.
+ * (base64 PTB, via [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner]) are wired today. XRP
+ * is deposit-only — SwapKit returns no tx body, so the payload carries an empty [txPayload] plus
+ * the deposit address + destination tag and the cosigning peer rebuilds a plain XRP Payment via the
+ * existing `RippleHelper`. The remaining types (TON, CARDANO, …) still surface as
+ * [SwapKitError.UnsupportedTxType] so the picker falls back to another provider rather than signing
+ * garbage, until their signers land. `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are
+ * aliased; SwapKit flipped them once before.
  */
 internal class SwapKitQuoteSource
 @Inject
@@ -177,7 +179,8 @@ constructor(
                 )
             TxKind.PSBT,
             TxKind.TRON,
-            TxKind.SUI ->
+            TxKind.SUI,
+            TxKind.XRP ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -265,6 +268,7 @@ constructor(
             Chain.Sui -> 9
             Chain.Bitcoin -> 8
             Chain.Tron -> 6
+            Chain.Ripple -> 6
             else -> 18
         }
 
@@ -372,11 +376,12 @@ constructor(
                         ),
                 )
             }
-            // PSBT/TRON/SUI are dispatched to buildSwapKitNativeQuote before reaching here; the arm
-            // keeps the `when` exhaustive and refuses anything that slips through.
+            // PSBT/TRON/SUI/XRP are dispatched to buildSwapKitNativeQuote before reaching here; the
+            // arm keeps the `when` exhaustive and refuses anything that slips through.
             TxKind.PSBT,
             TxKind.TRON,
             TxKind.SUI,
+            TxKind.XRP,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
@@ -398,11 +403,22 @@ constructor(
         val srcToken = request.srcToken
         val dstToken = request.dstToken
         val toAmountDecimal = parseExpectedBuyAmount(response.expectedBuyAmount)
-        // Deposit-only chains (Cardano / XRP) route entirely on `targetAddress`, so a blank value
-        // would stage an unspendable quote — refuse it rather than emit a quote that can't settle.
-        val targetAddress =
+        val isXrp = txTypeOf(response) == TxKind.XRP
+        // Deposit-only chains (XRP) route entirely on `targetAddress`, so a blank value would stage
+        // an unspendable quote — refuse it rather than emit a quote that can't settle. For XRP the
+        // address may carry a `?dt=`/`|` destination-tag suffix; strip it so only the bare
+        // r-address
+        // is used as the payment destination (the tag rides `memo`).
+        val rawTargetAddress =
             response.targetAddress?.takeIf { it.isNotBlank() }
                 ?: throw SwapKitError.Decoding("SwapKit non-EVM response missing targetAddress")
+        val targetAddress =
+            if (isXrp) extractTagSuffix(rawTargetAddress).first else rawTargetAddress
+        // XRP destination tag (rare): top-level field → meta → address suffix. Carried as a numeric
+        // string in `memo`; RippleHelper parses a numeric memo into the RippleOperationPayment's
+        // destinationTag. Mirrors iOS' resolvedDestinationTag.
+        val memo =
+            if (isXrp) resolveDestinationTag(response, rawTargetAddress)?.toString() else null
         val payload =
             SwapKitSwapPayloadJson(
                 fromCoin = srcToken,
@@ -412,7 +428,7 @@ constructor(
                 txType = response.meta.txType,
                 txPayload = encodeNativeTxPayload(response),
                 targetAddress = targetAddress,
-                memo = null,
+                memo = memo,
                 subProvider = subProvider.orEmpty(),
                 swapId = response.swapId.orEmpty(),
             )
@@ -456,8 +472,57 @@ constructor(
                     ?: throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
                 json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
             }
+            // XRP is deposit-only: SwapKit returns no transaction body. The cosigning peer rebuilds
+            // a plain XRP Payment from the payload's targetAddress / fromAmount / memo, so there is
+            // nothing to carry here.
+            TxKind.XRP -> ByteArray(0)
             else -> decodeBinaryTx(response.tx)
         }
+
+    /**
+     * Resolve the XRP destination tag, highest priority first: top-level `destinationTag` → meta →
+     * `?dt=`/`|` suffix on the (raw, un-stripped) target address. Each numeric source is parsed
+     * defensively (number or string). Mirrors iOS' `resolvedDestinationTag`.
+     */
+    private fun resolveDestinationTag(
+        response: SwapKitSwapResponseJson,
+        rawTargetAddress: String,
+    ): Long? =
+        tagLongOrNull(response.destinationTag)
+            ?: tagLongOrNull(response.meta.destinationTag)
+            ?: extractTagSuffix(rawTargetAddress).second
+
+    /** Parse a destination tag that may arrive as a JSON number or a numeric string. */
+    private fun tagLongOrNull(element: JsonElement?): Long? =
+        (element as? JsonPrimitive)?.content?.trim()?.toLongOrNull()
+
+    /**
+     * Split an XRP target address into its bare r-address and an optional destination tag carried
+     * as a `?dt=N` query parameter or a `|N` suffix. Returns the address verbatim with a null tag
+     * when neither form is present. Mirrors iOS' `extractTagSuffix`.
+     */
+    private fun extractTagSuffix(address: String): Pair<String, Long?> {
+        val q = address.indexOf('?')
+        if (q >= 0) {
+            val bare = address.substring(0, q)
+            val tag =
+                address
+                    .substring(q + 1)
+                    .split('&')
+                    .filter { it.isNotEmpty() }
+                    .firstNotNullOfOrNull { pair ->
+                        val parts = pair.split('=', limit = 2)
+                        if (parts.size == 2 && parts[0] == "dt") parts[1].toLongOrNull() else null
+                    }
+            return bare to tag
+        }
+        val pipe = address.indexOf('|')
+        if (pipe >= 0) {
+            val tag = address.substring(pipe + 1).toLongOrNull()
+            if (tag != null) return address.substring(0, pipe) to tag
+        }
+        return address to null
+    }
 
     /**
      * Decode a base64 unsigned-tx blob (PSBT today; PTB / CBOR as more chains land) from `tx` into
@@ -494,6 +559,10 @@ constructor(
             "psbt" -> TxKind.PSBT
             "tron" -> TxKind.TRON
             "sui" -> TxKind.SUI
+            // SwapKit has shipped both `XRP` (canonical) and `RIPPLE` for the same deposit-only
+            // flow; accept both so a wire flip doesn't drop the route. Mirrors iOS.
+            "xrp",
+            "ripple" -> TxKind.XRP
             else -> TxKind.UNSUPPORTED
         }
 
@@ -529,6 +598,7 @@ constructor(
         PSBT,
         TRON,
         SUI,
+        XRP,
         UNSUPPORTED,
     }
 
@@ -590,6 +660,7 @@ constructor(
             Chain.Bitcoin -> "BTC"
             Chain.Tron -> "TRON"
             Chain.Sui -> "SUI"
+            Chain.Ripple -> "XRP"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -541,7 +541,16 @@ constructor(
 
     /** Parse a destination tag that may arrive as a JSON number or a numeric string. */
     private fun tagLongOrNull(element: JsonElement?): Long? =
-        (element as? JsonPrimitive)?.content?.trim()?.toLongOrNull()
+        (element as? JsonPrimitive)?.content?.destinationTagOrNull()
+
+    /**
+     * Parse a destination-tag string, rejecting anything outside XRP's uint32 `DestinationTag`
+     * range. Signed `toLongOrNull` would otherwise let a negative or `>2^32-1` wire value flow
+     * through `memo` onto the uint32 field; iOS rejects the same with `UInt64(...)` and emits no
+     * tag.
+     */
+    private fun String.destinationTagOrNull(): Long? =
+        trim().toLongOrNull()?.takeIf { it in 0..0xFFFFFFFFL }
 
     /**
      * Split an XRP target address into its bare r-address and an optional destination tag carried
@@ -559,21 +568,21 @@ constructor(
                     .filter { it.isNotEmpty() }
                     .firstNotNullOfOrNull { pair ->
                         val parts = pair.split('=', limit = 2)
-                        if (parts.size == 2 && parts[0] == "dt") parts[1].toLongOrNull() else null
+                        if (parts.size == 2 && parts[0] == "dt") parts[1].destinationTagOrNull()
+                        else null
                     }
             return bare to tag
         }
         val pipe = address.indexOf('|')
         if (pipe >= 0) {
-            // A `|` unambiguously announces a destination tag. If the suffix isn't numeric the
-            // response is malformed — fail the route rather than pass `rAddr|abc` through as the
-            // XRP
-            // destination (unsignable) or silently drop a tag the deposit may require to be
-            // credited.
+            // A `|` unambiguously announces a destination tag. If the suffix isn't a valid uint32
+            // tag the response is malformed — fail the route rather than pass `rAddr|abc` through
+            // as the XRP destination (unsignable) or silently drop a tag the deposit may require to
+            // be credited.
             val tag =
-                address.substring(pipe + 1).toLongOrNull()
+                address.substring(pipe + 1).destinationTagOrNull()
                     ?: throw SwapKitError.Decoding(
-                        "SwapKit XRP targetAddress has a non-numeric destination-tag suffix"
+                        "SwapKit XRP targetAddress has an invalid destination-tag suffix"
                     )
             return address.substring(0, pipe) to tag
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -425,7 +425,11 @@ constructor(
                 toCoin = dstToken,
                 fromAmount = request.tokenValue.value,
                 toAmountDecimal = toAmountDecimal,
-                txType = response.meta.txType,
+                // Store the canonical discriminator, NOT the raw wire value: SwapKit ships XRP as
+                // either `XRP` or `RIPPLE`, so persisting `meta.txType` verbatim would make the
+                // signing-side gate (which matches TX_TYPE_XRP) reject a `RIPPLE` route. Mirrors
+                // iOS, which normalises the payload txType in buildSwapKitRipplePayload.
+                txType = canonicalTxType(response),
                 txPayload = encodeNativeTxPayload(response),
                 targetAddress = targetAddress,
                 memo = memo,
@@ -477,6 +481,23 @@ constructor(
             // nothing to carry here.
             TxKind.XRP -> ByteArray(0)
             else -> decodeBinaryTx(response.tx)
+        }
+
+    /**
+     * Map the route onto the canonical [SwapKitSwapPayloadJson] txType discriminator the signing
+     * side dispatches on — independent of the raw `meta.txType` casing/aliasing (e.g. SwapKit's
+     * `XRP` vs `RIPPLE`). Only the native (non-EVM/Solana) kinds reach [buildSwapKitNativeQuote].
+     */
+    private fun canonicalTxType(response: SwapKitSwapResponseJson): String =
+        when (txTypeOf(response)) {
+            TxKind.PSBT -> SwapKitSwapPayloadJson.TX_TYPE_PSBT
+            TxKind.TRON -> SwapKitSwapPayloadJson.TX_TYPE_TRON
+            TxKind.SUI -> SwapKitSwapPayloadJson.TX_TYPE_SUI
+            TxKind.XRP -> SwapKitSwapPayloadJson.TX_TYPE_XRP
+            // EVM/Solana ride the EVM envelope and never reach the native-quote builder; fall back
+            // to the raw value so an unexpected kind still surfaces a descriptive
+            // UnsupportedTxType.
+            else -> response.meta.txType
         }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -539,8 +539,17 @@ constructor(
         }
         val pipe = address.indexOf('|')
         if (pipe >= 0) {
-            val tag = address.substring(pipe + 1).toLongOrNull()
-            if (tag != null) return address.substring(0, pipe) to tag
+            // A `|` unambiguously announces a destination tag. If the suffix isn't numeric the
+            // response is malformed — fail the route rather than pass `rAddr|abc` through as the
+            // XRP
+            // destination (unsignable) or silently drop a tag the deposit may require to be
+            // credited.
+            val tag =
+                address.substring(pipe + 1).toLongOrNull()
+                    ?: throw SwapKitError.Decoding(
+                        "SwapKit XRP targetAddress has a non-numeric destination-tag suffix"
+                    )
+            return address.substring(0, pipe) to tag
         }
         return address to null
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -124,7 +124,10 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                     )
                 else setOf(SwapProvider.JUPITER, SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
-            Chain.Ripple -> setOf(SwapProvider.THORCHAIN)
+            // SwapKit XRP is deposit-only — no signer; the native RippleHelper builds the Payment
+            // to
+            // SwapKit's deposit r-address. Mirrors iOS' `.ripple → [.thorchain, .swapkit]`.
+            Chain.Ripple -> setOf(SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
 
             // SwapKit TRON routes are signed by SwapKitTronSigner (TronWeb object → sha256 of
             // raw_data_hex). Mirrors iOS' `.tron → [.thorchain, .swapkit]`.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -928,6 +928,29 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch normalises a RIPPLE wire txType to the canonical XRP discriminator`() = runTest {
+        // SwapKit ships XRP as either "XRP" or "RIPPLE". The payload must carry the canonical
+        // TX_TYPE_XRP so the signing-side gate (which matches "XRP") accepts a "RIPPLE" route —
+        // otherwise pressing Swap throws "Unsupported SwapKit txType for swap: RIPPLE".
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "RIPPLE"),
+                targetAddress = "rDepositAddr123",
+                expectedBuyAmount = "1",
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertEquals("XRP", quote.data.txType)
+    }
+
+    @Test
     fun `fetch falls back to meta destinationTag when the top-level tag is absent`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -1042,6 +1042,72 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch drops an out-of-uint32-range top-level XRP destination tag`() = runTest {
+        // XRP's DestinationTag is uint32. A negative (or >2^32-1) wire value must not flow onto the
+        // field — emit no tag, matching iOS' UInt64 guard, rather than passing it through `memo`.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                targetAddress = "rDepositAddr123",
+                expectedBuyAmount = "1",
+                destinationTag = JsonPrimitive(-1L),
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertNull(quote.data.memo)
+        assertEquals("rDepositAddr123", quote.data.targetAddress)
+    }
+
+    @Test
+    fun `fetch accepts the max uint32 XRP destination tag`() = runTest {
+        // 2^32-1 is the largest valid DestinationTag — it must survive the range guard.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                targetAddress = "rDepositAddr123",
+                expectedBuyAmount = "1",
+                destinationTag = JsonPrimitive(4294967295L),
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertEquals("4294967295", quote.data.memo)
+    }
+
+    @Test
+    fun `fetch throws Decoding when the XRP pipe suffix is out of uint32 range`() = runTest {
+        // A `|` announces a tag; an out-of-uint32-range suffix is as malformed as a non-numeric
+        // one.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                targetAddress = "rDepositAddr123|4294967296",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = rippleCoin())) }
+    }
+
+    @Test
     fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -996,6 +996,48 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch extracts the XRP destination tag from the pipe suffix and strips it`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                // `|N` pipe form of the destination-tag suffix.
+                targetAddress = "rDepositAddr123|42",
+                expectedBuyAmount = "1",
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertEquals("42", quote.data.memo)
+        assertEquals("rDepositAddr123", quote.data.targetAddress)
+    }
+
+    @Test
+    fun `fetch throws Decoding when the XRP pipe suffix is non-numeric`() = runTest {
+        // A `|` announces a tag; a non-numeric suffix is malformed. Fail the route rather than pass
+        // an unsignable address (or silently drop a tag the deposit may require) downstream.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                targetAddress = "rDepositAddr123|abc",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = rippleCoin())) }
+    }
+
+    @Test
     fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -25,6 +25,7 @@ import java.util.Locale
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -887,6 +888,91 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch decodes an XRP route into a deposit-only Native SwapQuote SwapKit`() = runTest {
+        // XRP is deposit-only: SwapKit returns no tx body. The payload carries an empty txPayload
+        // plus the deposit r-address; the top-level destinationTag (numeric) rides `memo`. The
+        // inbound XRP fee scales by 6 native decimals (drops).
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val xrp = rippleCoin()
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(routeId = "r-xrp", providers = listOf("NEAR"), expectedBuy = "9.1")
+                    )
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "xrp-swap-1",
+                tx = JsonNull, // deposit-only: no body
+                meta = SwapKitTxMeta(txType = "XRP"),
+                targetAddress = "rDepositAddr123",
+                expectedBuyAmount = "9.1",
+                destinationTag = JsonPrimitive(123456L),
+                fees = listOf(SwapKitFee(type = "inbound", chain = "XRP", amount = "0.1")),
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = xrp, dstToken = ethCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+
+        assertEquals("XRP", quote.data.txType)
+        assertEquals(0, quote.data.txPayload.size) // deposit-only → no tx body
+        assertEquals("rDepositAddr123", quote.data.targetAddress)
+        assertEquals("123456", quote.data.memo) // destination tag → numeric memo
+        assertEquals("xrp-swap-1", quote.data.swapId)
+        // 0.1 XRP inbound fee scaled by 6 native decimals = 100_000 drops.
+        assertEquals(BigInteger("100000"), quote.fees.value)
+        assertEquals("XRP", quote.fees.unit)
+    }
+
+    @Test
+    fun `fetch falls back to meta destinationTag when the top-level tag is absent`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                // Tag arrives string-encoded in meta — parsed defensively.
+                meta = SwapKitTxMeta(txType = "XRP", destinationTag = JsonPrimitive("77")),
+                targetAddress = "rDepositAddr123",
+                expectedBuyAmount = "1",
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertEquals("77", quote.data.memo)
+        assertEquals("rDepositAddr123", quote.data.targetAddress)
+    }
+
+    @Test
+    fun `fetch extracts the XRP destination tag from the address suffix and strips it`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-xrp", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonNull,
+                meta = SwapKitTxMeta(txType = "XRP"),
+                // No top-level / meta tag — the tag is a `?dt=` suffix on the address.
+                targetAddress = "rDepositAddr123?dt=42",
+                expectedBuyAmount = "1",
+            )
+
+        val result = source().fetch(request(srcToken = rippleCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+        assertEquals("42", quote.data.memo)
+        // Suffix stripped — only the bare r-address is the payment destination.
+        assertEquals("rDepositAddr123", quote.data.targetAddress)
+    }
+
+    @Test
     fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -1114,6 +1200,19 @@ internal class SwapKitQuoteSourceTest {
             decimal = 9,
             hexPublicKey = "pub",
             priceProviderID = "sui",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun rippleCoin() =
+        Coin(
+            chain = Chain.Ripple,
+            ticker = "XRP",
+            logo = "",
+            address = "rSenderAddr",
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "ripple",
             contractAddress = "",
             isNativeToken = true,
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -43,6 +43,7 @@ internal class SwapProviderTableTest {
                 coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
                 coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
                 coin(Chain.Sui, "SUI", isNative = true), // SUI PTB route
+                coin(Chain.Ripple, "XRP", isNative = true), // XRP deposit-only route
             )
 
         swapKitCoins.forEach { c ->
@@ -70,7 +71,6 @@ internal class SwapProviderTableTest {
                 coin(Chain.ThorChain, "RUNE", isNative = true),
                 coin(Chain.MayaChain, "CACAO", isNative = true),
                 coin(Chain.Zcash, "ZEC", isNative = true),
-                coin(Chain.Ripple, "XRP", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
                 coin(Chain.Ton, "TON", isNative = true),
                 coin(Chain.Cardano, "ADA", isNative = true),
@@ -91,7 +91,7 @@ internal class SwapProviderTableTest {
         // account screen. A chain can offer SWAPKIT in the provider table yet stay invisible to the
         // user if it is missing from isSwapSupported — the Sui regression that hid the button while
         // iOS showed it. Pin every SwapKit-wired native chain here.
-        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui).forEach { chain ->
+        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui, Chain.Ripple).forEach { chain ->
             assertTrue(
                 chain.isSwapSupported,
                 "$chain offers SWAPKIT but is not marked isSwapSupported — Swap button would hide",


### PR DESCRIPTION
Closes #4701.

## Summary

Wires SwapKit's **XRP** swap path end-to-end on Android, mirroring iOS. Unlike BTC/TRON/SUI (which carry a pre-built tx and a dedicated signer), **XRP is deposit-only**: SwapKit returns no transaction body — only a deposit r-address and an optional destination tag. There is no SwapKit signer; the cosigning peer rebuilds a plain XRP Payment to the deposit address for the sell amount and signs it with the existing `RippleHelper` (which already turns a numeric `memo` into the Payment's `destinationTag`).

### Tranasction hash:
https://xrpscan.com/tx/B64334E044B7DDF09A3CE75898B0D51AD030DD3E789CDC85D4CBC0F339EE59A5

## Changes

- **`SwapKitSwapPayloadJson`**: added `TX_TYPE_XRP`. The payload carries an empty `txPayload` plus the deposit address (`targetAddress`) and the destination tag (in `memo`).
- **`SwapKitSwapResponseJson`**: added top-level + `meta` `destinationTag` (decoded defensively as number-or-string), and `tx` now defaults to `JsonNull` so deposit-only responses that omit the body still decode.
- **`SwapKitQuoteSource`**:
  - `XRP` tx-kind (accepts both `XRP` and `RIPPLE`), `chainPrefix(Ripple) → "XRP"`, native decimals `6`.
  - Empty `txPayload` for XRP (no body).
  - 3-source destination-tag resolution — top-level field → `meta` → `?dt=`/`|` suffix on the address — with the suffix stripped off the bare r-address used as the payment destination (mirrors iOS' `resolvedDestinationTag` / `extractTagSuffix`).
- **`SigningHelper`**: XRP arm reuses `RippleHelper.getPreSignedImageHash` / `getSignedTransaction` in both dispatch sites (matches iOS letting XRP fall through to the per-chain helper).
- **`SwapProviderTable`**: `Chain.Ripple` now offers `SWAPKIT` (mirrors iOS `.ripple → [thorchain, swapkit]`). `Chain.Ripple` is already in `isSwapSupported`, so the Swap button shows.
- **`SwapFormViewModel`**: the SwapKit gate accepts XRP.

## Test plan

- New `SwapKitQuoteSourceTest` cases: an XRP route decodes into a deposit-only Native `SwapQuote.SwapKit` (empty `txPayload`, fee scaled by 6 decimals); the destination tag resolves from the top-level field, from `meta` (string-encoded), and from the `?dt=` address suffix (with stripping).
- Updated `SwapProviderTableTest` (Ripple moved into the SwapKit list + the swap-supported pin).
- `./gradlew :data:testDebugUnitTest` green; `:app` swap tests + both `compileDebugKotlin` green.

## Notes

- No new signer — XRP reuses the existing `RippleHelper`, so there's no JNI-only seam to worry about; the deposit Payment is the same one the normal XRP send path already produces and broadcasts.
- Live routability for XRP on the SwapKit proxy is subject to the same upstream/provider liquidity state noted for Sui; the wiring is correct and dormant until SwapKit serves XRP routes.
- Remaining iOS parity gaps after this: TON, ADA (Cardano — in progress by someone else), and the legacy-P2PKH UTXO chains (DOGE/BCH/DASH/ZEC/LTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XRP (Ripple) support for SwapKit routes as a deposit-only on‑ramp; destination-tag extraction and memo resolution improved; Swap availability updated so Ripple appears as a supported provider.

* **Tests**
  * Added unit tests covering XRP quote decoding, empty/absent transaction payloads, destination-tag parsing/validation, address-suffix handling, and provider availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
