### PR TITLE
fix(zcash): enable ZIP-317 fee so multi-UTXO sends are accepted

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -97,6 +97,7 @@ class UtxoHelper(
             .setHashType(BitcoinScript.hashTypeForCoin(coinType))
             .setUseMaxAmount(utxo.sendMaxAmount)
             .setByteFee(utxo.byteFee.toLong())
+            .setZip0317(coinType == CoinType.ZCASH)
             .setFixedDustThreshold(coinType.getDustThreshold)
         for (item in keysignPayload.utxos) {
             val lockScript =
@@ -160,6 +161,7 @@ class UtxoHelper(
                 .setToAddress(keysignPayload.toAddress)
                 .setChangeAddress(keysignPayload.coin.address)
                 .setByteFee(utxo.byteFee.toLong())
+                .setZip0317(coinType == CoinType.ZCASH)
                 .setCoinType(coinType.value())
                 .setFixedDustThreshold(coinType.getDustThreshold)
         keysignPayload.memo?.let { input.setOutputOpReturn(ByteString.copyFromUtf8(it)) }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelperTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import vultisig.keysign.v1.BitcoinInput
 import vultisig.keysign.v1.BitcoinOutput
 import vultisig.keysign.v1.SignBitcoin
+import wallet.core.jni.Base58
 import wallet.core.jni.BitcoinScript
 import wallet.core.jni.CoinType
 import wallet.core.jni.PublicKey
@@ -78,6 +79,47 @@ class UtxoHelperTest {
             wasmExecuteContractPayload = null,
         )
 
+    private fun zcashPayload(
+        address: String,
+        utxoAmounts: List<Long>,
+        toAmount: BigInteger,
+    ): KeysignPayload =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Zcash,
+                    ticker = "ZEC",
+                    logo = "",
+                    address = address,
+                    decimal = 8,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = address,
+            toAmount = toAmount,
+            blockChainSpecific =
+                BlockChainSpecific.UTXO(
+                    byteFee = BigInteger.valueOf(1_000L),
+                    sendMaxAmount = false,
+                ),
+            utxos =
+                utxoAmounts.mapIndexed { i, amount ->
+                    UtxoInfo(
+                        hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda3$i$i",
+                        amount = amount,
+                        index = i.toUInt(),
+                    )
+                },
+            memo = null,
+            swapPayload = null,
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+        )
+
     // Dust threshold tests — pure Kotlin when-expression, no native calls required
 
     @Test
@@ -114,6 +156,48 @@ class UtxoHelperTest {
         try {
             val plan = helper.getBitcoinTransactionPlan(payload)
             assertTrue(plan.fee > 0L, "Expected positive fee, got ${plan.fee}")
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `getBitcoinTransactionPlan - Zcash applies ZIP-317 fee that scales with logical actions`() {
+        // ZIP-317 conventional fee = 5000 * max(2 grace actions, max(inputs, outputs)). WalletCore
+        // only computes this when zip_0317 is set on the signing input; without it the Zcash fee
+        // does not scale with input count, so multi-UTXO sends pay below the conventional fee and
+        // the node rejects them with "tx unpaid action limit exceeds limit of 0".
+        val helper = UtxoHelper(CoinType.ZCASH, "", "")
+
+        try {
+            // t1 transparent address (P2PKH, prefix 0x1CB8) built with a Base58Check checksum.
+            val zcashAddress =
+                Base58.encode(byteArrayOf(0x1C, 0xB8.toByte()) + ByteArray(20) { it.toByte() })
+
+            // Single input + recipient + change => 2 logical actions => grace floor => 5000 * 2.
+            val singleInputPlan =
+                helper.getBitcoinTransactionPlan(
+                    zcashPayload(
+                        address = zcashAddress,
+                        utxoAmounts = listOf(100_000L),
+                        toAmount = BigInteger.valueOf(50_000L),
+                    )
+                )
+            assertEquals(SigningError.OK, singleInputPlan.error)
+            assertEquals(10_000L, singleInputPlan.fee)
+
+            // Three inputs are required to fund the send => 3 logical actions => 5000 * 3.
+            val multiInputPlan =
+                helper.getBitcoinTransactionPlan(
+                    zcashPayload(
+                        address = zcashAddress,
+                        utxoAmounts = listOf(40_000L, 40_000L, 40_000L),
+                        toAmount = BigInteger.valueOf(100_000L),
+                    )
+                )
+            assertEquals(SigningError.OK, multiInputPlan.error)
+            assertEquals(3, multiInputPlan.utxosList.size)
+            assertEquals(15_000L, multiInputPlan.fee)
         } catch (e: Throwable) {
             skipIfJniUnavailable(e)
         }


### PR DESCRIPTION
## Summary
- Zcash sends that spend **3+ UTXOs** were rejected by the node with `66: tx unpaid action limit exceeds limit of 0` (ZIP-317).
- WalletCore ships a `Zip0317FeeCalculator` (`fee = 5000 × max(2 grace actions, max(inputs, outputs))`) but only uses it when `zip_0317` is set on the Bitcoin signing input — which the app never did.
- Without the flag, the Zcash fee did not scale with input count. A 1-input send is covered by the 2 grace actions, but as soon as a tx has 3+ logical actions it paid **below** the conventional fee → unpaid actions → rejected (the broadcast node uses `-txunpaidactionlimit=0`).
- Fix: set `zip_0317 = true` for Zcash in both signing-input builders (`getSigningInputData` + `getBitcoinSigningInput`) so WalletCore computes the correct ZIP-317 fee. The Verify screen reads the same plan, so the displayed fee stays consistent.

https://blockchair.com/zcash/transaction/014c076839cf3f86f4ae695f5afb2c763f2019e7933193df82e86a9c3db71ee1

## Root cause detail
`getFeeCalculator(TWCoinTypeZcash, …, zip0317)` in WalletCore returns `Zip0317FeeCalculator` only when `zip0317 == true`; otherwise it falls back to a calculator whose fee does not track logical actions. The `zip_0317` proto field (`Bitcoin.SigningInput` #18) exists in the bundled `wallet-core` 4.3.22 but was never set.

## Test Plan
- [x] Added regression test `getBitcoinTransactionPlan - Zcash applies ZIP-317 fee that scales with logical actions` (1 input → fee 10 000; 3 inputs → fee 15 000). JNI-gated like the existing plan tests.
- [x] `./gradlew :data:lint` passes
- [x] `./gradlew :data:compileDebugKotlin` + `:data:testDebugUnitTest` pass
- [ ] **Manual on-device verification recommended:** perform a real ZEC send spending 3+ UTXOs and confirm it broadcasts (the fee assertions can't execute in CI without the WalletCore native lib — the test skips gracefully there)

## Notes
- Shared `data`-layer fix; covers the native **send** path. Zcash **swaps** go through `SwapKitZcashSigner` (its own PSBT plan with a SwapKit-provided fee) and are unaffected.
- iOS has the same latent gap (`UTXOChainsHelper.swift` never sets `zip0317`) — worth a parity fix there.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zcash transaction fee calculation to properly implement ZIP-317 fee mechanism, which scales fees dynamically based on the number of logical transaction actions.

* **Tests**
  * Added comprehensive test coverage for Zcash ZIP-317 fee behavior, verifying correct fee calculation for single and multiple UTXO transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->