### PR TITLE
fix(swap): reject zero network fee or expected output

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -206,7 +206,7 @@ constructor(
                     )
 
             val gasFee =
-                gasFee.value
+                gasFee.value?.takeIf { it.value != BigInteger.ZERO }
                     ?: throw InvalidTransactionDataException(
                         UiText.StringResource(R.string.swap_screen_invalid_gas_fee_calculation)
                     )
@@ -249,7 +249,7 @@ constructor(
             val srcTokenValue = convertTokenAndValueToTokenValue(srcToken, srcAmountInt)
 
             val quote =
-                quoteState.quote
+                quoteState.quote?.takeIf { it.expectedDstValue.value != BigInteger.ZERO }
                     ?: throw InvalidTransactionDataException(
                         UiText.StringResource(R.string.swap_screen_invalid_quote_calculation)
                     )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -1648,6 +1648,97 @@ internal class SwapFormViewModelTest {
             assertFalse(vm.uiState.value.isLoadingNextScreen)
         }
 
+    @Test
+    fun `swap with zero gas fee shows error and does not stage`() =
+        runTest(mainDispatcher) {
+            coEvery { swapGasCalculator.calculateGasFee(any(), any()) } returns
+                GasCalculationResult(
+                    gasFee = TokenValue(value = BigInteger.ZERO, token = ETH_COIN),
+                    estimated =
+                        EstimatedGasFee(
+                            formattedTokenValue = "0 ETH",
+                            formattedFiatValue = "$0.00",
+                            tokenValue = TokenValue(value = BigInteger.ZERO, token = ETH_COIN),
+                            fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+                        ),
+                    chain = Chain.Ethereum,
+                )
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.5")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            vm.swap()
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swap_screen_invalid_gas_fee_calculation),
+                vm.uiState.value.error,
+            )
+            assertFalse(vm.uiState.value.isLoadingNextScreen)
+            coVerify(exactly = 0) { swapTransactionRepository.addTransaction(any()) }
+        }
+
+    @Test
+    fun `swap with zero expected destination amount shows error and does not stage`() =
+        runTest(mainDispatcher) {
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns
+                createDefaultQuoteFetchResult(
+                    quote =
+                        createThorChainQuote(
+                            expectedDstValue =
+                                TokenValue(value = BigInteger.ZERO, token = USDC_COIN)
+                        )
+                )
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.5")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            vm.swap()
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swap_screen_invalid_quote_calculation),
+                vm.uiState.value.error,
+            )
+            assertFalse(vm.uiState.value.isLoadingNextScreen)
+            coVerify(exactly = 0) { swapTransactionRepository.addTransaction(any()) }
+        }
+
     // endregion
 
     // region collectSelectedAccounts


### PR DESCRIPTION
## Summary
`SwapFormViewModel.swap()` only checked that the gas fee and its fiat value were non-null, so a resolved-but-zero gas fee — or a quote with a zero expected destination amount — could still be staged and advance to Verify Swap. iOS blocks both at the form level (`SwapCryptoLogic.validateForm` requires `fee != .zero` and `!toAmount.isZero`).

This adds the two missing guards to `swap()`, mirroring the existing source-amount zero check and reusing the existing gas-fee / quote error strings (no new copy or localization). Both run before the transaction is built or persisted, so the keysign/co-sign flow only ever receives a valid swap; a normal successful quote already implies a non-zero fee and output, so this is a defensive boundary for a degenerate state.

## Testing
`./gradlew :app:testDebugUnitTest --tests "*.SwapFormViewModelTest" --tests "*.SwapValidatorTest"` — added two regression tests for the zero-fee and zero-output cases (both fail without the guards).

Closes #4801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap transaction validation to reject invalid gas fee calculations and zero-value quote amounts
  * Enhanced error handling to prevent swaps from proceeding with incomplete or corrupted quote information
  * Strengthened pre-transaction checks to ensure all required values are valid before staging operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->