### PR TITLE
fix(swap): show loading on input, move ahead of the debounce

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -923,9 +923,12 @@ constructor(
                     address to srcAmount
                 }
                 .combine(refreshQuoteState) { it, _ -> it }
-                .debounce(450L)
+                // Show the spinner immediately on input, ahead of the debounce, so the form
+                // doesn't look frozen while we wait. The debounce below still coalesces the
+                // actual quote fetch, so this adds no extra provider requests.
+                .onEach { isLoading = true }
+                .debounce(300L)
                 .collect { (address, amount) ->
-                    isLoading = true
                     val (src, dst) = address
 
                     val srcToken = src.account.token

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -919,16 +920,25 @@ constructor(
                     src to dst
                 }
                 .distinctUntilChanged()
-                .combine(srcAmountState.textAsFlow().filter { it.isNotEmpty() }) { address, _ ->
+                .combine(
+                    srcAmountState
+                        .textAsFlow()
+                        .filter { it.isNotEmpty() }
+                        // Show the spinner immediately on real typing, ahead of the debounce, so
+                        // the form doesn't look frozen while we wait. Gating it on this branch
+                        // keeps it to user input: the silent refreshes (refreshQuoteState timer,
+                        // gas bump) don't flow through here, so they no longer flash the spinner
+                        // (#4712). The debounce below still coalesces the actual quote fetch, so
+                        // this adds no extra provider requests.
+                        .onEach { isLoading = true }
+                ) { address, _ ->
                     address to srcAmount
                 }
                 .combine(refreshQuoteState) { it, _ -> it }
-                // Show the spinner immediately on input, ahead of the debounce, so the form
-                // doesn't look frozen while we wait. The debounce below still coalesces the
-                // actual quote fetch, so this adds no extra provider requests.
-                .onEach { isLoading = true }
                 .debounce(300L)
-                .collect { (address, amount) ->
+                // collectLatest so newer input cancels an in-flight fetch instead of letting a
+                // stale fetch write isLoading = false after the user has already typed again.
+                .collectLatest { (address, amount) ->
                     val (src, dst) = address
 
                     val srcToken = src.account.token

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -641,7 +641,7 @@ internal fun SwapScreen(
                 } else {
                     VsButton(
                         label =
-                            if (state.isLoading) {
+                            if (srcAmountTextFieldState.text.isEmpty()) {
                                 stringResource(R.string.swap_swap_button_fill_in_amount)
                             } else {
                                 stringResource(R.string.swap_swap_button)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -663,7 +663,7 @@ internal class SwapFormViewModelTest {
             assertEquals("0", state.srcFiatValue)
             assertNull(state.formError)
             // hasQuote must drop on flip, otherwise the fee block stays on screen during the
-            // 450ms debounce while collectTotalFee can still combine the new pair's gas with
+            // 300ms debounce while collectTotalFee can still combine the new pair's gas with
             // the prior pair's swapFeeFiat.
             assertFalse(state.hasQuote)
         }
@@ -706,15 +706,18 @@ internal class SwapFormViewModelTest {
             vm.srcAmountState.setTextAndPlaceCursorAtEnd("100")
             Snapshot.sendApplyNotifications()
 
-            // Before debounce expires, isLoading should not have triggered full calculation
-            advanceTimeBy(100) // total 500ms, debounce is 450ms from last change
+            // The spinner is set ahead of the debounce, so it shows immediately on input even
+            // before the 300ms debounce expires and the quote fetch starts.
+            advanceTimeBy(100) // total 500ms elapsed, but only 100ms since the last change
+            assertTrue(vm.uiState.value.isLoading)
 
-            // Let debounce complete
+            // Let the debounce expire and the (single) quote fetch complete.
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            // Only the final amount "100" should have been used for quote
-            // (verified indirectly by checking state settled)
+            // Only the final amount "100" should have been used for one quote fetch, and the
+            // spinner clears once it settles.
+            assertFalse(vm.uiState.value.isLoading)
         }
 
     // endregion

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -715,8 +715,21 @@ internal class SwapFormViewModelTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            // Only the final amount "100" should have been used for one quote fetch, and the
-            // spinner clears once it settles.
+            // Only the final amount "100" should have been used for one quote fetch (rapid edits
+            // are coalesced by the debounce), and the spinner clears once it settles.
+            coVerify(exactly = 1) {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
             assertFalse(vm.uiState.value.isLoading)
         }
 


### PR DESCRIPTION
Closes #4711

## Problem
`SwapFormViewModel.calculateFees()` set `isLoading = true` **inside** `.collect`, i.e. *after* the 450ms debounce window. So for ~450ms after the user stopped typing, the swap form showed no loading feedback and felt frozen.

## Changes
1. **Move the loading state ahead of the debounce** — `isLoading = true` now runs in an `.onEach` before `.debounce(...)`, so the spinner appears immediately on input. The debounce still gates the actual quote network call (`fetchBestQuote` fans out to THOR/Maya/Kyber/1inch/LiFi/SwapKit), so **no extra provider requests fire**.
2. **Tighten the debounce 450ms → 300ms** — brings the *quote start* closer to iOS (200ms) while keeping request coalescing.

No caching changes — Android already caches the discount-tier pre-work via `GetDiscountBpsUseCase`, so nothing on-chain sits on the quote critical path (per the issue).

## Diff
```kotlin
.combine(refreshQuoteState) { it, _ -> it }
.onEach { isLoading = true }   // immediate UI feedback
.debounce(300L)                // still coalesces the network call
.collect { (address, amount) ->
    // isLoading = true  (removed from here)
    ...
```

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [ ] Open Swap, enter a source amount → spinner appears immediately on keystroke (no ~450ms freeze)
- [ ] Quote still fetches once per pause; rapid typing does not fire multiple quote requests
- [ ] Error paths (zero/negative amount, same asset, unsupported pair) still clear loading correctly

## Screenshots
N/A — this is a transient loading-timing change (spinner appears earlier after a keystroke), not a visual/layout change against Figma. There is no static before/after frame to capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap form now shows loading immediately when you change the amount, shortens the debounce interval, and cancels stale quote requests so outdated results don't overwrite newer input.
  * Primary action label now reflects whether the amount field is empty (prompt to fill in) rather than relying on loading state.

* **Tests**
  * Updated tests to match the refined debounce timing and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->