### PR TITLE
fix(cosmos): add back navigation to staking screens

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -34,6 +35,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -147,6 +149,10 @@ constructor(
 
     fun dismissError() {
         _state.update { it.copy(errorMessage = null) }
+    }
+
+    fun back() {
+        viewModelScope.launch { navigator.back() }
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.math.BigDecimal
@@ -44,6 +45,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -199,6 +201,10 @@ constructor(
 
     fun dismissError() {
         _state.update { it.copy(errorMessage = null) }
+    }
+
+    fun back() {
+        viewModelScope.launch { navigator.back() }
     }
 
     /** Excluded set passed to the picker — the source is never a valid destination for itself. */

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
@@ -15,7 +15,10 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
@@ -27,6 +30,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -68,6 +72,7 @@ constructor(
     private val vaultPasswordRepository: VaultPasswordRepository,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
     private val launchKeysign: LaunchKeysignUseCase,
+    private val navigator: Navigator<Destination>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -234,6 +239,10 @@ constructor(
 
     fun dismissError() {
         _state.update { it.copy(errorText = null) }
+    }
+
+    fun back() {
+        viewModelScope.launch { navigator.back() }
     }
 
     private fun keysign(initType: KeysignInitType) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModel.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.math.BigDecimal
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -136,6 +138,10 @@ constructor(
 
     fun dismissError() {
         _state.update { it.copy(errorMessage = null) }
+    }
+
+    fun back() {
+        viewModelScope.launch { navigator.back() }
     }
 
     fun submit() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosWithdrawRewardsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosWithdrawRewardsViewModel.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -33,6 +34,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -116,6 +118,10 @@ constructor(
 
     fun dismissError() {
         _state.update { it.copy(errorMessage = null) }
+    }
+
+    fun back() {
+        viewModelScope.launch { navigator.back() }
     }
 
     fun toggle(validatorAddress: String) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -32,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -64,7 +66,11 @@ internal fun CosmosDelegateScreen(viewModel: CosmosDelegateViewModel = hiltViewM
 
     V2Scaffold(
         title =
-            stringResource(R.string.cosmos_staking_delegate_title, state.ticker.ifEmpty { "Token" })
+            stringResource(
+                R.string.cosmos_staking_delegate_title,
+                state.ticker.ifEmpty { "Token" },
+            ),
+        onBackClick = viewModel::back,
     ) {
         DelegateContent(
             state = state,
@@ -443,4 +449,32 @@ private fun formatVotingPower(votingPowerBaseUnits: BigDecimal): String {
     // Terra (LUNA) and Terra Classic (LUNC) both use 6 base-unit decimals.
     val whole = votingPowerBaseUnits.movePointLeft(6).toBigInteger()
     return "%,d".format(whole)
+}
+
+@Preview
+@Composable
+private fun CosmosDelegateScreenPreview() {
+    V2Scaffold(title = "Stake LUNA", onBackClick = {}) {
+        DelegateContent(
+            state =
+                CosmosDelegateUiState(
+                    ticker = "LUNA",
+                    stakeableBalance = BigDecimal("12.482"),
+                    percentageSelected = 50,
+                    selectedValidator =
+                        CosmosValidator(
+                            operatorAddress = "terravaloper1allnodes78wk",
+                            moniker = "Allnodes",
+                            commission = BigDecimal("0.05"),
+                            jailed = false,
+                            status = CosmosValidator.Status.Bonded,
+                            votingPower = BigDecimal.ZERO,
+                        ),
+                ),
+            amountFieldState = rememberTextFieldState("6.24"),
+            onPercentage = {},
+            onPickValidator = {},
+            onSubmit = {},
+        )
+    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -18,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
@@ -29,6 +31,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosRedelegateViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import java.math.BigDecimal
 
 /**
  * Redelegate input form for LUNA / LUNC. Amount first, then destination picker via a modal-bottom-
@@ -45,7 +48,8 @@ internal fun CosmosRedelegateScreen(viewModel: CosmosRedelegateViewModel = hiltV
             stringResource(
                 R.string.cosmos_staking_redelegate_title,
                 state.ticker.ifEmpty { "Token" },
-            )
+            ),
+        onBackClick = viewModel::back,
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
@@ -172,5 +176,40 @@ private fun DstValidatorPickerRow(selected: CosmosValidator?, onClick: () -> Uni
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.secondary,
         )
+    }
+}
+
+@Preview
+@Composable
+private fun CosmosRedelegateScreenPreview() {
+    V2Scaffold(title = "Redelegate LUNA", onBackClick = {}) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                ValidatorReadonlyBlock(moniker = "Allnodes", address = "terravaloper1allnodes78wk")
+                StakingAmountCard(
+                    ticker = "LUNA",
+                    amountFieldState = rememberTextFieldState("1.0"),
+                    available = BigDecimal("2.5"),
+                    percentageSelected = 50,
+                    onPercentage = {},
+                )
+                Text(
+                    text = stringResource(R.string.cosmos_staking_redelegate_source),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.primary,
+                )
+                DstValidatorPickerRow(selected = null, onClick = {})
+            }
+            VsButton(
+                label = "Continue",
+                variant = VsButtonVariant.CTA,
+                state = VsButtonState.Enabled,
+                onClick = {},
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
@@ -37,6 +38,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
+import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorRow
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyViewModel
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
@@ -72,7 +74,10 @@ internal fun CosmosStakingVerifyScreen(viewModel: CosmosStakingVerifyViewModel =
         )
     }
 
-    V2Scaffold(title = stringResource(R.string.verify_deposit_function_overview)) {
+    V2Scaffold(
+        title = stringResource(R.string.verify_deposit_function_overview),
+        onBackClick = viewModel::back,
+    ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
                 modifier =
@@ -203,3 +208,47 @@ private fun SummaryRow(label: String, value: String, secondary: String? = null) 
 private fun truncatedMiddle(value: String): String =
     if (value.length > 14) "${value.substring(0, 8)}…${value.substring(value.length - 4)}"
     else value
+
+@Preview
+@Composable
+private fun CosmosStakingVerifyScreenPreview() {
+    V2Scaffold(title = "Overview", onBackClick = {}) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier =
+                    Modifier.fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp)
+                        .padding(bottom = 96.dp)
+            ) {
+                SummaryCard(
+                    state =
+                        CosmosStakingVerifyUiState(
+                            headlineRes = R.string.cosmos_staking_youre_claiming,
+                            amount = "0.000001",
+                            ticker = "LUNA",
+                            vaultName = "Main Vault",
+                            fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
+                            validatorRows =
+                                listOf(
+                                    CosmosStakingVerifyValidatorRow(
+                                        labelRes = R.string.cosmos_staking_validator_picker,
+                                        value = "Allnodes (5% commission)",
+                                    )
+                                ),
+                            networkName = "Terra",
+                            feeCrypto = "0.01 LUNA",
+                            isLoading = false,
+                        )
+                )
+            }
+            VsButton(
+                label = stringResource(R.string.cosmos_staking_verify_sign),
+                variant = VsButtonVariant.CTA,
+                state = VsButtonState.Enabled,
+                onClick = {},
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -17,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
@@ -28,6 +30,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosUndelegateViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import java.math.BigDecimal
 
 /**
  * Undelegate input form for LUNA / LUNC. Same shape as the iOS `CosmosUndelegateTransactionScreen`
@@ -43,7 +46,8 @@ internal fun CosmosUndelegateScreen(viewModel: CosmosUndelegateViewModel = hiltV
             stringResource(
                 R.string.cosmos_staking_undelegate_title,
                 state.ticker.ifEmpty { stringResource(R.string.cosmos_staking_token_fallback) },
-            )
+            ),
+        onBackClick = viewModel::back,
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
@@ -151,5 +155,37 @@ internal fun UnbondingLockNotice(message: String) {
             style = Theme.brockmann.supplementary.caption,
             color = Theme.v2.colors.text.primary,
         )
+    }
+}
+
+@Preview
+@Composable
+private fun CosmosUndelegateScreenPreview() {
+    V2Scaffold(title = "Unstake LUNA", onBackClick = {}) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                ValidatorReadonlyBlock(moniker = "Allnodes", address = "terravaloper1allnodes78wk")
+                StakingAmountCard(
+                    ticker = "LUNA",
+                    amountFieldState = rememberTextFieldState("2.5"),
+                    available = BigDecimal("2.5"),
+                    percentageSelected = 100,
+                    onPercentage = {},
+                )
+                UnbondingLockNotice(
+                    message = "Funds are locked for 21 days. Available on Jul 24, 2026."
+                )
+            }
+            VsButton(
+                label = "Continue",
+                variant = VsButtonVariant.CTA,
+                state = VsButtonState.Enabled,
+                onClick = {},
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
@@ -33,6 +34,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosWithdrawRewardsViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import java.math.BigDecimal
 
 /**
  * Selection-driven claim-rewards screen for LUNA / LUNC. Per-validator pending reward list with a
@@ -46,7 +48,10 @@ internal fun CosmosWithdrawRewardsScreen(
     viewModel: CosmosWithdrawRewardsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
-    V2Scaffold(title = stringResource(R.string.cosmos_staking_claim_rewards_title)) {
+    V2Scaffold(
+        title = stringResource(R.string.cosmos_staking_claim_rewards_title),
+        onBackClick = viewModel::back,
+    ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
                 HeaderRow(
@@ -279,5 +284,38 @@ private fun androidx.compose.foundation.layout.BoxScope.FooterSummary(
             onClick = onSubmit,
             modifier = Modifier.fillMaxWidth(),
         )
+    }
+}
+
+@Preview
+@Composable
+private fun CosmosWithdrawRewardsScreenPreview() {
+    V2Scaffold(title = "Claim Rewards", onBackClick = {}) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                HeaderRow(maxBatchSize = 8, onSelectAll = {})
+                UiSpacer(size = 12.dp)
+                CandidateRow(
+                    candidate =
+                        CosmosWithdrawRewardsCandidate(
+                            validatorAddress = "terravaloper1allnodes78wk",
+                            validatorMoniker = "Allnodes",
+                            pendingReward = BigDecimal("0.000001"),
+                        ),
+                    isSelected = true,
+                    ticker = "LUNA",
+                    onToggle = {},
+                )
+            }
+            FooterSummary(
+                ticker = "LUNA",
+                totalSelectedReward = "0.000001",
+                estimatedFee = "0.01",
+                hasSufficientBalanceForFee = true,
+                isSubmitting = false,
+                isValidForm = true,
+                onSubmit = {},
+            )
+        }
     }
 }


### PR DESCRIPTION
## Problem

Reported after #4687 was merged: the Cosmos staking screens (**claim / stake / unstake / delegate / verify**) have no top **back** button, so once a user enters any of those flows they can't navigate back.

## Root cause

Each screen called `V2Scaffold(title = …)` **without** `onBackClick`. `V2Topbar` only renders the back caret when `onBackClick != null`:

```kotlin
navigationIcon = onBackClick?.let { { /* back caret */ } } ?: {}
```

So the bar showed the title but no way back.

## Fix

- Added a `back()` method — the codebase's standard `viewModelScope.launch { navigator.back() }` idiom — to the four form view-models and the verify view-model.
- `CosmosStakingVerifyViewModel` didn't inject `Navigator<Destination>`; added it to its Hilt constructor.
- Wired `onBackClick = viewModel::back` into all five screens' `V2Scaffold`.
- The positions / DeFi-tab screen is embedded in `ChainDashboard`, which already supplies its own top bar — left untouched.

## Previews

Added a `@Preview` for each screen (reusing each file's stateless sub-components inside `V2Scaffold(onBackClick = {})` with mock data) so the back button is visible in the IDE preview pane without touching the production wrappers.

## Test plan

- [x] `:app:assembleDebug` clean
- [x] `:app:testDebugUnitTest` (cosmos staking package) green
- [ ] Manual: enter each staking flow → back caret appears top-left and pops to the DeFi tab

Closes the back-navigation gap on the merged #4687 staking flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added back navigation support to Cosmos staking screens (Delegate, Redelegate, Verify, Undelegate, Withdraw Rewards).

* **Tests**
  * Added preview support for Cosmos staking screens to improve development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->