### PR TITLE
fix(keysign): normalize coin logo to square canvas in signing animation

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -65,6 +65,7 @@ import com.vultisig.wallet.ui.models.keygen.ImportSeedphraseUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultBackupState
 import com.vultisig.wallet.ui.models.keygen.VerifyPinState
 import com.vultisig.wallet.ui.models.keysign.DecodedFunctionParam
+import com.vultisig.wallet.ui.models.keysign.KeysignState
 import com.vultisig.wallet.ui.models.keysign.TonMessageOperation
 import com.vultisig.wallet.ui.models.keysign.TonMessageUiModel
 import com.vultisig.wallet.ui.models.keysign.TransactionStatus
@@ -81,6 +82,7 @@ import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
 import com.vultisig.wallet.ui.screens.keygen.SelectVaultTypeScreenPreview
+import com.vultisig.wallet.ui.screens.keysign.KeysignView
 import com.vultisig.wallet.ui.screens.qbtc.QbtcClaimScreen
 import com.vultisig.wallet.ui.screens.referral.ContentRow
 import com.vultisig.wallet.ui.screens.referral.EmptyReferralBanner
@@ -185,6 +187,7 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_claim_done" -> QbtcClaimDonePreview()
                     "qbtc_claim_error" -> QbtcClaimErrorPreview()
                     "qbtc_claim_blocked" -> QbtcClaimBlockedPreview()
+                    "keysign_signing_lunc" -> KeysignSigningLuncPreview()
                     "btc_detail_claim" -> BtcDetailClaimPreview()
                     "qbtc_detail_claim" -> QbtcDetailClaimPreview()
                     else -> SwapConfirmPreview()
