### PR TITLE
fix(qbtc): square up the claim co-sign QR code

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -182,6 +184,7 @@ class PreviewActivity : ComponentActivity() {
                     "universal_router_verify_after" ->
                         VerifyUniversalRouterPreview(expanded = true, useUrRows = true)
                     "qbtc_claim" -> QbtcClaimSelectingPreview()
+                    "qbtc_claim_pairing" -> QbtcClaimPairingPreview()
                     "qbtc_claim_done" -> QbtcClaimDonePreview()
                     "qbtc_claim_error" -> QbtcClaimErrorPreview()
                     "qbtc_claim_blocked" -> QbtcClaimBlockedPreview()
@@ -1605,6 +1608,44 @@ private fun QbtcClaimSelectingPreview() {
         )
     QbtcClaimScreen(
         state = state,
+        isFastVault = true,
+        onBackClick = {},
+        onToggle = {},
+        onConfirm = {},
+        onStartSecureVault = {},
+        onRetry = {},
+    )
+}
+
+/**
+ * The QBTC claim co-sign pairing screen ("Scan this with your other device to co-sign the claim").
+ * The QR is built exactly like
+ * [com.vultisig.wallet.ui.models.qbtc.QbtcClaimViewModel.renderPairingQr] — black-on-white, no logo
+ * — so the painter's intrinsic size matches production and the rendering is a faithful repro.
+ */
+@Composable
+private fun QbtcClaimPairingPreview() {
+    val context = LocalContext.current
+    val qr = remember {
+        val entry =
+            EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                ShareQrPreviewEntryPoint::class.java,
+            )
+        // A representative-length pairing deep link so the QR version (module count) matches a
+        // real claim payload rather than a tiny low-version code.
+        val deepLink =
+            "https://vultisig.com?type=SignTransaction&resharePrefix=0&vault=03a1b2c3" +
+                "&jsonData=" +
+                "H4sIAAAAAAAA_y2OQQ6CMBBF7zJrFy1Q2rIzkRhciAvdGBfYTrCJgGlL1Bju" +
+                "biTu5r2X-fMnsK7vIIPe9Q5KZIxnPGM5zxjnGUtZyhJWZJxJkQqRZpKkUmRS" +
+                "ZHLPF_kRbEpyqLclNtyV-7LQ3ko9-Wxqo7VqTpX5-pSXatbdatu1b16VI_qW" +
+                "T2rV_WuPtSn-lJf62v9rb_1r_42IIAdwAEcwRm8wAd8wQ_8AQ"
+        val bitmap = entry.generateQrBitmap().invoke(deepLink, Color.Black, Color.White, null)
+        BitmapPainter(bitmap.asImageBitmap(), filterQuality = FilterQuality.None)
+    }
+    QbtcClaimScreen(
+        state = QbtcClaimUiState.Pairing(qr = qr, joinedDevices = listOf("iPhone 15 Pro")),
         isFastVault = true,
         onBackClick = {},
         onToggle = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -501,15 +502,25 @@ private fun PairingContent(state: QbtcClaimUiState.Pairing) {
         )
         val qr = state.qr
         if (qr != null) {
-            Image(
-                painter = qr,
-                contentDescription = null,
+            // Force a square white card and let the QR fill it. The pairing QR bitmap is generated
+            // without a logo, so its intrinsic size is the raw QR-matrix pixel count (~tens of px);
+            // without aspectRatio(1f) the Image collapses to that tiny height inside a full-width
+            // box, leaving a small QR in a wide white strip. This mirrors QrContainer / the keysign
+            // peer-discovery co-sign QR.
+            Box(
                 modifier =
                     Modifier.fillMaxWidth()
                         .padding(horizontal = 48.dp)
+                        .aspectRatio(1f)
                         .clip(RoundedCornerShape(16.dp))
-                        .background(Theme.v2.colors.text.primary),
-            )
+                        .background(Theme.v2.colors.text.primary)
+            ) {
+                Image(
+                    painter = qr,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().padding(16.dp),
+                )
+            }
         } else {
             VsSigningProgressIndicator(text = stringResource(R.string.qbtc_claim_title))
         }


### PR DESCRIPTION
The QR on the QBTC claim co-sign screen ("Scan this with your other device to co-sign the claim") was rendering as a tiny code stuck in a wide white strip instead of a proper square card.

The pairing QR bitmap is generated without a logo, so it keeps its raw QR-matrix pixel size, and the `Image` had no aspect-ratio constraint — so the white card collapsed to the bitmap's height and stretched across the full width. Wrapping it in a square `aspectRatio(1f)` card and letting the image fill it (the same pattern as the keysign peer-discovery / receive QR) makes the QR render full-size and stay scannable.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/0oQ5lRO.png) | ![after](https://i.imgur.com/Zt1hSFS.png) |

### Testing
- Rendered the pairing state on a Pixel 9 Pro via a PreviewActivity entry (added here).
- Opened as a draft — still want to run it through the real claim co-sign flow on device first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced the QR code display on the QBTC claim pairing screen to maintain a square aspect ratio for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->