### PR TITLE
fix(cosmos): align LUNA/LUNC staking forms with Figma

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
@@ -171,6 +171,9 @@ constructor(
                     v.moniker.lowercase().contains(query) ||
                         v.operatorAddress.lowercase().contains(query)
             }
+            // The picker LazyColumn keys on operatorAddress, so the list must not contain a
+            // duplicate operator (a repeated LCD entry would otherwise crash the list).
+            .distinctBy { it.operatorAddress }
             .sortedByDescending { it.votingPower }
             .toList()
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
@@ -220,6 +220,9 @@ constructor(
                     v.moniker.lowercase().contains(query) ||
                         v.operatorAddress.lowercase().contains(query)
             }
+            // The picker LazyColumn keys on operatorAddress, so the list must not contain a
+            // duplicate operator (a repeated LCD entry would otherwise crash the list).
+            .distinctBy { it.operatorAddress }
             .sortedByDescending { it.votingPower }
             .toList()
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -41,6 +42,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosValidator
 import com.vultisig.wallet.ui.components.PercentageChip
 import com.vultisig.wallet.ui.components.TokenAmountInput
+import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
@@ -107,7 +109,9 @@ private fun DelegateContent(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            // fillMaxSize + the weighted amount card make the form fill the screen (Figma); the
+            // bottom reservation keeps the validator row clear of the pinned Continue button.
+            modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             StakingAmountCard(
@@ -116,6 +120,7 @@ private fun DelegateContent(
                 available = state.stakeableBalance,
                 percentageSelected = state.percentageSelected,
                 onPercentage = onPercentage,
+                modifier = Modifier.weight(1f),
             )
 
             ValidatorPickerField(selected = state.selectedValidator, onClick = onPickValidator)
@@ -141,9 +146,11 @@ private fun DelegateContent(
 }
 
 /**
- * Centered amount input + 25/50/75/Max chips + balance-available row, in a bordered card. Shared by
- * the delegate / undelegate / redelegate forms — `available` is the stakeable balance (delegate) or
- * the staked balance at the source validator (undelegate / redelegate).
+ * Centered amount input + 25/50/75/Max chips + balance-available row, in a bordered card that fills
+ * the available height (Figma "Stake LUNA"): the "Amount" label pins to the top, the amount is
+ * vertically centered in the slack, and the chips + balance pill pin to the bottom — mirroring the
+ * SendFormScreen amount section. Shared by the delegate / redelegate forms. Pass
+ * `Modifier.weight(1f)` so the card expands to fill the screen.
  */
 @Composable
 internal fun StakingAmountCard(
@@ -152,11 +159,13 @@ internal fun StakingAmountCard(
     available: BigDecimal,
     percentageSelected: Int,
     onPercentage: (Int) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val percentages = listOf(25, 50, 75, 100)
     Column(
         modifier =
-            Modifier.fillMaxWidth()
+            modifier
+                .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .border(
                     width = 1.dp,
@@ -171,13 +180,16 @@ internal fun StakingAmountCard(
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.primary,
         )
-        TokenAmountInput(
-            primaryFieldState = amountFieldState,
-            primaryLabel = ticker.ifEmpty { "Token" },
-            secondaryText = "",
-            maxBalance = available.takeIf { it > BigDecimal.ZERO },
-            modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-        )
+        // Amount vertically centered in the card's slack (SendFormScreen pattern).
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            TokenAmountInput(
+                primaryFieldState = amountFieldState,
+                primaryLabel = ticker.ifEmpty { "Token" },
+                secondaryText = "",
+                maxBalance = available.takeIf { it > BigDecimal.ZERO },
+                modifier = Modifier.fillMaxWidth().align(Alignment.Center),
+            )
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -191,22 +203,43 @@ internal fun StakingAmountCard(
                 )
             }
         }
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(
-                text = stringResource(R.string.send_form_balance_available),
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.secondary,
-            )
-            Text(
-                text = "${available.stripTrailingZeros().toPlainString()} $ticker",
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.primary,
-            )
-        }
+        BalanceAvailableRow(ticker = ticker, available = available)
     }
 }
 
-/** "Validator >" picker opener row — shows the selected validator's moniker when picked. */
+/** Filled "Balance available …" pill, matching the SendFormScreen amount section. */
+@Composable
+internal fun BalanceAvailableRow(ticker: String, available: BigDecimal) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .background(
+                    color = Theme.v2.colors.backgrounds.secondary,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .padding(all = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.send_form_balance_available),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+        Text(
+            text = "${available.stripTrailingZeros().toPlainString()} $ticker",
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.secondary,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * "Validator" picker opener row. Once a validator is picked it shows the avatar + moniker on the
+ * left and a confirmed-check + edit affordance on the right (Figma "Stake LUNA"); before selection
+ * it shows the "Validator" label and a chevron. The whole row re-opens the picker.
+ */
 @Composable
 internal fun ValidatorPickerField(selected: CosmosValidator?, onClick: () -> Unit) {
     Row(
@@ -223,20 +256,52 @@ internal fun ValidatorPickerField(selected: CosmosValidator?, onClick: () -> Uni
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text =
-                selected?.moniker?.ifEmpty { selected.operatorAddress }
-                    ?: stringResource(R.string.cosmos_staking_validator_picker),
-            style = Theme.brockmann.body.s.medium,
-            color =
-                if (selected != null) Theme.v2.colors.text.primary
-                else Theme.v2.colors.text.secondary,
-        )
-        Text(
-            text = "›",
-            style = Theme.brockmann.body.s.medium,
-            color = Theme.v2.colors.text.secondary,
-        )
+        Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.cosmos_staking_validator_picker),
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.primary,
+            )
+            if (selected != null) {
+                UiSpacer(size = 12.dp)
+                ValidatorAvatar(
+                    avatarUrl = null,
+                    monogram =
+                        selected.moniker.ifEmpty { selected.operatorAddress }.take(1).uppercase(),
+                    size = 24.dp,
+                    colorKey = selected.operatorAddress,
+                )
+                UiSpacer(size = 8.dp)
+                Text(
+                    text = selected.moniker.ifEmpty { truncated(selected.operatorAddress) },
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.secondary,
+                    maxLines = 1,
+                )
+            }
+        }
+        if (selected != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                UiIcon(
+                    drawableResId = R.drawable.check,
+                    size = 20.dp,
+                    tint = Theme.v2.colors.alerts.success,
+                )
+                UiSpacer(size = 12.dp)
+                UiIcon(
+                    drawableResId = R.drawable.ic_edit_pencil,
+                    size = 18.dp,
+                    tint = Theme.v2.colors.text.secondary,
+                    onClick = onClick,
+                )
+            }
+        } else {
+            Text(
+                text = "›",
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.secondary,
+            )
+        }
     }
 }
 
