### PR TITLE
fix(zcash): update consensus branch id to 0x30f33754

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -26,7 +26,7 @@ internal class SwapKitZcashSignerException(message: String) : Exception(message)
  *
  * Sighash: WalletCore's ZEC signer implements ZIP-243 (the Sapling signature digest with the
  * personalised Blake2b-256). It reads the branch id from the plan — the existing native ZEC send
- * uses [ZCASH_BRANCH_ID_HEX] `f04dec4d`, and we match that so the digest is identical to a manually
+ * uses [ZCASH_BRANCH_ID_HEX] `30f33754`, and we match that so the digest is identical to a manually
  * sent ZEC transaction. (Deviating to the Sapling-v4 spec id `0x76b809bb` would produce a different
  * digest the chain rejects.)
  *
@@ -445,6 +445,6 @@ internal class SwapKitZcashSigner(
          * personalised-Blake2b branch identifier; diverging to the Sapling-v4-spec `0x76b809bb`
          * would produce a digest the network rejects.
          */
-        private const val ZCASH_BRANCH_ID_HEX = "f04dec4d"
+        private const val ZCASH_BRANCH_ID_HEX = "30f33754"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSigner.kt
@@ -443,8 +443,9 @@ internal class SwapKitZcashSigner(
         /**
          * Branch id matching the existing native ZEC send. WalletCore reads it as the ZIP-243
          * personalised-Blake2b branch identifier; diverging to the Sapling-v4-spec `0x76b809bb`
-         * would produce a digest the network rejects.
+         * would produce a digest the network rejects. Sourced from [ZCASH_ZIP243_BRANCH_ID_HEX] so
+         * both signing paths stay locked together.
          */
-        private const val ZCASH_BRANCH_ID_HEX = "30f33754"
+        private const val ZCASH_BRANCH_ID_HEX = ZCASH_ZIP243_BRANCH_ID_HEX
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -218,7 +218,7 @@ class UtxoHelper(
 
         val plan =
             if (coinType == CoinType.ZCASH) {
-                initialPlan.toBuilder().setBranchId(ByteString.fromHex("f04dec4d")).build()
+                initialPlan.toBuilder().setBranchId(ByteString.fromHex("30f33754")).build()
             } else initialPlan
 
         signingInput.setPlan(plan)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -218,7 +218,10 @@ class UtxoHelper(
 
         val plan =
             if (coinType == CoinType.ZCASH) {
-                initialPlan.toBuilder().setBranchId(ByteString.fromHex("30f33754")).build()
+                initialPlan
+                    .toBuilder()
+                    .setBranchId(ByteString.fromHex(ZCASH_ZIP243_BRANCH_ID_HEX))
+                    .build()
             } else initialPlan
 
         signingInput.setPlan(plan)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConstants.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConstants.kt
@@ -1,0 +1,11 @@
+package com.vultisig.wallet.data.chains.helpers
+
+/**
+ * ZIP-243 consensus branch id WalletCore reads as the personalised-Blake2b sighash identifier for
+ * transparent ZEC spends. Single source of truth shared by the native send plan ([UtxoHelper]) and
+ * the SwapKit signer ([SwapKitZcashSigner]) so the two digest paths can never drift apart.
+ *
+ * Regenerate per Zcash network upgrade: take `getblockchaininfo` -> `consensus.nextblock`
+ * (currently NU6.2 `5437f330`) and reverse its four bytes to little endian -> `30f33754`.
+ */
+internal const val ZCASH_ZIP243_BRANCH_ID_HEX = "30f33754"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -219,6 +219,9 @@ class SwapKitZcashSignerTest {
             assertEquals(39_000L, input.plan.change)
             assertEquals(1_000L, input.plan.fee)
             // ZIP-243 branch id must be on the plan or WalletCore derives the wrong digest.
+            // Hardcoded on purpose (not the production constant): a golden value that fails loudly
+            // if the branch id is ever changed without a deliberate update here per network
+            // upgrade.
             assertEquals("30f33754", Numeric.toHexStringNoPrefix(input.plan.branchId.toByteArray()))
 
             assertEquals(1, input.utxoCount)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitZcashSignerTest.kt
@@ -219,7 +219,7 @@ class SwapKitZcashSignerTest {
             assertEquals(39_000L, input.plan.change)
             assertEquals(1_000L, input.plan.fee)
             // ZIP-243 branch id must be on the plan or WalletCore derives the wrong digest.
-            assertEquals("f04dec4d", Numeric.toHexStringNoPrefix(input.plan.branchId.toByteArray()))
+            assertEquals("30f33754", Numeric.toHexStringNoPrefix(input.plan.branchId.toByteArray()))
 
             assertEquals(1, input.utxoCount)
             val utxo = input.getUtxo(0)


### PR DESCRIPTION
## Summary
- Updates the Zcash ZIP-243 consensus branch id from `f04dec4d` to `30f33754` so the signature digest matches the active network consensus rules.
- Applies to both the native ZEC send plan (`UtxoHelper`) and the SwapKit ZEC signer (`SwapKitZcashSigner`).
- Updates the doc comments and the frozen-plan test assertion accordingly.

## Why
The branch id feeds WalletCore's ZIP-243 personalised-Blake2b sighash. It must equal the current consensus branch id or the network rejects the transaction.

## Test plan
- [ ] `./gradlew :data:test` — `SwapKitZcashSignerTest` passes with the new branch id
- [ ] Manual ZEC send signs and broadcasts successfully
- [ ] ZEC swap via SwapKit/NEAR Intents signs and broadcasts successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Zcash transaction signing to use the correct ZIP-243 branch identifier, ensuring proper Zcash transaction compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->