### PR TITLE
fix(polkadot): confirm tx status via RPC block-scan, drop Subscan

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -61,7 +61,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             VaultNotificationSettingsEntity::class,
             TransactionHistoryEntity::class,
         ],
-    version = 32,
+    version = 33,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_29_30
 import com.vultisig.wallet.data.db.migrations.MIGRATION_2_3
 import com.vultisig.wallet.data.db.migrations.MIGRATION_30_31
 import com.vultisig.wallet.data.db.migrations.MIGRATION_31_32
+import com.vultisig.wallet.data.db.migrations.MIGRATION_32_33
 import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
@@ -100,6 +101,7 @@ internal interface DatabaseModule {
                     MIGRATION_29_30,
                     MIGRATION_30_31,
                     MIGRATION_31_32,
+                    MIGRATION_32_33,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -760,3 +760,16 @@ internal val MIGRATION_31_32 =
             }
         }
     }
+
+// Adds broadcastBlockNumber: the chain head block number captured at broadcast. Polkadot status
+// confirmation scans the absolute inclusion window from this block instead of a head-relative
+// window, so a confirmed transfer is no longer missed once the head advances past it. Nullable —
+// existing rows keep NULL and fall back to the legacy head-relative scan.
+internal val MIGRATION_32_33 =
+    object : Migration(32, 33) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Nullable column, no DEFAULT clause — matches the entity (no defaultValue annotation)
+            // so Room's TableInfo validation passes; existing rows get NULL implicitly.
+            db.execSQL("ALTER TABLE transaction_history ADD COLUMN broadcastBlockNumber INTEGER")
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -866,6 +866,14 @@ constructor(
                         confirmedAt = null,
                         failureReason = null,
                         lastCheckedAt = now,
+                        // Polkadot extrinsics are mortal: persist the head block at broadcast so
+                        // the
+                        // status poller can scan the absolute inclusion window instead of a
+                        // head-relative one that drifts out of reach. Null for other chains.
+                        broadcastBlockNumber =
+                            (keysignPayload?.blockChainSpecific as? BlockChainSpecific.Polkadot)
+                                ?.currentBlockNumber
+                                ?.toLong(),
                     )
                 transactionHistoryRepository.recordTransaction(
                     vaultId = vault.id,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -239,10 +239,21 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
         // Anchor at the top of the window and descend via parentHash. Block numbers are sequential
         // in Substrate, so the parent of block N is N-1 — we count down instead of re-reading the
         // header number each hop.
-        var blockHash: String? = getBlockHashByNumber(toBlock) ?: return false
+        //
+        // A null hash/block mid-walk means the RPC returned an error envelope (postRpc reads a
+        // nullable result), not that the extrinsic is absent. Returning false here would be
+        // indistinguishable from a genuine miss, so checkByInclusionWindow could terminally Fail a
+        // confirmed transfer once the head passes the window. Instead we throw on an incomplete
+        // scan so it propagates to checkStatus and the tx stays Pending for a later retry; false is
+        // returned only after the full window was traversed without a match.
+        var blockHash: String =
+            getBlockHashByNumber(toBlock)
+                ?: error("Polkadot block hash unavailable for $toBlock; inclusion scan incomplete")
         var current = toBlock
         while (current >= fromBlock) {
-            val block = getBlock(blockHash)?.block ?: break
+            val block =
+                getBlock(blockHash)?.block
+                    ?: error("Polkadot block $current unavailable; inclusion scan incomplete")
             if (block.extrinsics.any { extrinsicHash(it) == target }) {
                 return true
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -62,8 +62,22 @@ interface PolkadotApi {
      * contains an extrinsic whose blake2b-256 hash matches [txHash]. Substrate full nodes do not
      * index extrinsics by hash, so confirmation is done by scanning recent blocks via plain RPC
      * instead of depending on a third-party indexer (e.g. Subscan).
+     *
+     * Head-relative, so only suitable right after broadcast (the inclusion block is near the head).
+     * For status polling that may run long after broadcast, use [isExtrinsicInBlockRange], whose
+     * window is anchored to an absolute block and does not drift as the head advances.
      */
     suspend fun isExtrinsicInChain(txHash: String, depth: Int): Boolean
+
+    /**
+     * Returns true if an extrinsic whose blake2b-256 hash matches [txHash] appears in any block in
+     * the inclusive number range `[fromBlock, toBlock]`. The range is anchored at [toBlock] (which
+     * the caller caps at the live head) and walked backward via `parentHash` down to [fromBlock] —
+     * Substrate blocks only link to their parent and number sequentially, so the absolute window is
+     * scanned regardless of how far the head has since advanced past it. This keeps a confirmed but
+     * already-buried inclusion block reachable, unlike a head-relative scan.
+     */
+    suspend fun isExtrinsicInBlockRange(txHash: String, fromBlock: Long, toBlock: Long): Boolean
 }
 
 internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpClient) :
@@ -213,6 +227,40 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
         }
         return false
     }
+
+    override suspend fun isExtrinsicInBlockRange(
+        txHash: String,
+        fromBlock: Long,
+        toBlock: Long,
+    ): Boolean {
+        val target = txHash.removePrefix("0x").lowercase()
+        if (target.isEmpty() || toBlock < fromBlock) return false
+
+        // Anchor at the top of the window and descend via parentHash. Block numbers are sequential
+        // in Substrate, so the parent of block N is N-1 — we count down instead of re-reading the
+        // header number each hop.
+        var blockHash: String? = getBlockHashByNumber(toBlock) ?: return false
+        var current = toBlock
+        while (current >= fromBlock) {
+            val block = getBlock(blockHash)?.block ?: break
+            if (block.extrinsics.any { extrinsicHash(it) == target }) {
+                return true
+            }
+            blockHash = block.header.parentHash
+            current--
+        }
+        return false
+    }
+
+    private suspend fun getBlockHashByNumber(number: Long): String? =
+        httpClient
+            .postRpc<PolkadotGetBlockHashJson>(
+                url = POLKADOT_API_URL,
+                method = "chain_getBlockHash",
+                params = buildJsonArray { add(number) },
+            )
+            .result
+            .takeIf { it.isNotBlank() }
 
     private suspend fun getBlock(blockHash: String?): PolkadotBlockResultJson? {
         return httpClient

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -2,14 +2,17 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.PolkadotGetStorageJson
 import com.vultisig.wallet.data.api.models.RpcPayload
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotBlockResultJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotBroadcastTransactionJson
-import com.vultisig.wallet.data.api.models.cosmos.PolkadotExtrinsicResponseJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetBlockHashJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetBlockHeaderJson
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetBlockJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetNonceJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotGetRunTimeVersionJson
 import com.vultisig.wallet.data.api.models.cosmos.PolkadotQueryInfoResponseJson
 import com.vultisig.wallet.data.api.utils.postRpc
+import com.vultisig.wallet.data.common.Utils
+import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -54,7 +57,13 @@ interface PolkadotApi {
 
     suspend fun getPartialFee(tx: String): BigInteger
 
-    suspend fun getTxStatus(txHash: String): PolkadotExtrinsicResponseJson?
+    /**
+     * Walks back up to [depth] blocks from the current best head and returns true if a block
+     * contains an extrinsic whose blake2b-256 hash matches [txHash]. Substrate full nodes do not
+     * index extrinsics by hash, so confirmation is done by scanning recent blocks via plain RPC
+     * instead of depending on a third-party indexer (e.g. Subscan).
+     */
+    suspend fun isExtrinsicInChain(txHash: String, depth: Int): Boolean
 }
 
 internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpClient) :
