### PR TITLE
test(deposit): DepositFormViewModel + DeFiNavActions coverage (#4186)

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -498,9 +498,6 @@ internal class DepositFormViewModelTest {
         assertTrue(vm.state.value.availableSecuredAssets.isEmpty())
     }
 
-    // --- selectDepositOption default-token mapping
-    // ------------------------------------------------
-
     @Test
     fun `selectDepositOption Unbond on ThorChain sets RUNE as selected token`() = runTest {
         val vm = buildViewModel()
@@ -536,8 +533,6 @@ internal class DepositFormViewModelTest {
 
         assertEquals(Coins.ThorChain.RUNE, vm.state.value.selectedToken)
     }
-
-    // --- loadData per-chain deposit-option scoping -----------------------------------------------
 
     @Test
     fun `loadData for ThorChain exposes bond unbond leave custom merge unmerge and withdraw`() =
@@ -586,8 +581,6 @@ internal class DepositFormViewModelTest {
             vm.state.value.depositOptions,
         )
     }
-
-    // --- provider / operator-address validation --------------------------------------------------
 
     @Test
     fun `validateProvider with blank provider sets providerError`() = runTest {
@@ -645,8 +638,6 @@ internal class DepositFormViewModelTest {
         assertEquals(R.string.send_error_no_address, (error as UiText.StringResource).resId)
     }
 
-    // --- operator-fee basis-points validation ----------------------------------------------------
-
     @Test
     fun `validateOperatorFee with zero sets operatorFeeError`() = runTest {
         val vm = buildViewModel()
@@ -695,15 +686,11 @@ internal class DepositFormViewModelTest {
             val priorError = vm.state.value.operatorFeeError
             assertNotNull(priorError)
 
-            // Blank input is intentionally not validated, so it must neither clear nor replace the
-            // existing error (unlike the slippage/provider validators which error on blank).
             vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("")
             vm.validateOperatorFee()
 
             assertEquals(priorError, vm.state.value.operatorFeeError)
         }
-
-    // --- slippage validation ---------------------------------------------------------------------
 
     @Test
     fun `validateSlippage with blank sets required error`() = runTest {
@@ -753,8 +740,6 @@ internal class DepositFormViewModelTest {
 
         assertEquals(null, vm.state.value.slippageError)
     }
-
-    // --- assets / LP-units character validation --------------------------------------------------
 
     @Test
     fun `validateAssets with invalid characters sets assetsError`() = runTest {
@@ -806,16 +791,12 @@ internal class DepositFormViewModelTest {
         assertEquals(null, vm.state.value.lpUnitsError)
     }
 
-    // --- thor-address validation is scoped to the Switch sub-form
-    // ---------------------------------
-
     @Test
     fun `validateThorAddress is a no-op outside the Switch flow`() = runTest {
         val vm = buildViewModel()
         vm.loadData("vault1", Chain.ThorChain.raw, null, null)
         advanceUntilIdle()
 
-        // Default option after loading ThorChain is Bond, not Switch.
         vm.thorAddressFieldState.setTextAndPlaceCursorAtEnd("garbage-not-an-address")
         vm.validateThorAddress()
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.SendDst
 import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -495,5 +496,329 @@ internal class DepositFormViewModelTest {
 
         assertTrue(vm.state.value.securedAssetsLoaded)
         assertTrue(vm.state.value.availableSecuredAssets.isEmpty())
+    }
+
+    // --- selectDepositOption default-token mapping
+    // ------------------------------------------------
+
+    @Test
+    fun `selectDepositOption Unbond on ThorChain sets RUNE as selected token`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.selectDepositOption(DepositOption.Unbond)
+        advanceUntilIdle()
+
+        assertEquals(Coins.ThorChain.RUNE, vm.state.value.selectedToken)
+    }
+
+    @Test
+    fun `selectDepositOption Leave on ThorChain sets RUNE as selected token`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.selectDepositOption(DepositOption.Leave)
+        advanceUntilIdle()
+
+        assertEquals(Coins.ThorChain.RUNE, vm.state.value.selectedToken)
+    }
+
+    @Test
+    fun `selectDepositOption AddLiquidity on ThorChain sets RUNE as selected token`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.selectDepositOption(DepositOption.AddLiquidity)
+        advanceUntilIdle()
+
+        assertEquals(Coins.ThorChain.RUNE, vm.state.value.selectedToken)
+    }
+
+    // --- loadData per-chain deposit-option scoping -----------------------------------------------
+
+    @Test
+    fun `loadData for ThorChain exposes bond unbond leave custom merge unmerge and withdraw`() =
+        runTest {
+            val vm = buildViewModel()
+
+            vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(
+                    DepositOption.Bond,
+                    DepositOption.Unbond,
+                    DepositOption.Leave,
+                    DepositOption.Custom,
+                    DepositOption.Merge,
+                    DepositOption.UnMerge,
+                    DepositOption.WithdrawSecuredAsset,
+                ),
+                vm.state.value.depositOptions,
+            )
+        }
+
+    @Test
+    fun `loadData for GaiaChain exposes only IBC transfer and switch`() = runTest {
+        val vm = buildViewModel()
+
+        vm.loadData("vault1", Chain.GaiaChain.raw, null, null)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(DepositOption.TransferIbc, DepositOption.Switch),
+            vm.state.value.depositOptions,
+        )
+    }
+
+    @Test
+    fun `loadData for Ton exposes only stake and unstake`() = runTest {
+        val vm = buildViewModel()
+
+        vm.loadData("vault1", Chain.Ton.raw, null, null)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(DepositOption.Stake, DepositOption.Unstake),
+            vm.state.value.depositOptions,
+        )
+    }
+
+    // --- provider / operator-address validation --------------------------------------------------
+
+    @Test
+    fun `validateProvider with blank provider sets providerError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.validateProvider()
+
+        val error = vm.state.value.providerError
+        assertNotNull(error)
+        assertTrue(error is UiText.StringResource)
+        assertEquals(R.string.send_error_no_address, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateProvider with invalid address sets providerError`() = runTest {
+        val vm = buildViewModel()
+        every { chainAccountAddressRepository.isValid(Chain.ThorChain, "not-an-address") } returns
+            false
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.providerFieldState.setTextAndPlaceCursorAtEnd("not-an-address")
+        vm.validateProvider()
+
+        val error = vm.state.value.providerError
+        assertNotNull(error)
+        assertEquals(R.string.send_error_no_address, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateProvider with valid address clears providerError`() = runTest {
+        val vm = buildViewModel()
+        every { chainAccountAddressRepository.isValid(Chain.ThorChain, "thor1valid") } returns true
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.providerFieldState.setTextAndPlaceCursorAtEnd("thor1valid")
+        vm.validateProvider()
+
+        assertEquals(null, vm.state.value.providerError)
+    }
+
+    @Test
+    fun `validateNodeAddress with blank address sets nodeAddressError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        vm.validateNodeAddress()
+
+        val error = vm.state.value.nodeAddressError
+        assertNotNull(error)
+        assertEquals(R.string.send_error_no_address, (error as UiText.StringResource).resId)
+    }
+
+    // --- operator-fee basis-points validation ----------------------------------------------------
+
+    @Test
+    fun `validateOperatorFee with zero sets operatorFeeError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("0")
+        vm.validateOperatorFee()
+
+        val error = vm.state.value.operatorFeeError
+        assertNotNull(error)
+        assertEquals(R.string.send_from_invalid_amount, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateOperatorFee above one hundred sets operatorFeeError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("150")
+        vm.validateOperatorFee()
+
+        val error = vm.state.value.operatorFeeError
+        assertNotNull(error)
+        assertEquals(R.string.send_from_invalid_amount, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateOperatorFee within range clears operatorFeeError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("5")
+        vm.validateOperatorFee()
+
+        assertEquals(null, vm.state.value.operatorFeeError)
+    }
+
+    @Test
+    fun `validateOperatorFee with blank input is a no-op and leaves a prior error in place`() =
+        runTest {
+            val vm = buildViewModel()
+            vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+            vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("0")
+            vm.validateOperatorFee()
+            val priorError = vm.state.value.operatorFeeError
+            assertNotNull(priorError)
+
+            // Blank input is intentionally not validated, so it must neither clear nor replace the
+            // existing error (unlike the slippage/provider validators which error on blank).
+            vm.operatorFeeFieldState.setTextAndPlaceCursorAtEnd("")
+            vm.validateOperatorFee()
+
+            assertEquals(priorError, vm.state.value.operatorFeeError)
+        }
+
+    // --- slippage validation ---------------------------------------------------------------------
+
+    @Test
+    fun `validateSlippage with blank sets required error`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.validateSlippage()
+
+        val error = vm.state.value.slippageError
+        assertNotNull(error)
+        assertEquals(R.string.slippage_required_error, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateSlippage above one hundred sets invalid error`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.slippageFieldState.setTextAndPlaceCursorAtEnd("150")
+        vm.validateSlippage()
+
+        val error = vm.state.value.slippageError
+        assertNotNull(error)
+        assertEquals(R.string.slippage_invalid_error, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateSlippage with non-numeric sets format error`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.slippageFieldState.setTextAndPlaceCursorAtEnd("abc")
+        vm.validateSlippage()
+
+        val error = vm.state.value.slippageError
+        assertNotNull(error)
+        assertEquals(R.string.slippage_format_error, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateSlippage within range clears slippageError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.slippageFieldState.setTextAndPlaceCursorAtEnd("50")
+        vm.validateSlippage()
+
+        assertEquals(null, vm.state.value.slippageError)
+    }
+
+    // --- assets / LP-units character validation --------------------------------------------------
+
+    @Test
+    fun `validateAssets with invalid characters sets assetsError`() = runTest {
+        val vm = buildViewModel()
+        every { isAssetCharsValid.invoke(any()) } returns false
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.assetsFieldState.setTextAndPlaceCursorAtEnd("!!bad!!")
+        vm.validateAssets()
+
+        val error = vm.state.value.assetsError
+        assertNotNull(error)
+        assertEquals(R.string.deposit_error_invalid_assets, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateAssets with valid characters clears assetsError`() = runTest {
+        val vm = buildViewModel()
+        every { isAssetCharsValid.invoke(any()) } returns true
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.assetsFieldState.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        vm.validateAssets()
+
+        assertEquals(null, vm.state.value.assetsError)
+    }
+
+    @Test
+    fun `validateLpUnits with non-digits sets lpUnitsError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("abc")
+        vm.validateLpUnits()
+
+        val error = vm.state.value.lpUnitsError
+        assertNotNull(error)
+        assertEquals(R.string.deposit_error_invalid_lpunits, (error as UiText.StringResource).resId)
+    }
+
+    @Test
+    fun `validateLpUnits with positive integer clears lpUnitsError`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+
+        vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("1000")
+        vm.validateLpUnits()
+
+        assertEquals(null, vm.state.value.lpUnitsError)
+    }
+
+    // --- thor-address validation is scoped to the Switch sub-form
+    // ---------------------------------
+
+    @Test
+    fun `validateThorAddress is a no-op outside the Switch flow`() = runTest {
+        val vm = buildViewModel()
+        vm.loadData("vault1", Chain.ThorChain.raw, null, null)
+        advanceUntilIdle()
+
+        // Default option after loading ThorChain is Bond, not Switch.
+        vm.thorAddressFieldState.setTextAndPlaceCursorAtEnd("garbage-not-an-address")
+        vm.validateThorAddress()
+
+        assertEquals(null, vm.state.value.thorAddressError)
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
@@ -6,11 +6,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 
-/**
- * Covers every [DeFiNavActions] path: the wire-string parser [parseDepositType] and the
- * coin-to-action mappers [getStakeDeFiNavAction] / [getUnstakeDeFiNavAction]. A wrong mapping here
- * routes a deposit/stake deeplink to the wrong on-chain flow, so each assertion pins an exact enum.
- */
 internal class DeFiNavActionsTest {
 
     @Test
@@ -55,8 +50,6 @@ internal class DeFiNavActionsTest {
 
     @Test
     fun `parseDepositType folds case for both the when-arm and valueOf-fallback paths`() {
-        // Deeplink args arrive with unguaranteed case; the parser lowercases before matching and
-        // the catch-all routes via valueOf(uppercase). Both paths must tolerate mixed case.
         assertEquals(DeFiNavActions.BOND, parseDepositType("BOND"))
         assertEquals(DeFiNavActions.STAKE_RUJI, parseDepositType("Stake_Ruji"))
         assertEquals(DeFiNavActions.DEPOSIT_USDC_CIRCLE, parseDepositType("Deposit_USDC_Circle"))
@@ -64,10 +57,8 @@ internal class DeFiNavActionsTest {
 
     @Test
     fun `parseDepositType resolves the underscored USDC circle wire strings via the valueOf fallback`() {
-        // The literal when-arms for these two still contain underscores, which the separator-
-        // stripping normalization can never produce, so they resolve only through the valueOf
-        // fallback on the original string. Their separator-free spelling therefore does NOT parse —
-        // this pins that asymmetry so a regression in either path is caught.
+        // The underscored when-arms are unreachable (input is separator-stripped first), so these
+        // resolve only via the valueOf fallback and their separator-free spelling returns null.
         assertEquals(DeFiNavActions.DEPOSIT_USDC_CIRCLE, parseDepositType("deposit_usdc_circle"))
         assertEquals(DeFiNavActions.WITHDRAW_USDC_CIRCLE, parseDepositType("withdraw_usdc_circle"))
         assertNull(parseDepositType("depositusdccircle"))

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
@@ -1,0 +1,112 @@
+package com.vultisig.wallet.ui.screens.v2.defi.model
+
+import com.vultisig.wallet.data.models.Coins
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers every [DeFiNavActions] path: the wire-string parser [parseDepositType] and the
+ * coin-to-action mappers [getStakeDeFiNavAction] / [getUnstakeDeFiNavAction]. A wrong mapping here
+ * routes a deposit/stake deeplink to the wrong on-chain flow, so each assertion pins an exact enum.
+ */
+internal class DeFiNavActionsTest {
+
+    @Test
+    fun `parseDepositType round-trips the wire type of every action`() {
+        DeFiNavActions.entries.forEach { action ->
+            assertEquals(action, parseDepositType(action.type), "wire type ${action.type}")
+        }
+    }
+
+    @Test
+    fun `parseDepositType maps each canonical wire string to its action`() {
+        assertEquals(DeFiNavActions.BOND, parseDepositType("bond"))
+        assertEquals(DeFiNavActions.UNBOND, parseDepositType("unbond"))
+        assertEquals(DeFiNavActions.STAKE_RUJI, parseDepositType("stake_ruji"))
+        assertEquals(DeFiNavActions.UNSTAKE_RUJI, parseDepositType("unstake_ruji"))
+        assertEquals(DeFiNavActions.WITHDRAW_RUJI, parseDepositType("withdraw"))
+        assertEquals(DeFiNavActions.STAKE_TCY, parseDepositType("stake_tcy"))
+        assertEquals(DeFiNavActions.UNSTAKE_TCY, parseDepositType("unstake_tcy"))
+        assertEquals(DeFiNavActions.MINT_YRUNE, parseDepositType("mint_yrune"))
+        assertEquals(DeFiNavActions.REDEEM_YRUNE, parseDepositType("redeem_yrune"))
+        assertEquals(DeFiNavActions.MINT_YTCY, parseDepositType("mint_ytcy"))
+        assertEquals(DeFiNavActions.REDEEM_YTCY, parseDepositType("redeem_ytcy"))
+        assertEquals(DeFiNavActions.STAKE_STCY, parseDepositType("stake_stcy"))
+        assertEquals(DeFiNavActions.UNSTAKE_STCY, parseDepositType("unstake_stcy"))
+        assertEquals(DeFiNavActions.DEPOSIT_USDC_CIRCLE, parseDepositType("deposit_usdc_circle"))
+        assertEquals(DeFiNavActions.WITHDRAW_USDC_CIRCLE, parseDepositType("withdraw_usdc_circle"))
+        assertEquals(DeFiNavActions.STAKE_CACAO, parseDepositType("stake_cacao"))
+        assertEquals(DeFiNavActions.UNSTAKE_CACAO, parseDepositType("unstake_cacao"))
+        assertEquals(DeFiNavActions.ADD_LP, parseDepositType("add_lp"))
+        assertEquals(DeFiNavActions.REMOVE_LP, parseDepositType("remove_lp"))
+        assertEquals(DeFiNavActions.FREEZE_TRX, parseDepositType("freeze_trx"))
+        assertEquals(DeFiNavActions.UNFREEZE_TRX, parseDepositType("unfreeze_trx"))
+    }
+
+    @Test
+    fun `parseDepositType accepts separator-free and alias spellings`() {
+        assertEquals(DeFiNavActions.STAKE_RUJI, parseDepositType("stakeruji"))
+        assertEquals(DeFiNavActions.MINT_YRUNE, parseDepositType("receive_yrune"))
+        assertEquals(DeFiNavActions.REDEEM_YRUNE, parseDepositType("sell_yrune"))
+        assertEquals(DeFiNavActions.UNFREEZE_TRX, parseDepositType("unfreezetrx"))
+    }
+
+    @Test
+    fun `parseDepositType folds case for both the when-arm and valueOf-fallback paths`() {
+        // Deeplink args arrive with unguaranteed case; the parser lowercases before matching and
+        // the catch-all routes via valueOf(uppercase). Both paths must tolerate mixed case.
+        assertEquals(DeFiNavActions.BOND, parseDepositType("BOND"))
+        assertEquals(DeFiNavActions.STAKE_RUJI, parseDepositType("Stake_Ruji"))
+        assertEquals(DeFiNavActions.DEPOSIT_USDC_CIRCLE, parseDepositType("Deposit_USDC_Circle"))
+    }
+
+    @Test
+    fun `parseDepositType resolves the underscored USDC circle wire strings via the valueOf fallback`() {
+        // The literal when-arms for these two still contain underscores, which the separator-
+        // stripping normalization can never produce, so they resolve only through the valueOf
+        // fallback on the original string. Their separator-free spelling therefore does NOT parse —
+        // this pins that asymmetry so a regression in either path is caught.
+        assertEquals(DeFiNavActions.DEPOSIT_USDC_CIRCLE, parseDepositType("deposit_usdc_circle"))
+        assertEquals(DeFiNavActions.WITHDRAW_USDC_CIRCLE, parseDepositType("withdraw_usdc_circle"))
+        assertNull(parseDepositType("depositusdccircle"))
+        assertNull(parseDepositType("withdrawusdccircle"))
+    }
+
+    @Test
+    fun `parseDepositType returns null for unknown or absent type`() {
+        assertNull(parseDepositType(null))
+        assertNull(parseDepositType("not_a_real_action"))
+    }
+
+    @Test
+    fun `getStakeDeFiNavAction maps each stakeable coin to its stake action`() {
+        assertEquals(DeFiNavActions.STAKE_RUJI, Coins.ThorChain.RUJI.getStakeDeFiNavAction())
+        assertEquals(DeFiNavActions.STAKE_TCY, Coins.ThorChain.TCY.getStakeDeFiNavAction())
+        assertEquals(DeFiNavActions.MINT_YRUNE, Coins.ThorChain.yRUNE.getStakeDeFiNavAction())
+        assertEquals(DeFiNavActions.MINT_YTCY, Coins.ThorChain.yTCY.getStakeDeFiNavAction())
+        assertEquals(DeFiNavActions.STAKE_STCY, Coins.ThorChain.sTCY.getStakeDeFiNavAction())
+        assertEquals(DeFiNavActions.STAKE_CACAO, Coins.MayaChain.CACAO.getStakeDeFiNavAction())
+    }
+
+    @Test
+    fun `getUnstakeDeFiNavAction maps each stakeable coin to its unstake action`() {
+        assertEquals(DeFiNavActions.UNSTAKE_RUJI, Coins.ThorChain.RUJI.getUnstakeDeFiNavAction())
+        assertEquals(DeFiNavActions.UNSTAKE_TCY, Coins.ThorChain.TCY.getUnstakeDeFiNavAction())
+        assertEquals(DeFiNavActions.REDEEM_YRUNE, Coins.ThorChain.yRUNE.getUnstakeDeFiNavAction())
+        assertEquals(DeFiNavActions.REDEEM_YTCY, Coins.ThorChain.yTCY.getUnstakeDeFiNavAction())
+        assertEquals(DeFiNavActions.UNSTAKE_STCY, Coins.ThorChain.sTCY.getUnstakeDeFiNavAction())
+        assertEquals(DeFiNavActions.UNSTAKE_CACAO, Coins.MayaChain.CACAO.getUnstakeDeFiNavAction())
+    }
+
+    @Test
+    fun `getStakeDeFiNavAction throws for an unsupported coin`() {
+        assertFailsWith<IllegalStateException> { Coins.ThorChain.RUNE.getStakeDeFiNavAction() }
+    }
+
+    @Test
+    fun `getUnstakeDeFiNavAction throws for an unsupported coin`() {
+        assertFailsWith<IllegalStateException> { Coins.ThorChain.RUNE.getUnstakeDeFiNavAction() }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the test coverage requested in #4186. Refs #4186 (also changed the stale things for scope)

- `ThorchainFunctionsTest` already covers **all 7** memo builders (`stakeRUJI`, `unstakeRUJI`, `claimRujiRewards`, `mintYToken`, `redeemYToken`, `stakeTcyCompound`, `unStakeTcyCompound`) — 22 tests, green.
- `DepositFormViewModelTest` already existed (18 tests), and per-action transaction construction is covered by `BondStrategyTest` / `UnbondStrategyTest` / `LeaveStrategyTest`.
- The RUJI/TCY/yToken/TRX/Circle flows moved out of the deposit VM into the **Send** module; in the deposit VM, `loadData` now maps only `BOND`/`UNBOND`/`STAKE_CACAO`/`UNSTAKE_CACAO`/`ADD_LP`/`REMOVE_LP` to a `DepositOption`.

This PR fills the **genuine remaining gaps** against the ticket's intent, with **no production changes**.

## What's added

### `DepositFormViewModelTest` (+23 tests → 41 total)
- **Per-chain deposit-option scoping**: ThorChain (Bond/Unbond/Leave/Custom/Merge/UnMerge/WithdrawSecuredAsset), GaiaChain (TransferIbc/Switch), Ton (Stake/Unstake), alongside the existing MayaChain (Leave/Custom) case.
- **`selectDepositOption` default-token mapping** for Unbond/Leave/AddLiquidity on ThorChain (RUNE).
- **Previously-untested validators**: provider/operator address, node address, operator-fee basis points (incl. the intentional blank no-op), slippage (required/invalid/format/valid), asset chars, LP-unit chars, and the Switch-scoped thor-address no-op.

### `DeFiNavActionsTest` (new, 10 tests)
- `parseDepositType` round-trips **every** `DeFiNavActions` value, plus aliases, case-folding, `unknown → null`, and the USDC-circle `valueOf` fallback path.
- `getStakeDeFiNavAction` / `getUnstakeDeFiNavAction` coin → action mappings, incl. unsupported coin → throws.

## Notes / follow-ups (production deliberately untouched per the ticket)

- **`parseDepositType` dead `when`-arms** — the input is underscore-stripped before the `when`, so the literal `"deposit_usdc_circle"` / `"withdraw_usdc_circle"` arms can never match; those two resolve only via the `valueOf` fallback, and their separator-free spelling returns `null` (unlike every other multi-word action). Pinned by a test; worth a follow-up if separator-free support is intended.
- **`selectDepositOption` token tests are chain-conditional, not displacement-based.** They assert the per-chain token and guard against an option selecting the *wrong* token, but because `loadData` already sets the chain default, they don't independently prove the handler *re-sets* it. A stronger "displace-then-verify" variant was prototyped (seeding a non-default native token via the address load) but **reverted**: forcing the address load to emit triggers the VM's hardcoded `withContext(Dispatchers.IO)` collectors, which leak past the test and race `Dispatchers.resetMain()`, making the suite flaky. Per-action construction is already covered deterministically by the strategy tests.
- **`mintYToken`** stays in the JVM `ThorchainFunctionsTest` behind an `assumeTrue` JNI guard (skips when WalletCore native is absent) rather than moving to `androidTest`; it still asserts the produced `executeMsg` / affiliate / coins.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.deposit.DepositFormViewModelTest"` — green (41 tests)
- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActionsTest"` — green (10 tests)
- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.chains.helpers.ThorchainFunctionsTest"` — green (22 tests, 1 JNI-skipped)
- [x] `./gradlew :app:ktfmtCheckTest` — clean
- [x] Stress-ran the deposit + DeFi suites 10× to confirm no flakiness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded deposit form validation tests covering token selection defaults, per-chain deposit option availability, and extensive input validation flows (provider, node address, operator fee, slippage, asset/LP input rules, and address validation behavior).
  * Added DeFi navigation action tests validating parsing, coin-to-action mappings, accepted input formats/aliases, and handling of unknown or unsupported inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->