### PR TITLE
fix(home): keep cached portfolio total/row while a slow chain refetches (#4768)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.blockchain.TierRemoteNFTService
+import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
@@ -17,7 +18,7 @@ import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
-import com.vultisig.wallet.data.models.calculateAddressesTotalFiatValue
+import com.vultisig.wallet.data.models.calculateAddressesPartialFiatValue
 import com.vultisig.wallet.data.models.isFastVault
 import com.vultisig.wallet.data.models.isSecureVault
 import com.vultisig.wallet.data.models.isSwapSupported
@@ -162,6 +163,12 @@ constructor(
     private var loadDeFiBalancesJob: Job? = null
     private var buyVultBannerJob: Job? = null
 
+    // Last merged snapshot per stream (wallet / DeFi), keyed in-memory so a chain that comes back
+    // with a null balance mid-refetch can carry its previously-shown value forward (#4768). Reset
+    // on vault switch so one vault's balances never leak into the next.
+    private var lastWalletAddresses: List<Address> = emptyList()
+    private var lastDeFiAddresses: List<Address> = emptyList()
+
     // In-memory "dismissed for this visit" flag. When the vault holds less than the Silver-tier
     // VULT amount, closing the Buy VULT banner only flips this (no persistence), so it returns the
     // next time the home screen is entered or the vault is switched.
@@ -228,6 +235,18 @@ constructor(
         if (vaultChanged) {
             // Don't carry a per-visit Buy VULT dismissal across to the next vault.
             buyVultSessionDismissed.value = false
+            // Drop the previous vault's balances so the retain/partial-total logic can't surface
+            // one vault's totals or rows under the next (#4768).
+            lastWalletAddresses = emptyList()
+            lastDeFiAddresses = emptyList()
+            uiState.update {
+                it.copy(
+                    accounts = emptyList(),
+                    defiAccounts = emptyList(),
+                    totalFiatValue = null,
+                    totalDeFiValue = null,
+                )
+            }
         }
         collectBuyVultBannerDismissed(vaultId)
         loadVaultNameAndShowBackup(vaultId)
@@ -536,27 +555,25 @@ constructor(
         searchQuery: String,
         isDefi: Boolean = false,
     ) {
+        // Retain at the Address level, then derive both the total and the rows from the same merged
+        // list. The headline figure then always equals the sum its rows render (#4768), rather than
+        // the total counting only freshly-resolved chains while a row still shows a cached one.
+        val previous = if (isDefi) lastDeFiAddresses else lastWalletAddresses
+        val merged = this.retainLastKnownBalances(previous)
+        if (isDefi) lastDeFiAddresses = merged else lastWalletAddresses = merged
+
         val totalFiatValue =
-            this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
-        val accountsUiModel = this.map { addressToUiModelMapper(it) }
+            merged.calculateAddressesPartialFiatValue()?.let { fiatValueToStringMapper(it) }
+        val accountsUiModel =
+            merged.map { addressToUiModelMapper(it) }.filteredAccounts(searchQuery)
 
         uiState.update { state ->
-            val previousAccounts = if (isDefi) state.defiAccounts else state.accounts
-            val mergedAccounts =
-                accountsUiModel
-                    .retainLastKnownValues(previousAccounts)
-                    .filteredAccounts(searchQuery)
             if (!isDefi) {
-                state.copy(
-                    // Don't blank an already-shown total while a slow chain refetches (#4768).
-                    totalFiatValue = totalFiatValue ?: state.totalFiatValue,
-                    accounts = mergedAccounts,
-                )
+                state.copy(totalFiatValue = totalFiatValue, accounts = accountsUiModel)
             } else {
-                state.copy(
-                    totalDeFiValue = totalFiatValue ?: state.totalDeFiValue,
-                    defiAccounts = mergedAccounts,
-                )
+                // An empty merged list (e.g. every DeFi chain deselected) yields a null total here,
+                // clearing the header instead of stranding a stale figure over zero rows (#4768).
+                state.copy(totalDeFiValue = totalFiatValue, defiAccounts = accountsUiModel)
             }
         }
 
@@ -564,23 +581,37 @@ constructor(
     }
 
     /**
-     * While a chain's balance is refetching its mapped fiat/native amounts come back null. Carry
-     * the last-known value for that chain forward so its row keeps showing the cached balance
-     * instead of blanking until the fresh value resolves (#4768). A non-null new value always wins.
+     * While a chain's balance is refetching, its mapped fiat/native values come back null. Carry
+     * the last-known [Account] values for that row forward so both the row and the portfolio total
+     * keep showing the cached balance instead of blanking until the fresh value resolves (#4768). A
+     * non-null fresh value always wins.
+     *
+     * Keyed by chain + address + provider flag, not chain alone, so two DeFi rows that share a
+     * chain (e.g. a Circle position and another Ethereum position) never carry each other's value
+     * forward.
      */
-    private fun List<AccountUiModel>.retainLastKnownValues(
-        previous: List<AccountUiModel>
-    ): List<AccountUiModel> {
+    private fun List<Address>.retainLastKnownBalances(previous: List<Address>): List<Address> {
         if (previous.isEmpty()) return this
-        val previousByChain = previous.associateBy { it.model.chain }
+        val previousByKey = previous.associateBy { it.retainKey() }
+        return map { address ->
+            val last = previousByKey[address.retainKey()] ?: return@map address
+            address.copy(accounts = address.accounts.retainMissing(last.accounts))
+        }
+    }
+
+    private fun List<Account>.retainMissing(previous: List<Account>): List<Account> {
+        val previousByToken = previous.associateBy { it.token.id }
         return map { account ->
-            val last = previousByChain[account.model.chain] ?: return@map account
+            val last = previousByToken[account.token.id] ?: return@map account
             account.copy(
-                fiatAmount = account.fiatAmount ?: last.fiatAmount,
-                nativeTokenAmount = account.nativeTokenAmount ?: last.nativeTokenAmount,
+                tokenValue = account.tokenValue ?: last.tokenValue,
+                fiatValue = account.fiatValue ?: last.fiatValue,
+                price = account.price ?: last.price,
             )
         }
     }
+
+    private fun Address.retainKey(): String = "${chain.id}|$address|$isDefiProvider"
 
     private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {
         if (searchQuery.isBlank()) return this

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -540,23 +540,46 @@ constructor(
             this.calculateAddressesTotalFiatValue()?.let { fiatValueToStringMapper(it) }
         val accountsUiModel = this.map { addressToUiModelMapper(it) }
 
-        if (!isDefi) {
-            uiState.update {
-                it.copy(
-                    totalFiatValue = totalFiatValue,
-                    accounts = accountsUiModel.filteredAccounts(searchQuery),
+        uiState.update { state ->
+            val previousAccounts = if (isDefi) state.defiAccounts else state.accounts
+            val mergedAccounts =
+                accountsUiModel
+                    .retainLastKnownValues(previousAccounts)
+                    .filteredAccounts(searchQuery)
+            if (!isDefi) {
+                state.copy(
+                    // Don't blank an already-shown total while a slow chain refetches (#4768).
+                    totalFiatValue = totalFiatValue ?: state.totalFiatValue,
+                    accounts = mergedAccounts,
                 )
-            }
-        } else {
-            uiState.update {
-                it.copy(
-                    totalDeFiValue = totalFiatValue,
-                    defiAccounts = accountsUiModel.filteredAccounts(searchQuery),
+            } else {
+                state.copy(
+                    totalDeFiValue = totalFiatValue ?: state.totalDeFiValue,
+                    defiAccounts = mergedAccounts,
                 )
             }
         }
 
         Timber.d("Update updateUiStateFromList: %s", "$this")
+    }
+
+    /**
+     * While a chain's balance is refetching its mapped fiat/native amounts come back null. Carry
+     * the last-known value for that chain forward so its row keeps showing the cached balance
+     * instead of blanking until the fresh value resolves (#4768). A non-null new value always wins.
+     */
+    private fun List<AccountUiModel>.retainLastKnownValues(
+        previous: List<AccountUiModel>
+    ): List<AccountUiModel> {
+        if (previous.isEmpty()) return this
+        val previousByChain = previous.associateBy { it.model.chain }
+        return map { account ->
+            val last = previousByChain[account.model.chain] ?: return@map account
+            account.copy(
+                fiatAmount = account.fiatAmount ?: last.fiatAmount,
+                nativeTokenAmount = account.nativeTokenAmount ?: last.nativeTokenAmount,
+            )
+        }
     }
 
     private fun List<AccountUiModel>.filteredAccounts(searchQuery: String): List<AccountUiModel> {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -600,6 +600,9 @@ constructor(
     }
 
     private fun List<Account>.retainMissing(previous: List<Account>): List<Account> {
+        // A progressive snapshot can re-emit an address with no accounts; fall back to the cached
+        // ones rather than blanking the row for that cycle (#4768).
+        if (isEmpty()) return previous
         val previousByToken = previous.associateBy { it.token.id }
         return map { account ->
             val last = previousByToken[account.token.id] ?: return@map account

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapper.kt
@@ -2,7 +2,7 @@ package com.vultisig.wallet.ui.models.mappers
 
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.Address
-import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
+import com.vultisig.wallet.data.models.calculateAccountsPartialFiatValue
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.ui.models.AccountUiModel
 import javax.inject.Inject
@@ -27,8 +27,11 @@ constructor(
             logo = if (isDefiProvider) defiChain.logo else from.chain.logo,
             address = from.address,
             nativeTokenAmount = nativeAccount.tokenValue?.let(mapTokenValueToStringWithUnitMapper),
+            // Lenient sum (skips still-pending tokens) so the row's fiat equals exactly its
+            // contribution to the partial portfolio total — a multi-token chain with one token
+            // pending no longer feeds the headline while the whole row blanks (#4768).
             fiatAmount =
-                from.accounts.calculateAccountsTotalFiatValue()?.let {
+                from.accounts.calculateAccountsPartialFiatValue()?.let {
                     fiatValueToStringMapper(it)
                 },
             assetsSize = from.accounts.size,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -14,7 +14,7 @@ import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
+import com.vultisig.wallet.data.models.calculateAccountsPartialFiatValue
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.AddressBalancesUpdate
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
@@ -678,6 +678,39 @@ internal class VaultAccountsViewModelTest {
         }
 
     /**
+     * Regression for #4768: within a single chain holding several tokens, a still-pending token
+     * must not blank the whole row. The partial total counts the resolved tokens, so the row must
+     * too — here Ethereum's native token resolves to $10 while an ERC-20 is still pending; the row
+     * reads $10 (not blank) and equals its contribution to the total.
+     */
+    @Test
+    fun `multi-token row shows resolved sum while one token is pending`() =
+        runTest(testDispatcher) {
+            val ethPartial =
+                buildMultiTokenAddress(
+                    Chain.Ethereum,
+                    "0xeth",
+                    nativeFiat = BigDecimal("10"),
+                    tokenFiat = null,
+                )
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flowOf(AddressBalancesUpdate(listOf(ethPartial), isComplete = true))
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // The pending ERC-20 does not blank the row; it shows the resolved native $10.
+            vm.uiState.value.accounts.first { it.model.chain == Chain.Ethereum }.fiatAmount shouldBe
+                "$10"
+            // And the row equals its contribution to the headline total.
+            vm.uiState.value.totalFiatValue shouldBe "$10"
+        }
+
+    /**
      * Regression for #4768: switching vaults must not leak the previous vault's total or rows. When
      * vault-2's first emission resolves nothing, the total/row must reset rather than carrying
      * vault-1's $10 forward via the retain logic.
@@ -685,8 +718,10 @@ internal class VaultAccountsViewModelTest {
     @Test
     fun `switching vault clears the previous vault total and rows`() =
         runTest(testDispatcher) {
-            val vault1Eth = buildTestAddress(Chain.Ethereum, "0xeth1", fiat = BigDecimal("10"))
-            val vault2EthPending = buildTestAddress(Chain.Ethereum, "0xeth2", fiat = null)
+            // Same chain + address in both vaults so their retainKey collides — only the
+            // vault-change reset (not a key mismatch) can stop vault-1's $10 from leaking through.
+            val vault1Eth = buildTestAddress(Chain.Ethereum, "0xeth", fiat = BigDecimal("10"))
+            val vault2EthPending = buildTestAddress(Chain.Ethereum, "0xeth", fiat = null)
 
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns
                 flowOf("vault-1", "vault-2")
@@ -743,7 +778,9 @@ internal class VaultAccountsViewModelTest {
         uiState.value.accounts.first { it.model.chain == Chain.Solana }
 
     /**
-     * Maps each [Address] to a UiModel whose fiat is null exactly when the chain hasn't resolved.
+     * Maps each [Address] to a UiModel using the same lenient per-row fold as production
+     * (`calculateAccountsPartialFiatValue`): fiat is null only when nothing in the address has
+     * resolved, and a partially-resolved address sums its resolved tokens (#4768).
      */
     private fun stubBalanceMappers() {
         coEvery { addressToUiModelMapper(any()) } answers
@@ -757,7 +794,7 @@ internal class VaultAccountsViewModelTest {
                     address = addr.address,
                     nativeTokenAmount = native.tokenValue?.let { "1.0" },
                     fiatAmount =
-                        addr.accounts.calculateAccountsTotalFiatValue()?.let {
+                        addr.accounts.calculateAccountsPartialFiatValue()?.let {
                             "$" + it.value.toPlainString()
                         },
                     assetsSize = addr.accounts.size,
@@ -792,6 +829,49 @@ internal class VaultAccountsViewModelTest {
                 price = fiat?.let { FiatValue(value = it, currency = "USD") },
             )
         return Address(chain = chain, address = address, accounts = listOf(account))
+    }
+
+    /**
+     * Builds an [Address] with a resolved native account plus a second (ERC-20-style) token whose
+     * fiat may be pending, to exercise the lenient per-row fold (#4768).
+     */
+    private fun buildMultiTokenAddress(
+        chain: Chain,
+        address: String,
+        nativeFiat: BigDecimal,
+        tokenFiat: BigDecimal?,
+    ): Address {
+        fun coin(ticker: String, native: Boolean) =
+            Coin(
+                chain = chain,
+                ticker = ticker,
+                logo = "",
+                address = address,
+                decimal = 18,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = if (native) "" else "0xtoken",
+                isNativeToken = native,
+            )
+
+        fun account(coin: Coin, fiat: BigDecimal?) =
+            Account(
+                token = coin,
+                tokenValue =
+                    fiat?.let { TokenValue(value = BigInteger.ONE, unit = coin.ticker, 18) },
+                fiatValue = fiat?.let { FiatValue(value = it, currency = "USD") },
+                price = fiat?.let { FiatValue(value = it, currency = "USD") },
+            )
+
+        return Address(
+            chain = chain,
+            address = address,
+            accounts =
+                listOf(
+                    account(coin(chain.feeUnit, native = true), nativeFiat),
+                    account(coin("TKN", native = false), tokenFiat),
+                ),
+        )
     }
 
     private fun buildTestAddress(chain: Chain, address: String): Address {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.AddressBalancesUpdate
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
@@ -581,6 +582,121 @@ internal class VaultAccountsViewModelTest {
 
             coVerify(exactly = 0) { navigator.route(any<Route.Swap>()) }
         }
+
+    /**
+     * Regression for #4768: when a chain's balance refetch is in flight its mapped fiat comes back
+     * null, but the row must keep showing the last-known value instead of blanking. Here Solana
+     * resolves to $5 on the first load, then a refresh re-emits Solana with an unresolved (null)
+     * fiat — the Solana row must still read $5 while Ethereum updates normally.
+     */
+    @Test
+    fun `per-chain row keeps last-known fiat while it refetches`() =
+        runTest(testDispatcher) {
+            val eth = buildTestAddress(Chain.Ethereum, "0xeth", fiat = BigDecimal("10"))
+            val solResolved = buildTestAddress(Chain.Solana, "sol", fiat = BigDecimal("5"))
+            val solPending = buildTestAddress(Chain.Solana, "sol", fiat = null)
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returnsMany
+                listOf(
+                    flowOf(AddressBalancesUpdate(listOf(eth, solResolved), isComplete = true)),
+                    flowOf(AddressBalancesUpdate(listOf(eth, solPending), isComplete = true)),
+                )
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.solanaRow().fiatAmount shouldBe "$5"
+
+            vm.refreshData()
+            advanceUntilIdle()
+
+            // Solana refetch returned null fiat — the row retains the previously-shown $5.
+            vm.solanaRow().fiatAmount shouldBe "$5"
+            // Ethereum stayed resolved and still shows its own value.
+            vm.uiState.value.accounts.first { it.model.chain == Chain.Ethereum }.fiatAmount shouldBe
+                "$10"
+        }
+
+    /**
+     * Regression for #4768: the big portfolio total must not blank while a chain refetches. With
+     * one chain resolved and another pending the total reflects the resolved chain rather than
+     * going null.
+     */
+    @Test
+    fun `total reflects resolved chains while another is pending`() =
+        runTest(testDispatcher) {
+            val eth = buildTestAddress(Chain.Ethereum, "0xeth", fiat = BigDecimal("10"))
+            val solPending = buildTestAddress(Chain.Solana, "sol", fiat = null)
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flowOf(AddressBalancesUpdate(listOf(eth, solPending), isComplete = true))
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiState.value.totalFiatValue shouldBe "$10"
+        }
+
+    private fun VaultAccountsViewModel.solanaRow(): AccountUiModel =
+        uiState.value.accounts.first { it.model.chain == Chain.Solana }
+
+    /**
+     * Maps each [Address] to a UiModel whose fiat is null exactly when the chain hasn't resolved.
+     */
+    private fun stubBalanceMappers() {
+        coEvery { addressToUiModelMapper(any()) } answers
+            {
+                val addr = firstArg<Address>()
+                val native = addr.accounts.first()
+                AccountUiModel(
+                    model = addr,
+                    chainName = addr.chain.raw,
+                    logo = 0,
+                    address = addr.address,
+                    nativeTokenAmount = native.tokenValue?.let { "1.0" },
+                    fiatAmount =
+                        addr.accounts.calculateAccountsTotalFiatValue()?.let {
+                            "$" + it.value.toPlainString()
+                        },
+                    assetsSize = addr.accounts.size,
+                    nativeTokenTicker = native.token.ticker,
+                )
+            }
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                "$" + firstArg<FiatValue>().value.toPlainString()
+            }
+    }
+
+    private fun buildTestAddress(chain: Chain, address: String, fiat: BigDecimal?): Address {
+        val nativeCoin =
+            Coin(
+                chain = chain,
+                ticker = chain.feeUnit,
+                logo = "",
+                address = address,
+                decimal = 18,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val account =
+            Account(
+                token = nativeCoin,
+                tokenValue =
+                    fiat?.let { TokenValue(value = BigInteger.ONE, unit = nativeCoin.ticker, 18) },
+                fiatValue = fiat?.let { FiatValue(value = it, currency = "USD") },
+                price = fiat?.let { FiatValue(value = it, currency = "USD") },
+            )
+        return Address(chain = chain, address = address, accounts = listOf(account))
+    }
 
     private fun buildTestAddress(chain: Chain, address: String): Address {
         val nativeCoin =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -706,6 +706,39 @@ internal class VaultAccountsViewModelTest {
             vm.uiState.value.accounts.none { it.fiatAmount == "$10" }.shouldBeTrue()
         }
 
+    /**
+     * Regression for #4768: a progressive snapshot can re-emit an address with no accounts. Retain
+     * must fall back to the cached accounts for that cycle rather than blanking the row/total.
+     */
+    @Test
+    fun `row keeps cached value when an address re-emits with empty accounts`() =
+        runTest(testDispatcher) {
+            val ethResolved = buildTestAddress(Chain.Ethereum, "0xeth", fiat = BigDecimal("10"))
+            val ethEmpty =
+                Address(chain = Chain.Ethereum, address = "0xeth", accounts = emptyList())
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returnsMany
+                listOf(
+                    flowOf(AddressBalancesUpdate(listOf(ethResolved), isComplete = true)),
+                    flowOf(AddressBalancesUpdate(listOf(ethEmpty), isComplete = true)),
+                )
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.totalFiatValue shouldBe "$10"
+
+            vm.refreshData()
+            advanceUntilIdle()
+
+            // The empty re-emission must not blank the row or the total.
+            vm.uiState.value.accounts.first { it.model.chain == Chain.Ethereum }.fiatAmount shouldBe
+                "$10"
+            vm.uiState.value.totalFiatValue shouldBe "$10"
+        }
+
     private fun VaultAccountsViewModel.solanaRow(): AccountUiModel =
         uiState.value.accounts.first { it.model.chain == Chain.Solana }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -643,6 +643,69 @@ internal class VaultAccountsViewModelTest {
             vm.uiState.value.totalFiatValue shouldBe "$10"
         }
 
+    /**
+     * Regression for #4768: the portfolio total must equal the sum of the values its rows render.
+     * Solana resolves to $5 then refetches (null); because retain keeps Solana's $5 in both the row
+     * and the total, the headline stays $15 (10 + 5) rather than dropping to $10 and disagreeing
+     * with the row that still shows $5.
+     */
+    @Test
+    fun `total stays consistent with the rows while a chain refetches`() =
+        runTest(testDispatcher) {
+            val eth = buildTestAddress(Chain.Ethereum, "0xeth", fiat = BigDecimal("10"))
+            val solResolved = buildTestAddress(Chain.Solana, "sol", fiat = BigDecimal("5"))
+            val solPending = buildTestAddress(Chain.Solana, "sol", fiat = null)
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returnsMany
+                listOf(
+                    flowOf(AddressBalancesUpdate(listOf(eth, solResolved), isComplete = true)),
+                    flowOf(AddressBalancesUpdate(listOf(eth, solPending), isComplete = true)),
+                )
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.totalFiatValue shouldBe "$15"
+
+            vm.refreshData()
+            advanceUntilIdle()
+
+            // Row still shows the retained $5, and the total still counts it: 10 + 5 = 15.
+            vm.solanaRow().fiatAmount shouldBe "$5"
+            vm.uiState.value.totalFiatValue shouldBe "$15"
+        }
+
+    /**
+     * Regression for #4768: switching vaults must not leak the previous vault's total or rows. When
+     * vault-2's first emission resolves nothing, the total/row must reset rather than carrying
+     * vault-1's $10 forward via the retain logic.
+     */
+    @Test
+    fun `switching vault clears the previous vault total and rows`() =
+        runTest(testDispatcher) {
+            val vault1Eth = buildTestAddress(Chain.Ethereum, "0xeth1", fiat = BigDecimal("10"))
+            val vault2EthPending = buildTestAddress(Chain.Ethereum, "0xeth2", fiat = null)
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns
+                flowOf("vault-1", "vault-2")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "One")
+            coEvery { vaultRepository.get("vault-2") } returns Vault(id = "vault-2", name = "Two")
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flowOf(AddressBalancesUpdate(listOf(vault1Eth), isComplete = true))
+            every { accountsRepository.loadAddressBalances("vault-2") } returns
+                flowOf(AddressBalancesUpdate(listOf(vault2EthPending), isComplete = true))
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // vault-2 resolved nothing — neither vault-1's $10 total nor its row may leak through.
+            vm.uiState.value.totalFiatValue shouldBe null
+            vm.uiState.value.accounts.none { it.fiatAmount == "$10" }.shouldBeTrue()
+        }
+
     private fun VaultAccountsViewModel.solanaRow(): AccountUiModel =
         uiState.value.accounts.first { it.model.chain == Chain.Solana }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -54,8 +54,19 @@ fun List<Address>.calculateAddressesTotalFiatValue(): FiatValue? =
  * non-USD portfolio is labelled correctly (mixed-currency lists were never supported by either
  * fold).
  */
-fun List<Address>.calculateAddressesPartialFiatValue(): FiatValue? {
-    val resolved = this.flatMap { it.accounts }.mapNotNull { it.fiatValue }
+fun List<Address>.calculateAddressesPartialFiatValue(): FiatValue? =
+    this.flatMap { it.accounts }.calculateAccountsPartialFiatValue()
+
+/**
+ * Lenient per-address total mirroring [calculateAddressesPartialFiatValue]: sums each account's
+ * resolved fiat value and skips the ones still pending, returning null only when nothing in the
+ * address has loaded. The home row mapper uses this so a row's fiat equals exactly its contribution
+ * to the partial portfolio total — a chain holding several tokens with one still pending no longer
+ * feeds the headline while its row blanks (the strict [calculateAccountsTotalFiatValue] would null
+ * the whole row). See issue #4768.
+ */
+fun List<Account>.calculateAccountsPartialFiatValue(): FiatValue? {
+    val resolved = this.mapNotNull { it.fiatValue }
     if (resolved.isEmpty()) return null
     return resolved.fold(FiatValue(BigDecimal.ZERO, resolved.first().currency)) { acc, fiatValue ->
         FiatValue(acc.value + fiatValue.value, fiatValue.currency)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -29,13 +29,32 @@ fun List<Account>.calculateAccountsTotalFiatValue(): FiatValue? =
     }
 
 /**
+ * Strict all-or-nothing total: null as soon as *any* chain hasn't resolved its fiat ("not loaded
+ * yet"). Used by the vault list and the delete screen, which want a final figure and would rather
+ * show a loading state than an understated partial sum. The home stream wants the partial figure —
+ * use [calculateAddressesPartialFiatValue] there.
+ */
+fun List<Address>.calculateAddressesTotalFiatValue(): FiatValue? =
+    this.fold(FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)) { acc, account ->
+        // if any account dont have fiat value, return null, as in "not loaded yet"
+        val fiatValue =
+            account.accounts.calculateAccountsTotalFiatValue()
+                ?: return@calculateAddressesTotalFiatValue null
+        FiatValue(acc.value + fiatValue.value, fiatValue.currency)
+    }
+
+/**
  * Sum of every account's fiat value across all addresses, skipping the ones that haven't resolved
  * yet. Returns null only when *nothing* has loaded (so the UI can show a loading state on a cold
  * start), but as soon as a single chain resolves its value contributes to the total. A slow chain
  * (e.g. Solana) therefore no longer blanks the whole portfolio total — the previously-known chains
  * keep counting while it refetches. See issue #4768.
+ *
+ * The seed currency is taken from the first resolved value rather than a hardcoded USD, so a
+ * non-USD portfolio is labelled correctly (mixed-currency lists were never supported by either
+ * fold).
  */
-fun List<Address>.calculateAddressesTotalFiatValue(): FiatValue? {
+fun List<Address>.calculateAddressesPartialFiatValue(): FiatValue? {
     val resolved = this.flatMap { it.accounts }.mapNotNull { it.fiatValue }
     if (resolved.isEmpty()) return null
     return resolved.fold(FiatValue(BigDecimal.ZERO, resolved.first().currency)) { acc, fiatValue ->

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -28,11 +28,17 @@ fun List<Account>.calculateAccountsTotalFiatValue(): FiatValue? =
         FiatValue(acc.value + fiatValue.value, fiatValue.currency)
     }
 
-fun List<Address>.calculateAddressesTotalFiatValue(): FiatValue? =
-    this.fold(FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)) { acc, account ->
-        // if any account dont have fiat value, return null, as in "not loaded yet"
-        val fiatValue =
-            account.accounts.calculateAccountsTotalFiatValue()
-                ?: return@calculateAddressesTotalFiatValue null
+/**
+ * Sum of every account's fiat value across all addresses, skipping the ones that haven't resolved
+ * yet. Returns null only when *nothing* has loaded (so the UI can show a loading state on a cold
+ * start), but as soon as a single chain resolves its value contributes to the total. A slow chain
+ * (e.g. Solana) therefore no longer blanks the whole portfolio total — the previously-known chains
+ * keep counting while it refetches. See issue #4768.
+ */
+fun List<Address>.calculateAddressesTotalFiatValue(): FiatValue? {
+    val resolved = this.flatMap { it.accounts }.mapNotNull { it.fiatValue }
+    if (resolved.isEmpty()) return null
+    return resolved.fold(FiatValue(BigDecimal.ZERO, resolved.first().currency)) { acc, fiatValue ->
         FiatValue(acc.value + fiatValue.value, fiatValue.currency)
     }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateTotalFiatValueTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateTotalFiatValueTest.kt
@@ -7,8 +7,13 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 /**
- * Tests for [calculateAddressesTotalFiatValue]: a slow/unresolved chain must not blank the whole
- * portfolio total — resolved chains keep contributing and only a fully-unresolved set yields null.
+ * Tests for the two portfolio-total folds:
+ * - [calculateAddressesTotalFiatValue] (strict): null as soon as any chain is unresolved — used by
+ *   the vault list and delete screen, which want a final figure.
+ * - [calculateAddressesPartialFiatValue] (partial): a slow/unresolved chain must not blank the
+ *   whole home total — resolved chains keep contributing and only a fully-unresolved set yields
+ *   null.
+ *
  * Regression coverage for issue #4768.
  */
 class CalculateTotalFiatValueTest {
@@ -40,7 +45,7 @@ class CalculateTotalFiatValueTest {
         Address(chain = chain, address = "addr-${chain.raw}", accounts = accounts.toList())
 
     @Test
-    fun `total sums all chains when every chain is resolved`() {
+    fun `both folds sum all chains when every chain is resolved`() {
         val addresses =
             listOf(
                 address(Chain.Ethereum, account(Chain.Ethereum, "ETH", BigDecimal("10"))),
@@ -48,10 +53,11 @@ class CalculateTotalFiatValueTest {
             )
 
         assertEquals(BigDecimal("15"), addresses.calculateAddressesTotalFiatValue()?.value)
+        assertEquals(BigDecimal("15"), addresses.calculateAddressesPartialFiatValue()?.value)
     }
 
     @Test
-    fun `total ignores an unresolved chain instead of returning null`() {
+    fun `partial ignores an unresolved chain while strict blanks to null`() {
         val addresses =
             listOf(
                 address(Chain.Ethereum, account(Chain.Ethereum, "ETH", BigDecimal("10"))),
@@ -59,12 +65,13 @@ class CalculateTotalFiatValueTest {
                 address(Chain.Solana, account(Chain.Solana, "SOL", null)),
             )
 
-        // Old behavior returned null (blank total); now it returns the resolved chains' sum.
-        assertEquals(BigDecimal("10"), addresses.calculateAddressesTotalFiatValue()?.value)
+        // Partial returns the resolved chains' sum; strict stays null until every chain loads.
+        assertEquals(BigDecimal("10"), addresses.calculateAddressesPartialFiatValue()?.value)
+        assertNull(addresses.calculateAddressesTotalFiatValue())
     }
 
     @Test
-    fun `total counts only resolved tokens within a partially-loaded chain`() {
+    fun `partial counts only resolved tokens within a partially-loaded chain`() {
         val addresses =
             listOf(
                 address(
@@ -74,22 +81,30 @@ class CalculateTotalFiatValueTest {
                 )
             )
 
-        assertEquals(BigDecimal("10"), addresses.calculateAddressesTotalFiatValue()?.value)
+        assertEquals(BigDecimal("10"), addresses.calculateAddressesPartialFiatValue()?.value)
+        assertNull(addresses.calculateAddressesTotalFiatValue())
     }
 
     @Test
-    fun `total is null only when nothing has resolved yet`() {
+    fun `both folds are null only when nothing has resolved yet`() {
         val addresses =
             listOf(
                 address(Chain.Ethereum, account(Chain.Ethereum, "ETH", null)),
                 address(Chain.Solana, account(Chain.Solana, "SOL", null)),
             )
 
+        assertNull(addresses.calculateAddressesPartialFiatValue())
         assertNull(addresses.calculateAddressesTotalFiatValue())
     }
 
     @Test
-    fun `total is null for an empty address list`() {
-        assertNull(emptyList<Address>().calculateAddressesTotalFiatValue())
+    fun `empty address list yields null partial and a zero strict total`() {
+        // Partial returns null ("nothing loaded"); strict folds an empty list to its $0 seed, which
+        // is the pre-#4768 behavior the vault list and delete screen already relied on.
+        assertNull(emptyList<Address>().calculateAddressesPartialFiatValue())
+        assertEquals(
+            BigDecimal.ZERO,
+            emptyList<Address>().calculateAddressesTotalFiatValue()?.value,
+        )
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateTotalFiatValueTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateTotalFiatValueTest.kt
@@ -1,0 +1,95 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [calculateAddressesTotalFiatValue]: a slow/unresolved chain must not blank the whole
+ * portfolio total — resolved chains keep contributing and only a fully-unresolved set yields null.
+ * Regression coverage for issue #4768.
+ */
+class CalculateTotalFiatValueTest {
+
+    private fun coin(chain: Chain, ticker: String, isNativeToken: Boolean = true) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = "addr-$ticker",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = isNativeToken,
+        )
+
+    private fun account(chain: Chain, ticker: String, fiat: BigDecimal?): Account {
+        val token = coin(chain, ticker)
+        return Account(
+            token = token,
+            tokenValue = TokenValue(BigInteger.ONE, ticker, 18),
+            fiatValue = fiat?.let { FiatValue(it, "USD") },
+            price = fiat?.let { FiatValue(it, "USD") },
+        )
+    }
+
+    private fun address(chain: Chain, vararg accounts: Account) =
+        Address(chain = chain, address = "addr-${chain.raw}", accounts = accounts.toList())
+
+    @Test
+    fun `total sums all chains when every chain is resolved`() {
+        val addresses =
+            listOf(
+                address(Chain.Ethereum, account(Chain.Ethereum, "ETH", BigDecimal("10"))),
+                address(Chain.Solana, account(Chain.Solana, "SOL", BigDecimal("5"))),
+            )
+
+        assertEquals(BigDecimal("15"), addresses.calculateAddressesTotalFiatValue()?.value)
+    }
+
+    @Test
+    fun `total ignores an unresolved chain instead of returning null`() {
+        val addresses =
+            listOf(
+                address(Chain.Ethereum, account(Chain.Ethereum, "ETH", BigDecimal("10"))),
+                // Solana still loading — fiat is null.
+                address(Chain.Solana, account(Chain.Solana, "SOL", null)),
+            )
+
+        // Old behavior returned null (blank total); now it returns the resolved chains' sum.
+        assertEquals(BigDecimal("10"), addresses.calculateAddressesTotalFiatValue()?.value)
+    }
+
+    @Test
+    fun `total counts only resolved tokens within a partially-loaded chain`() {
+        val addresses =
+            listOf(
+                address(
+                    Chain.Ethereum,
+                    account(Chain.Ethereum, "ETH", BigDecimal("10")),
+                    account(Chain.Ethereum, "USDC", null),
+                )
+            )
+
+        assertEquals(BigDecimal("10"), addresses.calculateAddressesTotalFiatValue()?.value)
+    }
+
+    @Test
+    fun `total is null only when nothing has resolved yet`() {
+        val addresses =
+            listOf(
+                address(Chain.Ethereum, account(Chain.Ethereum, "ETH", null)),
+                address(Chain.Solana, account(Chain.Solana, "SOL", null)),
+            )
+
+        assertNull(addresses.calculateAddressesTotalFiatValue())
+    }
+
+    @Test
+    fun `total is null for an empty address list`() {
+        assertNull(emptyList<Address>().calculateAddressesTotalFiatValue())
+    }
+}


### PR DESCRIPTION
## Summary
On the home/Wallet portfolio, when one chain is slow to fetch (e.g. Solana), that chain's row **and the big total balance** went blank instead of showing the previously-known value until the fresh balance arrived. Fixes #4768.

### Root cause
`calculateAddressesTotalFiatValue()` folded over every account and returned `null` the moment *one* account had an unresolved `fiatValue` — so a single pending chain zeroed the **entire** total. Per-chain rows had no retain-last logic either, so a refetching chain blanked.

### Changes
- **`Account.kt`** — `calculateAddressesTotalFiatValue()` now sums the **resolved** accounts and returns `null` only when *nothing* has loaded (cold start still shows a loading state). One pending chain no longer zeroes the total. The strict per-chain helper (`calculateAccountsTotalFiatValue`) is left as-is so a pending row reports "not loaded" and can fall back to its cached value.
- **`VaultAccountsViewModel.kt`** — retains the last-known **total** (`?: previous`) and last-known **per-chain** fiat/native amounts while a refetch is in flight (a non-null fresh value always wins). Applies to both wallet and DeFi lists.

### Cross-platform note
iOS *batches* all balances and applies at once; Android/Windows stream per-chain. This keeps Android's streaming but makes it resilient to partial state rather than switching to batching — lower-risk and matches the "keep cached value until new one resolves" ask.

## Test plan
- `CalculateTotalFiatValueTest` (new, data): sums resolved chains, ignores a pending chain, counts only resolved tokens within a partial chain, `null` only when nothing resolved / empty list.
- `VaultAccountsViewModelTest` (added 2 tests): Solana row keeps `$5` across a refetch returning null fiat while ETH updates; total reads `$10` when one chain is pending.
- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` green; ktfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retain per-chain last-known balances across partial refreshes so rows and headline totals no longer blank unexpectedly.
  * Clear previous vault totals and rows when switching vaults to prevent carryover.

* **New Features**
  * Partial-total behavior: portfolio and row totals sum only resolved fiat values (returns null only when nothing is resolved), ensuring headline matches row contributions.

* **Tests**
  * Added regression tests covering retention, partial totals, multi-token partial sums, and vault-switch clearing.

* **Documentation**
  * Clarified strict vs. partial total semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->