### PR TITLE
refactor(swap): extract swap() transaction build into SwapTransactionBuilder

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -11,21 +11,13 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.errors.SwapKitError
-import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.FiatValue
-import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
-import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
-import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
-import com.vultisig.wallet.data.models.payload.BlockChainSpecific
-import com.vultisig.wallet.data.models.payload.SwapPayload
-import com.vultisig.wallet.data.repositories.AllowanceRepository
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
@@ -52,10 +44,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
-import java.util.UUID
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -121,7 +110,6 @@ constructor(
     private val fiatValueToString: FiatValueToStringMapper,
     private val convertTokenAndValueToTokenValue: ConvertTokenAndValueToTokenValueUseCase,
     private val swapQuoteRepository: SwapQuoteRepository,
-    private val allowanceRepository: AllowanceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val swapTransactionRepository: SwapTransactionRepository,
     private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
@@ -131,6 +119,7 @@ constructor(
     private val swapGasCalculator: SwapGasCalculator,
     private val swapTokenSelector: SwapTokenSelector,
     private val swapQuoteManager: SwapQuoteManager,
+    private val swapTransactionBuilder: SwapTransactionBuilder,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -344,270 +333,19 @@ constructor(
 
             viewModelScope.launch {
                 try {
-                    val dstTokenValue = quote.expectedDstValue
-
                     val transaction =
-                        when (quote) {
-                            is SwapQuote.ThorChain -> {
-                                val dstAddress =
-                                    quote.data.router ?: quote.data.inboundAddress ?: srcAddress
-                                val isRouterDeposit =
-                                    !srcToken.isNativeToken &&
-                                        srcToken.chain.standard == TokenStandard.EVM &&
-                                        !quote.data.router.isNullOrEmpty()
-                                val specificAndUtxo =
-                                    swapGasCalculator.getSpecificAndUtxo(
-                                        srcToken = srcToken,
-                                        srcAddress = srcAddress,
-                                        gasFee = gasFee,
-                                        isThorchainRouterDeposit = isRouterDeposit,
-                                        dstAddress = if (isRouterDeposit) dstAddress else null,
-                                        memo = if (isRouterDeposit) quote.data.memo else null,
-                                        tokenAmountValue =
-                                            if (isRouterDeposit) srcTokenValue.value else null,
-                                    )
-                                val allowance =
-                                    allowanceRepository.getAllowance(
-                                        chain = srcToken.chain,
-                                        contractAddress = srcToken.contractAddress,
-                                        srcAddress = srcAddress,
-                                        dstAddress = dstAddress,
-                                    )
-                                val isApprovalRequired =
-                                    allowance != null && allowance < srcTokenValue.value
-
-                                val isAffiliate = true
-
-                                RegularSwapTransaction(
-                                    id = UUID.randomUUID().toString(),
-                                    vaultId = vaultId,
-                                    srcToken = srcToken,
-                                    srcTokenValue = srcTokenValue,
-                                    dstToken = dstToken,
-                                    dstAddress = dstAddress,
-                                    expectedDstTokenValue = dstTokenValue,
-                                    blockChainSpecific = specificAndUtxo,
-                                    estimatedFees = quote.fees,
-                                    gasFees = estimatedNetworkFeeTokenValue.value ?: gasFee,
-                                    isApprovalRequired = isApprovalRequired,
-                                    memo = quote.data.memo,
-                                    gasFeeFiatValue =
-                                        estimatedNetworkFeeFiatValue.value ?: gasFeeFiatValue,
-                                    payload =
-                                        SwapPayload.ThorChain(
-                                            THORChainSwapPayload(
-                                                fromAddress = srcAddress,
-                                                fromCoin = srcToken,
-                                                toCoin = dstToken,
-                                                vaultAddress =
-                                                    quote.data.inboundAddress ?: srcAddress,
-                                                routerAddress = quote.data.router,
-                                                fromAmount = srcTokenValue.value,
-                                                toAmountDecimal = dstTokenValue.decimal,
-                                                toAmountLimit = "0",
-                                                streamingInterval = "1",
-                                                streamingQuantity = "0",
-                                                expirationTime =
-                                                    (System.currentTimeMillis().milliseconds +
-                                                            15.minutes)
-                                                        .inWholeSeconds
-                                                        .toULong(),
-                                                isAffiliate = isAffiliate,
-                                            )
-                                        ),
-                                )
-                            }
-
-                            is SwapQuote.MayaChain -> {
-                                val isRouterDeposit =
-                                    !srcToken.isNativeToken &&
-                                        srcToken.chain.standard == TokenStandard.EVM &&
-                                        !quote.data.router.isNullOrEmpty()
-                                val dstAddress =
-                                    if (
-                                        !srcToken.isNativeToken &&
-                                            srcToken.chain.standard == TokenStandard.EVM
-                                    ) {
-                                        quote.data.router ?: quote.data.inboundAddress ?: srcAddress
-                                    } else {
-                                        quote.data.inboundAddress ?: srcAddress
-                                    }
-                                val specificAndUtxo =
-                                    swapGasCalculator.getSpecificAndUtxo(
-                                        srcToken = srcToken,
-                                        srcAddress = srcAddress,
-                                        gasFee = gasFee,
-                                        isThorchainRouterDeposit = isRouterDeposit,
-                                        dstAddress = if (isRouterDeposit) dstAddress else null,
-                                        memo = if (isRouterDeposit) quote.data.memo else null,
-                                        tokenAmountValue =
-                                            if (isRouterDeposit) srcTokenValue.value else null,
-                                    )
-
-                                val allowance =
-                                    allowanceRepository.getAllowance(
-                                        chain = srcToken.chain,
-                                        contractAddress = srcToken.contractAddress,
-                                        srcAddress = srcAddress,
-                                        dstAddress = dstAddress,
-                                    )
-                                val isApprovalRequired =
-                                    allowance != null && allowance < srcTokenValue.value
-
-                                val isAffiliate = true
-
-                                RegularSwapTransaction(
-                                    id = UUID.randomUUID().toString(),
-                                    vaultId = vaultId,
-                                    srcToken = srcToken,
-                                    srcTokenValue = srcTokenValue,
-                                    dstToken = dstToken,
-                                    dstAddress = dstAddress,
-                                    expectedDstTokenValue = dstTokenValue,
-                                    blockChainSpecific = specificAndUtxo,
-                                    estimatedFees = quote.fees,
-                                    gasFees = estimatedNetworkFeeTokenValue.value ?: gasFee,
-                                    memo = quote.data.memo,
-                                    isApprovalRequired = isApprovalRequired,
-                                    gasFeeFiatValue =
-                                        estimatedNetworkFeeFiatValue.value ?: gasFeeFiatValue,
-                                    payload =
-                                        SwapPayload.MayaChain(
-                                            THORChainSwapPayload(
-                                                fromAddress = srcAddress,
-                                                fromCoin = srcToken,
-                                                toCoin = dstToken,
-                                                vaultAddress =
-                                                    quote.data.inboundAddress ?: srcAddress,
-                                                routerAddress = quote.data.router,
-                                                fromAmount = srcTokenValue.value,
-                                                toAmountDecimal = dstTokenValue.decimal,
-                                                toAmountLimit = "0",
-                                                streamingInterval = "3",
-                                                streamingQuantity = "0",
-                                                expirationTime =
-                                                    (System.currentTimeMillis().milliseconds +
-                                                            15.minutes)
-                                                        .inWholeSeconds
-                                                        .toULong(),
-                                                isAffiliate = isAffiliate,
-                                            )
-                                        ),
-                                )
-                            }
-
-                            is SwapQuote.SwapKit -> {
-                                // Pre-flight gate: refuse a route whose txType has no wired signing
-                                // path before staging keysign. Sourced from
-                                // SwapKitSwapPayloadJson.SIGNABLE_TX_TYPES — the same list
-                                // SigningHelper dispatches on — so this guard can't drift from what
-                                // the dispatcher actually accepts.
-                                require(
-                                    SwapKitSwapPayloadJson.isSignableTxType(quote.data.txType)
-                                ) {
-                                    "Unsupported SwapKit txType for swap: ${quote.data.txType}"
-                                }
-                                val specificAndUtxo =
-                                    swapGasCalculator.getSpecificAndUtxo(
-                                        srcToken = srcToken,
-                                        srcAddress = srcAddress,
-                                        gasFee = gasFee,
-                                    )
-                                RegularSwapTransaction(
-                                    id = UUID.randomUUID().toString(),
-                                    vaultId = vaultId,
-                                    srcToken = srcToken,
-                                    srcTokenValue = srcTokenValue,
-                                    dstToken = dstToken,
-                                    // SwapKit's source-chain deposit address. Signing is driven
-                                    // entirely by the payload bytes (PSBT / TronWeb object), not by
-                                    // this blockChainSpecific.
-                                    dstAddress = quote.data.targetAddress,
-                                    expectedDstTokenValue = dstTokenValue,
-                                    blockChainSpecific = specificAndUtxo,
-                                    estimatedFees = quote.fees,
-                                    gasFees = estimatedNetworkFeeTokenValue.value ?: gasFee,
-                                    memo = quote.data.memo,
-                                    isApprovalRequired = false,
-                                    gasFeeFiatValue =
-                                        estimatedNetworkFeeFiatValue.value ?: gasFeeFiatValue,
-                                    payload = SwapPayload.SwapKit(quote.data),
-                                )
-                            }
-
-                            is SwapQuote.OneInch -> {
-                                val dstAddress = quote.data.tx.to
-                                // The ERC20 allowance must be granted to the provider's token-
-                                // transfer proxy, which for SwapKit differs from the swap `to`.
-                                // Derivation is factored into approveSpenderFor (pinned by test) so
-                                // a regression collapsing it to `to` can't pass CI silently.
-                                val approveSpender = approveSpenderFor(quote.data.tx)
-                                val specificAndUtxo =
-                                    swapGasCalculator.getSpecificAndUtxo(
-                                        srcToken,
-                                        srcAddress,
-                                        gasFee,
-                                    )
-
-                                val allowance =
-                                    allowanceRepository.getAllowance(
-                                        chain = srcToken.chain,
-                                        contractAddress = srcToken.contractAddress,
-                                        srcAddress = srcAddress,
-                                        dstAddress = approveSpender,
-                                    )
-                                val isApprovalRequired =
-                                    allowance != null && allowance < srcTokenValue.value
-
-                                val specific = specificAndUtxo.blockChainSpecific
-                                val gasLimit =
-                                    if (srcToken.chain == Chain.Mantle) {
-                                        DEFAULT_MANTLE_SWAP_LIMIT.toLong()
-                                    } else {
-                                        quote.data.tx.gas
-                                    }
-                                val quoteData =
-                                    if (specific is BlockChainSpecific.Ethereum) {
-                                        quote.data.copy(
-                                            tx =
-                                                quote.data.tx.copy(
-                                                    gasPrice = specific.maxFeePerGasWei.toString(),
-                                                    gas = gasLimit,
-                                                )
-                                        )
-                                    } else {
-                                        quote.data
-                                    }
-
-                                RegularSwapTransaction(
-                                    id = UUID.randomUUID().toString(),
-                                    vaultId = vaultId,
-                                    srcToken = srcToken,
-                                    srcTokenValue = srcTokenValue,
-                                    dstToken = dstToken,
-                                    dstAddress = dstAddress,
-                                    approveSpender = approveSpender,
-                                    expectedDstTokenValue = dstTokenValue,
-                                    blockChainSpecific = specificAndUtxo,
-                                    estimatedFees = quote.fees,
-                                    gasFees = estimatedNetworkFeeTokenValue.value ?: gasFee,
-                                    memo = null,
-                                    isApprovalRequired = isApprovalRequired,
-                                    gasFeeFiatValue = gasFeeFiatValue,
-                                    payload =
-                                        SwapPayload.EVM(
-                                            EVMSwapPayloadJson(
-                                                fromCoin = srcToken,
-                                                toCoin = dstToken,
-                                                fromAmount = srcTokenValue.value,
-                                                toAmountDecimal = dstTokenValue.decimal,
-                                                quote = quoteData,
-                                                provider = quote.provider,
-                                            )
-                                        ),
-                                )
-                            }
-                        }
+                        swapTransactionBuilder.build(
+                            vaultId = vaultId,
+                            srcToken = srcToken,
+                            dstToken = dstToken,
+                            srcAddress = srcAddress,
+                            srcTokenValue = srcTokenValue,
+                            quote = quote,
+                            gasFee = gasFee,
+                            gasFeeFiatValue = gasFeeFiatValue,
+                            estimatedNetworkFeeTokenValue = estimatedNetworkFeeTokenValue.value,
+                            estimatedNetworkFeeFiatValue = estimatedNetworkFeeFiatValue.value,
+                        )
 
                     swapTransactionRepository.addTransaction(transaction)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -1,0 +1,292 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.repositories.AllowanceRepository
+import java.util.UUID
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Assembles the provider-specific [RegularSwapTransaction] for an already-validated swap.
+ *
+ * Extracted from `SwapFormViewModel.swap()` so the transaction-construction logic — the
+ * `when(quote)` block that fetches the block-chain-specific/UTXO plan, resolves allowances, and
+ * builds the payload for ThorChain / MayaChain / SwapKit / 1inch — lives in a single unit that can
+ * be unit-tested in isolation. The ViewModel keeps pre-flight validation, persistence, and
+ * navigation; this builder is pure transaction construction over resolved inputs.
+ */
+internal class SwapTransactionBuilder
+@Inject
+constructor(
+    private val swapGasCalculator: SwapGasCalculator,
+    private val allowanceRepository: AllowanceRepository,
+) {
+
+    suspend fun build(
+        vaultId: String,
+        srcToken: Coin,
+        dstToken: Coin,
+        srcAddress: String,
+        srcTokenValue: TokenValue,
+        quote: SwapQuote,
+        gasFee: TokenValue,
+        gasFeeFiatValue: FiatValue,
+        estimatedNetworkFeeTokenValue: TokenValue?,
+        estimatedNetworkFeeFiatValue: FiatValue?,
+    ): RegularSwapTransaction {
+        val dstTokenValue = quote.expectedDstValue
+
+        return when (quote) {
+            is SwapQuote.ThorChain -> {
+                val dstAddress = quote.data.router ?: quote.data.inboundAddress ?: srcAddress
+                val isRouterDeposit =
+                    !srcToken.isNativeToken &&
+                        srcToken.chain.standard == TokenStandard.EVM &&
+                        !quote.data.router.isNullOrEmpty()
+                val specificAndUtxo =
+                    swapGasCalculator.getSpecificAndUtxo(
+                        srcToken = srcToken,
+                        srcAddress = srcAddress,
+                        gasFee = gasFee,
+                        isThorchainRouterDeposit = isRouterDeposit,
+                        dstAddress = if (isRouterDeposit) dstAddress else null,
+                        memo = if (isRouterDeposit) quote.data.memo else null,
+                        tokenAmountValue = if (isRouterDeposit) srcTokenValue.value else null,
+                    )
+                val allowance =
+                    allowanceRepository.getAllowance(
+                        chain = srcToken.chain,
+                        contractAddress = srcToken.contractAddress,
+                        srcAddress = srcAddress,
+                        dstAddress = dstAddress,
+                    )
+                val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
+
+                val isAffiliate = true
+
+                RegularSwapTransaction(
+                    id = UUID.randomUUID().toString(),
+                    vaultId = vaultId,
+                    srcToken = srcToken,
+                    srcTokenValue = srcTokenValue,
+                    dstToken = dstToken,
+                    dstAddress = dstAddress,
+                    expectedDstTokenValue = dstTokenValue,
+                    blockChainSpecific = specificAndUtxo,
+                    estimatedFees = quote.fees,
+                    gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
+                    isApprovalRequired = isApprovalRequired,
+                    memo = quote.data.memo,
+                    gasFeeFiatValue = estimatedNetworkFeeFiatValue ?: gasFeeFiatValue,
+                    payload =
+                        SwapPayload.ThorChain(
+                            THORChainSwapPayload(
+                                fromAddress = srcAddress,
+                                fromCoin = srcToken,
+                                toCoin = dstToken,
+                                vaultAddress = quote.data.inboundAddress ?: srcAddress,
+                                routerAddress = quote.data.router,
+                                fromAmount = srcTokenValue.value,
+                                toAmountDecimal = dstTokenValue.decimal,
+                                toAmountLimit = "0",
+                                streamingInterval = "1",
+                                streamingQuantity = "0",
+                                expirationTime =
+                                    (System.currentTimeMillis().milliseconds + 15.minutes)
+                                        .inWholeSeconds
+                                        .toULong(),
+                                isAffiliate = isAffiliate,
+                            )
+                        ),
+                )
+            }
+
+            is SwapQuote.MayaChain -> {
+                val isRouterDeposit =
+                    !srcToken.isNativeToken &&
+                        srcToken.chain.standard == TokenStandard.EVM &&
+                        !quote.data.router.isNullOrEmpty()
+                val dstAddress =
+                    if (!srcToken.isNativeToken && srcToken.chain.standard == TokenStandard.EVM) {
+                        quote.data.router ?: quote.data.inboundAddress ?: srcAddress
+                    } else {
+                        quote.data.inboundAddress ?: srcAddress
+                    }
+                val specificAndUtxo =
+                    swapGasCalculator.getSpecificAndUtxo(
+                        srcToken = srcToken,
+                        srcAddress = srcAddress,
+                        gasFee = gasFee,
+                        isThorchainRouterDeposit = isRouterDeposit,
+                        dstAddress = if (isRouterDeposit) dstAddress else null,
+                        memo = if (isRouterDeposit) quote.data.memo else null,
+                        tokenAmountValue = if (isRouterDeposit) srcTokenValue.value else null,
+                    )
+
+                val allowance =
+                    allowanceRepository.getAllowance(
+                        chain = srcToken.chain,
+                        contractAddress = srcToken.contractAddress,
+                        srcAddress = srcAddress,
+                        dstAddress = dstAddress,
+                    )
+                val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
+
+                val isAffiliate = true
+
+                RegularSwapTransaction(
+                    id = UUID.randomUUID().toString(),
+                    vaultId = vaultId,
+                    srcToken = srcToken,
+                    srcTokenValue = srcTokenValue,
+                    dstToken = dstToken,
+                    dstAddress = dstAddress,
+                    expectedDstTokenValue = dstTokenValue,
+                    blockChainSpecific = specificAndUtxo,
+                    estimatedFees = quote.fees,
+                    gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
+                    memo = quote.data.memo,
+                    isApprovalRequired = isApprovalRequired,
+                    gasFeeFiatValue = estimatedNetworkFeeFiatValue ?: gasFeeFiatValue,
+                    payload =
+                        SwapPayload.MayaChain(
+                            THORChainSwapPayload(
+                                fromAddress = srcAddress,
+                                fromCoin = srcToken,
+                                toCoin = dstToken,
+                                vaultAddress = quote.data.inboundAddress ?: srcAddress,
+                                routerAddress = quote.data.router,
+                                fromAmount = srcTokenValue.value,
+                                toAmountDecimal = dstTokenValue.decimal,
+                                toAmountLimit = "0",
+                                streamingInterval = "3",
+                                streamingQuantity = "0",
+                                expirationTime =
+                                    (System.currentTimeMillis().milliseconds + 15.minutes)
+                                        .inWholeSeconds
+                                        .toULong(),
+                                isAffiliate = isAffiliate,
+                            )
+                        ),
+                )
+            }
+
+            is SwapQuote.SwapKit -> {
+                // Pre-flight gate: refuse a route whose txType has no wired signing
+                // path before staging keysign. Sourced from
+                // SwapKitSwapPayloadJson.SIGNABLE_TX_TYPES — the same list
+                // SigningHelper dispatches on — so this guard can't drift from what
+                // the dispatcher actually accepts.
+                require(SwapKitSwapPayloadJson.isSignableTxType(quote.data.txType)) {
+                    "Unsupported SwapKit txType for swap: ${quote.data.txType}"
+                }
+                val specificAndUtxo =
+                    swapGasCalculator.getSpecificAndUtxo(
+                        srcToken = srcToken,
+                        srcAddress = srcAddress,
+                        gasFee = gasFee,
+                    )
+                RegularSwapTransaction(
+                    id = UUID.randomUUID().toString(),
+                    vaultId = vaultId,
+                    srcToken = srcToken,
+                    srcTokenValue = srcTokenValue,
+                    dstToken = dstToken,
+                    // SwapKit's source-chain deposit address. Signing is driven
+                    // entirely by the payload bytes (PSBT / TronWeb object), not by
+                    // this blockChainSpecific.
+                    dstAddress = quote.data.targetAddress,
+                    expectedDstTokenValue = dstTokenValue,
+                    blockChainSpecific = specificAndUtxo,
+                    estimatedFees = quote.fees,
+                    gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
+                    memo = quote.data.memo,
+                    isApprovalRequired = false,
+                    gasFeeFiatValue = estimatedNetworkFeeFiatValue ?: gasFeeFiatValue,
+                    payload = SwapPayload.SwapKit(quote.data),
+                )
+            }
+
+            is SwapQuote.OneInch -> {
+                val dstAddress = quote.data.tx.to
+                // The ERC20 allowance must be granted to the provider's token-
+                // transfer proxy, which for SwapKit differs from the swap `to`.
+                // Derivation is factored into approveSpenderFor (pinned by test) so
+                // a regression collapsing it to `to` can't pass CI silently.
+                val approveSpender = approveSpenderFor(quote.data.tx)
+                val specificAndUtxo =
+                    swapGasCalculator.getSpecificAndUtxo(srcToken, srcAddress, gasFee)
+
+                val allowance =
+                    allowanceRepository.getAllowance(
+                        chain = srcToken.chain,
+                        contractAddress = srcToken.contractAddress,
+                        srcAddress = srcAddress,
+                        dstAddress = approveSpender,
+                    )
+                val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
+
+                val specific = specificAndUtxo.blockChainSpecific
+                val gasLimit =
+                    if (srcToken.chain == Chain.Mantle) {
+                        DEFAULT_MANTLE_SWAP_LIMIT.toLong()
+                    } else {
+                        quote.data.tx.gas
+                    }
+                val quoteData =
+                    if (specific is BlockChainSpecific.Ethereum) {
+                        quote.data.copy(
+                            tx =
+                                quote.data.tx.copy(
+                                    gasPrice = specific.maxFeePerGasWei.toString(),
+                                    gas = gasLimit,
+                                )
+                        )
+                    } else {
+                        quote.data
+                    }
+
+                RegularSwapTransaction(
+                    id = UUID.randomUUID().toString(),
+                    vaultId = vaultId,
+                    srcToken = srcToken,
+                    srcTokenValue = srcTokenValue,
+                    dstToken = dstToken,
+                    dstAddress = dstAddress,
+                    approveSpender = approveSpender,
+                    expectedDstTokenValue = dstTokenValue,
+                    blockChainSpecific = specificAndUtxo,
+                    estimatedFees = quote.fees,
+                    gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
+                    memo = null,
+                    isApprovalRequired = isApprovalRequired,
+                    gasFeeFiatValue = gasFeeFiatValue,
+                    payload =
+                        SwapPayload.EVM(
+                            EVMSwapPayloadJson(
+                                fromCoin = srcToken,
+                                toCoin = dstToken,
+                                fromAmount = srcTokenValue.value,
+                                toAmountDecimal = dstTokenValue.decimal,
+                                quote = quoteData,
+                                provider = quote.provider,
+                            )
+                        ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -198,7 +198,6 @@ internal class SwapFormViewModelTest {
                 fiatValueToString = fiatValueToString,
                 convertTokenAndValueToTokenValue = convertTokenAndValueToTokenValue,
                 swapQuoteRepository = swapQuoteRepository,
-                allowanceRepository = allowanceRepository,
                 appCurrencyRepository = appCurrencyRepository,
                 swapTransactionRepository = swapTransactionRepository,
                 getDiscountBpsUseCase = getDiscountBpsUseCase,
@@ -208,6 +207,8 @@ internal class SwapFormViewModelTest {
                 swapGasCalculator = swapGasCalculator,
                 swapTokenSelector = swapTokenSelector,
                 swapQuoteManager = swapQuoteManager,
+                swapTransactionBuilder =
+                    SwapTransactionBuilder(swapGasCalculator, allowanceRepository),
                 ioDispatcher = ioDispatcher,
             )
             .also { createdViewModels += it }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -1,0 +1,302 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.repositories.AllowanceRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SwapTransactionBuilderTest {
+
+    private val swapGasCalculator: SwapGasCalculator = mockk(relaxed = true)
+    private val allowanceRepository: AllowanceRepository = mockk(relaxed = true)
+
+    private lateinit var builder: SwapTransactionBuilder
+
+    private val specificAndUtxo =
+        BlockChainSpecificAndUtxo(blockChainSpecific = mockk(relaxed = true))
+
+    @BeforeEach
+    fun setUp() {
+        builder = SwapTransactionBuilder(swapGasCalculator, allowanceRepository)
+        coEvery {
+            swapGasCalculator.getSpecificAndUtxo(
+                srcToken = any(),
+                srcAddress = any(),
+                gasFee = any(),
+                isThorchainRouterDeposit = any(),
+                dstAddress = any(),
+                memo = any(),
+                tokenAmountValue = any(),
+            )
+        } returns specificAndUtxo
+        coEvery { allowanceRepository.getAllowance(any(), any(), any(), any()) } returns null
+    }
+
+    @Test
+    fun `builds ThorChain swap with inbound dst address and estimated-fee fallbacks`() = runTest {
+        val srcToken = coin(Chain.Bitcoin, "BTC", "bc1qsrc", 8, isNative = true)
+        val dstToken = coin(Chain.Ethereum, "ETH", "0xdst", 18, isNative = true)
+        val data =
+            mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { router } returns null
+                every { inboundAddress } returns "thor-inbound"
+                every { memo } returns "=:ETH.ETH:0xdst"
+            }
+        val quote =
+            SwapQuote.ThorChain(
+                expectedDstValue = TokenValue(BigInteger.valueOf(100), dstToken),
+                fees = TokenValue(BigInteger.valueOf(7), srcToken),
+                expiredAt = Clock.System.now(),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
+                data = data,
+            )
+        val estimatedNetworkFee = TokenValue(BigInteger.valueOf(11), srcToken)
+        val estimatedNetworkFeeFiat = FiatValue(BigDecimal("1.50"), "USD")
+
+        val tx =
+            builder.build(
+                vaultId = "vault-1",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "bc1qsrc",
+                srcTokenValue = TokenValue(BigInteger.valueOf(1_000), srcToken),
+                quote = quote,
+                gasFee = TokenValue(BigInteger.valueOf(5), srcToken),
+                gasFeeFiatValue = FiatValue(BigDecimal("0.99"), "USD"),
+                estimatedNetworkFeeTokenValue = estimatedNetworkFee,
+                estimatedNetworkFeeFiatValue = estimatedNetworkFeeFiat,
+            )
+
+        assertEquals("vault-1", tx.vaultId)
+        assertEquals(srcToken, tx.srcToken)
+        assertEquals(dstToken, tx.dstToken)
+        assertEquals("thor-inbound", tx.dstAddress)
+        assertEquals(specificAndUtxo, tx.blockChainSpecific)
+        // estimatedNetworkFee* take precedence over the passed gasFee/gasFeeFiatValue
+        assertEquals(estimatedNetworkFee, tx.gasFees)
+        assertEquals(estimatedNetworkFeeFiat, tx.gasFeeFiatValue)
+        assertFalse(tx.isApprovalRequired)
+        assertIs<SwapPayload.ThorChain>(tx.payload)
+    }
+
+    @Test
+    fun `builds MayaChain swap with inbound dst address for native source`() = runTest {
+        val srcToken = coin(Chain.MayaChain, "CACAO", "maya1src", 10, isNative = true)
+        val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
+        val data =
+            mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { router } returns null
+                every { inboundAddress } returns "maya-inbound"
+                every { memo } returns "=:BTC.BTC:bc1qdst"
+            }
+        val quote =
+            SwapQuote.MayaChain(
+                expectedDstValue = TokenValue(BigInteger.valueOf(200), dstToken),
+                fees = TokenValue(BigInteger.valueOf(3), srcToken),
+                expiredAt = Clock.System.now(),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
+                data = data,
+            )
+
+        val tx =
+            builder.build(
+                vaultId = "vault-2",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "maya1src",
+                srcTokenValue = TokenValue(BigInteger.valueOf(500), srcToken),
+                quote = quote,
+                gasFee = TokenValue(BigInteger.valueOf(4), srcToken),
+                gasFeeFiatValue = FiatValue(BigDecimal("0.10"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+
+        assertEquals("maya-inbound", tx.dstAddress)
+        // No estimated fee available -> falls back to the passed gasFee / gasFeeFiatValue
+        assertEquals(TokenValue(BigInteger.valueOf(4), srcToken), tx.gasFees)
+        assertEquals(FiatValue(BigDecimal("0.10"), "USD"), tx.gasFeeFiatValue)
+        assertFalse(tx.isApprovalRequired)
+        assertIs<SwapPayload.MayaChain>(tx.payload)
+    }
+
+    @Test
+    fun `builds SwapKit swap targeting the deposit address and never requires approval`() =
+        runTest {
+            val srcToken = coin(Chain.Bitcoin, "BTC", "bc1qsrc", 8, isNative = true)
+            val dstToken = coin(Chain.Ton, "TON", "ton-dst", 9, isNative = true)
+            coEvery {
+                swapGasCalculator.getSpecificAndUtxo(
+                    srcToken = any(),
+                    srcAddress = any(),
+                    gasFee = any(),
+                )
+            } returns specificAndUtxo
+            val data =
+                mockk<SwapKitSwapPayloadJson>(relaxed = true).apply {
+                    every { txType } returns SwapKitSwapPayloadJson.TX_TYPE_TON
+                    every { targetAddress } returns "swapkit-deposit"
+                    every { memo } returns null
+                }
+            val quote =
+                SwapQuote.SwapKit(
+                    expectedDstValue = TokenValue(BigInteger.valueOf(300), dstToken),
+                    fees = TokenValue(BigInteger.valueOf(2), srcToken),
+                    expiredAt = Clock.System.now(),
+                    data = data,
+                    subProvider = "NEAR",
+                )
+
+            val tx =
+                builder.build(
+                    vaultId = "vault-3",
+                    srcToken = srcToken,
+                    dstToken = dstToken,
+                    srcAddress = "bc1qsrc",
+                    srcTokenValue = TokenValue(BigInteger.valueOf(900), srcToken),
+                    quote = quote,
+                    gasFee = TokenValue(BigInteger.valueOf(6), srcToken),
+                    gasFeeFiatValue = FiatValue(BigDecimal("0.20"), "USD"),
+                    estimatedNetworkFeeTokenValue = null,
+                    estimatedNetworkFeeFiatValue = null,
+                )
+
+            assertEquals("swapkit-deposit", tx.dstAddress)
+            assertFalse(tx.isApprovalRequired)
+            assertIs<SwapPayload.SwapKit>(tx.payload)
+        }
+
+    @Test
+    fun `rejects SwapKit route whose txType has no wired signing path`() = runTest {
+        val srcToken = coin(Chain.Bitcoin, "BTC", "bc1qsrc", 8, isNative = true)
+        val dstToken = coin(Chain.Ton, "TON", "ton-dst", 9, isNative = true)
+        val data =
+            mockk<SwapKitSwapPayloadJson>(relaxed = true).apply {
+                every { txType } returns "UNSUPPORTED"
+                every { targetAddress } returns "swapkit-deposit"
+            }
+        val quote =
+            SwapQuote.SwapKit(
+                expectedDstValue = TokenValue(BigInteger.valueOf(300), dstToken),
+                fees = TokenValue(BigInteger.valueOf(2), srcToken),
+                expiredAt = Clock.System.now(),
+                data = data,
+                subProvider = null,
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            builder.build(
+                vaultId = "vault-3",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "bc1qsrc",
+                srcTokenValue = TokenValue(BigInteger.valueOf(900), srcToken),
+                quote = quote,
+                gasFee = TokenValue(BigInteger.valueOf(6), srcToken),
+                gasFeeFiatValue = FiatValue(BigDecimal("0.20"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+        }
+    }
+
+    @Test
+    fun `builds OneInch swap approving the allowance target proxy when allowance is insufficient`() =
+        runTest {
+            val srcToken =
+                coin(Chain.Ethereum, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
+            val dstToken = coin(Chain.Ethereum, "ETH", "0xdst", 18, isNative = true)
+            coEvery { swapGasCalculator.getSpecificAndUtxo(any(), any(), any()) } returns
+                specificAndUtxo
+            // Allowance below the swap amount -> approval required.
+            coEvery { allowanceRepository.getAllowance(any(), any(), any(), any()) } returns
+                BigInteger.ZERO
+            val tx0 =
+                OneInchSwapTxJson(
+                    from = "0xsrc",
+                    to = "0xrouter",
+                    allowanceTarget = "0xproxy",
+                    gas = 21_000,
+                    data = "0xdata",
+                    value = "0",
+                    gasPrice = "1",
+                )
+            val quote =
+                SwapQuote.OneInch(
+                    expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
+                    fees = TokenValue(BigInteger.valueOf(9), dstToken),
+                    expiredAt = Clock.System.now(),
+                    data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
+                    provider = "1inch",
+                )
+
+            val tx =
+                builder.build(
+                    vaultId = "vault-4",
+                    srcToken = srcToken,
+                    dstToken = dstToken,
+                    srcAddress = "0xsrc",
+                    srcTokenValue = TokenValue(BigInteger.valueOf(1_000), srcToken),
+                    quote = quote,
+                    gasFee = TokenValue(BigInteger.valueOf(8), srcToken),
+                    gasFeeFiatValue = FiatValue(BigDecimal("2.00"), "USD"),
+                    estimatedNetworkFeeTokenValue = null,
+                    estimatedNetworkFeeFiatValue = FiatValue(BigDecimal("9.99"), "USD"),
+                )
+
+            assertEquals("0xrouter", tx.dstAddress)
+            // The ERC20 approve spender is the dedicated allowance target, not the swap `to`.
+            assertEquals("0xproxy", tx.approveSpender)
+            assertTrue(tx.isApprovalRequired)
+            // OneInch always uses the passed gasFeeFiatValue (no estimated-fee fallback).
+            assertEquals(FiatValue(BigDecimal("2.00"), "USD"), tx.gasFeeFiatValue)
+            // gasFees still falls back to gasFee when no estimated network fee is available.
+            assertEquals(TokenValue(BigInteger.valueOf(8), srcToken), tx.gasFees)
+            assertIs<SwapPayload.EVM>(tx.payload)
+        }
+
+    private fun coin(
+        chain: Chain,
+        ticker: String,
+        address: String,
+        decimals: Int,
+        isNative: Boolean,
+        contract: String = "",
+    ) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = address,
+            decimal = decimals,
+            hexPublicKey = "pub",
+            priceProviderID = ticker.lowercase(),
+            contractAddress = contract,
+            isNativeToken = isNative,
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -5,16 +5,19 @@ package com.vultisig.wallet.ui.models.swap
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.repositories.AllowanceRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
@@ -101,7 +104,13 @@ internal class SwapTransactionBuilderTest {
         assertEquals(estimatedNetworkFee, tx.gasFees)
         assertEquals(estimatedNetworkFeeFiat, tx.gasFeeFiatValue)
         assertFalse(tx.isApprovalRequired)
-        assertIs<SwapPayload.ThorChain>(tx.payload)
+        val payload = assertIs<SwapPayload.ThorChain>(tx.payload)
+        // ThorChain streams in single-block intervals; MayaChain uses "3".
+        assertEquals("1", payload.data.streamingInterval)
+        assertEquals("0", payload.data.toAmountLimit)
+        assertTrue(payload.data.isAffiliate)
+        // Expiration is stamped ~15 minutes ahead, so it must be in the future.
+        assertTrue(payload.data.expirationTime > (System.currentTimeMillis() / 1000).toULong())
     }
 
     @Test
@@ -142,7 +151,116 @@ internal class SwapTransactionBuilderTest {
         assertEquals(TokenValue(BigInteger.valueOf(4), srcToken), tx.gasFees)
         assertEquals(FiatValue(BigDecimal("0.10"), "USD"), tx.gasFeeFiatValue)
         assertFalse(tx.isApprovalRequired)
-        assertIs<SwapPayload.MayaChain>(tx.payload)
+        val payload = assertIs<SwapPayload.MayaChain>(tx.payload)
+        // MayaChain streams in 3-block intervals; ThorChain uses "1".
+        assertEquals("3", payload.data.streamingInterval)
+        assertEquals("0", payload.data.toAmountLimit)
+        assertTrue(payload.data.isAffiliate)
+        // Expiration is stamped ~15 minutes ahead, so it must be in the future.
+        assertTrue(payload.data.expirationTime > (System.currentTimeMillis() / 1000).toULong())
+    }
+
+    @Test
+    fun `builds ThorChain swap routing an EVM token deposit through the router`() = runTest {
+        val srcToken =
+            coin(Chain.Ethereum, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
+        val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
+        val data =
+            mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { router } returns "0xrouter"
+                every { inboundAddress } returns "thor-inbound"
+                every { memo } returns "=:BTC.BTC:bc1qdst"
+            }
+        val quote =
+            SwapQuote.ThorChain(
+                expectedDstValue = TokenValue(BigInteger.valueOf(100), dstToken),
+                fees = TokenValue(BigInteger.valueOf(7), srcToken),
+                expiredAt = Clock.System.now(),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
+                data = data,
+            )
+        val srcTokenValue = TokenValue(BigInteger.valueOf(1_000), srcToken)
+        val gasFee = TokenValue(BigInteger.valueOf(5), srcToken)
+
+        val tx =
+            builder.build(
+                vaultId = "vault-1",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "0xsrc",
+                srcTokenValue = srcTokenValue,
+                quote = quote,
+                gasFee = gasFee,
+                gasFeeFiatValue = FiatValue(BigDecimal("0.99"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+
+        // router takes precedence over inboundAddress for the dst address.
+        assertEquals("0xrouter", tx.dstAddress)
+        // EVM non-native source is a router deposit, so dstAddress/memo/amount are forwarded.
+        coVerify {
+            swapGasCalculator.getSpecificAndUtxo(
+                srcToken = srcToken,
+                srcAddress = "0xsrc",
+                gasFee = gasFee,
+                isThorchainRouterDeposit = true,
+                dstAddress = "0xrouter",
+                memo = "=:BTC.BTC:bc1qdst",
+                tokenAmountValue = srcTokenValue.value,
+            )
+        }
+    }
+
+    @Test
+    fun `builds MayaChain swap resolving the EVM source dst address from the router`() = runTest {
+        val srcToken =
+            coin(Chain.Ethereum, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
+        val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
+        val data =
+            mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { router } returns "0xrouter"
+                every { inboundAddress } returns "maya-inbound"
+                every { memo } returns "=:BTC.BTC:bc1qdst"
+            }
+        val quote =
+            SwapQuote.MayaChain(
+                expectedDstValue = TokenValue(BigInteger.valueOf(200), dstToken),
+                fees = TokenValue(BigInteger.valueOf(3), srcToken),
+                expiredAt = Clock.System.now(),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
+                data = data,
+            )
+        val srcTokenValue = TokenValue(BigInteger.valueOf(500), srcToken)
+        val gasFee = TokenValue(BigInteger.valueOf(4), srcToken)
+
+        val tx =
+            builder.build(
+                vaultId = "vault-2",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "0xsrc",
+                srcTokenValue = srcTokenValue,
+                quote = quote,
+                gasFee = gasFee,
+                gasFeeFiatValue = FiatValue(BigDecimal("0.10"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+
+        // EVM source resolves the router before the inbound address.
+        assertEquals("0xrouter", tx.dstAddress)
+        coVerify {
+            swapGasCalculator.getSpecificAndUtxo(
+                srcToken = srcToken,
+                srcAddress = "0xsrc",
+                gasFee = gasFee,
+                isThorchainRouterDeposit = true,
+                dstAddress = "0xrouter",
+                memo = "=:BTC.BTC:bc1qdst",
+                tokenAmountValue = srcTokenValue.value,
+            )
+        }
     }
 
     @Test
@@ -232,7 +350,7 @@ internal class SwapTransactionBuilderTest {
                 coin(Chain.Ethereum, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
             val dstToken = coin(Chain.Ethereum, "ETH", "0xdst", 18, isNative = true)
             coEvery { swapGasCalculator.getSpecificAndUtxo(any(), any(), any()) } returns
-                specificAndUtxo
+                ethereumSpecificAndUtxo(maxFeePerGasWei = BigInteger.valueOf(99))
             // Allowance below the swap amount -> approval required.
             coEvery { allowanceRepository.getAllowance(any(), any(), any(), any()) } returns
                 BigInteger.ZERO
@@ -277,8 +395,71 @@ internal class SwapTransactionBuilderTest {
             assertEquals(FiatValue(BigDecimal("2.00"), "USD"), tx.gasFeeFiatValue)
             // gasFees still falls back to gasFee when no estimated network fee is available.
             assertEquals(TokenValue(BigInteger.valueOf(8), srcToken), tx.gasFees)
-            assertIs<SwapPayload.EVM>(tx.payload)
+            val payload = assertIs<SwapPayload.EVM>(tx.payload)
+            // On an Ethereum plan the tx gas price is patched with the plan's maxFeePerGas.
+            assertEquals("99", payload.data.quote.tx.gasPrice)
+            // Non-Mantle chains keep the quote's original gas limit.
+            assertEquals(21_000L, payload.data.quote.tx.gas)
         }
+
+    @Test
+    fun `builds OneInch swap overriding the gas limit on Mantle`() = runTest {
+        val srcToken =
+            coin(Chain.Mantle, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
+        val dstToken = coin(Chain.Mantle, "MNT", "0xdst", 18, isNative = true)
+        coEvery { swapGasCalculator.getSpecificAndUtxo(any(), any(), any()) } returns
+            ethereumSpecificAndUtxo(maxFeePerGasWei = BigInteger.valueOf(7))
+        val tx0 =
+            OneInchSwapTxJson(
+                from = "0xsrc",
+                to = "0xrouter",
+                allowanceTarget = "0xproxy",
+                gas = 21_000,
+                data = "0xdata",
+                value = "0",
+                gasPrice = "1",
+            )
+        val quote =
+            SwapQuote.OneInch(
+                expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
+                fees = TokenValue(BigInteger.valueOf(9), dstToken),
+                expiredAt = Clock.System.now(),
+                data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
+                provider = "1inch",
+            )
+
+        val tx =
+            builder.build(
+                vaultId = "vault-5",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "0xsrc",
+                srcTokenValue = TokenValue(BigInteger.valueOf(1_000), srcToken),
+                quote = quote,
+                gasFee = TokenValue(BigInteger.valueOf(8), srcToken),
+                gasFeeFiatValue = FiatValue(BigDecimal("2.00"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+
+        val payload = assertIs<SwapPayload.EVM>(tx.payload)
+        // Mantle overrides the quote's gas limit with the dedicated swap limit.
+        assertEquals(DEFAULT_MANTLE_SWAP_LIMIT.toLong(), payload.data.quote.tx.gas)
+        // The gas price is still patched from the EVM plan.
+        assertEquals("7", payload.data.quote.tx.gasPrice)
+    }
+
+    /** Plan fixture whose [BlockChainSpecific] is a real [BlockChainSpecific.Ethereum]. */
+    private fun ethereumSpecificAndUtxo(maxFeePerGasWei: BigInteger) =
+        BlockChainSpecificAndUtxo(
+            blockChainSpecific =
+                BlockChainSpecific.Ethereum(
+                    maxFeePerGasWei = maxFeePerGasWei,
+                    priorityFeeWei = BigInteger.ONE,
+                    nonce = BigInteger.ZERO,
+                    gasLimit = BigInteger.valueOf(21_000),
+                )
+        )
 
     private fun coin(
         chain: Chain,


### PR DESCRIPTION
## Summary

Extracts the transaction-construction half of `SwapFormViewModel.swap()` into a dedicated, unit-testable `SwapTransactionBuilder`, as requested in #4723. This is the **low-risk half** of that issue; the `calculateFees()` reactive-pipeline extraction is tracked separately in #4735.

`swap()` carried ~405 lines of provider-specific `when(quote)` logic (ThorChain / MayaChain / SwapKit / 1inch) inside a `viewModelScope.launch`. That body now lives in `SwapTransactionBuilder.build(...)`, which takes the already-resolved inputs and returns a `RegularSwapTransaction`. The ViewModel keeps pre-flight validation/resolution, persistence (`addTransaction`), navigation, and error handling — `swap()` is now a thin delegator.

**`SwapFormViewModel.kt`: 1,447 → 1,185 lines.**

## Behaviour preserved (no functional change)
- SwapKit `isSignableTxType` pre-flight guard
- SwapKit allowance-target (`approveSpenderFor`) derivation
- `estimatedNetworkFeeTokenValue ?: gasFee` and `estimatedNetworkFeeFiatValue ?: gasFeeFiatValue` fee fallbacks (and OneInch's no-fallback `gasFeeFiatValue`)
- 1inch Mantle gas-limit override and Ethereum gas-price patching
- Identical validation messages and navigation

## Tests
- New `SwapTransactionBuilderTest` — one case per quote type (ThorChain / MayaChain / SwapKit / OneInch) asserting dst-address derivation, approval logic, fee fallbacks, and payload type, plus the SwapKit unsupported-`txType` guard.
- `SwapFormViewModelTest` updated for the new constructor (wires a real builder).
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.*"` ✅
- `./gradlew assembleDebug` ✅

## Notes
This was originally assigned to the repo agent on #4723, but its planning step stalled repeatedly on a decompose loop, so the change was implemented manually. No UI is touched, so no before/after screenshots apply.

Closes #4723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal swap transaction assembly delegated to a new, injected builder to simplify internals; end-to-end swap behavior unchanged for users.
* **Tests**
  * Expanded unit coverage for swap transaction assembly across providers and edge cases, including fee handling and routing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->