@@ -344,26 +409,31 @@ internal fun ValidatorPickerSheet(
  */
 @Composable
 private fun ValidatorPickerHeader(title: String, onClose: () -> Unit, onConfirm: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        VsCircleButton(
-            drawableResId = R.drawable.big_close,
-            onClick = onClose,
-            type = VsCircleButtonType.Tertiary,
-            size = VsCircleButtonSize.Small,
-        )
+    // Figma: ✕ / ✓ on one row, then the large title left-aligned on its own line beneath them.
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            VsCircleButton(
+                drawableResId = R.drawable.big_close,
+                onClick = onClose,
+                type = VsCircleButtonType.Tertiary,
+                size = VsCircleButtonSize.Small,
+            )
+            VsCircleButton(
+                drawableResId = R.drawable.big_tick,
+                onClick = onConfirm,
+                size = VsCircleButtonSize.Small,
+            )
+        }
+        UiSpacer(size = 16.dp)
         Text(
             text = title,
             style = Theme.brockmann.headings.title3,
             color = Theme.v2.colors.text.primary,
-        )
-        VsCircleButton(
-            drawableResId = R.drawable.big_tick,
-            onClick = onConfirm,
-            size = VsCircleButtonSize.Small,
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -385,8 +455,9 @@ private fun ValidatorPickerRow(
             Modifier.fillMaxWidth()
                 .padding(vertical = 4.dp)
                 .clip(RoundedCornerShape(12.dp))
+                .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
-                    width = if (isSelected) 2.dp else 1.dp,
+                    width = if (isSelected) 1.5.dp else 1.dp,
                     color =
                         if (isSelected) Theme.v2.colors.primary.accent4
                         else Theme.v2.colors.border.normal,
@@ -419,6 +490,15 @@ private fun ValidatorPickerRow(
             )
         }
         UiSpacer(size = 8.dp)
+        // Selected row carries a green confirmed-check to the left of the commission (Figma).
+        if (isSelected) {
+            UiIcon(
+                drawableResId = R.drawable.check,
+                size = 18.dp,
+                tint = Theme.v2.colors.alerts.success,
+            )
+            UiSpacer(size = 8.dp)
+        }
         Text(
             text = "${formatCommissionPercent(validator.commission)}%",
             style = Theme.brockmann.body.s.medium,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -457,7 +457,9 @@ private fun ValidatorPickerRow(
                 .clip(RoundedCornerShape(12.dp))
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
-                    width = if (isSelected) 1.5.dp else 1.dp,
+                    // Keep a 1.dp border in both states (1px Figma parity); the accent colour +
+                    // green check already distinguish the selected row.
+                    width = 1.dp,
                     color =
                         if (isSelected) Theme.v2.colors.primary.accent4
                         else Theme.v2.colors.border.normal,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
@@ -53,7 +53,7 @@ internal fun CosmosRedelegateScreen(viewModel: CosmosRedelegateViewModel = hiltV
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 if (state.cooldownState is CosmosRedelegationCooldownState.Blocked) {
@@ -76,6 +76,7 @@ internal fun CosmosRedelegateScreen(viewModel: CosmosRedelegateViewModel = hiltV
                         available = state.stakedBalance,
                         percentageSelected = state.percentageSelected,
                         onPercentage = viewModel::onPercentageChange,
+                        modifier = Modifier.weight(1f),
                     )
 
                     Text(
@@ -185,7 +186,7 @@ private fun CosmosRedelegateScreenPreview() {
     V2Scaffold(title = "Redelegate LUNA", onBackClick = {}) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 ValidatorReadonlyBlock(moniker = "Allnodes", address = "terravaloper1allnodes78wk")
@@ -195,6 +196,7 @@ private fun CosmosRedelegateScreenPreview() {
                     available = BigDecimal("2.5"),
                     percentageSelected = 50,
                     onPercentage = {},
+                    modifier = Modifier.weight(1f),
                 )
                 Text(
                     text = stringResource(R.string.cosmos_staking_redelegate_source),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -178,7 +178,14 @@ internal fun CosmosStakingPositionsScreen(
                                     color = Theme.v2.colors.text.secondary,
                                 )
                             }
-                            items(state.positions, key = { it.validatorAddress }) { position ->
+                            items(
+                                state.positions,
+                                // Prefix the key: a validator can appear in BOTH this list and the
+                                // pending-unbondings list below (partial unstake keeps the rest
+                                // delegated), and LazyColumn keys must be unique across the whole
+                                // list — a bare validatorAddress would collide and crash on scroll.
+                                key = { "position-${it.validatorAddress}" },
+                            ) { position ->
                                 PositionRow(
                                     position = position,
                                     ticker = state.ticker,
@@ -221,8 +228,10 @@ internal fun CosmosStakingPositionsScreen(
                                     color = Theme.v2.colors.text.primary,
                                 )
                             }
-                            items(state.pendingUnbondings, key = { it.validatorAddress }) {
-                                unbonding ->
+                            items(
+                                state.pendingUnbondings,
+                                key = { "unbonding-${it.validatorAddress}" },
+                            ) { unbonding ->
                                 UnbondingCard(unbonding = unbonding)
                             }
                         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -76,7 +76,11 @@ internal fun CosmosStakingVerifyScreen(viewModel: CosmosStakingVerifyViewModel =
 
     V2Scaffold(
         title = stringResource(R.string.verify_deposit_function_overview),
-        onBackClick = viewModel::back,
+        // Figma "Overview" uses a close (✕) button top-right rather than a back caret — it still
+        // pops the verify entry, matching the design while keeping the screen exitable.
+        onBackClick = null,
+        rightIcon = R.drawable.big_close,
+        onRightIconClick = viewModel::back,
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
@@ -212,7 +216,12 @@ private fun truncatedMiddle(value: String): String =
 @Preview
 @Composable
 private fun CosmosStakingVerifyScreenPreview() {
-    V2Scaffold(title = "Overview", onBackClick = {}) {
+    V2Scaffold(
+        title = "Overview",
+        onBackClick = null,
+        rightIcon = R.drawable.big_close,
+        onRightIconClick = {},
+    ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
                 modifier =

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -255,24 +255,50 @@ private fun UnstakePercentSlider(percent: Float, onPercentChanged: (Float) -> Un
     }
 }
 
+/**
+ * Read-only validator row for the unstake / redelegate-source slot. Styled like the Stake screen's
+ * "Validator" picker button (bordered row, "Validator" label + avatar + moniker), but without the
+ * picker affordance since the validator is fixed by the caller.
+ */
 @Composable
 internal fun ValidatorReadonlyBlock(moniker: String, address: String) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.normal,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Text(
             text = stringResource(R.string.cosmos_staking_validator_picker),
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.primary,
         )
-        Text(
-            text = moniker.ifEmpty { address },
-            style = Theme.brockmann.body.s.medium,
-            color = Theme.v2.colors.text.primary,
-        )
-        Text(
-            text = address,
-            style = Theme.brockmann.supplementary.caption,
-            color = Theme.v2.colors.text.secondary,
-        )
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ValidatorAvatar(
+                avatarUrl = null,
+                monogram = moniker.ifEmpty { address }.take(1).uppercase(),
+                size = 24.dp,
+                colorKey = address,
+            )
+            UiSpacer(size = 8.dp)
+            Text(
+                text = moniker.ifEmpty { truncated(address) },
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.secondary,
+                maxLines = 1,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -1,28 +1,43 @@
 package com.vultisig.wallet.ui.screens.cosmosstaking
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingConfig
+import com.vultisig.wallet.ui.components.TokenAmountInput
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
@@ -31,6 +46,7 @@ import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosUndelegateViewModel
 import com.vultisig.wallet.ui.theme.Theme
 import java.math.BigDecimal
+import kotlin.math.roundToInt
 
 /**
  * Undelegate input form for LUNA / LUNC. Same shape as the iOS `CosmosUndelegateTransactionScreen`
@@ -51,7 +67,7 @@ internal fun CosmosUndelegateScreen(viewModel: CosmosUndelegateViewModel = hiltV
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 ValidatorReadonlyBlock(
@@ -59,12 +75,13 @@ internal fun CosmosUndelegateScreen(viewModel: CosmosUndelegateViewModel = hiltV
                     address = state.validatorAddress,
                 )
 
-                StakingAmountCard(
+                UnstakeAmountCard(
                     ticker = state.ticker,
                     amountFieldState = viewModel.amountFieldState,
                     available = state.stakedBalance,
                     percentageSelected = state.percentageSelected,
                     onPercentage = viewModel::onPercentageChange,
+                    modifier = Modifier.weight(1f),
                 )
 
                 val unbondingMsg = state.unbondingLockMessage
@@ -106,6 +123,135 @@ internal fun CosmosUndelegateScreen(viewModel: CosmosUndelegateViewModel = hiltV
                 modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
             )
         }
+    }
+}
+
+/**
+ * Unstake amount card — mirrors Figma "Unstake LUNA": centered amount with a live "{percent}%"
+ * subline and a 0–100% drag slider (with 25/50/75 tick stops), rather than the 25/50/75/Max chips
+ * the Stake form uses. The slider is the primary control; the percentage drives the amount field.
+ */
+@Composable
+private fun UnstakeAmountCard(
+    ticker: String,
+    amountFieldState: TextFieldState,
+    available: BigDecimal,
+    percentageSelected: Int,
+    onPercentage: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.normal,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.cosmos_staking_amount),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+        // Amount + live "{percent}%" subline, vertically centered in the card slack (SendForm).
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            TokenAmountInput(
+                primaryFieldState = amountFieldState,
+                primaryLabel = ticker.ifEmpty { "Token" },
+                secondaryText = "${percentageSelected.coerceIn(0, 100)}%",
+                maxBalance = available.takeIf { it > BigDecimal.ZERO },
+                modifier = Modifier.fillMaxWidth().align(Alignment.Center),
+            )
+        }
+        UnstakePercentSlider(
+            percent = (percentageSelected.coerceIn(0, 100)) / 100f,
+            onPercentChanged = { onPercentage((it * 100).toInt()) },
+        )
+        BalanceAvailableRow(ticker = ticker, available = available)
+    }
+}
+
+/**
+ * 0% … slider … 100% with a pill thumb. Drags smoothly (continuous) and snaps to the nearest
+ * quarter (0/25/50/75/100%) on release, with three quarter tick dots drawn on the track.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UnstakePercentSlider(percent: Float, onPercentChanged: (Float) -> Unit) {
+    val tickColor = Theme.v2.colors.border.normal
+    // Local drag value so the thumb glides freely; the snapped quarter is committed on release.
+    var sliderValue by remember(percent) { mutableFloatStateOf(percent) }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = "0%",
+            style = Theme.brockmann.body.xs.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Slider(
+                value = sliderValue,
+                onValueChange = { sliderValue = it },
+                onValueChangeFinished = {
+                    val snapped = (sliderValue * 4).roundToInt() / 4f
+                    sliderValue = snapped
+                    onPercentChanged(snapped)
+                },
+                valueRange = 0f..1f,
+                thumb = {
+                    Box(
+                        modifier =
+                            Modifier.shadow(
+                                    elevation = 4.dp,
+                                    spotColor = Theme.v2.colors.shadow.low,
+                                    ambientColor = Theme.v2.colors.shadow.low,
+                                )
+                                .width(38.dp)
+                                .height(24.dp)
+                                .background(
+                                    color = Theme.v2.colors.text.primary,
+                                    shape = RoundedCornerShape(100),
+                                )
+                    )
+                },
+                track = { sliderState ->
+                    Box {
+                        SliderDefaults.Track(
+                            sliderState = sliderState,
+                            colors =
+                                SliderDefaults.colors(
+                                    activeTrackColor = Theme.v2.colors.primary.accent3,
+                                    inactiveTrackColor = Theme.v2.colors.border.normal,
+                                    thumbColor = Theme.v2.colors.text.primary,
+                                ),
+                            thumbTrackGapSize = 0.dp,
+                            modifier = Modifier.height(6.dp),
+                        )
+                        // Quarter tick dots (25/50/75%) — drawn manually since the slider is
+                        // continuous (no `steps`, so SliderDefaults stop-indicators don't apply).
+                        Canvas(modifier = Modifier.matchParentSize()) {
+                            listOf(0.25f, 0.5f, 0.75f).forEach { fraction ->
+                                drawCircle(
+                                    color = tickColor,
+                                    radius = 2.dp.toPx(),
+                                    center = Offset(x = size.width * fraction, y = size.height / 2f),
+                                )
+                            }
+                        }
+                    }
+                },
+            )
+        }
+        Text(
+            text = "100%",
+            style = Theme.brockmann.body.xs.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
     }
 }
 
@@ -164,16 +310,17 @@ private fun CosmosUndelegateScreenPreview() {
     V2Scaffold(title = "Unstake LUNA", onBackClick = {}) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 ValidatorReadonlyBlock(moniker = "Allnodes", address = "terravaloper1allnodes78wk")
-                StakingAmountCard(
+                UnstakeAmountCard(
                     ticker = "LUNA",
                     amountFieldState = rememberTextFieldState("2.5"),
                     available = BigDecimal("2.5"),
                     percentageSelected = 100,
                     onPercentage = {},
+                    modifier = Modifier.weight(1f),
                 )
                 UnbondingLockNotice(
                     message = "Funds are locked for 21 days. Available on Jul 24, 2026."

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -196,7 +196,12 @@ private fun UnstakePercentSlider(percent: Float, onPercentChanged: (Float) -> Un
             Spacer(modifier = Modifier.height(4.dp))
             Slider(
                 value = sliderValue,
-                onValueChange = { sliderValue = it },
+                // Push the live value while dragging so the amount + "{percent}%" subline track the
+                // thumb; snap to the nearest quarter on release.
+                onValueChange = {
+                    sliderValue = it
+                    onPercentChanged(it)
+                },
                 onValueChangeFinished = {
                     val snapped = (sliderValue * 4).roundToInt() / 4f
                     sliderValue = snapped


### PR DESCRIPTION
## Summary

Validates the merged LUNA/LUNC staking screens (#4687) against the Figma "Earn/Staking" designs and corrects the visual mismatches found.

## Changes

### Amount forms — Stake / Unstake / Redelegate
- **Fills the screen**: the amount card now takes `weight(1f)` and expands between the top bar and the pinned Continue button, with the amount vertically centered — matching the tall Figma card (was a compact wrap-content card with empty space below).
- **Styled like `SendFormScreen`**: amount centered in a weighted box; the "Balance available" row is now a filled rounded pill (`backgrounds.secondary`) instead of plain text.

### Unstake amount control
- Replaced the 25/50/75/Max chips with a **0–100% slider** + a live `"{percent}%"` subline (Figma "Unstake LUNA").
- The slider **drags smoothly and snaps to the nearest quarter** (0/25/50/75/100%) on release; quarter tick dots drawn on the track.
- Stake / Redelegate keep their chips.

### Validator picker
- Stake's picked-validator row → avatar + moniker + green ✓ + edit ✏️ (was moniker + "›").
- Picker sheet header → ✕/✓ on one row, large title left-aligned on its own line below (was centered inline).
- Picker rows → filled cards; selected row shows a green ✓ (was border-only).

### Verify / Overview
- Close (✕) button top-right instead of a back caret top-left, matching the Figma "Overview" frame (still pops the verify entry).

### Previews
- Per-screen `@Preview` composables updated to render the new full-height layout, slider, picker, and ✕ nav.

## Out of scope
Several Figma frames in this section are THORChain-flavored (RUNE rewards, TCY bond memo, "Next Churn"); those don't apply to Cosmos/Terra and were intentionally excluded. The Select-Positions sheet and empty-state render from shared components and weren't touched.

## Test plan
- [x] `:app:assembleDebug` clean
- [x] `:app:compileDebugKotlin` clean
- [ ] Manual: Stake/Unstake/Redelegate amount cards fill the screen; unstake slider glides + snaps to quarters and updates the amount; validator picker shows avatar/check/pencil; verify shows ✕ top-right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Percentage-based unstaking slider with snap-to-quarter increments and continuous drag
  * Visual confirmation indicators for selected validators and clearer selection controls

* **Improvements**
  * Refined staking/unstaking layouts to better allocate space and keep the Continue button accessible
  * Dedicated balance-available display beneath amount input
  * Updated validator picker header and row layouts for clearer actions and compact presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-android/pull/4726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->