### PR TITLE
fix(qbtc): block claims for UTXOs with 144 or fewer confirmations

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/ClaimableUtxo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/ClaimableUtxo.kt
@@ -4,8 +4,8 @@ package com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim
  * A Bitcoin UTXO that can be claimed on the QBTC chain. [amount] is in satoshis; once the chain has
  * cross-checked the UTXO it reflects the chain's remaining `entitled_amount`, not the raw
  * Blockchair value. [confirmations] is the number of blocks mined since the UTXO was confirmed
- * (current tip − the UTXO's block height + 1), used only for display; it is `null` for an
- * unconfirmed (mempool) UTXO or when the chain tip is unknown.
+ * (current tip − the UTXO's block height + 1); it is `null` for an unconfirmed (mempool) UTXO or
+ * when the chain tip is unknown. It also gates claim maturity — see [isMature].
  */
 data class ClaimableUtxo(
     val txid: String,
@@ -13,3 +13,11 @@ data class ClaimableUtxo(
     val amount: Long,
     val confirmations: Long? = null,
 )
+
+/**
+ * True when the UTXO has enough confirmations to be claimable. The chain requires strictly more
+ * than [QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS], so a `null` count (mempool / unknown tip) is
+ * treated as immature — fail closed.
+ */
+internal fun ClaimableUtxo.isMature(): Boolean =
+    (confirmations ?: 0L) > QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/ClaimableUtxo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/ClaimableUtxo.kt
@@ -19,5 +19,5 @@ data class ClaimableUtxo(
  * than [QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS], so a `null` count (mempool / unknown tip) is
  * treated as immature — fail closed.
  */
-internal fun ClaimableUtxo.isMature(): Boolean =
-    (confirmations ?: 0L) > QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS
+internal val ClaimableUtxo.isMature: Boolean
+    get() = confirmations != null && confirmations > QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
@@ -67,7 +67,7 @@ constructor(
         val filtered =
             try {
                 val candidates = utxosService.fetchClaimableCandidates(btcAddress)
-                chainService.filterClaimable(candidates)
+                chainService.filterClaimable(candidates).filter { it.isMature() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
@@ -67,7 +67,7 @@ constructor(
         val filtered =
             try {
                 val candidates = utxosService.fetchClaimableCandidates(btcAddress)
-                chainService.filterClaimable(candidates).filter { it.isMature() }
+                chainService.filterClaimable(candidates).filter { it.isMature }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcClaimConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcClaimConfig.kt
@@ -12,6 +12,12 @@ object QbtcClaimConfig {
     const val MAX_CLAIM_UTXOS = 50
 
     /**
+     * The chain rejects a claim unless the funding UTXO has strictly more than this many
+     * confirmations ("no valid claimable UTXOs found"), so the client filters immature UTXOs out.
+     */
+    const val MIN_CLAIM_CONFIRMATIONS = 144L
+
+    /**
      * The proof service expects `signature_r` zero-padded to this byte width — 24, not 32, matching
      * the proof circuit's witness size.
      */

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
@@ -8,7 +8,12 @@ import org.junit.jupiter.api.Test
 class LoadClaimableQbtcUtxosUseCaseTest {
 
     private val p2wpkh = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
-    private val candidate = ClaimableUtxo(txid = "aa".repeat(32), vout = 0, amount = 100_000)
+    // Mature (> 144 confirmations) so it passes the maturity gate.
+    private val candidate =
+        ClaimableUtxo(txid = "aa".repeat(32), vout = 0, amount = 100_000, confirmations = 145)
+
+    private fun utxoWith(confirmations: Long?) =
+        candidate.copy(txid = "bb".repeat(32), confirmations = confirmations)
 
     @Test
     fun `unsupported btc address blocks before any network call`() = runTest {
@@ -72,6 +77,65 @@ class LoadClaimableQbtcUtxosUseCaseTest {
     fun `available when claimable utxos remain`() = runTest {
         val result = useCase(FakeChainService(), FakeUtxosService(listOf(candidate))).invoke(p2wpkh)
         assertEquals(listOf(candidate), (result as QbtcClaimLoadResult.Available).utxos)
+    }
+
+    @Test
+    fun `utxo with 143 confirmations is excluded as immature`() = runTest {
+        val result =
+            useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(143)))).invoke(p2wpkh)
+        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
+    }
+
+    @Test
+    fun `utxo with exactly 144 confirmations is excluded since chain requires strictly more`() =
+        runTest {
+            val result =
+                useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(144)))).invoke(p2wpkh)
+            assertEquals(
+                QbtcClaimBlockedReason.NoUtxos,
+                (result as QbtcClaimLoadResult.Blocked).reason,
+            )
+        }
+
+    @Test
+    fun `utxo with 145 confirmations is available`() = runTest {
+        val mature = utxoWith(145)
+        val result = useCase(FakeChainService(), FakeUtxosService(listOf(mature))).invoke(p2wpkh)
+        assertEquals(listOf(mature), (result as QbtcClaimLoadResult.Available).utxos)
+    }
+
+    @Test
+    fun `utxo with null confirmations is excluded as immature`() = runTest {
+        val result =
+            useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(null)))).invoke(p2wpkh)
+        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
+    }
+
+    @Test
+    fun `only mature utxos survive a mixed set`() = runTest {
+        val mature =
+            ClaimableUtxo(txid = "cc".repeat(32), vout = 0, amount = 50_000, confirmations = 145)
+        val immatureLow =
+            ClaimableUtxo(txid = "dd".repeat(32), vout = 0, amount = 60_000, confirmations = 144)
+        val immatureNull =
+            ClaimableUtxo(txid = "ee".repeat(32), vout = 0, amount = 70_000, confirmations = null)
+        val result =
+            useCase(FakeChainService(), FakeUtxosService(listOf(immatureLow, mature, immatureNull)))
+                .invoke(p2wpkh)
+        assertEquals(listOf(mature), (result as QbtcClaimLoadResult.Available).utxos)
+    }
+
+    @Test
+    fun `all immature utxos block as no utxos`() = runTest {
+        val immature =
+            listOf(
+                ClaimableUtxo(txid = "11".repeat(32), vout = 0, amount = 1, confirmations = 0),
+                ClaimableUtxo(txid = "22".repeat(32), vout = 0, amount = 1, confirmations = 143),
+                ClaimableUtxo(txid = "33".repeat(32), vout = 0, amount = 1, confirmations = 144),
+                ClaimableUtxo(txid = "44".repeat(32), vout = 0, amount = 1, confirmations = null),
+            )
+        val result = useCase(FakeChainService(), FakeUtxosService(immature)).invoke(p2wpkh)
+        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
     }
 
     private fun useCase(chain: FakeChainService, utxos: FakeUtxosService) =


### PR DESCRIPTION
The QBTC chain rejects a claim at broadcast unless the funding Bitcoin UTXO has **more than 144 confirmations** — it fails gas simulation with `no valid claimable UTXOs found`. Today nothing stops a user from selecting a too-fresh UTXO, so the failure only shows up *after* a full co-sign round, ending in a generic "Claim failed".

This gates the claim eligibility pipeline on confirmation depth: any UTXO with ≤144 confirmations (or an unconfirmed / unknown-tip one) is filtered out before it can be selected, so the claim never fails on-chain. When no mature UTXOs remain, the existing "No claimable UTXOs" state is shown.

### Changes
- `QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS = 144` — single source of truth for the chain rule.
- `ClaimableUtxo.isMature()` — `confirmations > MIN_CLAIM_CONFIRMATIONS`; `null` (mempool / unknown tip) is treated as immature (fail closed).
- `LoadClaimableQbtcUtxosUseCase` filters immature UTXOs out after the chain cross-check.

### Tests
`LoadClaimableQbtcUtxosUseCaseTest` — boundary at 143 / 144 / 145, null confirmations, mixed sets (only mature survive), and all-immature → `NoUtxos`.

### Scope
Data-layer only. The richer "this UTXO is still maturing — wait N more blocks" UX needs Figma and is tracked in #4798.

Closes #4797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QBTC claims now enforce maturity verification: only funding UTXOs with strictly more than 144 confirmations are eligible; unconfirmed/mempool or unknown-tip UTXOs are treated as immature.

* **Tests**
  * Added comprehensive tests covering confirmation thresholds, null/unknown confirmations, mixed sets, and no-UTXO failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->