@@ -1656,5 +1659,25 @@ private fun QbtcClaimBlockedPreview() {
         onConfirm = {},
         onStartSecureVault = {},
         onRetry = {},
+    )
+}
+
+// Renders the real keysign "Signing" Rive animation with the non-square LUNC logo injected into the
+// "toToken" slot — the repro for issue #4755.
+@Composable
+private fun KeysignSigningLuncPreview() {
+    KeysignView(
+        state = KeysignState.KeysignECDSA,
+        txHash = "",
+        approveTransactionHash = "",
+        transactionLink = "",
+        approveTransactionLink = "",
+        onComplete = {},
+        onAddToAddressBook = {},
+        progressLink = null,
+        transactionTypeUiModel = null,
+        hasBackClick = false,
+        showSaveToAddressBook = false,
+        coinLogoRes = R.drawable.lunc,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.screens.keysign
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
 import app.rive.Fit
 import app.rive.ImageAsset
@@ -215,30 +217,85 @@ private fun KeysignRiveProgress(progress: Float, @DrawableRes coinLogoRes: Int?)
 /**
  * Rasterizes a (vector or raster) drawable resource to PNG bytes for Rive ImageAsset binding.
  *
- * The rasterized size is bounded by [RIVE_TO_TOKEN_IMAGE_MAX_PX] (aspect ratio preserved) so the
- * image we hand to Rive can never produce an oversized decode allocation — see the constant for why
- * an unbounded size crashes the process.
+ * The logo is drawn — aspect ratio preserved — centered onto a square canvas (see
+ * [squareLogoLayout]) so Rive's square "toToken" image slot renders every coin at the same
+ * proportion. Handing Rive a non-square PNG makes the slot stretch/fill it differently and the logo
+ * renders oversized / distorted (issue #4755). The canvas side is bounded by
+ * [RIVE_TO_TOKEN_IMAGE_MAX_PX] so the image we hand to Rive can never produce an oversized decode
+ * allocation — see the constant for why an unbounded size crashes the process.
  */
 private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): ByteArray? {
     val drawable = AppCompatResources.getDrawable(context, resId) ?: return null
-    val (width, height) = boundedLogoSize(drawable.intrinsicWidth, drawable.intrinsicHeight)
+    val layout = squareLogoLayout(drawable.intrinsicWidth, drawable.intrinsicHeight)
     return try {
-        val bitmap =
-            drawable.toBitmap(width = width, height = height, config = Bitmap.Config.ARGB_8888)
+        val logo =
+            drawable.toBitmap(
+                width = layout.logoWidth,
+                height = layout.logoHeight,
+                config = Bitmap.Config.ARGB_8888,
+            )
+        // An already-square logo needs no padding — skip the extra allocation and copy.
+        val square =
+            if (layout.isSquare) {
+                logo
+            } else {
+                createBitmap(layout.canvasSize, layout.canvasSize).also { canvas ->
+                    Canvas(canvas)
+                        .drawBitmap(logo, layout.left.toFloat(), layout.top.toFloat(), null)
+                }
+            }
         try {
             ByteArrayOutputStream().use { stream ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                square.compress(Bitmap.CompressFormat.PNG, 100, stream)
                 stream.toByteArray()
             }
         } finally {
-            bitmap.recycle()
+            if (square !== logo) square.recycle()
+            logo.recycle()
         }
     } catch (e: Exception) {
-        // toBitmap()/compress()/toByteArray() can throw; the caller treats null as "no logo" and
-        // logs it. Never let this escape into the LaunchedEffect coroutine and crash the screen.
+        // toBitmap()/createBitmap()/compress()/toByteArray() can throw; the caller treats null as
+        // "no logo" and logs it. Never let this escape into the LaunchedEffect coroutine and crash
+        // the screen.
         Timber.e(e, "Failed to encode coin logo res %d as PNG", resId)
         null
     }
+}
+
+/**
+ * Placement of an aspect-preserved coin logo on a square canvas. The canvas is square so Rive's
+ * square "toToken" slot renders the logo without distortion; the logo is centered within it
+ * ([left], [top]) and the canvas side equals the logo's larger dimension, so a square logo gets no
+ * padding while a non-square one is letterboxed with transparency.
+ */
+@VisibleForTesting
+internal data class SquareLogoLayout(
+    val canvasSize: Int,
+    val logoWidth: Int,
+    val logoHeight: Int,
+    val left: Int,
+    val top: Int,
+) {
+    val isSquare: Boolean
+        get() = logoWidth == logoHeight
+}
+
+/**
+ * Computes the [SquareLogoLayout] for a drawable's intrinsic bounds. The logo dimensions come from
+ * [boundedLogoSize] (clamped to [RIVE_TO_TOKEN_IMAGE_MAX_PX], aspect preserved); the canvas side is
+ * their max so the logo always fits centered with transparent padding.
+ */
+@VisibleForTesting
+internal fun squareLogoLayout(intrinsicWidth: Int, intrinsicHeight: Int): SquareLogoLayout {
+    val (width, height) = boundedLogoSize(intrinsicWidth, intrinsicHeight)
+    val side = maxOf(width, height)
+    return SquareLogoLayout(
+        canvasSize = side,
+        logoWidth = width,
+        logoHeight = height,
+        left = (side - width) / 2,
+        top = (side - height) / 2,
+    )
 }
 
 /**

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.toBitmap
 import app.rive.Fit
 import app.rive.ImageAsset
 import app.rive.Result
@@ -228,35 +227,28 @@ private fun encodeDrawableAsPng(context: Context, @DrawableRes resId: Int): Byte
     val drawable = AppCompatResources.getDrawable(context, resId) ?: return null
     val layout = squareLogoLayout(drawable.intrinsicWidth, drawable.intrinsicHeight)
     return try {
-        val logo =
-            drawable.toBitmap(
-                width = layout.logoWidth,
-                height = layout.logoHeight,
-                config = Bitmap.Config.ARGB_8888,
-            )
-        // An already-square logo needs no padding — skip the extra allocation and copy.
-        val square =
-            if (layout.isSquare) {
-                logo
-            } else {
-                createBitmap(layout.canvasSize, layout.canvasSize).also { canvas ->
-                    Canvas(canvas)
-                        .drawBitmap(logo, layout.left.toFloat(), layout.top.toFloat(), null)
-                }
-            }
+        // Draw the aspect-preserved logo straight onto a transparent square canvas — a single
+        // bitmap, no intermediate copy — so Rive's square "toToken" slot renders it without
+        // distortion.
+        val square = createBitmap(layout.canvasSize, layout.canvasSize)
         try {
+            drawable.setBounds(
+                layout.left,
+                layout.top,
+                layout.left + layout.logoWidth,
+                layout.top + layout.logoHeight,
+            )
+            drawable.draw(Canvas(square))
             ByteArrayOutputStream().use { stream ->
                 square.compress(Bitmap.CompressFormat.PNG, 100, stream)
                 stream.toByteArray()
             }
         } finally {
-            if (square !== logo) square.recycle()
-            logo.recycle()
+            square.recycle()
         }
     } catch (e: Exception) {
-        // toBitmap()/createBitmap()/compress()/toByteArray() can throw; the caller treats null as
-        // "no logo" and logs it. Never let this escape into the LaunchedEffect coroutine and crash
-        // the screen.
+        // Any step here can throw; the caller treats null as "no logo" and logs it. Never let this
+        // escape into the LaunchedEffect coroutine and crash the screen.
         Timber.e(e, "Failed to encode coin logo res %d as PNG", resId)
         null
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/keysign/KeysignLogoSizeTest.kt
@@ -57,4 +57,48 @@ class KeysignLogoSizeTest {
         width shouldBe RIVE_TO_TOKEN_IMAGE_MAX_PX
         height shouldBe 1 // coerced up from 0
     }
+
+    @Test
+    fun `square logo gets a square canvas with no padding`() {
+        val layout = squareLogoLayout(96, 96)
+        layout.canvasSize shouldBe 96
+        layout.logoWidth shouldBe 96
+        layout.logoHeight shouldBe 96
+        layout.left shouldBe 0
+        layout.top shouldBe 0
+        layout.isSquare shouldBe true
+    }
+
+    @Test
+    fun `wide logo is centered vertically on a square canvas`() {
+        // 1024x512 -> clamped to 256x128 -> square side 256, padded top/bottom by (256-128)/2.
+        val layout = squareLogoLayout(1024, 512)
+        layout.canvasSize shouldBe 256
+        layout.logoWidth shouldBe 256
+        layout.logoHeight shouldBe 128
+        layout.left shouldBe 0
+        layout.top shouldBe 64
+        layout.isSquare shouldBe false
+    }
+
+    @Test
+    fun `tall logo is centered horizontally on a square canvas`() {
+        // 512x1024 -> clamped to 128x256 -> square side 256, padded left/right by (256-128)/2.
+        val layout = squareLogoLayout(512, 1024)
+        layout.canvasSize shouldBe 256
+        layout.logoWidth shouldBe 128
+        layout.logoHeight shouldBe 256
+        layout.left shouldBe 64
+        layout.top shouldBe 0
+        layout.isSquare shouldBe false
+    }
+
+    @Test
+    fun `missing intrinsic bounds yield a square max-size canvas`() {
+        val layout = squareLogoLayout(-1, -1)
+        layout.canvasSize shouldBe RIVE_TO_TOKEN_IMAGE_MAX_PX
+        layout.left shouldBe 0
+        layout.top shouldBe 0
+        layout.isSquare shouldBe true
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #4755 — on the keysign **"Signing"** animation, the destination coin logo (LUNC/LUNA in the repro) rendered out of proportion (a stretched oval) versus the other icon.

**Root cause:** the logo is injected into the Rive animation's fixed, **square** `"toToken"` image slot. `encodeDrawableAsPng` rasterized the drawable **preserving its intrinsic aspect ratio**, so a non-square logo produced a non-square PNG that Rive stretched to fill the square slot. `lunc.xml` is a **3102.2 × 2291.6** (~1.35:1) vector — exactly the offending case — while square logos (luna, terra_classic) were unaffected.

**Fix:** center the aspect-preserved logo onto a **square transparent canvas** (`squareLogoLayout`) before binding, so every coin fills the slot at a true 1:1 ratio regardless of its intrinsic bounds. Square logos short-circuit the extra allocation, and the existing `RIVE_TO_TOKEN_IMAGE_MAX_PX` OOM guard is preserved.

## Before / After

Full keysign "Signing" screen with the LUNC logo injected:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/ARENzxj.jpeg) | ![after](https://i.imgur.com/RZQ1ibv.jpeg) |

Zoomed to the animation icons — the LUNC badge (right) goes from a stretched oval to a proper circle:

| Before | After |
|--------|-------|
| ![before-crop](https://i.imgur.com/Y4YokKj.png) | ![after-crop](https://i.imgur.com/utZHMpS.png) |

## Test plan
- Added 4 regression tests to `KeysignLogoSizeTest` covering square (no padding), wide (vertical centering), tall (horizontal centering), and missing-bounds (max-size square) cases — green.
- `:app:assembleDebug` builds; ktfmt clean.
- Verified on emulator via a debug-only `PreviewActivity` entry rendering the real Rive animation with the LUNC logo (see screenshots above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug preview for LUNC keysign signing.

* **Improvements**
  * Logo rendering now produces consistent square images with automatic centering and transparent padding for non-square assets.

* **Tests**
  * Added regression tests covering square logo layout, centering, and handling of missing intrinsic bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->