### PR TITLE
feat(swap): gate cross-chain SwapKit Success on /track settlement

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.KeysignVerify
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.FeatureFlagJson
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
 import com.vultisig.wallet.data.chains.helpers.THORChainSwaps
 import com.vultisig.wallet.data.common.md5
@@ -25,6 +26,7 @@ import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.SendTransactionHistoryData
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
@@ -34,6 +36,7 @@ import com.vultisig.wallet.data.models.UnknownTransactionHistoryData
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.getEcdsaSigningKey
 import com.vultisig.wallet.data.models.getEddsaSigningKey
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -86,6 +89,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -97,6 +101,12 @@ import vultisig.keysign.v1.CustomMessagePayload
 private const val DEFAULT_ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'/0/0"
 private const val MAX_EVM_RECEIPT_RETRIES = 5
 private const val EVM_RECEIPT_RETRY_DELAY_MS = 2_000L
+
+/**
+ * Foreground SwapKit `/track` poll budget on the done screen. After this the row is left in-flight
+ * and handed off to the background tx-history poller, mirroring iOS' 30-minute give-up window.
+ */
+private const val SWAPKIT_FOREGROUND_TIMEOUT_MS = 30 * 60 * 1000L
 
 /** UI state for an in-progress or completed keysign session. */
 internal sealed class KeysignState {
@@ -235,6 +245,7 @@ constructor(
     private val transactionHistoryRepository: TransactionHistoryRepository,
     private val balanceRepository: BalanceRepository,
     private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+    private val swapKitTrackingService: SwapKitTrackingService,
 ) : ViewModel() {
 
     /** Creates [KeysignViewModel] with runtime-provided assisted parameters. */
@@ -886,6 +897,18 @@ constructor(
     }
 
     private fun startForegroundPolling(txHash: String, chain: Chain) {
+        // A SwapKit-routed swap settles on its destination leg, which the source-chain status
+        // service can't see — gate Success on `/track` instead (parity with the tx-history poller
+        // in RefreshPendingTransactionsUseCase) so a cross-chain swap (e.g. ETH→SOL) doesn't flip
+        // to Success the instant its source-chain deposit confirms.
+        val isSwapKitSwap =
+            (transactionHistoryData as? SwapTransactionHistoryData)?.provider ==
+                SwapProvider.SWAPKIT.getSwapProviderId()
+        if (isSwapKitSwap && swapKitTrackingService.canTrack(chain)) {
+            startSwapKitForegroundPolling(txHash, chain)
+            return
+        }
+
         pollingTxStatusJob?.cancel()
 
         transactionStatusServiceManager.startPolling(txHash, chain)
@@ -923,6 +946,69 @@ constructor(
                         }
 
                         else -> Unit
+                    }
+                }
+            }
+    }
+
+    /**
+     * SwapKit settlement poll for the done screen — calls `/track` on the source [chain]'s
+     * broadcast hash and gates Success on the destination-leg status. Runs in [viewModelScope] (no
+     * foreground service): when the user leaves the screen the job is cancelled and the tx-history
+     * poller ([com.vultisig.wallet.data.usecases.RefreshPendingTransactionsUseCase]) takes over. On
+     * the timeout the row is left in-flight (handed off to that poller) rather than marked
+     * terminal.
+     */
+    private fun startSwapKitForegroundPolling(txHash: String, chain: Chain) {
+        pollingTxStatusJob?.cancel()
+        pollingTxStatusJob =
+            viewModelScope.launch {
+                currentState.value =
+                    KeysignState.KeysignFinished(transactionStatus = TransactionStatus.Pending)
+                val pollInterval =
+                    txStatusConfigurationProvider
+                        .getConfigurationForChain(chain)
+                        .pollIntervalSeconds
+                        .seconds
+                val startTime = System.currentTimeMillis()
+                while (isActive) {
+                    if (System.currentTimeMillis() - startTime >= SWAPKIT_FOREGROUND_TIMEOUT_MS) {
+                        // Hand off to the background tx-history poller; leave the row pending.
+                        currentState.value =
+                            KeysignState.KeysignFinished(
+                                transactionStatus = TransactionStatus.Pending
+                            )
+                        return@launch
+                    }
+
+                    val statusResult = swapKitTrackingService.checkSettlementStatus(txHash, chain)
+                    runCatching {
+                            transactionHistoryRepository.updateTransactionStatus(
+                                chain = chain.raw,
+                                txHash = txHash,
+                                result = statusResult,
+                            )
+                        }
+                        .onFailure {
+                            Timber.w(
+                                it,
+                                "Failed to update SwapKit tx history status for %s",
+                                txHash,
+                            )
+                        }
+                    currentState.value =
+                        KeysignState.KeysignFinished(
+                            transactionStatus = statusResult.toTransactionStatus()
+                        )
+                    when (statusResult) {
+                        TransactionResult.Confirmed,
+                        is TransactionResult.Failed,
+                        is TransactionResult.Refunded -> {
+                            tryUpdateEvmActualFee(txHash, chain)
+                            return@launch
+                        }
+
+                        else -> delay(pollInterval)
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToHistoryDataMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToHistoryDataMapper.kt
@@ -22,5 +22,6 @@ internal class SwapTransactionToHistoryDataMapperImpl @Inject constructor() :
             toTokenLogo = from.dst.token.logo,
             provider = from.provider,
             fiatValue = from.src.fiatValue,
+            swapId = from.swapId,
         )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -37,6 +37,16 @@ constructor(
                 is SwapPayload.SwapKit -> SwapProvider.SWAPKIT
             }
 
+        // SwapKit `/track` correlation key, threaded onto the tx-history row. EVM/Solana SwapKit
+        // routes carry it on the EVM payload; native routes (PSBT/TON/…) on the SwapKit payload.
+        val swapId: String? =
+            when (val payload = from.payload) {
+                is SwapPayload.EVM -> payload.data.swapId?.takeIf { it.isNotBlank() }
+                is SwapPayload.SwapKit -> payload.data.swapId.takeIf { it.isNotBlank() }
+                is SwapPayload.ThorChain,
+                is SwapPayload.MayaChain -> null
+            }
+
         val tokenValue =
             when (provider) {
                 SwapProvider.THORCHAIN,
@@ -92,6 +102,7 @@ constructor(
                 mapTokenValueToDecimalUiString(from.gasFees) + " ${from.gasFees.unit}",
             totalFee = fiatValueToStringMapper(quotesFeesFiat + from.gasFeeFiatValue, asFee = true),
             provider = provider.getSwapProviderId(),
+            swapId = swapId,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -770,6 +770,8 @@ constructor(
                     // keep it as the canonical id. The sub-provider drives the UI label below.
                     provider = SwapProvider.SWAPKIT.getSwapProviderId(),
                     subProvider = evmResult.subProvider,
+                    // Correlation key for `/track` settlement gating of this cross-chain swap.
+                    swapId = evmResult.swapId,
                 )
             }
         // Read the sub-provider off the returned quote (not a hoisted var): a cache HIT skips the

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -283,6 +283,7 @@ constructor(
                                 toAmountDecimal = dstTokenValue.decimal,
                                 quote = quoteData,
                                 provider = quote.provider,
+                                swapId = quote.swapId,
                             )
                         ),
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -49,6 +49,10 @@ internal data class SwapTransactionUiModel(
     val providerFeeFormatted: String = "",
     val hasConsentAllowance: Boolean = false,
     val provider: String = "",
+    // SwapKit `/v3/swap` swap id — correlation key persisted on the tx-history row so a cross-chain
+    // SwapKit swap's Success can be gated on the destination-leg `/track` settlement. Null for
+    // non-SwapKit providers and for SwapKit rows rebuilt on a cosigning peer without it.
+    val swapId: String? = null,
 )
 
 internal data class ValuedToken(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelBroadcastRecoveryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelBroadcastRecoveryTest.kt
@@ -122,6 +122,7 @@ internal class KeysignViewModelBroadcastRecoveryTest {
             transactionHistoryRepository = mockk(relaxed = true),
             balanceRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
+            swapKitTrackingService = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
@@ -102,6 +102,7 @@ internal class KeysignViewModelSaveTransactionHistoryTest {
             transactionHistoryRepository = transactionHistoryRepository,
             balanceRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
+            swapKitTrackingService = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
@@ -144,6 +144,7 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
             transactionHistoryRepository = mockk(relaxed = true),
             balanceRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            swapKitTrackingService = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitTrackResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitTrackResponseJson.kt
@@ -1,0 +1,39 @@
+package com.vultisig.wallet.data.api.models.quotes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request body for SwapKit `POST /track`. Keys off the on-chain broadcast [hash] plus the source
+ * [chainId] (decimal EIP-155 id for EVM, slug for non-EVM — see
+ * [com.vultisig.wallet.data.api.txstatus.SwapKitChainIdentifier]). `/track` does NOT key off the
+ * `swapId`. Mirrors iOS' `SwapKitTrackRequest`.
+ */
+@Serializable
+data class SwapKitTrackRequest(
+    @SerialName("hash") val hash: String,
+    @SerialName("chainId") val chainId: String,
+)
+
+/**
+ * Decodable model for SwapKit `POST /track`. Surfaces both the coarse [status] (7-value
+ * `TxnStatus`) and the fine-grained [trackingStatus] (14-value); the mapper prefers
+ * [trackingStatus] when present since it conveys destination-leg progress the coarse field
+ * collapses. Mirrors iOS' `SwapKitTrackingResponse`.
+ */
+@Serializable
+data class SwapKitTrackResponseJson(
+    @SerialName("chainId") val chainId: String? = null,
+    @SerialName("hash") val hash: String? = null,
+    @SerialName("block") val block: Long? = null,
+    @SerialName("type") val type: String? = null,
+    @SerialName("status") val status: String? = null,
+    @SerialName("trackingStatus") val trackingStatus: String? = null,
+    @SerialName("fromAsset") val fromAsset: String? = null,
+    @SerialName("fromAmount") val fromAmount: String? = null,
+    @SerialName("fromAddress") val fromAddress: String? = null,
+    @SerialName("toAsset") val toAsset: String? = null,
+    @SerialName("toAmount") val toAmount: String? = null,
+    @SerialName("toAddress") val toAddress: String? = null,
+    @SerialName("finalisedAt") val finalisedAt: Double? = null,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/SwapKitApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/SwapKitApi.kt
@@ -6,6 +6,8 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitQuoteResponseJson
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapRequest
 import com.vultisig.wallet.data.api.models.quotes.SwapKitSwapResponseJson
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackResponseJson
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.accept
@@ -36,6 +38,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * - [quote] — POST /v3/quote: candidate routes
  * - [swap] — POST /v3/swap: unsigned tx for the winning route
  * - [providers] — GET /providers: per-provider chain enablement (cached upstream, 24h TTL)
+ * - [track] — POST /track: destination-leg settlement status for a broadcast swap
  */
 interface SwapKitApi {
 
@@ -47,6 +50,13 @@ interface SwapKitApi {
 
     /** Returns the set of chains each sub-provider currently routes on. */
     suspend fun providers(): SwapKitProvidersResponseJson
+
+    /**
+     * Settlement status for a broadcast swap, keyed off the on-chain broadcast hash + source
+     * chainId. Used to gate cross-chain Success on the destination leg rather than the source-chain
+     * deposit. Lives off the bare proxy root (`/track`), not under `/v3` — same as `/providers`.
+     */
+    suspend fun track(request: SwapKitTrackRequest): SwapKitTrackResponseJson
 }
 
 /** Ktor-backed [SwapKitApi] hitting the Vultisig SwapKit proxy with a 30s per-request timeout. */
@@ -66,6 +76,15 @@ constructor(private val httpClient: HttpClient, private val json: Json) : SwapKi
     override suspend fun swap(request: SwapKitSwapRequest): SwapKitSwapResponseJson =
         execute(SWAP_URL) {
             httpClient.post(SWAP_URL) {
+                headers { accept(ContentType.Application.Json) }
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(request))
+            }
+        }
+
+    override suspend fun track(request: SwapKitTrackRequest): SwapKitTrackResponseJson =
+        execute(TRACK_URL) {
+            httpClient.post(TRACK_URL) {
                 headers { accept(ContentType.Application.Json) }
                 contentType(ContentType.Application.Json)
                 setBody(json.encodeToString(request))
@@ -163,6 +182,8 @@ constructor(private val httpClient: HttpClient, private val json: Json) : SwapKi
         private const val QUOTE_URL = "$BASE_URL/v3/quote"
         private const val SWAP_URL = "$BASE_URL/v3/swap"
         private const val PROVIDERS_URL = "$BASE_URL/providers"
+        // `/track` (like `/providers`) is unversioned — it sits off the bare proxy root, not /v3.
+        private const val TRACK_URL = "$BASE_URL/track"
         private const val REQUEST_TIMEOUT_MS = 30_000L
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitChainIdentifier.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitChainIdentifier.kt
@@ -1,0 +1,48 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.models.Chain
+
+/**
+ * Translates a Vultisig [Chain] to the chainId string SwapKit's `/track` endpoint expects — EVM
+ * chains use the decimal EIP-155 chainId, non-EVM chains use SwapKit's slug. Returns `null` for
+ * chains outside SwapKit's route catalogue: the caller's signal to skip `/track` gating and fall
+ * back to the source-chain status check rather than poll an unknown chainId forever. Ported from
+ * iOS' `SwapKitChainIdentifier`.
+ *
+ * Kept separate from the asset-prefix mapping in
+ * [com.vultisig.wallet.data.repositories.swap.SwapKitQuoteSource] (`ETH`/`ARB`/`BTC`): `/track`
+ * needs the numeric/slug chainId, which only overlaps for a couple of chains.
+ */
+internal object SwapKitChainIdentifier {
+    fun chainId(chain: Chain): String? =
+        when (chain) {
+            Chain.Ethereum -> "1"
+            Chain.Arbitrum -> "42161"
+            Chain.Avalanche -> "43114"
+            Chain.Base -> "8453"
+            Chain.BscChain -> "56"
+            Chain.Polygon -> "137"
+            Chain.Optimism -> "10"
+            Chain.Blast -> "81457"
+            Chain.ZkSync -> "324"
+            Chain.Tron -> "728126428"
+            Chain.Cardano -> "cardano"
+            Chain.Ton -> "ton"
+            Chain.Solana -> "solana"
+            Chain.Bitcoin -> "bitcoin"
+            Chain.BitcoinCash -> "bitcoincash"
+            Chain.Litecoin -> "litecoin"
+            Chain.Ripple -> "ripple"
+            Chain.GaiaChain -> "cosmoshub-4"
+            Chain.Dash -> "dash"
+            Chain.Zcash -> "zcash"
+            Chain.Sui -> "sui"
+            Chain.Dogecoin -> "dogecoin"
+            Chain.Kujira -> "kaiyo-1"
+            // THORChain/Maya are filtered out of SwapKit routes (Vultisig pays those affiliates
+            // directly), so a SwapKit swap is never sourced from them — but kept for iOS parity.
+            Chain.MayaChain -> "mayachain-mainnet-v1"
+            Chain.ThorChain -> "thorchain-1"
+            else -> null
+        }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingService.kt
@@ -1,0 +1,60 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackRequest
+import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
+
+/**
+ * Gates a SwapKit-routed swap's settlement on the destination-leg status reported by `POST /track`,
+ * the same way [ThorMayaChainStatusProvider] gates THORChain/Maya swaps on Midgard. A cross-chain
+ * SwapKit swap (e.g. ETH→SOL via Chainflip/NEAR) only reaches [TransactionResult.Confirmed] once
+ * the destination asset has actually settled — not when the source-chain deposit confirms (which is
+ * all the chain-routed [TransactionStatusProvider] for the source chain can see).
+ *
+ * Ported from iOS' `SwapKitTrackingService`, collapsed onto Android's existing poll-by-status
+ * model: the per-swap poller lifecycle + ScenePhase handling iOS owns is already provided here by
+ * [com.vultisig.wallet.data.usecases.RefreshPendingTransactionsUseCase] (tx history, with its own
+ * exponential backoff) and by the keysign foreground poll (done screen).
+ */
+interface SwapKitTrackingService {
+
+    /**
+     * Whether [chain] is in SwapKit's `/track` catalogue. `false` means the caller should leave the
+     * row on the existing source-chain status path rather than poll an unknown chainId.
+     */
+    fun canTrack(chain: Chain): Boolean
+
+    /**
+     * One-shot `/track` settlement check for [broadcastHash] on the source [chain]. Transient
+     * network / decode errors return [TransactionResult.Pending] so the caller keeps polling
+     * (mirrors [ThorMayaChainStatusProvider]). A chain SwapKit can't track also returns
+     * [TransactionResult.Pending], leaving the row in-flight rather than flipping it terminal.
+     */
+    suspend fun checkSettlementStatus(broadcastHash: String, chain: Chain): TransactionResult
+}
+
+internal class SwapKitTrackingServiceImpl @Inject constructor(private val api: SwapKitApi) :
+    SwapKitTrackingService {
+
+    override fun canTrack(chain: Chain): Boolean = SwapKitChainIdentifier.chainId(chain) != null
+
+    override suspend fun checkSettlementStatus(
+        broadcastHash: String,
+        chain: Chain,
+    ): TransactionResult {
+        val chainId = SwapKitChainIdentifier.chainId(chain) ?: return TransactionResult.Pending
+        return try {
+            val response = api.track(SwapKitTrackRequest(hash = broadcastHash, chainId = chainId))
+            SwapKitTrackingStatusMapper.map(response)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "SwapKit /track check failed for %s on %s", broadcastHash, chain.raw)
+            TransactionResult.Pending
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingStatusMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingStatusMapper.kt
@@ -1,0 +1,67 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackResponseJson
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import java.util.Locale
+
+/**
+ * Pure mapping from SwapKit's `/track` status fields to the app's [TransactionResult]. Ported from
+ * iOS' `SwapKitTrackingStatusMapper`, collapsed onto Android's status model — which has no distinct
+ * "swapping" state, so an in-flight destination leg is [TransactionResult.Pending] until it
+ * settles.
+ *
+ * The fine-grained `trackingStatus` (14-value) wins over the coarse `status` (7-value) when both
+ * are present: `outbound`/`swapping` mean the destination leg is still moving, which the coarse
+ * field would otherwise round up. Unrecognised values fall through to [TransactionResult.Pending]
+ * so a future SwapKit-side enum value keeps the row in-flight instead of flipping it terminal.
+ *
+ * Full `trackingStatus` → result table (see the SwapKit tx-history plan §"State mapping"):
+ * ```
+ *   not_started, starting, broadcasted, mempool, inbound, outbound, swapping, unknown → Pending
+ *   completed                                                                         → Confirmed
+ *   refunded, partially_refunded                                                      → Refunded
+ *   dropped, reverted, replaced, retries_exceeded, parsing_error, failed              → Failed
+ * ```
+ */
+internal object SwapKitTrackingStatusMapper {
+
+    fun map(response: SwapKitTrackResponseJson): TransactionResult {
+        response.trackingStatus
+            ?.takeIf { it.isNotBlank() }
+            ?.let {
+                return mapTrackingStatus(it)
+            }
+        return mapCoarseStatus(response.status)
+    }
+
+    private fun mapTrackingStatus(raw: String): TransactionResult =
+        when (val status = raw.lowercase(Locale.ROOT)) {
+            "not_started",
+            "starting",
+            "broadcasted",
+            "mempool",
+            "inbound",
+            "outbound",
+            "swapping",
+            "unknown" -> TransactionResult.Pending
+            "completed" -> TransactionResult.Confirmed
+            "refunded",
+            "partially_refunded" -> TransactionResult.Refunded("SwapKit refunded: $status")
+            "dropped",
+            "reverted",
+            "replaced",
+            "retries_exceeded",
+            "parsing_error",
+            "failed" -> TransactionResult.Failed("SwapKit failed: $status")
+            else -> TransactionResult.Pending
+        }
+
+    private fun mapCoarseStatus(status: String?): TransactionResult =
+        when (status?.lowercase(Locale.ROOT)) {
+            "completed" -> TransactionResult.Confirmed
+            "refunded" -> TransactionResult.Refunded("SwapKit refunded")
+            "failed" -> TransactionResult.Failed("SwapKit failed")
+            // not_started / pending / swapping / unknown / null → destination leg still settling.
+            else -> TransactionResult.Pending
+        }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/EVMSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/EVMSwapPayloadJson.kt
@@ -11,4 +11,8 @@ data class EVMSwapPayloadJson(
     val toAmountDecimal: BigDecimal,
     val quote: EVMSwapQuoteJson,
     val provider: String,
+    // SwapKit `/v3/swap` swap id for EVM/Solana routes — persisted on the tx-history row so a
+    // cross-chain swap's Success is gated on the destination-leg `/track` settlement. Null for
+    // direct EVM aggregators (1inch / Kyber / LiFi), which settle on the source chain.
+    val swapId: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -57,6 +57,15 @@ data class SwapTransactionHistoryData(
     val toTokenLogo: String,
     val provider: String,
     val fiatValue: String,
+    /**
+     * SwapKit `/v3/swap` swap id, persisted as the `/track` correlation key so a cross-chain
+     * SwapKit swap's Success is gated on the destination-leg settlement rather than the
+     * source-chain deposit (see
+     * [com.vultisig.wallet.data.usecases.RefreshPendingTransactionsUseCase]). Null for non-SwapKit
+     * providers and for legacy rows recorded before this field existed (serialized as JSON into the
+     * `payload` column, so a default keeps old rows readable — no Room migration).
+     */
+    val swapId: String? = null,
 ) : TransactionHistoryData
 
 internal fun TransactionHistoryData.toEntity(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -21,6 +21,9 @@ sealed class SwapQuote {
         // not a transient local var — so the "via <sub-provider>" label survives a quote cache hit
         // instead of collapsing back to the generic "SwapKit". Null for 1inch / Kyber / LiFi.
         val subProvider: String? = null,
+        // SwapKit `/v3/swap` swap id, carried onto the persisted swap so its tx-history Success can
+        // be gated on the destination-leg `/track` settlement. Null for 1inch / Kyber / LiFi.
+        val swapId: String? = null,
     ) : SwapQuote()
 
     data class ThorChain(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -1,6 +1,9 @@
 package com.vultisig.wallet.data.repositories
 
+import com.vultisig.wallet.data.api.txstatus.SwapKitChainIdentifier
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import javax.inject.Inject
 
@@ -31,8 +34,17 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
         return "${chain.blockExplorerUrl}$address"
     }
 
-    override fun getSwapProgressLink(tx: String, payload: SwapPayload?): String? =
-        when (payload) {
+    override fun getSwapProgressLink(tx: String, payload: SwapPayload?): String? {
+        // SwapKit-routed cross-chain swaps settle on a destination leg the source-chain explorer
+        // can't show. Point "Track" at SwapKit's own tracker (both legs) when the source chain is
+        // in SwapKit's route catalogue; otherwise fall through to the source-chain link below.
+        if (payload != null && payload.isSwapKitRouted()) {
+            val chainId = SwapKitChainIdentifier.chainId(payload.srcToken.chain)
+            if (chainId != null) {
+                return "https://track.swapkit.dev/?hash=$tx&chainId=$chainId"
+            }
+        }
+        return when (payload) {
             is SwapPayload.ThorChain -> "https://runescan.io/tx/${tx.removePrefix("0x")}"
             is SwapPayload.MayaChain ->
                 "https://www.explorer.mayachain.info/tx/${tx.removePrefix("0x")}"
@@ -50,6 +62,16 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
             }
 
             else -> null
+        }
+    }
+
+    // EVM/Solana SwapKit routes ride [SwapPayload.EVM] tagged `provider = "SwapKit"`; BTC/TON/ADA/
+    // TRON/SUI/ZEC routes use [SwapPayload.SwapKit], which is SwapKit by construction.
+    private fun SwapPayload.isSwapKitRouted(): Boolean =
+        when (this) {
+            is SwapPayload.SwapKit -> true
+            is SwapPayload.EVM -> data.provider == SwapProvider.SWAPKIT.getSwapProviderId()
+            else -> false
         }
 
     private val Chain.transactionExplorerUrl: String

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -151,10 +151,11 @@ constructor(
                     destinationAddress = request.dstAddress.ifBlank { request.dstToken.address },
                 )
             )
-        // TODO(swapkit /track polling, later task): persist swapResponse.swapId on the resulting
-        //  SwapTransaction so /track lookups can correlate cross-chain settlement back to this
-        //  specific quote. The DTO already carries it; the persistence wiring lands with the
-        //  tx-history Phase D work.
+        // SwapKit `/v3/swap` swap id, carried onto the resulting transaction (EVM/Solana ride the
+        // EVMSwapQuoteJson envelope, which has no slot for it, so it's threaded out-of-band on
+        // SwapQuoteResult.Evm). Persisted on the tx-history row so a cross-chain swap's Success is
+        // gated on the destination-leg `/track` settlement rather than the source-chain deposit.
+        val swapId = swapResponse.swapId?.takeIf { it.isNotBlank() }
 
         // Sub-provider tag (Chainflip / NEAR Intents / Garden / Flashnet) — surfaced on the verify
         // screen so the user can reason about ETA and debug routing. Prefer
@@ -181,6 +182,7 @@ constructor(
                             best.fees,
                         ),
                     subProvider = subProvider,
+                    swapId = swapId,
                 )
             TxKind.PSBT,
             TxKind.TRON,
@@ -457,7 +459,7 @@ constructor(
                 targetAddress = targetAddress,
                 memo = memo,
                 subProvider = subProvider.orEmpty(),
-                swapId = response.swapId.orEmpty(),
+                swapId = response.swapId?.takeIf { it.isNotBlank() }.orEmpty(),
             )
         return SwapQuote.SwapKit(
             expectedDstValue =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -33,9 +33,15 @@ sealed class SwapQuoteResult {
 
     /**
      * EVM-shaped envelope. [subProvider] disambiguates SwapKit's downstream protocol (Chainflip /
-     * NEAR / Garden); `null` for direct aggregators (1inch, Kyber, LiFi, Jupiter).
+     * NEAR / Garden); `null` for direct aggregators (1inch, Kyber, LiFi, Jupiter). [swapId] is the
+     * SwapKit `/v3/swap` swap id, carried through so the resulting transaction can be gated on the
+     * destination-leg `/track` settlement; `null` for direct aggregators.
      */
-    data class Evm(val data: EVMSwapQuoteJson, val subProvider: String? = null) : SwapQuoteResult()
+    data class Evm(
+        val data: EVMSwapQuoteJson,
+        val subProvider: String? = null,
+        val swapId: String? = null,
+    ) : SwapQuoteResult()
 
     // A future SwapKit non-EVM route (BTC / TON / ADA / TRON / SUI / ZEC) rides Native, since
     // SwapQuote.SwapKit is itself a SwapQuote — no dedicated result variant is needed.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
@@ -1,8 +1,12 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapTransactionHistoryData
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusRepository
@@ -28,6 +32,7 @@ class RefreshPendingTransactionsUseCaseImpl
 constructor(
     private val transactionHistoryRepository: TransactionHistoryRepository,
     private val transactionStatusRepository: TransactionStatusRepository,
+    private val swapKitTrackingService: SwapKitTrackingService,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : RefreshPendingTransactionsUseCase {
 
@@ -54,7 +59,7 @@ constructor(
                 }
 
         try {
-            val result = transactionStatusRepository.checkTransactionStatus(tx.txHash, chain)
+            val result = checkStatus(tx, chain)
             transactionHistoryRepository.updateTransactionStatus(tx.chain, tx.txHash, result)
         } catch (e: CancellationException) {
             throw e
@@ -63,6 +68,25 @@ constructor(
             runSafeCatching {
                 transactionHistoryRepository.incrementRetryCount(tx.chain, tx.txHash)
             }
+        }
+    }
+
+    /**
+     * Resolve the settlement status for [tx]. A SwapKit-routed swap on a `/track`-capable source
+     * chain is gated on the destination-leg settlement (`/track`) — the same way THORChain/Maya
+     * swaps are gated through `ThorMayaChainStatusProvider` — so a cross-chain swap (e.g. ETH→SOL)
+     * isn't marked Success the instant its source-chain deposit confirms. Every other transaction
+     * (sends, same-chain non-SwapKit swaps, SwapKit on a chain `/track` can't address) keeps the
+     * existing source-chain-by-tx-hash check unchanged.
+     */
+    private suspend fun checkStatus(tx: TransactionHistoryEntity, chain: Chain): TransactionResult {
+        val isSwapKitSwap =
+            (tx.payload as? SwapTransactionHistoryData)?.provider ==
+                SwapProvider.SWAPKIT.getSwapProviderId()
+        return if (isSwapKitSwap && swapKitTrackingService.canTrack(chain)) {
+            swapKitTrackingService.checkSettlementStatus(tx.txHash, chain)
+        } else {
+            transactionStatusRepository.checkTransactionStatus(tx.txHash, chain)
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/TxStatusModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/TxStatusModule.kt
@@ -8,6 +8,8 @@ import com.vultisig.wallet.data.api.txstatus.PolkadotStatusProvider
 import com.vultisig.wallet.data.api.txstatus.RippleStatusProvider
 import com.vultisig.wallet.data.api.txstatus.SolanaStatusProvider
 import com.vultisig.wallet.data.api.txstatus.SuiStatusProvider
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingServiceImpl
 import com.vultisig.wallet.data.api.txstatus.ThorMayaChainStatusProvider
 import com.vultisig.wallet.data.api.txstatus.TonStatusProvider
 import com.vultisig.wallet.data.api.txstatus.TronStatusProvider
@@ -98,6 +100,10 @@ internal interface TxStatusModule {
     @Binds
     @Singleton
     fun bindPollingTxStatusUseCase(impl: PollingTxStatusUseCaseImpl): PollingTxStatusUseCase
+
+    @Binds
+    @Singleton
+    fun bindSwapKitTrackingService(impl: SwapKitTrackingServiceImpl): SwapKitTrackingService
 }
 
 @Qualifier @Retention(AnnotationRetention.BINARY) annotation class EvmTxStatus

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingServiceTest.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackRequest
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackResponseJson
+import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the SwapKit settlement gate:
+ * - [SwapKitTrackingService.canTrack] follows the chain catalogue (EVM/Solana yes, Polkadot no).
+ * - `/track` is queried with the broadcast hash + the source chain's `/track` chainId.
+ * - the response maps through [SwapKitTrackingStatusMapper].
+ * - a transient `/track` failure (or an untrackable chain) returns Pending so polling keeps running
+ *   rather than flipping the row terminal.
+ */
+class SwapKitTrackingServiceTest {
+
+    private val api: SwapKitApi = mockk()
+
+    private fun service(): SwapKitTrackingService = SwapKitTrackingServiceImpl(api)
+
+    @Test
+    fun `canTrack reflects the chain catalogue`() {
+        with(service()) {
+            canTrack(Chain.Ethereum) shouldBe true
+            canTrack(Chain.Solana) shouldBe true
+            canTrack(Chain.Polkadot) shouldBe false
+        }
+    }
+
+    @Test
+    fun `checkSettlementStatus queries track with broadcast hash and source chainId`() = runTest {
+        val request = slot<SwapKitTrackRequest>()
+        coEvery { api.track(capture(request)) } returns
+            SwapKitTrackResponseJson(trackingStatus = "completed")
+
+        val result = service().checkSettlementStatus("0xbroadcast", Chain.Ethereum)
+
+        result shouldBe TransactionResult.Confirmed
+        request.captured.hash shouldBe "0xbroadcast"
+        request.captured.chainId shouldBe "1"
+    }
+
+    @Test
+    fun `checkSettlementStatus maps an in-flight destination leg to Pending`() = runTest {
+        coEvery { api.track(any()) } returns
+            SwapKitTrackResponseJson(status = "completed", trackingStatus = "outbound")
+
+        service().checkSettlementStatus("0xbroadcast", Chain.Ethereum) shouldBe
+            TransactionResult.Pending
+    }
+
+    @Test
+    fun `transient track failure returns Pending to keep polling`() = runTest {
+        coEvery { api.track(any()) } throws RuntimeException("boom")
+
+        service().checkSettlementStatus("0xbroadcast", Chain.Ethereum) shouldBe
+            TransactionResult.Pending
+    }
+
+    @Test
+    fun `untrackable chain returns Pending without hitting the API`() = runTest {
+        service().checkSettlementStatus("0xbroadcast", Chain.Polkadot) shouldBe
+            TransactionResult.Pending
+    }
+
+    @Test
+    fun `refund maps to Refunded`() = runTest {
+        coEvery { api.track(any()) } returns SwapKitTrackResponseJson(trackingStatus = "refunded")
+
+        service()
+            .checkSettlementStatus("0xbroadcast", Chain.Ethereum)
+            .shouldBeInstanceOf<TransactionResult.Refunded>()
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingStatusMapperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingStatusMapperTest.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackResponseJson
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the SwapKit `/track` status mapping (ported from iOS' SwapKitTrackingStatusMapper, collapsed
+ * onto Android's [TransactionResult] model):
+ * - in-flight `trackingStatus` (inbound / outbound / swapping / unknown / …) → Pending
+ * - `completed` → Confirmed
+ * - `refunded` / `partially_refunded` → Refunded
+ * - terminal failures (dropped / reverted / replaced / retries_exceeded / parsing_error / failed) →
+ *   Failed
+ * - fine-grained `trackingStatus` wins over the coarse `status` when both are present
+ * - unrecognised / missing values fall through to Pending so the row stays pollable
+ */
+class SwapKitTrackingStatusMapperTest {
+
+    private fun response(
+        status: String? = null,
+        trackingStatus: String? = null,
+    ): SwapKitTrackResponseJson =
+        SwapKitTrackResponseJson(status = status, trackingStatus = trackingStatus)
+
+    @Test
+    fun `in-flight tracking statuses map to Pending`() {
+        listOf(
+                "not_started",
+                "starting",
+                "broadcasted",
+                "mempool",
+                "inbound",
+                "outbound",
+                "swapping",
+                "unknown",
+            )
+            .forEach { raw ->
+                SwapKitTrackingStatusMapper.map(response(trackingStatus = raw)) shouldBe
+                    TransactionResult.Pending
+            }
+    }
+
+    @Test
+    fun `completed maps to Confirmed`() {
+        SwapKitTrackingStatusMapper.map(response(trackingStatus = "completed")) shouldBe
+            TransactionResult.Confirmed
+    }
+
+    @Test
+    fun `refund statuses map to Refunded`() {
+        listOf("refunded", "partially_refunded").forEach { raw ->
+            SwapKitTrackingStatusMapper.map(response(trackingStatus = raw))
+                .shouldBeInstanceOf<TransactionResult.Refunded>()
+        }
+    }
+
+    @Test
+    fun `terminal failures map to Failed`() {
+        listOf("dropped", "reverted", "replaced", "retries_exceeded", "parsing_error", "failed")
+            .forEach { raw ->
+                SwapKitTrackingStatusMapper.map(response(trackingStatus = raw))
+                    .shouldBeInstanceOf<TransactionResult.Failed>()
+            }
+    }
+
+    @Test
+    fun `casing is ignored`() {
+        SwapKitTrackingStatusMapper.map(response(trackingStatus = "COMPLETED")) shouldBe
+            TransactionResult.Confirmed
+    }
+
+    @Test
+    fun `fine-grained trackingStatus wins over coarse status`() {
+        // Coarse says completed, but the destination leg is still outbound → Pending.
+        SwapKitTrackingStatusMapper.map(
+            response(status = "completed", trackingStatus = "outbound")
+        ) shouldBe TransactionResult.Pending
+    }
+
+    @Test
+    fun `falls back to coarse status when trackingStatus is absent or blank`() {
+        SwapKitTrackingStatusMapper.map(response(status = "completed")) shouldBe
+            TransactionResult.Confirmed
+        SwapKitTrackingStatusMapper.map(
+            response(status = "completed", trackingStatus = "")
+        ) shouldBe TransactionResult.Confirmed
+        SwapKitTrackingStatusMapper.map(response(status = "failed"))
+            .shouldBeInstanceOf<TransactionResult.Failed>()
+    }
+
+    @Test
+    fun `unrecognised and empty values stay Pending`() {
+        SwapKitTrackingStatusMapper.map(response(trackingStatus = "some_future_status")) shouldBe
+            TransactionResult.Pending
+        SwapKitTrackingStatusMapper.map(response()) shouldBe TransactionResult.Pending
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepositoryImplTest.kt
@@ -1,6 +1,17 @@
 package com.vultisig.wallet.data.repositories
 
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.getSwapProviderId
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -65,6 +76,51 @@ class ExplorerLinkRepositoryImplTest {
     }
 
     @Test
+    fun `SwapKit native route Track link points to SwapKit tracker with slug chainId`() {
+        val hash = "abc123bitcoinhash"
+        val link = repository.getSwapProgressLink(hash, swapKitNativePayload(Chain.Bitcoin))
+        assertEquals("https://track.swapkit.dev/?hash=$hash&chainId=bitcoin", link)
+    }
+
+    @Test
+    fun `SwapKit-routed EVM Track link uses decimal chainId and keeps 0x hash`() {
+        val hash = "0x0ae1d2cacbc01f3f1326e8affaddc8dc9718e8cd3e9ca2770f9cbeae5635f90b"
+        val link =
+            repository.getSwapProgressLink(
+                hash,
+                evmPayload(Chain.Ethereum, SwapProvider.SWAPKIT.getSwapProviderId()),
+            )
+        assertEquals("https://track.swapkit.dev/?hash=$hash&chainId=1", link)
+    }
+
+    @Test
+    fun `non-SwapKit EVM route Track link is unchanged`() {
+        val hash = "0xdeadbeef"
+        val link =
+            repository.getSwapProgressLink(
+                hash,
+                evmPayload(Chain.Ethereum, SwapProvider.LIFI.getSwapProviderId()),
+            )
+        assertEquals("https://scan.li.fi/tx/$hash", link)
+    }
+
+    @Test
+    fun `SwapKit-routed EVM on untrackable source chain falls back to source-chain path`() {
+        // Hyperliquid is EVM-shaped but outside SwapKit's /track catalogue, so the SwapKit branch
+        // is skipped and the existing EVM source-chain logic applies (empty swapFee -> null).
+        val link =
+            repository.getSwapProgressLink(
+                "0xabc",
+                evmPayload(
+                    Chain.Hyperliquid,
+                    SwapProvider.SWAPKIT.getSwapProviderId(),
+                    swapFee = "",
+                ),
+            )
+        assertEquals(null, link)
+    }
+
+    @Test
     fun `all chains produce address links without throwing`() {
         for (chain in Chain.entries) {
             val link = repository.getAddressLink(chain, "test_address")
@@ -73,4 +129,44 @@ class ExplorerLinkRepositoryImplTest {
             }
         }
     }
+
+    private fun coin(chain: Chain) = Coin.EMPTY.copy(chain = chain)
+
+    private fun swapKitNativePayload(srcChain: Chain) =
+        SwapPayload.SwapKit(
+            SwapKitSwapPayloadJson(
+                fromCoin = coin(srcChain),
+                toCoin = coin(Chain.Ethereum),
+                fromAmount = BigInteger.ONE,
+                toAmountDecimal = BigDecimal.ONE,
+                txType = SwapKitSwapPayloadJson.TX_TYPE_PSBT,
+                txPayload = ByteArray(0),
+                targetAddress = "addr",
+            )
+        )
+
+    private fun evmPayload(srcChain: Chain, provider: String, swapFee: String = "0") =
+        SwapPayload.EVM(
+            EVMSwapPayloadJson(
+                fromCoin = coin(srcChain),
+                toCoin = coin(Chain.Solana),
+                fromAmount = BigInteger.ONE,
+                toAmountDecimal = BigDecimal.ONE,
+                quote =
+                    EVMSwapQuoteJson(
+                        dstAmount = "1",
+                        tx =
+                            OneInchSwapTxJson(
+                                from = "from",
+                                to = "to",
+                                gas = 0,
+                                data = "0x",
+                                value = "0",
+                                gasPrice = "0",
+                                swapFee = swapFee,
+                            ),
+                    ),
+                provider = provider,
+            )
+        )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCaseSwapKitGateTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCaseSwapKitGateTest.kt
@@ -1,0 +1,164 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
+import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
+import com.vultisig.wallet.data.db.models.TransactionStatus
+import com.vultisig.wallet.data.db.models.TransactionType
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SendTransactionHistoryData
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapTransactionHistoryData
+import com.vultisig.wallet.data.models.TransactionHistoryData
+import com.vultisig.wallet.data.models.getSwapProviderId
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the SwapKit settlement gate in [RefreshPendingTransactionsUseCase] (the Android analogue of
+ * iOS' TransactionStatusPollerSwapKitGateTests):
+ * - a SwapKit-routed swap on a `/track`-capable chain is gated on `/track` (destination leg), not
+ *   the source-chain status check — so a cross-chain swap isn't marked Success on source confirm.
+ * - a non-SwapKit transaction keeps the existing source-chain status path.
+ * - a SwapKit swap on a chain `/track` can't address falls back to the source-chain path rather
+ *   than poll an unknown chainId.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RefreshPendingTransactionsUseCaseSwapKitGateTest {
+
+    private val historyRepository: TransactionHistoryRepository = mockk(relaxed = true)
+    private val statusRepository: TransactionStatusRepository = mockk()
+    private val trackingService: SwapKitTrackingService = mockk()
+
+    private fun useCase(): RefreshPendingTransactionsUseCase =
+        RefreshPendingTransactionsUseCaseImpl(
+            transactionHistoryRepository = historyRepository,
+            transactionStatusRepository = statusRepository,
+            swapKitTrackingService = trackingService,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    @Test
+    fun `SwapKit swap on a trackable chain is gated on track`() = runTest {
+        val tx = entity(chain = Chain.Ethereum, payload = swapPayload(SWAPKIT))
+        coEvery { historyRepository.getPendingTransactions(VAULT) } returns listOf(tx)
+        coEvery { trackingService.canTrack(Chain.Ethereum) } returns true
+        coEvery { trackingService.checkSettlementStatus(tx.txHash, Chain.Ethereum) } returns
+            TransactionResult.Pending
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().invoke(VAULT)
+
+        coVerify(exactly = 1) { trackingService.checkSettlementStatus(tx.txHash, Chain.Ethereum) }
+        coVerify(exactly = 0) { statusRepository.checkTransactionStatus(any(), any()) }
+    }
+
+    @Test
+    fun `non-SwapKit transaction keeps the source-chain status path`() = runTest {
+        val tx =
+            entity(
+                chain = Chain.Ethereum,
+                payload =
+                    SendTransactionHistoryData(
+                        fromAddress = "",
+                        toAddress = "",
+                        amount = "",
+                        token = "",
+                        tokenLogo = "",
+                        feeEstimate = "",
+                        memo = "",
+                        fiatValue = "",
+                    ),
+                type = TransactionType.SEND,
+            )
+        coEvery { historyRepository.getPendingTransactions(VAULT) } returns listOf(tx)
+        coEvery { statusRepository.checkTransactionStatus(tx.txHash, Chain.Ethereum) } returns
+            TransactionResult.Confirmed
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().invoke(VAULT)
+
+        coVerify(exactly = 1) { statusRepository.checkTransactionStatus(tx.txHash, Chain.Ethereum) }
+        coVerify(exactly = 0) { trackingService.checkSettlementStatus(any(), any()) }
+    }
+
+    @Test
+    fun `non-SwapKit EVM-aggregator swap keeps the source-chain status path`() = runTest {
+        val tx = entity(chain = Chain.Ethereum, payload = swapPayload("1inch"))
+        coEvery { historyRepository.getPendingTransactions(VAULT) } returns listOf(tx)
+        coEvery { statusRepository.checkTransactionStatus(tx.txHash, Chain.Ethereum) } returns
+            TransactionResult.Confirmed
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().invoke(VAULT)
+
+        coVerify(exactly = 1) { statusRepository.checkTransactionStatus(tx.txHash, Chain.Ethereum) }
+        coVerify(exactly = 0) { trackingService.checkSettlementStatus(any(), any()) }
+    }
+
+    @Test
+    fun `SwapKit swap on an untrackable chain falls back to the source-chain path`() = runTest {
+        val tx = entity(chain = Chain.Polkadot, payload = swapPayload(SWAPKIT))
+        coEvery { historyRepository.getPendingTransactions(VAULT) } returns listOf(tx)
+        coEvery { trackingService.canTrack(Chain.Polkadot) } returns false
+        coEvery { statusRepository.checkTransactionStatus(tx.txHash, Chain.Polkadot) } returns
+            TransactionResult.Confirmed
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().invoke(VAULT)
+
+        coVerify(exactly = 1) { statusRepository.checkTransactionStatus(tx.txHash, Chain.Polkadot) }
+        coVerify(exactly = 0) { trackingService.checkSettlementStatus(any(), any()) }
+    }
+
+    private fun swapPayload(provider: String): SwapTransactionHistoryData =
+        SwapTransactionHistoryData(
+            fromToken = "ETH",
+            fromAmount = "1",
+            fromChain = "Ethereum",
+            fromTokenLogo = "",
+            toToken = "SOL",
+            toAmount = "10",
+            toChain = "Solana",
+            toTokenLogo = "",
+            provider = provider,
+            fiatValue = "100",
+            swapId = "swap-123",
+        )
+
+    private fun entity(
+        chain: Chain,
+        payload: TransactionHistoryData,
+        type: TransactionType = TransactionType.SWAP,
+    ): TransactionHistoryEntity =
+        TransactionHistoryEntity(
+            id = "${chain.raw}:0xhash",
+            vaultId = VAULT,
+            type = type,
+            status = TransactionStatus.BROADCASTED,
+            chain = chain.raw,
+            timestamp = 0L,
+            txHash = "0xhash",
+            explorerUrl = "",
+            payload = payload,
+            confirmedAt = null,
+            failureReason = null,
+            lastCheckedAt = null,
+            retryCount = 0,
+            broadcastBlockNumber = null,
+        )
+
+    private companion object {
+        const val VAULT = "vault-id"
+        val SWAPKIT: String = SwapProvider.SWAPKIT.getSwapProviderId()
+    }
+}


### PR DESCRIPTION
Closes #4662.

## Problem
A cross-chain SwapKit swap (EVM↔Solana, e.g. ETH→SOL via Chainflip / NEAR) flipped to **Success** in transaction history as soon as the **source-chain** deposit confirmed, even though the destination leg may still be settling or could refund upstream. Both pollers route by `chain.standard`, so the source-chain status provider only ever sees the source leg. (THORChain/Maya swaps avoid this because their *source chain* is Thor/Maya, so `ThorMayaChainStatusProvider` already gates on Midgard.)

## Solution
Gate SwapKit-routed swaps on the destination-leg settlement reported by SwapKit's `POST /track`, mirroring the THORChain/Maya gating pattern. A swap only reaches **Success** once `/track` reports the destination asset has settled (or a refund/failure is observed).

Ported from iOS (`SwapKitTrackingService`, `SwapKitTrackingStatusMapper`, `SwapKitTrackingResponse`), collapsed onto Android's existing poll-by-status model — the per-swap poller lifecycle iOS owns is already provided here by `RefreshPendingTransactionsUseCase` (background, with backoff) and the keysign foreground poll.

### Changes
- **New** `SwapKitApi.track` + `SwapKitTrackResponseJson`; `SwapKitChainIdentifier` (Chain → `/track` chainId — decimal for EVM, slug for non-EVM); `SwapKitTrackingStatusMapper` (14-value `trackingStatus` → `TransactionResult`, preferring it over the coarse 7-value `status`); `SwapKitTrackingService` (`canTrack` + `checkSettlementStatus`; a transient error or untrackable chain → `Pending` so polling keeps running).
- **Gating** at both poll sites: `RefreshPendingTransactionsUseCase` (transaction history) and the keysign done-screen foreground poll. A row is identified as SwapKit by `provider == "SwapKit"` (survives the keysign proto round-trip on both devices). Non-SwapKit and same-chain rows keep the existing source-chain status path **unchanged**.
- **swapId persistence** (replaces the TODO at `SwapKitQuoteSource`): the `/v3/swap` `swapId` is threaded quote → `EVMSwapPayloadJson` / `SwapKitSwapPayloadJson` → `SwapTransactionHistoryData` as the correlation key. It's stored in the JSON `payload` column (kotlinx, `ignoreUnknownKeys`), so **no Room migration** is needed — legacy rows default to null.

`/track` keys off the **broadcast hash + source chainId**, not the `swapId`, so `swapId` is persisted as a best-effort correlation key while the gate itself routes on `provider` + a trackable chain.

## Tests
- `SwapKitTrackingStatusMapperTest`, `SwapKitTrackingServiceTest`, `RefreshPendingTransactionsUseCaseSwapKitGateTest` (Android analogue of iOS' poller-gate test).
- Existing `SwapKitQuoteSourceTest` / `SwapTransactionBuilderTest` / `KeysignViewModel*Test` updated and green.

## Test plan
- [x] `./gradlew assembleDebug`
- [x] `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` (affected suites) + ktfmt
- [ ] On-device E2E: a real ETH→SOL SwapKit swap stays pending in history until `/track` reports `completed`

## Notes
- The commondata `oneinch` swap proto is a do-not-edit submodule, so EVM `swapId` does not survive the keysign proto round-trip — a cosigning device's EVM row gets `swapId = null`. The gate uses `provider`, so settlement gating still works there; native SwapKit (`swap_id = 11`) already round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time settlement tracking for SwapKit-routed cross-chain swaps with foreground polling and timeout handoff to background checks.
  * Explorer/share links now point to the SwapKit tracker for supported routed swaps.
  * Persisted swap correlation IDs to improve tracking/correlation and finalize fee reconciliation when swaps reach a terminal state.

* **Tests**
  * Added comprehensive unit tests for tracking behavior, status mapping, and explorer link routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->