### PR TITLE
fix(verify): match FastSignPairedButtons order to Figma

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -126,6 +126,7 @@ class PreviewActivity : ComponentActivity() {
             OnBoardingComposeTheme {
                 when (screen) {
                     "swap_confirm" -> SwapConfirmPreview()
+                    "swap_confirm_disabled" -> SwapConfirmPreview(allConsents = false)
                     "asset_action_button" -> AssetActionButtonPreview()
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
@@ -210,7 +211,7 @@ private fun BannerPreview() {
 }
 
 @Composable
-private fun SwapConfirmPreview() {
+private fun SwapConfirmPreview(allConsents: Boolean = true) {
     val ethCoin = Coins.Ethereum.ETH
     val btcCoin = Coins.Bitcoin.BTC
 
@@ -230,8 +231,8 @@ private fun SwapConfirmPreview() {
         state =
             VerifySwapUiModel(
                 tx = tx,
-                consentAmount = true,
-                consentReceiveAmount = true,
+                consentAmount = allConsents,
+                consentReceiveAmount = allConsents,
                 consentAllowance = false,
                 hasFastSign = true,
                 txScanStatus =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/FastSignPairedButtons.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/FastSignPairedButtons.kt
@@ -28,20 +28,22 @@ fun FastSignPairedButtons(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth(),
     ) {
-        VsButton(
-            label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
-            variant = VsButtonVariant.CTA,
-            state = state,
-            onClick = onFastSignClick,
-            modifier = Modifier.weight(1f),
-        )
-
+        // Figma order: Paired is the narrow leading button (wraps its content), Fast Sign is the
+        // wide trailing CTA that fills the remaining width.
         VsButton(
             label = stringResource(R.string.verify_transaction_paired_btn_title),
             iconLeft = R.drawable.ic_paired_devices,
             variant = VsButtonVariant.Secondary,
             state = state,
             onClick = onPairedSignClick,
+        )
+
+        VsButton(
+            label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
+            variant = VsButtonVariant.CTA,
+            state = state,
+            onClick = onFastSignClick,
+            modifier = Modifier.weight(1f),
         )
     }
 }


### PR DESCRIPTION
Closes #4765

## Summary
The dual sign CTA on the transaction verify screens (Send / Swap / Deposit) rendered **Fast Sign first** (left, `weight(1f)`) then **Paired** (right) — the reverse of [Figma](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=67186-146845). This swaps the order so **Paired** is the narrow leading button and **Fast Sign** is the wide trailing CTA that fills the remaining width, matching the design.

### Notes on the reported discrepancies
- **Order (item 1):** fixed — Paired leading, Fast Sign trailing.
- **Proportions (item 2):** Paired wraps its content, Fast Sign uses `weight(1f)`; enabled colors already map exactly to Figma tokens (`#11284A` secondary, `#0B4EFF` CTA, `#F0F4FC` text).
- **Disabled state (item 3):** the issue claimed Figma greys out *only* Fast Sign while Paired stays enabled. Checking the design, the unchecked-consents frame greys out **both** buttons (`buttons/disabled` + `text/button/disabled`). The existing shared `state` on both buttons is therefore correct and is **kept unchanged** — no gating change was made.

## Before / After

**Enabled (consents checked)**

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/OEMsITL.png) | ![after](https://i.imgur.com/yWqPMKm.png) |

**Disabled (consents unchecked)**

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/xfMIxzU.png) | ![after](https://i.imgur.com/lKKTkqa.png) |

## Test plan
- Rendered the real `VerifySwapScreen` (full screen, mocked state) via `PreviewActivity` and captured before/after for both the enabled and disabled (unchecked-consents) states on the emulator.
- Confirmed order now matches Figma and both buttons grey out together when consents are unmet.
- `:app:ktfmtFormat` clean; `:app:installDebug` succeeds.

## Scope
`FastSignPairedButtons` is shared by the Send / Swap / Deposit verify screens, so the corrected order applies to all of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Reordered buttons in the paired device signing interface to enhance user interaction flow and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->