### PR TITLE
fix(keysign): show dApp-supplied cosmos fee on join Network Fee row

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -1652,11 +1652,9 @@ constructor(
         }
 
     /**
-     * Network Fee for the join-keysign deposit and non-UTXO send paths. Prefers the dApp-supplied
-     * fee carried in the signed Cosmos message ([dappSuppliedNativeFee]) so Rujira/CosmWasm
-     * requests show the fee that is actually broadcast (issue #4390); otherwise falls back to
-     * [computeJoinKeysignNetworkFee]. [resolveFallbackFeeAmount] and its fee-service call only run
-     * when no dApp fee is present.
+     * Network Fee for the join-keysign deposit and non-UTXO send paths: the dApp-supplied fee when
+     * present ([dappSuppliedNativeFee], issue #4390), otherwise [computeJoinKeysignNetworkFee]. The
+     * fallback and its fee-service call only run when there is no dApp fee.
      */
     private suspend fun resolveJoinKeysignNetworkFee(
         payload: KeysignPayload,
@@ -1919,20 +1917,13 @@ internal fun defaultEvmSwapGasLimit(chain: Chain): BigInteger =
     else EthereumFeeService.DEFAULT_SWAP_LIMIT
 
 /**
- * The native-denom fee a dApp embedded in this keysign request, or `null` when it carries no
- * dApp-supplied Cosmos fee — i.e. a wallet-built native tx, where [KeysignPayload.signAmino] and
- * [KeysignPayload.signDirect] are both absent. Callers fall back to the estimated fee on `null`.
+ * The fee a dApp signed in [KeysignPayload.signAmino] or [KeysignPayload.signDirect], or `null` for
+ * a wallet-built native tx (both absent) so callers fall back to the estimate. The cosmos signers
+ * sign these bytes verbatim, so this is the fee actually broadcast — including the `0` Rujira uses
+ * today (issue #4390).
  *
- * Rujira/CosmWasm dApps put the fee they want signed in [KeysignPayload.signAmino] (Amino JSON) or
- * [KeysignPayload.signDirect] (`authInfo` protobuf), and `ThorChainHelper`/`CosmosHelper` sign
- * those bytes verbatim — so this is the fee actually broadcast, including the legitimate `0` Rujira
- * uses today. Reading it keeps the join Network Fee row in step with the signed message instead of
- * the wallet's own estimate (issue #4390).
- *
- * Only entries in the chain's [Chain.cosmosNativeDenom] are summed: a fee specified purely in
- * another denom yields `null` (fall back to the estimate) rather than mixing units on one row,
- * matching the Windows resolver. Returns `null` if any matched amount is unparseable, so the caller
- * never displays a misleading `0`.
+ * Only [Chain.cosmosNativeDenom] entries are summed; a fee in another denom, or an unparseable
+ * amount, yields `null` rather than a misleading `0`. Mirrors the Windows resolver.
  */
 internal fun KeysignPayload.dappSuppliedNativeFee(
     chain: Chain,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.data.models.TransactionHistoryData
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.cosmosNativeDenom
 import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.isSecuredAssetEligible
@@ -956,13 +957,12 @@ constructor(
 
                     val nativeCoin =
                         withContext(Dispatchers.IO) { tokenRepository.getNativeToken(chain.id) }
-                    val fallbackFeeAmount =
-                        resolveFallbackFeeAmount(payload.blockChainSpecific, blockchainTransaction)
                     val estimatedTokenFees =
-                        computeJoinKeysignNetworkFee(
-                            blockChainSpecific = payload.blockChainSpecific,
+                        resolveJoinKeysignNetworkFee(
+                            payload = payload,
+                            chain = chain,
                             nativeCoin = nativeCoin,
-                            fallbackFeeAmount = fallbackFeeAmount,
+                            blockchainTransaction = blockchainTransaction,
                         )
 
                     val totalGasAndFee =
@@ -1042,15 +1042,11 @@ constructor(
                             }
                             TokenValue(value = BigInteger.valueOf(plan.fee), token = nativeCoin)
                         } else {
-                            val fallbackFeeAmount =
-                                resolveFallbackFeeAmount(
-                                    payload.blockChainSpecific,
-                                    blockchainTransaction,
-                                )
-                            computeJoinKeysignNetworkFee(
-                                blockChainSpecific = payload.blockChainSpecific,
+                            resolveJoinKeysignNetworkFee(
+                                payload = payload,
+                                chain = chain,
                                 nativeCoin = nativeCoin,
-                                fallbackFeeAmount = fallbackFeeAmount,
+                                blockchainTransaction = blockchainTransaction,
                             )
                         }
 
@@ -1656,6 +1652,29 @@ constructor(
         }
 
     /**
+     * Network Fee for the join-keysign deposit and non-UTXO send paths. Prefers the dApp-supplied
+     * fee carried in the signed Cosmos message ([dappSuppliedNativeFee]) so Rujira/CosmWasm
+     * requests show the fee that is actually broadcast (issue #4390); otherwise falls back to
+     * [computeJoinKeysignNetworkFee]. [resolveFallbackFeeAmount] and its fee-service call only run
+     * when no dApp fee is present.
+     */
+    private suspend fun resolveJoinKeysignNetworkFee(
+        payload: KeysignPayload,
+        chain: Chain,
+        nativeCoin: Coin,
+        blockchainTransaction: Transfer,
+    ): TokenValue =
+        payload.dappSuppliedNativeFee(chain, parseCosmosMessage)?.let {
+            TokenValue(value = it, token = nativeCoin)
+        }
+            ?: computeJoinKeysignNetworkFee(
+                blockChainSpecific = payload.blockChainSpecific,
+                nativeCoin = nativeCoin,
+                fallbackFeeAmount =
+                    resolveFallbackFeeAmount(payload.blockChainSpecific, blockchainTransaction),
+            )
+
+    /**
      * Fetches the chain's native coin for the Universal Router swap-intent decoder so a native-ETH
      * leg renders the right ticker. Non-fatal — a failed RPC just means the row displays the bare
      * zero address. [CancellationException] propagates so structured-concurrency cancellation isn't
@@ -1898,3 +1917,54 @@ internal fun computeJoinKeysignSwapNetworkFee(
 internal fun defaultEvmSwapGasLimit(chain: Chain): BigInteger =
     if (chain == Chain.Mantle) EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
     else EthereumFeeService.DEFAULT_SWAP_LIMIT
+
+/**
+ * The native-denom fee a dApp embedded in this keysign request, or `null` when it carries no
+ * dApp-supplied Cosmos fee — i.e. a wallet-built native tx, where [KeysignPayload.signAmino] and
+ * [KeysignPayload.signDirect] are both absent. Callers fall back to the estimated fee on `null`.
+ *
+ * Rujira/CosmWasm dApps put the fee they want signed in [KeysignPayload.signAmino] (Amino JSON) or
+ * [KeysignPayload.signDirect] (`authInfo` protobuf), and `ThorChainHelper`/`CosmosHelper` sign
+ * those bytes verbatim — so this is the fee actually broadcast, including the legitimate `0` Rujira
+ * uses today. Reading it keeps the join Network Fee row in step with the signed message instead of
+ * the wallet's own estimate (issue #4390).
+ *
+ * Only entries in the chain's [Chain.cosmosNativeDenom] are summed: a fee specified purely in
+ * another denom yields `null` (fall back to the estimate) rather than mixing units on one row,
+ * matching the Windows resolver. Returns `null` if any matched amount is unparseable, so the caller
+ * never displays a misleading `0`.
+ */
+internal fun KeysignPayload.dappSuppliedNativeFee(
+    chain: Chain,
+    parseCosmosMessage: ParseCosmosMessageUseCase,
+): BigInteger? {
+    val nativeDenom = chain.cosmosNativeDenom ?: return null
+
+    val aminoMatched =
+        signAmino?.fee?.amount?.filter { it?.denom?.lowercase() == nativeDenom }.orEmpty()
+    if (aminoMatched.isNotEmpty()) {
+        return aminoMatched.map { it?.amount }.sumDenomAmountsOrNull()
+    }
+
+    val directMatched =
+        signDirect
+            ?.let { runCatching { parseCosmosMessage(it) }.getOrNull() }
+            ?.authInfoFee
+            ?.amount
+            ?.filter { it.denom.lowercase() == nativeDenom }
+            .orEmpty()
+    if (directMatched.isNotEmpty()) {
+        return directMatched.map { it.amount }.sumDenomAmountsOrNull()
+    }
+
+    return null
+}
+
+/** Sums the raw Cosmos fee amounts, or `null` if any entry is missing or not a valid integer. */
+private fun List<String?>.sumDenomAmountsOrNull(): BigInteger? {
+    var total = BigInteger.ZERO
+    for (raw in this) {
+        total += raw?.toBigIntegerOrNull() ?: return null
+    }
+    return total
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -306,6 +306,15 @@ internal class JoinKeysignSendGasFeeTest {
         payload.dappSuppliedNativeFee(Chain.ThorChain, parse) shouldBe null
     }
 
+    /** A signDirect fee purely in a foreign denom is treated as "no dApp fee" (fall back). */
+    @Test
+    fun `dapp fee returns null when signDirect fee is in a foreign denom`() {
+        val payload = cosmosPayload(signDirect = signDirect())
+        val parse = parseReturning(directFee("ibc/ABC123" to "100"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, parse) shouldBe null
+    }
+
     /** Amino is consulted first; signDirect is only parsed when Amino has no native-denom entry. */
     @Test
     fun `dapp fee prefers signAmino over signDirect`() {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -4,11 +4,21 @@ import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.cosmosNativeDenom
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
+import com.vultisig.wallet.data.usecases.Amount
+import com.vultisig.wallet.data.usecases.CosmosMessage
+import com.vultisig.wallet.data.usecases.Fee
+import com.vultisig.wallet.data.usecases.ParseCosmosMessageUseCase
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.math.BigInteger
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.CosmosCoin
+import vultisig.keysign.v1.CosmosFee
+import vultisig.keysign.v1.SignAmino
 import vultisig.keysign.v1.TransactionType
 
 internal class JoinKeysignSendGasFeeTest {
@@ -228,4 +238,157 @@ internal class JoinKeysignSendGasFeeTest {
             )
         }
     }
+
+    /** dApp Amino fee in the chain's native denom is summed and returned. */
+    @Test
+    fun `dapp fee reads native-denom amount from signAmino`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "2000000"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe
+            BigInteger.valueOf(2_000_000)
+    }
+
+    /**
+     * The Rujira bug (#4390): a dApp that signs `fee.amount = 0` must surface `0`, not `null` — so
+     * the caller shows the real zero fee instead of falling back to the wallet's estimate.
+     */
+    @Test
+    fun `dapp fee of zero is returned as zero, not null`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "0"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe BigInteger.ZERO
+    }
+
+    /** Only the native-denom entries are summed; a co-listed foreign denom is ignored. */
+    @Test
+    fun `dapp fee sums only native-denom entries`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "100", "tcy" to "50"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe
+            BigInteger.valueOf(100)
+    }
+
+    /** A fee specified purely in a non-native denom is treated as "no dApp fee" (fall back). */
+    @Test
+    fun `dapp fee returns null when no native-denom entry present`() {
+        val payload = cosmosPayload(signAmino = aminoFee("tcy" to "50"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe null
+    }
+
+    /**
+     * An unparseable amount must not be silently summed to zero — return null to use the estimate.
+     */
+    @Test
+    fun `dapp fee returns null when a matched amount is unparseable`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "not-a-number"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe null
+    }
+
+    /**
+     * signDirect requests have no Amino block; the fee is decoded from authInfo via the use case.
+     */
+    @Test
+    fun `dapp fee reads native-denom amount from signDirect authInfo`() {
+        val payload = cosmosPayload(signDirect = signDirect())
+        val parse = parseReturning(directFee("rune" to "5000"))
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, parse) shouldBe BigInteger.valueOf(5_000)
+    }
+
+    /** A malformed signDirect payload (parse throws) falls back rather than crashing. */
+    @Test
+    fun `dapp fee returns null when signDirect cannot be parsed`() {
+        val payload = cosmosPayload(signDirect = signDirect())
+        val parse = ParseCosmosMessageUseCase { error("malformed authInfo") }
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, parse) shouldBe null
+    }
+
+    /** Amino is consulted first; signDirect is only parsed when Amino has no native-denom entry. */
+    @Test
+    fun `dapp fee prefers signAmino over signDirect`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "7"), signDirect = signDirect())
+
+        payload.dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe
+            BigInteger.valueOf(7)
+    }
+
+    /**
+     * Non-Cosmos chains have no native denom, so a stray Amino block is never interpreted as a fee.
+     */
+    @Test
+    fun `dapp fee returns null for non-cosmos chains`() {
+        val payload = cosmosPayload(signAmino = aminoFee("rune" to "2000000"))
+
+        payload.dappSuppliedNativeFee(Chain.Ethereum, failingParseCosmos) shouldBe null
+    }
+
+    /** A wallet-built native tx (no signAmino/signDirect) has no dApp fee. */
+    @Test
+    fun `dapp fee returns null when neither signAmino nor signDirect is present`() {
+        cosmosPayload().dappSuppliedNativeFee(Chain.ThorChain, failingParseCosmos) shouldBe null
+    }
+
+    @Test
+    fun `cosmosNativeDenom maps cosmos chains and is null for others`() {
+        Chain.ThorChain.cosmosNativeDenom shouldBe "rune"
+        Chain.MayaChain.cosmosNativeDenom shouldBe "cacao"
+        Chain.GaiaChain.cosmosNativeDenom shouldBe "uatom"
+        Chain.TerraClassic.cosmosNativeDenom shouldBe "uluna"
+        Chain.Ethereum.cosmosNativeDenom shouldBe null
+        Chain.Bitcoin.cosmosNativeDenom shouldBe null
+    }
+
+    private val failingParseCosmos = ParseCosmosMessageUseCase {
+        error("parseCosmosMessage should not be called")
+    }
+
+    private fun parseReturning(message: CosmosMessage) = ParseCosmosMessageUseCase { message }
+
+    private fun aminoFee(vararg amounts: Pair<String, String>) =
+        SignAmino(
+            fee =
+                CosmosFee(amount = amounts.map { CosmosCoin(denom = it.first, amount = it.second) })
+        )
+
+    private fun directFee(vararg amounts: Pair<String, String>) =
+        CosmosMessage(
+            chainId = "thorchain-1",
+            accountNumber = "1",
+            sequence = "0",
+            memo = "",
+            messages = emptyList(),
+            authInfoFee = Fee(amount = amounts.map { Amount(denom = it.first, amount = it.second) }),
+        )
+
+    private fun signDirect() =
+        SignDirectProto(
+            bodyBytes = "",
+            authInfoBytes = "",
+            chainId = "thorchain-1",
+            accountNumber = "1",
+        )
+
+    private fun cosmosPayload(signAmino: SignAmino? = null, signDirect: SignDirectProto? = null) =
+        KeysignPayload(
+            coin = runeCoin,
+            toAddress = "thoraddr",
+            toAmount = BigInteger.ZERO,
+            blockChainSpecific =
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ONE,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.valueOf(2_000_000),
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+            signAmino = signAmino,
+            signDirect = signDirect,
+        )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -456,14 +456,9 @@ val Chain.blockTimeMs: Long
         }
 
 /**
- * The on-chain native fee denomination for a Cosmos-family chain, exactly as it appears in the
- * Cosmos `Fee` message (`signAmino.fee.amount[].denom` or the decoded `authInfo` fee). Returns
- * `null` for non-Cosmos chains.
- *
- * Kept separate from [feeUnit] on purpose: [feeUnit] doubles as a UI label that, for other chains,
- * holds values like `Gwei` or `BTC/vbyte`, and for THORChain the ticker `Rune` rather than the
- * `rune` denom — matching a dApp fee needs the protocol denom, not the label. Mirrors the Windows
- * `cosmosFeeCoinDenom` table so both platforms resolve the same denom.
+ * The on-chain native fee denom for a Cosmos-family chain (e.g. `rune`, `uatom`), `null` otherwise.
+ * Separate from [feeUnit], which carries UI labels (`Gwei`, `BTC/vbyte`) and THORChain's `Rune`
+ * ticker rather than the `rune` denom. Mirrors the Windows `cosmosFeeCoinDenom` table.
  */
 val Chain.cosmosNativeDenom: String?
     get() =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -455,6 +455,33 @@ val Chain.blockTimeMs: Long
             else -> 4_000L
         }
 
