### PR TITLE
feat(swap): banded provider preference (1% band) on top of best-output selection

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -377,8 +377,38 @@ constructor(
         // for THOR/MAYA (their expectedAmountOut is already net of protocol fees)
         // and mix apples-to-oranges since swapFeeFiat is gas for 1inch/Kyber but
         // an integrator fee for LI.FI.
-        return successes.maxBy { it.result.estimatedDstFiat.value }
+        //
+        // On top of that metric a banded provider-preference layer applies: among
+        // quotes within PROVIDER_PREFERENCE_BAND (1%) of the best output, the
+        // highest-priority provider wins instead of the raw maximum. This keeps
+        // near-tie routes on the more trusted/integrated provider without ever
+        // trading away a materially better rate (anything outside the band loses
+        // on output). iOS is the cross-platform anchor for this rule; the canonical
+        // spec lives in vultisig-sdk and other platforms mirror this implementation.
+        val best = successes.maxBy { it.result.estimatedDstFiat.value }
+        val floor = best.result.estimatedDstFiat.value * (BigDecimal.ONE - PROVIDER_PREFERENCE_BAND)
+        val inBand = successes.filter { it.result.estimatedDstFiat.value >= floor }
+        return inBand.minWithOrNull(
+            compareBy<BestQuote> { providerPriority(it.candidate.provider) }
+                .thenByDescending { it.result.estimatedDstFiat.value }
+        ) ?: best
     }
+
+    /**
+     * Provider preference order for the banded selection. Lower index = preferred. THORChain is
+     * most preferred, then MayaChain, SwapKit, KyberSwap, 1inch, LI.FI; Jupiter (Solana-only,
+     * rarely competing in the same candidate set) ranks last.
+     */
+    private fun providerPriority(provider: SwapProvider): Int =
+        when (provider) {
+            SwapProvider.THORCHAIN -> 0
+            SwapProvider.MAYA -> 1
+            SwapProvider.SWAPKIT -> 2
+            SwapProvider.KYBER -> 3
+            SwapProvider.ONEINCH -> 4
+            SwapProvider.LIFI -> 5
+            SwapProvider.JUPITER -> 6
+        }
 
     /**
      * Ranks a failed-quote [error] so the most actionable failure is surfaced when every provider
@@ -991,6 +1021,12 @@ constructor(
          * Matches the firm quote's UI formatter cap so the indicative value never out-renders it.
          */
         private const val MAX_INDICATIVE_DECIMALS = 8
