### PR TITLE
fix(defi): left-align icon, center label in DeFi action buttons

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -112,6 +112,7 @@ import com.vultisig.wallet.ui.screens.transaction.TransactionHistoryEmptyState
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfo
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfoType
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
+import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
@@ -203,6 +204,7 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_claim_error" -> QbtcClaimErrorPreview()
                     "qbtc_claim_blocked" -> QbtcClaimBlockedPreview()
                     "keysign_signing_lunc" -> KeysignSigningLuncPreview()
+                    "circle_usdc_widget" -> CircleUsdcWidgetPreview()
                     "btc_detail_claim" -> BtcDetailClaimPreview()
                     "qbtc_detail_claim" -> QbtcDetailClaimPreview()
                     "keysign_devices_plus_before" -> KeysignDevicesCountPreview(allowsMore = true)
@@ -262,6 +264,25 @@ private fun KeysignDevicesCountPreview(allowsMore: Boolean) {
         onDismissQrHelpModal = {},
         showHelp = false,
     )
+}
+
+@Composable
+private fun CircleUsdcWidgetPreview() {
+    Box(
+        modifier =
+            Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary).padding(16.dp)
+    ) {
+        HeaderDeFiWidget(
+            title = "USDC deposited",
+            iconRes = R.drawable.usdc,
+            buttonFirstActionText = "Withdraw",
+            buttonSecondActionText = "Deposit",
+            onClickFirstAction = {},
+            onClickSecondAction = {},
+            totalAmount = "1500 USDC",
+            totalPrice = "$1,500.34",
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -286,30 +286,39 @@ fun ActionButton(
                 }
             },
         shape = RoundedCornerShape(50),
-        contentPadding = PaddingValues(start = 4.dp, top = 6.dp, end = 16.dp, bottom = 6.dp),
+        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 6.dp),
         modifier = modifier.height(42.dp).actionButtonInnerBevel(enabled = enabled),
     ) {
-        if (icon != null) {
-            Box(
-                modifier =
-                    Modifier.size(30.dp)
-                        .background(
-                            if (enabled) iconCircleColor else iconCircleColor.copy(alpha = 0.5f),
-                            RoundedCornerShape(50),
-                        ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    painter = painterResource(id = icon),
-                    contentDescription = null,
-                    modifier = Modifier.size(12.dp),
-                    tint = if (enabled) contentColor else contentColor.copy(alpha = 0.5f),
-                )
+        // Figma docks the icon to the button's leading edge while the label stays centered across
+        // the full width, so the icon is absolutely positioned and the text is centered on top.
+        Box(modifier = Modifier.fillMaxWidth()) {
+            if (icon != null) {
+                Box(
+                    modifier =
+                        Modifier.align(Alignment.CenterStart)
+                            .size(30.dp)
+                            .background(
+                                if (enabled) iconCircleColor
+                                else iconCircleColor.copy(alpha = 0.5f),
+                                RoundedCornerShape(50),
+                            ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(id = icon),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = if (enabled) contentColor else contentColor.copy(alpha = 0.5f),
+                    )
+                }
             }
-            UiSpacer(5.dp)
-        }
 
-        Text(text = title, style = Theme.brockmann.button.medium.medium)
+            Text(
+                text = title,
+                style = Theme.brockmann.button.medium.medium,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -316,7 +317,14 @@ fun ActionButton(
             Text(
                 text = title,
                 style = Theme.brockmann.button.medium.medium,
-                modifier = Modifier.align(Alignment.Center),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                // Reserve the icon lane symmetrically so a long (translated) label can never paint
+                // over the docked icon, while keeping the label centered on the button's true
+                // center.
+                modifier =
+                    Modifier.align(Alignment.Center)
+                        .padding(horizontal = if (icon != null) 30.dp else 0.dp),
             )
         }
     }


### PR DESCRIPTION
## Summary

In the DeFi action buttons (`ActionButton` in `DeFiComponents.kt`), the leading icon and the label were grouped together and centered as a unit, leaving dead space on the left. Figma docks the icon to the button's **start edge** while the **label stays centered** across the full button width.

This lays the button content out in a full-width `Box` with the icon pinned to `CenterStart` and the label centered on top, and evens out the horizontal content padding so the label centers on the true button center. The label reserves the icon lane symmetrically (`maxLines = 1` + ellipsis) so long translated labels stay centered without overlapping the icon.

`ActionButton` is the shared DeFi action button, so this applies consistently to every DeFi action button that has an icon (Staking Stake/Unstake, LP, Bonded, and the Circle USDC Withdraw).

> **Note:** Tron freeze/unfreeze render through a separate component (`TronFreezeActionButton` in `TronFreezePositionCard.kt`) that this PR does not touch. Consolidating it into the shared `ActionButton` is a follow-up, out of scope here.

## Before / After

Captured on emulator via `PreviewActivity` (Circle USDC deposited card).

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/5oUzwyS.png) | ![after](https://i.imgur.com/EOxwpNY.png) |

The ⊖ icon now sits at the button's left edge with "Withdraw" centered, matching Figma.

## Notes

- The Circle USDC **Deposit** button has no icon in the app but shows a circled **+** in Figma — that's a separate mismatch, left out of scope here.
- A debug-only `circle_usdc_widget` preview was added to `PreviewActivity` to capture the screenshots.

## Test plan

- [x] `./gradlew :app:ktfmtCheck` passes
- [x] `./gradlew :app:assembleDebug` / `installDebug` succeed
- [x] Verified on emulator: icon left-aligned, label centered (see After)
- [ ] Spot-check Staking / LP / Bonded action buttons render correctly

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preview for the Circle USDC DeFi widget to visualize header, totals and actions.

* **Bug Fixes**
  * Improved action button layout to properly center labels and handle icon positioning when present.
  * Enhanced text truncation with ellipsis to prevent label overlap and preserve centering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->