+/**
+ * The on-chain native fee denomination for a Cosmos-family chain, exactly as it appears in the
+ * Cosmos `Fee` message (`signAmino.fee.amount[].denom` or the decoded `authInfo` fee). Returns
+ * `null` for non-Cosmos chains.
+ *
+ * Kept separate from [feeUnit] on purpose: [feeUnit] doubles as a UI label that, for other chains,
+ * holds values like `Gwei` or `BTC/vbyte`, and for THORChain the ticker `Rune` rather than the
+ * `rune` denom — matching a dApp fee needs the protocol denom, not the label. Mirrors the Windows
+ * `cosmosFeeCoinDenom` table so both platforms resolve the same denom.
+ */
+val Chain.cosmosNativeDenom: String?
+    get() =
+        when (this) {
+            Chain.ThorChain -> "rune"
+            Chain.MayaChain -> "cacao"
+            Chain.GaiaChain -> "uatom"
+            Chain.Kujira -> "ukuji"
+            Chain.Dydx -> "adydx"
+            Chain.Osmosis -> "uosmo"
+            Chain.Terra,
+            Chain.TerraClassic -> "uluna"
+            Chain.Noble -> "uusdc"
+            Chain.Akash -> "uakt"
+            Chain.Qbtc -> "qbtc"
+            else -> null
+        }
+
 fun Chain.toValue(value: BigInteger): BigDecimal = coinType.toValue(value)
 
 fun Chain.toValue(value: BigDecimal): BigDecimal = coinType.toValue(value)


