### PR TITLE
fix(staking): align LUNA/LUNC validator picker to Figma (#4753)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -332,7 +331,9 @@ internal fun ValidatorPickerSheet(
         sheetState = sheetState,
         containerColor = Theme.v2.colors.backgrounds.primary,
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        // Full-screen sheet (Figma node 75918:74747): the column fills the height so the list
+        // expands instead of leaving the stake screen visible above a ~¾-height sheet.
+        Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
             ValidatorPickerHeader(
                 title = title,
                 onClose = onDismiss,
@@ -345,57 +346,99 @@ internal fun ValidatorPickerSheet(
 
             UiSpacer(size = 12.dp)
 
-            BasicTextField(
-                value = searchQuery,
-                onValueChange = onSearchQueryChange,
-                singleLine = true,
-                textStyle = TextStyle(color = Theme.v2.colors.text.primary, fontSize = 16.sp),
-                decorationBox = { inner ->
-                    if (searchQuery.isEmpty()) {
-                        Text(
-                            text = stringResource(R.string.token_selection_search_hint),
-                            style = Theme.brockmann.body.s.medium,
-                            color = Theme.v2.colors.text.secondary,
-                        )
-                    }
-                    inner()
-                },
+            // Figma: pill-shaped search with a leading magnifier (node 75918:74796).
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Theme.v2.colors.backgrounds.secondary)
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
-            )
-
-            UiSpacer(size = 12.dp)
-
-            when {
-                isLoading ->
-                    Text(
-                        text = stringResource(R.string.cosmos_staking_loading_validators),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.secondary,
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    )
-                validators.isEmpty() ->
-                    Text(
-                        text = stringResource(R.string.cosmos_staking_no_validators_found),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.secondary,
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    )
-                else ->
-                    LazyColumn(modifier = Modifier.fillMaxWidth().height(440.dp)) {
-                        items(validators, key = { it.operatorAddress }) { validator ->
-                            ValidatorPickerRow(
-                                validator = validator,
-                                ticker = ticker,
-                                isSelected = validator.operatorAddress == pickedAddress,
-                                onResolveAvatar = onResolveAvatar,
-                                onClick = { pickedAddress = validator.operatorAddress },
+                        .clip(RoundedCornerShape(99.dp))
+                        .background(Theme.v2.colors.backgrounds.surface1)
+                        .border(
+                            width = 1.dp,
+                            color = Theme.v2.colors.border.normal,
+                            shape = RoundedCornerShape(99.dp),
+                        )
+                        .padding(horizontal = 12.dp, vertical = 12.dp),
+            ) {
+                UiIcon(
+                    drawableResId = R.drawable.ic_search,
+                    size = 16.dp,
+                    tint = Theme.v2.colors.text.tertiary,
+                )
+                BasicTextField(
+                    value = searchQuery,
+                    onValueChange = onSearchQueryChange,
+                    singleLine = true,
+                    textStyle = TextStyle(color = Theme.v2.colors.text.primary, fontSize = 16.sp),
+                    decorationBox = { inner ->
+                        if (searchQuery.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.token_selection_search_hint),
+                                style = Theme.brockmann.supplementary.footnote,
+                                color = Theme.v2.colors.text.tertiary,
                             )
                         }
-                    }
+                        inner()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            UiSpacer(size = 16.dp)
+
+            // Figma: column header clarifies the bare right-hand % is the validator's commission
+            // rate (node 76925:75467), not voting power.
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = stringResource(R.string.cosmos_staking_validator_picker),
+                    style = Theme.brockmann.supplementary.footnote,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                Text(
+                    text = stringResource(R.string.cosmos_staking_validator_commission),
+                    style = Theme.brockmann.supplementary.footnote,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+            }
+
+            UiSpacer(size = 8.dp)
+
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                when {
+                    isLoading ->
+                        Text(
+                            text = stringResource(R.string.cosmos_staking_loading_validators),
+                            style = Theme.brockmann.body.s.medium,
+                            color = Theme.v2.colors.text.secondary,
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        )
+                    validators.isEmpty() ->
+                        Text(
+                            text = stringResource(R.string.cosmos_staking_no_validators_found),
+                            style = Theme.brockmann.body.s.medium,
+                            color = Theme.v2.colors.text.secondary,
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        )
+                    else ->
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(validators, key = { it.operatorAddress }) { validator ->
+                                ValidatorPickerRow(
+                                    validator = validator,
+                                    ticker = ticker,
+                                    isSelected = validator.operatorAddress == pickedAddress,
+                                    onResolveAvatar = onResolveAvatar,
+                                    onClick = { pickedAddress = validator.operatorAddress },
+                                )
+                            }
+                        }
+                }
             }
 
             UiSpacer(size = 16.dp)
@@ -450,23 +493,28 @@ private fun ValidatorPickerRow(
         produceState<String?>(initialValue = null, key1 = validator.operatorAddress) {
             value = onResolveAvatar(validator.identity)
         }
+    // Figma (node 75918:75259 / 75918:75266): spaced rounded-16 cards on surface-1. The selected
+    // card carries a success-tinted fill + border; unselected cards are borderless.
+    val shape = RoundedCornerShape(16.dp)
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .padding(vertical = 4.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(Theme.v2.colors.backgrounds.secondary)
-                .border(
-                    // Keep a 1.dp border in both states (1px Figma parity); the accent colour +
-                    // green check already distinguish the selected row.
-                    width = 1.dp,
-                    color =
-                        if (isSelected) Theme.v2.colors.primary.accent4
-                        else Theme.v2.colors.border.normal,
-                    shape = RoundedCornerShape(12.dp),
+                .clip(shape)
+                .background(
+                    if (isSelected) Theme.v2.colors.backgrounds.success
+                    else Theme.v2.colors.backgrounds.surface1
+                )
+                .then(
+                    if (isSelected)
+                        Modifier.border(
+                            width = 1.dp,
+                            color = Theme.v2.colors.alerts.success,
+                            shape = shape,
+                        )
+                    else Modifier
                 )
                 .clickable(onClick = onClick)
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 14.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1284,6 +1284,7 @@
     <string name="cosmos_staking_validator_active">Aktiv</string>
     <string name="cosmos_staking_validator_churned_out">Ausgeschieden</string>
     <string name="cosmos_staking_validator_picker">Validator</string>
+    <string name="cosmos_staking_validator_commission">Provision</string>
     <string name="cosmos_staking_validators">Validatoren</string>
     <string name="cosmos_staking_pick_destination">Ziel auswählen</string>
     <string name="cosmos_staking_pick_destination_validator">Ziel-Validator auswählen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1282,6 +1282,7 @@
     <string name="cosmos_staking_validator_active">Activo</string>
     <string name="cosmos_staking_validator_churned_out">Excluido</string>
     <string name="cosmos_staking_validator_picker">Validador</string>
+    <string name="cosmos_staking_validator_commission">Comisión</string>
     <string name="cosmos_staking_validators">Validadores</string>
     <string name="cosmos_staking_pick_destination">Elegir destino</string>
     <string name="cosmos_staking_pick_destination_validator">Elige un validador de destino</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1292,6 +1292,7 @@
     <string name="cosmos_staking_validator_active">Aktivan</string>
     <string name="cosmos_staking_validator_churned_out">Isključen</string>
     <string name="cosmos_staking_validator_picker">Validator</string>
+    <string name="cosmos_staking_validator_commission">Provizija</string>
     <string name="cosmos_staking_validators">Validatori</string>
     <string name="cosmos_staking_pick_destination">Odaberi odredište</string>
     <string name="cosmos_staking_pick_destination_validator">Odaberi odredišni validator</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1285,6 +1285,7 @@
     <string name="cosmos_staking_validator_active">Attivo</string>
     <string name="cosmos_staking_validator_churned_out">Escluso</string>
     <string name="cosmos_staking_validator_picker">Validatore</string>
+    <string name="cosmos_staking_validator_commission">Commissione</string>
     <string name="cosmos_staking_validators">Validatori</string>
     <string name="cosmos_staking_pick_destination">Scegli destinazione</string>
     <string name="cosmos_staking_pick_destination_validator">Scegli un validatore di destinazione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1301,6 +1301,7 @@
     <string name="cosmos_staking_validator_active">활성</string>
     <string name="cosmos_staking_validator_churned_out">탈락</string>
     <string name="cosmos_staking_validator_picker">검증인</string>
+    <string name="cosmos_staking_validator_commission">수수료</string>
     <string name="cosmos_staking_validators">검증인</string>
     <string name="cosmos_staking_pick_destination">대상 선택</string>
     <string name="cosmos_staking_pick_destination_validator">도착 검증인 선택</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1276,6 +1276,7 @@
     <string name="cosmos_staking_validator_active">Actief</string>
     <string name="cosmos_staking_validator_churned_out">Uitgevallen</string>
     <string name="cosmos_staking_validator_picker">Validator</string>
+    <string name="cosmos_staking_validator_commission">Commissie</string>
     <string name="cosmos_staking_validators">Validators</string>
     <string name="cosmos_staking_pick_destination">Kies bestemming</string>
     <string name="cosmos_staking_pick_destination_validator">Kies een bestemmingsvalidator</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1280,6 +1280,7 @@
     <string name="cosmos_staking_validator_active">Ativo</string>
     <string name="cosmos_staking_validator_churned_out">Excluído</string>
     <string name="cosmos_staking_validator_picker">Validador</string>
+    <string name="cosmos_staking_validator_commission">Comissão</string>
     <string name="cosmos_staking_validators">Validadores</string>
     <string name="cosmos_staking_pick_destination">Escolher destino</string>
     <string name="cosmos_staking_pick_destination_validator">Escolha um validador de destino</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1294,6 +1294,7 @@
     <string name="cosmos_staking_validator_active">Активен</string>
     <string name="cosmos_staking_validator_churned_out">Выбыл</string>
     <string name="cosmos_staking_validator_picker">Валидатор</string>
+    <string name="cosmos_staking_validator_commission">Комиссия</string>
     <string name="cosmos_staking_validators">Валидаторы</string>
     <string name="cosmos_staking_pick_destination">Выбрать назначение</string>
     <string name="cosmos_staking_pick_destination_validator">Выберите целевой валидатор</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1607,6 +1607,7 @@
     <string name="cosmos_staking_validator_active">活跃</string>
     <string name="cosmos_staking_validator_churned_out">已退出</string>
     <string name="cosmos_staking_validator_picker">验证人</string>
+    <string name="cosmos_staking_validator_commission">佣金</string>
     <string name="cosmos_staking_validators">验证人</string>
     <string name="cosmos_staking_pick_destination">选择目标</string>
     <string name="cosmos_staking_pick_destination_validator">选择目标验证人</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1335,6 +1335,7 @@
     <string name="cosmos_staking_validator_active">Active</string>
     <string name="cosmos_staking_validator_churned_out">Churned Out</string>
     <string name="cosmos_staking_validator_picker">Validator</string>
+    <string name="cosmos_staking_validator_commission">Commission</string>
     <string name="cosmos_staking_validators">Validators</string>
     <string name="cosmos_staking_pick_destination">Pick destination</string>
     <string name="cosmos_staking_pick_destination_validator">Pick a destination validator</string>


### PR DESCRIPTION
## Summary

The validator selection sheet (shared by LUNA & LUNC staking — `CosmosDelegateScreen.ValidatorPickerSheet`) diverged from the Figma source ([node 75918:74747](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=75918-74747)). This brings it in line.

Closes #4753.

### Changes
- **Full-screen sheet** — drop the fixed `LazyColumn(... .height(440.dp))`; the column now `fillMaxSize` so the list expands instead of leaving the stake screen visible above a ~¾-height sheet (`skipPartiallyExpanded` was already set).
- **Clarify the %** — add a **Validator / Commission** column header so the bare right-hand value reads as the validator's commission rate, not voting power. Figma renders this same header. New string `cosmos_staking_validator_commission` added to all 10 locales.
- **Pixel polish** — pill-shaped search with a leading magnifier; spaced rounded-16 cards on `surface-1`; selected card gets a success-tinted fill + border (borderless otherwise).

### Scoping note — item #3 (auto-close on select)
The issue's third item ("tapping a validator commits and closes immediately") is intentionally **not** implemented: the issue author's own comment states two-tap staging is shared by design across Android/iOS/desktop, and Figma still renders the ✓ header button. The existing two-tap (row stages, ✓ commits) is preserved.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/fD4QALC.png) | ![after](https://i.imgur.com/9Qdvph4.png) |

## Test plan
- [x] `./gradlew :app:ktfmtFormat`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Rendered the sheet on an emulator (before/after above) — full-screen height, column header, pill search, spaced cards, selected-row treatment all verified
- [ ] Manual smoke on a real LUNA/LUNC stake flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validator commission label to Cosmos staking validator selector.

* **UI Improvements**
  * Redesigned validator picker interface with improved search functionality and refined validator card styling.

* **Localization**
  * Added validator commission translations across German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->