### PR TITLE
fix(swap): send KyberSwap slippage tolerance as 100 bps

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/KyberJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/KyberJson.kt
@@ -73,7 +73,7 @@ data class KyberSwapBuildRequest(
     val routeSummary: KyberSwapRouteResponse.RouteSummary,
     val sender: String,
     val recipient: String,
-    val slippageTolerance: Double,
+    val slippageTolerance: Int,
     val deadline: Int,
     val enableGasEstimation: Boolean,
     val source: String,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/KyberApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/KyberApi.kt
@@ -189,6 +189,7 @@ constructor(
         private const val REFERRER_ADDRESS = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
         private const val CLIENT_ID = "vultisig-android"
         private const val NULL_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-        private const val SLIPPAGE_TOLERANCE = 2.5
+        // Slippage tolerance in basis points (10000 = 100%); 100 = 1%.
+        private const val SLIPPAGE_TOLERANCE = 100
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/KyberApiSlippageToleranceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/KyberApiSlippageToleranceTest.kt
@@ -1,0 +1,109 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.models.KyberSwapRouteResponse
+import com.vultisig.wallet.data.api.swapAggregators.KyberApiImpl
+import com.vultisig.wallet.data.models.Chain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Pins the slippage tolerance sent to KyberSwap's aggregator API. KyberSwap denominates
+ * `slippageTolerance` in basis points (10000 = 100%), so the integer 100 (= 1%) must be sent
+ * verbatim on both the `/routes` query and the `/route/build` body, matching iOS and the Windows
+ * extension. Each test responds with an error so the request — not the (unparsed) response — is the
+ * subject under test.
+ */
+class KyberApiSlippageToleranceTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun apiCapturing(onRequest: (HttpRequestData) -> Unit) =
+        KyberApiImpl(
+            httpClient =
+                HttpClient(
+                    MockEngine { request ->
+                        onRequest(request)
+                        respond("""{"message":"stop"}""", HttpStatusCode.BadRequest, jsonHeaders)
+                    }
+                ),
+            kyberSwapQuoteResponseJsonSerializer = mockk(),
+            json = json,
+        )
+
+    @Test
+    fun `getSwapQuote sends 100 basis point slippage tolerance on the routes query`() = runTest {
+        var slippageParam: String? = null
+        val api = apiCapturing { slippageParam = it.url.parameters["slippageTolerance"] }
+
+        api.getSwapQuote(
+            chain = Chain.Ethereum,
+            srcTokenContractAddress = "0xsrc",
+            dstTokenContractAddress = "0xdst",
+            amount = "1000",
+            srcAddress = "0xfrom",
+            affiliateBps = 0,
+        )
+
+        assertEquals("100", slippageParam)
+    }
+
+    @Test
+    fun `getKyberSwapQuote sends 100 basis point slippage tolerance as an integer in the build body`() =
+        runTest {
+            var requestBody: String? = null
+            val api = apiCapturing { requestBody = (it.body as TextContent).text }
+
+            assertThrows<SwapException> {
+                api.getKyberSwapQuote(
+                    chain = Chain.Ethereum,
+                    routeSummary = routeSummary(),
+                    from = "0xfrom",
+                    enableGasEstimation = true,
+                    affiliateBps = 0,
+                )
+            }
+
+            val slippage =
+                json.parseToJsonElement(requestBody!!).jsonObject.getValue("slippageTolerance")
+            assertEquals("100", slippage.jsonPrimitive.content)
+        }
+
+    private fun routeSummary() =
+        KyberSwapRouteResponse.RouteSummary(
+            tokenIn = "0xsrc",
+            amountIn = "1000",
+            amountInUsd = "1",
+            tokenOut = "0xdst",
+            amountOut = "990",
+            amountOutUsd = "1",
+            gas = "21000",
+            gasPrice = "1",
+            gasUsd = "0",
+            route = emptyList(),
+            routeID = "route-id",
+            checksum = "checksum",
+            timestamp = 0,
+        )
+}


### PR DESCRIPTION
Closes #4800

KyberSwap denominates `slippageTolerance` in basis points (10000 = 100%). Android sent `2.5` (~0.025%) on both the `/routes` query and the `/route/build` body — two orders of magnitude tighter than the `100` (1%) that iOS and the Windows extension send — so Kyber route builds and on-chain swaps reverted for most pairs, effectively dropping KyberSwap as a usable provider on Android.

## Changes

- **`KyberApi.kt`** — `SLIPPAGE_TOLERANCE` changed from `2.5` to `100` (with a basis-points comment). It is sent verbatim on both the routes GET query and the route/build POST body.
- **`KyberJson.kt`** — typed `KyberSwapBuildRequest.slippageTolerance` as `Int` so the build POST serialises a clean `100` instead of `100.0`, matching iOS (`KyberSwapService.swift` sends `slippageTolerance: 100` typed `Int`) and the Windows extension (`kyberSwapSlippageTolerance = 100`).

## Signing

No new signing path. The slippage value only changes what KyberSwap bakes into the router calldata it returns; that calldata is signed verbatim by the existing keysign path, so co-signing is unaffected — only the swap's slippage bound now matches the other platforms.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*KyberApiSlippageToleranceTest*" --tests "*KyberApiErrorPathTest*"` — passing
- [x] New tests assert `slippageTolerance` is sent as the integer `100` on both the routes query and the build body, and fail without the change (`expected: <100> but was: <2.5>`)
- [x] `./gradlew :data:ktfmtFormat`

## Notes

- No UI surface — outbound aggregator request parameter only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated slippage tolerance configuration in Kyber swap operations to align with the new expected format and value requirements.

* **Tests**
  * Added test coverage for Kyber swap slippage tolerance validation to ensure correct request formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->