### PR TITLE
SwapKit: Cardano (ADA) signer for pre-built CBOR

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,17 +475,19 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT, TRON (TronWeb object), SUI (PTB), and Cardano (CBOR)
-                                // are wired; the remaining SwapKit txTypes (e.g. TON) land with
-                                // their per-chain signers. Guarded loudly so an un-wired txType
-                                // can't reach signing.
+                                // BTC PSBT, TRON (TronWeb object), SUI (PTB), and both Cardano
+                                // flows (deposit-only CARDANO + pre-built CARDANO_PREBUILT) are
+                                // wired; the remaining SwapKit txTypes (e.g. TON) land with their
+                                // per-chain signers. Guarded loudly so an un-wired txType can't
+                                // reach signing.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI ||
                                         quote.data.txType ==
                                             SwapKitSwapPayloadJson.TX_TYPE_CARDANO ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_CBOR
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,14 +475,17 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT, TRON (TronWeb object), and SUI (PTB) are wired; the
-                                // remaining SwapKit txTypes (TON / ADA) land with their per-chain
-                                // signers. Guarded loudly so an un-wired txType can't reach
-                                // signing.
+                                // BTC PSBT, TRON (TronWeb object), SUI (PTB), and Cardano (CBOR)
+                                // are wired; the remaining SwapKit txTypes (e.g. TON) land with
+                                // their per-chain signers. Guarded loudly so an un-wired txType
+                                // can't reach signing.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI ||
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO ||
+                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_CBOR
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitSwapResponseJson.kt
@@ -26,7 +26,10 @@ data class SwapKitSwapRequest(
 @Serializable
 data class SwapKitSwapResponseJson(
     @SerialName("swapId") val swapId: String? = null,
-    @SerialName("tx") val tx: JsonElement,
+    // Nullable: deposit-only flows (Cardano / XRP) return `tx: null` or omit it entirely — routing
+    // lives entirely in [targetAddress]. Pre-built flows (Cardano CBOR, PSBT, …) carry the unsigned
+    // tx here. Callers must treat both null and `JsonNull` as "no tx".
+    @SerialName("tx") val tx: JsonElement? = null,
     @SerialName("meta") val meta: SwapKitTxMeta,
     @SerialName("targetAddress") val targetAddress: String? = null,
     @SerialName("expectedBuyAmount") val expectedBuyAmount: String? = null,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -120,6 +120,10 @@ object SigningHelper {
                             SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                                 SwapKitSuiSigner(eddsaKey)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
+                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO,
+                            SwapKitSwapPayloadJson.TX_TYPE_CBOR ->
+                                SwapKitCardanoSigner(eddsaKey)
+                                    .getPreSignedImageHash(swapPayload.data.txPayload)
                             else ->
                                 error(
                                     "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
@@ -316,6 +320,10 @@ object SigningHelper {
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
                         SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                             SwapKitSuiSigner(eddsaKey)
+                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO,
+                        SwapKitSwapPayloadJson.TX_TYPE_CBOR ->
+                            SwapKitCardanoSigner(eddsaKey)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
                         else ->
                             error(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -120,10 +120,13 @@ object SigningHelper {
                             SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                                 SwapKitSuiSigner(eddsaKey)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
-                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO,
-                            SwapKitSwapPayloadJson.TX_TYPE_CBOR ->
+                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
                                 SwapKitCardanoSigner(eddsaKey)
                                     .getPreSignedImageHash(swapPayload.data.txPayload)
+                            // Deposit-only Cardano: no CBOR to sign — hash a plain ADA send to
+                            // targetAddress built from the blockChainSpecific, via the native path.
+                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
+                                CardanoHelper.getPreSignedImageHash(payload)
                             else ->
                                 error(
                                     "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
@@ -321,10 +324,18 @@ object SigningHelper {
                         SwapKitSwapPayloadJson.TX_TYPE_SUI ->
                             SwapKitSuiSigner(eddsaKey)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
-                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO,
-                        SwapKitSwapPayloadJson.TX_TYPE_CBOR ->
+                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
                             SwapKitCardanoSigner(eddsaKey)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        // Deposit-only Cardano: build & sign a plain ADA send to targetAddress via
+                        // the native Cardano path (same as a non-swap send).
+                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
+                            CardanoHelper.getSignedTransaction(
+                                vaultHexPublicKey = eddsaKey,
+                                vaultHexChainCode = vault.hexChainCode,
+                                keysignPayload = keysignPayload,
+                                signatures = signatures,
+                            )
                         else ->
                             error(
                                 "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitCardanoSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitCardanoSigner.kt
@@ -1,0 +1,273 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.tss.getSignature
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import tss.KeysignResponse
+import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
+
+internal class SwapKitCardanoSignerException(message: String) : Exception(message)
+
+/**
+ * Signs SwapKit's pre-built Cardano CBOR transaction. Ported from iOS' `SwapKitCardanoSigner` +
+ * `CardanoSignedTxBuilder`. SwapKit performs UTXO selection, change splitting, and fee computation
+ * server-side and returns the unsigned tx as a hex-encoded CBOR envelope (routed via NEAR Intents).
+ * We sign the body bytes verbatim — never through WalletCore's `Cardano.SigningInput` (which can't
+ * take a pre-built envelope) — so the broadcast tx_id matches the one the route tracks by.
+ *
+ * Cardano signing model (Shelley-era):
+ * ```
+ *   tx_envelope = [
+ *       transaction_body,        // CBOR map — the bytes we hash
+ *       transaction_witness_set, // unsigned: empty (a0); we splice the vkey witness here
+ *       is_valid,                // true (f5)
+ *       auxiliary_data           // null (f6)
+ *   ]
+ *   tx_id  = blake2b_256(cbor(transaction_body))
+ *   digest = tx_id                              // the message MPC's Ed25519 signs
+ *   witness_set = { 0: [[vkey_32, signature_64]] }
+ * ```
+ *
+ * The digest path uses Bouncy Castle Blake2b-256 (JNI-free, unit-testable, identical to
+ * WalletCore's `Hash.blake2b(_, 32)`); the signing path adds a WalletCore Ed25519 verify before
+ * assembly. The body / is_valid / auxiliary_data bytes are re-emitted byte-for-byte — re-encoding
+ * could change CBOR integer widths or map ordering and invalidate the signature. A tiny
+ * definite-length CBOR walker measures the four envelope items; Cardano envelopes are small and
+ * well-formed by construction, so we don't pull in a CBOR library.
+ *
+ * The 32-byte vkey written into the witness is the vault's Ed25519 public key — the same key
+ * Vultisig derives the Cardano enterprise address from (`CardanoUtils.createEnterpriseAddress`), so
+ * its blake2b-224 hash matches the payment credential SwapKit built the tx against.
+ */
+internal class SwapKitCardanoSigner(private val vaultHexPublicKey: String) {
+
+    /**
+     * Cardano signing digest = `blake2b_256(cbor(transaction_body))`. Cardano signs the body bytes
+     * only (not the whole envelope), so we slice item 0 verbatim and hash. A single-element list: a
+     * Cardano transaction signs one hash regardless of input count; hex-encoded to match the
+     * keysign message-hash convention.
+     */
+    fun getPreSignedImageHash(cborBytes: ByteArray): List<String> =
+        listOf(digest(cborBytes).toHexString())
+
+    /**
+     * Assemble the signed broadcast envelope: keep items 0/2/3 verbatim and replace item 1
+     * (witness_set) with `{ 0: [[vkey, sig]] }`. [rawTransaction][SignedTransactionResult] is the
+     * broadcast hex consumed by the Cardano submit endpoint;
+     * [transactionHash][SignedTransactionResult] is the Cardano tx_id (== blake2b_256(body)).
+     */
+    fun getSignedTransaction(
+        cborBytes: ByteArray,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val pubKeyData = vaultHexPublicKey.hexToByteArray()
+        val publicKey = PublicKey(pubKeyData, PublicKeyType.ED25519)
+
+        val parsed = parseEnvelope(cborBytes)
+        val digest = blake2b256(parsed.body)
+        val key = digest.toHexString()
+        val signature =
+            signatures[key]?.getSignature()
+                ?: throw SwapKitCardanoSignerException(
+                    "Missing signature for Cardano digest ${key.take(16)}…"
+                )
+        if (!publicKey.verify(signature, digest)) {
+            throw SwapKitCardanoSignerException("SwapKit Cardano signature verification failed")
+        }
+
+        val assembled = assembleSignedTransaction(parsed, pubKeyData, signature)
+        return SignedTransactionResult(
+            rawTransaction = assembled.toHexString(),
+            transactionHash = key,
+        )
+    }
+
+    /**
+     * Blake2b-256 of `cbor(transaction_body)`. Exposed (internal) so a unit test can pin the digest
+     * of a known-good envelope without JNI.
+     */
+    internal fun digest(cborBytes: ByteArray): ByteArray = blake2b256(parseEnvelope(cborBytes).body)
+
+    /**
+     * Assemble the broadcast-format envelope from raw signature + vkey bytes. Exposed (internal) so
+     * a unit test can verify the witness framing without going through MPC.
+     */
+    internal fun assembleSignedTransaction(
+        cborBytes: ByteArray,
+        signature: ByteArray,
+        verificationKey: ByteArray,
+    ): ByteArray = assembleSignedTransaction(parseEnvelope(cborBytes), verificationKey, signature)
+
+    private fun assembleSignedTransaction(
+        parsed: ParsedEnvelope,
+        publicKey: ByteArray,
+        signature: ByteArray,
+    ): ByteArray {
+        require(publicKey.size == PUBLIC_KEY_LENGTH) {
+            "Cardano vkey must be $PUBLIC_KEY_LENGTH bytes, got ${publicKey.size}"
+        }
+        require(signature.size == SIGNATURE_LENGTH) {
+            "Cardano signature must be $SIGNATURE_LENGTH bytes, got ${signature.size}"
+        }
+
+        // witness_set = { 0: [ [vkey, sig] ] }  →  a1 00 81 82 <bytes(vkey)> <bytes(sig)>
+        val witness =
+            byteArrayOf(0xA1.toByte(), 0x00, 0x81.toByte(), 0x82.toByte()) +
+                cborBytes(publicKey) +
+                cborBytes(signature)
+
+        // tx_envelope = array(4) [body, witness_set, is_valid, auxiliary_data]
+        return byteArrayOf(0x84.toByte()) + parsed.body + witness + parsed.isValid + parsed.auxData
+    }
+
+    /**
+     * Byte ranges of the four top-level envelope items we re-emit during assembly. The body is also
+     * the input to the signing digest.
+     */
+    private class ParsedEnvelope(
+        val body: ByteArray,
+        val isValid: ByteArray,
+        val auxData: ByteArray,
+    )
+
+    private fun parseEnvelope(data: ByteArray): ParsedEnvelope {
+        require(data.isNotEmpty()) { "SwapKit Cardano payload is empty" }
+        if (data[0] != 0x84.toByte()) {
+            throw SwapKitCardanoSignerException(
+                "expected top-level array(4) (0x84), got 0x${(data[0].toInt() and 0xFF).toString(16)}"
+            )
+        }
+
+        var offset = 1
+        val bodyLen = cborItemLength(data, offset)
+        val body = data.copyOfRange(offset, offset + bodyLen)
+        offset += bodyLen
+
+        offset += cborItemLength(data, offset) // witness_set (discarded; we build our own)
+
+        val ivLen = cborItemLength(data, offset)
+        val isValid = data.copyOfRange(offset, offset + ivLen)
+        offset += ivLen
+
+        val adLen = cborItemLength(data, offset)
+        val auxData = data.copyOfRange(offset, offset + adLen)
+        offset += adLen
+
+        // Cardano envelopes are well-formed by construction; trailing bytes signal a malformed
+        // payload, not forward compatibility.
+        if (offset != data.size) {
+            throw SwapKitCardanoSignerException(
+                "trailing bytes after array(4): consumed $offset, total ${data.size}"
+            )
+        }
+
+        return ParsedEnvelope(body = body, isValid = isValid, auxData = auxData)
+    }
+
+    /**
+     * Byte length of the definite-length CBOR data item at [offset]. Cardano transactions never use
+     * indefinite-length items, so an indefinite/reserved header is a malformed envelope.
+     */
+    private fun cborItemLength(data: ByteArray, offset: Int): Int {
+        if (offset >= data.size)
+            throw SwapKitCardanoSignerException("SwapKit Cardano CBOR is truncated")
+        val start = offset
+        var cursor = offset
+        val head = data[cursor].toInt() and 0xFF
+        cursor += 1
+        val majorType = head shr 5
+        val additionalInfo = head and 0x1F
+
+        val argument: Long =
+            when (additionalInfo) {
+                in 0..23 -> additionalInfo.toLong()
+                24 -> {
+                    if (cursor >= data.size) throw SwapKitCardanoSignerException("CBOR truncated")
+                    (data[cursor].toLong() and 0xFF).also { cursor += 1 }
+                }
+                25 -> readBE(data, cursor, 2).also { cursor += 2 }
+                26 -> readBE(data, cursor, 4).also { cursor += 4 }
+                27 -> readBE(data, cursor, 8).also { cursor += 8 }
+                else ->
+                    throw SwapKitCardanoSignerException(
+                        "indefinite-length or reserved CBOR additional-info: $additionalInfo"
+                    )
+            }
+
+        return when (majorType) {
+            // unsigned int / negative int / simple-or-float — header only.
+            0,
+            1,
+            7 -> cursor - start
+            // byte string / text string — header + `argument` bytes payload.
+            2,
+            3 -> {
+                val payload = argument.toInt()
+                if (cursor + payload > data.size)
+                    throw SwapKitCardanoSignerException("CBOR truncated")
+                (cursor - start) + payload
+            }
+            // array: `argument` items follow.
+            4 -> {
+                var sub = cursor
+                repeat(argument.toInt()) { sub += cborItemLength(data, sub) }
+                sub - start
+            }
+            // map: `argument` (key, value) pairs follow.
+            5 -> {
+                var sub = cursor
+                repeat(argument.toInt()) {
+                    sub += cborItemLength(data, sub)
+                    sub += cborItemLength(data, sub)
+                }
+                sub - start
+            }
+            // tag: header + one tagged item.
+            6 -> (cursor - start) + cborItemLength(data, cursor)
+            else -> throw SwapKitCardanoSignerException("unknown CBOR major type: $majorType")
+        }
+    }
+
+    private fun readBE(data: ByteArray, offset: Int, bytes: Int): Long {
+        if (offset + bytes > data.size) throw SwapKitCardanoSignerException("CBOR truncated")
+        var value = 0L
+        for (i in 0 until bytes) {
+            value = (value shl 8) or (data[offset + i].toLong() and 0xFF)
+        }
+        return value
+    }
+
+    private fun blake2b256(data: ByteArray): ByteArray {
+        val blake = Blake2bDigest(256)
+        blake.update(data, 0, data.size)
+        return ByteArray(blake.digestSize).also { blake.doFinal(it, 0) }
+    }
+
+    /**
+     * CBOR byte-string length prefix for the 32-byte vkey / 64-byte sig, matching iOS'
+     * `CardanoSignedTxBuilder.cborBytes` (and the native send path).
+     */
+    private fun cborBytes(data: ByteArray): ByteArray {
+        val length = data.size
+        val header =
+            when {
+                length < 24 -> byteArrayOf((0x40 or length).toByte())
+                length < 256 -> byteArrayOf(0x58.toByte(), length.toByte())
+                else ->
+                    byteArrayOf(
+                        0x59.toByte(),
+                        ((length shr 8) and 0xFF).toByte(),
+                        (length and 0xFF).toByte(),
+                    )
+            }
+        return header + data
+    }
+
+    private companion object {
+        private const val PUBLIC_KEY_LENGTH = 32
+        private const val SIGNATURE_LENGTH = 64
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -199,6 +199,7 @@ val Chain.isSwapSupported: Boolean
                 Chain.Zcash,
                 Chain.Tron,
                 Chain.Sui,
+                Chain.Cardano,
                 Chain.Hyperliquid,
             )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -79,5 +79,19 @@ data class SwapKitSwapPayloadJson(
          * Sui's submit envelope. Mirrors iOS' `"SUI"`.
          */
         const val TX_TYPE_SUI = "SUI"
+
+        /**
+         * `meta.txType` discriminator for the Cardano signing path. SwapKit returns a hex-encoded
+         * pre-built unsigned CBOR transaction envelope, hex-decoded into [txPayload]; the signer
+         * hashes `cbor(transaction_body)` with Blake2b-256, then splices the Ed25519 vkey witness
+         * back into the envelope. Mirrors iOS' `"CARDANO"`.
+         */
+        const val TX_TYPE_CARDANO = "CARDANO"
+
+        /**
+         * Alias SwapKit also emits for the Cardano CBOR path. Treated identically to
+         * [TX_TYPE_CARDANO] by the dispatcher.
+         */
+        const val TX_TYPE_CBOR = "CBOR"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -81,16 +81,29 @@ data class SwapKitSwapPayloadJson(
         const val TX_TYPE_SUI = "SUI"
 
         /**
-         * `meta.txType` discriminator for the Cardano signing path. SwapKit returns a hex-encoded
-         * pre-built unsigned CBOR transaction envelope, hex-decoded into [txPayload]; the signer
-         * hashes `cbor(transaction_body)` with Blake2b-256, then splices the Ed25519 vkey witness
-         * back into the envelope. Mirrors iOS' `"CARDANO"`.
+         * Keysign-payload discriminator for the **deposit-only** Cardano flow. SwapKit returns no
+         * `tx` (null/absent), so [txPayload] is empty and the only routing info is [targetAddress];
+         * the dispatcher builds a plain ADA send to it via the native Cardano path (no CBOR
+         * signer). Canonical `CARDANO` case in `swapkit_swap_payload.proto`. Mirrors iOS'
+         * deposit-only `.cardano` → `txType="CARDANO"`.
          */
         const val TX_TYPE_CARDANO = "CARDANO"
 
         /**
-         * Alias SwapKit also emits for the Cardano CBOR path. Treated identically to
-         * [TX_TYPE_CARDANO] by the dispatcher.
+         * Keysign-payload discriminator for the **pre-built CBOR** Cardano flow. SwapKit returns a
+         * hex-encoded unsigned CBOR transaction envelope, hex-decoded into [txPayload]; the signer
+         * hashes `cbor(transaction_body)` with Blake2b-256, then splices the Ed25519 vkey witness
+         * back into the envelope. Distinct from the deposit-only [TX_TYPE_CARDANO] so the
+         * dispatcher routes independently — and so a vault mixing iOS and Android cosigns the same
+         * flow (iOS emits `"CARDANO_PREBUILT"` here too).
+         */
+        const val TX_TYPE_CARDANO_PREBUILT = "CARDANO_PREBUILT"
+
+        /**
+         * Wire-level `meta.txType` alias SwapKit also emits for the Cardano CBOR response (upstream
+         * switched from `"CARDANO"` to `"CBOR"` un-versioned). The quote source normalizes it onto
+         * [TX_TYPE_CARDANO] / [TX_TYPE_CARDANO_PREBUILT] based on `tx` presence before it reaches
+         * the keysign payload, so it is never a keysign discriminator itself.
          */
         const val TX_TYPE_CBOR = "CBOR"
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -178,7 +179,8 @@ constructor(
             TxKind.PSBT,
             TxKind.TRON,
             TxKind.SUI,
-            TxKind.CARDANO ->
+            TxKind.CARDANO,
+            TxKind.CARDANO_PREBUILT ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -381,6 +383,7 @@ constructor(
             TxKind.TRON,
             TxKind.SUI,
             TxKind.CARDANO,
+            TxKind.CARDANO_PREBUILT,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
@@ -413,7 +416,16 @@ constructor(
                 toCoin = dstToken,
                 fromAmount = request.tokenValue.value,
                 toAmountDecimal = toAmountDecimal,
-                txType = response.meta.txType,
+                // Normalize the keysign-payload discriminator. PSBT/TRON/SUI pass the wire txType
+                // through verbatim, but Cardano's wire `CARDANO`/`CBOR` is split by `tx` presence
+                // into the deposit-only `CARDANO` and the pre-built `CARDANO_PREBUILT` so the
+                // cosigning peer (incl. iOS, which emits the same strings) dispatches correctly.
+                txType =
+                    when (txTypeOf(response)) {
+                        TxKind.CARDANO -> SwapKitSwapPayloadJson.TX_TYPE_CARDANO
+                        TxKind.CARDANO_PREBUILT -> SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT
+                        else -> response.meta.txType
+                    },
                 txPayload = encodeNativeTxPayload(response),
                 targetAddress = targetAddress,
                 memo = null,
@@ -460,10 +472,13 @@ constructor(
                     ?: throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
                 json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
             }
-            // SwapKit returns the Cardano tx as a hex-encoded CBOR string (not base64), mirroring
-            // iOS' `Data(hexString:)` decode path. Decode hex into the raw CBOR envelope bytes the
-            // signer hashes and re-frames.
-            TxKind.CARDANO -> decodeHexTx(response.tx)
+            // Deposit-only Cardano: no `tx` to sign — the keysign side builds a plain ADA send to
+            // targetAddress from the blockChainSpecific. Empty payload, mirroring iOS' `.cardano`.
+            TxKind.CARDANO -> ByteArray(0)
+            // Pre-built Cardano: SwapKit returns the tx as a hex-encoded CBOR string (not base64),
+            // mirroring iOS' `Data(hexString:)` path. Decode hex into the raw CBOR envelope bytes
+            // the signer hashes and re-frames.
+            TxKind.CARDANO_PREBUILT -> decodeHexTx(response.tx)
             else -> decodeBinaryTx(response.tx)
         }
 
@@ -472,7 +487,7 @@ constructor(
      * [SwapKitSwapPayloadJson.txPayload]. Tolerates an optional `0x` prefix. Rejects odd-length /
      * non-hex / empty payloads so an unsignable blob is dropped here rather than at sign time.
      */
-    private fun decodeHexTx(element: JsonElement): ByteArray {
+    private fun decodeHexTx(element: JsonElement?): ByteArray {
         val hex =
             (element as? JsonPrimitive)?.takeIf { it.isString }?.content?.trim()
                 ?: throw SwapKitError.Decoding("SwapKit Cardano tx is not a hex string")
@@ -497,7 +512,7 @@ constructor(
      * raw bytes for [SwapKitSwapPayloadJson.txPayload]. V3 ships these as a top-level base64
      * [JsonPrimitive].
      */
-    private fun decodeBinaryTx(element: JsonElement): ByteArray {
+    private fun decodeBinaryTx(element: JsonElement?): ByteArray {
         val base64 =
             (element as? JsonPrimitive)?.takeIf { it.isString }?.content
                 ?: throw SwapKitError.Decoding("SwapKit non-EVM tx is not a base64 string")
@@ -527,18 +542,26 @@ constructor(
             "psbt" -> TxKind.PSBT
             "tron" -> TxKind.TRON
             "sui" -> TxKind.SUI
-            // SwapKit emits both "CARDANO" and the "CBOR" alias for the pre-built Cardano envelope.
+            // SwapKit emits both "CARDANO" and the "CBOR" alias for either Cardano shape. The shape
+            // is told apart by `tx`, not the discriminator string: a present `tx` is a pre-built
+            // CBOR envelope to sign; a null/absent `tx` is the deposit-only flow (route entirely on
+            // targetAddress). Mirrors iOS' `.cardanoPrebuilt` vs `.cardano` decode split.
             "cardano",
-            "cbor" -> TxKind.CARDANO
+            "cbor" -> if (response.tx.isTxPresent()) TxKind.CARDANO_PREBUILT else TxKind.CARDANO
             else -> TxKind.UNSUPPORTED
         }
+
+    /**
+     * True when `tx` carries a payload — absent (`null`) and JSON `null` ([JsonNull]) both fail.
+     */
+    private fun JsonElement?.isTxPresent(): Boolean = this != null && this !is JsonNull
 
     /**
      * Pull the Solana base64 swap blob out of `tx`. V3 ships it as a top-level [JsonPrimitive];
      * fall back to the legacy [SwapKitSolanaTx] object shape so a transitional response (or a test
      * fixture using either form) is decoded safely.
      */
-    private fun solanaBase64(element: JsonElement): String {
+    private fun solanaBase64(element: JsonElement?): String {
         (element as? JsonPrimitive)
             ?.takeIf { it.isString }
             ?.content
@@ -566,6 +589,7 @@ constructor(
         TRON,
         SUI,
         CARDANO,
+        CARDANO_PREBUILT,
         UNSUPPORTED,
     }
 
@@ -649,15 +673,17 @@ constructor(
             .getOrNull()
     }
 
-    private inline fun <reified T> decode(element: JsonElement, label: String): T =
-        try {
-            json.decodeFromJsonElement<T>(element)
+    private inline fun <reified T> decode(element: JsonElement?, label: String): T {
+        val el = element ?: throw SwapKitError.Decoding("SwapKit $label tx payload is missing")
+        return try {
+            json.decodeFromJsonElement<T>(el)
         } catch (e: Exception) {
             throw SwapKitError.Decoding(
                 message = "Failed to decode SwapKit $label tx payload",
                 cause = e,
             )
         }
+    }
 
     private companion object {
         /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -55,12 +55,12 @@ import timber.log.Timber
  *
  * Non-EVM/non-Solana `txType`s surface as a fully-formed [SwapQuote.SwapKit] for a per-chain signer
  * to consume: PSBT (Bitcoin, via [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]), TRON
- * (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]), and SUI
- * (base64 PTB, via [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner]) are wired today. The
- * remaining types (TON, CARDANO, RIPPLE, …) still surface as [SwapKitError.UnsupportedTxType] so
- * the picker falls back to another provider rather than signing garbage, until their signers land.
- * `SOLANA` and the legacy `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once
- * before.
+ * (TronWeb object, via [com.vultisig.wallet.data.chains.helpers.SwapKitTronSigner]), SUI (base64
+ * PTB, via [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner]), and CARDANO (hex CBOR, via
+ * [com.vultisig.wallet.data.chains.helpers.SwapKitCardanoSigner]) are wired today. The remaining
+ * types (TON, RIPPLE, …) still surface as [SwapKitError.UnsupportedTxType] so the picker falls back
+ * to another provider rather than signing garbage, until their signers land. `SOLANA` and the
+ * legacy `SERIALIZED_BASE64` discriminator are aliased; SwapKit flipped them once before.
  */
 internal class SwapKitQuoteSource
 @Inject
@@ -177,7 +177,8 @@ constructor(
                 )
             TxKind.PSBT,
             TxKind.TRON,
-            TxKind.SUI ->
+            TxKind.SUI,
+            TxKind.CARDANO ->
                 SwapQuoteResult.Native(
                     buildSwapKitNativeQuote(swapResponse, request, subProvider, best.fees)
                 )
@@ -265,6 +266,8 @@ constructor(
             Chain.Sui -> 9
             Chain.Bitcoin -> 8
             Chain.Tron -> 6
+            // ADA is denominated in lovelace (1 ADA = 1e6 lovelace).
+            Chain.Cardano -> 6
             else -> 18
         }
 
@@ -372,11 +375,12 @@ constructor(
                         ),
                 )
             }
-            // PSBT/TRON/SUI are dispatched to buildSwapKitNativeQuote before reaching here; the arm
-            // keeps the `when` exhaustive and refuses anything that slips through.
+            // PSBT/TRON/SUI/CARDANO are dispatched to buildSwapKitNativeQuote before reaching here;
+            // the arm keeps the `when` exhaustive and refuses anything that slips through.
             TxKind.PSBT,
             TxKind.TRON,
             TxKind.SUI,
+            TxKind.CARDANO,
             TxKind.UNSUPPORTED -> throw SwapKitError.UnsupportedTxType(response.meta.txType)
         }
     }
@@ -456,8 +460,37 @@ constructor(
                     ?: throw SwapKitError.Decoding("SwapKit TRON tx is missing raw_data_hex")
                 json.encodeToString(JsonObject.serializer(), obj).encodeToByteArray()
             }
+            // SwapKit returns the Cardano tx as a hex-encoded CBOR string (not base64), mirroring
+            // iOS' `Data(hexString:)` decode path. Decode hex into the raw CBOR envelope bytes the
+            // signer hashes and re-frames.
+            TxKind.CARDANO -> decodeHexTx(response.tx)
             else -> decodeBinaryTx(response.tx)
         }
+
+    /**
+     * Decode a hex-encoded unsigned-tx blob (Cardano CBOR) from `tx` into raw bytes for
+     * [SwapKitSwapPayloadJson.txPayload]. Tolerates an optional `0x` prefix. Rejects odd-length /
+     * non-hex / empty payloads so an unsignable blob is dropped here rather than at sign time.
+     */
+    private fun decodeHexTx(element: JsonElement): ByteArray {
+        val hex =
+            (element as? JsonPrimitive)?.takeIf { it.isString }?.content?.trim()
+                ?: throw SwapKitError.Decoding("SwapKit Cardano tx is not a hex string")
+        val stripped = hex.removePrefix("0x").removePrefix("0X")
+        if (stripped.isEmpty() || stripped.length % 2 != 0) {
+            throw SwapKitError.Decoding("SwapKit Cardano tx is not valid hex")
+        }
+        val decoded =
+            runCatching {
+                    ByteArray(stripped.length / 2) {
+                        stripped.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+                    }
+                }
+                .getOrElse {
+                    throw SwapKitError.Decoding("SwapKit Cardano tx is not valid hex", it)
+                }
+        return decoded
+    }
 
     /**
      * Decode a base64 unsigned-tx blob (PSBT today; PTB / CBOR as more chains land) from `tx` into
@@ -494,6 +527,9 @@ constructor(
             "psbt" -> TxKind.PSBT
             "tron" -> TxKind.TRON
             "sui" -> TxKind.SUI
+            // SwapKit emits both "CARDANO" and the "CBOR" alias for the pre-built Cardano envelope.
+            "cardano",
+            "cbor" -> TxKind.CARDANO
             else -> TxKind.UNSUPPORTED
         }
 
@@ -529,6 +565,7 @@ constructor(
         PSBT,
         TRON,
         SUI,
+        CARDANO,
         UNSUPPORTED,
     }
 
@@ -590,6 +627,7 @@ constructor(
             Chain.Bitcoin -> "BTC"
             Chain.Tron -> "TRON"
             Chain.Sui -> "SUI"
+            Chain.Cardano -> "ADA"
             else -> null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -136,6 +136,10 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             // PTB, Ed25519 envelope). Mirrors iOS' `.sui → [.swapkit]`.
             Chain.Sui -> setOf(SwapProvider.SWAPKIT)
 
+            // SwapKit Cardano routes are signed by SwapKitCardanoSigner (Blake2b-256 of the CBOR tx
+            // body, Ed25519 vkey witness). Mirrors iOS' `.cardano → [.swapkit]`.
+            Chain.Cardano -> setOf(SwapProvider.SWAPKIT)
+
             Chain.Polkadot,
             Chain.Bittensor,
             Chain.Dydx,
@@ -145,7 +149,6 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             Chain.TerraClassic,
             Chain.Noble,
             Chain.Akash,
-            Chain.Cardano,
             Chain.Sei,
             Chain.Qbtc -> emptySet()
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteDecodingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteDecodingTest.kt
@@ -168,7 +168,7 @@ class SwapKitQuoteDecodingTest {
         assertEquals("999500000", response.expectedBuyAmount)
 
         // tx is JsonElement until the caller decodes onto the matching DTO
-        val evm = json.decodeFromJsonElement(SwapKitEvmTx.serializer(), response.tx)
+        val evm = json.decodeFromJsonElement(SwapKitEvmTx.serializer(), response.tx!!)
         assertEquals("0xRouter", evm.to)
         assertEquals("0xabcdef", evm.data)
         assertEquals("210000", evm.gas)
@@ -190,7 +190,7 @@ class SwapKitQuoteDecodingTest {
 
         // type is lower-cased so dispatch is case-insensitive
         assertEquals(SwapKitTxMeta.TYPE_SOLANA, response.meta.type)
-        val solana = json.decodeFromJsonElement(SwapKitSolanaTx.serializer(), response.tx)
+        val solana = json.decodeFromJsonElement(SwapKitSolanaTx.serializer(), response.tx!!)
         assertEquals("AQID", solana.swapTransaction)
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteDecodingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteDecodingTest.kt
@@ -168,7 +168,7 @@ class SwapKitQuoteDecodingTest {
         assertEquals("999500000", response.expectedBuyAmount)
 
         // tx is JsonElement until the caller decodes onto the matching DTO
-        val evm = json.decodeFromJsonElement(SwapKitEvmTx.serializer(), response.tx!!)
+        val evm = json.decodeFromJsonElement(SwapKitEvmTx.serializer(), response.tx)
         assertEquals("0xRouter", evm.to)
         assertEquals("0xabcdef", evm.data)
         assertEquals("210000", evm.gas)
@@ -190,7 +190,7 @@ class SwapKitQuoteDecodingTest {
 
         // type is lower-cased so dispatch is case-insensitive
         assertEquals(SwapKitTxMeta.TYPE_SOLANA, response.meta.type)
-        val solana = json.decodeFromJsonElement(SwapKitSolanaTx.serializer(), response.tx!!)
+        val solana = json.decodeFromJsonElement(SwapKitSolanaTx.serializer(), response.tx)
         assertEquals("AQID", solana.swapTransaction)
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitCardanoSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitCardanoSignerTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [SwapKitCardanoSigner]'s pure (no-JNI) surface: the Blake2b-256 signing digest, the
+ * CBOR envelope walker, and the witness-assembly framing. Cardano signs
+ * `blake2b_256(cbor(tx_body))` — item 0 of the `[body, witness_set, is_valid, aux_data]` array —
+ * and broadcasts the same envelope with item 1 replaced by `{0: [[vkey, sig]]}`. Expected digests
+ * are recomputed here with an independent Blake2b so a drift in the walker's body boundary
+ * surfaces.
+ *
+ * Ed25519 signature verification needs the WalletCore JNI and is exercised by the iOS port +
+ * integration, mirroring the headless framing tests in [SwapKitSuiSignerTest].
+ */
+class SwapKitCardanoSignerTest {
+
+    // The vault key is only read in the JNI-dependent signing path, not by digest()/assembly.
+    private val signer = SwapKitCardanoSigner(vaultHexPublicKey = "")
+
+    private fun blake2b256(data: ByteArray): ByteArray {
+        val d = Blake2bDigest(256)
+        d.update(data, 0, data.size)
+        return ByteArray(d.digestSize).also { d.doFinal(it, 0) }
+    }
+
+    @Test
+    fun `digest is blake2b-256 of the transaction body`() {
+        // Envelope = array(4) [ body=empty-map(a0), witness_set=a0, is_valid=true(f5), aux=null(f6)
+        // ]
+        val body = "a0"
+        val envelope = "84a0a0f5f6".hexToByteArray()
+        val expected = blake2b256(body.hexToByteArray())
+
+        val actual = signer.digest(envelope)
+
+        assertEquals(32, actual.size, "Cardano digest is Blake2b-256")
+        assertEquals(expected.toHexString(), actual.toHexString())
+    }
+
+    @Test
+    fun `walker slices the body across nested arrays, maps, byte strings and wide ints`() {
+        // A realistic-shaped body: { 0: [[<32-byte hash>, 0]], 1: [[<addr>, 1_000_000]] }.
+        val body =
+            "a2" + // map(2)
+                "00" + // key 0 (inputs)
+                "81" + // array(1)
+                "82" + // array(2)
+                "5820" +
+                "11".repeat(32) + // byte string(32): tx hash
+                "00" + // index 0
+                "01" + // key 1 (outputs)
+                "81" + // array(1)
+                "82" + // array(2)
+                "4100" + // byte string(1): address
+                "1a000f4240" // uint 1_000_000 (4-byte argument)
+        val envelope = ("84" + body + "a0" + "f5" + "f6").hexToByteArray()
+
+        // The digest must equal Blake2b-256 over exactly the body bytes — proves the walker found
+        // the correct body boundary through the nested structure.
+        assertEquals(
+            blake2b256(body.hexToByteArray()).toHexString(),
+            signer.digest(envelope).toHexString(),
+        )
+    }
+
+    @Test
+    fun `pre-signed image hash is a single entry equal to the digest`() {
+        val envelope = "84a0a0f5f6".hexToByteArray()
+        val hashes = signer.getPreSignedImageHash(envelope)
+        assertEquals(1, hashes.size)
+        assertEquals(signer.digest(envelope).toHexString(), hashes[0])
+    }
+
+    @Test
+    fun `assembly splices the vkey witness and re-emits items 0-2-3 verbatim`() {
+        val envelope = "84a0a0f5f6".hexToByteArray()
+        val vkey = ByteArray(32) { 0xAB.toByte() }
+        val sig = ByteArray(64) { 0xCD.toByte() }
+
+        // witness_set = { 0: [[vkey, sig]] } = a1 00 81 82 5820<vkey> 5840<sig>
+        // envelope     = 84 <body=a0> <witness> <is_valid=f5> <aux=f6>
+        val expected =
+            "84a0" + "a1008182" + "5820" + "ab".repeat(32) + "5840" + "cd".repeat(64) + "f5f6"
+
+        val assembled = signer.assembleSignedTransaction(envelope, sig, vkey)
+        assertEquals(expected, assembled.toHexString())
+    }
+
+    @Test
+    fun `empty payload is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { signer.digest(ByteArray(0)) }
+    }
+
+    @Test
+    fun `non-array top-level header is rejected`() {
+        // Leading 0xa0 (map) is not the expected array(4) envelope header.
+        assertThrows(SwapKitCardanoSignerException::class.java) {
+            signer.digest("a0".hexToByteArray())
+        }
+    }
+
+    @Test
+    fun `trailing bytes after the envelope are rejected`() {
+        assertThrows(SwapKitCardanoSignerException::class.java) {
+            signer.digest("84a0a0f5f600".hexToByteArray())
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -25,6 +25,7 @@ import java.util.Locale
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -888,8 +889,9 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch decodes a Cardano CBOR route into a Native SwapQuote SwapKit payload`() = runTest {
-        // Cardano's tx is a hex-encoded pre-built CBOR envelope (NOT base64 like PSBT/SUI) →
-        // hex-decoded into txPayload bytes. The inbound ADA fee scales by 6 native decimals.
+        // A present `tx` is the pre-built CBOR flow: hex-encoded (NOT base64 like PSBT/SUI) →
+        // hex-decoded into txPayload bytes, normalized to the CARDANO_PREBUILT discriminator. The
+        // inbound ADA fee scales by 6 native decimals.
         every { config.isFeatureEnabled } returns flowOf(true)
         val cborBytes =
             byteArrayOf(0x84.toByte(), 0xA0.toByte(), 0xA0.toByte(), 0xF5.toByte(), 0xF6.toByte())
@@ -918,7 +920,7 @@ internal class SwapKitQuoteSourceTest {
         val quote = result.quote as SwapQuote.SwapKit
 
         assertEquals("NEAR", quote.subProvider)
-        assertEquals("CARDANO", quote.data.txType)
+        assertEquals("CARDANO_PREBUILT", quote.data.txType)
         assertTrue(cborBytes.contentEquals(quote.data.txPayload))
         assertEquals("addr1qtarget", quote.data.targetAddress)
         assertEquals("ada-swap-1", quote.data.swapId)
@@ -927,6 +929,48 @@ internal class SwapKitQuoteSourceTest {
         assertEquals(BigInteger("170000"), quote.fees.value)
         assertEquals("ADA", quote.fees.unit)
     }
+
+    @Test
+    fun `fetch decodes a deposit-only Cardano route (null tx) into a native ADA send payload`() =
+        runTest {
+            // The two real captured ADA fixtures return `tx: null` — the deposit-only flow. Routing
+            // lives entirely in targetAddress; the payload carries an empty txPayload and the
+            // CARDANO discriminator (vs CARDANO_PREBUILT), so the keysign side builds a plain ADA
+            // send rather than signing pre-built CBOR. Mirrors iOS' `.cardano`.
+            every { config.isFeatureEnabled } returns flowOf(true)
+            val ada = cardanoCoin()
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r-ada-dep",
+                                providers = listOf("NEAR"),
+                                expectedBuy = "12.5",
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                SwapKitSwapResponseJson(
+                    swapId = "ada-swap-2",
+                    tx = JsonNull,
+                    meta = SwapKitTxMeta(txType = "CARDANO"),
+                    targetAddress = "addr1qtarget",
+                    expectedBuyAmount = "12.5",
+                    fees = listOf(SwapKitFee(type = "inbound", chain = "ADA", amount = "0.17")),
+                    providers = listOf("NEAR"),
+                )
+
+            val result =
+                source().fetch(request(srcToken = ada, dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+            val quote = result.quote as SwapQuote.SwapKit
+
+            assertEquals("CARDANO", quote.data.txType)
+            assertTrue(quote.data.txPayload.isEmpty())
+            assertEquals("addr1qtarget", quote.data.targetAddress)
+            assertEquals("ada-swap-2", quote.data.swapId)
+        }
 
     @Test
     fun `fetch throws Decoding when the Cardano tx is not valid hex`() = runTest {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -504,8 +504,8 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch throws UnsupportedTxType for a still-unwired non-EVM txType`() = runTest {
-        // PSBT (Bitcoin), TRON, and SUI are now wired to a Native SwapQuote.SwapKit; the remaining
-        // non-EVM txTypes (TON/CARDANO/RIPPLE) still have no signer, so they surface as
+        // PSBT (Bitcoin), TRON, SUI, and CARDANO are now wired to a Native SwapQuote.SwapKit; the
+        // remaining non-EVM txTypes (TON/RIPPLE) still have no signer, so they surface as
         // UnsupportedTxType.
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -887,6 +887,66 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch decodes a Cardano CBOR route into a Native SwapQuote SwapKit payload`() = runTest {
+        // Cardano's tx is a hex-encoded pre-built CBOR envelope (NOT base64 like PSBT/SUI) →
+        // hex-decoded into txPayload bytes. The inbound ADA fee scales by 6 native decimals.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val cborBytes =
+            byteArrayOf(0x84.toByte(), 0xA0.toByte(), 0xA0.toByte(), 0xF5.toByte(), 0xF6.toByte())
+        val hex = "84a0a0f5f6"
+        val ada = cardanoCoin()
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(routeId = "r-ada", providers = listOf("NEAR"), expectedBuy = "12.5")
+                    )
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "ada-swap-1",
+                tx = JsonPrimitive(hex),
+                meta = SwapKitTxMeta(txType = "CARDANO"),
+                targetAddress = "addr1qtarget",
+                expectedBuyAmount = "12.5",
+                fees = listOf(SwapKitFee(type = "inbound", chain = "ADA", amount = "0.17")),
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = ada, dstToken = ethCoin())) as SwapQuoteResult.Native
+        val quote = result.quote as SwapQuote.SwapKit
+
+        assertEquals("NEAR", quote.subProvider)
+        assertEquals("CARDANO", quote.data.txType)
+        assertTrue(cborBytes.contentEquals(quote.data.txPayload))
+        assertEquals("addr1qtarget", quote.data.targetAddress)
+        assertEquals("ada-swap-1", quote.data.swapId)
+        assertEquals(ada, quote.data.fromCoin)
+        // 0.17 ADA inbound fee scaled by 6 native decimals = 170_000 lovelace.
+        assertEquals(BigInteger("170000"), quote.fees.value)
+        assertEquals("ADA", quote.fees.unit)
+    }
+
+    @Test
+    fun `fetch throws Decoding when the Cardano tx is not valid hex`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "r-ada", providers = listOf("NEAR")))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive("zzz-not-hex"),
+                meta = SwapKitTxMeta(txType = "CBOR"),
+                targetAddress = "addr1qtarget",
+                expectedBuyAmount = "1",
+            )
+
+        assertThrows<SwapKitError.Decoding> { source().fetch(request(srcToken = cardanoCoin())) }
+    }
+
+    @Test
     fun `fetch throws Decoding when the TRON tx is not a JSON object`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns
@@ -1114,6 +1174,19 @@ internal class SwapKitQuoteSourceTest {
             decimal = 9,
             hexPublicKey = "pub",
             priceProviderID = "sui",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun cardanoCoin() =
+        Coin(
+            chain = Chain.Cardano,
+            ticker = "ADA",
+            logo = "",
+            address = "addr1vtarget",
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "cardano",
             contractAddress = "",
             isNativeToken = true,
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -43,6 +43,7 @@ internal class SwapProviderTableTest {
                 coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
                 coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
                 coin(Chain.Sui, "SUI", isNative = true), // SUI PTB route
+                coin(Chain.Cardano, "ADA", isNative = true), // Cardano CBOR route
             )
 
         swapKitCoins.forEach { c ->
@@ -73,7 +74,6 @@ internal class SwapProviderTableTest {
                 coin(Chain.Ripple, "XRP", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
                 coin(Chain.Ton, "TON", isNative = true),
-                coin(Chain.Cardano, "ADA", isNative = true),
                 coin(Chain.Polkadot, "DOT", isNative = true),
             )
 
@@ -91,7 +91,7 @@ internal class SwapProviderTableTest {
         // account screen. A chain can offer SWAPKIT in the provider table yet stay invisible to the
         // user if it is missing from isSwapSupported — the Sui regression that hid the button while
         // iOS showed it. Pin every SwapKit-wired native chain here.
-        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui).forEach { chain ->
+        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui, Chain.Cardano).forEach { chain ->
             assertTrue(
                 chain.isSwapSupported,
                 "$chain offers SWAPKIT but is not marked isSwapSupported — Swap button would hide",


### PR DESCRIPTION
Closes #4700 (split from #4675).

## Summary

SwapKit returns Cardano swaps as a **pre-built, hex-encoded unsigned CBOR** transaction (routed via NEAR Intents). WalletCore 4.3.22's `Cardano.SigningInput` can't ingest a pre-built envelope (and has no memo field), so we sign the bytes directly — mirroring iOS' `SwapKitCardanoSigner` + `CardanoSignedTxBuilder`.

Cardano signing model (Shelley-era):

```
tx_envelope = [ transaction_body, transaction_witness_set, is_valid, auxiliary_data ]
digest      = blake2b_256(cbor(transaction_body))   // == tx_id, the message Ed25519 signs
witness_set = { 0: [[vkey_32, signature_64]] }
```

### Transaction hash
 https://cardanoscan.io/transaction/70782335101d34163ee0de278c38660bb011e5fe8d1dc9baf2ca24300834b7b3

The signer slices item 0 (the body) verbatim, hashes it, and on assembly re-emits items 0/2/3 byte-for-byte while replacing item 1 with the vkey witness — re-encoding the body could change CBOR integer widths or map ordering and invalidate the signature.

- **Digest path** uses Bouncy Castle `Blake2b-256` (JNI-free, so it's unit-testable headlessly — same equivalence the SUI signer relies on). Ed25519 verification uses WalletCore.
- **vkey** is the vault EdDSA key (`getEddsaSigningKey(Chain.Cardano)`) — the same key the Cardano enterprise address is derived from, so its hash matches the payment credential SwapKit built against.
- The signed `rawTransaction` is hex CBOR — the same wire format the existing native Cardano submit path already broadcasts, so no broadcast changes were needed.

## Changes

- **New** `SwapKitCardanoSigner` (+ tests) — definite-length CBOR walker, Blake2b-256 digest, witness framing.
- `SwapKitSwapPayloadJson` — `TX_TYPE_CARDANO` + `CBOR` alias.
- `SwapKitQuoteSource` — `TxKind.CARDANO`, **hex** decode (Cardano's `tx` is hex, not base64 like PSBT/SUI), `ADA` chain prefix, native decimals 6, dispatch to the Native quote.
- `SigningHelper` — dispatch Cardano in both pre-sign and signed-tx paths.
- `SwapProviderTable` — `Chain.Cardano -> {SWAPKIT}`; add `Chain.Cardano` to `isSwapSupported` so the Swap button shows.
- `SwapFormViewModel` — allow the `CARDANO`/`CBOR` txType through the swap gate.

## Test plan

- `:data:testDebugUnitTest` — new `SwapKitCardanoSignerTest` (digest, nested-structure CBOR walker, witness framing, reject empty/non-array/trailing-bytes) + new `SwapKitQuoteSourceTest` cases (hex CBOR → Native quote, bad hex → `Decoding`); updated `SwapProviderTableTest`. ✅ green
- `:app:compileDebugKotlin` ✅ green
- `:data:ktfmtCheck` ✅ green

Signature verification (Ed25519) needs the WalletCore JNI and is exercised by the iOS port + integration; this PR pins the JNI-free surface headlessly. **Pending on-device E2E** (real ADA swap sign + broadcast) once SwapKit serves live ADA routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cardano (ADA) added as a supported swap chain with both native deposit and pre-built CBOR swap flows.
  * Cardano-aware transaction signing and pre-signed image/hash handling for broadcast-ready Cardano transactions.

* **Documentation**
  * Clarified Cardano signing, tx semantics, and CBOR payload expectations.

* **Tests**
  * New and expanded tests for Cardano decoding, signing, routing, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->