+        /**
+         * Width of the priority band, as a fraction of the best output. Quotes whose output lands
+         * within this band of the best are treated as effectively tied on rate, so the
+         * higher-priority provider is preferred over a marginally larger raw output. 1%.
+         */
+        private val PROVIDER_PREFERENCE_BAND = BigDecimal("0.01")
     }
 }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -296,6 +296,111 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchBestQuote prefers higher-priority provider on a near-tie within the 1pct band`() =
+        runTest {
+            // THORChain (priority 0) prices the dst slightly lower than SwapKit (priority 2), but
+            // within the 1% band (99.5 vs 100, floor = 99). Both are in-band, so the banded layer
+            // tilts to the higher-priority THORChain instead of the marginally larger raw output.
+            val best = rankTwoProviders(thorFiat = "99.5", swapKitFiat = "100")
+
+            assertEquals(SwapProvider.THORCHAIN, best.candidate.provider)
+            assertEquals(BigDecimal("99.5"), best.result.estimatedDstFiat.value)
+        }
+
+    @Test
+    fun `fetchBestQuote keeps the materially-better quote when it is outside the 1pct band`() =
+        runTest {
+            // THORChain prices 2% below SwapKit (98 vs 100, floor = 99). THORChain falls outside
+            // the
+            // band, so the priority preference does not apply and the better-rate SwapKit wins.
+            val best = rankTwoProviders(thorFiat = "98", swapKitFiat = "100")
+
+            assertEquals(SwapProvider.SWAPKIT, best.candidate.provider)
+            assertEquals(BigDecimal("100"), best.result.estimatedDstFiat.value)
+        }
+
+    /**
+     * Runs [SwapQuoteManager.fetchBestQuote] over a THORChain + SwapKit candidate pair on a
+     * BTC->ETH pair, where each provider's dst is converted to [thorFiat] / [swapKitFiat]
+     * respectively. The raw dst token amounts are arbitrary; ranking is driven purely by the mocked
+     * fiat values.
+     */
+    private suspend fun rankTwoProviders(thorFiat: String, swapKitFiat: String): BestQuote {
+        val btc = coin(Chain.Bitcoin, "BTC", address = "bc1qsrc", decimals = 8)
+        val eth = coin(Chain.Ethereum, "ETH", address = "0xdst", decimals = 18)
+
+        val thorDst = TokenValue(BigInteger.valueOf(100), eth)
+        val swapKitDst = TokenValue(BigInteger.valueOf(200), eth)
+
+        val thorQuote =
+            SwapQuote.ThorChain(
+                expectedDstValue = thorDst,
+                fees = TokenValue(BigInteger.ZERO, eth),
+                expiredAt = Clock.System.now().plus(5.minutes),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
+                data =
+                    THORChainSwapQuote(
+                        dustThreshold = null,
+                        expectedAmountOut = "100",
+                        expiry = BigInteger.ZERO,
+                        fees = Fees(affiliate = "0", asset = "0", outbound = "0", total = "0"),
+                        inboundAddress = "thorinbound",
+                        inboundConfirmationBlocks = null,
+                        inboundConfirmationSeconds = null,
+                        maxStreamingQuantity = 0,
+                        memo = "memo",
+                        notes = "",
+                        outboundDelayBlocks = BigInteger.ZERO,
+                        outboundDelaySeconds = BigInteger.ZERO,
+                        recommendedMinAmountIn = "0",
+                        streamingSwapBlocks = BigInteger.ZERO,
+                        totalSwapSeconds = 0L,
+                        warning = "",
+                        router = null,
+                        error = null,
+                    ),
+            )
+        val swapKitQuote =
+            SwapQuote.SwapKit(
+                expectedDstValue = swapKitDst,
+                fees = TokenValue(BigInteger.valueOf(400), btc),
+                expiredAt = Clock.System.now().plus(5.minutes),
+                data = mockk(relaxed = true),
+                subProvider = null,
+            )
+
+        coEvery { tokenRepository.getNativeToken(any()) } returns btc
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        coEvery { convertTokenValueToFiat(any(), thorDst, any()) } returns
+            FiatValue(BigDecimal(thorFiat), "USD")
+        coEvery { convertTokenValueToFiat(any(), swapKitDst, any()) } returns
+            FiatValue(BigDecimal(swapKitFiat), "USD")
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns
+            SwapQuoteResult.Native(thorQuote)
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) } returns
+            SwapQuoteResult.Native(swapKitQuote)
+
+        return createManager()
+            .fetchBestQuote(
+                candidates =
+                    listOf(
+                        QuoteCandidate(SwapProvider.THORCHAIN, null, null),
+                        QuoteCandidate(SwapProvider.SWAPKIT, null, null),
+                    ),
+                src = mockk(relaxed = true),
+                dst = mockk(relaxed = true),
+                srcToken = btc,
+                dstToken = eth,
+                srcTokenValue = BigInteger.ONE,
+                tokenValue = TokenValue(BigInteger.ONE, btc),
+                currency = AppCurrency.USD,
+                amount = BigDecimal.ONE,
+            )
+    }
+
+    @Test
     fun `computeIndicativeQuote derives dst from cached spot prices`() = runTest {
         val src = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
         val dst = coin(Chain.Bitcoin, "BTC", "btc", 8)


### PR DESCRIPTION
## What

Adds a banded provider-preference layer on top of `SwapQuoteManager.fetchBestQuote`. Previously selection was a pure max-by-output (`successes.maxBy { it.result.estimatedDstFiat.value }`). Now:

1. `best` = max `estimatedDstFiat.value` (unchanged metric).
2. **1% band:** `floor = best × (1 − 0.01)`. Among quotes with output `>= floor`, the **highest-priority** provider wins. Tie-break within the same priority by higher output.
3. Falls back to `best` if nothing is in band.

### Priority order (lower = preferred)

| Provider | Priority |
|---|---|
| THORCHAIN | 0 |
| MAYA | 1 |
| SWAPKIT | 2 |
| KYBER | 3 |
| ONEINCH | 4 |
| LIFI | 5 |
| JUPITER | 6 |

Keyed off the `SwapProvider` enum. Jupiter (Solana-only, rarely in the same candidate set) ranks last; iOS has no Jupiter case so this slot is Android-specific.

### The metric is unchanged

The ranking metric is still `estimatedDstFiat` — the destination amount the user receives. The band only resolves **near-ties**: anything outside 1% of the best still loses on rate, so a materially better quote always wins.

`PROVIDER_PREFERENCE_BAND` is a `BigDecimal("0.01")` and the floor math stays in `BigDecimal` (no `Double`), mirroring iOS's `Decimal` arithmetic.

iOS is the cross-platform **anchor** for this rule. Canonical spec: vultisig/vultisig-sdk#605. Mirrors merged iOS PR vultisig/vultisig-ios#4467.

## Tests

`SwapQuoteManagerTest` — two new cases plus a shared `rankTwoProviders` helper:
- Near-tie within the band → higher-priority THORChain wins despite slightly lower output (99.5 vs 100).
- Just outside the band → materially-better SwapKit wins on rate (98 vs 100); priority does not override.

The existing `fetchBestQuote picks the highest estimatedDstFiat` test stays green and unmodified. Full suite passes.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapQuoteManagerTest"` — BUILD SUCCESSFUL
- [ ] Manual swap on a near-tie pair confirms the higher-priority provider is selected

Closes #4685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced swap quote selection to intelligently balance price competitiveness with provider reliability, ensuring optimal results within a 1% price tolerance band.

* **Tests**
  * Added test coverage for improved quote selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->