### PR TITLE
fix(swap): granular "trading temporarily halted" error (#4749)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -426,6 +426,7 @@ constructor(
             is SwapException.InsufficientFunds,
             is SwapException.HighPriceImpact,
             is SwapException.RateLimitExceeded,
+            is SwapException.TradingHalted,
             is SwapException.TimeOut,
             is TimeoutCancellationException,
             is SwapException.NetworkConnection,
@@ -910,6 +911,8 @@ constructor(
                 UiText.StringResource(R.string.swap_error_amount_too_low)
             is SwapException.SwapRouteNotAvailable ->
                 UiText.StringResource(R.string.swap_route_not_available)
+            is SwapException.TradingHalted ->
+                UiText.StringResource(R.string.swap_error_trading_halted)
             is SwapException.TimeOut -> UiText.StringResource(R.string.swap_error_time_out)
             is SwapException.NetworkConnection ->
                 UiText.StringResource(R.string.network_connection_lost)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -345,6 +345,7 @@
     <string name="swap_error_high_price_impact">Die Preisauswirkung ist zu hoch. Versuchen Sie einen kleineren Betrag oder ein anderes Token-Paar.</string>
     <string name="swap_error_quote_failed">Swap-Angebot fehlgeschlagen. Bitte versuchen Sie es erneut oder passen Sie den Betrag an.</string>
     <string name="swap_error_rate_limit">Zu viele Anfragen. Bitte versuchen Sie es später erneut.</string>
+    <string name="swap_error_trading_halted">Der Handel mit diesem Asset ist vorübergehend ausgesetzt. Bitte versuchen Sie es später erneut.</string>
     <string name="swap_screen_invalid_no_vault">Kein Tresor ausgewählt</string>
     <string name="swap_screen_invalid_no_src_error">Kein Quelltoken ausgewählt</string>
     <string name="swap_screen_invalid_selected_no_dst">Kein Ziel-Token ausgewählt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -345,6 +345,7 @@
     <string name="swap_error_high_price_impact">El impacto en el precio es demasiado alto. Prueba con un monto menor o un par de tokens diferente.</string>
     <string name="swap_error_quote_failed">La cotización del swap falló. Inténtalo de nuevo o ajusta el monto.</string>
     <string name="swap_error_rate_limit">Demasiadas solicitudes. Inténtelo de nuevo más tarde.</string>
+    <string name="swap_error_trading_halted">El comercio de este activo está temporalmente suspendido. Inténtelo de nuevo más tarde.</string>
     <string name="swap_screen_invalid_no_vault">No se ha seleccionado ninguna bóveda</string>
     <string name="swap_screen_invalid_no_src_error">No se ha seleccionado ningún token de origen</string>
     <string name="swap_screen_invalid_selected_no_dst">No se ha seleccionado ningún token de destino</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -345,6 +345,7 @@
     <string name="swap_error_high_price_impact">Utjecaj na cijenu je prevelik. Pokušajte s manjim iznosom ili drugim parom tokena.</string>
     <string name="swap_error_quote_failed">Ponuda za zamjenu nije uspjela. Pokušajte ponovno ili prilagodite iznos.</string>
     <string name="swap_error_rate_limit">Previše zahtjeva. Pokušajte ponovno kasnije.</string>
+    <string name="swap_error_trading_halted">Trgovanje ovom imovinom privremeno je obustavljeno. Pokušajte ponovno kasnije.</string>
     <string name="swap_screen_invalid_no_vault">Trezor nije odabran</string>
     <string name="swap_screen_invalid_no_src_error">Nije odabran izvorni token</string>
     <string name="swap_screen_invalid_selected_no_dst">Nije odabran odredišni token</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -345,6 +345,7 @@
     <string name="swap_error_high_price_impact">L\'impatto sul prezzo è troppo alto. Prova con un importo inferiore o una coppia di token diversa.</string>
     <string name="swap_error_quote_failed">Preventivo di swap fallito. Riprova o modifica l\'importo.</string>
     <string name="swap_error_rate_limit">Troppe richieste. Riprova più tardi.</string>
+    <string name="swap_error_trading_halted">Lo scambio di questo asset è temporaneamente sospeso. Riprova più tardi.</string>
     <string name="swap_screen_invalid_no_vault">Nessun caveau selezionato</string>
     <string name="swap_screen_invalid_no_src_error">Nessun token sorgente selezionato</string>
     <string name="swap_screen_invalid_selected_no_dst">Nessun token di destinazione selezionato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -434,6 +434,7 @@
     <string name="swap_error_high_price_impact">가격 영향이 너무 큽니다. 더 적은 금액이나 다른 토큰 쌍을 시도하세요.</string>
     <string name="swap_error_quote_failed">스왑 견적에 실패했습니다. 다시 시도하거나 금액을 조정하세요.</string>
     <string name="swap_error_rate_limit">요청이 너무 많습니다. 나중에 다시 시도해 주세요.</string>
+    <string name="swap_error_trading_halted">이 자산의 거래가 일시적으로 중단되었습니다. 나중에 다시 시도해 주세요.</string>
     <string name="swap_screen_invalid_no_vault">볼트가 선택되지 않았습니다</string>
     <string name="swap_screen_invalid_no_src_error">출발 토큰이 선택되지 않았습니다</string>
     <string name="swap_screen_invalid_selected_no_dst">도착 토큰이 선택되지 않았습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -344,6 +344,7 @@
     <string name="swap_error_high_price_impact">De prijsimpact is te hoog. Probeer een kleiner bedrag of een ander tokenpaar.</string>
     <string name="swap_error_quote_failed">Swap-offerte mislukt. Probeer het opnieuw of pas het bedrag aan.</string>
     <string name="swap_error_rate_limit">Te veel verzoeken. Probeer het later opnieuw.</string>
+    <string name="swap_error_trading_halted">De handel in dit asset is tijdelijk stilgelegd. Probeer het later opnieuw.</string>
     <string name="swap_screen_invalid_no_vault">Geen kluis geselecteerd</string>
     <string name="swap_screen_invalid_no_src_error">Geen brontoken geselecteerd</string>
     <string name="swap_screen_invalid_selected_no_dst">Geen bestemmingstoken geselecteerd</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -345,6 +345,7 @@
     <string name="swap_error_high_price_impact">O impacto no preço é muito alto. Tente um valor menor ou um par de tokens diferente.</string>
     <string name="swap_error_quote_failed">Cotação do swap falhou. Tente novamente ou ajuste o valor.</string>
     <string name="swap_error_rate_limit">Demasiados pedidos. Tente novamente mais tarde.</string>
+    <string name="swap_error_trading_halted">A negociação deste ativo está temporariamente suspensa. Tente novamente mais tarde.</string>
     <string name="swap_screen_invalid_no_vault">Nenhum cofre selecionado</string>
     <string name="swap_screen_invalid_no_src_error">Nenhum token de origem selecionado</string>
     <string name="swap_screen_invalid_selected_no_dst">Nenhum token de destino selecionado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -344,6 +344,7 @@
     <string name="swap_error_high_price_impact">Влияние на цену слишком высокое. Попробуйте меньшую сумму или другую пару токенов.</string>
     <string name="swap_error_quote_failed">Не удалось получить котировку. Попробуйте снова или измените сумму.</string>
     <string name="swap_error_rate_limit">Слишком много запросов. Попробуйте позже.</string>
+    <string name="swap_error_trading_halted">Торговля этим активом временно приостановлена. Попробуйте позже.</string>
     <string name="swap_screen_invalid_no_vault">Хранилище не выбрано</string>
     <string name="swap_screen_invalid_no_src_error">Исходный токен не выбран</string>
     <string name="swap_screen_invalid_selected_no_dst">Токен назначения не выбран</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -633,6 +633,7 @@
     <string name="swap_error_high_price_impact">价格影响过高。请尝试较小的金额或不同的代币对。</string>
     <string name="swap_error_quote_failed">兑换报价失败。请重试或调整金额。</string>
     <string name="swap_error_rate_limit">请求次数过多。请稍后重试。</string>
+    <string name="swap_error_trading_halted">该资产的交易暂时暂停。请稍后重试。</string>
 
     <!-- Swap Screen Invalid -->
     <string name="swap_screen_invalid_no_vault">未选择保险库</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,6 +444,7 @@
     <string name="swap_error_high_price_impact">Price impact is too high. Try a smaller amount or a different token pair.</string>
     <string name="swap_error_quote_failed">Swap quote failed. Please try again or adjust the amount.</string>
     <string name="swap_error_rate_limit">Too many requests. Please try again later.</string>
+    <string name="swap_error_trading_halted">Trading for this asset is temporarily halted. Try again later.</string>
     <string name="swap_screen_invalid_no_vault">No vault selected</string>
     <string name="swap_screen_invalid_no_src_error">No source token selected</string>
     <string name="swap_screen_invalid_selected_no_dst">No destination token selected</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -25,7 +25,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.ktor.http.isSuccess
 import io.ktor.http.path
 import javax.inject.Inject
 import kotlinx.serialization.SerialName
@@ -205,18 +204,22 @@ constructor(
                     parameter("affiliate_bps", if (isAffiliate) affiliateFeeRate else "0")
                     header(xClientID, xClientIDValue)
                 }
-            if (!response.status.isSuccess()) {
-                return THORChainSwapQuoteDeserialized.Error(
-                    THORChainSwapQuoteError(
-                        HttpStatusCode.fromValue(response.status.value).description
+            val responseRawString = response.bodyAsText()
+            return runCatching {
+                    json.decodeFromString(
+                        thorChainSwapQuoteResponseJsonSerializer,
+                        responseRawString,
                     )
-                )
-            }
-            val responseRawString = response.bodyOrThrow<String>()
-            return json.decodeFromString(
-                thorChainSwapQuoteResponseJsonSerializer,
-                responseRawString,
-            )
+                }
+                .getOrElse {
+                    THORChainSwapQuoteDeserialized.Error(
+                        THORChainSwapQuoteError(
+                            responseRawString.ifBlank {
+                                HttpStatusCode.fromValue(response.status.value).description
+                            }
+                        )
+                    )
+                }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             return THORChainSwapQuoteDeserialized.Error(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -21,6 +21,9 @@ sealed class SwapException(message: String) : Exception(message) {
     class SwapRouteNotAvailable(message: String) : SwapException(message)
 
     @Suppress("SerialVersionUIDInSerializableClass")
+    class TradingHalted(message: String) : SwapException(message)
+
+    @Suppress("SerialVersionUIDInSerializableClass")
     class TimeOut(message: String) : SwapException(message)
 
     @Suppress("SerialVersionUIDInSerializableClass")
@@ -59,7 +62,8 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("amount less than dust threshold") -> AmountBelowDustThreshold(error)
                     contains("amount less than min swap amount") -> SmallSwapAmount(error)
                     contains("pool does not exist") -> SwapRouteNotAvailable(error)
-                    contains("trading is halted") -> SwapRouteNotAvailable(error)
+                    contains("trading is halted") || contains("trading halted") ->
+                        TradingHalted(error)
                     contains("timeout") -> TimeOut(error)
                     contains("unable to resolve host") -> NetworkConnection(error)
                     contains("no internet connection") -> NetworkConnection(error)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiBodyReadTest.kt
@@ -217,9 +217,10 @@ class MayaChainApiBodyReadTest {
     }
 
     // -------------------------------------------------------------------------
-    // getSwapQuotes — body<String>() fed into ThorChainSwapQuoteResponseJsonSerializer
-    // Pins: 200 body is read and delegated to the serializer; non-2xx returns early via the
-    // isSuccess guard without touching the body (same shape as the LiFi error-path tests).
+    // getSwapQuotes — body fed into ThorChainSwapQuoteResponseJsonSerializer
+    // Pins: the body is read and delegated to the serializer regardless of status, so a non-2xx
+    // error body (e.g. a trading halt) is preserved; only a blank body falls back to the generic
+    // HTTP status description.
     // -------------------------------------------------------------------------
 
     @Test
@@ -246,7 +247,33 @@ class MayaChainApiBodyReadTest {
     }
 
     @Test
-    fun `getSwapQuotes on non-2xx returns Error with HTTP status description without reading body`() =
+    fun `getSwapQuotes on non-2xx preserves the halt reason from the body`() = runBlocking {
+        // MAYAnode returns the halt reason in the body alongside a non-2xx status (the ETH->ZEC
+        // repro). Discarding the body here for the generic status description is what previously
+        // prevented handleSwapException from classifying it as TradingHalted.
+        val body = """{"error": "trading is halted on pool BTC.BTC"}"""
+
+        val result =
+            newApi(body, status = HttpStatusCode.BadRequest)
+                .getSwapQuotes(
+                    address = "maya1abc",
+                    fromAsset = "ETH.ETH",
+                    toAsset = "ZEC.ZEC",
+                    amount = "100000000",
+                    isAffiliate = false,
+                    bpsDiscount = 0,
+                    referralCode = "",
+                )
+
+        assertTrue(result is THORChainSwapQuoteDeserialized.Error)
+        assertEquals(
+            "trading is halted on pool BTC.BTC",
+            (result as THORChainSwapQuoteDeserialized.Error).error.message,
+        )
+    }
+
+    @Test
+    fun `getSwapQuotes on non-2xx with blank body falls back to HTTP status description`() =
         runBlocking {
             val result =
                 newApi(body = "", status = HttpStatusCode.InternalServerError)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
@@ -69,9 +69,24 @@ class HandleSwapExceptionTest {
     }
 
     @Test
-    fun `trading halted maps to SwapRouteNotAvailable`() {
+    fun `trading is halted maps to TradingHalted`() {
         val result = SwapException.handleSwapException("Trading is halted for this pool")
-        assertInstanceOf(SwapException.SwapRouteNotAvailable::class.java, result)
+        assertInstanceOf(SwapException.TradingHalted::class.java, result)
+    }
+
+    @Test
+    fun `trading halted variant maps to TradingHalted`() {
+        val result = SwapException.handleSwapException("asset trading halted upstream")
+        assertInstanceOf(SwapException.TradingHalted::class.java, result)
+    }
+
+    @Test
+    fun `maya simulate halt message maps to TradingHalted`() {
+        val result =
+            SwapException.handleSwapException(
+                "failed to simulate swap: trading is halted, can't process swap"
+            )
+        assertInstanceOf(SwapException.TradingHalted::class.java, result)
     }
 
     @Test


### PR DESCRIPTION
## What

When a swap pair fails because the destination chain is **halted upstream** (THORChain/MAYAChain trading pause), the form showed the same generic *"Swap route not available"* as a genuinely unsupported pair. Users couldn't tell *temporarily paused, retry later* from *this pair will never work*.

Closes #4749.

## Changes

- **`SwapException`**: new `TradingHalted` type; `"trading is halted"` (and the `"trading halted"` variant) now map to it instead of `SwapRouteNotAvailable`.
- **`SwapQuoteManager`**: maps `TradingHalted` to a new localized string, and ranks it as **transient/recoverable** in `swapFailurePriority` (same bucket as timeout/rate-limit) so the informative halt message wins over a generic route error when providers disagree.
- **Strings**: added `swap_error_trading_halted` — *"Trading for this asset is temporarily halted. Try again later."* — across all 10 locales, using each locale's established retry phrasing.
- **Tests**: updated the now-incorrect `trading halted → SwapRouteNotAvailable` case and added coverage for the variant plus the real-world Maya message `failed to simulate swap: trading is halted, can't process swap`.

## Repro (before)

ETH → ZEC while MAYAChain has ZEC trading paused → app showed "Swap route not available." Now shows the temporary-halt message.

## Test plan

- [x] `:data:testDebugUnitTest --tests HandleSwapExceptionTest` passes
- [x] `:data` and `:app` compile clean
- [x] ktfmt applied
- [ ] Manual: trigger a halted pair (e.g. ETH → ZEC) and confirm the new copy appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap error handling so temporary trading halts are detected and shown as a specific halt message (preserving server-provided halt reasons when present) instead of a generic fallback, giving users clearer guidance to try again later.

* **Localization**
  * Added localized "trading halted" messages across supported languages so the halt notice appears in the user's language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->