### PR TITLE
fix(cosmos): floor Akash fee to 0.025 AKT so txs clear network minimum

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -10,6 +10,13 @@ class CosmosFeeService : FeeService {
 
     companion object {
         internal const val OSMOSIS_MIN_FEE_UOSMO = 25_000L
+
+        // `gasLimit * gasPrice` lands below what Akash's validators accept: the
+        // chain-registry price (0.025 uakt/gas) on a ~300k-gas delegation yields
+        // only 7500 uakt (0.0075 AKT), which the mempool rejects for insufficient
+        // fee. Floor the injected fee to 0.025 AKT — the minimum Akash accepts.
+        // Mirrors vultisig-windows `keplrMinInjectedFee.Akash` (PR #4025).
+        internal const val AKASH_MIN_FEE_UAKT = 25_000L
     }
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
@@ -35,10 +42,12 @@ class CosmosFeeService : FeeService {
                     amount = OSMOSIS_MIN_FEE_UOSMO.toBigInteger(),
                 )
             }
+            Chain.Akash -> {
+                GasFees(limit = gasLimit.toBigInteger(), amount = AKASH_MIN_FEE_UAKT.toBigInteger())
+            }
             Chain.GaiaChain,
             Chain.Kujira,
             Chain.Terra,
-            Chain.Akash,
             Chain.Qbtc -> {
                 GasFees(limit = gasLimit.toBigInteger(), amount = 7500.toBigInteger())
             }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -77,6 +77,14 @@ class CosmosFeeServiceTest {
     }
 
     @Test
+    fun `Akash fee amount is floored to 25000 uakt`() = runTest {
+        // Akash's chain-registry gas price computes only 7500 uakt, below the
+        // network's accepted minimum. The default fee must floor to 0.025 AKT.
+        val fee = feeService.calculateDefaultFees(transfer(Chain.Akash)) as GasFees
+        assertEquals(CosmosFeeService.AKASH_MIN_FEE_UAKT.toBigInteger(), fee.amount)
+    }
+
+    @Test
     fun `QBTC returns GasFees type`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Qbtc))
         assertTrue(fee is GasFees)


### PR DESCRIPTION
## Summary

Akash (AKT) transactions were being rejected by the network for an insufficient fee. Akash's chain-registry gas price (0.025 uakt/gas) on a ~300k-gas transaction computes only **7500 uakt (0.0075 AKT)**, which is below the minimum the network's validators accept. `CosmosFeeService` hardcoded that 7500 uakt for Akash, so the wallet overrode any user-supplied fee back down to 0.0075 AKT.

This floors the Akash default fee to **25000 uakt (0.025 AKT)** — the minimum the network accepts — by pulling Akash out of the shared 7500-uakt branch into its own branch, following the existing `OSMOSIS_MIN_FEE_UOSMO` pattern.

## Suggested solution

This matches the fix suggested directly on the issue:

> I think for this one the minimum gas fee forced by the wallet just needs to be increased to 0.025 AKT. we tried forcing it through our own ui but the wallet still overrode it to 0.0075.

— https://github.com/vultisig/vultisig-android/issues/4307#issuecomment-4332383790

It also mirrors the equivalent fix on vultisig-windows (`keplrMinInjectedFee.Akash = 25_000n`, PR vultisig/vultisig-windows#4025).

## Changes

- `CosmosFeeService.kt` — add `AKASH_MIN_FEE_UAKT = 25_000L` and a dedicated `Chain.Akash` fee branch (0.025 AKT). Other Cosmos chains are unchanged.
- `CosmosFeeServiceTest.kt` — add a test asserting the Akash default fee floors to 25000 uakt.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*.CosmosFeeServiceTest"` passes (incl. the new Akash floor test and the unchanged 7500-uakt assertions for GaiaChain/QBTC).
- [x] ktfmt formatting applied.
- Manual: send a small AKT amount and confirm the verify screen shows a **0.025 AKT** fee and the tx broadcasts and confirms on-chain (mintscan shows 25000 uakt fee).

## Notes / scope

This is a focused fix for the fee floor, equivalent to the vultisig-windows PR. It corrects the fee for all Akash transactions but does not add a native Akash *staking* UI (Android has none for Akash yet) — that would be a separate, larger feature.

Closes #4307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented proper minimum fee handling for the Akash blockchain network to ensure transactions meet network requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->