### PR TITLE
feat(swap): enable missing Swap aggregators on Optimism, Polygon & Arbitrum

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -65,6 +65,14 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             SwapProvider.KYBER,
             SwapProvider.SWAPKIT,
         )
+    private val mayaPlusEvmAggregators =
+        setOf(
+            SwapProvider.MAYA,
+            SwapProvider.ONEINCH,
+            SwapProvider.LIFI,
+            SwapProvider.KYBER,
+            SwapProvider.SWAPKIT,
+        )
 
     /** Providers that only quote same-chain swaps; filtered out for cross-chain pairs. */
     private val sameChainOnly = setOf(SwapProvider.ONEINCH, SwapProvider.KYBER)
@@ -117,9 +125,7 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
             Chain.Zcash -> setOf(SwapProvider.MAYA, SwapProvider.SWAPKIT)
 
             Chain.Arbitrum ->
-                if (ticker in mayaArbTokens)
-                    setOf(SwapProvider.LIFI, SwapProvider.MAYA, SwapProvider.SWAPKIT)
-                else setOf(SwapProvider.LIFI, SwapProvider.SWAPKIT)
+                if (ticker in mayaArbTokens) mayaPlusEvmAggregators else evmAggregators
 
             Chain.Blast,
             Chain.CronosChain -> setOf(SwapProvider.LIFI)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -93,7 +93,7 @@ internal class SwapProviderTableImpl @Inject constructor() : SwapProviderTable {
                 else setOf(SwapProvider.LIFI, SwapProvider.SWAPKIT)
 
             Chain.Optimism,
-            Chain.Polygon -> setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.SWAPKIT)
+            Chain.Polygon -> evmAggregators
 
             Chain.ZkSync -> setOf(SwapProvider.ONEINCH, SwapProvider.LIFI)
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -11,11 +11,9 @@ import org.junit.jupiter.api.Test
 
 /**
  * Pins the SWAPKIT slice of [SwapProviderTableImpl]'s eligibility matrix — the most fan-out-prone
- * part of the integration — plus the KyberSwap-on-Optimism/Polygon parity with iOS. A regression
- * that drops SWAPKIT from an EVM/Solana branch, that adds it to
- * [SwapProviderTableImpl.sameChainOnly] (which would silently kill cross-chain SwapKit quoting), or
- * that drops KyberSwap from Optimism or Polygon must fail CI rather than ship a quietly-degraded
- * provider list.
+ * part of the integration. A regression that drops SWAPKIT from an EVM/Solana branch, or that adds
+ * it to [SwapProviderTableImpl.sameChainOnly] (which would silently kill cross-chain SwapKit
+ * quoting), must fail CI rather than ship a quietly-degraded provider list.
  */
 internal class SwapProviderTableTest {
 
@@ -91,7 +89,6 @@ internal class SwapProviderTableTest {
 
     @Test
     fun `KyberSwap is offered alongside the EVM aggregators on Optimism and Polygon`() {
-        // Pins iOS parity: Optimism/Polygon route the full evmAggregators set, incl. KyberSwap.
         val expected =
             setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.KYBER, SwapProvider.SWAPKIT)
 
@@ -106,7 +103,6 @@ internal class SwapProviderTableTest {
 
     @Test
     fun `KyberSwap is dropped on a cross-chain Optimism to Polygon pair`() {
-        // Cross-chain drops the sameChainOnly aggregators (now incl. KYBER); LIFI/SWAPKIT stay.
         val eligible =
             table.eligibleProvidersFor(
                 srcToken = coin(Chain.Optimism, "ZZZ", isNative = false),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -4,15 +4,18 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.isSwapSupported
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
  * Pins the SWAPKIT slice of [SwapProviderTableImpl]'s eligibility matrix — the most fan-out-prone
- * part of the integration. A regression that drops SWAPKIT from an EVM/Solana branch, or that adds
- * it to [SwapProviderTableImpl.sameChainOnly] (which would silently kill cross-chain SwapKit
- * quoting), must fail CI rather than ship a quietly-degraded provider list.
+ * part of the integration — plus the KyberSwap-on-Optimism/Polygon parity with iOS. A regression
+ * that drops SWAPKIT from an EVM/Solana branch, that adds it to
+ * [SwapProviderTableImpl.sameChainOnly] (which would silently kill cross-chain SwapKit quoting), or
+ * that drops KyberSwap from Optimism or Polygon must fail CI rather than ship a quietly-degraded
+ * provider list.
  */
 internal class SwapProviderTableTest {
 
@@ -84,6 +87,36 @@ internal class SwapProviderTableTest {
                 "Did not expect SWAPKIT for ${c.chain}/${c.ticker} but got ${table.providersFor(c)}",
             )
         }
+    }
+
+    @Test
+    fun `KyberSwap is offered alongside the EVM aggregators on Optimism and Polygon`() {
+        // Pins iOS parity: Optimism/Polygon route the full evmAggregators set, incl. KyberSwap.
+        val expected =
+            setOf(SwapProvider.ONEINCH, SwapProvider.LIFI, SwapProvider.KYBER, SwapProvider.SWAPKIT)
+
+        listOf(Chain.Optimism, Chain.Polygon).forEach { chain ->
+            assertEquals(
+                expected,
+                table.providersFor(coin(chain, "ZZZ", isNative = false)),
+                "Expected the full evmAggregators set (incl. KYBER) on $chain",
+            )
+        }
+    }
+
+    @Test
+    fun `KyberSwap is dropped on a cross-chain Optimism to Polygon pair`() {
+        // Cross-chain drops the sameChainOnly aggregators (now incl. KYBER); LIFI/SWAPKIT stay.
+        val eligible =
+            table.eligibleProvidersFor(
+                srcToken = coin(Chain.Optimism, "ZZZ", isNative = false),
+                dstToken = coin(Chain.Polygon, "YYY", isNative = false),
+            )
+
+        assertTrue(SwapProvider.SWAPKIT in eligible, "SWAPKIT dropped on cross-chain: $eligible")
+        assertTrue(SwapProvider.LIFI in eligible, "LIFI dropped on cross-chain: $eligible")
+        assertFalse(SwapProvider.KYBER in eligible, "KYBER (sameChainOnly) leaked: $eligible")
+        assertFalse(SwapProvider.ONEINCH in eligible, "ONEINCH (sameChainOnly) leaked: $eligible")
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -116,6 +116,31 @@ internal class SwapProviderTableTest {
     }
 
     @Test
+    fun `Arbitrum offers 1inch and KyberSwap, keeping Maya for Maya-routable tokens`() {
+        assertEquals(
+            setOf(
+                SwapProvider.MAYA,
+                SwapProvider.ONEINCH,
+                SwapProvider.LIFI,
+                SwapProvider.KYBER,
+                SwapProvider.SWAPKIT,
+            ),
+            table.providersFor(coin(Chain.Arbitrum, "ARB", isNative = false)),
+            "Maya-routable Arbitrum token should keep MAYA and gain the EVM aggregators",
+        )
+        assertEquals(
+            setOf(
+                SwapProvider.ONEINCH,
+                SwapProvider.LIFI,
+                SwapProvider.KYBER,
+                SwapProvider.SWAPKIT,
+            ),
+            table.providersFor(coin(Chain.Arbitrum, "ZZZ", isNative = false)),
+            "Generic Arbitrum token should get the full evmAggregators set",
+        )
+    }
+
+    @Test
     fun `SwapKit-wired chains are marked swap-supported so the Swap action button shows`() {
         // ChainTokensViewModel.canSwap reads Chain.isSwapSupported to show the Swap button on the
         // account screen. A chain can offer SWAPKIT in the provider table yet stay invisible to the


### PR DESCRIPTION
Closes #4746

Aligns the Optimism, Polygon and Arbitrum swap provider sets with iOS, which offers EVM aggregators these chains were missing on Android. All providers are already wired chain-agnostically, so this is purely provider-table entries.

## Changes

- **Optimism / Polygon** now return the full `evmAggregators` set — adds **KyberSwap** alongside 1inch / LI.FI / SwapKit, matching iOS' `.optimism, .polygon`.
- **Arbitrum** now adds **1inch + KyberSwap** in both arms, via a new `mayaPlusEvmAggregators` set mirroring the existing `thorchainPlusEvmAggregators` — Maya-routable tokens keep Maya, the generic arm is `evmAggregators`, matching iOS' `.arbitrum`.
- Nothing else needed: 1inch maps `Chain.Arbitrum -> 42161` (`oneInchChainId`), Kyber builds its request from `chain.raw.lowercase()` (`optimism`/`polygon`/`arbitrum`), and `gasForChain` already covers all three.

## Signing

No new signing path. A Kyber- or 1inch-won EVM swap goes through the same single `OneInchSwap` keysign path that LI.FI / 1inch already use on these chains, so co-signing is unaffected — the provider is only a display label, never part of the signed payload.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*SwapProviderTableTest*"` — passing
- [x] New Optimism/Polygon and Arbitrum parity tests each fail on `main` without the change (regression guards)
- [x] `./gradlew :data:ktfmtCheckMain :data:ktfmtCheckTest`

## Notes

- No UI surface — quote-provider routing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * KyberSwap is now offered for same-chain Polygon swaps and provider eligibility on Polygon and Arbitrum has been expanded to include the full EVM aggregator set where appropriate.

* **Tests**
  * Added regression tests covering KyberSwap availability, same-chain vs cross-chain provider exclusions, and Arbitrum-specific token routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->