### PR TITLE
fix(verify): consolidate staking & custom-sign onto FastSignPairedButtons (#4754)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -9,12 +9,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -27,6 +30,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -44,8 +48,12 @@ import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.MakeQrCodeBitmapShareFormat
 import com.vultisig.wallet.data.usecases.QrShareField
 import com.vultisig.wallet.data.usecases.QrShareInfo
+import com.vultisig.wallet.ui.components.SignMessageCard
 import com.vultisig.wallet.ui.components.SignTonDisplayView
 import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
 import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBottomSheetContent
@@ -60,6 +68,8 @@ import com.vultisig.wallet.ui.models.ChainTokensUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
+import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
+import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorRow
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.keygen.ImportSeedphraseUiModel
 import com.vultisig.wallet.ui.models.keygen.VaultBackupState
@@ -80,6 +90,7 @@ import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.screens.TransactionDoneView
+import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
@@ -196,6 +207,10 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_detail_claim" -> QbtcDetailClaimPreview()
                     "keysign_devices_plus_before" -> KeysignDevicesCountPreview(allowsMore = true)
                     "keysign_devices_plus_after" -> KeysignDevicesCountPreview(allowsMore = false)
+                    "staking_verify_before" -> CosmosStakingVerifyCtaPreview(newButtons = false)
+                    "staking_verify_after" -> CosmosStakingVerifyCtaPreview(newButtons = true)
+                    "sign_message_before" -> VerifySignMessageCtaPreview(newButtons = false)
+                    "sign_message_after" -> VerifySignMessageCtaPreview(newButtons = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1717,4 +1732,91 @@ private fun KeysignSigningLuncPreview() {
         showSaveToAddressBook = false,
         coinLogoRes = R.drawable.lunc,
     )
+}
+
+@Composable
+private fun CosmosStakingVerifyCtaPreview(newButtons: Boolean) {
+    val state =
+        CosmosStakingVerifyUiState(
+            headlineRes = R.string.cosmos_staking_youre_staking,
+            amount = "12.5",
+            ticker = "LUNA",
+            vaultName = "Main Vault",
+            fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
+            validatorRows =
+                listOf(
+                    CosmosStakingVerifyValidatorRow(
+                        labelRes = R.string.cosmos_staking_validator_picker,
+                        value = "Allnodes (5% commission)",
+                    )
+                ),
+            networkName = "Terra",
+            feeCrypto = "0.01 LUNA",
+            feeFiat = "$0.02",
+            hasFastSign = true,
+            isLoading = false,
+        )
+    CosmosStakingVerifyContent(state = state, onClose = {}) {
+        val ctaModifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
+        if (newButtons) {
+            FastSignPairedButtons(
+                onFastSignClick = {},
+                onPairedSignClick = {},
+                modifier = ctaModifier,
+            )
+        } else {
+            VsButton(
+                label = stringResource(R.string.cosmos_staking_verify_sign),
+                variant = VsButtonVariant.CTA,
+                onClick = {},
+                modifier = ctaModifier,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VerifySignMessageCtaPreview(newButtons: Boolean) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        bottomBar = {
+            Column(modifier = Modifier.fillMaxWidth().padding(all = 16.dp)) {
+                VerifySignMessageCta(newButtons = newButtons)
+            }
+        },
+    ) { padding ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(padding).padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            SignMessageCard(
+                title = stringResource(R.string.verify_sign_message_signing_method),
+                value = "personal_sign",
+            )
+            SignMessageCard(
+                title = stringResource(R.string.verify_sign_message_message_sign),
+                value = "Sign in to Uniswap",
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.VerifySignMessageCta(newButtons: Boolean) {
+    if (newButtons) {
+        FastSignPairedButtons(onFastSignClick = {}, onPairedSignClick = {})
+    } else {
+        VsButton(
+            label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.padding(top = 16.dp))
+        VsButton(
+            label = stringResource(R.string.verify_swap_sign_button),
+            onClick = {},
+            variant = VsButtonVariant.Secondary,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.cosmosstaking
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,6 +33,7 @@ import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiGradientHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
@@ -74,13 +76,42 @@ internal fun CosmosStakingVerifyScreen(viewModel: CosmosStakingVerifyViewModel =
         )
     }
 
+    CosmosStakingVerifyContent(state = state, onClose = viewModel::back) {
+        val signState = if (state.isLoading) VsButtonState.Disabled else VsButtonState.Enabled
+        val bottomModifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
+
+        if (state.hasFastSign) {
+            FastSignPairedButtons(
+                onFastSignClick = { if (!viewModel.tryToFastSignWithPassword()) authorize() },
+                onPairedSignClick = viewModel::confirm,
+                state = signState,
+                modifier = bottomModifier,
+            )
+        } else {
+            VsButton(
+                label = stringResource(R.string.cosmos_staking_verify_sign),
+                variant = VsButtonVariant.CTA,
+                state = signState,
+                onClick = viewModel::confirm,
+                modifier = bottomModifier,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun CosmosStakingVerifyContent(
+    state: CosmosStakingVerifyUiState,
+    onClose: () -> Unit,
+    cta: @Composable BoxScope.() -> Unit,
+) {
     V2Scaffold(
         title = stringResource(R.string.verify_deposit_function_overview),
         // Figma "Overview" uses a close (✕) button top-right rather than a back caret — it still
         // pops the verify entry, matching the design while keeping the screen exitable.
         onBackClick = null,
         rightIcon = R.drawable.big_close,
-        onRightIconClick = viewModel::back,
+        onRightIconClick = onClose,
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
@@ -92,20 +123,7 @@ internal fun CosmosStakingVerifyScreen(viewModel: CosmosStakingVerifyViewModel =
             ) {
                 SummaryCard(state = state)
             }
-
-            VsButton(
-                label = stringResource(R.string.cosmos_staking_verify_sign),
-                variant = VsButtonVariant.CTA,
-                state = if (state.isLoading) VsButtonState.Disabled else VsButtonState.Enabled,
-                onClick = {
-                    if (state.hasFastSign) {
-                        if (!viewModel.tryToFastSignWithPassword()) authorize()
-                    } else {
-                        viewModel.confirm()
-                    }
-                },
-                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
-            )
+            cta()
         }
     }
 }
@@ -216,48 +234,32 @@ private fun truncatedMiddle(value: String): String =
 @Preview
 @Composable
 private fun CosmosStakingVerifyScreenPreview() {
-    V2Scaffold(
-        title = "Overview",
-        onBackClick = null,
-        rightIcon = R.drawable.big_close,
-        onRightIconClick = {},
-    ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(
-                modifier =
-                    Modifier.fillMaxSize()
-                        .verticalScroll(rememberScrollState())
-                        .padding(16.dp)
-                        .padding(bottom = 96.dp)
-            ) {
-                SummaryCard(
-                    state =
-                        CosmosStakingVerifyUiState(
-                            headlineRes = R.string.cosmos_staking_youre_claiming,
-                            amount = "0.000001",
-                            ticker = "LUNA",
-                            vaultName = "Main Vault",
-                            fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
-                            validatorRows =
-                                listOf(
-                                    CosmosStakingVerifyValidatorRow(
-                                        labelRes = R.string.cosmos_staking_validator_picker,
-                                        value = "Allnodes (5% commission)",
-                                    )
-                                ),
-                            networkName = "Terra",
-                            feeCrypto = "0.01 LUNA",
-                            isLoading = false,
+    CosmosStakingVerifyContent(
+        state =
+            CosmosStakingVerifyUiState(
+                headlineRes = R.string.cosmos_staking_youre_claiming,
+                amount = "0.000001",
+                ticker = "LUNA",
+                vaultName = "Main Vault",
+                fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
+                validatorRows =
+                    listOf(
+                        CosmosStakingVerifyValidatorRow(
+                            labelRes = R.string.cosmos_staking_validator_picker,
+                            value = "Allnodes (5% commission)",
                         )
-                )
-            }
-            VsButton(
-                label = stringResource(R.string.cosmos_staking_verify_sign),
-                variant = VsButtonVariant.CTA,
-                state = VsButtonState.Enabled,
-                onClick = {},
-                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
-            )
-        }
+                    ),
+                networkName = "Terra",
+                feeCrypto = "0.01 LUNA",
+                hasFastSign = true,
+                isLoading = false,
+            ),
+        onClose = {},
+    ) {
+        FastSignPairedButtons(
+            onFastSignClick = {},
+            onPairedSignClick = {},
+            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+        )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
@@ -21,9 +21,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.SignMessageCard
 import com.vultisig.wallet.ui.components.UiAlertDialog
-import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
-import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
@@ -116,19 +115,9 @@ private fun VerifySignMessageScreen(
         bottomBar = {
             Column(modifier = Modifier.fillMaxWidth().padding(all = 16.dp)) {
                 if (hasFastSign) {
-                    VsButton(
-                        label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
-                        onClick = onFastSignClick,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-
-                    UiSpacer(size = 16.dp)
-
-                    VsButton(
-                        label = confirmTitle,
-                        onClick = onConfirm,
-                        variant = VsButtonVariant.Secondary,
-                        modifier = Modifier.fillMaxWidth(),
+                    FastSignPairedButtons(
+                        onFastSignClick = onFastSignClick,
+                        onPairedSignClick = onConfirm,
                     )
                 } else {
                     VsButton(


### PR DESCRIPTION
## What
The Send / Swap / Deposit verify screens already use the shared `FastSignPairedButtons` dual-CTA (Paired + Fast Sign), but two verify surfaces still rendered bespoke buttons:

1. **LUNA/LUNC staking verify** ("Function overview") — a single `VsButton("Sign transaction")` that forked fast-sign inside its `onClick`.
2. **Custom sign-message verify** — stacked `Fast Sign` + secondary `Sign transaction` buttons.

This migrates both onto the shared component so the sign CTA pair is consistent everywhere. Each screen keeps its existing `hasFastSign` / fast-sign-with-password behavior — only the button layout changes.

Closes #4754.

## Changes
- **`CosmosStakingVerifyScreen`** — extracted a stateless `CosmosStakingVerifyContent` with a CTA slot (reuses `SummaryCard`); gates `FastSignPairedButtons` vs the single fallback CTA on `hasFastSign`. Keeps the ✕-close "Overview" chrome.
- **`VerifySignMessageScreen`** — replaced the stacked buttons with `FastSignPairedButtons` in the `hasFastSign` branch; single confirm button retained for the non-fast path.
- **`PreviewActivity`** — added before/after previews for both screens.

> Prerequisite #4765 (button order / proportions) already landed via #4785, so this is unblocked.

## Before / After

### Staking verify ("Function overview")
| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/KilhbbE.png) | ![after](https://i.imgur.com/O70kuFu.png) |

### Custom sign-message verify
| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/TRhkq5i.png) | ![after](https://i.imgur.com/VZRPS3b.png) |

## Test plan
- `./gradlew :app:assembleDebug` — green.
- ktfmt-formatted.
- Screenshots are real Android renders (PreviewActivity + `screencap`), full-screen with mock data in the fast-sign state.
- Manual: verify Fast Sign (server co-sign w/ password/biometric) and Paired (paired-device flow) both route correctly on each screen; confirm the non-fast vault still shows the single CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview variants for Cosmos staking verification and sign message verification flows.

* **Refactor**
  * Updated Cosmos staking verification screen layout with improved CTA component structure.
  * Enhanced sign message verification screen with new button component layout for faster signing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->