### PR TITLE
fix: change transaction-history icon from calendar-clock to history (#4741)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -155,7 +155,7 @@ internal fun ChainTokensScreen(
                         VsCircleButton(
                             onClick = onHistory,
                             size = VsCircleButtonSize.Small,
-                            icon = R.drawable.calendar_clock,
+                            icon = R.drawable.clock_arrow_circlepath,
                             type = VsCircleButtonType.Secondary,
                             designType = DesignType.Shined,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TopRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/TopRow.kt
@@ -28,7 +28,7 @@ internal fun TopRow(
 
         VsCircleButton(
             onClick = onOpenHistoryClick,
-            icon = R.drawable.calendar_clock,
+            icon = R.drawable.clock_arrow_circlepath,
             size = VsCircleButtonSize.Small,
             type = VsCircleButtonType.Secondary,
             designType = DesignType.Shined,

--- a/app/src/main/res/drawable/clock_arrow_circlepath.xml
+++ b/app/src/main/res/drawable/clock_arrow_circlepath.xml
@@ -4,21 +4,21 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:pathData="M7.75,4.75V2.75M16.25,4.75V2.75M8.75,20.25H5.75C4.645,20.25 3.75,19.355 3.75,18.25V6.75C3.75,5.645 4.645,4.75 5.75,4.75H18.25C19.355,4.75 20.25,5.645 20.25,6.75V8.75"
+      android:pathData="M3,12A9,9 0 1 0 5.26,5.74L3,8"
       android:strokeLineJoin="round"
       android:strokeWidth="1.5"
       android:fillColor="#00000000"
       android:strokeColor="#F0F4FC"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M17,22.25C19.899,22.25 22.25,19.899 22.25,17C22.25,14.101 19.899,11.75 17,11.75C14.101,11.75 11.75,14.101 11.75,17C11.75,19.899 14.101,22.25 17,22.25Z"
+      android:pathData="M3,3V8H8"
       android:strokeLineJoin="round"
       android:strokeWidth="1.5"
       android:fillColor="#00000000"
       android:strokeColor="#F0F4FC"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M17,14.75V17L18.75,18.75"
+      android:pathData="M12,7V12L15,14"
       android:strokeLineJoin="round"
       android:strokeWidth="1.5"
       android:fillColor="#00000000"


### PR DESCRIPTION
## What
The transaction-history button used `R.drawable.calendar_clock` — a calendar-with-clock icon that reads as a scheduler/date rather than transaction history. This replaces it with a proper history icon (a clock wrapped by a circular arrow), matching the iOS app's SF Symbol `clock.arrow.circlepath`.

## Where
Both surfaces flagged in the issue:
- `ui/screens/v2/home/components/TopRow.kt` — home top row
- `ui/screens/v2/chaintokens/ChainTokensScreen.kt` — chain-detail header

## Changes
- Added `drawable/clock_arrow_circlepath.xml` — outlined history icon mirroring the iOS SF Symbol, using the same stroke style (1.5px, round caps) as the icon it replaces.
- Pointed both buttons at the new drawable.
- Removed the now-orphaned `drawable/calendar_clock.xml` (no remaining references; the separate `ic_calendar_clock` used by the transaction-history screen header is untouched).

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/P9N3E1i.png) | ![after](https://i.imgur.com/lnEDMmn.png) |

(History button is top-right in the chain-detail header.)

## Test plan
- `./gradlew :app:assembleDebug` ✅
- Rendered `ChainTokensScreen` via PreviewActivity on emulator and verified the new icon renders correctly in both before/after builds.

Closes #4741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the history button icon throughout the application interface for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->