### PR TITLE
feat(swap): SwapKit UTXO sources — BCH / DOGE / LTC / DASH / ZEC (#4702)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,30 +475,13 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC/LTC segwit PSBT, DOGE/BCH/DASH legacy-P2PKH PSBT, ZEC
-                                // Sapling-v4 PSBT, TRON (TronWeb object), SUI (PTB), TON (native
-                                // transfer), XRP (deposit-only native Payment), and both Cardano
-                                // flows (deposit-only CARDANO + pre-built CARDANO_PREBUILT) are
-                                // wired with their per-chain signers/native paths. Guarded loudly
-                                // so an un-wired txType can't reach signing.
+                                // Pre-flight gate: refuse a route whose txType has no wired signing
+                                // path before staging keysign. Sourced from
+                                // SwapKitSwapPayloadJson.SIGNABLE_TX_TYPES — the same list
+                                // SigningHelper dispatches on — so this guard can't drift from what
+                                // the dispatcher actually accepts.
                                 require(
-                                    quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TON ||
-                                        quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_XRP ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO ||
-                                        quote.data.txType ==
-                                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT
+                                    SwapKitSwapPayloadJson.isSignableTxType(quote.data.txType)
                                 ) {
                                     "Unsupported SwapKit txType for swap: ${quote.data.txType}"
                                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -475,13 +475,22 @@ constructor(
                             }
 
                             is SwapQuote.SwapKit -> {
-                                // BTC PSBT, TRON (TronWeb object), SUI (PTB), TON (native
+                                // BTC/LTC segwit PSBT, DOGE/BCH/DASH legacy-P2PKH PSBT, ZEC
+                                // Sapling-v4 PSBT, TRON (TronWeb object), SUI (PTB), TON (native
                                 // transfer), XRP (deposit-only native Payment), and both Cardano
                                 // flows (deposit-only CARDANO + pre-built CARDANO_PREBUILT) are
                                 // wired with their per-chain signers/native paths. Guarded loudly
                                 // so an un-wired txType can't reach signing.
                                 require(
                                     quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_PSBT ||
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE ||
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH ||
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ||
+                                        quote.data.txType ==
+                                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TRON ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_SUI ||
                                         quote.data.txType == SwapKitSwapPayloadJson.TX_TYPE_TON ||

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -125,6 +125,7 @@ object SigningHelper {
                                     .getPreSignedImageHash(
                                         psbtBytes = swapPayload.data.txPayload,
                                         targetAddress = swapPayload.data.targetAddress,
+                                        fromAmount = swapPayload.data.fromAmount,
                                     )
                             // Transparent ZEC (Sapling-v4 body, ZIP-243 sighash).
                             SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
@@ -132,6 +133,7 @@ object SigningHelper {
                                     .getPreSignedImageHash(
                                         psbtBytes = swapPayload.data.txPayload,
                                         targetAddress = swapPayload.data.targetAddress,
+                                        fromAmount = swapPayload.data.fromAmount,
                                     )
                             SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                                 SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
@@ -357,6 +359,7 @@ object SigningHelper {
                                 .getSignedTransaction(
                                     psbtBytes = swapPayload.data.txPayload,
                                     targetAddress = swapPayload.data.targetAddress,
+                                    fromAmount = swapPayload.data.fromAmount,
                                     signatures = signatures,
                                 )
                         SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
@@ -364,6 +367,7 @@ object SigningHelper {
                                 .getSignedTransaction(
                                     psbtBytes = swapPayload.data.txPayload,
                                     targetAddress = swapPayload.data.targetAddress,
+                                    fromAmount = swapPayload.data.fromAmount,
                                     signatures = signatures,
                                 )
                         SwapKitSwapPayloadJson.TX_TYPE_TRON ->

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -107,12 +107,31 @@ object SigningHelper {
                 is SwapPayload.SwapKit -> {
                     messages +=
                         when (swapPayload.data.txType) {
+                            // Segwit PSBT (BTC + LTC). CoinType is picked from the source chain;
+                            // the BIP-143 sighash + segwit serialization are otherwise identical.
                             SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
-                                SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                                SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
                                     .getPreSignedImageHash(
                                         psbtBytes = swapPayload.data.txPayload,
                                         targetAddress = swapPayload.data.targetAddress,
                                         fromAmount = swapPayload.data.fromAmount,
+                                    )
+                            // Legacy P2PKH UTXO chains (DOGE / BCH / DASH). DOGE/DASH use classic
+                            // ECDSA sighashing; BCH adds SIGHASH_FORKID via its CoinType.
+                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE,
+                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH,
+                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ->
+                                SwapKitLegacyP2PKHSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
+                                    .getPreSignedImageHash(
+                                        psbtBytes = swapPayload.data.txPayload,
+                                        targetAddress = swapPayload.data.targetAddress,
+                                    )
+                            // Transparent ZEC (Sapling-v4 body, ZIP-243 sighash).
+                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
+                                SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
+                                    .getPreSignedImageHash(
+                                        psbtBytes = swapPayload.data.txPayload,
+                                        targetAddress = swapPayload.data.targetAddress,
                                     )
                             SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                                 SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
@@ -329,8 +348,24 @@ object SigningHelper {
                 is SwapPayload.SwapKit -> {
                     return when (swapPayload.data.txType) {
                         SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
-                            SwapKitBtcSigner(ecdsaKey, ecdsaChainCode)
+                            SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE,
+                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH,
+                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ->
+                            SwapKitLegacyP2PKHSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
+                                .getSignedTransaction(
+                                    psbtBytes = swapPayload.data.txPayload,
+                                    targetAddress = swapPayload.data.targetAddress,
+                                    signatures = signatures,
+                                )
+                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
+                            SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
+                                .getSignedTransaction(
+                                    psbtBytes = swapPayload.data.txPayload,
+                                    targetAddress = swapPayload.data.targetAddress,
+                                    signatures = signatures,
+                                )
                         SwapKitSwapPayloadJson.TX_TYPE_TRON ->
                             SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
                                 .getSignedTransaction(swapPayload.data.txPayload, signatures)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
@@ -28,12 +28,17 @@ internal class SwapKitBtcSignerException(message: String) : Exception(message)
  * and the SwapKit BTC providers observed (NEAR / GARDEN / FLASHNET), which place only the user's
  * UTXOs in the inputs (every input is `is_ours`). PSBT framing primitives live in
  * [SwapKitPsbtParser]; the BIP-144 unsigned-tx body parser stays here.
+ *
+ * [coinType] is BITCOIN by default and LITECOIN for the LTC route. Litecoin is also native segwit
+ * (P2WPKH / P2SH-P2WPKH) so the BIP-143 sighash + segwit serialization are byte-identical; only the
+ * vault address / lock-script derivation (used for the change-output binding) differs, and those go
+ * through [coinType]. Mirrors iOS, where BTC and LTC share `SwapKitBTCSigner`.
  */
 internal class SwapKitBtcSigner(
     private val vaultHexPublicKey: String,
     private val vaultHexChainCode: String,
+    private val coinType: CoinType = CoinType.BITCOIN,
 ) {
-    private val coinType = CoinType.BITCOIN
     private val utxo = UtxoHelper(coinType, vaultHexPublicKey, vaultHexChainCode)
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
@@ -330,8 +330,15 @@ internal class SwapKitLegacyP2PKHSigner(
             (0L until inCount).map {
                 val prevBytes = cursor.readBytes(32) // internal little-endian wire order
                 val prevIndex = cursor.readUInt32LE()
+                // A PSBT's unsigned tx must carry empty scriptSigs. Reject a non-empty one rather
+                // than silently skip it — the frozen plan rebuilds the tx from these parsed fields,
+                // so dropped bytes would change the broadcast tx_id the route is tracked by.
                 val scriptSigLen = cursor.readCompactSize()
-                cursor.readBytes(cursor.asLength(scriptSigLen)) // empty in unsigned tx
+                if (scriptSigLen != 0L) {
+                    throw SwapKitLegacyP2PKHSignerException(
+                        "SwapKit PSBT unsigned-tx input #$it scriptSig must be empty"
+                    )
+                }
                 val sequence = cursor.readUInt32LE()
                 ParsedLegacyTxInput(prevBytes, prevIndex, sequence)
             }
@@ -343,6 +350,13 @@ internal class SwapKitLegacyP2PKHSigner(
                 LegacyP2PKHOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
             }
         cursor.readUInt32LE() // locktime
+        // The unsigned-tx body must consume exactly; trailing bytes (e.g. a stray BIP-144 witness
+        // flag) would be silently dropped from the rebuilt tx, diverging it from the PSBT body.
+        if (!cursor.isAtEnd) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT unsigned-tx body has trailing bytes"
+            )
+        }
         return ParsedLegacyTx(inputs, outputs)
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
@@ -5,6 +5,8 @@ import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.getDustThreshold
+import java.math.BigInteger
+import java.security.MessageDigest
 import tss.KeysignResponse
 import wallet.core.jni.Base58
 import wallet.core.jni.BitcoinScript
@@ -48,8 +50,12 @@ internal class SwapKitLegacyP2PKHSigner(
      * preimage construction via the frozen-plan input data and [coinType] (BCH gets SIGHASH_FORKID
      * through `hashTypeForCoin`).
      */
-    fun getPreSignedImageHash(psbtBytes: ByteArray, targetAddress: String): List<String> {
-        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+    fun getPreSignedImageHash(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        fromAmount: BigInteger,
+    ): List<String> {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress, fromAmount)
         val preHashes = TransactionCompiler.preImageHashes(coinType, inputData)
         val preSigningOutput = Bitcoin.PreSigningOutput.parseFrom(preHashes).checkError()
         return preSigningOutput.hashPublicKeysList
@@ -66,18 +72,24 @@ internal class SwapKitLegacyP2PKHSigner(
     fun getSignedTransaction(
         psbtBytes: ByteArray,
         targetAddress: String,
+        fromAmount: BigInteger,
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
-        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        val inputData = buildSigningInputData(psbtBytes, targetAddress, fromAmount)
         return utxo.getSignedTransaction(inputData, signatures)
     }
 
     /**
      * Build the serialized [Bitcoin.SigningInput] with a **frozen** [Bitcoin.TransactionPlan]
-     * derived directly from the PSBT bytes. Exposed `internal` so per-chain unit tests can pin the
-     * structural shape (input count, scriptPubKey patterns, plan amount/change/fee).
+     * derived directly from the PSBT bytes. [fromAmount] is the quoted swap amount (source-chain
+     * base units) used to bound the miner fee. Exposed `internal` so per-chain unit tests can pin
+     * the structural shape (input count, scriptPubKey patterns, plan amount/change/fee).
      */
-    internal fun buildSigningInputData(psbtBytes: ByteArray, targetAddress: String): ByteArray {
+    internal fun buildSigningInputData(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        fromAmount: BigInteger,
+    ): ByteArray {
         if (psbtBytes.isEmpty()) {
             throw SwapKitLegacyP2PKHSignerException("SwapKit PSBT payload is empty")
         }
@@ -98,7 +110,12 @@ internal class SwapKitLegacyP2PKHSigner(
         val inputs =
             parsedTx.inputs.mapIndexed { index, parsedInput ->
                 val (amount, scriptPubKey) =
-                    resolvePrevUtxo(inputMaps[index], parsedInput.prevIndex, index)
+                    resolvePrevUtxo(
+                        inputMaps[index],
+                        parsedInput.prevTxIdLE,
+                        parsedInput.prevIndex,
+                        index,
+                    )
                 val keyHash = assertP2PKHAndExtractKeyHash(scriptPubKey, index, "input")
                 LegacyP2PKHInput(
                     prevTxIdLE = parsedInput.prevTxIdLE,
@@ -110,7 +127,13 @@ internal class SwapKitLegacyP2PKHSigner(
                 )
             }
 
-        return assembleSigningInput(inputs, parsedTx.outputs, parsedTx.lockTime, targetAddress)
+        return assembleSigningInput(
+            inputs,
+            parsedTx.outputs,
+            parsedTx.lockTime,
+            fromAmount,
+            targetAddress,
+        )
     }
 
     /**
@@ -126,6 +149,7 @@ internal class SwapKitLegacyP2PKHSigner(
         inputs: List<LegacyP2PKHInput>,
         outputs: List<LegacyP2PKHOutput>,
         lockTime: Long,
+        fromAmount: BigInteger,
         targetAddressHint: String,
     ): ByteArray {
         if (inputs.isEmpty() || outputs.isEmpty()) {
@@ -147,6 +171,18 @@ internal class SwapKitLegacyP2PKHSigner(
         if (fee < 0) {
             throw SwapKitLegacyP2PKHSignerException(
                 "SwapKit PSBT negative fee: inputs=$totalIn outputs=$totalOut"
+            )
+        }
+        // Fee ceiling. The Verify screen never surfaces the miner fee, and the legacy path doesn't
+        // bind the deposit address, so a PSBT that under-allocates the change output would burn the
+        // remainder to the miner. A fixed sat/vByte ceiling like the BTC path isn't portable here
+        // (DOGE's legitimate fees run orders of magnitude higher), so bound the fee by the quoted
+        // swap amount: a miner fee larger than the amount being swapped is pathological and
+        // refused.
+        if (BigInteger.valueOf(fee) > fromAmount) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT miner fee $fee exceeds the quoted swap amount $fromAmount; refusing " +
+                    "to sign"
             )
         }
 
@@ -233,11 +269,12 @@ internal class SwapKitLegacyP2PKHSigner(
      */
     private fun resolvePrevUtxo(
         inputMap: Map<String, ByteArray>,
+        prevTxIdLE: ByteArray,
         prevIndex: Long,
         inputIndex: Int,
     ): Pair<Long, ByteArray> {
         inputMap[KEY_NON_WITNESS_UTXO]?.let {
-            return parseNonWitnessUtxo(it, prevIndex, inputIndex)
+            return parseNonWitnessUtxo(it, prevTxIdLE, prevIndex, inputIndex)
         }
         inputMap[KEY_WITNESS_UTXO]?.let {
             return parseWitnessUtxo(it, inputIndex)
@@ -253,9 +290,20 @@ internal class SwapKitLegacyP2PKHSigner(
      */
     private fun parseNonWitnessUtxo(
         data: ByteArray,
+        prevTxIdLE: ByteArray,
         prevIndex: Long,
         inputIndex: Int,
     ): Pair<Long, ByteArray> {
+        // BIP-174 binds a NON_WITNESS_UTXO to its input: double-SHA256 of the embedded prev-tx must
+        // equal the outpoint txid. Without this a substituted record feeds a forged amount into the
+        // sighash — and because BCH (SIGHASH_FORKID) and ZEC (ZIP-243) commit the input amount to
+        // the digest, a wrong value only surfaces as a network rejection at broadcast instead of a
+        // clear failure up front.
+        if (!sha256d(data).contentEquals(prevTxIdLE)) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT input #$inputIndex NON_WITNESS_UTXO does not hash to its outpoint txid"
+            )
+        }
         val cursor = PsbtCursor(data)
         cursor.readUInt32LE() // version
         val inCount = cursor.readCompactSize()
@@ -414,6 +462,11 @@ internal class SwapKitLegacyP2PKHSigner(
             CoinType.DASH -> byteArrayOf(0x4C)
             else -> null
         }
+
+    private fun sha256d(data: ByteArray): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(digest.digest(data))
+    }
 
     private companion object {
         private const val KEY_NON_WITNESS_UTXO = "00"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
@@ -377,7 +377,21 @@ internal class SwapKitLegacyP2PKHSigner(
      */
     private fun parseLegacyUnsignedTx(data: ByteArray): ParsedLegacyTx {
         val cursor = PsbtCursor(data)
-        cursor.readUInt32LE() // version
+        val version = cursor.readUInt32LE()
+        // WalletCore's legacy Bitcoin compiler takes no tx-version input and emits version 1 on
+        // this
+        // path (confirmed against the DOGE / BCH / DASH mainnet broadcasts, whose tx_ids matched
+        // the
+        // quoted PSBT). A PSBT declaring any other version can't be reproduced — it would rebuild
+        // to
+        // a different tx_id and silently break NEAR route tracking — so reject it loudly, mirroring
+        // the ZEC expiryHeight guard.
+        if (version != WALLETCORE_LEGACY_TX_VERSION) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT unsigned-tx version $version is unsupported; WalletCore reproduces " +
+                    "only version $WALLETCORE_LEGACY_TX_VERSION on the legacy P2PKH path"
+            )
+        }
         val inCount = cursor.readCompactSize()
         val inputs =
             (0L until inCount).map {
@@ -471,5 +485,10 @@ internal class SwapKitLegacyP2PKHSigner(
     private companion object {
         private const val KEY_NON_WITNESS_UTXO = "00"
         private const val KEY_WITNESS_UTXO = "01"
+
+        /**
+         * Tx version WalletCore emits (and thus can reproduce) on the legacy P2PKH compile path.
+         */
+        private const val WALLETCORE_LEGACY_TX_VERSION = 1L
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
@@ -1,0 +1,403 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.crypto.checkError
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.utils.Numeric
+import com.vultisig.wallet.data.utils.getDustThreshold
+import tss.KeysignResponse
+import wallet.core.jni.Base58
+import wallet.core.jni.BitcoinScript
+import wallet.core.jni.CoinType
+import wallet.core.jni.TransactionCompiler
+import wallet.core.jni.proto.Bitcoin
+import wallet.core.jni.proto.Common.SigningError
+
+internal class SwapKitLegacyP2PKHSignerException(message: String) : Exception(message)
+
+/**
+ * Shared bridge between a SwapKit PSBT and WalletCore's `TransactionCompiler` for **legacy P2PKH
+ * UTXO chains**: DOGE (no segwit ever), BCH (forked 2017, no segwit), DASH (no segwit). Ported from
+ * iOS' `SwapKitLegacyP2PKHSigner`.
+ *
+ * Why this exists separately from [SwapKitBtcSigner]: that signer computes **BIP-143** sighashes,
+ * which are segwit-only (`hashPrevouts` / `hashSequence` / `hashOutputs` assume witness semantics).
+ * DOGE / BCH / DASH inputs are pure P2PKH (`76 a9 14 <20> 88 ac`) and need **legacy sighashing**,
+ * which WalletCore's `TransactionCompiler` handles end-to-end via the per-chain [CoinType] (the
+ * same path the native send helper rides). BCH adds `SIGHASH_FORKID` natively via
+ * `BitcoinScript.hashTypeForCoin(BITCOINCASH)`.
+ *
+ * The "frozen plan" pattern is load-bearing: if we let WalletCore replan UTXO selection it would
+ * compute a different tx and a different `tx_id`. NEAR Intents tracks the route by the tx_id
+ * SwapKit baked into the PSBT — we sign verbatim or we break tracking. So we build the
+ * [Bitcoin.SigningInput] with a frozen [Bitcoin.TransactionPlan] derived directly from the PSBT
+ * bytes instead of calling `AnySigner.plan`.
+ *
+ * PSBT framing primitives live in [SwapKitPsbtParser]; the legacy (non-witness) unsigned-tx body
+ * parser stays here.
+ */
+internal class SwapKitLegacyP2PKHSigner(
+    private val vaultHexPublicKey: String,
+    private val vaultHexChainCode: String,
+    private val coinType: CoinType,
+) {
+    private val utxo = UtxoHelper(coinType, vaultHexPublicKey, vaultHexChainCode)
+
+    /**
+     * Legacy ECDSA P2PKH sighashes (sorted hex) for every input. WalletCore handles the per-input
+     * preimage construction via the frozen-plan input data and [coinType] (BCH gets SIGHASH_FORKID
+     * through `hashTypeForCoin`).
+     */
+    fun getPreSignedImageHash(psbtBytes: ByteArray, targetAddress: String): List<String> {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        val preHashes = TransactionCompiler.preImageHashes(coinType, inputData)
+        val preSigningOutput = Bitcoin.PreSigningOutput.parseFrom(preHashes).checkError()
+        return preSigningOutput.hashPublicKeysList
+            .map { Numeric.toHexStringNoPrefix(it.dataHash.toByteArray()) }
+            .sorted()
+    }
+
+    /**
+     * Assemble the signed broadcast tx from the SwapKit PSBT and MPC signatures. Reuses
+     * [UtxoHelper.getSignedTransaction] over the frozen-plan input data: it re-derives the vault
+     * pubkey, verifies every ECDSA-DER signature against its per-input preimage hash, and runs
+     * `TransactionCompiler.compileWithSignatures`.
+     */
+    fun getSignedTransaction(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        return utxo.getSignedTransaction(inputData, signatures)
+    }
+
+    /**
+     * Build the serialized [Bitcoin.SigningInput] with a **frozen** [Bitcoin.TransactionPlan]
+     * derived directly from the PSBT bytes. Exposed `internal` so per-chain unit tests can pin the
+     * structural shape (input count, scriptPubKey patterns, plan amount/change/fee).
+     */
+    internal fun buildSigningInputData(psbtBytes: ByteArray, targetAddress: String): ByteArray {
+        if (psbtBytes.isEmpty()) {
+            throw SwapKitLegacyP2PKHSignerException("SwapKit PSBT payload is empty")
+        }
+
+        // 1. Parse BIP-174 framing + the legacy unsigned-tx body.
+        val header = SwapKitPsbtParser.parseFramingHeader(psbtBytes)
+        val parsedTx = parseLegacyUnsignedTx(header.unsignedTxBytes)
+
+        // 2. Drain the per-input and per-output maps off the cursor (outputs parsed for spec
+        // compliance / forward-compat even though no per-output field is read).
+        val cursor = header.cursor
+        val inputMaps = parsedTx.inputs.map { cursor.readMap() }
+        parsedTx.outputs.forEach { cursor.readMap() }
+
+        // 3. Resolve per-input scriptPubKey + amount + keyHash. SwapKit ships either
+        // NON_WITNESS_UTXO (full prev-tx, key 0x00 — BIP-174's recommendation for legacy P2PKH;
+        // DOGE confirmed) or WITNESS_UTXO (key 0x01, BTC-style compact). Accept both.
+        val inputs =
+            parsedTx.inputs.mapIndexed { index, parsedInput ->
+                val (amount, scriptPubKey) =
+                    resolvePrevUtxo(inputMaps[index], parsedInput.prevIndex, index)
+                val keyHash = assertP2PKHAndExtractKeyHash(scriptPubKey, index, "input")
+                LegacyP2PKHInput(
+                    prevTxIdLE = parsedInput.prevTxIdLE,
+                    prevIndex = parsedInput.prevIndex,
+                    sequence = parsedInput.sequence,
+                    amount = amount,
+                    scriptPubKey = scriptPubKey,
+                    keyHash = keyHash,
+                )
+            }
+
+        return assembleSigningInput(inputs, parsedTx.outputs, targetAddress)
+    }
+
+    /**
+     * Build the [Bitcoin.SigningInput] with a frozen plan. WalletCore reconstructs every output
+     * from `toAddress` + `changeAddress` (it does NOT consume per-output scripts from the plan), so
+     * we assert every output is a P2PKH we can faithfully re-emit through the address-only API,
+     * then derive both addresses from the PSBT's actual output hash160s — making the rebuilt tx
+     * byte-identical to the PSBT's intended outputs (preserves the NEAR Intents route `tx_id` and
+     * the deposit destination). Anything other than 1 deposit + optional 1 change P2PKH output is
+     * hard-rejected.
+     */
+    private fun assembleSigningInput(
+        inputs: List<LegacyP2PKHInput>,
+        outputs: List<LegacyP2PKHOutput>,
+        targetAddressHint: String,
+    ): ByteArray {
+        if (inputs.isEmpty() || outputs.isEmpty()) {
+            throw SwapKitLegacyP2PKHSignerException("SwapKit PSBT has empty inputs or outputs")
+        }
+        if (outputs.size > 2) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT has ${outputs.size} outputs; legacy signer expects 1 deposit + " +
+                    "optional 1 change"
+            )
+        }
+        val outputKeyHashes =
+            outputs.mapIndexed { idx, out ->
+                assertP2PKHAndExtractKeyHash(out.scriptPubKey, idx, "output")
+            }
+        val totalIn = inputs.sumOf { it.amount }
+        val totalOut = outputs.sumOf { it.amount }
+        val fee = totalIn - totalOut
+        if (fee < 0) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT negative fee: inputs=$totalIn outputs=$totalOut"
+            )
+        }
+
+        val depositAmount = outputs[0].amount
+        val changeAmount = outputs.drop(1).sumOf { it.amount }
+        // Derive addresses that round-trip back to the exact scriptPubKeys the PSBT shipped. The
+        // SwapKit `targetAddress` hint is used only if hash160 → address derivation fails
+        // (shouldn't
+        // happen for DOGE/BCH/DASH — all decode via single-byte base58check).
+        val depositAddress = legacyAddress(outputKeyHashes[0]) ?: targetAddressHint
+        val changeAddress =
+            if (outputs.size >= 2) {
+                legacyAddress(outputKeyHashes[1]) ?: targetAddressHint
+            } else {
+                // No change output — point `changeAddress` at the source pubkey hash so
+                // WalletCore's
+                // validator accepts the input. The plan's `change = 0` means no change output is
+                // actually emitted, so the address is a structural placeholder.
+                legacyAddress(inputs[0].keyHash) ?: targetAddressHint
+            }
+
+        val utxos =
+            inputs.map { input ->
+                Bitcoin.UnspentTransaction.newBuilder()
+                    .setAmount(input.amount)
+                    .setOutPoint(
+                        // `prevTxIdLE` is already in internal little-endian wire order — set it
+                        // verbatim (do NOT reverse, unlike the native send path which starts from a
+                        // display-order hash).
+                        Bitcoin.OutPoint.newBuilder()
+                            .setHash(ByteString.copyFrom(input.prevTxIdLE))
+                            .setIndex(input.prevIndex.toInt())
+                            .setSequence(input.sequence.toInt())
+                            .build()
+                    )
+                    .setScript(ByteString.copyFrom(input.scriptPubKey))
+                    .build()
+            }
+
+        // Frozen plan. Critical: do NOT replan — the replanner would re-select UTXOs and could
+        // produce a different on-chain tx_id, breaking NEAR Intents route tracking.
+        val plan =
+            Bitcoin.TransactionPlan.newBuilder()
+                .setAmount(depositAmount)
+                .setAvailableAmount(totalIn)
+                .setFee(fee)
+                .setChange(changeAmount)
+                .setError(SigningError.OK)
+                .addAllUtxos(utxos)
+                .build()
+
+        val signingInput =
+            Bitcoin.SigningInput.newBuilder()
+                .setHashType(BitcoinScript.hashTypeForCoin(coinType))
+                .setByteFee(1L) // Frozen plan supersedes — the replanner won't run.
+                .setUseMaxAmount(false)
+                .setAmount(depositAmount)
+                .setCoinType(coinType.value())
+                .setToAddress(depositAddress)
+                .setChangeAddress(changeAddress)
+                .setFixedDustThreshold(coinType.getDustThreshold)
+                .addAllUtxo(utxos)
+                .setPlan(plan)
+
+        // scripts map: keyHash.hex → P2PKH redeem script. Mirrors the native send path.
+        inputs.forEach { input ->
+            val redeem = BitcoinScript.buildPayToPublicKeyHash(input.keyHash)
+            signingInput.putScripts(
+                Numeric.toHexStringNoPrefix(input.keyHash),
+                ByteString.copyFrom(redeem.data()),
+            )
+        }
+
+        return signingInput.build().toByteArray()
+    }
+
+    /**
+     * SwapKit may ship either `PSBT_IN_NON_WITNESS_UTXO` (key 0x00, embedded prev-tx) or
+     * `PSBT_IN_WITNESS_UTXO` (key 0x01, compact amount + scriptPubKey). Both surface the same
+     * `amount` + `scriptPubKey` pair; whichever ships is accepted.
+     */
+    private fun resolvePrevUtxo(
+        inputMap: Map<String, ByteArray>,
+        prevIndex: Long,
+        inputIndex: Int,
+    ): Pair<Long, ByteArray> {
+        inputMap[KEY_NON_WITNESS_UTXO]?.let {
+            return parseNonWitnessUtxo(it, prevIndex, inputIndex)
+        }
+        inputMap[KEY_WITNESS_UTXO]?.let {
+            return parseWitnessUtxo(it, inputIndex)
+        }
+        throw SwapKitLegacyP2PKHSignerException(
+            "SwapKit PSBT input #$inputIndex is missing a prev-tx UTXO record"
+        )
+    }
+
+    /**
+     * Parse a `PSBT_IN_NON_WITNESS_UTXO` record: the full previous transaction in legacy
+     * (pre-segwit) wire serialization. We extract `outputs[prevIndex]`.
+     */
+    private fun parseNonWitnessUtxo(
+        data: ByteArray,
+        prevIndex: Long,
+        inputIndex: Int,
+    ): Pair<Long, ByteArray> {
+        val cursor = PsbtCursor(data)
+        cursor.readUInt32LE() // version
+        val inCount = cursor.readCompactSize()
+        repeat(cursor.asLength(inCount)) {
+            cursor.readBytes(32) // prev txid
+            cursor.readUInt32LE() // prev index
+            val sigLen = cursor.readCompactSize()
+            cursor.readBytes(cursor.asLength(sigLen)) // scriptSig
+            cursor.readUInt32LE() // sequence
+        }
+        val outCount = cursor.readCompactSize()
+        if (prevIndex >= outCount) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT input #$inputIndex prev index $prevIndex >= output count $outCount"
+            )
+        }
+        var amount = 0L
+        var scriptPubKey = ByteArray(0)
+        for (i in 0 until outCount) {
+            val outAmount = cursor.readUInt64LE()
+            val scriptLen = cursor.readCompactSize()
+            val script = cursor.readBytes(cursor.asLength(scriptLen))
+            if (i == prevIndex) {
+                amount = outAmount
+                scriptPubKey = script
+            }
+        }
+        return amount to scriptPubKey
+    }
+
+    /** WITNESS_UTXO value: 8-byte LE amount + varint-prefixed scriptPubKey. */
+    private fun parseWitnessUtxo(data: ByteArray, inputIndex: Int): Pair<Long, ByteArray> {
+        val cursor = PsbtCursor(data)
+        val amount = cursor.readUInt64LE()
+        val scriptLen = cursor.readCompactSize()
+        val script = cursor.readBytes(cursor.asLength(scriptLen))
+        if (!cursor.isAtEnd) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT input #$inputIndex WITNESS_UTXO has trailing bytes"
+            )
+        }
+        return amount to script
+    }
+
+    private data class LegacyP2PKHInput(
+        val prevTxIdLE: ByteArray,
+        val prevIndex: Long,
+        val sequence: Long,
+        val amount: Long,
+        val scriptPubKey: ByteArray,
+        val keyHash: ByteArray,
+    )
+
+    private data class LegacyP2PKHOutput(val amount: Long, val scriptPubKey: ByteArray)
+
+    private data class ParsedLegacyTxInput(
+        val prevTxIdLE: ByteArray,
+        val prevIndex: Long,
+        val sequence: Long,
+    )
+
+    private data class ParsedLegacyTx(
+        val inputs: List<ParsedLegacyTxInput>,
+        val outputs: List<LegacyP2PKHOutput>,
+    )
+
+    /**
+     * Parse the legacy (non-witness) unsigned-tx body BIP-174 stores under global key 0x00. DOGE /
+     * BCH / DASH have no segwit, so the body never carries a marker+flag.
+     */
+    private fun parseLegacyUnsignedTx(data: ByteArray): ParsedLegacyTx {
+        val cursor = PsbtCursor(data)
+        cursor.readUInt32LE() // version
+        val inCount = cursor.readCompactSize()
+        val inputs =
+            (0L until inCount).map {
+                val prevBytes = cursor.readBytes(32) // internal little-endian wire order
+                val prevIndex = cursor.readUInt32LE()
+                val scriptSigLen = cursor.readCompactSize()
+                cursor.readBytes(cursor.asLength(scriptSigLen)) // empty in unsigned tx
+                val sequence = cursor.readUInt32LE()
+                ParsedLegacyTxInput(prevBytes, prevIndex, sequence)
+            }
+        val outCount = cursor.readCompactSize()
+        val outputs =
+            (0L until outCount).map {
+                val amount = cursor.readUInt64LE()
+                val scriptLen = cursor.readCompactSize()
+                LegacyP2PKHOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
+            }
+        cursor.readUInt32LE() // locktime
+        return ParsedLegacyTx(inputs, outputs)
+    }
+
+    /**
+     * P2PKH scriptPubKey: 25 bytes — `OP_DUP OP_HASH160 PUSH20 <20-byte hash> OP_EQUALVERIFY
+     * OP_CHECKSIG` = `76 a9 14 <20> 88 ac`. Returns the 20-byte hash160. [role] tags the error
+     * (`input`/`output`) so non-P2PKH rejections read distinctly in logs.
+     */
+    private fun assertP2PKHAndExtractKeyHash(
+        scriptPubKey: ByteArray,
+        index: Int,
+        role: String,
+    ): ByteArray {
+        if (
+            !(scriptPubKey.size == 25 &&
+                scriptPubKey[0] == 0x76.toByte() &&
+                scriptPubKey[1] == 0xa9.toByte() &&
+                scriptPubKey[2] == 0x14.toByte() &&
+                scriptPubKey[23] == 0x88.toByte() &&
+                scriptPubKey[24] == 0xac.toByte())
+        ) {
+            throw SwapKitLegacyP2PKHSignerException(
+                "SwapKit PSBT $role #$index scriptPubKey is not P2PKH: " +
+                    Numeric.toHexStringNoPrefix(scriptPubKey)
+            )
+        }
+        return scriptPubKey.copyOfRange(3, 23)
+    }
+
+    /**
+     * Build a legacy base58-check P2PKH address for [coinType] from a 20-byte hash160. Used to
+     * derive the deposit + change addresses WalletCore re-emits as output scripts. Returns null if
+     * no version prefix is defined for the coin (caller falls back to the SwapKit `targetAddress`
+     * hint).
+     */
+    private fun legacyAddress(hash: ByteArray): String? {
+        val prefix = versionPrefix(coinType) ?: return null
+        return Base58.encode(prefix + hash)
+    }
+
+    /**
+     * Mainnet P2PKH version prefix per chain. Listed inline because [CoinType] doesn't surface the
+     * prefix bytes. DOGE `0x1E` (`D…`), BCH `0x00` legacy `1…` (CashAddr derives the same hash),
+     * DASH `0x4C` (`X…`).
+     */
+    private fun versionPrefix(coin: CoinType): ByteArray? =
+        when (coin) {
+            CoinType.DOGECOIN -> byteArrayOf(0x1E)
+            CoinType.BITCOINCASH -> byteArrayOf(0x00)
+            CoinType.DASH -> byteArrayOf(0x4C)
+            else -> null
+        }
+
+    private companion object {
+        private const val KEY_NON_WITNESS_UTXO = "00"
+        private const val KEY_WITNESS_UTXO = "01"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSigner.kt
@@ -110,7 +110,7 @@ internal class SwapKitLegacyP2PKHSigner(
                 )
             }
 
-        return assembleSigningInput(inputs, parsedTx.outputs, targetAddress)
+        return assembleSigningInput(inputs, parsedTx.outputs, parsedTx.lockTime, targetAddress)
     }
 
     /**
@@ -125,6 +125,7 @@ internal class SwapKitLegacyP2PKHSigner(
     private fun assembleSigningInput(
         inputs: List<LegacyP2PKHInput>,
         outputs: List<LegacyP2PKHOutput>,
+        lockTime: Long,
         targetAddressHint: String,
     ): ByteArray {
         if (inputs.isEmpty() || outputs.isEmpty()) {
@@ -204,6 +205,9 @@ internal class SwapKitLegacyP2PKHSigner(
                 .setUseMaxAmount(false)
                 .setAmount(depositAmount)
                 .setCoinType(coinType.value())
+                // Reproduce the PSBT's lockTime so the rebuilt tx_id matches the one the NEAR route
+                // tracks; WalletCore otherwise defaults it to 0.
+                .setLockTime(lockTime.toInt())
                 .setToAddress(depositAddress)
                 .setChangeAddress(changeAddress)
                 .setFixedDustThreshold(coinType.getDustThreshold)
@@ -314,6 +318,7 @@ internal class SwapKitLegacyP2PKHSigner(
     )
 
     private data class ParsedLegacyTx(
+        val lockTime: Long,
         val inputs: List<ParsedLegacyTxInput>,
         val outputs: List<LegacyP2PKHOutput>,
     )
@@ -349,7 +354,7 @@ internal class SwapKitLegacyP2PKHSigner(
                 val scriptLen = cursor.readCompactSize()
                 LegacyP2PKHOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
             }
-        cursor.readUInt32LE() // locktime
+        val lockTime = cursor.readUInt32LE()
         // The unsigned-tx body must consume exactly; trailing bytes (e.g. a stray BIP-144 witness
         // flag) would be silently dropped from the rebuilt tx, diverging it from the PSBT body.
         if (!cursor.isAtEnd) {
@@ -357,7 +362,7 @@ internal class SwapKitLegacyP2PKHSigner(
                 "SwapKit PSBT unsigned-tx body has trailing bytes"
             )
         }
-        return ParsedLegacyTx(inputs, outputs)
+        return ParsedLegacyTx(lockTime, inputs, outputs)
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -98,12 +98,13 @@ internal class SwapKitZcashSigner(
                 )
             }
 
-        return assembleSigningInput(inputs, parsedTx.outputs, targetAddress)
+        return assembleSigningInput(inputs, parsedTx.outputs, parsedTx.lockTime, targetAddress)
     }
 
     private fun assembleSigningInput(
         inputs: List<SaplingInput>,
         outputs: List<SaplingOutput>,
+        lockTime: Long,
         targetAddressHint: String,
     ): ByteArray {
         if (inputs.isEmpty() || outputs.isEmpty()) {
@@ -176,6 +177,9 @@ internal class SwapKitZcashSigner(
                 .setUseMaxAmount(false)
                 .setAmount(depositAmount)
                 .setCoinType(coinType.value())
+                // Reproduce the PSBT's lockTime so the rebuilt tx_id matches the one the NEAR route
+                // tracks; WalletCore otherwise defaults it to 0.
+                .setLockTime(lockTime.toInt())
                 .setToAddress(depositAddress)
                 .setChangeAddress(changeAddress)
                 .addAllUtxo(utxos)
@@ -274,6 +278,7 @@ internal class SwapKitZcashSigner(
     )
 
     private data class ParsedSaplingTx(
+        val lockTime: Long,
         val inputs: List<ParsedSaplingTxInput>,
         val outputs: List<SaplingOutput>,
     )
@@ -318,8 +323,19 @@ internal class SwapKitZcashSigner(
                 val scriptLen = cursor.readCompactSize()
                 SaplingOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
             }
-        cursor.readUInt32LE() // lockTime
-        cursor.readUInt32LE() // expiryHeight
+        val lockTime = cursor.readUInt32LE()
+        val expiryHeight = cursor.readUInt32LE()
+        // WalletCore's `Bitcoin.SigningInput` has no expiryHeight field, so a non-zero expiryHeight
+        // can't be threaded into the rebuilt tx — WalletCore would emit it with expiryHeight 0 and
+        // a
+        // different tx_id than the PSBT the NEAR route is tracked by. Reject it loudly rather than
+        // silently mistrack. (lockTime, by contrast, IS settable — see assembleSigningInput.)
+        if (expiryHeight != 0L) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT has expiryHeight $expiryHeight; only 0 (no expiry) is supported " +
+                    "because WalletCore can't reproduce a non-zero expiry in the rebuilt tx"
+            )
+        }
         // Sapling-v4 transparent-only: all shielded fields must be zero.
         val valueBalance = cursor.readUInt64LE()
         val nShieldedSpend = cursor.readCompactSize()
@@ -338,7 +354,7 @@ internal class SwapKitZcashSigner(
         if (!cursor.isAtEnd) {
             throw SwapKitZcashSignerException("SwapKit ZEC unsigned-tx body has trailing bytes")
         }
-        return ParsedSaplingTx(inputs, outputs)
+        return ParsedSaplingTx(lockTime, inputs, outputs)
     }
 
     private fun assertP2PKHAndExtractKeyHash(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -4,6 +4,8 @@ import com.google.protobuf.ByteString
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.utils.Numeric
+import java.math.BigInteger
+import java.security.MessageDigest
 import tss.KeysignResponse
 import wallet.core.jni.Base58
 import wallet.core.jni.BitcoinScript
@@ -39,8 +41,12 @@ internal class SwapKitZcashSigner(
     private val utxo = UtxoHelper(coinType, vaultHexPublicKey, vaultHexChainCode)
 
     /** ZIP-243 preimage hashes (sorted hex) for every input. */
-    fun getPreSignedImageHash(psbtBytes: ByteArray, targetAddress: String): List<String> {
-        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+    fun getPreSignedImageHash(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        fromAmount: BigInteger,
+    ): List<String> {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress, fromAmount)
         val preHashes = TransactionCompiler.preImageHashes(coinType, inputData)
         val preSigningOutput = Bitcoin.PreSigningOutput.parseFrom(preHashes).checkError()
         return preSigningOutput.hashPublicKeysList
@@ -57,17 +63,23 @@ internal class SwapKitZcashSigner(
     fun getSignedTransaction(
         psbtBytes: ByteArray,
         targetAddress: String,
+        fromAmount: BigInteger,
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
-        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        val inputData = buildSigningInputData(psbtBytes, targetAddress, fromAmount)
         return utxo.getSignedTransaction(inputData, signatures)
     }
 
     /**
      * Build the serialized [Bitcoin.SigningInput] with a frozen [Bitcoin.TransactionPlan] (branch
-     * id set) derived directly from the Sapling PSBT bytes. Exposed `internal` for unit tests.
+     * id set) derived directly from the Sapling PSBT bytes. [fromAmount] is the quoted swap amount
+     * (zatoshi) used to bound the miner fee. Exposed `internal` for unit tests.
      */
-    internal fun buildSigningInputData(psbtBytes: ByteArray, targetAddress: String): ByteArray {
+    internal fun buildSigningInputData(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        fromAmount: BigInteger,
+    ): ByteArray {
         if (psbtBytes.isEmpty()) {
             throw SwapKitZcashSignerException("SwapKit ZEC PSBT payload is empty")
         }
@@ -86,7 +98,12 @@ internal class SwapKitZcashSigner(
         val inputs =
             parsedTx.inputs.mapIndexed { index, parsedInput ->
                 val (amount, scriptPubKey) =
-                    resolvePrevUtxo(inputMaps[index], parsedInput.prevIndex, index)
+                    resolvePrevUtxo(
+                        inputMaps[index],
+                        parsedInput.prevTxIdLE,
+                        parsedInput.prevIndex,
+                        index,
+                    )
                 val keyHash = assertP2PKHAndExtractKeyHash(scriptPubKey, index, "input")
                 SaplingInput(
                     prevTxIdLE = parsedInput.prevTxIdLE,
@@ -98,13 +115,20 @@ internal class SwapKitZcashSigner(
                 )
             }
 
-        return assembleSigningInput(inputs, parsedTx.outputs, parsedTx.lockTime, targetAddress)
+        return assembleSigningInput(
+            inputs,
+            parsedTx.outputs,
+            parsedTx.lockTime,
+            fromAmount,
+            targetAddress,
+        )
     }
 
     private fun assembleSigningInput(
         inputs: List<SaplingInput>,
         outputs: List<SaplingOutput>,
         lockTime: Long,
+        fromAmount: BigInteger,
         targetAddressHint: String,
     ): ByteArray {
         if (inputs.isEmpty() || outputs.isEmpty()) {
@@ -126,6 +150,16 @@ internal class SwapKitZcashSigner(
         if (fee < 0) {
             throw SwapKitZcashSignerException(
                 "SwapKit ZEC PSBT negative fee: inputs=$totalIn outputs=$totalOut"
+            )
+        }
+        // Fee ceiling — bound the miner fee by the quoted swap amount (the Verify screen never
+        // shows
+        // the fee and the deposit address isn't bound, so an under-allocated change output would
+        // otherwise burn the remainder to the miner). Mirrors the legacy signer.
+        if (BigInteger.valueOf(fee) > fromAmount) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT miner fee $fee exceeds the quoted swap amount $fromAmount; " +
+                    "refusing to sign"
             )
         }
 
@@ -198,11 +232,12 @@ internal class SwapKitZcashSigner(
 
     private fun resolvePrevUtxo(
         inputMap: Map<String, ByteArray>,
+        prevTxIdLE: ByteArray,
         prevIndex: Long,
         inputIndex: Int,
     ): Pair<Long, ByteArray> {
         inputMap[KEY_NON_WITNESS_UTXO]?.let {
-            return parseNonWitnessUtxo(it, prevIndex, inputIndex)
+            return parseNonWitnessUtxo(it, prevTxIdLE, prevIndex, inputIndex)
         }
         inputMap[KEY_WITNESS_UTXO]?.let {
             return parseWitnessUtxo(it, inputIndex)
@@ -214,9 +249,18 @@ internal class SwapKitZcashSigner(
 
     private fun parseNonWitnessUtxo(
         data: ByteArray,
+        prevTxIdLE: ByteArray,
         prevIndex: Long,
         inputIndex: Int,
     ): Pair<Long, ByteArray> {
+        // BIP-174: double-SHA256 of the embedded prev-tx must equal the outpoint txid, or a
+        // substituted record could feed a forged amount into the ZIP-243 sighash (which commits the
+        // input amount) — caught here rather than as a broadcast rejection.
+        if (!sha256d(data).contentEquals(prevTxIdLE)) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT input #$inputIndex NON_WITNESS_UTXO does not hash to its outpoint txid"
+            )
+        }
         val cursor = PsbtCursor(data)
         cursor.readUInt32LE()
         val inCount = cursor.readCompactSize()
@@ -381,6 +425,11 @@ internal class SwapKitZcashSigner(
     /** ZEC transparent `t1…` address from a 20-byte hash160 (two-byte prefix `0x1C 0xB8`). */
     private fun zcashAddress(hash: ByteArray): String? =
         Base58.encode(byteArrayOf(0x1C, 0xB8.toByte()) + hash)
+
+    private fun sha256d(data: ByteArray): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(digest.digest(data))
+    }
 
     private companion object {
         private const val KEY_NON_WITNESS_UTXO = "00"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -298,8 +298,16 @@ internal class SwapKitZcashSigner(
             (0L until inCount).map {
                 val prevBytes = cursor.readBytes(32)
                 val prevIndex = cursor.readUInt32LE()
+                // Unsigned-tx inputs must carry empty scriptSigs; reject a non-empty one rather
+                // than
+                // silently skip it (the frozen plan rebuilds the tx from these fields, so dropped
+                // bytes would change the broadcast tx_id the route is tracked by).
                 val sigLen = cursor.readCompactSize()
-                cursor.readBytes(cursor.asLength(sigLen))
+                if (sigLen != 0L) {
+                    throw SwapKitZcashSignerException(
+                        "SwapKit ZEC unsigned-tx input #$it scriptSig must be empty"
+                    )
+                }
                 val sequence = cursor.readUInt32LE()
                 ParsedSaplingTxInput(prevBytes, prevIndex, sequence)
             }
@@ -323,6 +331,12 @@ internal class SwapKitZcashSigner(
             throw SwapKitZcashSignerException(
                 "SwapKit ZEC PSBT carries a shielded bundle; only transparent-only txs are supported"
             )
+        }
+        // Transparent-only Sapling v4 ends right after the (all-zero) shielded counts — there is no
+        // joinSplit/binding-sig payload. Trailing bytes would be dropped from the rebuilt tx and
+        // diverge it from the quoted PSBT body, so consume the body exactly.
+        if (!cursor.isAtEnd) {
+            throw SwapKitZcashSignerException("SwapKit ZEC unsigned-tx body has trailing bytes")
         }
         return ParsedSaplingTx(inputs, outputs)
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -1,0 +1,371 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.crypto.checkError
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.utils.Numeric
+import tss.KeysignResponse
+import wallet.core.jni.Base58
+import wallet.core.jni.BitcoinScript
+import wallet.core.jni.CoinType
+import wallet.core.jni.TransactionCompiler
+import wallet.core.jni.proto.Bitcoin
+import wallet.core.jni.proto.Common.SigningError
+
+internal class SwapKitZcashSignerException(message: String) : Exception(message)
+
+/**
+ * Signs SwapKit's pre-built ZEC PSBT. Ported from iOS' `SwapKitZcashSigner`. The transparent ZEC tx
+ * is wrapped in a BIP-174 envelope but the inner unsigned-tx body is **Sapling-v4**, not BIP-144
+ * segwit: extra `nVersionGroupId` (4B), `expiryHeight` (4B), `valueBalance` (i64), and three varint
+ * zeros for shielded counts. We walk those, assert the chain is on Sapling-v4 transparent-only (v5
+ * NU5 hard-rejected; non-zero shielded fields hard-rejected), then hand the P2PKH inputs to
+ * WalletCore's `CoinType.ZCASH` path.
+ *
+ * Sighash: WalletCore's ZEC signer implements ZIP-243 (the Sapling signature digest with the
+ * personalised Blake2b-256). It reads the branch id from the plan — the existing native ZEC send
+ * uses [ZCASH_BRANCH_ID_HEX] `f04dec4d`, and we match that so the digest is identical to a manually
+ * sent ZEC transaction. (Deviating to the Sapling-v4 spec id `0x76b809bb` would produce a different
+ * digest the chain rejects.)
+ *
+ * The frozen-plan pattern is load-bearing for the same reason as [SwapKitLegacyP2PKHSigner]: NEAR
+ * Intents tracks the route by the tx_id SwapKit baked into the PSBT, so we sign verbatim.
+ */
+internal class SwapKitZcashSigner(
+    private val vaultHexPublicKey: String,
+    private val vaultHexChainCode: String,
+) {
+    private val coinType = CoinType.ZCASH
+    private val utxo = UtxoHelper(coinType, vaultHexPublicKey, vaultHexChainCode)
+
+    /** ZIP-243 preimage hashes (sorted hex) for every input. */
+    fun getPreSignedImageHash(psbtBytes: ByteArray, targetAddress: String): List<String> {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        val preHashes = TransactionCompiler.preImageHashes(coinType, inputData)
+        val preSigningOutput = Bitcoin.PreSigningOutput.parseFrom(preHashes).checkError()
+        return preSigningOutput.hashPublicKeysList
+            .map { Numeric.toHexStringNoPrefix(it.dataHash.toByteArray()) }
+            .sorted()
+    }
+
+    /**
+     * Assemble the signed broadcast tx with the Sapling-v4 header + ZIP-243 sighash baked into
+     * WalletCore's compileWithSignatures. Reuses [UtxoHelper.getSignedTransaction] over the
+     * frozen-plan input data (re-derives the vault pubkey, verifies each ECDSA-DER signature, then
+     * compiles).
+     */
+    fun getSignedTransaction(
+        psbtBytes: ByteArray,
+        targetAddress: String,
+        signatures: Map<String, KeysignResponse>,
+    ): SignedTransactionResult {
+        val inputData = buildSigningInputData(psbtBytes, targetAddress)
+        return utxo.getSignedTransaction(inputData, signatures)
+    }
+
+    /**
+     * Build the serialized [Bitcoin.SigningInput] with a frozen [Bitcoin.TransactionPlan] (branch
+     * id set) derived directly from the Sapling PSBT bytes. Exposed `internal` for unit tests.
+     */
+    internal fun buildSigningInputData(psbtBytes: ByteArray, targetAddress: String): ByteArray {
+        if (psbtBytes.isEmpty()) {
+            throw SwapKitZcashSignerException("SwapKit ZEC PSBT payload is empty")
+        }
+
+        // 1. Parse BIP-174 framing + the Sapling-v4 body.
+        val header = SwapKitPsbtParser.parseFramingHeader(psbtBytes)
+        val parsedTx = parseSaplingUnsignedTx(header.unsignedTxBytes)
+
+        // 2. Drain per-input + per-output maps.
+        val cursor = header.cursor
+        val inputMaps = parsedTx.inputs.map { cursor.readMap() }
+        parsedTx.outputs.forEach { cursor.readMap() }
+
+        // 3. Resolve per-input UTXO (ZEC ships WITNESS_UTXO per the captured fixture; accept
+        // NON_WITNESS_UTXO too for robustness).
+        val inputs =
+            parsedTx.inputs.mapIndexed { index, parsedInput ->
+                val (amount, scriptPubKey) =
+                    resolvePrevUtxo(inputMaps[index], parsedInput.prevIndex, index)
+                val keyHash = assertP2PKHAndExtractKeyHash(scriptPubKey, index, "input")
+                SaplingInput(
+                    prevTxIdLE = parsedInput.prevTxIdLE,
+                    prevIndex = parsedInput.prevIndex,
+                    sequence = parsedInput.sequence,
+                    amount = amount,
+                    scriptPubKey = scriptPubKey,
+                    keyHash = keyHash,
+                )
+            }
+
+        return assembleSigningInput(inputs, parsedTx.outputs, targetAddress)
+    }
+
+    private fun assembleSigningInput(
+        inputs: List<SaplingInput>,
+        outputs: List<SaplingOutput>,
+        targetAddressHint: String,
+    ): ByteArray {
+        if (inputs.isEmpty() || outputs.isEmpty()) {
+            throw SwapKitZcashSignerException("SwapKit ZEC PSBT has empty inputs or outputs")
+        }
+        if (outputs.size > 2) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT has ${outputs.size} outputs; ZEC signer expects 1 deposit + " +
+                    "optional 1 change"
+            )
+        }
+        val outputKeyHashes =
+            outputs.mapIndexed { idx, out ->
+                assertP2PKHAndExtractKeyHash(out.scriptPubKey, idx, "output")
+            }
+        val totalIn = inputs.sumOf { it.amount }
+        val totalOut = outputs.sumOf { it.amount }
+        val fee = totalIn - totalOut
+        if (fee < 0) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT negative fee: inputs=$totalIn outputs=$totalOut"
+            )
+        }
+
+        val depositAmount = outputs[0].amount
+        val changeAmount = outputs.drop(1).sumOf { it.amount }
+        // Derive t1 addresses from the parsed output hash160s (NOT from `targetAddress` — the route
+        // may allocate a transparent deposit address that differs from the SwapKit hint). Fall back
+        // to the hint only if derivation fails.
+        val depositAddress = zcashAddress(outputKeyHashes[0]) ?: targetAddressHint
+        val changeAddress =
+            if (outputs.size >= 2) {
+                zcashAddress(outputKeyHashes[1]) ?: targetAddressHint
+            } else {
+                zcashAddress(inputs[0].keyHash) ?: targetAddressHint
+            }
+
+        val utxos =
+            inputs.map { input ->
+                Bitcoin.UnspentTransaction.newBuilder()
+                    .setAmount(input.amount)
+                    .setOutPoint(
+                        Bitcoin.OutPoint.newBuilder()
+                            .setHash(ByteString.copyFrom(input.prevTxIdLE))
+                            .setIndex(input.prevIndex.toInt())
+                            .setSequence(input.sequence.toInt())
+                            .build()
+                    )
+                    .setScript(ByteString.copyFrom(input.scriptPubKey))
+                    .build()
+            }
+
+        // ZEC ZIP-243 needs the branch id on the plan — WalletCore reads it during preimage
+        // construction. Mirror the native send path's value so digest derivation is identical.
+        val plan =
+            Bitcoin.TransactionPlan.newBuilder()
+                .setAmount(depositAmount)
+                .setAvailableAmount(totalIn)
+                .setFee(fee)
+                .setChange(changeAmount)
+                .setError(SigningError.OK)
+                .setBranchId(ByteString.fromHex(ZCASH_BRANCH_ID_HEX))
+                .addAllUtxos(utxos)
+                .build()
+
+        val signingInput =
+            Bitcoin.SigningInput.newBuilder()
+                .setHashType(BitcoinScript.hashTypeForCoin(coinType))
+                .setByteFee(1L)
+                .setUseMaxAmount(false)
+                .setAmount(depositAmount)
+                .setCoinType(coinType.value())
+                .setToAddress(depositAddress)
+                .setChangeAddress(changeAddress)
+                .addAllUtxo(utxos)
+                .setPlan(plan)
+
+        inputs.forEach { input ->
+            val redeem = BitcoinScript.buildPayToPublicKeyHash(input.keyHash)
+            signingInput.putScripts(
+                Numeric.toHexStringNoPrefix(input.keyHash),
+                ByteString.copyFrom(redeem.data()),
+            )
+        }
+
+        return signingInput.build().toByteArray()
+    }
+
+    private fun resolvePrevUtxo(
+        inputMap: Map<String, ByteArray>,
+        prevIndex: Long,
+        inputIndex: Int,
+    ): Pair<Long, ByteArray> {
+        inputMap[KEY_NON_WITNESS_UTXO]?.let {
+            return parseNonWitnessUtxo(it, prevIndex, inputIndex)
+        }
+        inputMap[KEY_WITNESS_UTXO]?.let {
+            return parseWitnessUtxo(it, inputIndex)
+        }
+        throw SwapKitZcashSignerException(
+            "SwapKit ZEC PSBT input #$inputIndex is missing a prev-tx UTXO record"
+        )
+    }
+
+    private fun parseNonWitnessUtxo(
+        data: ByteArray,
+        prevIndex: Long,
+        inputIndex: Int,
+    ): Pair<Long, ByteArray> {
+        val cursor = PsbtCursor(data)
+        cursor.readUInt32LE()
+        val inCount = cursor.readCompactSize()
+        repeat(cursor.asLength(inCount)) {
+            cursor.readBytes(32)
+            cursor.readUInt32LE()
+            val sigLen = cursor.readCompactSize()
+            cursor.readBytes(cursor.asLength(sigLen))
+            cursor.readUInt32LE()
+        }
+        val outCount = cursor.readCompactSize()
+        if (prevIndex >= outCount) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT input #$inputIndex prev index $prevIndex >= output count $outCount"
+            )
+        }
+        var amount = 0L
+        var scriptPubKey = ByteArray(0)
+        for (i in 0 until outCount) {
+            val outAmount = cursor.readUInt64LE()
+            val scriptLen = cursor.readCompactSize()
+            val script = cursor.readBytes(cursor.asLength(scriptLen))
+            if (i == prevIndex) {
+                amount = outAmount
+                scriptPubKey = script
+            }
+        }
+        return amount to scriptPubKey
+    }
+
+    private fun parseWitnessUtxo(data: ByteArray, inputIndex: Int): Pair<Long, ByteArray> {
+        val cursor = PsbtCursor(data)
+        val amount = cursor.readUInt64LE()
+        val scriptLen = cursor.readCompactSize()
+        val script = cursor.readBytes(cursor.asLength(scriptLen))
+        if (!cursor.isAtEnd) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT input #$inputIndex WITNESS_UTXO has trailing bytes"
+            )
+        }
+        return amount to script
+    }
+
+    private data class SaplingInput(
+        val prevTxIdLE: ByteArray,
+        val prevIndex: Long,
+        val sequence: Long,
+        val amount: Long,
+        val scriptPubKey: ByteArray,
+        val keyHash: ByteArray,
+    )
+
+    private data class SaplingOutput(val amount: Long, val scriptPubKey: ByteArray)
+
+    private data class ParsedSaplingTxInput(
+        val prevTxIdLE: ByteArray,
+        val prevIndex: Long,
+        val sequence: Long,
+    )
+
+    private data class ParsedSaplingTx(
+        val inputs: List<ParsedSaplingTxInput>,
+        val outputs: List<SaplingOutput>,
+    )
+
+    /**
+     * Parse the Sapling-v4 unsigned-tx body. Rejects NU5 (v5) outright — a different sighash
+     * construction (ZIP-244) — and any tx with shielded value flowing (we can't sign shielded
+     * bundles with MPC).
+     */
+    private fun parseSaplingUnsignedTx(data: ByteArray): ParsedSaplingTx {
+        val cursor = PsbtCursor(data)
+        val version = cursor.readUInt32LE()
+        val versionGroupID = cursor.readUInt32LE()
+        if (version != SAPLING_TX_VERSION || versionGroupID != SAPLING_VERSION_GROUP_ID) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC unsupported Zcash version 0x${version.toString(16)} / group " +
+                    "0x${versionGroupID.toString(16)} (only Sapling-v4 transparent is supported)"
+            )
+        }
+        val inCount = cursor.readCompactSize()
+        val inputs =
+            (0L until inCount).map {
+                val prevBytes = cursor.readBytes(32)
+                val prevIndex = cursor.readUInt32LE()
+                val sigLen = cursor.readCompactSize()
+                cursor.readBytes(cursor.asLength(sigLen))
+                val sequence = cursor.readUInt32LE()
+                ParsedSaplingTxInput(prevBytes, prevIndex, sequence)
+            }
+        val outCount = cursor.readCompactSize()
+        val outputs =
+            (0L until outCount).map {
+                val amount = cursor.readUInt64LE()
+                val scriptLen = cursor.readCompactSize()
+                SaplingOutput(amount, cursor.readBytes(cursor.asLength(scriptLen)))
+            }
+        cursor.readUInt32LE() // lockTime
+        cursor.readUInt32LE() // expiryHeight
+        // Sapling-v4 transparent-only: all shielded fields must be zero.
+        val valueBalance = cursor.readUInt64LE()
+        val nShieldedSpend = cursor.readCompactSize()
+        val nShieldedOutput = cursor.readCompactSize()
+        val nJoinSplit = cursor.readCompactSize()
+        if (
+            valueBalance != 0L || nShieldedSpend != 0L || nShieldedOutput != 0L || nJoinSplit != 0L
+        ) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT carries a shielded bundle; only transparent-only txs are supported"
+            )
+        }
+        return ParsedSaplingTx(inputs, outputs)
+    }
+
+    private fun assertP2PKHAndExtractKeyHash(
+        scriptPubKey: ByteArray,
+        index: Int,
+        role: String,
+    ): ByteArray {
+        if (
+            !(scriptPubKey.size == 25 &&
+                scriptPubKey[0] == 0x76.toByte() &&
+                scriptPubKey[1] == 0xa9.toByte() &&
+                scriptPubKey[2] == 0x14.toByte() &&
+                scriptPubKey[23] == 0x88.toByte() &&
+                scriptPubKey[24] == 0xac.toByte())
+        ) {
+            throw SwapKitZcashSignerException(
+                "SwapKit ZEC PSBT $role #$index scriptPubKey is not P2PKH: " +
+                    Numeric.toHexStringNoPrefix(scriptPubKey)
+            )
+        }
+        return scriptPubKey.copyOfRange(3, 23)
+    }
+
+    /** ZEC transparent `t1…` address from a 20-byte hash160 (two-byte prefix `0x1C 0xB8`). */
+    private fun zcashAddress(hash: ByteArray): String? =
+        Base58.encode(byteArrayOf(0x1C, 0xB8.toByte()) + hash)
+
+    private companion object {
+        private const val KEY_NON_WITNESS_UTXO = "00"
+        private const val KEY_WITNESS_UTXO = "01"
+
+        /** Overwinter flag (high bit) + version 4 — `0x80000004`. */
+        private const val SAPLING_TX_VERSION = 0x80000004L
+        /** Sapling consensus group id. */
+        private const val SAPLING_VERSION_GROUP_ID = 0x892F2085L
+
+        /**
+         * Branch id matching the existing native ZEC send. WalletCore reads it as the ZIP-243
+         * personalised-Blake2b branch identifier; diverging to the Sapling-v4-spec `0x76b809bb`
+         * would produce a digest the network rejects.
+         */
+        private const val ZCASH_BRANCH_ID_HEX = "f04dec4d"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -378,9 +378,10 @@ class UtxoHelper(
      * structured PSBT payload, ready to be dispatched to the MPC engine. Bypasses WalletCore tx
      * planning entirely. Only P2WPKH and P2SH-P2WPKH inputs are supported; P2TR is rejected.
      *
-     * Bitcoin-only: the witness-program shapes parsed here (`0x00 0x14 <20-byte hash>`) are
-     * meaningful only for the Bitcoin chain. UTXO siblings (BCH, Doge, LTC, Dash, Zcash) use legacy
-     * P2PKH and must not route through this path.
+     * Segwit-only: the witness-program shapes parsed here (`0x00 0x14 <20-byte hash>`) are
+     * meaningful only for the native-segwit chains (Bitcoin and Litecoin). UTXO siblings (BCH,
+     * Doge, Dash, Zcash) use legacy P2PKH and must not route through this path — they go through
+     * [SwapKitLegacyP2PKHSigner] / [SwapKitZcashSigner] instead.
      *
      * @param expectedToAddress destination shown on the Verify screen (`payload.toAddress`); pinned
      *   to a non-change output via its scriptPubKey so the displayed address can't drift from what
@@ -393,8 +394,8 @@ class UtxoHelper(
         expectedToAddress: String,
         expectedToAmount: BigInteger,
     ): List<String> {
-        require(coinType == CoinType.BITCOIN) {
-            "SignBitcoin PSBT co-signing is only supported on Bitcoin, got $coinType"
+        require(coinType == CoinType.BITCOIN || coinType == CoinType.LITECOIN) {
+            "SignBitcoin PSBT co-signing is only supported on Bitcoin and Litecoin, got $coinType"
         }
         verifyOwnership(signBitcoin, expectedToAddress, expectedToAmount)
         return computeOurSighashes(signBitcoin).map { Numeric.toHexStringNoPrefix(it) }.sorted()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -166,5 +166,35 @@ data class SwapKitSwapPayloadJson(
          * [memo]. Mirrors iOS' `"XRP"`.
          */
         const val TX_TYPE_XRP = "XRP"
+
+        /**
+         * Every `txType` the signing pipeline can actually handle — each has a branch in
+         * `SigningHelper`'s SwapKit dispatch (a per-chain signer or a native-helper fall-through).
+         * The single source of truth for "is this route signable", so the pre-flight gate in
+         * `SwapFormViewModel` cannot drift from what the dispatcher accepts: a new chain that
+         * reaches signing must be added here, and anything not listed is rejected before keysign
+         * instead of surfacing an `error(...)` mid-sign. [TX_TYPE_CBOR] is deliberately absent — it
+         * is a wire alias normalised onto the Cardano discriminators upstream and never a keysign
+         * txType.
+         */
+        val SIGNABLE_TX_TYPES: Set<String> =
+            setOf(
+                TX_TYPE_PSBT,
+                TX_TYPE_PSBT_DOGE,
+                TX_TYPE_PSBT_BCH,
+                TX_TYPE_PSBT_DASH,
+                TX_TYPE_PSBT_ZEC,
+                TX_TYPE_TRON,
+                TX_TYPE_SUI,
+                TX_TYPE_TON,
+                TX_TYPE_XRP,
+                TX_TYPE_CARDANO,
+                TX_TYPE_CARDANO_PREBUILT,
+            )
+
+        /**
+         * True when [txType] has a wired signing path in `SigningHelper`. See [SIGNABLE_TX_TYPES].
+         */
+        fun isSignableTxType(txType: String): Boolean = txType in SIGNABLE_TX_TYPES
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -62,8 +62,49 @@ data class SwapKitSwapPayloadJson(
     }
 
     companion object {
-        /** `meta.txType` discriminator for the Bitcoin PSBT signing path. */
+        /**
+         * `meta.txType` discriminator for the **segwit** PSBT signing path. Covers Bitcoin and
+         * Litecoin — both native-segwit (P2WPKH / P2SH-P2WPKH) UTXO chains whose BIP-143 sighashes
+         * are computed by [com.vultisig.wallet.data.chains.helpers.SwapKitBtcSigner]. The signing
+         * dispatcher picks the [CoinType] from the source chain. Mirrors iOS, where BTC and LTC
+         * both decode to the `"PSBT"` case routed through `SwapKitBTCSigner`.
+         */
         const val TX_TYPE_PSBT = "PSBT"
+
+        /**
+         * `meta.txType` discriminator for the **legacy P2PKH** Dogecoin signing path. DOGE never
+         * had segwit, so its UTXOs are classic P2PKH and need legacy (non-BIP-143) sighashing —
+         * handled by [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] via
+         * `CoinType.DOGECOIN`. Distinct from [TX_TYPE_PSBT] so a cosigning peer (incl. iOS, which
+         * emits the same `"PSBT_DOGE"`) routes to the legacy compiler rather than the segwit path.
+         */
+        const val TX_TYPE_PSBT_DOGE = "PSBT_DOGE"
+
+        /**
+         * `meta.txType` discriminator for the **legacy P2PKH** Bitcoin Cash signing path. BCH uses
+         * a BIP-143-style preimage with `SIGHASH_FORKID` over a legacy `scriptCode`; WalletCore's
+         * `CoinType.BITCOINCASH` injects the right hash type, so it rides the same
+         * [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] as DOGE/DASH. Mirrors
+         * iOS' `"PSBT_BCH"`.
+         */
+        const val TX_TYPE_PSBT_BCH = "PSBT_BCH"
+
+        /**
+         * `meta.txType` discriminator for the **legacy P2PKH** Dash signing path. DASH forked from
+         * Bitcoin pre-0.12.x and has no segwit, so it uses legacy sighashing via `CoinType.DASH`
+         * through [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner]. Mirrors iOS'
+         * `"PSBT_DASH"`.
+         */
+        const val TX_TYPE_PSBT_DASH = "PSBT_DASH"
+
+        /**
+         * `meta.txType` discriminator for the **transparent Zcash** signing path. The unsigned tx
+         * is wrapped in a BIP-174 envelope but the body is Sapling-v4 (extra version-group id,
+         * expiry height, value-balance, shielded counts) and the sighash is ZIP-243; handled by
+         * [com.vultisig.wallet.data.chains.helpers.SwapKitZcashSigner] via `CoinType.ZCASH` with
+         * the native branch id. Mirrors iOS' `"PSBT_ZEC"`.
+         */
+        const val TX_TYPE_PSBT_ZEC = "PSBT_ZEC"
 
         /**
          * `meta.txType` discriminator for the TRON signing path. SwapKit returns a TronWeb-shaped

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -275,7 +275,13 @@ constructor(
             Chain.Solana,
             Chain.Sui,
             Chain.Ton -> 9
-            Chain.Bitcoin -> 8
+            // All UTXO source chains are denominated in their base unit at 8 decimals.
+            Chain.Bitcoin,
+            Chain.Litecoin,
+            Chain.Dogecoin,
+            Chain.BitcoinCash,
+            Chain.Dash,
+            Chain.Zcash -> 8
             Chain.Tron -> 6
             // ADA is denominated in lovelace (1 ADA = 1e6 lovelace).
             Chain.Cardano -> 6
@@ -446,7 +452,7 @@ constructor(
                 // presence into deposit-only vs pre-built), so persisting `meta.txType` verbatim
                 // would make the signing-side gate reject those routes. Mirrors iOS, which
                 // normalises the payload txType in its buildSwapKit*Payload builders.
-                txType = canonicalTxType(response),
+                txType = canonicalTxType(response, srcToken.chain),
                 txPayload = encodeNativeTxPayload(response),
                 targetAddress = targetAddress,
                 memo = memo,
@@ -555,9 +561,14 @@ constructor(
      * side dispatches on — independent of the raw `meta.txType` casing/aliasing (e.g. SwapKit's
      * `XRP` vs `RIPPLE`). Only the native (non-EVM/Solana) kinds reach [buildSwapKitNativeQuote].
      */
-    private fun canonicalTxType(response: SwapKitSwapResponseJson): String =
+    private fun canonicalTxType(response: SwapKitSwapResponseJson, srcChain: Chain): String =
         when (txTypeOf(response)) {
-            TxKind.PSBT -> SwapKitSwapPayloadJson.TX_TYPE_PSBT
+            // SwapKit ships a single `psbt` wire type for every UTXO source, but the signing path
+            // differs: BTC/LTC are segwit (BIP-143), DOGE/BCH/DASH are legacy P2PKH, ZEC is
+            // Sapling-v4 (ZIP-243). Split by the source chain into the per-chain discriminators the
+            // dispatcher routes on — matching iOS, which derives the same `PSBT_*` strings from the
+            // sell asset.
+            TxKind.PSBT -> psbtTxTypeForChain(srcChain)
             TxKind.TRON -> SwapKitSwapPayloadJson.TX_TYPE_TRON
             TxKind.SUI -> SwapKitSwapPayloadJson.TX_TYPE_SUI
             TxKind.TON -> SwapKitSwapPayloadJson.TX_TYPE_TON
@@ -571,6 +582,20 @@ constructor(
             // to the raw value so an unexpected kind still surfaces a descriptive
             // UnsupportedTxType.
             else -> response.meta.txType
+        }
+
+    /**
+     * Map a UTXO source chain onto the per-chain PSBT txType discriminator. BTC/LTC share the
+     * segwit `PSBT`; DOGE/BCH/DASH/ZEC get their own legacy / Sapling discriminators. An unmapped
+     * chain (shouldn't happen — [chainPrefix] gates the route) falls back to the segwit `PSBT`.
+     */
+    private fun psbtTxTypeForChain(chain: Chain): String =
+        when (chain) {
+            Chain.Dogecoin -> SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE
+            Chain.BitcoinCash -> SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH
+            Chain.Dash -> SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH
+            Chain.Zcash -> SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC
+            else -> SwapKitSwapPayloadJson.TX_TYPE_PSBT
         }
 
     /**
@@ -796,6 +821,11 @@ constructor(
             Chain.Polygon -> "POL"
             Chain.Solana -> "SOL"
             Chain.Bitcoin -> "BTC"
+            Chain.Litecoin -> "LTC"
+            Chain.Dogecoin -> "DOGE"
+            Chain.BitcoinCash -> "BCH"
+            Chain.Dash -> "DASH"
+            Chain.Zcash -> "ZEC"
             Chain.Tron -> "TRON"
             Chain.Sui -> "SUI"
             Chain.Cardano -> "ADA"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -73,8 +73,11 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
         val ticker = coin.ticker.uppercase()
         return when (coin.chain) {
             Chain.MayaChain,
-            Chain.Dash,
             Chain.Kujira -> setOf(SwapProvider.MAYA)
+
+            // SwapKit DASH routes are signed by SwapKitLegacyP2PKHSigner (legacy P2PKH PSBT via
+            // CoinType.DASH). Mirrors iOS' `.dash → [.mayachain, .swapkit]`.
+            Chain.Dash -> setOf(SwapProvider.MAYA, SwapProvider.SWAPKIT)
 
             Chain.Ethereum -> ethereumProviders(ticker)
 
@@ -99,12 +102,19 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             Chain.ThorChain -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA)
             Chain.Bitcoin -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA, SwapProvider.SWAPKIT)
 
-            Chain.Dogecoin,
-            Chain.BitcoinCash,
-            Chain.Litecoin,
             Chain.GaiaChain -> setOf(SwapProvider.THORCHAIN)
 
-            Chain.Zcash -> setOf(SwapProvider.MAYA)
+            // SwapKit DOGE/BCH/LTC routes: DOGE/BCH are legacy P2PKH (SwapKitLegacyP2PKHSigner,
+            // with
+            // BCH's SIGHASH_FORKID), LTC is segwit PSBT (SwapKitBtcSigner). Mirrors iOS'
+            // `.dogecoin/.bitcoinCash/.litecoin → [.thorchain, .swapkit]`.
+            Chain.Dogecoin,
+            Chain.BitcoinCash,
+            Chain.Litecoin -> setOf(SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
+
+            // SwapKit ZEC routes are signed by SwapKitZcashSigner (Sapling-v4 transparent PSBT,
+            // ZIP-243 sighash). Mirrors iOS' `.zcash → [.mayachain, .swapkit]`.
+            Chain.Zcash -> setOf(SwapProvider.MAYA, SwapProvider.SWAPKIT)
 
             Chain.Arbitrum ->
                 if (ticker in mayaArbTokens)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSignerTest.kt
@@ -270,6 +270,54 @@ class SwapKitBtcSignerTest {
     }
 
     @Test
+    fun `getPreSignedImageHash - Litecoin route binds against the LTC vault + recipient`() {
+        try {
+            // LTC reuses the segwit signer with CoinType.LITECOIN: the vault address, lock script
+            // and change binding all flow through the coinType, so a valid LTC PSBT must produce
+            // one
+            // sighash without tripping the (now BTC-or-LTC) co-signing guard in UtxoHelper.
+            val vaultAddress = addressForCoin(vaultPubKeyHex, CoinType.LITECOIN)
+            val recipient = addressForCoin(recipientPubKeyHex, CoinType.LITECOIN)
+            val signer = SwapKitBtcSigner(vaultPubKeyHex, "", CoinType.LITECOIN)
+            val psbt =
+                encodePsbt(
+                    inputs =
+                        listOf(
+                            TestIn(
+                                prevTxIdDisplay =
+                                    "0000000000000000000000000000000000000000000000000000000000000001",
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                scriptHex = scriptHexForCoin(vaultAddress, CoinType.LITECOIN),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            TestOut(
+                                amount = 60_000,
+                                scriptHex = scriptHexForCoin(recipient, CoinType.LITECOIN),
+                            ),
+                            TestOut(
+                                amount = 39_500,
+                                scriptHex = scriptHexForCoin(vaultAddress, CoinType.LITECOIN),
+                            ),
+                        ),
+                )
+
+            val hashes =
+                signer.getPreSignedImageHash(
+                    psbtBytes = psbt,
+                    targetAddress = recipient,
+                    fromAmount = BigInteger.valueOf(60_000L),
+                )
+            assertEquals(1, hashes.size)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
     fun `getPreSignedImageHash - rejects when deposit amount diverges from fromAmount`() {
         try {
             val vaultAddress = addressFor(vaultPubKeyHex)
@@ -480,15 +528,17 @@ class SwapKitBtcSignerTest {
             else -> byteArrayOf(0xFEu.toByte()) + le32(v)
         }
 
-    private fun addressFor(pubKeyHex: String): String =
-        CoinType.BITCOIN.deriveAddressFromPublicKey(
+    private fun addressFor(pubKeyHex: String): String = addressForCoin(pubKeyHex, CoinType.BITCOIN)
+
+    private fun scriptHexFor(address: String): String = scriptHexForCoin(address, CoinType.BITCOIN)
+
+    private fun addressForCoin(pubKeyHex: String, coin: CoinType): String =
+        coin.deriveAddressFromPublicKey(
             PublicKey(Numeric.hexStringToByteArray(pubKeyHex), PublicKeyType.SECP256K1)
         )
 
-    private fun scriptHexFor(address: String): String =
-        Numeric.toHexStringNoPrefix(
-            BitcoinScript.lockScriptForAddress(address, CoinType.BITCOIN).data()
-        )
+    private fun scriptHexForCoin(address: String, coin: CoinType): String =
+        Numeric.toHexStringNoPrefix(BitcoinScript.lockScriptForAddress(address, coin).data())
 
     private fun skipIfJniUnavailable(e: Throwable) {
         if (

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -2,12 +2,15 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.utils.Numeric
 import java.io.ByteArrayOutputStream
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import wallet.core.jni.CoinType
+import wallet.core.jni.proto.Bitcoin
+import wallet.core.jni.proto.Common.SigningError
 
 /**
  * Tests for [SwapKitLegacyP2PKHSigner] (DOGE / BCH / DASH legacy-P2PKH PSBT signing).
@@ -277,6 +280,75 @@ class SwapKitLegacyP2PKHSignerTest {
         }
     }
 
+    @Test
+    fun `buildSigningInputData - frozen plan reproduces the PSBT inputs, outputs, lockTime (DOGE)`() {
+        try {
+            // The frozen Bitcoin.SigningInput is what WalletCore compiles into the broadcast tx, so
+            // pinning every field it carries pins the reconstruction the PR leans on. Building it
+            // needs the WalletCore JNI (address derivation, script building); parsing the proto
+            // back
+            // is pure, and the expectations are derived from the PSBT — no precomputed golden
+            // needed.
+            val depositHash = "22".repeat(20)
+            val changeHash = "11".repeat(20)
+            val psbt =
+                encodeLegacyPsbt(
+                    inputs =
+                        listOf(
+                            LegacyIn(
+                                prevTxIdDisplay = TXID_ONE,
+                                vout = 3,
+                                sequence = 0xFFFFFFFEL,
+                                amount = 100_000,
+                                prevScriptHex = p2pkh(changeHash),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            LegacyOut(amount = 60_000, scriptHex = p2pkh(depositHash)),
+                            LegacyOut(amount = 39_000, scriptHex = p2pkh(changeHash)),
+                        ),
+                    lockTime = 770_000,
+                )
+
+            val input =
+                Bitcoin.SigningInput.parseFrom(
+                    signer(CoinType.DOGECOIN).buildSigningInputData(psbt, "")
+                )
+
+            // lockTime threaded through (the review fix) so the rebuilt tx_id matches the PSBT.
+            assertEquals(770_000, input.lockTime)
+
+            // Frozen plan: amounts/fee derived verbatim from the PSBT, never replanned.
+            assertEquals(SigningError.OK, input.plan.error)
+            assertEquals(100_000L, input.plan.availableAmount)
+            assertEquals(60_000L, input.plan.amount)
+            assertEquals(39_000L, input.plan.change)
+            assertEquals(1_000L, input.plan.fee)
+
+            // The single UTXO is re-emitted verbatim: outpoint (LE hash + index + sequence),
+            // amount,
+            // and the exact prevout scriptPubKey.
+            assertEquals(1, input.utxoCount)
+            val utxo = input.getUtxo(0)
+            assertArrayEquals(
+                Numeric.hexStringToByteArray(TXID_ONE).reversedArray(),
+                utxo.outPoint.hash.toByteArray(),
+            )
+            assertEquals(3, utxo.outPoint.index)
+            assertEquals(0xFFFFFFFE.toInt(), utxo.outPoint.sequence)
+            assertEquals(100_000L, utxo.amount)
+            assertEquals(p2pkh(changeHash), Numeric.toHexStringNoPrefix(utxo.script.toByteArray()))
+
+            // toAddress/changeAddress are derived from the PSBT's own output hash160s (DOGE `D…`),
+            // so WalletCore re-emits the exact output scripts the PSBT shipped.
+            assertTrue(input.toAddress.startsWith("D"), "deposit ${input.toAddress}")
+            assertTrue(input.changeAddress.startsWith("D"), "change ${input.changeAddress}")
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
     private data class LegacyIn(
         val prevTxIdDisplay: String,
         val vout: Long,
@@ -302,6 +374,7 @@ class SwapKitLegacyP2PKHSignerTest {
     private fun encodeLegacyPsbt(
         inputs: List<LegacyIn>,
         outputs: List<LegacyOut>,
+        lockTime: Long = 0,
         unsignedTxTrailerHex: String? = null,
     ): ByteArray {
         val unsigned = ByteArrayOutputStream()
@@ -323,7 +396,7 @@ class SwapKitLegacyP2PKHSignerTest {
             unsigned.write(varInt(script.size.toLong()))
             unsigned.write(script)
         }
-        unsigned.write(le32(0)) // locktime
+        unsigned.write(le32(lockTime))
         unsignedTxTrailerHex?.let { unsigned.write(Numeric.hexStringToByteArray(it)) }
 
         val psbt = ByteArrayOutputStream()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -187,6 +187,32 @@ class SwapKitLegacyP2PKHSignerTest {
     }
 
     @Test
+    fun `rejects an unsigned-tx version other than 1`() {
+        // WalletCore emits version 1 on the legacy path and can't be told otherwise, so a v2 PSBT
+        // would rebuild to a different tx_id — reject it up front rather than mistrack.
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+                version = 2,
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
+            }
+        assertTrue(e.message!!.contains("version 2 is unsupported"))
+    }
+
+    @Test
     fun `rejects an unsigned-tx body with trailing bytes`() {
         val psbt =
             encodeLegacyPsbt(
@@ -496,6 +522,7 @@ class SwapKitLegacyP2PKHSignerTest {
         inputs: List<LegacyIn>,
         outputs: List<LegacyOut>,
         lockTime: Long = 0,
+        version: Long = 1,
         unsignedTxTrailerHex: String? = null,
     ): ByteArray {
         // Precompute the embedded prev-tx for NON_WITNESS inputs so the unsigned-tx outpoint can
@@ -513,7 +540,7 @@ class SwapKitLegacyP2PKHSignerTest {
         }
 
         val unsigned = ByteArrayOutputStream()
-        unsigned.write(le32(1)) // version
+        unsigned.write(le32(version))
         unsigned.write(varInt(inputs.size.toLong()))
         inputs.forEachIndexed { i, input ->
             unsigned.write(outpointLE(i))

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -1,0 +1,367 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.utils.Numeric
+import java.io.ByteArrayOutputStream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import wallet.core.jni.CoinType
+
+/**
+ * Tests for [SwapKitLegacyP2PKHSigner] (DOGE / BCH / DASH legacy-P2PKH PSBT signing).
+ *
+ * The PSBT parsing + structural validation (P2PKH shape, output count, fee sign, prev-UTXO
+ * presence) is pure JVM and runs headlessly — those rejections fire before any WalletCore call. The
+ * presigning happy path needs the WalletCore JNI (frozen plan → `TransactionCompiler`, address
+ * derivation) and skips gracefully when it is unavailable, the same pattern [SwapKitBtcSignerTest]
+ * uses.
+ */
+class SwapKitLegacyP2PKHSignerTest {
+
+    private fun signer(coin: CoinType = CoinType.DOGECOIN) = SwapKitLegacyP2PKHSigner("", "", coin)
+
+    @Test
+    fun `rejects empty payload`() {
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(ByteArray(0), "")
+            }
+        assertTrue(e.message!!.contains("empty"))
+    }
+
+    @Test
+    fun `rejects a non-P2PKH input scriptPubKey`() {
+        // A P2WPKH input (segwit) is not a legacy P2PKH — must be refused before any signing.
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = "0014" + "11".repeat(20), // P2WPKH, not P2PKH
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("input #0"))
+        assertTrue(e.message!!.contains("not P2PKH"))
+    }
+
+    @Test
+    fun `rejects a non-P2PKH output`() {
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                // OP_RETURN-style output — not P2PKH, can't be re-emitted through the address API.
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = "6a04deadbeef")),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("output #0"))
+        assertTrue(e.message!!.contains("not P2PKH"))
+    }
+
+    @Test
+    fun `rejects more than two outputs`() {
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                outputs =
+                    listOf(
+                        LegacyOut(amount = 30_000, scriptHex = p2pkh("22".repeat(20))),
+                        LegacyOut(amount = 30_000, scriptHex = p2pkh("33".repeat(20))),
+                        LegacyOut(amount = 30_000, scriptHex = p2pkh("44".repeat(20))),
+                    ),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("3 outputs"))
+    }
+
+    @Test
+    fun `rejects negative fee`() {
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 50_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                // Outputs exceed inputs → fee would be negative.
+                outputs = listOf(LegacyOut(amount = 60_000, scriptHex = p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("negative fee"))
+    }
+
+    @Test
+    fun `rejects a missing prev-tx UTXO record`() {
+        // Input map present but carries neither NON_WITNESS_UTXO (0x00) nor WITNESS_UTXO (0x01).
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                            omitPrevUtxo = true,
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("missing a prev-tx UTXO record"))
+    }
+
+    @Test
+    fun `getPreSignedImageHash - DOGE happy path returns one sighash per input (WITNESS_UTXO)`() {
+        try {
+            val psbt =
+                encodeLegacyPsbt(
+                    inputs =
+                        listOf(
+                            LegacyIn(
+                                prevTxIdDisplay = TXID_ONE,
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                prevScriptHex = p2pkh("11".repeat(20)),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            LegacyOut(amount = 60_000, scriptHex = p2pkh("22".repeat(20))),
+                            LegacyOut(amount = 39_000, scriptHex = p2pkh("11".repeat(20))),
+                        ),
+                )
+            val hashes = signer(CoinType.DOGECOIN).getPreSignedImageHash(psbt, "")
+            assertEquals(1, hashes.size)
+            assertEquals(64, hashes[0].length)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `getPreSignedImageHash - DASH happy path with two inputs (NON_WITNESS_UTXO)`() {
+        try {
+            val prevScript = p2pkh("11".repeat(20))
+            val psbt =
+                encodeLegacyPsbt(
+                    inputs =
+                        listOf(
+                            LegacyIn(
+                                prevTxIdDisplay = TXID_ONE,
+                                vout = 0,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 70_000,
+                                prevScriptHex = prevScript,
+                                useNonWitnessUtxo = true,
+                            ),
+                            LegacyIn(
+                                prevTxIdDisplay = TXID_TWO,
+                                vout = 1,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 40_000,
+                                prevScriptHex = prevScript,
+                                useNonWitnessUtxo = true,
+                            ),
+                        ),
+                    outputs =
+                        listOf(
+                            LegacyOut(amount = 100_000, scriptHex = p2pkh("22".repeat(20))),
+                            LegacyOut(amount = 9_000, scriptHex = prevScript),
+                        ),
+                )
+            val hashes = signer(CoinType.DASH).getPreSignedImageHash(psbt, "")
+            // One sighash per signable input.
+            assertEquals(2, hashes.size)
+            // Sorted, distinct, 32-byte hex digests.
+            assertEquals(hashes.sorted(), hashes)
+            assertEquals(2, hashes.toSet().size)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private data class LegacyIn(
+        val prevTxIdDisplay: String,
+        val vout: Long,
+        val sequence: Long,
+        val amount: Long,
+        val prevScriptHex: String,
+        val useNonWitnessUtxo: Boolean = false,
+        val omitPrevUtxo: Boolean = false,
+    )
+
+    private data class LegacyOut(val amount: Long, val scriptHex: String)
+
+    /**
+     * P2PKH scriptPubKey for a 20-byte hash160 hex: `OP_DUP OP_HASH160 PUSH20 <hash> EQ CHECKSIG`.
+     */
+    private fun p2pkh(hash20Hex: String): String = "76a914$hash20Hex" + "88ac"
+
+    /**
+     * Minimal BIP-174 PSBT encoder for a **legacy** (non-segwit) tx: magic + global unsigned-tx +
+     * per-input WITNESS_UTXO or NON_WITNESS_UTXO maps. The unsigned-tx body has no marker/flag.
+     */
+    private fun encodeLegacyPsbt(inputs: List<LegacyIn>, outputs: List<LegacyOut>): ByteArray {
+        val unsigned = ByteArrayOutputStream()
+        unsigned.write(le32(1)) // version
+        unsigned.write(varInt(inputs.size.toLong()))
+        inputs.forEach { input ->
+            unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
+            unsigned.write(le32(input.vout))
+            unsigned.write(varInt(0)) // empty scriptSig
+            unsigned.write(le32(input.sequence))
+        }
+        unsigned.write(varInt(outputs.size.toLong()))
+        outputs.forEach { output ->
+            unsigned.write(le64(output.amount))
+            val script = Numeric.hexStringToByteArray(output.scriptHex)
+            unsigned.write(varInt(script.size.toLong()))
+            unsigned.write(script)
+        }
+        unsigned.write(le32(0)) // locktime
+
+        val psbt = ByteArrayOutputStream()
+        psbt.write(MAGIC)
+        val unsignedBytes = unsigned.toByteArray()
+        psbt.write(byteArrayOf(0x01, 0x00)) // global key 0x00
+        psbt.write(varInt(unsignedBytes.size.toLong()))
+        psbt.write(unsignedBytes)
+        psbt.write(0x00) // global map terminator
+
+        inputs.forEach { input ->
+            if (!input.omitPrevUtxo) {
+                if (input.useNonWitnessUtxo) {
+                    // NON_WITNESS_UTXO (key 0x00): a full prev-tx whose output[vout] is the UTXO.
+                    val prevTx = encodePrevTx(input.vout, input.amount, input.prevScriptHex)
+                    psbt.write(byteArrayOf(0x01, 0x00))
+                    psbt.write(varInt(prevTx.size.toLong()))
+                    psbt.write(prevTx)
+                } else {
+                    // WITNESS_UTXO (key 0x01): amount(8 LE) + varint(scriptLen) + scriptPubKey.
+                    val witnessUtxo = ByteArrayOutputStream()
+                    witnessUtxo.write(le64(input.amount))
+                    val script = Numeric.hexStringToByteArray(input.prevScriptHex)
+                    witnessUtxo.write(varInt(script.size.toLong()))
+                    witnessUtxo.write(script)
+                    val wu = witnessUtxo.toByteArray()
+                    psbt.write(byteArrayOf(0x01, 0x01))
+                    psbt.write(varInt(wu.size.toLong()))
+                    psbt.write(wu)
+                }
+            }
+            psbt.write(0x00) // input map terminator
+        }
+        outputs.forEach { psbt.write(0x00) } // empty per-output maps
+        return psbt.toByteArray()
+    }
+
+    /**
+     * A minimal legacy prev-transaction whose output [vout] carries [amount]/[scriptHex]; padding
+     * outputs before [vout] are tiny P2PKH so the parser walks past them to the target.
+     */
+    private fun encodePrevTx(vout: Long, amount: Long, scriptHex: String): ByteArray {
+        val tx = ByteArrayOutputStream()
+        tx.write(le32(1)) // version
+        tx.write(varInt(1)) // one input
+        tx.write(ByteArray(32)) // prev txid (zeros)
+        tx.write(le32(0)) // prev vout
+        tx.write(varInt(0)) // empty scriptSig
+        tx.write(le32(0xFFFFFFFFL)) // sequence
+        val outCount = vout + 1
+        tx.write(varInt(outCount))
+        for (i in 0 until outCount) {
+            if (i == vout) {
+                tx.write(le64(amount))
+                val script = Numeric.hexStringToByteArray(scriptHex)
+                tx.write(varInt(script.size.toLong()))
+                tx.write(script)
+            } else {
+                tx.write(le64(1_000))
+                val pad = Numeric.hexStringToByteArray(p2pkh("00".repeat(20)))
+                tx.write(varInt(pad.size.toLong()))
+                tx.write(pad)
+            }
+        }
+        tx.write(le32(0)) // locktime
+        return tx.toByteArray()
+    }
+
+    private fun le32(v: Long): ByteArray =
+        byteArrayOf(v.toByte(), (v ushr 8).toByte(), (v ushr 16).toByte(), (v ushr 24).toByte())
+
+    private fun le64(v: Long): ByteArray = ByteArray(8) { i -> (v ushr (i * 8)).toByte() }
+
+    private fun varInt(v: Long): ByteArray =
+        when {
+            v < 0xFDL -> byteArrayOf(v.toByte())
+            v <= 0xFFFFL -> byteArrayOf(0xFDu.toByte(), v.toByte(), (v ushr 8).toByte())
+            else -> byteArrayOf(0xFEu.toByte()) + le32(v)
+        }
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+
+    private companion object {
+        private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+        private const val TXID_ONE =
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        private const val TXID_TWO =
+            "0000000000000000000000000000000000000000000000000000000000000002"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -159,6 +159,54 @@ class SwapKitLegacyP2PKHSignerTest {
     }
 
     @Test
+    fun `rejects an unsigned-tx input carrying a non-empty scriptSig`() {
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                            unsignedScriptSigHex = "ab",
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("scriptSig must be empty"))
+    }
+
+    @Test
+    fun `rejects an unsigned-tx body with trailing bytes`() {
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+                unsignedTxTrailerHex = "ff",
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("trailing bytes"))
+    }
+
+    @Test
     fun `getPreSignedImageHash - DOGE happy path returns one sighash per input (WITNESS_UTXO)`() {
         try {
             val psbt =
@@ -237,6 +285,7 @@ class SwapKitLegacyP2PKHSignerTest {
         val prevScriptHex: String,
         val useNonWitnessUtxo: Boolean = false,
         val omitPrevUtxo: Boolean = false,
+        val unsignedScriptSigHex: String? = null,
     )
 
     private data class LegacyOut(val amount: Long, val scriptHex: String)
@@ -250,14 +299,21 @@ class SwapKitLegacyP2PKHSignerTest {
      * Minimal BIP-174 PSBT encoder for a **legacy** (non-segwit) tx: magic + global unsigned-tx +
      * per-input WITNESS_UTXO or NON_WITNESS_UTXO maps. The unsigned-tx body has no marker/flag.
      */
-    private fun encodeLegacyPsbt(inputs: List<LegacyIn>, outputs: List<LegacyOut>): ByteArray {
+    private fun encodeLegacyPsbt(
+        inputs: List<LegacyIn>,
+        outputs: List<LegacyOut>,
+        unsignedTxTrailerHex: String? = null,
+    ): ByteArray {
         val unsigned = ByteArrayOutputStream()
         unsigned.write(le32(1)) // version
         unsigned.write(varInt(inputs.size.toLong()))
         inputs.forEach { input ->
             unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
             unsigned.write(le32(input.vout))
-            unsigned.write(varInt(0)) // empty scriptSig
+            val scriptSig =
+                input.unsignedScriptSigHex?.let { Numeric.hexStringToByteArray(it) } ?: ByteArray(0)
+            unsigned.write(varInt(scriptSig.size.toLong()))
+            unsigned.write(scriptSig)
             unsigned.write(le32(input.sequence))
         }
         unsigned.write(varInt(outputs.size.toLong()))
@@ -268,6 +324,7 @@ class SwapKitLegacyP2PKHSignerTest {
             unsigned.write(script)
         }
         unsigned.write(le32(0)) // locktime
+        unsignedTxTrailerHex?.let { unsigned.write(Numeric.hexStringToByteArray(it)) }
 
         val psbt = ByteArrayOutputStream()
         psbt.write(MAGIC)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -351,6 +351,69 @@ class SwapKitLegacyP2PKHSignerTest {
     }
 
     @Test
+    fun `buildSigningInputData - BCH reproduces the PSBT and selects the SIGHASH_FORKID hash type`() {
+        try {
+            // BCH rides the same legacy path as DOGE/DASH but is the one chain whose CoinType flips
+            // the sighash to SIGHASH_ALL | SIGHASH_FORKID (0x41). Pin both the reconstruction and
+            // that FORKID selection so the BCH-specific branch is covered.
+            val depositHash = "22".repeat(20)
+            val changeHash = "11".repeat(20)
+            val psbt =
+                encodeLegacyPsbt(
+                    inputs =
+                        listOf(
+                            LegacyIn(
+                                prevTxIdDisplay = TXID_ONE,
+                                vout = 3,
+                                sequence = 0xFFFFFFFEL,
+                                amount = 100_000,
+                                prevScriptHex = p2pkh(changeHash),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            LegacyOut(amount = 60_000, scriptHex = p2pkh(depositHash)),
+                            LegacyOut(amount = 39_000, scriptHex = p2pkh(changeHash)),
+                        ),
+                    lockTime = 770_000,
+                )
+
+            val input =
+                Bitcoin.SigningInput.parseFrom(
+                    signer(CoinType.BITCOINCASH).buildSigningInputData(psbt, "", FROM_AMOUNT)
+                )
+
+            // SIGHASH_ALL (0x01) | SIGHASH_FORKID (0x40) — the BCH-only sighash flag.
+            assertEquals(0x41, input.hashType)
+
+            assertEquals(770_000, input.lockTime)
+            assertEquals(SigningError.OK, input.plan.error)
+            assertEquals(100_000L, input.plan.availableAmount)
+            assertEquals(60_000L, input.plan.amount)
+            assertEquals(39_000L, input.plan.change)
+            assertEquals(1_000L, input.plan.fee)
+
+            assertEquals(1, input.utxoCount)
+            val utxo = input.getUtxo(0)
+            assertArrayEquals(
+                Numeric.hexStringToByteArray(TXID_ONE).reversedArray(),
+                utxo.outPoint.hash.toByteArray(),
+            )
+            assertEquals(3, utxo.outPoint.index)
+            assertEquals(0xFFFFFFFE.toInt(), utxo.outPoint.sequence)
+            assertEquals(100_000L, utxo.amount)
+            assertEquals(p2pkh(changeHash), Numeric.toHexStringNoPrefix(utxo.script.toByteArray()))
+
+            // BCH legacy P2PKH addresses use version byte 0x00 → Base58 `1…` (CashAddr derives the
+            // same hash160), so WalletCore re-emits the exact output scripts the PSBT shipped.
+            assertTrue(input.toAddress.startsWith("1"), "deposit ${input.toAddress}")
+            assertTrue(input.changeAddress.startsWith("1"), "change ${input.changeAddress}")
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
     fun `rejects a NON_WITNESS_UTXO that does not hash to the outpoint txid`() {
         // BIP-174 binding: the embedded prev-tx must double-SHA256 to the input's outpoint txid.
         // corruptNonWitnessTxid points the outpoint at an unrelated txid while still embedding a

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitLegacyP2PKHSignerTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.utils.Numeric
 import java.io.ByteArrayOutputStream
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -29,7 +30,7 @@ class SwapKitLegacyP2PKHSignerTest {
     fun `rejects empty payload`() {
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(ByteArray(0), "")
+                signer().buildSigningInputData(ByteArray(0), "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("empty"))
     }
@@ -53,7 +54,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("input #0"))
         assertTrue(e.message!!.contains("not P2PKH"))
@@ -78,7 +79,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("output #0"))
         assertTrue(e.message!!.contains("not P2PKH"))
@@ -107,7 +108,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("3 outputs"))
     }
@@ -131,7 +132,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("negative fee"))
     }
@@ -156,7 +157,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("missing a prev-tx UTXO record"))
     }
@@ -180,7 +181,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("scriptSig must be empty"))
     }
@@ -204,7 +205,7 @@ class SwapKitLegacyP2PKHSignerTest {
             )
         val e =
             assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("trailing bytes"))
     }
@@ -230,7 +231,7 @@ class SwapKitLegacyP2PKHSignerTest {
                             LegacyOut(amount = 39_000, scriptHex = p2pkh("11".repeat(20))),
                         ),
                 )
-            val hashes = signer(CoinType.DOGECOIN).getPreSignedImageHash(psbt, "")
+            val hashes = signer(CoinType.DOGECOIN).getPreSignedImageHash(psbt, "", FROM_AMOUNT)
             assertEquals(1, hashes.size)
             assertEquals(64, hashes[0].length)
         } catch (e: Throwable) {
@@ -269,7 +270,7 @@ class SwapKitLegacyP2PKHSignerTest {
                             LegacyOut(amount = 9_000, scriptHex = prevScript),
                         ),
                 )
-            val hashes = signer(CoinType.DASH).getPreSignedImageHash(psbt, "")
+            val hashes = signer(CoinType.DASH).getPreSignedImageHash(psbt, "", FROM_AMOUNT)
             // One sighash per signable input.
             assertEquals(2, hashes.size)
             // Sorted, distinct, 32-byte hex digests.
@@ -313,7 +314,7 @@ class SwapKitLegacyP2PKHSignerTest {
 
             val input =
                 Bitcoin.SigningInput.parseFrom(
-                    signer(CoinType.DOGECOIN).buildSigningInputData(psbt, "")
+                    signer(CoinType.DOGECOIN).buildSigningInputData(psbt, "", FROM_AMOUNT)
                 )
 
             // lockTime threaded through (the review fix) so the rebuilt tx_id matches the PSBT.
@@ -349,6 +350,59 @@ class SwapKitLegacyP2PKHSignerTest {
         }
     }
 
+    @Test
+    fun `rejects a NON_WITNESS_UTXO that does not hash to the outpoint txid`() {
+        // BIP-174 binding: the embedded prev-tx must double-SHA256 to the input's outpoint txid.
+        // corruptNonWitnessTxid points the outpoint at an unrelated txid while still embedding a
+        // (well-formed) prev-tx — the binding check must reject it before any signing.
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                            useNonWitnessUtxo = true,
+                            corruptNonWitnessTxid = true,
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 99_000, scriptHex = p2pkh("33".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
+            }
+        assertTrue(e.message!!.contains("does not hash to its outpoint txid"))
+    }
+
+    @Test
+    fun `rejects a miner fee that exceeds the quoted swap amount`() {
+        // inputs 100_000, single 10_000 output → 90_000 fee. With a quoted swap amount of only
+        // 1_000 the fee dwarfs it, so the ceiling refuses to sign (the balance-burn guard).
+        val psbt =
+            encodeLegacyPsbt(
+                inputs =
+                    listOf(
+                        LegacyIn(
+                            prevTxIdDisplay = TXID_ONE,
+                            vout = 0,
+                            sequence = 0xFFFFFFFFL,
+                            amount = 100_000,
+                            prevScriptHex = p2pkh("11".repeat(20)),
+                        )
+                    ),
+                outputs = listOf(LegacyOut(amount = 10_000, scriptHex = p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "", BigInteger.valueOf(1_000))
+            }
+        assertTrue(e.message!!.contains("exceeds the quoted swap amount"))
+    }
+
     private data class LegacyIn(
         val prevTxIdDisplay: String,
         val vout: Long,
@@ -358,6 +412,10 @@ class SwapKitLegacyP2PKHSignerTest {
         val useNonWitnessUtxo: Boolean = false,
         val omitPrevUtxo: Boolean = false,
         val unsignedScriptSigHex: String? = null,
+        // Force the unsigned-tx outpoint to [prevTxIdDisplay] instead of the embedded prev-tx's
+        // real
+        // double-SHA256, so the NON_WITNESS_UTXO binding check fails.
+        val corruptNonWitnessTxid: Boolean = false,
     )
 
     private data class LegacyOut(val amount: Long, val scriptHex: String)
@@ -377,11 +435,25 @@ class SwapKitLegacyP2PKHSignerTest {
         lockTime: Long = 0,
         unsignedTxTrailerHex: String? = null,
     ): ByteArray {
+        // Precompute the embedded prev-tx for NON_WITNESS inputs so the unsigned-tx outpoint can
+        // bind to its real double-SHA256 (the txid), matching BIP-174.
+        val prevTxByInput =
+            inputs.map { input ->
+                if (input.useNonWitnessUtxo && !input.omitPrevUtxo) {
+                    encodePrevTx(input.vout, input.amount, input.prevScriptHex)
+                } else null
+            }
+        fun outpointLE(i: Int): ByteArray {
+            val prevTx = prevTxByInput[i]
+            return if (prevTx != null && !inputs[i].corruptNonWitnessTxid) sha256d(prevTx)
+            else Numeric.hexStringToByteArray(inputs[i].prevTxIdDisplay).reversedArray()
+        }
+
         val unsigned = ByteArrayOutputStream()
         unsigned.write(le32(1)) // version
         unsigned.write(varInt(inputs.size.toLong()))
-        inputs.forEach { input ->
-            unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
+        inputs.forEachIndexed { i, input ->
+            unsigned.write(outpointLE(i))
             unsigned.write(le32(input.vout))
             val scriptSig =
                 input.unsignedScriptSigHex?.let { Numeric.hexStringToByteArray(it) } ?: ByteArray(0)
@@ -407,11 +479,11 @@ class SwapKitLegacyP2PKHSignerTest {
         psbt.write(unsignedBytes)
         psbt.write(0x00) // global map terminator
 
-        inputs.forEach { input ->
+        inputs.forEachIndexed { i, input ->
             if (!input.omitPrevUtxo) {
                 if (input.useNonWitnessUtxo) {
                     // NON_WITNESS_UTXO (key 0x00): a full prev-tx whose output[vout] is the UTXO.
-                    val prevTx = encodePrevTx(input.vout, input.amount, input.prevScriptHex)
+                    val prevTx = prevTxByInput[i]!!
                     psbt.write(byteArrayOf(0x01, 0x00))
                     psbt.write(varInt(prevTx.size.toLong()))
                     psbt.write(prevTx)
@@ -477,6 +549,11 @@ class SwapKitLegacyP2PKHSignerTest {
             else -> byteArrayOf(0xFEu.toByte()) + le32(v)
         }
 
+    private fun sha256d(data: ByteArray): ByteArray {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        return digest.digest(digest.digest(data))
+    }
+
     private fun skipIfJniUnavailable(e: Throwable) {
         if (
             e is UnsatisfiedLinkError ||
@@ -489,6 +566,9 @@ class SwapKitLegacyP2PKHSignerTest {
 
     private companion object {
         private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+        // Generous quoted swap amount — well above every fixture's fee so the fee-ceiling bound
+        // never trips except in the dedicated rejection test (which passes its own small value).
+        private val FROM_AMOUNT = BigInteger.valueOf(1_000_000)
         private const val TXID_ONE =
             "0000000000000000000000000000000000000000000000000000000000000001"
         private const val TXID_TWO =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -1,0 +1,229 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.utils.Numeric
+import java.io.ByteArrayOutputStream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [SwapKitZcashSigner] (transparent ZEC Sapling-v4 PSBT signing).
+ *
+ * The Sapling-v4 body parsing + structural validation (version/group gate, shielded-field
+ * rejection, P2PKH shape, output count, fee sign) is pure JVM and runs headlessly — those
+ * rejections fire before any WalletCore call. The presigning happy path needs the WalletCore JNI
+ * (frozen plan + branch id → `TransactionCompiler`, t1 address derivation) and skips gracefully
+ * when it is unavailable.
+ */
+class SwapKitZcashSignerTest {
+
+    private fun signer() = SwapKitZcashSigner("", "")
+
+    @Test
+    fun `rejects empty payload`() {
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(ByteArray(0), "")
+            }
+        assertTrue(e.message!!.contains("empty"))
+    }
+
+    @Test
+    fun `rejects a non-Sapling-v4 version group (NU5)`() {
+        val psbt =
+            encodeSaplingPsbt(
+                versionGroupId = NU5_VERSION_GROUP_ID,
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("unsupported Zcash version"))
+    }
+
+    @Test
+    fun `rejects a shielded bundle (non-zero valueBalance)`() {
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+                valueBalance =
+                    1, // any non-zero shielded value is unsignable via MPC transparent path
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("shielded"))
+    }
+
+    @Test
+    fun `rejects a shielded bundle (non-zero spend count)`() {
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+                nShieldedSpend = 1,
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("shielded"))
+    }
+
+    @Test
+    fun `rejects a non-P2PKH input scriptPubKey`() {
+        val psbt =
+            encodeSaplingPsbt(
+                inputs =
+                    listOf(saplingIn(amount = 100_000, prevScriptHex = "0014" + "11".repeat(20))),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("input #0"))
+        assertTrue(e.message!!.contains("not P2PKH"))
+    }
+
+    @Test
+    fun `getPreSignedImageHash - transparent happy path returns one sighash per input`() {
+        try {
+            val psbt =
+                encodeSaplingPsbt(
+                    inputs = listOf(saplingIn(amount = 100_000)),
+                    outputs =
+                        listOf(
+                            SaplingOut(60_000, p2pkh("22".repeat(20))),
+                            SaplingOut(39_000, p2pkh("11".repeat(20))),
+                        ),
+                )
+            val hashes = signer().getPreSignedImageHash(psbt, "")
+            assertEquals(1, hashes.size)
+            assertEquals(64, hashes[0].length)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private data class SaplingIn(
+        val prevTxIdDisplay: String,
+        val vout: Long,
+        val sequence: Long,
+        val amount: Long,
+        val prevScriptHex: String,
+    )
+
+    private data class SaplingOut(val amount: Long, val scriptHex: String)
+
+    private fun saplingIn(amount: Long, prevScriptHex: String = p2pkh("11".repeat(20))) =
+        SaplingIn(
+            prevTxIdDisplay = TXID_ONE,
+            vout = 0,
+            sequence = 0xFFFFFFFFL,
+            amount = amount,
+            prevScriptHex = prevScriptHex,
+        )
+
+    private fun p2pkh(hash20Hex: String): String = "76a914$hash20Hex" + "88ac"
+
+    /**
+     * Minimal BIP-174 PSBT encoder whose unsigned-tx body is **Sapling-v4**: version +
+     * versionGroupId
+     * + transparent inputs/outputs + lockTime + expiryHeight + valueBalance + three shielded varint
+     *   counts. Per-input maps carry WITNESS_UTXO (key 0x01), matching the captured ZEC fixture.
+     */
+    private fun encodeSaplingPsbt(
+        inputs: List<SaplingIn>,
+        outputs: List<SaplingOut>,
+        versionGroupId: Long = SAPLING_VERSION_GROUP_ID,
+        valueBalance: Long = 0,
+        nShieldedSpend: Long = 0,
+        nShieldedOutput: Long = 0,
+        nJoinSplit: Long = 0,
+    ): ByteArray {
+        val unsigned = ByteArrayOutputStream()
+        unsigned.write(le32(SAPLING_TX_VERSION)) // 0x80000004
+        unsigned.write(le32(versionGroupId))
+        unsigned.write(varInt(inputs.size.toLong()))
+        inputs.forEach { input ->
+            unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
+            unsigned.write(le32(input.vout))
+            unsigned.write(varInt(0)) // empty scriptSig
+            unsigned.write(le32(input.sequence))
+        }
+        unsigned.write(varInt(outputs.size.toLong()))
+        outputs.forEach { output ->
+            unsigned.write(le64(output.amount))
+            val script = Numeric.hexStringToByteArray(output.scriptHex)
+            unsigned.write(varInt(script.size.toLong()))
+            unsigned.write(script)
+        }
+        unsigned.write(le32(0)) // lockTime
+        unsigned.write(le32(0)) // expiryHeight
+        unsigned.write(le64(valueBalance))
+        unsigned.write(varInt(nShieldedSpend))
+        unsigned.write(varInt(nShieldedOutput))
+        unsigned.write(varInt(nJoinSplit))
+
+        val psbt = ByteArrayOutputStream()
+        psbt.write(MAGIC)
+        val unsignedBytes = unsigned.toByteArray()
+        psbt.write(byteArrayOf(0x01, 0x00)) // global key 0x00
+        psbt.write(varInt(unsignedBytes.size.toLong()))
+        psbt.write(unsignedBytes)
+        psbt.write(0x00) // global map terminator
+
+        inputs.forEach { input ->
+            val witnessUtxo = ByteArrayOutputStream()
+            witnessUtxo.write(le64(input.amount))
+            val script = Numeric.hexStringToByteArray(input.prevScriptHex)
+            witnessUtxo.write(varInt(script.size.toLong()))
+            witnessUtxo.write(script)
+            val wu = witnessUtxo.toByteArray()
+            psbt.write(byteArrayOf(0x01, 0x01)) // WITNESS_UTXO key 0x01
+            psbt.write(varInt(wu.size.toLong()))
+            psbt.write(wu)
+            psbt.write(0x00) // input map terminator
+        }
+        outputs.forEach { psbt.write(0x00) } // empty per-output maps
+        return psbt.toByteArray()
+    }
+
+    private fun le32(v: Long): ByteArray =
+        byteArrayOf(v.toByte(), (v ushr 8).toByte(), (v ushr 16).toByte(), (v ushr 24).toByte())
+
+    private fun le64(v: Long): ByteArray = ByteArray(8) { i -> (v ushr (i * 8)).toByte() }
+
+    private fun varInt(v: Long): ByteArray =
+        when {
+            v < 0xFDL -> byteArrayOf(v.toByte())
+            v <= 0xFFFFL -> byteArrayOf(0xFDu.toByte(), v.toByte(), (v ushr 8).toByte())
+            else -> byteArrayOf(0xFEu.toByte()) + le32(v)
+        }
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+
+    private companion object {
+        private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+        private const val TXID_ONE =
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        private const val SAPLING_TX_VERSION = 0x80000004L
+        private const val SAPLING_VERSION_GROUP_ID = 0x892F2085L
+        private const val NU5_VERSION_GROUP_ID = 0x26A7270AL
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.utils.Numeric
 import java.io.ByteArrayOutputStream
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -28,7 +29,7 @@ class SwapKitZcashSignerTest {
     fun `rejects empty payload`() {
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(ByteArray(0), "")
+                signer().buildSigningInputData(ByteArray(0), "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("empty"))
     }
@@ -43,7 +44,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("unsupported Zcash version"))
     }
@@ -59,7 +60,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("shielded"))
     }
@@ -74,7 +75,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("shielded"))
     }
@@ -89,7 +90,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("input #0"))
         assertTrue(e.message!!.contains("not P2PKH"))
@@ -107,7 +108,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("expiryHeight"))
     }
@@ -121,9 +122,25 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("scriptSig must be empty"))
+    }
+
+    @Test
+    fun `rejects a miner fee that exceeds the quoted swap amount`() {
+        // inputs 100_000, single 10_000 output → 90_000 fee. A quoted swap amount of only 1_000
+        // makes the fee dwarf it, so the ceiling refuses to sign (the balance-burn guard).
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(10_000, p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "", BigInteger.valueOf(1_000))
+            }
+        assertTrue(e.message!!.contains("exceeds the quoted swap amount"))
     }
 
     @Test
@@ -136,7 +153,7 @@ class SwapKitZcashSignerTest {
             )
         val e =
             assertThrows(SwapKitZcashSignerException::class.java) {
-                signer().buildSigningInputData(psbt, "")
+                signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
             }
         assertTrue(e.message!!.contains("trailing bytes"))
     }
@@ -153,7 +170,7 @@ class SwapKitZcashSignerTest {
                             SaplingOut(39_000, p2pkh("11".repeat(20))),
                         ),
                 )
-            val hashes = signer().getPreSignedImageHash(psbt, "")
+            val hashes = signer().getPreSignedImageHash(psbt, "", FROM_AMOUNT)
             assertEquals(1, hashes.size)
             assertEquals(64, hashes[0].length)
         } catch (e: Throwable) {
@@ -189,7 +206,10 @@ class SwapKitZcashSignerTest {
                     lockTime = 880_000,
                 )
 
-            val input = Bitcoin.SigningInput.parseFrom(signer().buildSigningInputData(psbt, ""))
+            val input =
+                Bitcoin.SigningInput.parseFrom(
+                    signer().buildSigningInputData(psbt, "", FROM_AMOUNT)
+                )
 
             assertEquals(880_000, input.lockTime)
 
@@ -340,6 +360,9 @@ class SwapKitZcashSignerTest {
 
     private companion object {
         private val MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xff.toByte())
+        // Generous quoted swap amount — above every fixture's fee so the ceiling never trips except
+        // in the dedicated rejection test (which passes its own small value).
+        private val FROM_AMOUNT = BigInteger.valueOf(1_000_000)
         private const val TXID_ONE =
             "0000000000000000000000000000000000000000000000000000000000000001"
         private const val SAPLING_TX_VERSION = 0x80000004L

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -2,11 +2,14 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.utils.Numeric
 import java.io.ByteArrayOutputStream
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
+import wallet.core.jni.proto.Bitcoin
+import wallet.core.jni.proto.Common.SigningError
 
 /**
  * Tests for [SwapKitZcashSigner] (transparent ZEC Sapling-v4 PSBT signing).
@@ -153,6 +156,64 @@ class SwapKitZcashSignerTest {
             val hashes = signer().getPreSignedImageHash(psbt, "")
             assertEquals(1, hashes.size)
             assertEquals(64, hashes[0].length)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `buildSigningInputData - frozen plan reproduces inputs, outputs, lockTime, branchId (ZEC)`() {
+        try {
+            // Building the Sapling Bitcoin.SigningInput needs the WalletCore JNI; parsing the proto
+            // back is pure and the expectations come from the PSBT, so this pins the reconstruction
+            // (the bytes WalletCore compiles into the broadcast tx) without a precomputed golden.
+            val depositHash = "22".repeat(20)
+            val changeHash = "11".repeat(20)
+            val psbt =
+                encodeSaplingPsbt(
+                    inputs =
+                        listOf(
+                            SaplingIn(
+                                prevTxIdDisplay = TXID_ONE,
+                                vout = 2,
+                                sequence = 0xFFFFFFFFL,
+                                amount = 100_000,
+                                prevScriptHex = p2pkh(changeHash),
+                            )
+                        ),
+                    outputs =
+                        listOf(
+                            SaplingOut(60_000, p2pkh(depositHash)),
+                            SaplingOut(39_000, p2pkh(changeHash)),
+                        ),
+                    lockTime = 880_000,
+                )
+
+            val input = Bitcoin.SigningInput.parseFrom(signer().buildSigningInputData(psbt, ""))
+
+            assertEquals(880_000, input.lockTime)
+
+            assertEquals(SigningError.OK, input.plan.error)
+            assertEquals(100_000L, input.plan.availableAmount)
+            assertEquals(60_000L, input.plan.amount)
+            assertEquals(39_000L, input.plan.change)
+            assertEquals(1_000L, input.plan.fee)
+            // ZIP-243 branch id must be on the plan or WalletCore derives the wrong digest.
+            assertEquals("f04dec4d", Numeric.toHexStringNoPrefix(input.plan.branchId.toByteArray()))
+
+            assertEquals(1, input.utxoCount)
+            val utxo = input.getUtxo(0)
+            assertArrayEquals(
+                Numeric.hexStringToByteArray(TXID_ONE).reversedArray(),
+                utxo.outPoint.hash.toByteArray(),
+            )
+            assertEquals(2, utxo.outPoint.index)
+            assertEquals(100_000L, utxo.amount)
+            assertEquals(p2pkh(changeHash), Numeric.toHexStringNoPrefix(utxo.script.toByteArray()))
+
+            // Derived from the PSBT output hash160s as transparent `t1…` addresses.
+            assertTrue(input.toAddress.startsWith("t1"), "deposit ${input.toAddress}")
+            assertTrue(input.changeAddress.startsWith("t1"), "change ${input.changeAddress}")
         } catch (e: Throwable) {
             skipIfJniUnavailable(e)
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -93,6 +93,35 @@ class SwapKitZcashSignerTest {
     }
 
     @Test
+    fun `rejects an unsigned-tx input carrying a non-empty scriptSig`() {
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000, unsignedScriptSigHex = "ab")),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("scriptSig must be empty"))
+    }
+
+    @Test
+    fun `rejects an unsigned-tx body with trailing bytes`() {
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+                unsignedTxTrailerHex = "ff",
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("trailing bytes"))
+    }
+
+    @Test
     fun `getPreSignedImageHash - transparent happy path returns one sighash per input`() {
         try {
             val psbt =
@@ -118,17 +147,23 @@ class SwapKitZcashSignerTest {
         val sequence: Long,
         val amount: Long,
         val prevScriptHex: String,
+        val unsignedScriptSigHex: String? = null,
     )
 
     private data class SaplingOut(val amount: Long, val scriptHex: String)
 
-    private fun saplingIn(amount: Long, prevScriptHex: String = p2pkh("11".repeat(20))) =
+    private fun saplingIn(
+        amount: Long,
+        prevScriptHex: String = p2pkh("11".repeat(20)),
+        unsignedScriptSigHex: String? = null,
+    ) =
         SaplingIn(
             prevTxIdDisplay = TXID_ONE,
             vout = 0,
             sequence = 0xFFFFFFFFL,
             amount = amount,
             prevScriptHex = prevScriptHex,
+            unsignedScriptSigHex = unsignedScriptSigHex,
         )
 
     private fun p2pkh(hash20Hex: String): String = "76a914$hash20Hex" + "88ac"
@@ -147,6 +182,7 @@ class SwapKitZcashSignerTest {
         nShieldedSpend: Long = 0,
         nShieldedOutput: Long = 0,
         nJoinSplit: Long = 0,
+        unsignedTxTrailerHex: String? = null,
     ): ByteArray {
         val unsigned = ByteArrayOutputStream()
         unsigned.write(le32(SAPLING_TX_VERSION)) // 0x80000004
@@ -155,7 +191,10 @@ class SwapKitZcashSignerTest {
         inputs.forEach { input ->
             unsigned.write(Numeric.hexStringToByteArray(input.prevTxIdDisplay).reversedArray())
             unsigned.write(le32(input.vout))
-            unsigned.write(varInt(0)) // empty scriptSig
+            val scriptSig =
+                input.unsignedScriptSigHex?.let { Numeric.hexStringToByteArray(it) } ?: ByteArray(0)
+            unsigned.write(varInt(scriptSig.size.toLong()))
+            unsigned.write(scriptSig)
             unsigned.write(le32(input.sequence))
         }
         unsigned.write(varInt(outputs.size.toLong()))
@@ -171,6 +210,7 @@ class SwapKitZcashSignerTest {
         unsigned.write(varInt(nShieldedSpend))
         unsigned.write(varInt(nShieldedOutput))
         unsigned.write(varInt(nJoinSplit))
+        unsignedTxTrailerHex?.let { unsigned.write(Numeric.hexStringToByteArray(it)) }
 
         val psbt = ByteArrayOutputStream()
         psbt.write(MAGIC)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -93,6 +93,23 @@ class SwapKitZcashSignerTest {
     }
 
     @Test
+    fun `rejects a non-zero expiryHeight`() {
+        // WalletCore can't reproduce a non-zero expiryHeight in the rebuilt tx, so a route shipping
+        // one is rejected loudly rather than mistracked under a diverging tx_id.
+        val psbt =
+            encodeSaplingPsbt(
+                inputs = listOf(saplingIn(amount = 100_000)),
+                outputs = listOf(SaplingOut(99_000, p2pkh("22".repeat(20)))),
+                expiryHeight = 1_000_000,
+            )
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                signer().buildSigningInputData(psbt, "")
+            }
+        assertTrue(e.message!!.contains("expiryHeight"))
+    }
+
+    @Test
     fun `rejects an unsigned-tx input carrying a non-empty scriptSig`() {
         val psbt =
             encodeSaplingPsbt(
@@ -178,6 +195,8 @@ class SwapKitZcashSignerTest {
         inputs: List<SaplingIn>,
         outputs: List<SaplingOut>,
         versionGroupId: Long = SAPLING_VERSION_GROUP_ID,
+        lockTime: Long = 0,
+        expiryHeight: Long = 0,
         valueBalance: Long = 0,
         nShieldedSpend: Long = 0,
         nShieldedOutput: Long = 0,
@@ -204,8 +223,8 @@ class SwapKitZcashSignerTest {
             unsigned.write(varInt(script.size.toLong()))
             unsigned.write(script)
         }
-        unsigned.write(le32(0)) // lockTime
-        unsigned.write(le32(0)) // expiryHeight
+        unsigned.write(le32(lockTime))
+        unsigned.write(le32(expiryHeight))
         unsigned.write(le64(valueBalance))
         unsigned.write(varInt(nShieldedSpend))
         unsigned.write(varInt(nShieldedOutput))

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -40,6 +40,11 @@ internal class SwapProviderTableTest {
                 coin(Chain.Solana, "SOL", isNative = true),
                 coin(Chain.Solana, "USDC", isNative = false),
                 coin(Chain.Bitcoin, "BTC", isNative = true), // BTC PSBT route
+                coin(Chain.Litecoin, "LTC", isNative = true), // LTC segwit PSBT route
+                coin(Chain.Dogecoin, "DOGE", isNative = true), // DOGE legacy P2PKH route
+                coin(Chain.BitcoinCash, "BCH", isNative = true), // BCH legacy P2PKH (FORKID) route
+                coin(Chain.Dash, "DASH", isNative = true), // DASH legacy P2PKH route
+                coin(Chain.Zcash, "ZEC", isNative = true), // ZEC Sapling-v4 transparent route
                 coin(Chain.Tron, "TRX", isNative = true), // TRON TronWeb route
                 coin(Chain.Tron, "USDT", isNative = false), // TRC-20 → TRON route
                 coin(Chain.Sui, "SUI", isNative = true), // SUI PTB route
@@ -66,13 +71,9 @@ internal class SwapProviderTableTest {
                 coin(Chain.Mantle, "MNT", isNative = true),
                 coin(Chain.Blast, "ETH", isNative = true),
                 coin(Chain.CronosChain, "CRO", isNative = true),
-                coin(Chain.BitcoinCash, "BCH", isNative = true),
-                coin(Chain.Litecoin, "LTC", isNative = true),
-                coin(Chain.Dogecoin, "DOGE", isNative = true),
                 coin(Chain.GaiaChain, "ATOM", isNative = true),
                 coin(Chain.ThorChain, "RUNE", isNative = true),
                 coin(Chain.MayaChain, "CACAO", isNative = true),
-                coin(Chain.Zcash, "ZEC", isNative = true),
                 coin(Chain.Hyperliquid, "HYPE", isNative = true),
                 coin(Chain.Polkadot, "DOT", isNative = true),
             )
@@ -91,7 +92,19 @@ internal class SwapProviderTableTest {
         // account screen. A chain can offer SWAPKIT in the provider table yet stay invisible to the
         // user if it is missing from isSwapSupported — the Sui regression that hid the button while
         // iOS showed it. Pin every SwapKit-wired native chain here.
-        listOf(Chain.Bitcoin, Chain.Tron, Chain.Sui, Chain.Cardano, Chain.Ton, Chain.Ripple)
+        listOf(
+                Chain.Bitcoin,
+                Chain.Litecoin,
+                Chain.Dogecoin,
+                Chain.BitcoinCash,
+                Chain.Dash,
+                Chain.Zcash,
+                Chain.Tron,
+                Chain.Sui,
+                Chain.Cardano,
+                Chain.Ton,
+                Chain.Ripple,
+            )
             .forEach { chain ->
                 assertTrue(
                     chain.isSwapSupported,


### PR DESCRIPTION
Closes #4702 (split from #4675). Extends SwapKit source-chain support beyond the BTC PSBT path (#4674) to the remaining UTXO chains, mirroring the iOS `SwapKit{Doge,Dash,Zcash}Signer` + the BCH/LTC paths.

## What

Three signing paths, picked from the source chain:

| Chain(s) | Path | Implementation |
|---|---|---|
| BTC, **LTC** | segwit / BIP-143 | `SwapKitBtcSigner` — now takes a `CoinType` (default `BITCOIN`); `UtxoHelper`'s PSBT co-signing guard widened to allow `LITECOIN` |
| **DOGE, BCH, DASH** | legacy P2PKH | new `SwapKitLegacyP2PKHSigner` — parses the legacy unsigned-tx body, builds a **frozen** `Bitcoin.TransactionPlan` (no replanning, so the broadcast tx_id the route is tracked by stays stable), signs via `TransactionCompiler` per `CoinType` (BCH gets `SIGHASH_FORKID` from `hashTypeForCoin`) |
| **ZEC** | Sapling-v4 / ZIP-243 | new `SwapKitZcashSigner` — walks the Sapling-v4 body, hard-rejects NU5/v5 and any shielded value, sets the native branch id on the frozen plan |

## Wiring

- `SwapKitSwapPayloadJson` — per-chain PSBT discriminators (`PSBT_DOGE` / `PSBT_BCH` / `PSBT_DASH` / `PSBT_ZEC`). The discriminator rides the shared keysign payload, so distinguishing segwit from legacy from Sapling here lets a mixed iOS/Android vault cosign correctly (iOS emits the same strings).
- `SigningHelper` — dispatch in both the presign and signed-tx paths, using the payload's source chain to pick the `CoinType`.
- `SwapProviderTable` — `DOGE`/`BCH`/`LTC` → `THORCHAIN` + `SWAPKIT`; `DASH`/`ZEC` → `MAYA` + `SWAPKIT`.
- `SwapKitQuoteSource` — chain prefixes, native decimals (8) for inbound-fee scaling, and chain-aware PSBT `txType` so a route is built and stamped with the right discriminator.
- `Chain.isSwapSupported` already listed all five.

## Tests

Per-signer suites for the legacy and ZEC signers, plus an LTC case in the BTC test, modelled on the existing `SwapKitBtcSignerTest` (PSBT-builder + `skipIfJniUnavailable`):

- **Headless (run + pass):** PSBT/Sapling framing and structural validation — P2PKH shape, output count, fee sign, prev-UTXO presence, and the ZEC version-group + shielded-field rejection.
- **WalletCore happy paths:** `getPreSignedImageHash` for DOGE (`WITNESS_UTXO`), DASH (`NON_WITNESS_UTXO`, two inputs) and transparent ZEC — these need the native lib so they skip locally and run in CI.

`SwapProviderTableTest` updated for the newly enabled chains.

## Test plan

- [x] `:data` main + unit-test compile
- [x] `:data:testDebugUnitTest --tests '*SwapKit*' --tests '*SwapProviderTable*'` green
- [x] `:data:ktfmtCheck` clean
- [x] On-device E2E: signed + broadcast a real **DOGE → TRX** SwapKit (NEAR) swap on the legacy P2PKH path — tx [`2d1249e27e90eee59e1868bf8e1f71883a219d9c94e16bef950686acd362b9e0`](https://blockchair.com/dogecoin/transaction/2d1249e27e90eee59e1868bf8e1f71883a219d9c94e16bef950686acd362b9e0)
- [x] On-device E2E: signed + broadcast a real **LTC** SwapKit swap on the segwit PSBT path — tx [`4334c1bf39e168a0f1d6e250f29da27edf5660d2827f48d900cb596b63ef9d4a`](https://blockchair.com/litecoin/transaction/4334c1bf39e168a0f1d6e250f29da27edf5660d2827f48d900cb596b63ef9d4a)
- [x] On-device E2E: signed + broadcast a real **BCH** SwapKit swap on the legacy P2PKH + `SIGHASH_FORKID` path — tx [`c44fe710efaa2130db3337be0bc05e114af1f6ef25365eb69eec88cabe33d886`](https://blockchair.com/bitcoin-cash/transaction/c44fe710efaa2130db3337be0bc05e114af1f6ef25365eb69eec88cabe33d886)
- [x] On-device E2E: signed + broadcast a real **DASH** SwapKit swap on the legacy P2PKH path — tx [`f837a5c1e788b9b3daf98038c2b60d54a862def8aedbb133daf884f656bede7d`](https://blockchair.com/dash/transaction/f837a5c1e788b9b3daf98038c2b60d54a862def8aedbb133daf884f656bede7d)
- [ ] On-device E2E for the remaining chain (ZEC)

### On-device proof (DASH → LTC SwapKit swap)

<img src="https://i.imgur.com/MvPO51u.png" width="300" alt="DASH to LTC swap — Transaction successful (tx f837a5…ede7d)" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SwapKit signing expanded to support Litecoin, Dogecoin, Bitcoin Cash, Dash, and Zcash PSBT routes.
  * Swap provider wiring updated so additional UTXO chains expose SwapKit where applicable.

* **Documentation**
  * Clarified PSBT signing paths, segwit vs legacy distinctions, and native-fee decimal handling for UTXO chains.

* **Tests**
  * Added JVM/JUnit tests covering PSBT signing happy paths and structural rejection cases for the new chains.

* **Bug Fixes / UX**
  * Swap quote selection and swap submission now recognize the new chain-specific PSBT tx types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->