### PR DESCRIPTION
## Summary

Rujira/CosmWasm dApps sign the fee they want in `signAmino`/`signDirect`, and the cosmos signers (`ThorChainHelper`/`CosmosHelper`) sign those bytes verbatim — so the broadcast fee can be the legitimate `0 RUNE` Rujira uses today. The join keysign Network Fee row instead showed the wallet's own estimate (e.g. `0.02 RUNE`), mismatching the signed message.

This reads the native-denom fee from `signAmino` (Amino JSON) or `signDirect` (`authInfo` protobuf, via `ParseCosmosMessageUseCase`) and prefers it on the deposit and send paths, falling back to the existing estimate when no dApp fee is present.

- `Chain.cosmosNativeDenom` resolves the protocol denom (`rune`, `uatom`, …) instead of reusing the display-oriented `feeUnit` (which holds `Gwei`/`BTC/vbyte`/`Rune` for other chains). Mirrors the Windows `cosmosFeeCoinDenom` table.
- Only native-denom entries are summed; a fee purely in another denom, or an unparseable amount, yields `null` (fall back to the estimate) rather than displaying a misleading `0`.
- A single `resolveJoinKeysignNetworkFee` helper keeps the deposit and send paths in lockstep.

The signed/broadcast transaction is unchanged — this only affects the displayed Network Fee, so co-sign signing is unaffected. The swap path is untouched (wallet-built swaps never carry a dApp `signAmino`/`signDirect`).

Supersedes the stalled external PR #4410 — rebased onto the #4391/#4546 fee-helper consolidation and covering the `signDirect` repro that #4410 missed.

## Cross-platform parity

Windows applies the equivalent fix at payload-build time (#3843); iOS applies it at display time in the join gas view model. This matches the iOS display-time approach and additionally decodes `signDirect`, which iOS currently skips.

## Testing

- `:app:testDebugUnitTest --tests "*JoinKeysignSendGasFeeTest"` — 19 passing, incl. the `fee.amount = 0` regression (shows `0`, not the estimate), the signAmino + signDirect paths, multi-denom filtering, unparseable→null, and non-cosmos→null.
- `:app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.keysign.*"`, `:data:ktfmtCheck :app:ktfmtCheck`, `:data:lint :app:lintDebug` — all green.

Closes #4390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Keysign fee estimation now prefers native-denom Cosmos fees supplied in dApp payloads (deposit and send flows), falling back to computed estimates when absent or invalid
  * Added explicit native-denom mapping for Cosmos-family chains to improve fee detection and accuracy

* **Tests**
  * Added comprehensive tests verifying dApp-supplied native fee parsing, precedence (Amino over Direct), denom filtering, zero-handling, and fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->