### PR TITLE
fix(cosmos): sign Terra dApp staking sent via amino, not just signDirect

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.models.getEddsaSigningKey
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.payload.carriesDappCosmosTx
 import java.math.BigInteger
 import vultisig.keysign.v1.CustomMessagePayload
 import wallet.core.jni.EthereumAbi
@@ -260,13 +261,15 @@ object SigningHelper {
 
                     Chain.Terra,
                     Chain.TerraClassic -> {
-                        // Staking flows carry a pre-encoded SignDoc (MsgDelegate / MsgUndelegate /
-                        // MsgBeginRedelegate / MsgWithdrawDelegatorReward) on `signDirect`.
-                        // TerraHelper only knows bank sends + CW20 transfers and would otherwise
-                        // sign a MsgSend to the `terravaloper…` validator — the chain rejects that
-                        // with "invalid to address: hrp does not match bech32 prefix". Route
-                        // signDirect through CosmosHelper, which signs the SignDoc verbatim.
-                        if (payload.signDirect != null) {
+                        // dApp staking flows carry a pre-encoded Cosmos tx — a protobuf SignDoc on
+                        // `signDirect` (MsgDelegate / MsgUndelegate / MsgBeginRedelegate /
+                        // MsgWithdrawDelegatorReward) or legacy amino JSON on `signAmino` (the path
+                        // Keplr-style sites like cosmosrescue.com use for LUNC). TerraHelper only
+                        // knows bank sends + CW20 transfers and would otherwise sign a MsgSend to
+                        // the `terravaloper…` validator — the chain rejects that with "invalid to
+                        // address: hrp does not match bech32 prefix". Route either through
+                        // CosmosHelper, which signs the supplied tx verbatim.
+                        if (payload.carriesDappCosmosTx) {
                             CosmosHelper(
                                     coinType = chain.coinType,
                                     denom = chain.feeUnit,
@@ -476,9 +479,10 @@ object SigningHelper {
 
             Chain.TerraClassic,
             Chain.Terra -> {
-                // Mirror the getPreSignedImageHash routing: staking SignDocs must be signed +
-                // assembled by CosmosHelper, not rebuilt as a bank send by TerraHelper.
-                return if (keysignPayload.signDirect != null) {
+                // Mirror the getPreSignedImageHash routing: a dApp-supplied Cosmos tx (signDirect
+                // SignDoc or amino JSON) must be signed + assembled by CosmosHelper, not rebuilt as
+                // a bank send by TerraHelper.
+                return if (keysignPayload.carriesDappCosmosTx) {
                     CosmosHelper(
                             coinType = chain.coinType,
                             denom = chain.feeUnit,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
@@ -55,3 +55,16 @@ enum class DeFiAction {
     NONE,
     CIRCLE_USDC_WITHDRAW,
 }
+
+/**
+ * True when the payload carries a pre-encoded Cosmos transaction supplied by an external dApp —
+ * either a protobuf SignDoc ([signDirect]) or legacy amino JSON ([signAmino]). Keplr-style dApps
+ * (e.g. cosmosrescue.com Terra delegations) sign LUNC via amino, LUNA via either.
+ *
+ * Such payloads must be signed verbatim by CosmosHelper, which understands both modes. Chain
+ * helpers like TerraHelper only know native bank/CW20 sends and would rebuild the message as a
+ * `MsgSend` to the `terravaloper…` validator — the chain rejects that with "invalid to address: hrp
+ * does not match bech32 prefix".
+ */
+internal val KeysignPayload.carriesDappCosmosTx: Boolean
+    get() = signDirect != null || signAmino != null

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/CarriesDappCosmosTxTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/payload/CarriesDappCosmosTxTest.kt
@@ -1,0 +1,84 @@
+package com.vultisig.wallet.data.models.payload
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignAmino
+
+/**
+ * Pins the routing predicate that decides whether a Terra / TerraClassic keysign carries a
+ * dApp-supplied Cosmos transaction (so [com.vultisig.wallet.data.chains.helpers.SigningHelper]
+ * signs it verbatim via CosmosHelper) or a native bank send (rebuilt by TerraHelper).
+ *
+ * Regression guard for the cosmosrescue.com Terra-delegation bug: a Keplr-style dApp that signs via
+ * legacy amino (`signAmino`, `signDirect == null`) used to fall through to TerraHelper, which
+ * rebuilt the MsgDelegate as a bank MsgSend to the `terravaloper…` validator — rejected by the
+ * chain with "invalid to address: hrp does not match bech32 prefix".
+ */
+class CarriesDappCosmosTxTest {
+
+    @Test
+    fun `signDirect-bearing payload carries a dApp cosmos tx`() {
+        assertTrue(payload(signDirect = SIGN_DIRECT).carriesDappCosmosTx)
+    }
+
+    @Test
+    fun `signAmino-bearing payload carries a dApp cosmos tx`() {
+        assertTrue(payload(signAmino = SignAmino()).carriesDappCosmosTx)
+    }
+
+    @Test
+    fun `payload with neither signDirect nor signAmino is a native send`() {
+        assertFalse(payload().carriesDappCosmosTx)
+    }
+
+    private fun payload(signDirect: SignDirectProto? = null, signAmino: SignAmino? = null) =
+        KeysignPayload(
+            coin = LUNC,
+            toAddress = "terravaloper1l3zgemxwql5fpa6p9z6h00000000000abcd",
+            toAmount = BigInteger("249770649"),
+            blockChainSpecific =
+                BlockChainSpecific.Cosmos(
+                    accountNumber = BigInteger.valueOf(12345),
+                    sequence = BigInteger.valueOf(7),
+                    gas = BigInteger.valueOf(100_000_000),
+                    ibcDenomTraces = null,
+                    transactionType =
+                        vultisig.keysign.v1.TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            memo = null,
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+            signDirect = signDirect,
+            signAmino = signAmino,
+        )
+
+    private companion object {
+        val SIGN_DIRECT =
+            SignDirectProto(
+                bodyBytes = "Cg0vY29zbW9zLk1zZ0RlbGVnYXRl",
+                authInfoBytes = "EgQKAggB",
+                chainId = "columbus-5",
+                accountNumber = "12345",
+            )
+
+        val LUNC =
+            Coin(
+                chain = Chain.TerraClassic,
+                ticker = "LUNC",
+                logo = "lunc",
+                address = "terra1pxpxmdrnv66w0000000000000000000000abcd",
+                decimal = 6,
+                hexPublicKey = "020202020202020202020202020202020202020202020202020202020202020202",
+                priceProviderID = "terra-luna",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

A dApp staking request on Terra / TerraClassic (e.g. **cosmosrescue.com → "LUNA Stake Master"**, the `terra-delegations` page) reaches the co-signing device carrying a pre-encoded Cosmos transaction. The earlier #4499 fix (`e2ad1d799`) routed these through `CosmosHelper` **only when `signDirect` was present**.

Keplr-style dApps that sign via **legacy amino** (`signAmino`, with `signDirect == null`) fell through the `else` branch to `TerraHelper`, which only knows native bank / CW20 sends. It rebuilt the `MsgDelegate` as a bank `MsgSend` to the validator's `terravaloper…` address — which the chain rejects with:

> `invalid to address: hrp does not match bech32 prefix`

That is exactly the "errors when attempting to stake LUNA" reported in #4303.

## Fix

`SigningHelper` now routes **either** form of dApp-supplied Cosmos tx (`signDirect` SignDoc **or** amino JSON) through `CosmosHelper`, which already handles both signing modes (`getPreSignedInputData` checks `signAmino` first, then `signDirect`). `TerraHelper` is still used only for native bank/CW20 sends.

The routing decision is extracted into a testable `KeysignPayload.carriesDappCosmosTx` predicate (`signDirect != null || signAmino != null`), applied at both routing sites (`getPreSignedImageHash` + `getSignedTransaction`).

`signAmino` and `signDirect` already survive the proto round-trip in both mapper directions, so no mapper change is needed.

## Proof (mainnet)

LUNA staking via cosmosrescue.com now signs and broadcasts successfully — the message lands as a staking message, not a rejected bank send:

https://atomscan.com/terra2/transactions/8281F8030545F3588477ADB6313EF50F490B5E98B4034B468314D134429EC442

## Test plan

- [x] `:data:testDebugUnitTest` — new `CarriesDappCosmosTxTest` (signDirect / signAmino / neither) + cosmos-staking + mapper suites pass
- [x] `:app:assembleDebug` succeeds
- [x] ktfmt clean
- [x] Manual mainnet smoke on Terra (LUNA) delegate via cosmosrescue.com (tx above)

Closes #4303.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Terra/TerraClassic transaction signing to properly identify and handle pre-encoded transactions from external dApps, ensuring accurate routing through the appropriate signing pathway.

* **Tests**
  * Added comprehensive test coverage for dApp transaction detection on Terra networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->