### PR TITLE
fix(solana): improve Solana SPL transfer error handling

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
+import com.vultisig.wallet.data.chains.helpers.SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.utils.UiText
@@ -23,8 +24,11 @@ internal fun KeysignErrorScreen(
             errorLabel = stringResource(R.string.signing_error_transaction_timeout)
         errorMessageString.contains("insufficient funds") ->
             errorLabel = stringResource(R.string.signing_error_insufficient_funds)
-        errorMessageString.contains("sender's associated token account not found") ->
-            errorLabel = stringResource(R.string.signing_error_token_account_not_found)
+        errorMessageString.contains(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX) -> {
+            val ticker =
+                errorMessageString.substringAfter(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX).trim()
+            errorLabel = stringResource(R.string.signing_error_token_account_not_found_s, ticker)
+        }
         errorMessageString.contains("failed to calculate bob mid and bob_mic_mc") ->
             errorLabel = stringResource(R.string.signing_error_mixed_reshare)
         errorMessageString.contains(CosmosBroadcastException.BROADCAST_FAILURE_MARKER) -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -23,6 +23,8 @@ internal fun KeysignErrorScreen(
             errorLabel = stringResource(R.string.signing_error_transaction_timeout)
         errorMessageString.contains("insufficient funds") ->
             errorLabel = stringResource(R.string.signing_error_insufficient_funds)
+        errorMessageString.contains("sender's associated token account not found") ->
+            errorLabel = stringResource(R.string.signing_error_token_account_not_found)
         errorMessageString.contains("failed to calculate bob mid and bob_mic_mc") ->
             errorLabel = stringResource(R.string.signing_error_mixed_reshare)
         errorMessageString.contains(CosmosBroadcastException.BROADCAST_FAILURE_MARKER) -> {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Weitermachen</string>
     <string name="password_should_not_be_empty">Das Passwort darf nicht leer sein</string>
     <string name="signing_error_insufficient_funds">Nicht genug Gas, um die Transaktionsgebühr zu decken.\n Bitte füllen Sie das Wallet auf.</string>
-    <string name="signing_error_token_account_not_found_s">Ihr %s-Konto konnte nicht geladen werden. Bitte versuchen Sie es erneut.</string>
+    <string name="signing_error_token_account_not_found_s">Ihr %s-Token-Konto konnte nicht geladen werden. Bitte versuchen Sie es erneut.</string>
     <string name="signing_error_mixed_reshare">Gemischte Reshare-Signatur.\nBitte verwenden Sie Vault-Freigaben aus dem gleichen Reshare-Zyklus.</string>
     <string name="signing_error_sequence_mismatch">Die Konto-Sequenz hat sich geändert — bitte versuchen Sie es erneut.</string>
     <string name="signing_error_broadcast_rejected">Transaktion vom Netzwerk abgelehnt.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Weitermachen</string>
     <string name="password_should_not_be_empty">Das Passwort darf nicht leer sein</string>
     <string name="signing_error_insufficient_funds">Nicht genug Gas, um die Transaktionsgebühr zu decken.\n Bitte füllen Sie das Wallet auf.</string>
-    <string name="signing_error_token_account_not_found">Dieses Token wurde in Ihrem Wallet nicht gefunden.\nBitte stellen Sie sicher, dass Sie es besitzen, bevor Sie senden.</string>
+    <string name="signing_error_token_account_not_found_s">Ihr %s-Konto konnte nicht geladen werden. Bitte versuchen Sie es erneut.</string>
     <string name="signing_error_mixed_reshare">Gemischte Reshare-Signatur.\nBitte verwenden Sie Vault-Freigaben aus dem gleichen Reshare-Zyklus.</string>
     <string name="signing_error_sequence_mismatch">Die Konto-Sequenz hat sich geändert — bitte versuchen Sie es erneut.</string>
     <string name="signing_error_broadcast_rejected">Transaktion vom Netzwerk abgelehnt.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -267,6 +267,7 @@
     <string name="keygen_email_continue_button">Weitermachen</string>
     <string name="password_should_not_be_empty">Das Passwort darf nicht leer sein</string>
     <string name="signing_error_insufficient_funds">Nicht genug Gas, um die Transaktionsgebühr zu decken.\n Bitte füllen Sie das Wallet auf.</string>
+    <string name="signing_error_token_account_not_found">Dieses Token wurde in Ihrem Wallet nicht gefunden.\nBitte stellen Sie sicher, dass Sie es besitzen, bevor Sie senden.</string>
     <string name="signing_error_mixed_reshare">Gemischte Reshare-Signatur.\nBitte verwenden Sie Vault-Freigaben aus dem gleichen Reshare-Zyklus.</string>
     <string name="signing_error_sequence_mismatch">Die Konto-Sequenz hat sich geändert — bitte versuchen Sie es erneut.</string>
     <string name="signing_error_broadcast_rejected">Transaktion vom Netzwerk abgelehnt.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">La contraseña no debe estar vacía</string>
     <string name="signing_error_insufficient_funds">No hay suficiente gas para cubrir la tarifa de transacción.\n Por favor, cargue la billetera.</string>
-    <string name="signing_error_token_account_not_found_s">No se pudo cargar tu cuenta de %s. Inténtalo de nuevo.</string>
+    <string name="signing_error_token_account_not_found_s">No se pudo cargar tu cuenta del token %s. Inténtalo de nuevo.</string>
     <string name="signing_error_mixed_reshare">Firma de recompartición mixta.\n Utilice recursos compartidos de bóveda del mismo ciclo de recompartición.</string>
     <string name="signing_error_sequence_mismatch">La secuencia de la cuenta ha cambiado — por favor, vuelva a intentarlo.</string>
     <string name="signing_error_broadcast_rejected">Transacción rechazada por la red.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -267,6 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">La contraseña no debe estar vacía</string>
     <string name="signing_error_insufficient_funds">No hay suficiente gas para cubrir la tarifa de transacción.\n Por favor, cargue la billetera.</string>
+    <string name="signing_error_token_account_not_found">No se encontró este token en su billetera.\nAsegúrese de tenerlo antes de enviar.</string>
     <string name="signing_error_mixed_reshare">Firma de recompartición mixta.\n Utilice recursos compartidos de bóveda del mismo ciclo de recompartición.</string>
     <string name="signing_error_sequence_mismatch">La secuencia de la cuenta ha cambiado — por favor, vuelva a intentarlo.</string>
     <string name="signing_error_broadcast_rejected">Transacción rechazada por la red.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">La contraseña no debe estar vacía</string>
     <string name="signing_error_insufficient_funds">No hay suficiente gas para cubrir la tarifa de transacción.\n Por favor, cargue la billetera.</string>
-    <string name="signing_error_token_account_not_found">No se encontró este token en su billetera.\nAsegúrese de tenerlo antes de enviar.</string>
+    <string name="signing_error_token_account_not_found_s">No se pudo cargar tu cuenta de %s. Inténtalo de nuevo.</string>
     <string name="signing_error_mixed_reshare">Firma de recompartición mixta.\n Utilice recursos compartidos de bóveda del mismo ciclo de recompartición.</string>
     <string name="signing_error_sequence_mismatch">La secuencia de la cuenta ha cambiado — por favor, vuelva a intentarlo.</string>
     <string name="signing_error_broadcast_rejected">Transacción rechazada por la red.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -267,6 +267,7 @@
     <string name="keygen_email_continue_button">Nastaviti</string>
     <string name="password_should_not_be_empty">Lozinka ne smije biti prazna</string>
     <string name="signing_error_insufficient_funds">Nema dovoljno goriva za pokrivanje naknade za transakciju.\n Molimo uplatite novčanik.</string>
+    <string name="signing_error_token_account_not_found">Ovaj token nije pronađen u vašem novčaniku.\nProvjerite imate li ga prije slanja.</string>
     <string name="signing_error_mixed_reshare">Potpisivanje mješovitog ponovnog dijeljenja.\nUpotrijebite dijeljenja trezora istog ciklusa ponovnog dijeljenja.</string>
     <string name="signing_error_sequence_mismatch">Slijed računa je promijenjen — pokušajte ponovno.</string>
     <string name="signing_error_broadcast_rejected">Mreža je odbila transakciju.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Nastaviti</string>
     <string name="password_should_not_be_empty">Lozinka ne smije biti prazna</string>
     <string name="signing_error_insufficient_funds">Nema dovoljno goriva za pokrivanje naknade za transakciju.\n Molimo uplatite novčanik.</string>
-    <string name="signing_error_token_account_not_found_s">Nije moguće učitati vaš %s račun. Pokušajte ponovno.</string>
+    <string name="signing_error_token_account_not_found_s">Nije moguće učitati vaš %s token račun. Pokušajte ponovno.</string>
     <string name="signing_error_mixed_reshare">Potpisivanje mješovitog ponovnog dijeljenja.\nUpotrijebite dijeljenja trezora istog ciklusa ponovnog dijeljenja.</string>
     <string name="signing_error_sequence_mismatch">Slijed računa je promijenjen — pokušajte ponovno.</string>
     <string name="signing_error_broadcast_rejected">Mreža je odbila transakciju.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Nastaviti</string>
     <string name="password_should_not_be_empty">Lozinka ne smije biti prazna</string>
     <string name="signing_error_insufficient_funds">Nema dovoljno goriva za pokrivanje naknade za transakciju.\n Molimo uplatite novčanik.</string>
-    <string name="signing_error_token_account_not_found">Ovaj token nije pronađen u vašem novčaniku.\nProvjerite imate li ga prije slanja.</string>
+    <string name="signing_error_token_account_not_found_s">Nije moguće učitati vaš %s račun. Pokušajte ponovno.</string>
     <string name="signing_error_mixed_reshare">Potpisivanje mješovitog ponovnog dijeljenja.\nUpotrijebite dijeljenja trezora istog ciklusa ponovnog dijeljenja.</string>
     <string name="signing_error_sequence_mismatch">Slijed računa je promijenjen — pokušajte ponovno.</string>
     <string name="signing_error_broadcast_rejected">Mreža je odbila transakciju.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuare</string>
     <string name="password_should_not_be_empty">La password non deve essere vuota</string>
     <string name="signing_error_insufficient_funds">Non c&#8217;è abbastanza benzina per coprire la commissione di transazione.\n Si prega di finanziare il portafoglio.</string>
-    <string name="signing_error_token_account_not_found">Questo token non è stato trovato nel tuo portafoglio.\nAssicurati di possederlo prima di inviare.</string>
+    <string name="signing_error_token_account_not_found_s">Impossibile caricare il tuo account %s. Riprova.</string>
     <string name="signing_error_mixed_reshare">Firma di condivisione mista.\nUtilizzare condivisioni Vault dello stesso ciclo di condivisione.</string>
     <string name="signing_error_sequence_mismatch">La sequenza dell&#8217;account è cambiata — riprova.</string>
     <string name="signing_error_broadcast_rejected">Transazione rifiutata dalla rete.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -267,6 +267,7 @@
     <string name="keygen_email_continue_button">Continuare</string>
     <string name="password_should_not_be_empty">La password non deve essere vuota</string>
     <string name="signing_error_insufficient_funds">Non c&#8217;è abbastanza benzina per coprire la commissione di transazione.\n Si prega di finanziare il portafoglio.</string>
+    <string name="signing_error_token_account_not_found">Questo token non è stato trovato nel tuo portafoglio.\nAssicurati di possederlo prima di inviare.</string>
     <string name="signing_error_mixed_reshare">Firma di condivisione mista.\nUtilizzare condivisioni Vault dello stesso ciclo di condivisione.</string>
     <string name="signing_error_sequence_mismatch">La sequenza dell&#8217;account è cambiata — riprova.</string>
     <string name="signing_error_broadcast_rejected">Transazione rifiutata dalla rete.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuare</string>
     <string name="password_should_not_be_empty">La password non deve essere vuota</string>
     <string name="signing_error_insufficient_funds">Non c&#8217;è abbastanza benzina per coprire la commissione di transazione.\n Si prega di finanziare il portafoglio.</string>
-    <string name="signing_error_token_account_not_found_s">Impossibile caricare il tuo account %s. Riprova.</string>
+    <string name="signing_error_token_account_not_found_s">Impossibile caricare il tuo account token %s. Riprova.</string>
     <string name="signing_error_mixed_reshare">Firma di condivisione mista.\nUtilizzare condivisioni Vault dello stesso ciclo di condivisione.</string>
     <string name="signing_error_sequence_mismatch">La sequenza dell&#8217;account è cambiata — riprova.</string>
     <string name="signing_error_broadcast_rejected">Transazione rifiutata dalla rete.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -356,7 +356,7 @@
     <string name="keygen_email_continue_button">계속</string>
     <string name="password_should_not_be_empty">비밀번호를 입력해 주세요</string>
     <string name="signing_error_insufficient_funds">거래 수수료를 충당할 가스가 부족합니다.\n지갑에 자금을 충전해 주세요.</string>
-    <string name="signing_error_token_account_not_found_s">%s 계정을 불러올 수 없습니다. 다시 시도해 주세요.</string>
+    <string name="signing_error_token_account_not_found_s">%s 토큰 계정을 불러올 수 없습니다. 다시 시도해 주세요.</string>
     <string name="signing_error_mixed_reshare">혼합 재공유 서명.\n동일한 재공유 주기의 볼트 공유를 사용해 주세요.</string>
     <string name="signing_error_sequence_mismatch">계정 시퀀스가 변경되었습니다 — 다시 시도해 주세요.</string>
     <string name="signing_error_broadcast_rejected">네트워크가 거래를 거부했습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -356,7 +356,7 @@
     <string name="keygen_email_continue_button">계속</string>
     <string name="password_should_not_be_empty">비밀번호를 입력해 주세요</string>
     <string name="signing_error_insufficient_funds">거래 수수료를 충당할 가스가 부족합니다.\n지갑에 자금을 충전해 주세요.</string>
-    <string name="signing_error_token_account_not_found">지갑에서 이 토큰을 찾을 수 없습니다.\n보내기 전에 보유하고 있는지 확인해 주세요.</string>
+    <string name="signing_error_token_account_not_found_s">%s 계정을 불러올 수 없습니다. 다시 시도해 주세요.</string>
     <string name="signing_error_mixed_reshare">혼합 재공유 서명.\n동일한 재공유 주기의 볼트 공유를 사용해 주세요.</string>
     <string name="signing_error_sequence_mismatch">계정 시퀀스가 변경되었습니다 — 다시 시도해 주세요.</string>
     <string name="signing_error_broadcast_rejected">네트워크가 거래를 거부했습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -356,6 +356,7 @@
     <string name="keygen_email_continue_button">계속</string>
     <string name="password_should_not_be_empty">비밀번호를 입력해 주세요</string>
     <string name="signing_error_insufficient_funds">거래 수수료를 충당할 가스가 부족합니다.\n지갑에 자금을 충전해 주세요.</string>
+    <string name="signing_error_token_account_not_found">지갑에서 이 토큰을 찾을 수 없습니다.\n보내기 전에 보유하고 있는지 확인해 주세요.</string>
     <string name="signing_error_mixed_reshare">혼합 재공유 서명.\n동일한 재공유 주기의 볼트 공유를 사용해 주세요.</string>
     <string name="signing_error_sequence_mismatch">계정 시퀀스가 변경되었습니다 — 다시 시도해 주세요.</string>
     <string name="signing_error_broadcast_rejected">네트워크가 거래를 거부했습니다.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -266,6 +266,7 @@
     <string name="keygen_email_continue_button">Doorgaan</string>
     <string name="password_should_not_be_empty">Wachtwoord mag niet leeg zijn</string>
     <string name="signing_error_insufficient_funds">Er is niet genoeg gas om de transactiekosten te dekken.\nSchakel geld in de wallet.</string>
+    <string name="signing_error_token_account_not_found">Dit token is niet gevonden in je wallet.\nZorg ervoor dat je het bezit voordat je verzendt.</string>
     <string name="signing_error_mixed_reshare">Gemengde Reshare-ondertekening.\nGebruik kluisshares van dezelfde Reshare-cyclus.</string>
     <string name="signing_error_sequence_mismatch">De accountvolgorde is gewijzigd — probeer het opnieuw.</string>
     <string name="signing_error_broadcast_rejected">Transactie geweigerd door het netwerk.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -266,7 +266,7 @@
     <string name="keygen_email_continue_button">Doorgaan</string>
     <string name="password_should_not_be_empty">Wachtwoord mag niet leeg zijn</string>
     <string name="signing_error_insufficient_funds">Er is niet genoeg gas om de transactiekosten te dekken.\nSchakel geld in de wallet.</string>
-    <string name="signing_error_token_account_not_found">Dit token is niet gevonden in je wallet.\nZorg ervoor dat je het bezit voordat je verzendt.</string>
+    <string name="signing_error_token_account_not_found_s">Kan je %s-account niet laden. Probeer het opnieuw.</string>
     <string name="signing_error_mixed_reshare">Gemengde Reshare-ondertekening.\nGebruik kluisshares van dezelfde Reshare-cyclus.</string>
     <string name="signing_error_sequence_mismatch">De accountvolgorde is gewijzigd — probeer het opnieuw.</string>
     <string name="signing_error_broadcast_rejected">Transactie geweigerd door het netwerk.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -266,7 +266,7 @@
     <string name="keygen_email_continue_button">Doorgaan</string>
     <string name="password_should_not_be_empty">Wachtwoord mag niet leeg zijn</string>
     <string name="signing_error_insufficient_funds">Er is niet genoeg gas om de transactiekosten te dekken.\nSchakel geld in de wallet.</string>
-    <string name="signing_error_token_account_not_found_s">Kan je %s-account niet laden. Probeer het opnieuw.</string>
+    <string name="signing_error_token_account_not_found_s">Kan je %s-tokenaccount niet laden. Probeer het opnieuw.</string>
     <string name="signing_error_mixed_reshare">Gemengde Reshare-ondertekening.\nGebruik kluisshares van dezelfde Reshare-cyclus.</string>
     <string name="signing_error_sequence_mismatch">De accountvolgorde is gewijzigd — probeer het opnieuw.</string>
     <string name="signing_error_broadcast_rejected">Transactie geweigerd door het netwerk.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -267,6 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">A palavra-passe não deve estar vazia</string>
     <string name="signing_error_insufficient_funds">Não há gás suficiente para cobrir a taxa de transação.\n Por favor, financie a carteira.</string>
+    <string name="signing_error_token_account_not_found">Este token não foi encontrado na sua carteira.\nCertifique-se de que o possui antes de enviar.</string>
     <string name="signing_error_mixed_reshare">Assinatura mista de nova partilha. \nUtilizar partilhas do cofre do mesmo ciclo de nova partilha.</string>
     <string name="signing_error_sequence_mismatch">A sequência da conta foi alterada — por favor, tente novamente.</string>
     <string name="signing_error_broadcast_rejected">Transação rejeitada pela rede.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">A palavra-passe não deve estar vazia</string>
     <string name="signing_error_insufficient_funds">Não há gás suficiente para cobrir a taxa de transação.\n Por favor, financie a carteira.</string>
-    <string name="signing_error_token_account_not_found">Este token não foi encontrado na sua carteira.\nCertifique-se de que o possui antes de enviar.</string>
+    <string name="signing_error_token_account_not_found_s">Não foi possível carregar a sua conta %s. Tente novamente.</string>
     <string name="signing_error_mixed_reshare">Assinatura mista de nova partilha. \nUtilizar partilhas do cofre do mesmo ciclo de nova partilha.</string>
     <string name="signing_error_sequence_mismatch">A sequência da conta foi alterada — por favor, tente novamente.</string>
     <string name="signing_error_broadcast_rejected">Transação rejeitada pela rede.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -267,7 +267,7 @@
     <string name="keygen_email_continue_button">Continuar</string>
     <string name="password_should_not_be_empty">A palavra-passe não deve estar vazia</string>
     <string name="signing_error_insufficient_funds">Não há gás suficiente para cobrir a taxa de transação.\n Por favor, financie a carteira.</string>
-    <string name="signing_error_token_account_not_found_s">Não foi possível carregar a sua conta %s. Tente novamente.</string>
+    <string name="signing_error_token_account_not_found_s">Não foi possível carregar a sua conta de token %s. Tente novamente.</string>
     <string name="signing_error_mixed_reshare">Assinatura mista de nova partilha. \nUtilizar partilhas do cofre do mesmo ciclo de nova partilha.</string>
     <string name="signing_error_sequence_mismatch">A sequência da conta foi alterada — por favor, tente novamente.</string>
     <string name="signing_error_broadcast_rejected">Transação rejeitada pela rede.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -266,7 +266,7 @@
     <string name="keygen_email_continue_button">Продолжить</string>
     <string name="password_should_not_be_empty">Пароль не должен быть пустым</string>
     <string name="signing_error_insufficient_funds">Недостаточно газа для покрытия комиссии за транзакцию.\n Пожалуйста, пополните кошелек.</string>
-    <string name="signing_error_token_account_not_found_s">Не удалось загрузить аккаунт %s. Попробуйте ещё раз.</string>
+    <string name="signing_error_token_account_not_found_s">Не удалось загрузить токен-аккаунт %s. Попробуйте ещё раз.</string>
     <string name="signing_error_mixed_reshare">Смешанное подписание Reshare.\nПожалуйста, используйте общие ресурсы хранилища одного и того же цикла Reshare.</string>
     <string name="signing_error_sequence_mismatch">Порядковый номер аккаунта изменился — пожалуйста, повторите попытку.</string>
     <string name="signing_error_broadcast_rejected">Транзакция отклонена сетью.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -266,6 +266,7 @@
     <string name="keygen_email_continue_button">Продолжить</string>
     <string name="password_should_not_be_empty">Пароль не должен быть пустым</string>
     <string name="signing_error_insufficient_funds">Недостаточно газа для покрытия комиссии за транзакцию.\n Пожалуйста, пополните кошелек.</string>
+    <string name="signing_error_token_account_not_found">Этот токен не найден в вашем кошельке.\nУбедитесь, что он у вас есть, перед отправкой.</string>
     <string name="signing_error_mixed_reshare">Смешанное подписание Reshare.\nПожалуйста, используйте общие ресурсы хранилища одного и того же цикла Reshare.</string>
     <string name="signing_error_sequence_mismatch">Порядковый номер аккаунта изменился — пожалуйста, повторите попытку.</string>
     <string name="signing_error_broadcast_rejected">Транзакция отклонена сетью.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -266,7 +266,7 @@
     <string name="keygen_email_continue_button">Продолжить</string>
     <string name="password_should_not_be_empty">Пароль не должен быть пустым</string>
     <string name="signing_error_insufficient_funds">Недостаточно газа для покрытия комиссии за транзакцию.\n Пожалуйста, пополните кошелек.</string>
-    <string name="signing_error_token_account_not_found">Этот токен не найден в вашем кошельке.\nУбедитесь, что он у вас есть, перед отправкой.</string>
+    <string name="signing_error_token_account_not_found_s">Не удалось загрузить аккаунт %s. Попробуйте ещё раз.</string>
     <string name="signing_error_mixed_reshare">Смешанное подписание Reshare.\nПожалуйста, используйте общие ресурсы хранилища одного и того же цикла Reshare.</string>
     <string name="signing_error_sequence_mismatch">Порядковый номер аккаунта изменился — пожалуйста, повторите попытку.</string>
     <string name="signing_error_broadcast_rejected">Транзакция отклонена сетью.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,7 +504,7 @@
 
     <!-- Signing Errors -->
     <string name="signing_error_insufficient_funds">没有足够的燃料来支付交易费用。\n请为钱包充值。</string>
-    <string name="signing_error_token_account_not_found_s">无法加载您的 %s 账户。请重试。</string>
+    <string name="signing_error_token_account_not_found_s">无法加载您的 %s 代币账户。请重试。</string>
     <string name="signing_error_mixed_reshare">混合重新分享签名。\n请使用相同重新分享周期的保险库份额。</string>
     <string name="signing_error_sequence_mismatch">账户序列号已更改 — 请重试。</string>
     <string name="signing_error_broadcast_rejected">交易被网络拒绝。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,6 +504,7 @@
 
     <!-- Signing Errors -->
     <string name="signing_error_insufficient_funds">没有足够的燃料来支付交易费用。\n请为钱包充值。</string>
+    <string name="signing_error_token_account_not_found">在您的钱包中未找到此代币。\n请确保您持有该代币后再发送。</string>
     <string name="signing_error_mixed_reshare">混合重新分享签名。\n请使用相同重新分享周期的保险库份额。</string>
     <string name="signing_error_sequence_mismatch">账户序列号已更改 — 请重试。</string>
     <string name="signing_error_broadcast_rejected">交易被网络拒绝。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,7 +504,7 @@
 
     <!-- Signing Errors -->
     <string name="signing_error_insufficient_funds">没有足够的燃料来支付交易费用。\n请为钱包充值。</string>
-    <string name="signing_error_token_account_not_found">在您的钱包中未找到此代币。\n请确保您持有该代币后再发送。</string>
+    <string name="signing_error_token_account_not_found_s">无法加载您的 %s 账户。请重试。</string>
     <string name="signing_error_mixed_reshare">混合重新分享签名。\n请使用相同重新分享周期的保险库份额。</string>
     <string name="signing_error_sequence_mismatch">账户序列号已更改 — 请重试。</string>
     <string name="signing_error_broadcast_rejected">交易被网络拒绝。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,7 +364,7 @@
     <string name="keygen_email_continue_button">Continue</string>
     <string name="password_should_not_be_empty">Password should not be empty</string>
     <string name="signing_error_insufficient_funds">Not enough gas to cover the transaction fee.\nPlease fund the wallet.</string>
-    <string name="signing_error_token_account_not_found">This token was not found in your wallet.\nPlease make sure you have it before sending.</string>
+    <string name="signing_error_token_account_not_found_s">Could not load your %s account. Please try again.</string>
     <string name="signing_error_mixed_reshare">Mixed Reshare signing.\nPlease use vault shares of the same Reshare cycle.</string>
     <string name="signing_error_sequence_mismatch">Account sequence changed — please retry the transaction.</string>
     <string name="signing_error_broadcast_rejected">Transaction rejected by the network.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,7 +364,7 @@
     <string name="keygen_email_continue_button">Continue</string>
     <string name="password_should_not_be_empty">Password should not be empty</string>
     <string name="signing_error_insufficient_funds">Not enough gas to cover the transaction fee.\nPlease fund the wallet.</string>
-    <string name="signing_error_token_account_not_found_s">Could not load your %s account. Please try again.</string>
+    <string name="signing_error_token_account_not_found_s">Could not load your %s token account. Please try again.</string>
     <string name="signing_error_mixed_reshare">Mixed Reshare signing.\nPlease use vault shares of the same Reshare cycle.</string>
     <string name="signing_error_sequence_mismatch">Account sequence changed — please retry the transaction.</string>
     <string name="signing_error_broadcast_rejected">Transaction rejected by the network.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,6 +364,7 @@
     <string name="keygen_email_continue_button">Continue</string>
     <string name="password_should_not_be_empty">Password should not be empty</string>
     <string name="signing_error_insufficient_funds">Not enough gas to cover the transaction fee.\nPlease fund the wallet.</string>
+    <string name="signing_error_token_account_not_found">This token was not found in your wallet.\nPlease make sure you have it before sending.</string>
     <string name="signing_error_mixed_reshare">Mixed Reshare signing.\nPlease use vault shares of the same Reshare cycle.</string>
     <string name="signing_error_sequence_mismatch">Account sequence changed — please retry the transaction.</string>
     <string name="signing_error_broadcast_rejected">Transaction rejected by the network.</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -25,6 +25,14 @@ internal const val SOLANA_PRIORITY_FEE_LIMIT = 100000
 
 const val SOLANA_DEFAULT_CONTRACT_ADDRESS = "So11111111111111111111111111111111111111112"
 
+/**
+ * Prefix of the error thrown when the sender has no associated token account for an SPL transfer.
+ * The coin ticker follows the prefix so the keysign error screen can name the token in a localized
+ * message; keep it in sync with the `KeysignErrorScreen` branch that matches on it.
+ */
+const val SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX =
+    "SPL token transfer failed: missing associated token account for "
+
 class SolanaHelper(private val vaultHexPublicKey: String) {
 
     private val coinType = CoinType.SOLANA
@@ -117,10 +125,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                     .build()
                     .toByteArray()
             } else {
-                error(
-                    "SPL token transfer failed: sender's associated token account not found. " +
-                        "Please ensure you have this token in your wallet."
-                )
+                error("$SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX${keysignPayload.coin.ticker}")
             }
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -48,6 +48,11 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         if (keysignPayload.coin.chain != Chain.Solana) {
             error("Chain is not Solana")
         }
+        if (
+            !keysignPayload.coin.isNativeToken && solanaSpecific.fromAddressPubKey.isNullOrEmpty()
+        ) {
+            error("$SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX${keysignPayload.coin.ticker}")
+        }
         val toAddress = AnyAddress(keysignPayload.toAddress, coinType)
 
         val input =
@@ -86,10 +91,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
 
             return input.setTransferTransaction(transfer.build()).build().toByteArray()
         } else {
-            if (
-                !solanaSpecific.fromAddressPubKey.isNullOrEmpty() &&
-                    !solanaSpecific.toAddressPubKey.isNullOrEmpty()
-            ) {
+            if (!solanaSpecific.toAddressPubKey.isNullOrEmpty()) {
                 val transfer =
                     Solana.TokenTransfer.newBuilder()
                         .setTokenMintAddress(keysignPayload.coin.contractAddress)
@@ -101,7 +103,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                 keysignPayload.memo?.let { transfer.setMemo(it) }
 
                 return input.setTokenTransferTransaction(transfer.build()).build().toByteArray()
-            } else if (!solanaSpecific.fromAddressPubKey.isNullOrEmpty()) {
+            } else {
                 val receiverAddress = SolanaAddress(toAddress.description())
                 val generatedRecipientAssociatedAddress =
                     if (solanaSpecific.programId == true) {
@@ -124,8 +126,6 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                     .setCreateAndTransferTokenTransaction(transferTokenMessage.build())
                     .build()
                     .toByteArray()
-            } else {
-                error("$SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX${keysignPayload.coin.ticker}")
             }
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -93,7 +93,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                 keysignPayload.memo?.let { transfer.setMemo(it) }
 
                 return input.setTokenTransferTransaction(transfer.build()).build().toByteArray()
-            } else {
+            } else if (!solanaSpecific.fromAddressPubKey.isNullOrEmpty()) {
                 val receiverAddress = SolanaAddress(toAddress.description())
                 val generatedRecipientAssociatedAddress =
                     if (solanaSpecific.programId == true) {
@@ -116,6 +116,11 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                     .setCreateAndTransferTokenTransaction(transferTokenMessage.build())
                     .build()
                     .toByteArray()
+            } else {
+                error(
+                    "SPL token transfer failed: sender's associated token account not found. " +
+                        "Please ensure you have this token in your wallet."
+                )
             }
         }
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.fail
  * Covers the SPL token branch of [SolanaHelper.getPreSignedInputData] across the three
  * sender/recipient associated-token-account (ATA) combinations. The missing-sender-ATA case used to
  * pass `null` to `CreateAndTransferToken.setSenderTokenAddress` and crash with an NPE; it must now
- * abort with a clear error, matching iOS. The JNI-dependent assertions are skipped when the
- * WalletCore native library is unavailable, as in [UtxoHelperTest].
+ * abort with a clear, ticker-bearing error instead. The JNI-dependent assertions are skipped when
+ * the WalletCore native library is unavailable, as in [UtxoHelperTest].
  */
 class SolanaHelperTest {
 
@@ -63,7 +63,7 @@ class SolanaHelperTest {
             helper.getPreSignedImageHash(payload)
             fail("Expected a missing sender ATA to abort signing")
         } catch (e: IllegalStateException) {
-            assertEquals(MISSING_SENDER_ATA_ERROR, e.message)
+            assertEquals(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX + usdcCoin.ticker, e.message)
         } catch (e: Throwable) {
             skipIfJniUnavailable(e)
         }
@@ -114,9 +114,5 @@ class SolanaHelperTest {
         const val SENDER_TOKEN_ACCOUNT = "2Z6WGEsKfycoKAnTogC1M35dMgMtnLjwVZVLXcGQsFpA"
         const val RECIPIENT_TOKEN_ACCOUNT = "8vdCT37Lc6MLXfep8K5XFyYU6HTPpaqjJ7hyXJjUCc12"
         const val RECENT_BLOCK_HASH = "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R"
-
-        const val MISSING_SENDER_ATA_ERROR =
-            "SPL token transfer failed: sender's associated token account not found. " +
-                "Please ensure you have this token in your wallet."
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -1,0 +1,122 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+
+/**
+ * Covers the SPL token branch of [SolanaHelper.getPreSignedInputData] across the three
+ * sender/recipient associated-token-account (ATA) combinations. The missing-sender-ATA case used to
+ * pass `null` to `CreateAndTransferToken.setSenderTokenAddress` and crash with an NPE; it must now
+ * abort with a clear error, matching iOS. The JNI-dependent assertions are skipped when the
+ * WalletCore native library is unavailable, as in [UtxoHelperTest].
+ */
+class SolanaHelperTest {
+
+    private val usdcCoin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "USDC",
+            logo = "",
+            address = SENDER_ADDRESS,
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = USDC_MINT,
+            isNativeToken = false,
+        )
+
+    private fun splPayload(fromAddressPubKey: String?, toAddressPubKey: String?): KeysignPayload =
+        KeysignPayload(
+            coin = usdcCoin,
+            toAddress = RECIPIENT_ADDRESS,
+            toAmount = BigInteger.valueOf(1_000_000L),
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = RECENT_BLOCK_HASH,
+                    priorityFee = BigInteger.ZERO,
+                    priorityLimit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
+                    fromAddressPubKey = fromAddressPubKey,
+                    toAddressPubKey = toAddressPubKey,
+                    programId = false,
+                ),
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+        )
+
+    @Test
+    fun `SPL transfer aborts with a clear error when the sender has no associated token account`() {
+        val helper = SolanaHelper(vaultHexPublicKey = "")
+        val payload = splPayload(fromAddressPubKey = null, toAddressPubKey = null)
+
+        try {
+            helper.getPreSignedImageHash(payload)
+            fail("Expected a missing sender ATA to abort signing")
+        } catch (e: IllegalStateException) {
+            assertEquals(MISSING_SENDER_ATA_ERROR, e.message)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `SPL transfer builds a create-and-transfer tx when only the recipient ATA is missing`() {
+        val helper = SolanaHelper(vaultHexPublicKey = "")
+        val payload = splPayload(fromAddressPubKey = SENDER_TOKEN_ACCOUNT, toAddressPubKey = null)
+
+        try {
+            assertTrue(helper.getPreSignedImageHash(payload).isNotEmpty())
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `SPL transfer builds a token transfer when both associated token accounts exist`() {
+        val helper = SolanaHelper(vaultHexPublicKey = "")
+        val payload =
+            splPayload(
+                fromAddressPubKey = SENDER_TOKEN_ACCOUNT,
+                toAddressPubKey = RECIPIENT_TOKEN_ACCOUNT,
+            )
+
+        try {
+            assertTrue(helper.getPreSignedImageHash(payload).isNotEmpty())
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+
+    private companion object {
+        const val SENDER_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+        const val RECIPIENT_ADDRESS = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR"
+        const val USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        const val SENDER_TOKEN_ACCOUNT = "2Z6WGEsKfycoKAnTogC1M35dMgMtnLjwVZVLXcGQsFpA"
+        const val RECIPIENT_TOKEN_ACCOUNT = "8vdCT37Lc6MLXfep8K5XFyYU6HTPpaqjJ7hyXJjUCc12"
+        const val RECENT_BLOCK_HASH = "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R"
+
+        const val MISSING_SENDER_ATA_ERROR =
+            "SPL token transfer failed: sender's associated token account not found. " +
+                "Please ensure you have this token in your wallet."
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -7,112 +7,53 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.assertThrows
 
-/**
- * Covers the SPL token branch of [SolanaHelper.getPreSignedInputData] across the three
- * sender/recipient associated-token-account (ATA) combinations. The missing-sender-ATA case used to
- * pass `null` to `CreateAndTransferToken.setSenderTokenAddress` and crash with an NPE; it must now
- * abort with a clear, ticker-bearing error instead. The JNI-dependent assertions are skipped when
- * the WalletCore native library is unavailable, as in [UtxoHelperTest].
- */
 class SolanaHelperTest {
 
-    private val usdcCoin =
-        Coin(
-            chain = Chain.Solana,
-            ticker = "USDC",
-            logo = "",
-            address = SENDER_ADDRESS,
-            decimal = 6,
-            hexPublicKey = "",
-            priceProviderID = "",
-            contractAddress = USDC_MINT,
-            isNativeToken = false,
-        )
-
-    private fun splPayload(fromAddressPubKey: String?, toAddressPubKey: String?): KeysignPayload =
-        KeysignPayload(
-            coin = usdcCoin,
-            toAddress = RECIPIENT_ADDRESS,
-            toAmount = BigInteger.valueOf(1_000_000L),
-            blockChainSpecific =
-                BlockChainSpecific.Solana(
-                    recentBlockHash = RECENT_BLOCK_HASH,
-                    priorityFee = BigInteger.ZERO,
-                    priorityLimit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
-                    fromAddressPubKey = fromAddressPubKey,
-                    toAddressPubKey = toAddressPubKey,
-                    programId = false,
-                ),
-            vaultPublicKeyECDSA = "",
-            vaultLocalPartyID = "",
-            libType = SigningLibType.GG20,
-            wasmExecuteContractPayload = null,
-        )
-
+    /**
+     * An SPL send whose sender holds no associated token account must fail with a clear,
+     * ticker-bearing error rather than passing `null` into `CreateAndTransferToken` and crashing
+     * with an NPE. The guard runs before any WalletCore call, so it is exercised without the native
+     * library.
+     */
     @Test
-    fun `SPL transfer aborts with a clear error when the sender has no associated token account`() {
-        val helper = SolanaHelper(vaultHexPublicKey = "")
-        val payload = splPayload(fromAddressPubKey = null, toAddressPubKey = null)
-
-        try {
-            helper.getPreSignedImageHash(payload)
-            fail("Expected a missing sender ATA to abort signing")
-        } catch (e: IllegalStateException) {
-            assertEquals(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX + usdcCoin.ticker, e.message)
-        } catch (e: Throwable) {
-            skipIfJniUnavailable(e)
-        }
-    }
-
-    @Test
-    fun `SPL transfer builds a create-and-transfer tx when only the recipient ATA is missing`() {
-        val helper = SolanaHelper(vaultHexPublicKey = "")
-        val payload = splPayload(fromAddressPubKey = SENDER_TOKEN_ACCOUNT, toAddressPubKey = null)
-
-        try {
-            assertTrue(helper.getPreSignedImageHash(payload).isNotEmpty())
-        } catch (e: Throwable) {
-            skipIfJniUnavailable(e)
-        }
-    }
-
-    @Test
-    fun `SPL transfer builds a token transfer when both associated token accounts exist`() {
-        val helper = SolanaHelper(vaultHexPublicKey = "")
+    fun `SPL transfer without a sender token account fails with a ticker-bearing error`() {
+        val usdc =
+            Coin(
+                chain = Chain.Solana,
+                ticker = "USDC",
+                logo = "",
+                address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                decimal = 6,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                isNativeToken = false,
+            )
         val payload =
-            splPayload(
-                fromAddressPubKey = SENDER_TOKEN_ACCOUNT,
-                toAddressPubKey = RECIPIENT_TOKEN_ACCOUNT,
+            KeysignPayload(
+                coin = usdc,
+                toAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
+                toAmount = BigInteger.valueOf(1_000_000L),
+                blockChainSpecific =
+                    BlockChainSpecific.Solana(
+                        recentBlockHash = "",
+                        priorityFee = BigInteger.ZERO,
+                        priorityLimit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
+                        fromAddressPubKey = null,
+                        toAddressPubKey = null,
+                        programId = false,
+                    ),
+                vaultPublicKeyECDSA = "",
+                vaultLocalPartyID = "",
+                libType = SigningLibType.GG20,
+                wasmExecuteContractPayload = null,
             )
 
-        try {
-            assertTrue(helper.getPreSignedImageHash(payload).isNotEmpty())
-        } catch (e: Throwable) {
-            skipIfJniUnavailable(e)
-        }
-    }
-
-    private fun skipIfJniUnavailable(e: Throwable) {
-        if (
-            e is UnsatisfiedLinkError ||
-                e is ExceptionInInitializerError ||
-                e is NoClassDefFoundError
-        ) {
-            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
-        } else throw e
-    }
-
-    private companion object {
-        const val SENDER_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
-        const val RECIPIENT_ADDRESS = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR"
-        const val USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-        const val SENDER_TOKEN_ACCOUNT = "2Z6WGEsKfycoKAnTogC1M35dMgMtnLjwVZVLXcGQsFpA"
-        const val RECIPIENT_TOKEN_ACCOUNT = "8vdCT37Lc6MLXfep8K5XFyYU6HTPpaqjJ7hyXJjUCc12"
-        const val RECENT_BLOCK_HASH = "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R"
+        val error =
+            assertThrows<IllegalStateException> { SolanaHelper("").getPreSignedImageHash(payload) }
+        assertEquals(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX + usdc.ticker, error.message)
     }
 }


### PR DESCRIPTION
Closes #4803

Sending an SPL token when the sender has no associated token account (ATA) for that mint — or when the ATA lookup fails over RPC — left `fromAddressPubKey` null. The create-and-transfer branch passed that null straight into `CreateAndTransferToken.setSenderTokenAddress`, which crashes with an NPE (protobuf-lite null check) or, with an empty string, builds an unbroadcastable transaction. There was no clean failure path.

## Changes

- `SolanaHelper` guards the SPL path: if the sender has no associated token account it aborts early (before any WalletCore call) with a clear error carrying the token ticker, instead of passing null into the token instructions. The non-native branch then only distinguishes a present vs missing recipient account (creating the recipient's account inline when needed).
- `KeysignErrorScreen` maps that error to a localized, token-named message (`signing_error_token_account_not_found_s`, added to all locales). The lookup almost always fails transiently, so the copy frames it as a retry rather than implying the user lacks the token.

## Signing

The guard runs while computing the pre-image hashes, before any keysign session starts, so Fast Vault and multi-device co-sign both fail fast locally with the same message rather than stalling. Valid SPL sends (recipient account present or missing) are unchanged.

## Screenshots

Pre-fix this path crashed, so there is no real prior screen. **Before** shows how the raw guard error reads in the app's generic error template (i.e. the guard without the localized mapping); **After** shows the localized, token-named message this PR adds. USDC example, on the keysign error screen.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/jXC5XS5.png) | ![after](https://i.imgur.com/9K3JVX1.png) |

## Testing

- `./gradlew :data:testDebugUnitTest --tests "*SolanaHelperTest*"` — the missing-sender-account case is asserted as a plain JVM test (the guard runs before WalletCore, so no native library is needed).
- `./gradlew :data:ktfmtCheckMain :data:ktfmtCheckTest :app:ktfmtCheckMain`
- `./gradlew :app:compileDebugKotlin`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana signing error handling: users now see a clear, specific message showing the affected token when a required token account can't be found.

* **Localization**
  * Added translated versions of the new error message in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.

* **Tests**
  * Added a test verifying failure behavior when a Solana token transfer is missing the sender token account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->