@@ -185,17 +194,44 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
             ?.toBigIntegerOrNull() ?: throw Exception("Can't obtained Partial Fee")
     }
 
-    override suspend fun getTxStatus(txHash: String): PolkadotExtrinsicResponseJson? {
+    override suspend fun isExtrinsicInChain(txHash: String, depth: Int): Boolean {
+        val target = txHash.removePrefix("0x").lowercase()
+        if (target.isEmpty()) return false
 
-        val response =
-            httpClient.post(POLKADOT_EXTRINSIC_API_URL) { setBody(mapOf("hash" to txHash)) }
-        return response.bodyOrThrow<PolkadotExtrinsicResponseJson>()
+        // Start from the best head (params omitted) and follow parentHash links. Inclusion in the
+        // best chain is enough to treat the transaction as on-chain; GRANDPA finalizes within a
+        // couple of blocks so a reorg deep enough to drop it is not a practical concern here.
+        var blockHash: String? = null
+        var scanned = 0
+        while (scanned < depth) {
+            val block = getBlock(blockHash)?.block ?: break
+            if (block.extrinsics.any { extrinsicHash(it) == target }) {
+                return true
+            }
+            blockHash = block.header.parentHash
+            scanned++
+        }
+        return false
     }
+
+    private suspend fun getBlock(blockHash: String?): PolkadotBlockResultJson? {
+        return httpClient
+            .postRpc<PolkadotGetBlockJson>(
+                url = POLKADOT_API_URL,
+                method = "chain_getBlock",
+                params = buildJsonArray { if (blockHash != null) add(blockHash) },
+            )
+            .result
+    }
+
+    // Canonical Substrate extrinsic hash: blake2b-256 over the full SCALE-encoded extrinsic, the
+    // same bytes broadcast via author_submitExtrinsic. Mirrors PolkadotHelper.getSignedTransaction.
+    private fun extrinsicHash(extrinsicHex: String): String =
+        Numeric.toHexStringNoPrefix(Utils.blake2bHash(Numeric.hexStringToByteArray(extrinsicHex)))
+            .lowercase()
 
     private companion object {
         private const val POLKADOT_API_URL = "https://api.vultisig.com/dot/"
-        private const val POLKADOT_EXTRINSIC_API_URL =
-            "https://assethub-polkadot.api.subscan.io/api/scan/extrinsic"
         // xxHash128("System") + xxHash128("Account") — well-known Substrate storage prefix
         private const val SYSTEM_ACCOUNT_PREFIX =
             "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/PolkadotResponse.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/PolkadotResponse.kt
@@ -47,25 +47,15 @@ data class PolkadotQueryInfoResponseJson(val result: QueryInfoPayload?) {
 }
 
 @Serializable
-data class PolkadotExtrinsicResponseJson(
-    @SerialName("code") val code: Int,
-    @SerialName("message") val message: String,
-    @SerialName("generated_at") val generatedAt: Long,
-    @SerialName("data") val data: PolkadotExtrinsicDataJson? = null,
+data class PolkadotGetBlockJson(@SerialName("result") val result: PolkadotBlockResultJson? = null)
+
+@Serializable data class PolkadotBlockResultJson(@SerialName("block") val block: PolkadotBlockJson)
+
+@Serializable
+data class PolkadotBlockJson(
+    @SerialName("header") val header: PolkadotBlockHeaderWithParentJson,
+    @SerialName("extrinsics") val extrinsics: List<String> = emptyList(),
 )
 
 @Serializable
-data class PolkadotExtrinsicDataJson(
-    @SerialName("error") val polkadotErrorData: PolkadotErrorData? = null,
-    @SerialName("extrinsic_hash") val extrinsicHash: String?,
-)
-
-@Serializable
-data class PolkadotErrorData(
-    @SerialName("batch_index") val batchIndex: Int,
-    @SerialName("doc") val doc: String,
-    @SerialName("module") val module: String,
-    @SerialName("name") val name: String,
-    @SerialName("value") val value: String,
-    @SerialName("version") val version: Int,
-)
+data class PolkadotBlockHeaderWithParentJson(@SerialName("parentHash") val parentHash: String)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -4,7 +4,6 @@ import com.vultisig.wallet.data.api.PolkadotApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
-import com.vultisig.wallet.data.utils.NetworkException
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
@@ -14,39 +13,27 @@ class PolkadotStatusProvider @Inject constructor(private val polkadotApi: Polkad
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
-            val tx = polkadotApi.getTxStatus(txHash)
-            when {
-                tx == null -> TransactionResult.NotFound
-                tx.message.equals("success", ignoreCase = true) -> TransactionResult.Confirmed
-                else -> TransactionResult.Failed(tx.data?.polkadotErrorData?.value ?: tx.message)
+            // Substrate has no "get transaction by hash" RPC and Subscan now blocks
+            // unauthenticated traffic, so confirmation is done by scanning recent blocks for the
+            // extrinsic hash over the same proxied RPC we broadcast through.
+            if (polkadotApi.isExtrinsicInChain(txHash, SCAN_DEPTH)) {
+                TransactionResult.Confirmed
+            } else {
+                // Not in a block yet — keep polling until the surrounding poll loop times out.
+                TransactionResult.Pending
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (e.isExplorerUnauthorized()) {
-                // Subscan's free tier now rejects unauthenticated traffic, so the lookup will
-                // never succeed. Surface a terminal result instead of polling for the full
-                // timeout window and hammering an endpoint that will keep refusing us.
-                Timber.w("Polkadot explorer unauthorized; ending status check for %s", txHash)
-                TransactionResult.TimedOut
-            } else {
-                Timber.w(e, "Polkadot status check failed for %s", txHash)
-                TransactionResult.Pending
-            }
+            Timber.w(e, "Polkadot status check failed for %s", txHash)
+            TransactionResult.Pending
         }
 
-    private fun Throwable.isExplorerUnauthorized(): Boolean {
-        val exception = this as? NetworkException ?: return false
-        if (exception.httpStatusCode != 400) return false
-        return SUBSCAN_AUTH_WALL_PHRASES.any { exception.message.contains(it, ignoreCase = true) }
-    }
-
     private companion object {
-        // Subscan returns HTTP 400 with body `{"code": 403, "message": "Subscan API strictly
-        // requires an API key. Unauthenticated access is disabled."}` when the request omits
-        // the API key. Match both phrases — looser matching could classify unrelated
-        // bad-request responses as terminal and stop polling early.
-        val SUBSCAN_AUTH_WALL_PHRASES =
-            listOf("requires an API key", "Unauthenticated access is disabled")
+        // Best head advances ~1 block per poll interval; this window keeps comfortable overlap so a
+        // confirmed extrinsic is never skipped between polls, while early-exit keeps the common
+        // case
+        // (extrinsic at or near the head) to a single block fetch.
+        const val SCAN_DEPTH = 10
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -2,21 +2,26 @@ package com.vultisig.wallet.data.api.txstatus
 
 import com.vultisig.wallet.data.api.PolkadotApi
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
-class PolkadotStatusProvider @Inject constructor(private val polkadotApi: PolkadotApi) :
-    TransactionStatusProvider {
+class PolkadotStatusProvider
+@Inject
+constructor(
+    private val polkadotApi: PolkadotApi,
+    private val transactionHistoryRepository: TransactionHistoryRepository,
+) : TransactionStatusProvider {
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
             // Substrate has no "get transaction by hash" RPC and Subscan now blocks
             // unauthenticated traffic, so confirmation is done by scanning recent blocks for the
             // extrinsic hash over the same proxied RPC we broadcast through.
-            if (polkadotApi.isExtrinsicInChain(txHash, SCAN_DEPTH)) {
+            if (polkadotApi.isExtrinsicInChain(txHash, scanDepthFor(txHash, chain))) {
                 TransactionResult.Confirmed
             } else {
                 // Not in a block yet — keep polling until the surrounding poll loop times out.
@@ -29,11 +34,42 @@ class PolkadotStatusProvider @Inject constructor(private val polkadotApi: Polkad
             TransactionResult.Pending
         }
 
+    /**
+     * The inclusion block recedes from the chain head as the head advances, so a fixed head window
+     * only works while the foreground poller is hammering right after broadcast. A background
+     * refresh that rechecks a still-pending row minutes later would walk a shallow window that no
+     * longer reaches the (now buried) inclusion block, leaving a confirmed transfer stuck on
+     * `Pending` forever. Scale the scan depth by how long ago the tx was broadcast so the walk
+     * always reaches back far enough, bounded so a stuck/dropped extrinsic can't trigger an
+     * unbounded scan: once an extrinsic is older than its mortal era it can never be included, so
+     * there is nothing to find beyond [MAX_SCAN_DEPTH] blocks from the head.
+     */
+    private suspend fun scanDepthFor(txHash: String, chain: Chain): Int {
+        val broadcastAt =
+            runCatching {
+                    transactionHistoryRepository.getTransaction(chain.raw, txHash)?.timestamp
+                }
+                .getOrNull() ?: return MIN_SCAN_DEPTH
+        val elapsedBlocks =
+            (System.currentTimeMillis() - broadcastAt).coerceAtLeast(0L) / BLOCK_TIME_MS
+        return (elapsedBlocks + SCAN_MARGIN_BLOCKS)
+            .coerceIn(MIN_SCAN_DEPTH.toLong(), MAX_SCAN_DEPTH.toLong())
+            .toInt()
+    }
+
     private companion object {
-        // Best head advances ~1 block per poll interval; this window keeps comfortable overlap so a
-        // confirmed extrinsic is never skipped between polls, while early-exit keeps the common
-        // case
-        // (extrinsic at or near the head) to a single block fetch.
-        const val SCAN_DEPTH = 10
+        // Polkadot relay-chain target block time.
+        const val BLOCK_TIME_MS = 6_000L
+        // Overlap added on top of the elapsed-block estimate to absorb the few-block inclusion lag
+        // and block-time jitter so the inclusion block is never just outside the window.
+        const val SCAN_MARGIN_BLOCKS = 10L
+        // Floor for the fresh-broadcast / unknown-broadcast-time case (extrinsic at or near the
+        // head); keeps the common foreground poll to a couple of block fetches via early-exit.
+        const val MIN_SCAN_DEPTH = 10
+        // Ceiling that bounds the walk: the 64-block mortal era (after which the extrinsic is
+        // permanently invalid) plus the ~50-block foreground poll window, with margin. A row not
+        // confirmed within this window is dropped, not still confirmable, so a deeper scan would
+        // only re-fetch buried history for nothing.
+        const val MAX_SCAN_DEPTH = 130
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProvider.kt
@@ -16,16 +16,24 @@ constructor(
     private val transactionHistoryRepository: TransactionHistoryRepository,
 ) : TransactionStatusProvider {
 
+    // Substrate has no "get transaction by hash" RPC and Subscan now blocks unauthenticated
+    // traffic, so confirmation is done by scanning blocks for the extrinsic hash over the same
+    // proxied RPC we broadcast through.
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
-            // Substrate has no "get transaction by hash" RPC and Subscan now blocks
-            // unauthenticated traffic, so confirmation is done by scanning recent blocks for the
-            // extrinsic hash over the same proxied RPC we broadcast through.
-            if (polkadotApi.isExtrinsicInChain(txHash, scanDepthFor(txHash, chain))) {
-                TransactionResult.Confirmed
+            val broadcastBlock =
+                runCatching {
+                        transactionHistoryRepository
+                            .getTransaction(chain.raw, txHash)
+                            ?.broadcastBlockNumber
+                    }
+                    .getOrNull()
+            if (broadcastBlock != null) {
+                checkByInclusionWindow(txHash, broadcastBlock)
             } else {
-                // Not in a block yet — keep polling until the surrounding poll loop times out.
-                TransactionResult.Pending
+                // Rows recorded before the broadcast block was persisted (legacy/non-Polkadot
+                // paths) fall back to the head-relative scan scaled by broadcast age.
+                checkByHeadWindow(txHash, chain)
             }
         } catch (e: CancellationException) {
             throw e
@@ -35,14 +43,46 @@ constructor(
         }
 
     /**
+     * Anchor the scan to the absolute block captured at broadcast and walk the mortal-era window
+     * `[broadcastBlock, broadcastBlock + INCLUSION_WINDOW_BLOCKS]`. The window is fixed and
+     * age-independent, so a confirmed transfer is found no matter how long after broadcast the
+     * check runs — unlike a head-relative scan, whose window slides past the (now buried) inclusion
+     * block. The signed extrinsic is mortal: once the head advances past the window (plus a
+     * finality margin) without inclusion it can never be included, so the result becomes terminal
+     * [Failed] instead of polling [Pending] forever.
+     */
+    private suspend fun checkByInclusionWindow(
+        txHash: String,
+        broadcastBlock: Long,
+    ): TransactionResult {
+        val head = polkadotApi.getBlockHeader().toLong()
+        val windowEnd = broadcastBlock + INCLUSION_WINDOW_BLOCKS
+        val toBlock = minOf(head, windowEnd)
+        if (polkadotApi.isExtrinsicInBlockRange(txHash, broadcastBlock, toBlock)) {
+            return TransactionResult.Confirmed
+        }
+        return if (head > windowEnd + FINALITY_MARGIN_BLOCKS) {
+            TransactionResult.Failed("Extrinsic expired: not included within its mortal era")
+        } else {
+            TransactionResult.Pending
+        }
+    }
+
+    private suspend fun checkByHeadWindow(txHash: String, chain: Chain): TransactionResult =
+        if (polkadotApi.isExtrinsicInChain(txHash, scanDepthFor(txHash, chain))) {
+            TransactionResult.Confirmed
+        } else {
+            // Not in a block yet — keep polling until the surrounding poll loop times out.
+            TransactionResult.Pending
+        }
+
+    /**
      * The inclusion block recedes from the chain head as the head advances, so a fixed head window
-     * only works while the foreground poller is hammering right after broadcast. A background
-     * refresh that rechecks a still-pending row minutes later would walk a shallow window that no
-     * longer reaches the (now buried) inclusion block, leaving a confirmed transfer stuck on
-     * `Pending` forever. Scale the scan depth by how long ago the tx was broadcast so the walk
-     * always reaches back far enough, bounded so a stuck/dropped extrinsic can't trigger an
-     * unbounded scan: once an extrinsic is older than its mortal era it can never be included, so
-     * there is nothing to find beyond [MAX_SCAN_DEPTH] blocks from the head.
+     * only works while the foreground poller is hammering right after broadcast. Scale the scan
+     * depth by how long ago the tx was broadcast so the walk always reaches back far enough,
+     * bounded by [MAX_SCAN_DEPTH] so a stuck/dropped extrinsic can't trigger an unbounded scan.
+     * Used only for legacy rows without a persisted broadcast block; new rows use the absolute
+     * inclusion window in [checkByInclusionWindow].
      */
     private suspend fun scanDepthFor(txHash: String, chain: Chain): Int {
         val broadcastAt =
@@ -58,18 +98,26 @@ constructor(
     }
 
     private companion object {
+        // Mortal-era period the signed extrinsic is built with (PolkadotHelper sets period = 64):
+        // the extrinsic is valid for inclusion only within this many blocks of its checkpoint, so
+        // scanning beyond the window can never find it.
+        const val INCLUSION_WINDOW_BLOCKS = 64L
+        // Extra blocks past the window before declaring a miss terminal, to absorb head-read
+        // staleness and the few-block inclusion lag so a just-included extrinsic isn't failed
+        // early.
+        const val FINALITY_MARGIN_BLOCKS = 10L
+
+        // --- legacy head-relative fallback ---
         // Polkadot relay-chain target block time.
         const val BLOCK_TIME_MS = 6_000L
-        // Overlap added on top of the elapsed-block estimate to absorb the few-block inclusion lag
-        // and block-time jitter so the inclusion block is never just outside the window.
+        // Overlap on top of the elapsed-block estimate to absorb inclusion lag and block-time
+        // jitter.
         const val SCAN_MARGIN_BLOCKS = 10L
-        // Floor for the fresh-broadcast / unknown-broadcast-time case (extrinsic at or near the
-        // head); keeps the common foreground poll to a couple of block fetches via early-exit.
+        // Floor for the fresh-broadcast / unknown-broadcast-time case (extrinsic at or near head).
         const val MIN_SCAN_DEPTH = 10
-        // Ceiling that bounds the walk: the 64-block mortal era (after which the extrinsic is
-        // permanently invalid) plus the ~50-block foreground poll window, with margin. A row not
-        // confirmed within this window is dropped, not still confirmable, so a deeper scan would
-        // only re-fetch buried history for nothing.
+        // Ceiling that bounds the walk: the 64-block mortal era plus the foreground poll window
+        // with
+        // margin. A row not confirmed within this window is no longer confirmable.
         const val MAX_SCAN_DEPTH = 130
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/PolkadotHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/PolkadotHelper.kt
@@ -135,10 +135,10 @@ class PolkadotHelper(private val vaultHexPublicKey: String) {
 
         return SignedTransactionResult(
             rawTransaction = Numeric.toHexStringNoPrefix(output.encoded.toByteArray()),
-            transactionHash =
-                Numeric.toHexString(
-                    Utils.blake2bHash(output.encoded.toByteArray().take(32).toByteArray())
-                ),
+            // Canonical Substrate extrinsic hash: blake2b-256 over the full SCALE-encoded
+            // extrinsic. The previous `.take(32)` truncation produced a hash that matched neither
+            // the on-chain extrinsic nor the explorer, breaking status lookups and the tx link.
+            transactionHash = Numeric.toHexString(Utils.blake2bHash(output.encoded.toByteArray())),
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
@@ -67,4 +67,12 @@ data class TransactionHistoryEntity(
      * [RefreshPendingTransactionsUseCase].
      */
     @ColumnInfo("retryCount", defaultValue = "0") val retryCount: Int = 0,
+    /**
+     * Chain head block number captured when the transaction was signed/broadcast. Currently only
+     * populated for Polkadot, where status is confirmed by scanning the absolute inclusion window
+     * `[broadcastBlockNumber, broadcastBlockNumber + mortal era]` rather than a head-relative
+     * window that drifts out of reach once the head advances. Null for chains that don't need it
+     * and for rows recorded before this column existed.
+     */
+    @ColumnInfo("broadcastBlockNumber") val broadcastBlockNumber: Long? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -25,6 +25,10 @@ data class CommonTransactionHistoryData(
     val timestamp: Long,
     val txHash: String,
     val explorerUrl: String,
+    /**
+     * Chain head block number at broadcast; see [TransactionHistoryEntity.broadcastBlockNumber].
+     */
+    val broadcastBlockNumber: Long? = null,
 )
 
 @Serializable
@@ -70,6 +74,7 @@ internal fun TransactionHistoryData.toEntity(
         confirmedAt = genericData.confirmedAt,
         failureReason = genericData.failureReason,
         lastCheckedAt = genericData.lastCheckedAt,
+        broadcastBlockNumber = genericData.broadcastBlockNumber,
         payload = this,
     )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -148,9 +148,7 @@ constructor(
                     broadcast = {
                         polkadotApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
                     },
-                    verify = { hash ->
-                        polkadotApi.getTxStatus(hash)?.data?.extrinsicHash?.isNotBlank() == true
-                    },
+                    verify = { hash -> polkadotApi.isExtrinsicInChain(hash, VERIFY_SCAN_DEPTH) },
                 )
 
             Chain.Bittensor -> {
@@ -249,5 +247,9 @@ constructor(
     private companion object {
         const val VERIFY_ATTEMPTS = 3
         const val VERIFY_BACKOFF_MS = 2_000L
+        // The duplicate-broadcast peer raced us moments ago, so its extrinsic is at the head; a
+        // shallow scan is enough to confirm it landed without re-fetching deep history each
+        // attempt.
+        const val VERIFY_SCAN_DEPTH = 5
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
@@ -12,6 +12,7 @@ import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -122,6 +123,35 @@ class PolkadotApiTest {
         // 1 getBlockHash + 3 getBlock (blocks 100, 99, 98); must not scan below fromBlock.
         assertEquals(4, requests)
     }
+
+    @Test
+    fun `isExtrinsicInBlockRange throws on a null block mid-window instead of reporting a miss`() =
+        runTest {
+            var requests = 0
+            val api =
+                polkadotApi(
+                    MockEngine {
+                        requests++
+                        // getBlockHash succeeds, the first getBlock has no match, and the second
+                        // returns a null result (RPC error envelope) partway through the window.
+                        val body =
+                            when (requests) {
+                                1 -> hashResponse(HEAD_HASH)
+                                2 -> blockResponse(parentHash = PARENT, extrinsics = emptyList())
+                                else -> nullResultResponse()
+                            }
+                        respond(content = body, status = HttpStatusCode.OK, headers = jsonHeaders)
+                    }
+                )
+
+            // An incomplete scan must not be reported as a genuine miss (which the caller would
+            // terminally Fail); it propagates so the tx stays Pending for a retry.
+            assertFailsWith<IllegalStateException> {
+                api.isExtrinsicInBlockRange(EXT_HASH, fromBlock = 98, toBlock = 100)
+            }
+        }
+
+    private fun nullResultResponse(): String = """{"jsonrpc":"2.0","id":1,"result":null}"""
 
     private fun hashResponse(hash: String): String = """{"jsonrpc":"2.0","id":1,"result":"$hash"}"""
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
@@ -13,7 +13,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
@@ -24,7 +24,7 @@ class PolkadotApiTest {
 
     @Test
     fun `isExtrinsicInChain matches the blake2b-256 hash of an extrinsic in the head block`() =
-        runBlocking {
+        runTest {
             var requests = 0
             val api =
                 polkadotApi(
@@ -44,7 +44,7 @@ class PolkadotApiTest {
         }
 
     @Test
-    fun `isExtrinsicInChain walks back to a parent block via parentHash`() = runBlocking {
+    fun `isExtrinsicInChain walks back to a parent block via parentHash`() = runTest {
         var requests = 0
         val api =
             polkadotApi(
@@ -65,24 +65,23 @@ class PolkadotApiTest {
     }
 
     @Test
-    fun `isExtrinsicInChain returns false and stops after depth blocks when not found`() =
-        runBlocking {
-            var requests = 0
-            val api =
-                polkadotApi(
-                    MockEngine {
-                        requests++
-                        respond(
-                            content = blockResponse(parentHash = PARENT, extrinsics = emptyList()),
-                            status = HttpStatusCode.OK,
-                            headers = jsonHeaders,
-                        )
-                    }
-                )
+    fun `isExtrinsicInChain returns false and stops after depth blocks when not found`() = runTest {
+        var requests = 0
+        val api =
+            polkadotApi(
+                MockEngine {
+                    requests++
+                    respond(
+                        content = blockResponse(parentHash = PARENT, extrinsics = emptyList()),
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
 
-            assertEquals(false, api.isExtrinsicInChain(EXT_HASH, depth = 3))
-            assertEquals(3, requests)
-        }
+        assertEquals(false, api.isExtrinsicInChain(EXT_HASH, depth = 3))
+        assertEquals(3, requests)
+    }
 
     private fun blockResponse(parentHash: String, extrinsics: List<String>): String {
         val ext = extrinsics.joinToString(",") { "\"$it\"" }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
@@ -83,6 +83,48 @@ class PolkadotApiTest {
         assertEquals(3, requests)
     }
 
+    @Test
+    fun `isExtrinsicInBlockRange finds an extrinsic inside the window`() = runTest {
+        var requests = 0
+        val api =
+            polkadotApi(
+                MockEngine {
+                    requests++
+                    // First call resolves the window-top block number to a hash, the rest fetch
+                    // blocks while walking down via parentHash.
+                    val body =
+                        if (requests == 1) hashResponse(HEAD_HASH)
+                        else blockResponse(parentHash = PARENT, extrinsics = listOf(EXT))
+                    respond(content = body, status = HttpStatusCode.OK, headers = jsonHeaders)
+                }
+            )
+
+        assertTrue(api.isExtrinsicInBlockRange(EXT_HASH, fromBlock = 100, toBlock = 102))
+        // 1 getBlockHash + 1 getBlock: found at the window top (block 102).
+        assertEquals(2, requests)
+    }
+
+    @Test
+    fun `isExtrinsicInBlockRange walks down to fromBlock and stops when not found`() = runTest {
+        var requests = 0
+        val api =
+            polkadotApi(
+                MockEngine {
+                    requests++
+                    val body =
+                        if (requests == 1) hashResponse(HEAD_HASH)
+                        else blockResponse(parentHash = PARENT, extrinsics = emptyList())
+                    respond(content = body, status = HttpStatusCode.OK, headers = jsonHeaders)
+                }
+            )
+
+        assertEquals(false, api.isExtrinsicInBlockRange(EXT_HASH, fromBlock = 98, toBlock = 100))
+        // 1 getBlockHash + 3 getBlock (blocks 100, 99, 98); must not scan below fromBlock.
+        assertEquals(4, requests)
+    }
+
+    private fun hashResponse(hash: String): String = """{"jsonrpc":"2.0","id":1,"result":"$hash"}"""
+
     private fun blockResponse(parentHash: String, extrinsics: List<String>): String {
         val ext = extrinsics.joinToString(",") { "\"$it\"" }
         return """
@@ -108,5 +150,6 @@ class PolkadotApiTest {
         const val EXT_HASH = "0xd3b70ba9181914a6c2132283204e411dd826b130dc5bb239f718938e788dee7e"
         const val PARENT = "0x98a821471c5f40bbaf9fd7798f89419ae81b9e6c4434dd16a2adecd55a82c9c2"
         const val GENESIS = "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+        const val HEAD_HASH = "0x7b2c8f0d6a3e1f4c5b9d8e2a1f0c3b6d9e8a7f4c1b0d3e6a9f8c7b4d1e0a3f6c"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
@@ -1,0 +1,113 @@
+package com.vultisig.wallet.data.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class PolkadotApiTest {
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    @Test
+    fun `isExtrinsicInChain matches the blake2b-256 hash of an extrinsic in the head block`() =
+        runBlocking {
+            var requests = 0
+            val api =
+                polkadotApi(
+                    MockEngine {
+                        requests++
+                        respond(
+                            content = blockResponse(parentHash = PARENT, extrinsics = listOf(EXT)),
+                            status = HttpStatusCode.OK,
+                            headers = jsonHeaders,
+                        )
+                    }
+                )
+
+            assertTrue(api.isExtrinsicInChain(EXT_HASH, depth = 5))
+            // Found at the head, so it must not walk further back.
+            assertEquals(1, requests)
+        }
+
+    @Test
+    fun `isExtrinsicInChain walks back to a parent block via parentHash`() = runBlocking {
+        var requests = 0
+        val api =
+            polkadotApi(
+                MockEngine {
+                    requests++
+                    val body =
+                        if (requests == 1) {
+                            blockResponse(parentHash = PARENT, extrinsics = emptyList())
+                        } else {
+                            blockResponse(parentHash = GENESIS, extrinsics = listOf(EXT))
+                        }
+                    respond(content = body, status = HttpStatusCode.OK, headers = jsonHeaders)
+                }
+            )
+
+        assertTrue(api.isExtrinsicInChain(EXT_HASH, depth = 5))
+        assertEquals(2, requests)
+    }
+
+    @Test
+    fun `isExtrinsicInChain returns false and stops after depth blocks when not found`() =
+        runBlocking {
+            var requests = 0
+            val api =
+                polkadotApi(
+                    MockEngine {
+                        requests++
+                        respond(
+                            content = blockResponse(parentHash = PARENT, extrinsics = emptyList()),
+                            status = HttpStatusCode.OK,
+                            headers = jsonHeaders,
+                        )
+                    }
+                )
+
+            assertEquals(false, api.isExtrinsicInChain(EXT_HASH, depth = 3))
+            assertEquals(3, requests)
+        }
+
+    private fun blockResponse(parentHash: String, extrinsics: List<String>): String {
+        val ext = extrinsics.joinToString(",") { "\"$it\"" }
+        return """
+            {"jsonrpc":"2.0","id":1,"result":{"block":{
+              "header":{"parentHash":"$parentHash","number":"0x1"},
+              "extrinsics":[$ext]
+            }}}
+        """
+            .trimIndent()
+    }
+
+    private fun polkadotApi(engine: MockEngine): PolkadotApi =
+        PolkadotApiImp(
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+                install(DefaultRequest) { contentType(ContentType.Application.Json) }
+            }
+        )
+
+    private companion object {
+        // A real Asset Hub inherent extrinsic and its canonical blake2b-256 hash.
+        const val EXT = "0x280503000b605dfd869e01"
+        const val EXT_HASH = "0xd3b70ba9181914a6c2132283204e411dd826b130dc5bb239f718938e788dee7e"
+        const val PARENT = "0x98a821471c5f40bbaf9fd7798f89419ae81b9e6c4434dd16a2adecd55a82c9c2"
+        const val GENESIS = "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
@@ -1,12 +1,17 @@
 package com.vultisig.wallet.data.api.txstatus
 
 import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -14,10 +19,12 @@ import org.junit.jupiter.api.assertThrows
 class PolkadotStatusProviderTest {
 
     private val polkadotApi = mockk<PolkadotApi>()
-    private val provider = PolkadotStatusProvider(polkadotApi)
+    private val transactionHistoryRepository = mockk<TransactionHistoryRepository>()
+    private val provider = PolkadotStatusProvider(polkadotApi, transactionHistoryRepository)
 
     @Test
     fun `extrinsic found in a recent block maps to Confirmed`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns null
         coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } returns true
 
         val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
@@ -27,6 +34,7 @@ class PolkadotStatusProviderTest {
 
     @Test
     fun `extrinsic not yet in a block keeps polling as Pending`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns null
         coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } returns false
 
         val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
@@ -36,6 +44,7 @@ class PolkadotStatusProviderTest {
 
     @Test
     fun `transient RPC errors keep polling alive as Pending`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns null
         coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } throws
             RuntimeException("Connection timed out")
 
@@ -46,13 +55,47 @@ class PolkadotStatusProviderTest {
 
     @Test
     fun `cancellation is not swallowed`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns null
         coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } throws
             CancellationException("cancelled")
 
         assertThrows<CancellationException> { provider.checkStatus(TX_HASH, Chain.Polkadot) }
     }
 
+    @Test
+    fun `an old broadcast scans deeper so a buried inclusion block is still reachable`() = runTest {
+        // Broadcast 6 minutes ago: the inclusion block is far behind the live head now, so the
+        // shallow head window the foreground poller used can no longer reach it.
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns
+            entityBroadcastMinutesAgo(6)
+        val depth = slot<Int>()
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, capture(depth)) } returns true
+
+        provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        // ~60 blocks of elapsed time + margin, well past the 10-block foreground floor.
+        assertTrue(depth.captured > 10, "expected a deep scan, got ${depth.captured}")
+    }
+
+    @Test
+    fun `scan depth is capped so a stuck extrinsic never triggers an unbounded walk`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns
+            entityBroadcastMinutesAgo(600)
+        val depth = slot<Int>()
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, capture(depth)) } returns false
+
+        provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(MAX_SCAN_DEPTH, depth.captured)
+    }
+
+    private fun entityBroadcastMinutesAgo(minutes: Long): TransactionHistoryEntity =
+        mockk(relaxed = true) {
+            every { timestamp } returns System.currentTimeMillis() - minutes * 60 * 1_000
+        }
+
     private companion object {
         const val TX_HASH = "0xdeadbeef"
+        const val MAX_SCAN_DEPTH = 130
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
@@ -9,6 +9,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import java.math.BigInteger
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -89,13 +90,66 @@ class PolkadotStatusProviderTest {
         assertEquals(MAX_SCAN_DEPTH, depth.captured)
     }
 
+    @Test
+    fun `extrinsic found inside the absolute inclusion window maps to Confirmed`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns
+            entityWithBroadcastBlock(BROADCAST_BLOCK)
+        coEvery { polkadotApi.getBlockHeader() } returns BigInteger.valueOf(BROADCAST_BLOCK + 5)
+        val from = slot<Long>()
+        val to = slot<Long>()
+        coEvery { polkadotApi.isExtrinsicInBlockRange(TX_HASH, capture(from), capture(to)) } returns
+            true
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Confirmed, result)
+        // Anchored at the broadcast block; the window top is capped at the live head (+5 here).
+        assertEquals(BROADCAST_BLOCK, from.captured)
+        assertEquals(BROADCAST_BLOCK + 5, to.captured)
+    }
+
+    @Test
+    fun `not yet included while the mortal era is still open stays Pending`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns
+            entityWithBroadcastBlock(BROADCAST_BLOCK)
+        // Head is past the inclusion window but still inside the finality margin.
+        coEvery { polkadotApi.getBlockHeader() } returns
+            BigInteger.valueOf(BROADCAST_BLOCK + INCLUSION_WINDOW_BLOCKS + 5)
+        coEvery { polkadotApi.isExtrinsicInBlockRange(TX_HASH, any(), any()) } returns false
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertEquals(TransactionResult.Pending, result)
+    }
+
+    @Test
+    fun `missing extrinsic past the mortal era resolves to terminal Failed`() = runTest {
+        coEvery { transactionHistoryRepository.getTransaction(any(), any()) } returns
+            entityWithBroadcastBlock(BROADCAST_BLOCK)
+        // Head has advanced well past the window + finality margin, so it can never be included.
+        coEvery { polkadotApi.getBlockHeader() } returns
+            BigInteger.valueOf(BROADCAST_BLOCK + INCLUSION_WINDOW_BLOCKS + FINALITY_MARGIN + 1)
+        coEvery { polkadotApi.isExtrinsicInBlockRange(TX_HASH, any(), any()) } returns false
+
+        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
+
+        assertTrue(result is TransactionResult.Failed, "expected terminal Failed, got $result")
+    }
+
     private fun entityBroadcastMinutesAgo(minutes: Long): TransactionHistoryEntity =
         mockk(relaxed = true) {
             every { timestamp } returns System.currentTimeMillis() - minutes * 60 * 1_000
+            every { broadcastBlockNumber } returns null
         }
+
+    private fun entityWithBroadcastBlock(block: Long): TransactionHistoryEntity =
+        mockk(relaxed = true) { every { broadcastBlockNumber } returns block }
 
     private companion object {
         const val TX_HASH = "0xdeadbeef"
         const val MAX_SCAN_DEPTH = 130
+        const val BROADCAST_BLOCK = 1_000_000L
+        const val INCLUSION_WINDOW_BLOCKS = 64L
+        const val FINALITY_MARGIN = 10L
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/PolkadotStatusProviderTest.kt
@@ -1,17 +1,15 @@
 package com.vultisig.wallet.data.api.txstatus
 
 import com.vultisig.wallet.data.api.PolkadotApi
-import com.vultisig.wallet.data.api.models.cosmos.PolkadotErrorData
-import com.vultisig.wallet.data.api.models.cosmos.PolkadotExtrinsicDataJson
-import com.vultisig.wallet.data.api.models.cosmos.PolkadotExtrinsicResponseJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
-import com.vultisig.wallet.data.utils.NetworkException
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class PolkadotStatusProviderTest {
 
@@ -19,9 +17,8 @@ class PolkadotStatusProviderTest {
     private val provider = PolkadotStatusProvider(polkadotApi)
 
     @Test
-    fun `maps subscan success response to Confirmed`() = runTest {
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns
-            successResponse(extrinsicHash = TX_HASH)
+    fun `extrinsic found in a recent block maps to Confirmed`() = runTest {
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } returns true
 
         val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
 
@@ -29,60 +26,8 @@ class PolkadotStatusProviderTest {
     }
 
     @Test
-    fun `maps null subscan response to NotFound`() = runTest {
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns null
-
-        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
-
-        assertEquals(TransactionResult.NotFound, result)
-    }
-
-    @Test
-    fun `maps on-chain failure to Failed with the error value`() = runTest {
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } returns
-            PolkadotExtrinsicResponseJson(
-                code = 0,
-                message = "indexer reports error",
-                generatedAt = 0,
-                data =
-                    PolkadotExtrinsicDataJson(
-                        polkadotErrorData =
-                            PolkadotErrorData(
-                                batchIndex = 0,
-                                doc = "",
-                                module = "system",
-                                name = "BadOrigin",
-                                value = "BadOrigin: invalid origin",
-                                version = 0,
-                            ),
-                        extrinsicHash = TX_HASH,
-                    ),
-            )
-
-        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
-
-        assertEquals(TransactionResult.Failed("BadOrigin: invalid origin"), result)
-    }
-
-    @Test
-    fun `subscan API key rejection terminates polling with TimedOut`() = runTest {
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
-            NetworkException(
-                httpStatusCode = 400,
-                message =
-                    "{\"code\": 403, \"message\": \"Subscan API strictly requires an API key. " +
-                        "Unauthenticated access is disabled.\"}",
-            )
-
-        val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
-
-        assertEquals(TransactionResult.TimedOut, result)
-    }
-
-    @Test
-    fun `transient network errors keep polling alive as Pending`() = runTest {
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
-            NetworkException(httpStatusCode = 0, message = "Connection timed out")
+    fun `extrinsic not yet in a block keeps polling as Pending`() = runTest {
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } returns false
 
         val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
 
@@ -90,25 +35,22 @@ class PolkadotStatusProviderTest {
     }
 
     @Test
-    fun `generic 400 without API-key phrasing keeps polling alive as Pending`() = runTest {
-        // An unrelated bad-request response — for example a malformed payload — must not be
-        // mistaken for the Subscan auth wall and stop polling early.
-        coEvery { polkadotApi.getTxStatus(TX_HASH) } throws
-            NetworkException(httpStatusCode = 400, message = "{\"error\":\"invalid hash format\"}")
+    fun `transient RPC errors keep polling alive as Pending`() = runTest {
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } throws
+            RuntimeException("Connection timed out")
 
         val result = provider.checkStatus(TX_HASH, Chain.Polkadot)
 
         assertEquals(TransactionResult.Pending, result)
     }
 
-    private fun successResponse(extrinsicHash: String) =
-        PolkadotExtrinsicResponseJson(
-            code = 0,
-            message = "success",
-            generatedAt = 1_700_000_000,
-            data =
-                PolkadotExtrinsicDataJson(polkadotErrorData = null, extrinsicHash = extrinsicHash),
-        )
+    @Test
+    fun `cancellation is not swallowed`() = runTest {
+        coEvery { polkadotApi.isExtrinsicInChain(TX_HASH, any()) } throws
+            CancellationException("cancelled")
+
+        assertThrows<CancellationException> { provider.checkStatus(TX_HASH, Chain.Polkadot) }
+    }
 
     private companion object {
         const val TX_HASH = "0xdeadbeef"


### PR DESCRIPTION
## Summary

Fixes #4684. Polkadot / Asset Hub transactions could never resolve to **Confirmed** — `getTxStatus` queried Subscan, which now hard-requires an API key and rejects unauthenticated traffic, so every status check degraded to `TimedOut` even for transactions successfully included on-chain.

Per the maintainer's decision on the issue (**Option 2 — drop the assethub/Subscan dependency**), status is now confirmed purely over the RPC we already broadcast through. Substrate exposes no "transaction by hash" RPC, so confirmation walks recent best-head blocks via `chain_getBlock` and blake2b-256-matches each extrinsic against the tx hash.

For reference: the SDK issue mentioned on #4684 (vultisig-sdk#609) does **not** remove Subscan — its status resolver still queries it; #609 fixed an unrelated broadcast race. So there was no RPC implementation to port.

## Changes

- **`PolkadotHelper`** — fix a latent bug: `transactionHash` hashed only the first 32 bytes of the encoded extrinsic (`output.encoded.take(32)`). The canonical Substrate hash is blake2b-256 over the **full** extrinsic (as the sibling `BittensorHelper` already does). The truncated value matched neither the on-chain extrinsic nor the explorer, breaking the tx link and any hash lookup. Required for block-scan to match.
- **`PolkadotApi`** — add `isExtrinsicInChain(hash, depth)` + `getBlock`; remove `getTxStatus` and the Subscan extrinsic URL.
- **`PolkadotStatusProvider`** — rewritten: extrinsic found in a recent block → `Confirmed`, otherwise `Pending` until the poll loop times out.
- **`BroadcastTxUseCase`** — the Polkadot broadcast safety net (verify-by-hash) also relied on the broken Subscan call; switch it to the same block-scan.
- Drop the now-unused Subscan response models.

## Known limitation

Metadata-free SCALE event decoding is not feasible over plain RPC, so an *included-but-dispatch-failed* extrinsic reports `Confirmed` rather than `Failed`. Acceptable for transfers, where balance and fee are pre-checked before signing.

## Test plan

- [x] `:data:testDebugUnitTest` (full suite) green
- [x] `:app:compileDebugKotlin` green
- [x] New `PolkadotApiTest` — block-scan + blake2b-256 match against a real extrinsic vector; walk-to-parent; depth bound
- [x] Rewrote `PolkadotStatusProviderTest`
- [ ] Manual mainnet smoke: send a small DOT transfer → status flips to Confirmed; the tx hash now resolves on Subscan/polkadot.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Proof (device, Polkadot mainnet)

Real DOT transfer signed on device — status now resolves to **Successful** (previously stuck pending → timed out).

<img src="https://i.imgur.com/fgS3v9o.png" width="320" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct on-chain block scanning to verify Polkadot extrinsic inclusion (head-relative and absolute block-range checks).
  * Persist broadcast block number when saving transactions to support absolute inclusion windows.

* **Bug Fixes**
  * Corrected canonical Polkadot extrinsic hash to match explorers.
  * Status polling now relies on on-chain scans, treats transient errors as pending, and rethrows cancellations; removed prior explorer-specific timeout behavior.
  * Scan depth computed from broadcast age with min/max bounds.

* **Tests**
  * Added/updated tests for block-scanning, block-range checks, scan-depth, error handling, and cancellations.

* **Chores**
  * Database migration and schema version bump to add broadcast block column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->