### PR TITLE
feat(defi): disable new Circle USDC deposits, keep withdrawals open

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModel.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.isDeFiSupported
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.mappers.ChainToDefiChainUiMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -64,14 +65,14 @@ constructor(
     }
 
     private fun loadChains() {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch {
             val vault = vaultRepository.get(vaultId)
 
             _uiState.update { it.copy(isLoading = true) }
 
             if (vault == null) {
                 _uiState.update { it.copy(defiChains = emptyList(), isLoading = false) }
-                return@launch
+                return@safeLaunch
             }
 
             // New Circle (USDC yield) deposits are disabled: only offer the Circle (Ethereum

--- a/app/src/main/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModel.kt
@@ -6,10 +6,12 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.DefiChainUiModel
 import com.vultisig.wallet.data.models.isDeFiSupported
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import com.vultisig.wallet.ui.models.mappers.ChainToDefiChainUiMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -42,6 +44,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val vaultRepository: VaultRepository,
     private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
+    private val hasCircleAccount: HasCircleAccountUseCase,
     private val mapChainDefi: ChainToDefiChainUiMapper,
     private val navigator: Navigator<Destination>,
 ) : ViewModel() {
@@ -71,8 +74,14 @@ constructor(
                 return@launch
             }
 
+            // New Circle (USDC yield) deposits are disabled: only offer the Circle (Ethereum
+            // DeFi) entry to vaults that already opened an account, so they can still withdraw.
+            val hasCircle = hasCircleAccount(vaultId)
             val availableChains =
-                vault.coins.map { it.chain }.distinct().filter { it.isDeFiSupported }
+                vault.coins
+                    .map { it.chain }
+                    .distinct()
+                    .filter { it.isDeFiSupported && (it != Chain.Ethereum || hasCircle) }
 
             val savedDeFiChains = defaultDeFiChainsRepository.getDefaultChains(vaultId).first()
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -35,6 +35,7 @@ import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import com.vultisig.wallet.data.usecases.IsGlobalBackupReminderRequiredUseCase
 import com.vultisig.wallet.data.usecases.NeverShowGlobalBackupReminderUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -62,6 +63,8 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -141,6 +144,7 @@ constructor(
     private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
     private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
     private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
+    private val hasCircleAccount: HasCircleAccountUseCase,
     private val tiersNFTRepository: TiersNFTRepository,
     private val remoteNFTService: TierRemoteNFTService,
     private val pushNotificationManager: PushNotificationManager,
@@ -491,7 +495,8 @@ constructor(
                             },
                         uiState.value.searchTextFieldState.textAsFlow(),
                         defaultDeFiChainsRepository.getDefaultChains(vaultId),
-                    ) { accounts, searchQuery, selectedDeFiChains ->
+                        flow { emit(hasCircleAccount(vaultId)) }.flowOn(ioDispatcher),
+                    ) { accounts, searchQuery, selectedDeFiChains, hasCircleAccount ->
                         Timber.d(
                             "DeFi Accounts Loaded for vault $vaultId: ${accounts.size} accounts, selected chains: ${selectedDeFiChains.map { it.raw }}"
                         )
@@ -499,8 +504,13 @@ constructor(
                         val filteredAccounts =
                             accounts.filter { address ->
                                 val isSelected = selectedDeFiChains.contains(address.chain)
+                                // New Circle (USDC yield) deposits are disabled: only surface the
+                                // Circle (Ethereum DeFi) row for vaults that already opened an
+                                // account, so they can still withdraw.
+                                val isCircleAllowed =
+                                    address.chain != Chain.Ethereum || hasCircleAccount
                                 Timber.d("Chain ${address.chain.raw} is selected: $isSelected")
-                                isSelected
+                                isSelected && isCircleAllowed
                             }
 
                         Timber.d("Filtered DeFi accounts: ${filteredAccounts.size} accounts")

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
@@ -69,8 +69,12 @@ internal data class SendStrategies(
 
             DeFiNavActions.WITHDRAW_USDC_CIRCLE -> withdrawUsdcCircle.submit()
 
+            // New Circle (USDC yield) deposits are disabled. The UI no longer exposes a deposit
+            // entry point; this no-op gates the submit path as defense-in-depth so a deposit can't
+            // be initiated even if that path is somehow reached.
+            DeFiNavActions.DEPOSIT_USDC_CIRCLE -> Unit
+
             null,
-            DeFiNavActions.DEPOSIT_USDC_CIRCLE,
             DeFiNavActions.STAKE_CACAO,
             DeFiNavActions.UNSTAKE_CACAO,
             DeFiNavActions.ADD_LP,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -544,6 +544,7 @@ internal fun HeaderDeFiWidget(
     totalPrice: String = "",
     isLoading: Boolean = false,
     isBalanceVisible: Boolean = true,
+    buttonState: VsButtonState = VsButtonState.Enabled,
 ) {
     Column(
         modifier =
@@ -611,7 +612,7 @@ internal fun HeaderDeFiWidget(
             label = buttonText,
             modifier = Modifier.fillMaxWidth(),
             onClick = onClickAction,
-            state = VsButtonState.Enabled,
+            state = buttonState,
         )
     }
 }
@@ -694,6 +695,7 @@ internal fun HeaderDeFiWidget(
     totalPrice: String = "",
     isLoading: Boolean = false,
     isBalanceVisible: Boolean = true,
+    isSecondActionEnabled: Boolean = true,
 ) {
     Column(
         modifier =
@@ -780,6 +782,7 @@ internal fun HeaderDeFiWidget(
                 contentColor = Theme.v2.colors.text.primary,
                 iconCircleColor = Color.White.copy(alpha = 0.12f),
                 modifier = Modifier.weight(1f),
+                enabled = isSecondActionEnabled,
                 onClick = onClickSecondAction,
             )
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.screens.v2.defi.BaseDeFiPositionsScreenContent
 import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.DeFiWarningBanner
@@ -118,6 +119,8 @@ private fun CircleContentDepositTab(
             totalPrice = state.totalDepositCurrency,
             isLoading = state.isLoading,
             isBalanceVisible = isBalanceVisible,
+            // New Circle deposits are disabled; existing positions can still be withdrawn.
+            isSecondActionEnabled = false,
         )
     } else {
         HeaderDeFiWidget(
@@ -134,6 +137,8 @@ private fun CircleContentDepositTab(
             totalPrice = state.totalDepositCurrency,
             isLoading = state.isLoading,
             isBalanceVisible = isBalanceVisible,
+            // New Circle deposits are disabled; this single CTA is deposit/open-account only.
+            buttonState = VsButtonState.Disabled,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
@@ -107,7 +107,9 @@ private fun CircleContentDepositTab(
         )
     }
 
-    if (state.hasActiveDeposit()) {
+    // Drive the actions off account ownership, not the parsed balance: an open account whose
+    // balance read fails or is unparseable must still expose Withdraw so a funded user can exit.
+    if (state.isAccountOpen) {
         HeaderDeFiWidget(
             title = stringResource(R.string.usdc_deposit_title),
             iconRes = R.drawable.usdc,
@@ -126,18 +128,13 @@ private fun CircleContentDepositTab(
         HeaderDeFiWidget(
             title = stringResource(R.string.usdc_deposit_title),
             iconRes = R.drawable.usdc,
-            buttonText =
-                if (state.isAccountOpen) {
-                    stringResource(R.string.deposit_usdc_button)
-                } else {
-                    stringResource(R.string.open_account_button)
-                },
+            buttonText = stringResource(R.string.open_account_button),
             onClickAction = onClickDepositOrCreateAccount,
             totalAmount = state.totalDeposit,
             totalPrice = state.totalDepositCurrency,
             isLoading = state.isLoading,
             isBalanceVisible = isBalanceVisible,
-            // New Circle deposits are disabled; this single CTA is deposit/open-account only.
+            // New Circle deposits are disabled, so opening a new account is also gated off.
             buttonState = VsButtonState.Disabled,
         )
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/DefiUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/DefiUiModel.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.ui.screens.v2.defi.model
 
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.models.defi.ThorchainDefiPositionsViewModel
-import java.math.BigDecimal
 
 data class DefiUiModel(
     // Global screen parameters
@@ -23,11 +22,5 @@ data class DefiUiModel(
         val closeWarning: Boolean = false,
         val totalDeposit: String = "0 USDC",
         val totalDepositCurrency: String = "$0",
-    ) {
-        fun hasActiveDeposit(): Boolean {
-            return totalDeposit.trim().split(" ").firstOrNull()?.toBigDecimalOrNull()?.let {
-                it > BigDecimal.ZERO
-            } ?: false
-        }
-    }
+    )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/DeFiChainSelectionViewModelTest.kt
@@ -1,0 +1,111 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
+import com.vultisig.wallet.ui.models.mappers.ChainToDefiChainUiMapperImpl
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DeFiChainSelectionViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var savedStateHandle: SavedStateHandle
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
+    private lateinit var hasCircleAccount: HasCircleAccountUseCase
+    private lateinit var navigator: Navigator<Destination>
+
+    private val vaultId = "vault-1"
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        savedStateHandle = mockk()
+        every { savedStateHandle.toRoute<Route.AddDeFiChainAccount>() } returns
+            Route.AddDeFiChainAccount(vaultId = vaultId)
+        vaultRepository = mockk()
+        defaultDeFiChainsRepository = mockk(relaxed = true)
+        hasCircleAccount = mockk()
+        navigator = mockk(relaxed = true)
+
+        // Vault holding Ethereum (Circle) and ThorChain, both DeFi-supported.
+        coEvery { vaultRepository.get(vaultId) } returns
+            Vault(
+                id = vaultId,
+                name = "Test",
+                coins = listOf(Coins.Ethereum.ETH, Coins.ThorChain.RUNE),
+            )
+        every { defaultDeFiChainsRepository.getDefaultChains(vaultId) } returns flowOf(emptySet())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() =
+        DeFiChainSelectionViewModel(
+            savedStateHandle = savedStateHandle,
+            vaultRepository = vaultRepository,
+            defaultDeFiChainsRepository = defaultDeFiChainsRepository,
+            hasCircleAccount = hasCircleAccount,
+            mapChainDefi = ChainToDefiChainUiMapperImpl(),
+            navigator = navigator,
+        )
+
+    @Test
+    fun `Circle entry is offered when the vault has a Circle account`() =
+        runTest(testDispatcher) {
+            coEvery { hasCircleAccount(vaultId) } returns true
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val chains = vm.uiState.value.defiChains.map { it.defiChain.chain }
+            assertTrue(chains.contains(Chain.Ethereum))
+            assertTrue(chains.contains(Chain.ThorChain))
+        }
+
+    @Test
+    fun `Circle entry is hidden when the vault has no Circle account`() =
+        runTest(testDispatcher) {
+            coEvery { hasCircleAccount(vaultId) } returns false
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val chains = vm.uiState.value.defiChains.map { it.defiChain.chain }
+            assertFalse(chains.contains(Chain.Ethereum))
+            assertTrue(chains.contains(Chain.ThorChain))
+        }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import com.vultisig.wallet.data.usecases.IsGlobalBackupReminderRequiredUseCase
 import com.vultisig.wallet.data.usecases.NeverShowGlobalBackupReminderUseCase
 import com.vultisig.wallet.ui.models.AccountUiModel
@@ -90,6 +91,7 @@ internal class VaultAccountsViewModelTest {
     private lateinit var getDiscountBpsUseCase: GetDiscountBpsUseCase
     private lateinit var cryptoConnectionTypeRepository: CryptoConnectionTypeRepository
     private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
+    private lateinit var hasCircleAccount: HasCircleAccountUseCase
     private lateinit var tiersNFTRepository: TiersNFTRepository
     private lateinit var remoteNFTService: TierRemoteNFTService
     private lateinit var pushNotificationManager: PushNotificationManager
@@ -117,6 +119,7 @@ internal class VaultAccountsViewModelTest {
         getDiscountBpsUseCase = mockk(relaxed = true)
         cryptoConnectionTypeRepository = mockk(relaxed = true)
         defaultDeFiChainsRepository = mockk(relaxed = true)
+        hasCircleAccount = mockk(relaxed = true)
         tiersNFTRepository = mockk(relaxed = true)
         remoteNFTService = mockk(relaxed = true)
         pushNotificationManager = mockk(relaxed = true)
@@ -158,6 +161,7 @@ internal class VaultAccountsViewModelTest {
             getDiscountBpsUseCase = getDiscountBpsUseCase,
             cryptoConnectionTypeRepository = cryptoConnectionTypeRepository,
             defaultDeFiChainsRepository = defaultDeFiChainsRepository,
+            hasCircleAccount = hasCircleAccount,
             tiersNFTRepository = tiersNFTRepository,
             remoteNFTService = remoteNFTService,
             pushNotificationManager = pushNotificationManager,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/SendStrategiesSubmitForTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/SendStrategiesSubmitForTest.kt
@@ -9,12 +9,14 @@ import org.junit.jupiter.params.provider.EnumSource
 
 /**
  * Pins the [SendStrategies.submitFor] routing: every [DeFiNavActions] entry (and `null`) must run
- * exactly one strategy's `submit()`, and only the expected one. The existing submit tests all run
- * with `defiType == null`, so a misrouted DeFi action would otherwise pass the suite silently.
+ * at most one strategy's `submit()`, and only the expected one. `DEPOSIT_USDC_CIRCLE` is a gated
+ * no-op (new Circle deposits are disabled) and runs none. The existing submit tests all run with
+ * `defiType == null`, so a misrouted DeFi action would otherwise pass the suite silently.
  */
 internal class SendStrategiesSubmitForTest {
 
     private enum class Target {
+        NONE,
         DEFAULT,
         BOND,
         UNBOND,
@@ -90,7 +92,8 @@ internal class SendStrategiesSubmitForTest {
                 DeFiNavActions.REDEEM_YTCY to Target.REDEEM,
                 DeFiNavActions.STAKE_STCY to Target.STAKE,
                 DeFiNavActions.UNSTAKE_STCY to Target.UNSTAKE,
-                DeFiNavActions.DEPOSIT_USDC_CIRCLE to Target.DEFAULT,
+                // New Circle deposits are disabled: the submit path is a no-op (no strategy runs).
+                DeFiNavActions.DEPOSIT_USDC_CIRCLE to Target.NONE,
                 DeFiNavActions.WITHDRAW_USDC_CIRCLE to Target.WITHDRAW_USDC_CIRCLE,
                 DeFiNavActions.STAKE_CACAO to Target.DEFAULT,
                 DeFiNavActions.UNSTAKE_CACAO to Target.DEFAULT,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -92,6 +92,10 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindHasCircleAccountUseCase(impl: HasCircleAccountUseCaseImpl): HasCircleAccountUseCase
+
+    @Binds
+    @Singleton
     fun bindSearchSolTokenUseCase(impl: SearchSolTokenUseCaseImpl): SearchSolTokenUseCase
 
     @Binds

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCase.kt
@@ -1,10 +1,6 @@
 package com.vultisig.wallet.data.usecases
 
-import com.vultisig.wallet.data.api.CircleApi
-import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
-import com.vultisig.wallet.data.repositories.VaultRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import timber.log.Timber
@@ -12,47 +8,25 @@ import timber.log.Timber
 /**
  * Resolves whether a vault already has a Circle (USDC yield) MSCA account.
  *
- * Checks the local cache first; if empty, discovers the account on-chain via [CircleApi] and caches
- * the result. Discovery keeps withdraw access working for existing accounts even on a fresh install
- * where the local cache is empty. New Circle deposits are disabled, so this is used to hide the
- * Circle entry for vaults that never opened an account.
+ * New Circle deposits are disabled, so this is used to hide the Circle entry for vaults that never
+ * opened an account. The account address is persisted locally (see [ScaCircleAccountRepository])
+ * when the account is created or first discovered on the Circle positions screen, so this read is
+ * cache-only and never hits the network.
  */
 interface HasCircleAccountUseCase : suspend (String) -> Boolean
 
 internal class HasCircleAccountUseCaseImpl
 @Inject
-constructor(
-    private val scaCircleAccountRepository: ScaCircleAccountRepository,
-    private val circleApi: CircleApi,
-    private val vaultRepository: VaultRepository,
-    private val chainAccountAddressRepository: ChainAccountAddressRepository,
-) : HasCircleAccountUseCase {
+constructor(private val scaCircleAccountRepository: ScaCircleAccountRepository) :
+    HasCircleAccountUseCase {
 
-    override suspend fun invoke(vaultId: String): Boolean {
-        if (scaCircleAccountRepository.getAccount(vaultId) != null) {
-            return true
-        }
-
-        return try {
-            val vault = vaultRepository.get(vaultId) ?: return false
-            val (evmAddress, _) = chainAccountAddressRepository.getAddress(Chain.Ethereum, vault)
-            val mscaAddress = circleApi.getScAccount(evmAddress)
-            if (mscaAddress != null) {
-                scaCircleAccountRepository.saveAccount(vaultId, mscaAddress)
-                true
-            } else {
-                false
-            }
+    override suspend fun invoke(vaultId: String): Boolean =
+        try {
+            scaCircleAccountRepository.getAccount(vaultId) != null
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            // A network blip must not wrongly hide an existing account; fall back to the cache.
-            Timber.e(
-                t,
-                "HasCircleAccountUseCase: failed to discover Circle account for %s",
-                vaultId,
-            )
+            Timber.e(t, "HasCircleAccountUseCase: failed to read Circle account for %s", vaultId)
             false
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCase.kt
@@ -1,0 +1,58 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CircleApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+/**
+ * Resolves whether a vault already has a Circle (USDC yield) MSCA account.
+ *
+ * Checks the local cache first; if empty, discovers the account on-chain via [CircleApi] and caches
+ * the result. Discovery keeps withdraw access working for existing accounts even on a fresh install
+ * where the local cache is empty. New Circle deposits are disabled, so this is used to hide the
+ * Circle entry for vaults that never opened an account.
+ */
+interface HasCircleAccountUseCase : suspend (String) -> Boolean
+
+internal class HasCircleAccountUseCaseImpl
+@Inject
+constructor(
+    private val scaCircleAccountRepository: ScaCircleAccountRepository,
+    private val circleApi: CircleApi,
+    private val vaultRepository: VaultRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+) : HasCircleAccountUseCase {
+
+    override suspend fun invoke(vaultId: String): Boolean {
+        if (scaCircleAccountRepository.getAccount(vaultId) != null) {
+            return true
+        }
+
+        return try {
+            val vault = vaultRepository.get(vaultId) ?: return false
+            val (evmAddress, _) = chainAccountAddressRepository.getAddress(Chain.Ethereum, vault)
+            val mscaAddress = circleApi.getScAccount(evmAddress)
+            if (mscaAddress != null) {
+                scaCircleAccountRepository.saveAccount(vaultId, mscaAddress)
+                true
+            } else {
+                false
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            // A network blip must not wrongly hide an existing account; fall back to the cache.
+            Timber.e(
+                t,
+                "HasCircleAccountUseCase: failed to discover Circle account for %s",
+                vaultId,
+            )
+            false
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCaseTest.kt
@@ -1,13 +1,7 @@
 package com.vultisig.wallet.data.usecases
 
-import com.vultisig.wallet.data.api.CircleApi
-import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
-import com.vultisig.wallet.data.repositories.VaultRepository
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -18,81 +12,34 @@ import org.junit.jupiter.api.Test
 internal class HasCircleAccountUseCaseTest {
 
     private lateinit var scaCircleAccountRepository: ScaCircleAccountRepository
-    private lateinit var circleApi: CircleApi
-    private lateinit var vaultRepository: VaultRepository
-    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var useCase: HasCircleAccountUseCaseImpl
 
     private val vaultId = "vault-1"
-    private val evmAddress = "0xVaultEvmAddress"
-    private val mscaAddress = "0xMscaAddress"
 
     @BeforeEach
     fun setUp() {
-        scaCircleAccountRepository = mockk(relaxed = true)
-        circleApi = mockk()
-        vaultRepository = mockk()
-        chainAccountAddressRepository = mockk()
-        useCase =
-            HasCircleAccountUseCaseImpl(
-                scaCircleAccountRepository,
-                circleApi,
-                vaultRepository,
-                chainAccountAddressRepository,
-            )
+        scaCircleAccountRepository = mockk()
+        useCase = HasCircleAccountUseCaseImpl(scaCircleAccountRepository)
     }
 
     @Test
-    fun `returns true from cache without hitting network`() = runTest {
-        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns mscaAddress
+    fun `returns true when a Circle account is cached`() = runTest {
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns "0xMscaAddress"
 
         assertTrue(useCase(vaultId))
-
-        coVerify(exactly = 0) { circleApi.getScAccount(any()) }
     }
 
     @Test
-    fun `discovers account on network, caches it, and returns true`() = runTest {
-        val vault = mockk<Vault>()
+    fun `returns false when no Circle account is cached`() = runTest {
         coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
-        coEvery { vaultRepository.get(vaultId) } returns vault
-        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
-            (evmAddress to "")
-        coEvery { circleApi.getScAccount(evmAddress) } returns mscaAddress
-
-        assertTrue(useCase(vaultId))
-
-        coVerify { scaCircleAccountRepository.saveAccount(vaultId, mscaAddress) }
-    }
-
-    @Test
-    fun `returns false when no cache and network finds no account`() = runTest {
-        val vault = mockk<Vault>()
-        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
-        coEvery { vaultRepository.get(vaultId) } returns vault
-        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
-            (evmAddress to "")
-        coEvery { circleApi.getScAccount(evmAddress) } returns null
 
         assertFalse(useCase(vaultId))
     }
 
     @Test
-    fun `returns false when network discovery throws`() = runTest {
-        val vault = mockk<Vault>()
-        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
-        coEvery { vaultRepository.get(vaultId) } returns vault
-        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
-            (evmAddress to "")
-        coEvery { circleApi.getScAccount(evmAddress) } throws RuntimeException("network down")
-
-        assertFalse(useCase(vaultId))
-    }
-
-    @Test
-    fun `returns false when vault not found`() = runTest {
-        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
-        coEvery { vaultRepository.get(vaultId) } returns null
+    fun `returns false when the cache read fails`() = runTest {
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } throws
+            RuntimeException("datastore error")
 
         assertFalse(useCase(vaultId))
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/HasCircleAccountUseCaseTest.kt
@@ -1,0 +1,99 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CircleApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class HasCircleAccountUseCaseTest {
+
+    private lateinit var scaCircleAccountRepository: ScaCircleAccountRepository
+    private lateinit var circleApi: CircleApi
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var useCase: HasCircleAccountUseCaseImpl
+
+    private val vaultId = "vault-1"
+    private val evmAddress = "0xVaultEvmAddress"
+    private val mscaAddress = "0xMscaAddress"
+
+    @BeforeEach
+    fun setUp() {
+        scaCircleAccountRepository = mockk(relaxed = true)
+        circleApi = mockk()
+        vaultRepository = mockk()
+        chainAccountAddressRepository = mockk()
+        useCase =
+            HasCircleAccountUseCaseImpl(
+                scaCircleAccountRepository,
+                circleApi,
+                vaultRepository,
+                chainAccountAddressRepository,
+            )
+    }
+
+    @Test
+    fun `returns true from cache without hitting network`() = runTest {
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns mscaAddress
+
+        assertTrue(useCase(vaultId))
+
+        coVerify(exactly = 0) { circleApi.getScAccount(any()) }
+    }
+
+    @Test
+    fun `discovers account on network, caches it, and returns true`() = runTest {
+        val vault = mockk<Vault>()
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
+        coEvery { vaultRepository.get(vaultId) } returns vault
+        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
+            (evmAddress to "")
+        coEvery { circleApi.getScAccount(evmAddress) } returns mscaAddress
+
+        assertTrue(useCase(vaultId))
+
+        coVerify { scaCircleAccountRepository.saveAccount(vaultId, mscaAddress) }
+    }
+
+    @Test
+    fun `returns false when no cache and network finds no account`() = runTest {
+        val vault = mockk<Vault>()
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
+        coEvery { vaultRepository.get(vaultId) } returns vault
+        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
+            (evmAddress to "")
+        coEvery { circleApi.getScAccount(evmAddress) } returns null
+
+        assertFalse(useCase(vaultId))
+    }
+
+    @Test
+    fun `returns false when network discovery throws`() = runTest {
+        val vault = mockk<Vault>()
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
+        coEvery { vaultRepository.get(vaultId) } returns vault
+        coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, vault) } returns
+            (evmAddress to "")
+        coEvery { circleApi.getScAccount(evmAddress) } throws RuntimeException("network down")
+
+        assertFalse(useCase(vaultId))
+    }
+
+    @Test
+    fun `returns false when vault not found`() = runTest {
+        coEvery { scaCircleAccountRepository.getAccount(vaultId) } returns null
+        coEvery { vaultRepository.get(vaultId) } returns null
+
+        assertFalse(useCase(vaultId))
+    }
+}


### PR DESCRIPTION
## Summary
Business decision (#4739): stop accepting **new deposits** into the Circle USDC yield product while keeping **withdrawals and existing positions** fully functional so users can always exit.

- **Detection**: new `HasCircleAccountUseCase` resolves whether a vault already has a Circle MSCA account — cache-first, then on-chain discovery via `circleApi.getScAccount` (caches the result). Discovery keeps withdraw access working even on a fresh install where the local cache is empty.
- **Hide Circle for vaults without an account**: the Circle (Ethereum DeFi) row is filtered out of the DeFi portfolio (`VaultAccountsViewModel`) and the DeFi chain-selection screen (`DeFiChainSelectionViewModel`).
- **Disable Deposit for vaults with an account**: the Deposit button on the Circle positions screen is greyed out / non-clickable; **Withdraw stays enabled**.
- **Defense-in-depth**: the deposit submit path (`DEPOSIT_USDC_CIRCLE`) is gated to a no-op in `SendStrategyFactory`, so a deposit can't be initiated even if the UI is bypassed. `WithdrawUsdcCircleStrategy` is left untouched.

Note: the "Circle" row is the Ethereum DeFi chain rebranded (`Chain.Ethereum.toDefi` -> `DefiChain(raw = "Circle")`), and Ethereum's only DeFi product is Circle — so the gating keys off `Chain.Ethereum` in DeFi mode.

## Issue
Closes #4739

## Test Plan
- [x] Unit test `HasCircleAccountUseCaseTest` (cache hit / network hit+cache / no account / network throws / vault missing) — passes
- [x] `:app:testDebugUnitTest --tests VaultAccountsViewModelTest` — passes
- [x] Lint passes (`./gradlew lint`)
- [x] Manual: vault **without** Circle account — Circle row absent from portfolio and chain-selection
- [ ] Manual: vault **with** Circle account + balance — Withdraw enabled, Deposit greyed/disabled
- [x] Manual: vault **with** Circle account + zero balance — single Deposit button greyed/disabled
- [ ] Manual: reaching Send with `DEPOSIT_USDC_CIRCLE` does not submit

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ethereum Circle (USDC yield) option is shown only for vaults with an existing Circle account.
  * CTA buttons now reflect account state (disabled when new Circle deposits are not available).

* **Bug Fixes**
  * Circle deposit submit path disabled to prevent initiating unavailable deposit flows.

* **Tests**
  * Added unit tests for Circle account presence, gating behavior, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->