### PR TITLE
feat(ton): decode jetton transfers on dApp keysign

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -65,6 +65,8 @@ import com.vultisig.wallet.ui.models.keygen.ImportSeedphraseUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultBackupState
 import com.vultisig.wallet.ui.models.keygen.VerifyPinState
 import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
+import com.vultisig.wallet.ui.models.keysign.TonMessageOperation
+import com.vultisig.wallet.ui.models.keysign.TonMessageUiModel
 import com.vultisig.wallet.ui.models.keysign.TransactionStatus
 import com.vultisig.wallet.ui.models.keysign.TransactionTypeUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
@@ -107,8 +109,6 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import vultisig.keysign.v1.SignTon
-import vultisig.keysign.v1.TonMessage
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -142,6 +142,8 @@ class PreviewActivity : ComponentActivity() {
                     "solana_display" -> SolanaDisplayPreview()
                     "ton_display_single" -> TonDisplayPreview(messageCount = 1)
                     "ton_display_multi" -> TonDisplayPreview(messageCount = 4)
+                    "verify_ton_jetton_before" -> VerifyTonJettonPreview(decoded = false)
+                    "verify_ton_jetton_after" -> VerifyTonJettonPreview(decoded = true)
                     "swap_error_before" -> SwapErrorBeforePreview()
                     "swap_error" -> SwapErrorPreview()
                     "swap_quote_loading" -> SwapFormQuoteLoadingPreview()
@@ -407,34 +409,30 @@ private fun SolanaInstructionMock(
 private fun TonDisplayPreview(messageCount: Int) {
     val messages =
         when (messageCount) {
-            1 ->
-                listOf(
-                    TonMessage(
-                        to = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "1500000000",
-                    )
-                )
+            1 -> listOf(TON_JETTON_MESSAGE)
             else ->
                 listOf(
-                    TonMessage(
-                        to = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "1500000000",
-                        payload = "te6ccgEBAQEABgAACAA=",
+                    TON_JETTON_MESSAGE,
+                    TonMessageUiModel(
+                        operation = TonMessageOperation.Transfer,
+                        recipient = "EQAB0000000000ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+                        amount = "0.25 TON",
+                        rawPayload = null,
+                        hasStateInit = true,
                     ),
-                    TonMessage(
-                        to = "EQAB0000000000ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "250000000",
-                        payload = "te6ccgEBAQEABgAACAA=",
-                        stateInit = "te6ccgEBAQEABwAA",
+                    TonMessageUiModel(
+                        operation = TonMessageOperation.ExcessGasRefund,
+                        recipient = null,
+                        amount = null,
+                        rawPayload = "te6cckEBAQEADgAAGNUydtsAAAAAAAAABxylUgg=",
+                        hasStateInit = false,
                     ),
-                    TonMessage(
-                        to = "EQAB9999999999ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "100000",
-                    ),
-                    TonMessage(
-                        to = "EQAB7777777777ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "5000000000",
-                        stateInit = "te6ccgEBAQEABwAA",
+                    TonMessageUiModel(
+                        operation = TonMessageOperation.NftTransfer,
+                        recipient = "EQAB7777777777ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+                        amount = "0.1 TON",
+                        rawPayload = "te6cckEBAQEAVAAAo1/MPRQ...",
+                        hasStateInit = false,
                     ),
                 )
         }
@@ -445,8 +443,100 @@ private fun TonDisplayPreview(messageCount: Int) {
                 .background(Theme.v2.colors.backgrounds.primary)
                 .padding(16.dp)
     ) {
-        SignTonDisplayView(signTon = SignTon(tonMessages = messages))
+        SignTonDisplayView(messages = messages, initiallyExpanded = true)
     }
+}
+
+private val TON_JETTON_MESSAGE =
+    TonMessageUiModel(
+        operation = TonMessageOperation.JettonTransfer,
+        recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF",
+        amount = "0.05 TON",
+        rawPayload =
+            "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf//////////////////" +
+                "////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5" +
+                "nb2Emhh6EgOvlFRU=",
+        hasStateInit = false,
+    )
+
+/**
+ * Full-screen keysign verify for a TonConnect jetton transfer. [decoded] = true shows the resolved
+ * jetton hero (100 USDT) + decoded message rows; false is the pre-decode state (the outer gas value
+ * as the hero, opaque transfer rows).
+ */
+@Composable
+private fun VerifyTonJettonPreview(decoded: Boolean) {
+    VerifySendScreen(
+        state = tonJettonSendState(decoded),
+        isConsentsEnabled = false,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
+        initiallyExpandedDetails = true,
+    )
+}
+
+private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
+    val senderJettonWallet = "EQByz1234senderJettonWallet5678abcdEFGHijklMNOpqRsT"
+    val recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF"
+    val tx =
+        TransactionDetailsUiModel(
+            // The outer message value is the forwarded gas, not the jetton amount.
+            token = ValuedToken(token = Coins.Ton.TON, value = "0.32", fiatValue = "$1.79"),
+            srcAddress = "UQAowner1234567890abcdefVaultTonAddress0987654321xY",
+            srcVaultName = "Main Vault",
+            dstAddress = senderJettonWallet,
+            networkFeeFiatValue = "$0.04",
+            networkFeeTokenValue = "0.0066 TON",
+            heroContent =
+                if (decoded) {
+                    HeroContent.Send(
+                        title = null,
+                        coin =
+                            HeroCoinAmount(
+                                amount = "100",
+                                ticker = "USDT",
+                                logo = Coins.Ton.USDT.logo,
+                            ),
+                    )
+                } else {
+                    null
+                },
+            tonMessages =
+                if (decoded) {
+                    listOf(
+                        TonMessageUiModel(
+                            operation = TonMessageOperation.JettonTransfer,
+                            recipient = recipient,
+                            amount = "0.05 TON",
+                            rawPayload = TON_JETTON_MESSAGE.rawPayload,
+                            hasStateInit = false,
+                        )
+                    )
+                } else {
+                    listOf(
+                        TonMessageUiModel(
+                            operation = TonMessageOperation.Transfer,
+                            recipient = senderJettonWallet,
+                            amount = "0.32 TON",
+                            rawPayload = TON_JETTON_MESSAGE.rawPayload,
+                            hasStateInit = false,
+                        )
+                    )
+                },
+        )
+    return VerifyTransactionUiModel(
+        transaction = tx,
+        consentAddress = false,
+        consentAmount = false,
+        hasFastSign = false,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
@@ -16,34 +16,42 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.models.keysign.TonMessageOperation
+import com.vultisig.wallet.ui.models.keysign.TonMessageUiModel
 import com.vultisig.wallet.ui.theme.Theme
-import java.math.BigInteger
-import vultisig.keysign.v1.SignTon
-import vultisig.keysign.v1.TonMessage
 
 /**
- * Displays a collapsible list of TON transfer messages for user review before signing.
+ * Displays a collapsible list of decoded TonConnect messages for user review before signing. Each
+ * message shows its operation (jetton transfer, NFT transfer, excess-gas refund, or plain
+ * transfer), the real recipient, the forwarded TON amount, and the raw BOC payload (copyable, so
+ * the full value stays recoverable behind the middle-ellipsis).
  *
- * @param signTon proto carrying one to four [vultisig.keysign.v1.TonMessage]s to display
+ * @param messages decoded messages, built by [com.vultisig.wallet.ui.models.keysign.mapTonMessages]
+ * @param initiallyExpanded preview-only override for the collapsed/expanded state; defaults to
+ *   collapsed so production behaviour is unchanged
  */
 @Composable
-fun SignTonDisplayView(signTon: SignTon, modifier: Modifier = Modifier) {
-    val messages = signTon.tonMessages.filterNotNull()
+internal fun SignTonDisplayView(
+    messages: List<TonMessageUiModel>,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+) {
     if (messages.isEmpty()) return
 
-    var isExpanded by remember { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -81,8 +89,8 @@ fun SignTonDisplayView(signTon: SignTon, modifier: Modifier = Modifier) {
                         .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                messages.forEachIndexed { index, msg ->
-                    TonMessageRow(message = msg, index = index)
+                messages.forEachIndexed { index, message ->
+                    TonMessageRow(message = message, index = index)
                 }
             }
         }
@@ -90,7 +98,7 @@ fun SignTonDisplayView(signTon: SignTon, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun TonMessageRow(message: TonMessage, index: Int) {
+private fun TonMessageRow(message: TonMessageUiModel, index: Int) {
     Column(
         modifier =
             Modifier.fillMaxWidth()
@@ -101,38 +109,81 @@ private fun TonMessageRow(message: TonMessage, index: Int) {
                 .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
             Text(
                 text = "#${index + 1}",
+                style = Theme.brockmann.button.medium.medium,
+                color = Theme.v2.colors.text.tertiary,
+                fontSize = 11.sp,
+            )
+            Text(
+                text = stringResource(message.operation.titleRes),
                 style = Theme.brockmann.button.medium.medium,
                 color = Theme.v2.colors.text.primary,
                 fontSize = 11.sp,
             )
-
-            if (!message.payload.isNullOrEmpty()) {
-                BadgeText(text = stringResource(R.string.sign_ton_payload))
-            }
-            if (!message.stateInit.isNullOrEmpty()) {
+            if (message.hasStateInit) {
                 BadgeText(text = stringResource(R.string.sign_ton_state_init))
             }
         }
 
+        message.recipient?.let { recipient ->
+            TonDetailRow(
+                label = stringResource(R.string.verify_transaction_to_title),
+                value = recipient,
+                copyableValue = recipient,
+                monospace = true,
+            )
+        }
+        message.amount?.let { amount ->
+            TonDetailRow(label = stringResource(message.operation.amountLabelRes), value = amount)
+        }
+        message.rawPayload?.let { payload ->
+            TonDetailRow(
+                label = stringResource(R.string.ton_raw_payload),
+                value = payload,
+                copyableValue = payload,
+                monospace = true,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TonDetailRow(
+    label: String,
+    value: String,
+    copyableValue: String? = null,
+    monospace: Boolean = false,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
         Text(
-            text = message.to,
+            text = label,
+            style = Theme.brockmann.button.medium.medium,
+            color = Theme.v2.colors.text.tertiary,
+            fontSize = 10.sp,
+        )
+        Text(
+            text = value,
+            modifier = Modifier.weight(1f),
             color = Theme.v2.colors.neutrals.n100,
             style = Theme.brockmann.button.medium.medium,
             fontSize = 10.sp,
-            fontFamily = FontFamily.Monospace,
+            fontFamily = if (monospace) FontFamily.Monospace else FontFamily.Default,
             maxLines = 1,
             overflow = TextOverflow.MiddleEllipsis,
+            textAlign = TextAlign.End,
         )
-
-        Text(
-            text = formatNanotons(message.amount),
-            color = Theme.v2.colors.text.primary,
-            style = Theme.brockmann.button.medium.medium,
-            fontSize = 11.sp,
-        )
+        if (copyableValue != null) {
+            CopyIcon(textToCopy = copyableValue, size = 14.dp)
+        }
     }
 }
 
@@ -152,61 +203,44 @@ private fun BadgeText(text: String) {
     )
 }
 
-private fun formatNanotons(raw: String): String {
-    val nano = raw.toBigIntegerOrNull() ?: return "Invalid TON amount"
-    if (nano.signum() < 0) return "Invalid TON amount"
-    val divisor = BigInteger.TEN.pow(9)
-    val whole = nano / divisor
-    val frac = (nano % divisor).toString().padStart(9, '0').trimEnd('0')
-    return if (frac.isEmpty()) "$whole TON" else "$whole.$frac TON"
-}
+private val TonMessageOperation.titleRes: Int
+    get() =
+        when (this) {
+            TonMessageOperation.JettonTransfer -> R.string.ton_op_jetton_transfer
+            TonMessageOperation.NftTransfer -> R.string.ton_op_nft_transfer
+            TonMessageOperation.ExcessGasRefund -> R.string.ton_op_excess_gas_refund
+            TonMessageOperation.Transfer -> R.string.ton_op_transfer
+        }
+
+private val TonMessageOperation.amountLabelRes: Int
+    get() =
+        when (this) {
+            TonMessageOperation.JettonTransfer,
+            TonMessageOperation.NftTransfer -> R.string.ton_forward_ton_amount
+            TonMessageOperation.ExcessGasRefund,
+            TonMessageOperation.Transfer -> R.string.verify_transaction_amount_title
+        }
 
 @Preview
 @Composable
-private fun PreviewSignTonDisplaySingle() {
+private fun PreviewSignTonDisplay() {
     SignTonDisplayView(
-        signTon =
-            SignTon(
-                tonMessages =
-                    listOf(
-                        TonMessage(
-                            to = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                            amount = "1500000000",
-                        )
-                    )
-            )
-    )
-}
-
-@Preview
-@Composable
-private fun PreviewSignTonDisplayMulti() {
-    SignTonDisplayView(
-        signTon =
-            SignTon(
-                tonMessages =
-                    listOf(
-                        TonMessage(
-                            to = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                            amount = "1500000000",
-                            payload = "te6ccg...",
-                        ),
-                        TonMessage(
-                            to = "EQAB0000000000ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                            amount = "250000000",
-                            payload = "te6...",
-                            stateInit = "te6state...",
-                        ),
-                        TonMessage(
-                            to = "EQAB9999999999ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                            amount = "100000",
-                        ),
-                        TonMessage(
-                            to = "EQAB7777777777ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                            amount = "5000000000",
-                            stateInit = "te6stateinit...",
-                        ),
-                    )
+        messages =
+            listOf(
+                TonMessageUiModel(
+                    operation = TonMessageOperation.JettonTransfer,
+                    recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF",
+                    amount = "0.001 TON",
+                    rawPayload = "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf...",
+                    hasStateInit = false,
+                ),
+                TonMessageUiModel(
+                    operation = TonMessageOperation.Transfer,
+                    recipient = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+                    amount = "0.32 TON",
+                    rawPayload = null,
+                    hasStateInit = true,
+                ),
             )
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
 import com.vultisig.wallet.ui.models.keysign.FunctionInfo
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
+import com.vultisig.wallet.ui.models.keysign.TonMessageUiModel
 import com.vultisig.wallet.ui.models.keysign.approvalSpenderArgIndex
 import com.vultisig.wallet.ui.models.keysign.enrichDecodedCall
 import com.vultisig.wallet.ui.models.keysign.isUnlimitedApproval
@@ -58,7 +59,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import timber.log.Timber
-import vultisig.keysign.v1.SignTon
 
 @Immutable
 internal data class TransactionDetailsUiModel(
@@ -75,7 +75,12 @@ internal data class TransactionDetailsUiModel(
     val signAmino: String? = null,
     val signDirect: String? = null,
     val signSolana: String? = null,
-    val signTon: SignTon? = null,
+    /**
+     * Per-message rows for a TonConnect signing request, each decoded from its BOC body into an
+     * operation label, real recipient, forward amount, and the raw payload. Empty for non-TON or
+     * undecodable requests. Built in [com.vultisig.wallet.ui.models.keysign.mapTonMessages].
+     */
+    val tonMessages: List<TonMessageUiModel> = emptyList(),
     val functionSignature: String? = null,
     val functionInputs: String? = null,
     val functionName: String? = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.LiFiChainApi
 import com.vultisig.wallet.data.api.RouterApi
 import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.utils.HttpException
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
@@ -75,6 +76,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.ParseCosmosMessageUseCase
 import com.vultisig.wallet.data.usecases.ThorchainMemoParser
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
@@ -134,6 +136,7 @@ import kotlinx.serialization.protobuf.ProtoBuf
 import timber.log.Timber
 import vultisig.keysign.v1.CustomMessagePayload
 import vultisig.keysign.v1.KeysignMessage
+import wallet.core.jni.TONAddressConverter
 import wallet.core.jni.proto.Common.SigningError
 
 sealed class JoinKeysignError(val message: UiText) {
@@ -230,6 +233,7 @@ constructor(
     private val routerApi: RouterApi,
     private val fourByteRepository: FourByteRepository,
     private val tokenMetadataResolver: TokenMetadataResolver,
+    private val tonApi: TonApi,
     private val securityScannerService: SecurityScannerContract,
     private val addressBookRepository: AddressBookRepository,
     private val feeServiceComposite: FeeServiceComposite,
@@ -279,6 +283,7 @@ constructor(
 
     private var _jobWaitingForKeysignStart: Job? = null
     private var blockaidSimulationJob: Job? = null
+    private var tonJettonHeroJob: Job? = null
     private val isJoiningKeysign = AtomicBoolean(false)
     private var isNavigateToHome: Boolean = false
 
@@ -1108,7 +1113,6 @@ constructor(
                             ?: ""
 
                     val signSolana = payload.signSolana?.rawTransactions?.firstOrNull() ?: ""
-                    val signTon = payload.signTon
                     val transaction =
                         Transaction(
                             id = UUID.randomUUID().toString(),
@@ -1127,7 +1131,6 @@ constructor(
                             signAmino = normalizedSignAmino,
                             signDirect = signDirect,
                             signSolana = signSolana,
-                            signTon = signTon,
                         )
 
                     val transactionToUiModel = mapTransactionToUiModel(transaction)
@@ -1191,6 +1194,11 @@ constructor(
                             nativeTokenLookup = { c -> nativeTokenOrNull(c.id) },
                         )
 
+                    val tonMessages =
+                        mapTonMessages(payload.signTon) { rawAddress ->
+                            TONAddressConverter.toUserFriendly(rawAddress, true, false)
+                                ?: rawAddress
+                        }
                     val namedTransactionUiModel =
                         transactionToUiModel.copy(
                             srcVaultName = srcVaultName,
@@ -1205,6 +1213,7 @@ constructor(
                             dstContractLabel = decodedExtras.dstContractLabel,
                             decodedFunctionParams = decodedExtras.decodedFunctionParams,
                             isUniversalRouterSwap = decodedExtras.isUniversalRouterSwap,
+                            tonMessages = tonMessages,
                         )
                     transactionTypeUiModel = TransactionTypeUiModel.Send(namedTransactionUiModel)
                     transactionHistoryData = mapTransactionHistoryData(namedTransactionUiModel)
@@ -1214,12 +1223,18 @@ constructor(
                         )
                     val uiModel = verifyUiModel.value
                     if (uiModel is VerifyUiModel.Send) {
-                        // Kick off the Blockaid simulation in parallel with the
+                        // Kick off the hero resolution in parallel with the
                         // existing security scan; the hero refresh and the badge
                         // refresh happen independently so neither blocks the
                         // other and the UI doesn't go through an "all loading
-                        // at once" state.
-                        loadBlockaidSimulation(payload, functionInfo?.functionName)
+                        // at once" state. Blockaid doesn't cover TON, so a
+                        // TonConnect request resolves its jetton hero from the
+                        // decoded BOC instead.
+                        if (chain == Chain.Ton && payload.signTon != null) {
+                            loadTonJettonHero(payload, vault.coins)
+                        } else {
+                            loadBlockaidSimulation(payload, functionInfo?.functionName)
+                        }
                         scanTransaction(transaction)
                     }
                 }
@@ -1315,6 +1330,41 @@ constructor(
                 // done screen's `KeysignViewModel` carries the same content forward
                 // — the cache covers the same lookup, but updating in place avoids
                 // a per-screen re-fetch and a flash of "loading" state on done.
+                (transactionTypeUiModel as? TransactionTypeUiModel.Send)?.let { send ->
+                    transactionTypeUiModel =
+                        TransactionTypeUiModel.Send(send.tx.copy(heroContent = hero))
+                }
+            }
+    }
+
+    /**
+     * Resolve the jetton hero for a TonConnect request from the decoded message bodies. Surfaces
+     * the first vault-held jetton transfer's real amount + ticker + logo in place of the misleading
+     * gas value. Best-effort: on a network failure or an unrecognised jetton the verify screen
+     * keeps its existing display. Mirrors [loadBlockaidSimulation] — Blockaid doesn't cover TON, so
+     * this is the TON hero path. Cancels any prior run (NSD can re-fire) and pushes the hero into
+     * both the verify model and [transactionTypeUiModel] so the done screen carries it forward.
+     */
+    private fun loadTonJettonHero(payload: KeysignPayload, vaultCoins: List<Coin>) {
+        val messages = payload.signTon?.tonMessages?.filterNotNull().orEmpty()
+        if (messages.isEmpty()) return
+        tonJettonHeroJob?.cancel()
+        tonJettonHeroJob =
+            viewModelScope.safeLaunch(
+                onError = { Timber.w(it, "TON jetton hero resolution failed during dApp signing") }
+            ) {
+                val coin =
+                    withContext(Dispatchers.IO) {
+                        resolveTonJettonHero(messages, vaultCoins) { wallet ->
+                            tonApi.getJettonMasterAddress(wallet)
+                        }
+                    } ?: return@safeLaunch
+                val hero = HeroContent.Send(title = null, coin = coin)
+                updateSendUiModel(verifyUiModel) { current ->
+                    current.copy(transaction = current.transaction.copy(heroContent = hero))
+                }
+                // Mirror the resolved hero into [transactionTypeUiModel] so the
+                // done screen's `KeysignViewModel` carries the same content forward.
                 (transactionTypeUiModel as? TransactionTypeUiModel.Send)?.let { send ->
                     transactionTypeUiModel =
                         TransactionTypeUiModel.Send(send.tx.copy(heroContent = hero))

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecode.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecode.kt
@@ -1,0 +1,115 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.crypto.ton.TonMessageBodyDecoder
+import com.vultisig.wallet.data.crypto.ton.TonMessageBodyIntent
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import java.math.BigDecimal
+import java.math.BigInteger
+import vultisig.keysign.v1.SignTon
+import vultisig.keysign.v1.TonMessage
+
+private val NANOTON_DIVISOR: BigInteger = BigInteger.TEN.pow(9)
+
+/**
+ * Decode each TonConnect message into a [TonMessageUiModel] for the keysign verify screen. Bodies
+ * that don't decode fall back to a plain transfer view. Decoded recipient addresses (raw
+ * `workchain:hex`) are converted to user-friendly form via [formatAddress]; the outer destination
+ * of a plain transfer is already user-friendly and is shown as-is.
+ */
+internal fun mapTonMessages(
+    signTon: SignTon?,
+    formatAddress: (String) -> String,
+): List<TonMessageUiModel> =
+    signTon?.tonMessages?.filterNotNull().orEmpty().map { message ->
+        val rawPayload = message.payload?.takeIf { it.isNotEmpty() }
+        val hasStateInit = !message.stateInit.isNullOrEmpty()
+        when (val intent = TonMessageBodyDecoder.decode(message.payload)) {
+            is TonMessageBodyIntent.JettonTransfer ->
+                TonMessageUiModel(
+                    operation = TonMessageOperation.JettonTransfer,
+                    recipient = formatAddress(intent.destination),
+                    amount = formatTon(intent.forwardTonAmount),
+                    rawPayload = rawPayload,
+                    hasStateInit = hasStateInit,
+                )
+
+            is TonMessageBodyIntent.NftTransfer ->
+                TonMessageUiModel(
+                    operation = TonMessageOperation.NftTransfer,
+                    recipient = formatAddress(intent.newOwner),
+                    amount = formatTon(intent.forwardAmount),
+                    rawPayload = rawPayload,
+                    hasStateInit = hasStateInit,
+                )
+
+            is TonMessageBodyIntent.Excesses ->
+                TonMessageUiModel(
+                    operation = TonMessageOperation.ExcessGasRefund,
+                    recipient = null,
+                    amount = null,
+                    rawPayload = rawPayload,
+                    hasStateInit = hasStateInit,
+                )
+
+            null ->
+                TonMessageUiModel(
+                    operation = TonMessageOperation.Transfer,
+                    recipient = message.to.takeIf { it.isNotEmpty() },
+                    amount =
+                        message.amount
+                            .toBigIntegerOrNull()
+                            ?.takeIf { it.signum() >= 0 }
+                            ?.let(::formatTon),
+                    rawPayload = rawPayload,
+                    hasStateInit = hasStateInit,
+                )
+        }
+    }
+
+/**
+ * Resolve the headline jetton amount for the keysign hero. Scans [messages] for the first jetton
+ * transfer whose token is held in the vault and returns its scaled amount + ticker + logo, or
+ * `null` when nothing resolves.
+ *
+ * On Android a vault jetton coin keeps the jetton master in [Coin.contractAddress] (its
+ * [Coin.address] is the owner wallet), so the message destination — the sender's jetton wallet — is
+ * mapped to a master via [resolveJettonMaster] before matching.
+ */
+internal suspend fun resolveTonJettonHero(
+    messages: List<TonMessage>,
+    vaultCoins: List<Coin>,
+    resolveJettonMaster: suspend (jettonWalletAddress: String) -> String?,
+): HeroCoinAmount? {
+    for (message in messages) {
+        val transfer =
+            TonMessageBodyDecoder.decode(message.payload) as? TonMessageBodyIntent.JettonTransfer
+                ?: continue
+        val master = resolveJettonMaster(message.to) ?: continue
+        val coin =
+            vaultCoins.firstOrNull {
+                // TON addresses are base64url and case-sensitive, so match exactly.
+                it.chain == Chain.Ton && !it.isNativeToken && it.contractAddress == master
+            } ?: continue
+        return HeroCoinAmount(
+            amount = formatJettonAmount(transfer.amount, coin.decimal),
+            ticker = coin.ticker,
+            logo = coin.logo,
+        )
+    }
+    return null
+}
+
+private fun formatTon(nanotons: BigInteger): String {
+    val whole = nanotons / NANOTON_DIVISOR
+    val fraction = (nanotons % NANOTON_DIVISOR).toString().padStart(9, '0').trimEnd('0')
+    return if (fraction.isEmpty()) "$whole TON" else "$whole.$fraction TON"
+}
+
+private fun formatJettonAmount(raw: BigInteger, decimals: Int): String =
+    if (decimals <= 0) {
+        raw.toString()
+    } else {
+        BigDecimal(raw).movePointLeft(decimals).stripTrailingZeros().toPlainString()
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageUiModel.kt
@@ -1,0 +1,25 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import androidx.compose.runtime.Immutable
+
+/** Operation surfaced by decoding a TonConnect message body. */
+internal enum class TonMessageOperation {
+    JettonTransfer,
+    NftTransfer,
+    ExcessGasRefund,
+    Transfer,
+}
+
+/**
+ * Display model for a single TonConnect message on the keysign verify screen. Built by decoding the
+ * message's BOC body; [recipient] is already in user-friendly form and [amount] is pre-formatted
+ * (e.g. `"0.05 TON"`).
+ */
+@Immutable
+internal data class TonMessageUiModel(
+    val operation: TonMessageOperation,
+    val recipient: String?,
+    val amount: String?,
+    val rawPayload: String?,
+    val hasStateInit: Boolean,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -31,7 +31,6 @@ constructor(
             signAmino = from.signAmino,
             signDirect = from.signDirect,
             signSolana = from.signSolana,
-            signTon = from.signTon,
             networkFeeFiatValue = from.estimatedFee,
             networkFeeTokenValue = from.totalGas,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -314,12 +314,15 @@ internal fun VerifySendScreen(
                             )
                         }
 
-                    tx.signTon
-                        ?.takeIf { it.tonMessages.isNotEmpty() }
-                        ?.let { signTon ->
+                    tx.tonMessages
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { tonMessages ->
                             VerifyCardDivider(0.dp)
 
-                            SignTonDisplayView(signTon = signTon)
+                            SignTonDisplayView(
+                                messages = tonMessages,
+                                initiallyExpanded = initiallyExpandedDetails,
+                            )
                         }
 
                     if (tx.isUnlimitedApproval) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1073,8 +1073,13 @@
     <string name="choose_device_count_a11y_description">Wie viele Geräte haben Sie? %1$s ausgewählt. Tippen, um eine andere Auswahl zu treffen.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Nachrichten</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton-Überweisung</string>
+    <string name="ton_op_nft_transfer">NFT-Überweisung</string>
+    <string name="ton_op_excess_gas_refund">Erstattung überschüssiger Gasgebühren</string>
+    <string name="ton_op_transfer">Überweisung</string>
+    <string name="ton_forward_ton_amount">Weitergeleiteter TON-Betrag</string>
+    <string name="ton_raw_payload">Rohes Payload</string>
 
     <string name="welcome_tip">Tipp: Sie können einen Browser als Gerät verwenden</string>
     <string name="vault_setup_your_vault_setup">Ihre Tresor-Einrichtung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1071,8 +1071,13 @@
     <string name="choose_device_count_a11y_description">¿Cuántos dispositivos tienes? Selección actual: %1$s. Toca para elegir otro.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Mensajes</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Transferencia de Jetton</string>
+    <string name="ton_op_nft_transfer">Transferencia de NFT</string>
+    <string name="ton_op_excess_gas_refund">Reembolso de gas sobrante</string>
+    <string name="ton_op_transfer">Transferencia</string>
+    <string name="ton_forward_ton_amount">Cantidad de TON reenviada</string>
+    <string name="ton_raw_payload">Payload sin procesar</string>
 
     <string name="welcome_tip">Consejo: Puedes usar un navegador como dispositivo</string>
     <string name="vault_setup_your_vault_setup">Tu configuración de bóveda</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1080,8 +1080,13 @@
     <string name="choose_device_count_a11y_description">Koliko uređaja imate? %1$s odabrano. Dodirnite za drugi odabir.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Poruke</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton prijenos</string>
+    <string name="ton_op_nft_transfer">NFT prijenos</string>
+    <string name="ton_op_excess_gas_refund">Povrat viška plina</string>
+    <string name="ton_op_transfer">Prijenos</string>
+    <string name="ton_forward_ton_amount">Proslijeđeni iznos TON-a</string>
+    <string name="ton_raw_payload">Neobrađeni payload</string>
 
     <string name="welcome_tip">Savjet: Možete koristiti preglednik kao uređaj</string>
     <string name="vault_setup_your_vault_setup">Postavljanje vašeg trezora</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1074,8 +1074,13 @@
     <string name="choose_device_count_a11y_description">Quanti dispositivi hai? Selezione attuale: %1$s. Tocca per sceglierne un altro.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Messaggi</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Trasferimento Jetton</string>
+    <string name="ton_op_nft_transfer">Trasferimento NFT</string>
+    <string name="ton_op_excess_gas_refund">Rimborso del gas in eccesso</string>
+    <string name="ton_op_transfer">Trasferimento</string>
+    <string name="ton_forward_ton_amount">Quantità di TON inoltrata</string>
+    <string name="ton_raw_payload">Payload grezzo</string>
 
     <string name="welcome_tip">Suggerimento: Puoi usare un browser come dispositivo</string>
     <string name="vault_setup_your_vault_setup">La configurazione del tuo vault</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1097,8 +1097,13 @@
     <string name="choose_device_count_a11y_description">기기를 몇 대 가지고 계신가요? 현재 선택: %1$s. 탭하여 다른 옵션을 선택하세요.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">메시지</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton 전송</string>
+    <string name="ton_op_nft_transfer">NFT 전송</string>
+    <string name="ton_op_excess_gas_refund">초과 가스 환불</string>
+    <string name="ton_op_transfer">전송</string>
+    <string name="ton_forward_ton_amount">전달된 TON 금액</string>
+    <string name="ton_raw_payload">원시 Payload</string>
 
     <string name="review_vault_devices_title">볼트 기기 확인</string>
     <string name="review_vault_devices_description">추가한 기기가 올바른지 확인하세요:</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1068,8 +1068,13 @@
     <string name="choose_device_count_a11y_description">Hoeveel apparaten hebt u? %1$s geselecteerd. Tik om een andere te kiezen.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Berichten</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton-overdracht</string>
+    <string name="ton_op_nft_transfer">NFT-overdracht</string>
+    <string name="ton_op_excess_gas_refund">Terugbetaling overtollig gas</string>
+    <string name="ton_op_transfer">Overdracht</string>
+    <string name="ton_forward_ton_amount">Doorgestuurd TON-bedrag</string>
+    <string name="ton_raw_payload">Ruwe payload</string>
 
     <string name="welcome_tip">Tip: U kunt een browser gebruiken als apparaat</string>
     <string name="vault_setup_your_vault_setup">Uw kluis-instelling</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1072,8 +1072,13 @@
     <string name="choose_device_count_a11y_description">Quantos dispositivos tem? Seleção atual: %1$s. Toque para escolher outro.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Mensagens</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Transferência de Jetton</string>
+    <string name="ton_op_nft_transfer">Transferência de NFT</string>
+    <string name="ton_op_excess_gas_refund">Reembolso de gás excedente</string>
+    <string name="ton_op_transfer">Transferência</string>
+    <string name="ton_forward_ton_amount">Montante de TON encaminhado</string>
+    <string name="ton_raw_payload">Payload bruto</string>
 
     <string name="welcome_tip">Dica: Pode usar um browser como dispositivo</string>
     <string name="vault_setup_your_vault_setup">A configuração do seu cofre</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1084,8 +1084,13 @@
     <string name="choose_device_count_a11y_description">Сколько у вас устройств? Выбрано: %1$s. Нажмите, чтобы выбрать другое.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Сообщения</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Перевод Jetton</string>
+    <string name="ton_op_nft_transfer">Перевод NFT</string>
+    <string name="ton_op_excess_gas_refund">Возврат излишка газа</string>
+    <string name="ton_op_transfer">Перевод</string>
+    <string name="ton_forward_ton_amount">Пересылаемая сумма TON</string>
+    <string name="ton_raw_payload">Необработанный payload</string>
 
     <string name="welcome_tip">Совет: Вы можете использовать браузер как устройство</string>
     <string name="vault_setup_your_vault_setup">Настройка вашего хранилища</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1400,8 +1400,13 @@
     <string name="choose_device_count_a11y_description">您有多少台设备？当前选择：%1$s。点击以选择其他。</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">消息</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton 转账</string>
+    <string name="ton_op_nft_transfer">NFT 转账</string>
+    <string name="ton_op_excess_gas_refund">超额燃料退款</string>
+    <string name="ton_op_transfer">转账</string>
+    <string name="ton_forward_ton_amount">转发的 TON 金额</string>
+    <string name="ton_raw_payload">原始 Payload</string>
 
     <string name="welcome_tip">提示：您可以将浏览器用作设备</string>
     <string name="vault_setup_your_vault_setup">您的保险库设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1145,8 +1145,13 @@
     <string name="choose_device_count_a11y_description">How many devices do you have? %1$s selected. Tap to choose another.</string>
     <!-- TonConnect multi-message sign payload -->
     <string name="sign_ton_messages">Messages</string>
-    <string name="sign_ton_payload">Payload</string>
     <string name="sign_ton_state_init">State Init</string>
+    <string name="ton_op_jetton_transfer">Jetton Transfer</string>
+    <string name="ton_op_nft_transfer">NFT Transfer</string>
+    <string name="ton_op_excess_gas_refund">Excess Gas Refund</string>
+    <string name="ton_op_transfer">Transfer</string>
+    <string name="ton_forward_ton_amount">Forward TON Amount</string>
+    <string name="ton_raw_payload">Raw Payload</string>
     <string name="key_import_error_title">Key Import Failed</string>
     <string name="key_import_error_description">Unable to import vault from seed phrase. Please check your seed phrase and try again.</string>
     <string name="key_import_error_no_mnemonic_description">No seed phrase found. Please re-enter your seed phrase and try again.</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecodeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecodeTest.kt
@@ -1,0 +1,167 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignTon
+import vultisig.keysign.v1.TonMessage
+
+internal class TonMessageDecodeTest {
+
+    // Jetton transfer of 100000000 base units, forward_ton_amount = 1000000 nanoton.
+    private val jettonTransfer =
+        "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2Emhh6EgOvlFRU="
+    private val excessesBody = "te6cckEBAQEADgAAGNUydtsAAAAAAAAABxylUgg="
+    private val recipient = "0:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+    private fun jettonCoin() =
+        Coin(
+            chain = Chain.Ton,
+            ticker = "USDT",
+            logo = "usdt",
+            address = "EQowner",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "tether",
+            contractAddress = "EQmaster",
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `maps a jetton transfer to a labelled row with the real recipient and forward amount`() {
+        val row =
+            mapTonMessages(
+                    SignTon(
+                        tonMessages =
+                            listOf(
+                                TonMessage(
+                                    to = "EQwallet",
+                                    amount = "50000000",
+                                    payload = jettonTransfer,
+                                )
+                            )
+                    ),
+                    formatAddress = { it },
+                )
+                .single()
+        assertEquals(TonMessageOperation.JettonTransfer, row.operation)
+        assertEquals(recipient, row.recipient)
+        assertEquals("0.001 TON", row.amount)
+        assertEquals(jettonTransfer, row.rawPayload)
+    }
+
+    @Test
+    fun `maps an excesses body to an excess gas refund row with no recipient or amount`() {
+        val row =
+            mapTonMessages(
+                    SignTon(
+                        tonMessages =
+                            listOf(
+                                TonMessage(to = "EQwallet", amount = "0", payload = excessesBody)
+                            )
+                    ),
+                    formatAddress = { it },
+                )
+                .single()
+        assertEquals(TonMessageOperation.ExcessGasRefund, row.operation)
+        assertNull(row.recipient)
+        assertNull(row.amount)
+    }
+
+    @Test
+    fun `maps an undecodable body to a plain transfer showing the outer destination as-is`() {
+        val row =
+            mapTonMessages(
+                    SignTon(tonMessages = listOf(TonMessage(to = "EQabc", amount = "1500000000"))),
+                    formatAddress = { error("plain transfer must not reformat the outer address") },
+                )
+                .single()
+        assertEquals(TonMessageOperation.Transfer, row.operation)
+        assertEquals("EQabc", row.recipient)
+        assertEquals("1.5 TON", row.amount)
+        assertNull(row.rawPayload)
+    }
+
+    @Test
+    fun `resolves the jetton hero against a held vault coin`() = runTest {
+        val hero =
+            resolveTonJettonHero(
+                messages =
+                    listOf(
+                        TonMessage(to = "EQwallet", amount = "50000000", payload = jettonTransfer)
+                    ),
+                vaultCoins = listOf(jettonCoin()),
+                resolveJettonMaster = { "EQmaster" },
+            )
+        assertEquals("100", hero?.amount)
+        assertEquals("USDT", hero?.ticker)
+        assertEquals("usdt", hero?.logo)
+    }
+
+    @Test
+    fun `returns no hero when the jetton is not held in the vault`() = runTest {
+        val hero =
+            resolveTonJettonHero(
+                messages =
+                    listOf(TonMessage(to = "EQwallet", amount = "1", payload = jettonTransfer)),
+                vaultCoins = emptyList(),
+                resolveJettonMaster = { "EQmaster" },
+            )
+        assertNull(hero)
+    }
+
+    @Test
+    fun `returns no hero when the wallet does not resolve to a master`() = runTest {
+        val hero =
+            resolveTonJettonHero(
+                messages =
+                    listOf(TonMessage(to = "EQwallet", amount = "1", payload = jettonTransfer)),
+                vaultCoins = listOf(jettonCoin()),
+                resolveJettonMaster = { null },
+            )
+        assertNull(hero)
+    }
+
+    @Test
+    fun `skips an excesses message and resolves the following jetton transfer`() = runTest {
+        val hero =
+            resolveTonJettonHero(
+                messages =
+                    listOf(
+                        TonMessage(to = "EQwallet", amount = "0", payload = excessesBody),
+                        TonMessage(to = "EQwallet", amount = "50000000", payload = jettonTransfer),
+                    ),
+                vaultCoins = listOf(jettonCoin()),
+                resolveJettonMaster = { "EQmaster" },
+            )
+        assertEquals("USDT", hero?.ticker)
+    }
+
+    @Test
+    fun `returns no hero when the resolved master case differs from the vault coin`() = runTest {
+        // TON addresses are case-sensitive, so a different-case master must not match.
+        val hero =
+            resolveTonJettonHero(
+                messages =
+                    listOf(TonMessage(to = "EQwallet", amount = "1", payload = jettonTransfer)),
+                vaultCoins = listOf(jettonCoin()),
+                resolveJettonMaster = { "eqmaster" },
+            )
+        assertNull(hero)
+    }
+
+    @Test
+    fun `maps a plain transfer with a negative amount to no amount`() {
+        val row =
+            mapTonMessages(
+                    SignTon(tonMessages = listOf(TonMessage(to = "EQabc", amount = "-5"))),
+                    formatAddress = { it },
+                )
+                .single()
+        assertEquals(TonMessageOperation.Transfer, row.operation)
+        assertNull(row.amount)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
@@ -24,6 +24,13 @@ interface TonApi {
 
     suspend fun getJettonWallet(address: String, contract: String): JettonWalletsJson
 
+    /**
+     * Resolve the jetton master address for a given jetton wallet contract. Returns `null` when the
+     * wallet is unknown to the indexer. Used to map a dApp transfer's destination wallet back to a
+     * vault token.
+     */
+    suspend fun getJettonMasterAddress(jettonWalletAddress: String): String?
+
     suspend fun estimateFee(address: String, serializedBoc: String): BigInteger
 
     suspend fun getTsStatus(txHash: String): TonStatusResult
@@ -89,6 +96,15 @@ internal class TonApiImpl @Inject constructor(private val http: HttpClient) : To
                 parameter("jetton_master_address", contract)
             }
             .bodyOrThrow<JettonWalletsJson>()
+
+    override suspend fun getJettonMasterAddress(jettonWalletAddress: String): String? =
+        http
+            .get("$BASE_URL/v3/jetton/wallets") {
+                parameter("address", jettonWalletAddress)
+                parameter("limit", 1)
+            }
+            .bodyOrThrow<JettonWalletsJson>()
+            .getMasterAddress()
 
     override suspend fun estimateFee(address: String, serializedBoc: String): BigInteger {
         val feeResponse =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
@@ -49,6 +49,16 @@ data class JettonWalletsJson(
         val jettonAddress = jettonWallets.firstOrNull()?.address ?: return null
         return addressBook[jettonAddress]?.userFriendly
     }
+
+    /**
+     * Resolve the jetton master address (in user-friendly form when the address book provides it)
+     * for the first returned wallet. Used to map a jetton wallet back to the token it holds when
+     * decoding a dApp transfer.
+     */
+    fun getMasterAddress(): String? {
+        val master = jettonWallets.firstOrNull()?.jetton ?: return null
+        return addressBook[master]?.userFriendly ?: master
+    }
 }
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonBocParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonBocParser.kt
@@ -1,0 +1,214 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.crypto.ton
+
+import java.util.Base64
+import java.util.zip.CRC32C
+
+/**
+ * Minimal TON BOC (Bag Of Cells) parser. Converts a base64 (or hex) payload to the root cell of its
+ * tree. Only single-root, ordinary-cell BOCs are accepted; indexed roots, exotic cells, and
+ * trailing junk are rejected so a hostile payload cannot hide bytes outside the Verify summary's
+ * view.
+ */
+internal object TonBocParser {
+
+    private val HEX_BOC_MAGIC_PREFIXES = listOf("b5ee9c72", "68ff65f3", "acc3a728")
+
+    /**
+     * Convert a hex-encoded BOC to base64 when it carries a recognised magic prefix; otherwise
+     * return the trimmed input unchanged. Returns `null` for blank input.
+     */
+    fun payloadToBase64(payload: String?): String? {
+        val trimmed = payload?.trim().orEmpty()
+        if (trimmed.isEmpty()) return null
+        if (!isHexBoc(trimmed)) return trimmed
+        return runCatching { Base64.getEncoder().encodeToString(trimmed.hexToByteArray()) }
+            .getOrNull()
+    }
+
+    fun parse(base64: String): TonCell {
+        val bytes =
+            runCatching { Base64.getDecoder().decode(base64) }.getOrNull()
+                ?: throw TonCellException("invalid base64 BOC")
+        return parse(bytes)
+    }
+
+    private fun parse(bytes: ByteArray): TonCell {
+        if (bytes.size < 6) throw TonCellException("truncated BOC")
+        // Only the canonical b5ee9c72 magic carries a parseable layout — the
+        // alternate magics surface only in payloadToBase64 hex detection.
+        if (
+            u(bytes, 0) != 0xb5 || u(bytes, 1) != 0xee || u(bytes, 2) != 0x9c || u(bytes, 3) != 0x72
+        ) {
+            throw TonCellException("invalid BOC magic")
+        }
+
+        var cursor = 4
+        val flags = u(bytes, cursor)
+        cursor++
+        val hasIdx = (flags and 0x80) != 0
+        val hasCrc32c = (flags and 0x40) != 0
+        // bit 0x20 (hasCacheBits) and bits 4..3 are metadata we don't read.
+        val sizeBytes = flags and 0x07
+        if (sizeBytes < 1 || sizeBytes > 4) throw TonCellException("truncated BOC")
+
+        if (cursor >= bytes.size) throw TonCellException("truncated BOC")
+        val offBytes = u(bytes, cursor)
+        cursor++
+        if (offBytes < 1 || offBytes > 8) throw TonCellException("truncated BOC")
+
+        if (cursor + sizeBytes * 3 + offBytes > bytes.size) throw TonCellException("truncated BOC")
+        val cellsCount = readBigEndian(bytes, cursor, sizeBytes)
+        cursor += sizeBytes
+        val rootsCount = readBigEndian(bytes, cursor, sizeBytes)
+        cursor += sizeBytes
+        val absentCount = readBigEndian(bytes, cursor, sizeBytes)
+        cursor += sizeBytes
+        val totCellsSizeRaw = readBigEndian(bytes, cursor, offBytes)
+        cursor += offBytes
+        // offBytes can be up to 8, so a hostile header could declare a length
+        // beyond the buffer (or negative as a signed Long). Bound it here, the
+        // way iOS's Int(exactly:) does.
+        if (totCellsSizeRaw < 0 || totCellsSizeRaw > bytes.size)
+            throw TonCellException("truncated BOC")
+        val totCellsSize = totCellsSizeRaw.toInt()
+
+        // Single-root BOCs only — this parser returns one cell, so accepting
+        // more roots would silently drop siblings.
+        if (rootsCount != 1L || absentCount != 0L || cellsCount < rootsCount) {
+            throw TonCellException("unsupported BOC layout")
+        }
+
+        // root_list
+        val rootListSize = (rootsCount * sizeBytes).toInt()
+        if (cursor + rootListSize > bytes.size) throw TonCellException("truncated BOC")
+        val rootIndex = readBigEndian(bytes, cursor, sizeBytes)
+        cursor += rootListSize
+        if (rootIndex >= cellsCount) throw TonCellException("truncated BOC")
+
+        if (hasIdx) {
+            val indexSize = cellsCount * offBytes
+            if (cursor + indexSize > bytes.size) throw TonCellException("truncated BOC")
+            cursor += indexSize.toInt()
+        }
+
+        // Strict envelope: the buffer ends exactly at the cells data plus the
+        // optional 4-byte CRC trailer. Trailing junk would let an attacker hide
+        // bytes outside the parser's view.
+        val trailerSize = if (hasCrc32c) 4 else 0
+        if (cursor.toLong() + totCellsSize + trailerSize != bytes.size.toLong()) {
+            throw TonCellException("truncated BOC")
+        }
+
+        // Each serialized cell needs at least its 2-byte header, so cellsCount
+        // is bounded by totCellsSize / 2 — guards against an extreme declared
+        // count exhausting memory before the structural failure surfaces.
+        if (cellsCount > (totCellsSize / 2).toLong()) throw TonCellException("invalid cell header")
+        val count = cellsCount.toInt()
+
+        // Phase 1: parse each cell into raw form (bits + ref indices).
+        val cellBits = arrayOfNulls<TonBitString>(count)
+        val cellRefs = arrayOfNulls<IntArray>(count)
+        val cellsEnd = cursor + totCellsSize
+        var cellsCursor = cursor
+        for (i in 0 until count) {
+            if (cellsCursor + 2 > cellsEnd) throw TonCellException("invalid cell header")
+            val d1 = u(bytes, cellsCursor)
+            cellsCursor++
+            val d2 = u(bytes, cellsCursor)
+            cellsCursor++
+            val refsCount = d1 and 0x07
+            val isExotic = (d1 and 0x08) != 0
+            val hasHashes = (d1 and 0x10) != 0
+            if (isExotic) throw TonCellException("unsupported cell type")
+
+            val dataBytes = (d2 + 1) / 2
+            val isAligned = (d2 and 1) == 0
+
+            if (hasHashes) {
+                // Skip pruned-branch hashes (32 bytes) + depths (2 bytes) per
+                // level. Ordinary cells have level 0 → one hash + one depth.
+                val levelMask = (d1 shr 5) and 0x07
+                val levels = Integer.bitCount(levelMask) + 1
+                val skip = levels * (32 + 2)
+                if (cellsCursor + skip > cellsEnd) throw TonCellException("invalid cell header")
+                cellsCursor += skip
+            }
+
+            if (cellsCursor + dataBytes > cellsEnd) throw TonCellException("invalid cell header")
+            val payload = bytes.copyOfRange(cellsCursor, cellsCursor + dataBytes)
+            cellsCursor += dataBytes
+
+            val bitLength =
+                if (isAligned) {
+                    dataBytes * 8
+                } else {
+                    // Non-aligned cells append a `1` marker then `0`s to the
+                    // byte boundary; strip everything at or below the lowest set
+                    // bit to recover the real bit length.
+                    val last = if (payload.isNotEmpty()) u(payload, payload.size - 1) else 0
+                    if (last == 0) throw TonCellException("invalid cell header")
+                    dataBytes * 8 - (Integer.numberOfTrailingZeros(last) + 1)
+                }
+            cellBits[i] = TonBitString(payload, bitLength)
+
+            if (cellsCursor + refsCount * sizeBytes > cellsEnd)
+                throw TonCellException("invalid cell header")
+            val refIndices = IntArray(refsCount)
+            for (r in 0 until refsCount) {
+                val refIndex = readBigEndian(bytes, cellsCursor, sizeBytes)
+                cellsCursor += sizeBytes
+                if (refIndex >= count) throw TonCellException("invalid cell header")
+                refIndices[r] = refIndex.toInt()
+            }
+            cellRefs[i] = refIndices
+        }
+
+        // Cells must consume the declared region exactly.
+        if (cellsCursor != cellsEnd) throw TonCellException("invalid cell header")
+
+        // Phase 2: tie refs together. BOCs serialize children before parents, so
+        // iterating from the last cell upward guarantees referenced cells exist.
+        val resolved = arrayOfNulls<TonCell>(count)
+        for (i in count - 1 downTo 0) {
+            val children =
+                cellRefs[i]!!.map { childIndex ->
+                    resolved[childIndex] ?: throw TonCellException("invalid cell header")
+                }
+            resolved[i] = TonCell(cellBits[i]!!, children)
+        }
+
+        if (hasCrc32c) {
+            // CRC-32C (Castagnoli) over every byte before the little-endian
+            // 4-byte trailer.
+            val crc = CRC32C()
+            crc.update(bytes, 0, cellsEnd)
+            val stored =
+                u(bytes, cellsEnd) or
+                    (u(bytes, cellsEnd + 1) shl 8) or
+                    (u(bytes, cellsEnd + 2) shl 16) or
+                    (u(bytes, cellsEnd + 3) shl 24)
+            if (stored != crc.value.toInt()) throw TonCellException("invalid cell header")
+        }
+
+        return resolved[rootIndex.toInt()] ?: throw TonCellException("truncated BOC")
+    }
+
+    private fun isHexBoc(payload: String): Boolean {
+        if (payload.length % 2 != 0) return false
+        if (!payload.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return false
+        val lower = payload.lowercase()
+        return HEX_BOC_MAGIC_PREFIXES.any { lower.startsWith(it) }
+    }
+
+    private fun readBigEndian(bytes: ByteArray, offset: Int, length: Int): Long {
+        var result = 0L
+        for (i in 0 until length) {
+            result = (result shl 8) or (bytes[offset + i].toLong() and 0xFF)
+        }
+        return result
+    }
+
+    private fun u(bytes: ByteArray, index: Int): Int = bytes[index].toInt() and 0xFF
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonBocParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonBocParser.kt
@@ -3,7 +3,6 @@
 package com.vultisig.wallet.data.crypto.ton
 
 import java.util.Base64
-import java.util.zip.CRC32C
 
 /**
  * Minimal TON BOC (Bag Of Cells) parser. Converts a base64 (or hex) payload to the root cell of its
@@ -14,6 +13,9 @@ import java.util.zip.CRC32C
 internal object TonBocParser {
 
     private val HEX_BOC_MAGIC_PREFIXES = listOf("b5ee9c72", "68ff65f3", "acc3a728")
+
+    // CRC-32C (Castagnoli) reflected polynomial.
+    private val CRC32C_POLYNOMIAL = 0x82F63B78.toInt()
 
     /**
      * Convert a hex-encoded BOC to base64 when it carries a recognised magic prefix; otherwise
@@ -182,14 +184,12 @@ internal object TonBocParser {
         if (hasCrc32c) {
             // CRC-32C (Castagnoli) over every byte before the little-endian
             // 4-byte trailer.
-            val crc = CRC32C()
-            crc.update(bytes, 0, cellsEnd)
             val stored =
                 u(bytes, cellsEnd) or
                     (u(bytes, cellsEnd + 1) shl 8) or
                     (u(bytes, cellsEnd + 2) shl 16) or
                     (u(bytes, cellsEnd + 3) shl 24)
-            if (stored != crc.value.toInt()) throw TonCellException("invalid cell header")
+            if (stored != crc32c(bytes, cellsEnd)) throw TonCellException("invalid cell header")
         }
 
         return resolved[rootIndex.toInt()] ?: throw TonCellException("truncated BOC")
@@ -200,6 +200,20 @@ internal object TonBocParser {
         if (!payload.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return false
         val lower = payload.lowercase()
         return HEX_BOC_MAGIC_PREFIXES.any { lower.startsWith(it) }
+    }
+
+    /**
+     * CRC-32C (Castagnoli) over the first [length] bytes, init/xor-out `0xFFFFFFFF`. Hand-rolled
+     * rather than `java.util.zip.CRC32C`, which is only available from API 34 (this module's min is
+     * 26).
+     */
+    private fun crc32c(bytes: ByteArray, length: Int): Int {
+        var crc = -1 // 0xFFFFFFFF
+        for (i in 0 until length) {
+            crc = crc xor (bytes[i].toInt() and 0xFF)
+            repeat(8) { crc = (crc ushr 1) xor (if (crc and 1 != 0) CRC32C_POLYNOMIAL else 0) }
+        }
+        return crc.inv()
     }
 
     private fun readBigEndian(bytes: ByteArray, offset: Int, length: Int): Long {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonCellSlice.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonCellSlice.kt
@@ -1,0 +1,146 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.crypto.ton
+
+import java.math.BigInteger
+
+/**
+ * Parse failure raised by the minimal TON BOC reader. Thrown at decoder boundaries and caught
+ * there, so a malformed or truncated body falls back to "unknown" rather than crashing the keysign
+ * UI.
+ */
+internal class TonCellException(message: String) : Exception(message)
+
+/**
+ * Immutable cell parsed from a BOC. Only the data needed for body decode is retained: the bit
+ * payload and the ordered refs.
+ */
+internal class TonCell(val bits: TonBitString, val refs: List<TonCell>) {
+    fun beginParse(): TonSlice = TonSlice(bits, refs)
+}
+
+/**
+ * Bit-addressable byte buffer. Length is tracked in bits because TON cells carry a non-byte-aligned
+ * bit count.
+ */
+internal class TonBitString(val bytes: ByteArray, val length: Int) {
+    fun bit(index: Int): Boolean {
+        if (index < 0 || index >= length) return false
+        val byte = bytes[index / 8].toInt()
+        val mask = 1 shl (7 - index % 8)
+        return (byte and mask) != 0
+    }
+}
+
+/**
+ * Cursor over a [TonBitString] and its refs. Mirrors `@ton/core`'s `Slice` just enough to decode
+ * the message-body shapes Vultisig surfaces. Addresses are returned in raw `workchain:hex` form —
+ * the UI layer applies WalletCore's user-friendly bounceable formatting, keeping this reader
+ * JNI-free and unit testable on the JVM.
+ */
+internal class TonSlice(private val bits: TonBitString, refs: List<TonCell>) {
+    private val refs = ArrayDeque(refs)
+    private var bitOffset = 0
+
+    val remainingBits: Int
+        get() = bits.length - bitOffset
+
+    val remainingRefs: Int
+        get() = refs.size
+
+    fun loadBit(): Boolean {
+        if (remainingBits < 1) throw TonCellException("missing bits")
+        val value = bits.bit(bitOffset)
+        bitOffset++
+        return value
+    }
+
+    /** Load [count] bits (≤ 64) as an unsigned integer, most-significant first. */
+    fun loadUInt(count: Int): Long {
+        if (count < 0 || count > 64) throw TonCellException("invalid number width")
+        if (remainingBits < count) throw TonCellException("missing bits")
+        var value = 0L
+        repeat(count) {
+            value = value shl 1
+            if (bits.bit(bitOffset)) value = value or 1L
+            bitOffset++
+        }
+        return value
+    }
+
+    /** Load [count] bits as an unsigned big integer (used for query ids and coins). */
+    fun loadUIntBig(count: Int): BigInteger {
+        if (count == 0) return BigInteger.ZERO
+        return BigInteger(1, loadBytes(count))
+    }
+
+    /**
+     * `var_uint$_ len:(## 4) value:(uint (len * 8))` — TON's variable-length "Coins"/Grams
+     * encoding.
+     */
+    fun loadCoins(): BigInteger {
+        val length = loadUInt(4).toInt()
+        if (length == 0) return BigInteger.ZERO
+        val bitCount = length * 8
+        if (bitCount > 256) throw TonCellException("invalid coins length")
+        return loadUIntBig(bitCount)
+    }
+
+    fun loadRef(): TonCell {
+        if (refs.isEmpty()) throw TonCellException("missing ref")
+        return refs.removeFirst()
+    }
+
+    /** Skip a `Maybe ^Cell` field, returning the ref when the discriminator is set. */
+    fun loadMaybeRef(): TonCell? = if (loadBit()) loadRef() else null
+
+    /**
+     * Read a TLB `MsgAddressInt`, returning the raw `workchain:hex` form. Throws on `addr_none` —
+     * callers wanting optional behaviour use [loadMaybeAddress].
+     */
+    fun loadAddress(): String =
+        loadAddressInternal(allowNone = false) ?: throw TonCellException("invalid address")
+
+    /** Read an optional `MsgAddress`. Returns `null` for `addr_none$00`. */
+    fun loadMaybeAddress(): String? = loadAddressInternal(allowNone = true)
+
+    private fun loadAddressInternal(allowNone: Boolean): String? {
+        if (remainingBits < 2) throw TonCellException("invalid address")
+        return when (loadUInt(2).toInt()) {
+            0b00 -> {
+                if (allowNone) null else throw TonCellException("invalid address")
+            }
+
+            0b10 -> {
+                // anycast:(Maybe Anycast) — not exercised by jetton/nft bodies;
+                // reject rather than guess at the rewrite-prefix encoding.
+                if (loadBit()) throw TonCellException("invalid address")
+                // workchain is a signed int8: reinterpret the high bit as sign.
+                val workchain = loadUInt(8).toByte().toInt()
+                val hash = loadBytes(256)
+                "$workchain:${hash.toHexString()}"
+            }
+
+            else -> throw TonCellException("invalid address")
+        }
+    }
+
+    /**
+     * Load [count] bits into a big-endian byte array, right-aligned with leading zeros so the value
+     * round-trips through [BigInteger].
+     */
+    private fun loadBytes(count: Int): ByteArray {
+        if (remainingBits < count) throw TonCellException("missing bits")
+        val out = ByteArray((count + 7) / 8)
+        val leadingZero = (8 - count % 8) % 8
+        for (pos in 0 until count) {
+            if (bits.bit(bitOffset)) {
+                val absolute = pos + leadingZero
+                out[absolute / 8] =
+                    (out[absolute / 8].toInt() or (1 shl (7 - absolute % 8))).toByte()
+            }
+            bitOffset++
+        }
+        return out
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyDecoder.kt
@@ -1,0 +1,93 @@
+package com.vultisig.wallet.data.crypto.ton
+
+/**
+ * Decodes a TonConnect message body (base64 or hex BOC) into a structured [TonMessageBodyIntent].
+ *
+ * Mirrors `decodeTonMessageBody` from the Vultisig SDK / iOS `TonMessageBodyDecoder`, scoped to the
+ * transfer opcodes surfaced on the keysign verify screen. Returns `null` for anything it cannot
+ * confidently classify — empty input, malformed/truncated BOCs, or unrecognised opcodes — so the
+ * keysign UI falls back to the raw message display rather than showing wrong information.
+ *
+ * Some dApps prefix a transfer body with an empty 32-bit "text comment" header (op = 0); in that
+ * case the real opcode is the next 32 bits.
+ */
+object TonMessageBodyDecoder {
+
+    // Opcode = first 32 bits of the message body.
+    private const val OP_JETTON_TRANSFER = 0x0f8a7ea5L // TEP-74
+    private const val OP_NFT_TRANSFER = 0x5fcc3d14L // TEP-62
+    private const val OP_EXCESSES = 0xd53276dbL // TEP-74 gas return
+
+    fun decode(payload: String?): TonMessageBodyIntent? {
+        val base64 = TonBocParser.payloadToBase64(payload) ?: return null
+        return try {
+            val slice = TonBocParser.parse(base64).beginParse()
+            if (slice.remainingBits < 32) return null
+            val op = slice.loadUInt(32)
+            if (op == 0L) {
+                // Peel the text-comment header and dispatch on the nested opcode.
+                if (slice.remainingBits < 32) return null
+                dispatch(slice.loadUInt(32), slice)
+            } else {
+                dispatch(op, slice)
+            }
+        } catch (_: TonCellException) {
+            null
+        }
+    }
+
+    private fun dispatch(op: Long, slice: TonSlice): TonMessageBodyIntent? =
+        when (op) {
+            OP_JETTON_TRANSFER -> parseJettonTransfer(slice)
+            OP_NFT_TRANSFER -> parseNftTransfer(slice)
+            OP_EXCESSES -> parseExcesses(slice)
+            else -> null
+        }
+
+    private fun parseJettonTransfer(slice: TonSlice): TonMessageBodyIntent {
+        val queryId = slice.loadUIntBig(64)
+        val amount = slice.loadCoins()
+        val destination = slice.loadAddress()
+        val responseDestination = slice.loadMaybeAddress()
+        slice.loadMaybeRef() // custom_payload:(Maybe ^Cell) — discarded
+        val forwardTonAmount = slice.loadCoins()
+        // forward_payload:(Either Cell ^Cell) — consumed (not surfaced) so a
+        // body truncated before this field is rejected.
+        consumeForwardPayload(slice)
+        return TonMessageBodyIntent.JettonTransfer(
+            queryId = queryId,
+            amount = amount,
+            destination = destination,
+            responseDestination = responseDestination,
+            forwardTonAmount = forwardTonAmount,
+        )
+    }
+
+    private fun parseNftTransfer(slice: TonSlice): TonMessageBodyIntent {
+        val queryId = slice.loadUIntBig(64)
+        val newOwner = slice.loadAddress()
+        val responseDestination = slice.loadMaybeAddress()
+        slice.loadMaybeRef() // custom_payload:(Maybe ^Cell) — discarded
+        val forwardAmount = slice.loadCoins()
+        consumeForwardPayload(slice)
+        return TonMessageBodyIntent.NftTransfer(
+            queryId = queryId,
+            newOwner = newOwner,
+            responseDestination = responseDestination,
+            forwardAmount = forwardAmount,
+        )
+    }
+
+    private fun parseExcesses(slice: TonSlice): TonMessageBodyIntent =
+        TonMessageBodyIntent.Excesses(queryId = slice.loadUIntBig(64))
+
+    /**
+     * Consume a `forward_payload:(Either Cell ^Cell)`. The content is not surfaced here; reading
+     * the discriminator bit (and the ref it claims) rejects bodies truncated at this field. An
+     * inline payload (the `Either` left case) is the slice's remaining tail and needs no further
+     * reads.
+     */
+    private fun consumeForwardPayload(slice: TonSlice) {
+        if (slice.loadBit()) slice.loadRef()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyIntent.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyIntent.kt
@@ -1,0 +1,33 @@
+package com.vultisig.wallet.data.crypto.ton
+
+import java.math.BigInteger
+
+/**
+ * Structured intent decoded from a TonConnect message body (BOC).
+ *
+ * Addresses are returned in raw `workchain:hex` form. The UI layer converts them to the
+ * user-friendly bounceable form via WalletCore's `TONAddressConverter`, keeping this decoder free
+ * of JNI so it stays unit testable on the JVM.
+ */
+sealed interface TonMessageBodyIntent {
+
+    /** TEP-74 jetton transfer (`0x0f8a7ea5`). */
+    data class JettonTransfer(
+        val queryId: BigInteger,
+        val amount: BigInteger,
+        val destination: String,
+        val responseDestination: String?,
+        val forwardTonAmount: BigInteger,
+    ) : TonMessageBodyIntent
+
+    /** TEP-62 NFT transfer (`0x5fcc3d14`). */
+    data class NftTransfer(
+        val queryId: BigInteger,
+        val newOwner: String,
+        val responseDestination: String?,
+        val forwardAmount: BigInteger,
+    ) : TonMessageBodyIntent
+
+    /** TEP-74 excess-gas return notification (`0xd53276db`). */
+    data class Excesses(val queryId: BigInteger) : TonMessageBodyIntent
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.UtxoInfo
-import vultisig.keysign.v1.SignTon
 
 typealias TransactionId = String
 
@@ -22,7 +21,6 @@ data class Transaction(
     val signAmino: String? = null,
     val signDirect: String? = null,
     val signSolana: String? = null,
-    val signTon: SignTon? = null,
     val estimatedFee: String,
     val blockChainSpecific: BlockChainSpecific,
     val utxos: List<UtxoInfo> = emptyList(),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/ton/JettonWalletsJsonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/ton/JettonWalletsJsonTest.kt
@@ -1,0 +1,39 @@
+package com.vultisig.wallet.data.api.chains.ton
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+internal class JettonWalletsJsonTest {
+
+    @Test
+    fun `getMasterAddress returns the user-friendly master from the address book`() {
+        val response =
+            JettonWalletsJson(
+                jettonWallets =
+                    listOf(
+                        JettonWalletJson(address = "0:wallet", jetton = "0:master", balance = "5")
+                    ),
+                addressBook = mapOf("0:master" to AddressEntryJson(userFriendly = "EQmaster")),
+            )
+        assertEquals("EQmaster", response.getMasterAddress())
+    }
+
+    @Test
+    fun `getMasterAddress falls back to the raw master when it is not in the address book`() {
+        val response =
+            JettonWalletsJson(
+                jettonWallets =
+                    listOf(
+                        JettonWalletJson(address = "0:wallet", jetton = "0:master", balance = "5")
+                    ),
+                addressBook = emptyMap(),
+            )
+        assertEquals("0:master", response.getMasterAddress())
+    }
+
+    @Test
+    fun `getMasterAddress returns null when there are no wallets`() {
+        assertNull(JettonWalletsJson().getMasterAddress())
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyDecoderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ton/TonMessageBodyDecoderTest.kt
@@ -1,0 +1,148 @@
+package com.vultisig.wallet.data.crypto.ton
+
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage parity with the iOS `TonOperationExtractorTests` and the SDK's
+ * `messageBody/decode.test.ts`. The base64 BOC fixtures were emitted from the SDK's `@ton/core`
+ * builders, so this decoder is validated against bit-for-bit-identical inputs.
+ *
+ * Addresses are asserted in raw `workchain:hex` form (this decoder is JNI-free); the raw values
+ * were derived from the fixtures' user-friendly addresses.
+ */
+internal class TonMessageBodyDecoderTest {
+
+    // Raw forms of the fixture addresses (user-friendly -> workchain:hex).
+    private val recipient = "0:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    private val response = "0:2f0df5851b4a185f5f63c0d0cd0412f5aca353f577da18ff47c936f99dbd849a"
+    private val stonfiV2Router =
+        "0:222d5ebbec1807357114b832770b0f0ae563a22523bceb187c610ab62ed84912"
+
+    // BOC fixtures (base64, from @ton/core builders).
+    private val jettonTransfer =
+        "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2Emhh6EgOvlFRU="
+    private val jettonTransferNoResponse =
+        "te6cckEBAQEAMgAAXw+KfqUAAAAAAAAAARKoAf/////////////////////////////////////////+ATfRtbw="
+    private val jettonTransferToStonfiRouterWithSwap =
+        "te6cckEBAwEA+gABrg+KfqUAAAAAAAAwOUBfXhAIAERavXfYMA5q4ilwZO4WHhXKx0RKR3nWMPjCFWxdsJIlAAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2Emhh6EgQEB4WZk3iqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQALw31hRtKGF9fY8DQzQQS9ayjU/V32hj/R8k2+Z29hJqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAD3AAgBTREaPhQgB//////////////////////////////////////////4AAAUQRrdCMQ=="
+    private val nftTransfer =
+        "te6cckEBAQEAVAAAo1/MPRQAAAAAAAAAY4Af//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2EmhYagiVJsdh"
+    private val excessesBody = "te6cckEBAQEADgAAGNUydtsAAAAAAAAABxylUgg="
+    private val unknownOpcode = "te6cckEBAQEADgAAGN6tvu8AAAAAAAAAAGer470="
+    private val jettonTransferTruncated = "te6cckEBAQEADgAAGA+KfqUAAAAAAAAAAdhtSVg="
+    private val jettonTransferEitherCellNoRef =
+        "te6cckEBAQEAUwAAog+KfqUAAAAAAAAAARKoAf//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2EmgZqiypM="
+    private val jettonTransferTruncatedMidEitherCell =
+        "te6cckEBAQEAUwAAoQ+KfqUAAAAAAAAAARKoAf//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2EmgbZISzw="
+    private val nftTransferTruncated =
+        "te6cckEBAQEAUgAAn1/MPRQAAAAAAAAAAYAf//////////////////////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5nb2EmgQzDtOhw=="
+    private val jettonTransferTextCommentPrefix =
+        "te6cckEBAQEAXQAAtgAAAAAPin6lAAAAAAAAMDlAX14QCAH//////////////////////////////////////////wALw31hRtKGF9fY8DQzQQS9ayjU/V32hj/R8k2+Z29hJoYehIDi8JQZ"
+
+    // Same body as [jettonTransfer], hex-encoded with the BOC magic prefix.
+    private val jettonTransferHex =
+        "b5ee9c724101010100590000ae0f8a7ea50000000000003039405f5e100801ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000bc37d6146d28617d7d8f034334104bd6b28d4fd5df6863fd1f24dbe676f6126861e8480ebe51515"
+
+    @Test
+    fun `decode returns null for null and empty input`() {
+        assertNull(TonMessageBodyDecoder.decode(null))
+        assertNull(TonMessageBodyDecoder.decode(""))
+        assertNull(TonMessageBodyDecoder.decode("   "))
+    }
+
+    @Test
+    fun `decode returns null for non-BOC garbage`() {
+        assertNull(TonMessageBodyDecoder.decode("not-a-boc"))
+    }
+
+    @Test
+    fun `decode parses a jetton transfer body`() {
+        val intent = TonMessageBodyDecoder.decode(jettonTransfer)
+        assertTrue(intent is TonMessageBodyIntent.JettonTransfer)
+        assertEquals(BigInteger("12345"), intent.queryId)
+        assertEquals(BigInteger("100000000"), intent.amount)
+        assertEquals(recipient, intent.destination)
+        assertEquals(response, intent.responseDestination)
+        assertEquals(BigInteger("1000000"), intent.forwardTonAmount)
+    }
+
+    @Test
+    fun `decode parses a jetton transfer without response destination`() {
+        val intent = TonMessageBodyDecoder.decode(jettonTransferNoResponse)
+        assertTrue(intent is TonMessageBodyIntent.JettonTransfer)
+        assertNull(intent.responseDestination)
+        assertEquals(BigInteger.ZERO, intent.forwardTonAmount)
+    }
+
+    @Test
+    fun `decode treats a swap-shaped jetton transfer as a plain jetton transfer`() {
+        // Phase 1C does not classify swaps: a jetton transfer whose forward
+        // payload is a STON.fi swap is surfaced as a jetton transfer to the
+        // router address, with the referenced payload consumed but ignored.
+        val intent = TonMessageBodyDecoder.decode(jettonTransferToStonfiRouterWithSwap)
+        assertTrue(intent is TonMessageBodyIntent.JettonTransfer)
+        assertEquals(stonfiV2Router, intent.destination)
+    }
+
+    @Test
+    fun `decode parses an NFT transfer body`() {
+        val intent = TonMessageBodyDecoder.decode(nftTransfer)
+        assertTrue(intent is TonMessageBodyIntent.NftTransfer)
+        assertEquals(BigInteger("99"), intent.queryId)
+        assertEquals(recipient, intent.newOwner)
+        assertEquals(response, intent.responseDestination)
+        assertEquals(BigInteger("50000"), intent.forwardAmount)
+    }
+
+    @Test
+    fun `decode parses an excesses body`() {
+        val intent = TonMessageBodyDecoder.decode(excessesBody)
+        assertTrue(intent is TonMessageBodyIntent.Excesses)
+        assertEquals(BigInteger("7"), intent.queryId)
+    }
+
+    @Test
+    fun `decode peels a 0x00000000 text-comment prefix before the opcode`() {
+        val intent = TonMessageBodyDecoder.decode(jettonTransferTextCommentPrefix)
+        assertTrue(intent is TonMessageBodyIntent.JettonTransfer)
+        assertEquals(BigInteger("100000000"), intent.amount)
+        assertEquals(recipient, intent.destination)
+    }
+
+    @Test
+    fun `decode accepts a hex-encoded BOC payload`() {
+        val intent = TonMessageBodyDecoder.decode(jettonTransferHex)
+        assertTrue(intent is TonMessageBodyIntent.JettonTransfer)
+        assertEquals(BigInteger("100000000"), intent.amount)
+        assertEquals(recipient, intent.destination)
+    }
+
+    @Test
+    fun `decode returns null for an unknown opcode`() {
+        assertNull(TonMessageBodyDecoder.decode(unknownOpcode))
+    }
+
+    @Test
+    fun `decode returns null when the jetton transfer body is truncated`() {
+        assertNull(TonMessageBodyDecoder.decode(jettonTransferTruncated))
+    }
+
+    @Test
+    fun `decode returns null when the forward payload claims a ref it does not have`() {
+        assertNull(TonMessageBodyDecoder.decode(jettonTransferEitherCellNoRef))
+    }
+
+    @Test
+    fun `decode returns null when truncated mid forward-payload discriminator`() {
+        assertNull(TonMessageBodyDecoder.decode(jettonTransferTruncatedMidEitherCell))
+    }
+
+    @Test
+    fun `decode returns null when the NFT transfer body is truncated`() {
+        assertNull(TonMessageBodyDecoder.decode(nftTransferTruncated))
+    }
+}


### PR DESCRIPTION
## Summary

TonConnect signing requests headlined the forwarded gas (e.g. 0.32 TON) instead of the real jetton amount, showed an opaque transfer to the sender's jetton wallet, and hid the BOC payload behind a badge. This decodes the message body so the keysign verify and done screens show the real operation.

- Minimal BOC reader + body decoder (jetton transfer, NFT transfer, excess-gas refund) under `data/crypto/ton`. It returns raw `workchain:hex` addresses so it stays JVM unit-testable; the UI formats them via `TONAddressConverter`.
- Jetton symbol resolution against the vault: the transfer's destination wallet is mapped to its master through the TON indexer, then matched to a held coin. On Android the master lives in `Coin.contractAddress` (the coin's `address` is the owner wallet), so the lookup is needed — unlike iOS, which stores the wallet in `Coin.address`.
- The resolved amount/ticker/logo becomes the keysign hero; each message renders its operation label, real recipient, forwarded TON amount, and a copyable raw payload.

Every Android device in a TonConnect co-sign joins the keysign, so the hero is wired once in `JoinKeysignViewModel` and carried to both the verify and done screens. Blockaid doesn't cover TON, so this replaces the (empty) Blockaid hero on the TON path.

Scope is the transfer opcodes; swap simulation and on-chain metadata for jettons the vault doesn't hold are left out.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/qZjIOV0.png) | ![after](https://i.imgur.com/5xe6jnH.png) |

Both are the full keysign verify screen with the messages section expanded, same vault/addresses/fee. Before headlines `0.32 TON` with `#1 Transfer` to the sender's jetton wallet; after headlines `100 USDT` with `#1 Jetton Transfer` to the real recipient, a `Forward TON Amount` row, and the copyable raw payload.

## Testing

- `./gradlew :data:testDebugUnitTest` — BOC decoder against canonical @ton/core fixtures (jetton/NFT/excesses, hex BOC, 0x00000000 text-comment prefix, truncation/unknown-opcode/no-ref error cases) + the jetton-master DTO helper.
- `./gradlew :app:testDebugUnitTest` — message-to-row mapping and vault jetton resolution (hit, not-in-vault, unresolved master, case-sensitive match, excesses skip, negative-amount guard).
- Before/after captured on the emulator via PreviewActivity.

Closes #4057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-message TON signing UI: per-message rows with operation labels (jetton, NFT, transfer, excess gas), recipient, amount, and raw payload.
  * Jetton “hero” resolution: prominent coin/ticker/amount shown when applicable.

* **Improvements**
  * Verify/send screens show expanded, per-message details with copyable fields.
  * Added localized TON operation labels across many languages.

* **Bug Fixes**
  * More robust TON message decoding and amount/address formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->