### PR TITLE
feat: QBTC Staking

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -209,6 +209,8 @@ class PreviewActivity : ComponentActivity() {
                     "keysign_devices_plus_after" -> KeysignDevicesCountPreview(allowsMore = false)
                     "staking_verify_before" -> CosmosStakingVerifyCtaPreview(newButtons = false)
                     "staking_verify_after" -> CosmosStakingVerifyCtaPreview(newButtons = true)
+                    "staking_verify_qbtc" ->
+                        CosmosStakingVerifyCtaPreview(newButtons = true, qbtc = true)
                     "sign_message_before" -> VerifySignMessageCtaPreview(newButtons = false)
                     "sign_message_after" -> VerifySignMessageCtaPreview(newButtons = true)
                     else -> SwapConfirmPreview()
@@ -1735,27 +1737,51 @@ private fun KeysignSigningLuncPreview() {
 }
 
 @Composable
-private fun CosmosStakingVerifyCtaPreview(newButtons: Boolean) {
+private fun CosmosStakingVerifyCtaPreview(newButtons: Boolean, qbtc: Boolean = false) {
     val state =
-        CosmosStakingVerifyUiState(
-            headlineRes = R.string.cosmos_staking_youre_staking,
-            amount = "12.5",
-            ticker = "LUNA",
-            vaultName = "Main Vault",
-            fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
-            validatorRows =
-                listOf(
-                    CosmosStakingVerifyValidatorRow(
-                        labelRes = R.string.cosmos_staking_validator_picker,
-                        value = "Allnodes (5% commission)",
-                    )
-                ),
-            networkName = "Terra",
-            feeCrypto = "0.01 LUNA",
-            feeFiat = "$0.02",
-            hasFastSign = true,
-            isLoading = false,
-        )
+        if (qbtc) {
+            // QBTC rides the same chain-generic verify screen as LUNA/LUNC. No price feed, so the
+            // fiat fee is hidden ($0.00 equivalent); the fee is the qbtc-testnet min_tx_fee.
+            CosmosStakingVerifyUiState(
+                headlineRes = R.string.cosmos_staking_youre_staking,
+                amount = "0.5",
+                ticker = "QBTC",
+                vaultName = "Main Vault",
+                fromAddress = "qbtc1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
+                validatorRows =
+                    listOf(
+                        CosmosStakingVerifyValidatorRow(
+                            labelRes = R.string.cosmos_staking_validator_picker,
+                            value = "QBTC Labs (3% commission)",
+                        )
+                    ),
+                networkName = "QBTC",
+                feeCrypto = "0.000008 QBTC",
+                feeFiat = "",
+                hasFastSign = true,
+                isLoading = false,
+            )
+        } else {
+            CosmosStakingVerifyUiState(
+                headlineRes = R.string.cosmos_staking_youre_staking,
+                amount = "12.5",
+                ticker = "LUNA",
+                vaultName = "Main Vault",
+                fromAddress = "terra1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxx78wk",
+                validatorRows =
+                    listOf(
+                        CosmosStakingVerifyValidatorRow(
+                            labelRes = R.string.cosmos_staking_validator_picker,
+                            value = "Allnodes (5% commission)",
+                        )
+                    ),
+                networkName = "Terra",
+                feeCrypto = "0.01 LUNA",
+                feeFiat = "$0.02",
+                hasFastSign = true,
+                isLoading = false,
+            )
+        }
     CosmosStakingVerifyContent(state = state, onClose = {}) {
         val ctaModifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
         if (newButtons) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainDashboardUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainDashboardUiModel.kt
@@ -105,6 +105,7 @@ constructor(
                         Chain.Tron.id,
                         Chain.Terra.id,
                         Chain.TerraClassic.id,
+                        Chain.Qbtc.id,
                     )
             )
                 BOTH_CRYPTO_CONNECTION_TYPES
@@ -141,7 +142,8 @@ constructor(
                                     ChainDashboardRoute.PositionMaya(vaultId = vaultId)
                                 Chain.Tron.id -> ChainDashboardRoute.PositionTron(vaultId = vaultId)
                                 Chain.Terra.id,
-                                Chain.TerraClassic.id ->
+                                Chain.TerraClassic.id,
+                                Chain.Qbtc.id ->
                                     ChainDashboardRoute.PositionCosmosStaking(
                                         vaultId = vaultId,
                                         chainId = requireNotNull(chainId),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -400,7 +400,8 @@ constructor(
                                 )
                             )
                         account.chainName.equals(Chain.Terra.raw, true) ||
-                            account.chainName.equals(Chain.TerraClassic.raw, true) ->
+                            account.chainName.equals(Chain.TerraClassic.raw, true) ||
+                            account.chainName.equals(Chain.Qbtc.raw, true) ->
                             navigator.route(
                                 Route.ChainDashboard(
                                     route =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosDelegateViewModel.kt
@@ -41,6 +41,8 @@ import timber.log.Timber
 
 internal data class CosmosDelegateUiState(
     val ticker: String = "",
+    /** Native-coin base-unit decimals — drives the validator picker's voting-power formatting. */
+    val decimal: Int = 0,
     val validators: List<CosmosValidator> = emptyList(),
     val selectedValidator: CosmosValidator? = null,
     val validatorSearchQuery: String = "",
@@ -326,7 +328,13 @@ constructor(
                 withContext(ioDispatcher) { balanceRepository.cachedSpendableBalance(nativeCoin) }
             val stakeable = (total - feeReservation).coerceAtLeast(BigDecimal.ZERO)
 
-            _state.update { it.copy(ticker = nativeCoin.ticker, stakeableBalance = stakeable) }
+            _state.update {
+                it.copy(
+                    ticker = nativeCoin.ticker,
+                    decimal = nativeCoin.decimal,
+                    stakeableBalance = stakeable,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
@@ -51,6 +51,8 @@ import timber.log.Timber
 
 internal data class CosmosRedelegateUiState(
     val ticker: String = "",
+    /** Native-coin base-unit decimals — drives the validator picker's voting-power formatting. */
+    val decimal: Int = 0,
     val srcValidatorAddress: String = "",
     val srcValidatorMoniker: String = "",
     val stakedBalance: BigDecimal = BigDecimal.ZERO,
@@ -405,6 +407,7 @@ constructor(
             _state.update {
                 it.copy(
                     ticker = nativeCoin.ticker,
+                    decimal = nativeCoin.decimal,
                     stakedBalance = stakedBalance,
                     percentageSelected = 100,
                     spendableBalance = spendableBalance,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
@@ -371,7 +371,13 @@ constructor(
                     // view on the next reopen until the live refresh repairs it. Skip the write so
                     // a
                     // transient LCD blip is never persisted as truth (issue #4773 review).
-                    val priceOk = resolvedPrice != null && resolvedPrice.signum() > 0
+                    // A chain with no price feed (QBTC) legitimately prices to $0.00 — that's not
+                    // the degraded "price fetch failed" case above, so only skip the write when a
+                    // feed-bearing chain couldn't be priced. Otherwise QBTC never caches and every
+                    // reopen is a cold load.
+                    val priceOk =
+                        coin.priceProviderID.isEmpty() ||
+                            (resolvedPrice != null && resolvedPrice.signum() > 0)
                     if (validatorsResult.isSuccess && priceOk) {
                         snapshotCache.write(
                             cacheKey,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
@@ -49,6 +49,13 @@ internal data class CosmosStakingPositionsUiState(
     val ticker: String = "",
     val coinLogo: String = "",
     val positions: List<CosmosStakePositionRow> = emptyList(),
+    /**
+     * True only when at least one validator has accrued a whole base unit of rewards. Rewards
+     * accrue as fractional base units (`cosmos.Dec`) but withdrawal floors to whole base units, so
+     * a sub-1-base-unit reward shows a non-zero tile yet is unclaimable — gating Claim on it would
+     * let the user pay a fee to withdraw nothing.
+     */
+    val hasClaimableRewards: Boolean = false,
     val pendingUnbondings: List<CosmosUnbondingDelegation> = emptyList(),
     val totalStaked: BigDecimal = BigDecimal.ZERO,
     val isLoading: Boolean = false,
@@ -180,6 +187,8 @@ constructor(
                         _state.update {
                             it.copy(
                                 positions = cached.positions,
+                                hasClaimableRewards =
+                                    hasClaimableRewards(cached.positions, coin.decimal),
                                 pendingUnbondings = cached.pendingUnbondings,
                                 totalStaked = cached.totalStaked,
                                 totalStakedFiat = cached.totalStakedFiat,
@@ -342,6 +351,7 @@ constructor(
                     _state.update {
                         it.copy(
                             positions = positions,
+                            hasClaimableRewards = hasClaimableRewards(positions, decimals),
                             pendingUnbondings = unbondings,
                             totalStaked = totalStaked,
                             totalStakedFiat = totalStakedFiat,
@@ -537,6 +547,16 @@ constructor(
             value > BigDecimal.ONE -> BigDecimal.ONE
             else -> value
         }
+
+    // A reward is claimable only once it reaches a whole base unit, since withdrawal floors the
+    // fractional cosmos.Dec accrual. `pendingReward` is in coin units, so one base unit is 10^-dp.
+    private fun hasClaimableRewards(
+        positions: List<CosmosStakePositionRow>,
+        decimals: Int,
+    ): Boolean {
+        val oneBaseUnit = BigDecimal.ONE.movePointLeft(decimals)
+        return positions.any { it.pendingReward >= oneBaseUnit }
+    }
 
     /**
      * Fires off Keybase avatar lookups for any row that has a non-empty identity. Lookups are

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -89,6 +89,7 @@ internal fun CosmosDelegateScreen(viewModel: CosmosDelegateViewModel = hiltViewM
                 isLoading = state.isLoadingValidators,
                 validators = viewModel.visibleValidators(state),
                 ticker = state.ticker,
+                decimal = state.decimal,
                 selectedValidatorAddress = state.selectedValidator?.operatorAddress,
                 onValidatorSelected = viewModel::selectValidator,
                 onResolveAvatar = viewModel::resolveValidatorAvatar,
@@ -317,6 +318,7 @@ internal fun ValidatorPickerSheet(
     isLoading: Boolean,
     validators: List<CosmosValidator>,
     ticker: String,
+    decimal: Int,
     selectedValidatorAddress: String?,
     onValidatorSelected: (CosmosValidator) -> Unit,
     onResolveAvatar: suspend (String?) -> String?,
@@ -432,6 +434,7 @@ internal fun ValidatorPickerSheet(
                                 ValidatorPickerRow(
                                     validator = validator,
                                     ticker = ticker,
+                                    decimal = decimal,
                                     isSelected = validator.operatorAddress == pickedAddress,
                                     onResolveAvatar = onResolveAvatar,
                                     onClick = { pickedAddress = validator.operatorAddress },
@@ -485,6 +488,7 @@ private fun ValidatorPickerHeader(title: String, onClose: () -> Unit, onConfirm:
 private fun ValidatorPickerRow(
     validator: CosmosValidator,
     ticker: String,
+    decimal: Int,
     isSelected: Boolean,
     onResolveAvatar: suspend (String?) -> String?,
     onClick: () -> Unit,
@@ -533,7 +537,7 @@ private fun ValidatorPickerRow(
                 maxLines = 1,
             )
             Text(
-                text = "${formatVotingPower(validator.votingPower)} $ticker",
+                text = "${formatVotingPower(validator.votingPower, decimal)} $ticker",
                 style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.text.secondary,
                 maxLines = 1,
@@ -572,12 +576,12 @@ private fun formatCommissionPercent(commission: BigDecimal): String =
 
 /**
  * Voting power arrives as bond-denom base units (uint string). Render it in whole-token units with
- * thousands separators, matching the iOS validator picker (e.g. "137,888,608,306 LUNC"). LUNA/LUNC
- * use 6 decimals.
+ * thousands separators, matching the iOS validator picker (e.g. "137,888,608,306 LUNC"). The
+ * base-unit decimals are chain-specific — LUNA/LUNC use 6, QBTC uses 8 — so the coin's [decimals]
+ * must be passed in rather than assumed.
  */
-private fun formatVotingPower(votingPowerBaseUnits: BigDecimal): String {
-    // Terra (LUNA) and Terra Classic (LUNC) both use 6 base-unit decimals.
-    val whole = votingPowerBaseUnits.movePointLeft(6).toBigInteger()
+private fun formatVotingPower(votingPowerBaseUnits: BigDecimal, decimals: Int): String {
+    val whole = votingPowerBaseUnits.movePointLeft(decimals).toBigInteger()
     return "%,d".format(whole)
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
@@ -138,6 +138,7 @@ internal fun CosmosRedelegateScreen(viewModel: CosmosRedelegateViewModel = hiltV
                 isLoading = state.isLoadingValidators,
                 validators = viewModel.visibleValidators(state),
                 ticker = state.ticker,
+                decimal = state.decimal,
                 selectedValidatorAddress = state.selectedDstValidator?.operatorAddress,
                 onValidatorSelected = viewModel::selectDstValidator,
                 onResolveAvatar = viewModel::resolveValidatorAvatar,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -156,8 +156,7 @@ internal fun CosmosStakingPositionsScreen(
                                 ticker = state.ticker,
                                 totalStaked = formatStakeAmount(state.totalStaked),
                                 totalFiat = state.totalStakedFiat,
-                                hasClaimableRewards =
-                                    state.positions.any { it.pendingReward > BigDecimal.ZERO },
+                                hasClaimableRewards = state.hasClaimableRewards,
                                 onClaim = viewModel::claimAll,
                                 onDelegateToNewValidator = viewModel::stakeMore,
                             )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
@@ -71,7 +71,7 @@ internal class CosmosStakingPositionsViewModelTest {
             address = "terra1delegator",
             decimal = 6,
             hexPublicKey = "02".repeat(33),
-            priceProviderID = "",
+            priceProviderID = "terra-luna",
             contractAddress = "",
             isNativeToken = true,
         )
@@ -359,12 +359,31 @@ internal class CosmosStakingPositionsViewModelTest {
     }
 
     @Test
-    fun `a missing price is not frozen into the cache`() = runTest {
-        // A price miss renders every fiat slot as $0.00; freezing that snapshot would reseed a
-        // zeroed-out screen on reopen, so the write is skipped until a real price is available.
+    fun `a missing price on a feed-bearing chain is not frozen into the cache`() = runTest {
+        // A price miss on a chain that HAS a feed renders every fiat slot as $0.00; freezing that
+        // snapshot would reseed a zeroed-out screen on reopen, so the write is skipped until a real
+        // price is available.
         coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns null
         vm()
         assertNull(snapshotCache.read("Terra:terra1delegator"))
+    }
+
+    @Test
+    fun `a no-price-feed chain still writes the cache despite a null price`() = runTest {
+        // QBTC has no price feed, so $0.00 fiat is correct rather than a failed fetch — the
+        // snapshot
+        // must still be cached so reopens render instantly instead of cold-loading every time.
+        coEvery { vaultRepository.get(any()) } returns
+            Vault(
+                id = "v1",
+                name = "v",
+                pubKeyECDSA = "pk",
+                localPartyID = "lp",
+                coins = listOf(coin.copy(priceProviderID = "")),
+            )
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns null
+        vm()
+        assertNotNull(snapshotCache.read("Terra:terra1delegator"))
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
@@ -152,6 +152,27 @@ internal class CosmosStakingPositionsViewModelTest {
             .also { it.setData(vaultId = "v1", chainId = "Terra") }
 
     @Test
+    fun `hasClaimableRewards is true when a reward exceeds one base unit`() = runTest {
+        // Fixture reward is 250000 uluna (0.25 LUNA) — well above one base unit, so claimable.
+        assertEquals(true, vm().state.value.hasClaimableRewards)
+    }
+
+    @Test
+    fun `hasClaimableRewards is false when rewards round down to zero base units`() = runTest {
+        // 0.5 uluna accrued — a fractional cosmos.Dec below one whole base unit, so withdrawal
+        // would yield 0; the Claim CTA must stay hidden rather than burn a fee on nothing.
+        coEvery { cosmosStakingService.fetchDelegatorRewards(any(), any()) } returns
+            CosmosDelegatorRewards(
+                rewards =
+                    listOf(
+                        CosmosDelegatorReward(activeVal, listOf(CosmosStakingCoin("uluna", "0.5")))
+                    ),
+                total = emptyList(),
+            )
+        assertEquals(false, vm().state.value.hasClaimableRewards)
+    }
+
+    @Test
     fun `builds rows with correct status and total staked`() = runTest {
         val model = vm()
         val s = model.state.value

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCase.kt
@@ -51,6 +51,9 @@ internal class BuildCosmosStakingKeysignPayloadUseCaseImpl @Inject constructor()
         vaultLocalPartyID: String,
         libType: SigningLibType?,
     ): KeysignPayload {
+        // The resolver derives the signing scheme from the chain — secp256k1 for the Terra family,
+        // ML-DSA for QBTC — so this single call serves both. The signed bytes round-trip via
+        // `signDirect` regardless of scheme.
         val signDirect =
             CosmosStakingSignDataResolver.resolve(
                 payload = payload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCase.kt
@@ -51,9 +51,6 @@ internal class BuildCosmosStakingKeysignPayloadUseCaseImpl @Inject constructor()
         vaultLocalPartyID: String,
         libType: SigningLibType?,
     ): KeysignPayload {
-        // The resolver derives the signing scheme from the chain — secp256k1 for the Terra family,
-        // ML-DSA for QBTC — so this single call serves both. The signed bytes round-trip via
-        // `signDirect` regardless of scheme.
         val signDirect =
             CosmosStakingSignDataResolver.resolve(
                 payload = payload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingAPYResolver.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingAPYResolver.kt
@@ -89,6 +89,11 @@ constructor(private val cosmosStakingService: CosmosStakingService) : CosmosStak
     private val inFlight = mutableMapOf<Chain, CompletableDeferred<CosmosChainApyData?>>()
 
     override suspend fun chainApy(chain: Chain, stakingDenom: String): CosmosChainApyData? {
+        // QBTC has no x/mint module, so the inflation fan-out always 501s and collapses to a null
+        // APY. Short-circuit before the four LCD round-trips so the positions screen isn't held up
+        // by ~1s of doomed requests on every load.
+        if (chain == Chain.Qbtc) return null
+
         // Cache hit, then in-flight coalescing, then fresh fan-out — all under the mutex.
         // Ownership is decided inside the mutex so only the creator runs the fan-out; an identity
         // check after the lock would be true for every coalescing caller too (they share the same

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
@@ -69,6 +69,25 @@ object CosmosStakingConfig {
                     feeAmount = 133_333_334L,
                     unbondingDays = 21,
                 ),
+            Chain.Qbtc to
+                Entry(
+                    // Live on-chain id (the network launched under it). All values verified against
+                    // the qbtc-testnet LCD; mirrors iOS PR vultisig-ios#4481.
+                    chainId = "qbtc-testnet",
+                    // `qbtc` is lowercase and NOT a micro-denom — QBTC has 8 decimals and the
+                    // staking bond_denom is the bare `qbtc` (live LCD `staking/params.bond_denom`).
+                    bondDenom = "qbtc",
+                    feeDenom = "qbtc",
+                    valoperHrp = "qbtcvaloper",
+                    // Matches Terra's post-OoG floor — a live MsgDelegate simulate burned 278_759;
+                    // redelegate (dual-record write + ~2.4 KB ML-DSA sig) is heavier.
+                    gasLimit = 400_000L,
+                    // The qbtc-testnet `min_tx_fee` floor; `min_gas_price` is 0, so the larger gas
+                    // budget does not raise the fee (unlike the QBTC send path's flat 7_500).
+                    feeAmount = 800L,
+                    // Live LCD `unbonding_time` = 1814400s = 21 days.
+                    unbondingDays = 21,
+                ),
         )
 
     fun entryFor(chain: Chain): Entry = table[chain] ?: throw CosmosStakingConfigException(chain)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
@@ -69,23 +69,19 @@ object CosmosStakingConfig {
                     feeAmount = 133_333_334L,
                     unbondingDays = 21,
                 ),
+            // Values verified against the live qbtc-testnet LCD; mirrors iOS #4481.
             Chain.Qbtc to
                 Entry(
-                    // Live on-chain id (the network launched under it). All values verified against
-                    // the qbtc-testnet LCD; mirrors iOS PR vultisig-ios#4481.
                     chainId = "qbtc-testnet",
-                    // `qbtc` is lowercase and NOT a micro-denom — QBTC has 8 decimals and the
-                    // staking bond_denom is the bare `qbtc` (live LCD `staking/params.bond_denom`).
+                    // Lowercase, not a micro-denom — QBTC's bond_denom is the bare `qbtc` (8 dp).
                     bondDenom = "qbtc",
                     feeDenom = "qbtc",
                     valoperHrp = "qbtcvaloper",
-                    // Matches Terra's post-OoG floor — a live MsgDelegate simulate burned 278_759;
-                    // redelegate (dual-record write + ~2.4 KB ML-DSA sig) is heavier.
+                    // Terra's post-OoG floor — a MsgDelegate simulate burned 278_759; redelegate
+                    // (dual-record write + ~2.4 KB ML-DSA sig) is heavier.
                     gasLimit = 400_000L,
-                    // The qbtc-testnet `min_tx_fee` floor; `min_gas_price` is 0, so the larger gas
-                    // budget does not raise the fee (unlike the QBTC send path's flat 7_500).
+                    // qbtc-testnet min_tx_fee floor (min_gas_price is 0, so gas can't raise it).
                     feeAmount = 800L,
-                    // Live LCD `unbonding_time` = 1814400s = 21 days.
                     unbondingDays = 21,
                 ),
         )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingDeFiBalanceService.kt
@@ -12,14 +12,14 @@ import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 /**
- * DeFi-balance provider for LUNA / LUNC staking. The user's DeFi position on Terra / TerraClassic
- * is the sum of their delegation balances (base units) — mirrors iOS
+ * DeFi-balance provider for Cosmos-SDK staking (LUNA / LUNC / QBTC). The user's DeFi position on
+ * the chain is the sum of their delegation balances (base units) — mirrors iOS
  * `DefiBalanceService.cosmosStakingTotalBalance`, where the chain's DeFi balance is the staked
  * total.
  *
  * Unlike the THORChain / Maya / Tron [com.vultisig.wallet.data.blockchain.DeFiService]
- * implementations this is **chain-aware**: Terra and TerraClassic share the same bech32 address, so
- * the chain must be passed explicitly to pick the right LCD + native coin.
+ * implementations this is **chain-aware**: every staking chain has its own LCD + native coin (and
+ * Terra / TerraClassic even share a bech32 address), so the chain must be passed explicitly.
  *
  * A network failure returns an empty list rather than throwing — the DeFi balance fan-out runs each
  * chain inside an `async`, so a thrown exception here would cancel the whole load and blank every
@@ -97,6 +97,7 @@ class CosmosStakingDeFiBalanceService(
         when (chain) {
             Chain.Terra -> Coins.Terra.LUNA
             Chain.TerraClassic -> Coins.TerraClassic.LUNC
+            Chain.Qbtc -> Coins.Qbtc.QBTC
             else -> null
         }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingHelper.kt
@@ -115,7 +115,12 @@ object CosmosStakingHelper {
     }
 
     /**
-     * Builds the `AuthInfo` for a single-signer secp256k1 tx in SIGN_MODE_DIRECT.
+     * Builds the `AuthInfo` for a single-signer tx in SIGN_MODE_DIRECT.
+     *
+     * [pubKeyTypeUrl] defaults to secp256k1 (the Terra path). QBTC passes the ML-DSA URL
+     * (`/cosmos.crypto.mldsa.PubKey`) so the post-quantum signing path reuses this single AuthInfo
+     * encoder rather than maintaining a divergent copy — only the inner `Any` type URL differs by
+     * scheme; the rest of the wire shape is pubkey-agnostic.
      *
      * AuthInfo: `{ signer_infos(1, repeated), fee(2) }`. SignerInfo: `{ public_key(1, Any),
      * mode_info(2), sequence(3) }`. ModeInfo: `{ single(1) }` → Single: `{ mode(1) }`. Fee: `{
@@ -127,12 +132,13 @@ object CosmosStakingHelper {
         gasLimit: Long,
         feeDenom: String,
         feeAmount: Long,
+        pubKeyTypeUrl: String = PUBKEY_TYPE_URL,
     ): ByteArray {
         val pubKeyInner = ByteArrayOutputStream()
         pubKeyInner.appendProtoBytes(1, pubKey)
 
         val pubKeyAny = ByteArrayOutputStream()
-        pubKeyAny.appendProtoString(1, PUBKEY_TYPE_URL)
+        pubKeyAny.appendProtoString(1, pubKeyTypeUrl)
         pubKeyAny.appendProtoBytes(2, pubKeyInner.toByteArray())
 
         val single = ByteArrayOutputStream()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingService.kt
@@ -170,7 +170,6 @@ internal class CosmosStakingServiceImpl @Inject constructor(private val httpClie
             mapOf(
                 Chain.Terra to "https://terra-lcd.publicnode.com",
                 Chain.TerraClassic to "https://terra-classic-lcd.publicnode.com",
-                // QBTC's Cosmos REST gateway, mirroring the host already wired in CosmosApi.
                 Chain.Qbtc to "https://api.vultisig.com/qbtc-rpc",
             )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingService.kt
@@ -170,6 +170,8 @@ internal class CosmosStakingServiceImpl @Inject constructor(private val httpClie
             mapOf(
                 Chain.Terra to "https://terra-lcd.publicnode.com",
                 Chain.TerraClassic to "https://terra-classic-lcd.publicnode.com",
+                // QBTC's Cosmos REST gateway, mirroring the host already wired in CosmosApi.
+                Chain.Qbtc to "https://api.vultisig.com/qbtc-rpc",
             )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingSignDataResolver.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingSignDataResolver.kt
@@ -1,6 +1,9 @@
 package com.vultisig.wallet.data.blockchain.cosmos.staking
 
+import com.vultisig.wallet.data.chains.helpers.QBTCTransactionHelper
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TssKeyType
+import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
 import java.util.Base64
@@ -66,8 +69,12 @@ object CosmosStakingSignDataResolver {
 
     /**
      * Resolves the SignDoc artefacts for a staking payload. Caller passes the immutable [payload],
-     * the [coin] being staked (provides chain, delegator address, public key), and the Cosmos
+     * the chain + delegator address + hex public key of the coin being staked, and the Cosmos
      * chain-specific (already populated upstream — sequence + account number).
+     *
+     * The signing scheme is derived from the chain: secp256k1 for the Terra family, ML-DSA
+     * (post-quantum) for QBTC — see [decodePubKeyAndType]. The staking msg bodies and gas/fee are
+     * scheme-independent, so only the pubkey decode + AuthInfo type URL differ.
      *
      * Returns a [SignDirectProto] ready to drop into
      * [com.vultisig.wallet.data.models.payload.KeysignPayload.signDirect].
@@ -82,8 +89,53 @@ object CosmosStakingSignDataResolver {
         if (chainSpecific !is BlockChainSpecific.Cosmos)
             throw ResolverException.MissingChainSpecific
 
-        val pubKey = decodePubKey(hexPublicKey) ?: throw ResolverException.InvalidPublicKey
+        val (pubKey, pubKeyTypeUrl) = decodePubKeyAndType(chain, hexPublicKey)
 
+        return buildSignDirect(
+            payload = payload,
+            chain = chain,
+            delegatorAddress = delegatorAddress,
+            pubKey = pubKey,
+            pubKeyTypeUrl = pubKeyTypeUrl,
+            chainSpecific = chainSpecific,
+        )
+    }
+
+    /**
+     * Decodes the signer pubkey and its Cosmos `Any` type URL for the chain's signing scheme.
+     *
+     * QBTC signs with ML-DSA (post-quantum), so its ~1312-byte pubkey can't pass the compressed-
+     * secp256k1 33-byte guard and its AuthInfo must carry `/cosmos.crypto.mldsa.PubKey`. The
+     * resulting `signDirect` bytes round-trip through the relay proto so the co-signing peer
+     * rebuilds the identical SignDoc hash;
+     * [com.vultisig.wallet.data.chains.helpers.QBTCTransactionHelper] consumes them directly
+     * instead of the secp256k1 / WalletCore path the Terra family feeds. Every other staking chain
+     * keeps the strict secp256k1 guard + URL.
+     */
+    private fun decodePubKeyAndType(chain: Chain, hexPublicKey: String): Pair<ByteArray, String> =
+        when (chain.TssKeysignType) {
+            TssKeyType.MLDSA ->
+                (hexPublicKey.hexToByteArrayOrNull()?.takeIf { it.isNotEmpty() }
+                    ?: throw ResolverException.InvalidPublicKey) to
+                    QBTCTransactionHelper.PUB_KEY_TYPE_URL
+            else ->
+                (decodePubKey(hexPublicKey) ?: throw ResolverException.InvalidPublicKey) to
+                    CosmosStakingHelper.PUBKEY_TYPE_URL
+        }
+
+    /**
+     * Shared SignDoc assembly for both signing schemes. The validator preflight, encoder dispatch
+     * and gas/fee scaling are pubkey-independent — only the AuthInfo's pubkey `Any` URL differs, so
+     * the scheme reaches here via [pubKeyTypeUrl].
+     */
+    private fun buildSignDirect(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegatorAddress: String,
+        pubKey: ByteArray,
+        pubKeyTypeUrl: String,
+        chainSpecific: BlockChainSpecific.Cosmos,
+    ): SignDirectProto {
         val entry = CosmosStakingConfig.entryFor(chain)
 
         val msgsAny = encodeMessages(payload, chain, delegatorAddress, entry.bondDenom)
@@ -102,6 +154,7 @@ object CosmosStakingSignDataResolver {
                 gasLimit = gasLimit,
                 feeDenom = entry.feeDenom,
                 feeAmount = feeAmount,
+                pubKeyTypeUrl = pubKeyTypeUrl,
             )
 
         return SignDirectProto(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingSignDataResolver.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingSignDataResolver.kt
@@ -42,10 +42,7 @@ object CosmosStakingSignDataResolver {
         object MissingChainSpecific :
             ResolverException("Cosmos blockchain-specific data is required")
 
-        object InvalidPublicKey :
-            ResolverException(
-                "Public key must be a compressed secp256k1 pubkey (33 bytes, 0x02/0x03 prefix)"
-            )
+        class InvalidPublicKey(message: String) : ResolverException(message)
 
         class MissingPayloadField(val field: String) :
             ResolverException("Missing required payload field: $field")
@@ -116,11 +113,14 @@ object CosmosStakingSignDataResolver {
         when (chain.TssKeysignType) {
             TssKeyType.MLDSA ->
                 (hexPublicKey.hexToByteArrayOrNull()?.takeIf { it.isNotEmpty() }
-                    ?: throw ResolverException.InvalidPublicKey) to
-                    QBTCTransactionHelper.PUB_KEY_TYPE_URL
+                    ?: throw ResolverException.InvalidPublicKey(
+                        "Public key must be a non-empty hex-encoded ML-DSA public key"
+                    )) to QBTCTransactionHelper.PUB_KEY_TYPE_URL
             else ->
-                (decodePubKey(hexPublicKey) ?: throw ResolverException.InvalidPublicKey) to
-                    CosmosStakingHelper.PUBKEY_TYPE_URL
+                (decodePubKey(hexPublicKey)
+                    ?: throw ResolverException.InvalidPublicKey(
+                        "Public key must be a compressed secp256k1 pubkey (33 bytes, 0x02/0x03 prefix)"
+                    )) to CosmosStakingHelper.PUBKEY_TYPE_URL
         }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
@@ -20,7 +20,9 @@ class QBTCTransactionHelper {
         private const val DENOM = "qbtc"
         // Higher than typical Cosmos chains — ML-DSA-44 signatures are ~2.4 KB
         internal const val GAS_LIMIT = 300_000L
-        private const val PUB_KEY_TYPE_URL = "/cosmos.crypto.mldsa.PubKey"
+        // Internal so the shared Cosmos staking resolver stamps the same ML-DSA pubkey `Any` URL
+        // into the AuthInfo it builds for QBTC delegate / undelegate / redelegate / claim.
+        internal const val PUB_KEY_TYPE_URL = "/cosmos.crypto.mldsa.PubKey"
         private const val MSG_SEND_TYPE_URL = "/cosmos.bank.v1beta1.MsgSend"
         private const val MSG_IBC_TRANSFER_TYPE_URL = "/ibc.applications.transfer.v1.MsgTransfer"
         private const val MSG_VOTE_TYPE_URL = "/cosmos.gov.v1beta1.MsgVote"
@@ -41,8 +43,7 @@ class QBTCTransactionHelper {
         val sig = signatures[hash] ?: error("Missing MLDSA signature for hash $hash")
         val signatureBytes = sig.derSignature.hexToByteArray()
 
-        val bodyBytes = buildTxBody(keysignPayload)
-        val authInfoBytes = buildAuthInfo(keysignPayload)
+        val (bodyBytes, authInfoBytes) = buildTxComponents(keysignPayload)
         val txRaw = buildTxRaw(bodyBytes, authInfoBytes, signatureBytes)
         val broadcastJson = buildBroadcastJson(txRaw)
         val txHash = sha256(txRaw).toHexString().uppercase()
@@ -50,20 +51,65 @@ class QBTCTransactionHelper {
         return SignedTransactionResult(broadcastJson, txHash)
     }
 
+    /**
+     * Resolves the TxBody + AuthInfo bytes for the SignDoc.
+     *
+     * Staking carries a fully-formed TxBody + AuthInfo on [KeysignPayload.signDirect] — built
+     * either in-app by `CosmosStakingSignDataResolver` (DeFi tab) or by the browser extension (dApp
+     * co-sign), both with the ML-DSA pubkey type URL. Those bytes round-trip through the relay
+     * proto, so every co-signing device reconstructs the identical SignDoc hash — consume them
+     * verbatim, never rebuild, to keep the signed bytes byte-exact.
+     *
+     * QBTC signs only in SIGN_MODE_DIRECT; ML-DSA has no legacy amino mode (the browser extension
+     * and the chain both reject amino for QBTC), so a dApp [KeysignPayload.signAmino] payload is
+     * invalid — fail loudly instead of silently rebuilding it as a `MsgSend` to the `qbtcvaloper…`
+     * validator, which the chain would reject as an invalid `to` address (cf. the Terra dApp-amino
+     * fix #4781). Send / IBC / vote carry neither field and fall back to the per-message builders.
+     */
+    private fun buildTxComponents(keysignPayload: KeysignPayload): Pair<ByteArray, ByteArray> {
+        keysignPayload.signDirect?.let { signDirect ->
+            return decodeBase64(signDirect.bodyBytes, "bodyBytes") to
+                decodeBase64(signDirect.authInfoBytes, "authInfoBytes")
+        }
+        check(keysignPayload.signAmino == null) {
+            "QBTC dApp signing requires SIGN_MODE_DIRECT; amino (signAmino) is unsupported for ML-DSA"
+        }
+        return buildTxBody(keysignPayload) to buildAuthInfo(keysignPayload)
+    }
+
     private fun buildSignDoc(keysignPayload: KeysignPayload): ByteArray {
-        val cosmosSpecific =
-            keysignPayload.blockChainSpecific as? BlockChainSpecific.Cosmos
-                ?: error("Invalid blockChainSpecific for QBTC")
-        val bodyBytes = buildTxBody(keysignPayload)
-        val authInfoBytes = buildAuthInfo(keysignPayload)
+        val (bodyBytes, authInfoBytes) = buildTxComponents(keysignPayload)
+
+        // For staking, `chain_id` + `account_number` come from the round-tripped `signDirect` so
+        // the SignDoc is reconstructed byte-for-byte on both devices, independent of any per-device
+        // chainSpecific drift. The send / IBC / vote path reads them from chainSpecific as before.
+        val signDirect = keysignPayload.signDirect
+        val chainId: String
+        val accountNumber: Long
+        if (signDirect != null) {
+            chainId = signDirect.chainId
+            accountNumber =
+                signDirect.accountNumber.toLongOrNull()
+                    ?: error("QBTC: invalid account number in signDirect")
+        } else {
+            val cosmosSpecific =
+                keysignPayload.blockChainSpecific as? BlockChainSpecific.Cosmos
+                    ?: error("Invalid blockChainSpecific for QBTC")
+            chainId = CHAIN_ID
+            accountNumber = cosmosSpecific.accountNumber.toLong()
+        }
 
         val result = mutableListOf<Byte>()
         result.addAll(protoBytes(1, bodyBytes))
         result.addAll(protoBytes(2, authInfoBytes))
-        result.addAll(protoString(3, CHAIN_ID))
-        result.addAll(protoVarint(4, cosmosSpecific.accountNumber.toLong()))
+        result.addAll(protoString(3, chainId))
+        result.addAll(protoVarint(4, accountNumber))
         return result.toByteArray()
     }
+
+    private fun decodeBase64(value: String, field: String): ByteArray =
+        runCatching { java.util.Base64.getDecoder().decode(value) }
+            .getOrElse { error("QBTC: invalid signDirect base64 in $field") }
 
     private fun buildTxBody(keysignPayload: KeysignPayload): ByteArray {
         val cosmosSpecific =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
@@ -20,8 +20,6 @@ class QBTCTransactionHelper {
         private const val DENOM = "qbtc"
         // Higher than typical Cosmos chains — ML-DSA-44 signatures are ~2.4 KB
         internal const val GAS_LIMIT = 300_000L
-        // Internal so the shared Cosmos staking resolver stamps the same ML-DSA pubkey `Any` URL
-        // into the AuthInfo it builds for QBTC delegate / undelegate / redelegate / claim.
         internal const val PUB_KEY_TYPE_URL = "/cosmos.crypto.mldsa.PubKey"
         private const val MSG_SEND_TYPE_URL = "/cosmos.bank.v1beta1.MsgSend"
         private const val MSG_IBC_TRANSFER_TYPE_URL = "/ibc.applications.transfer.v1.MsgTransfer"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
@@ -88,8 +88,11 @@ class QBTCTransactionHelper {
         val accountNumber: Long
         if (signDirect != null) {
             chainId = signDirect.chainId
+            // account_number is a uint64; encodeVarint only produces correct bytes for non-negative
+            // values, so reject a negative (or non-numeric) string rather than silently signing a
+            // SignDoc that differs from the relayed payload.
             accountNumber =
-                signDirect.accountNumber.toLongOrNull()
+                signDirect.accountNumber.toLongOrNull()?.takeIf { it >= 0 }
                     ?: error("QBTC: invalid account number in signDirect")
         } else {
             val cosmosSpecific =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -294,10 +294,11 @@ val Chain.isDeFiSupported: Boolean
             Chain.MayaChain,
             Chain.Ethereum,
             Chain.Tron,
-            // Terra family surfaces a DeFi (staking) positions view — delegate / undelegate /
+            // Terra family + QBTC surface a DeFi (staking) positions view — delegate / undelegate /
             // redelegate / claim. Matches Windows `supportedDefiChains` + iOS DeFi-tab `.stake`.
             Chain.Terra,
-            Chain.TerraClassic -> true
+            Chain.TerraClassic,
+            Chain.Qbtc -> true
             else -> false
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -342,6 +342,7 @@ constructor(
                     Chain.Tron to Coins.Tron.TRX,
                     Chain.Terra to Coins.Terra.LUNA,
                     Chain.TerraClassic to Coins.TerraClassic.LUNC,
+                    Chain.Qbtc to Coins.Qbtc.QBTC,
                 )
 
             val addressesByChain = addresses.associateBy { it.chain }
@@ -500,11 +501,12 @@ constructor(
             Chain.Ethereum -> true
             Chain.MayaChain -> true
             Chain.Tron -> true
-            // LUNA / LUNC surface a staking DeFi position; without these the chains are selectable
-            // in the "Select DeFi chains" sheet (isDeFiSupported) but never appear in the Portfolio
-            // DeFi list because their coins are filtered out of the candidate set here.
+            // LUNA / LUNC / QBTC surface a staking DeFi position. Without these their coins are
+            // dropped from the candidate set, so they pass isDeFiSupported (selectable in the
+            // "Select DeFi chains" sheet) yet never appear in the Portfolio DeFi list.
             Chain.Terra -> true
             Chain.TerraClassic -> true
+            Chain.Qbtc -> true
             else -> false
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -182,7 +182,8 @@ constructor(
             MayaChain,
             Chain.Tron,
             Chain.Terra,
-            Chain.TerraClassic -> "${chain.id}:$vaultId:$address"
+            Chain.TerraClassic,
+            Chain.Qbtc -> "${chain.id}:$vaultId:$address"
             else -> null
         }
 
@@ -228,7 +229,8 @@ constructor(
                 MayaChain -> mayaDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Tron -> tronDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Terra,
-                Chain.TerraClassic ->
+                Chain.TerraClassic,
+                Chain.Qbtc ->
                     cosmosStakingDeFiBalanceService.getCacheDeFiBalance(coin.chain, vaultId)
 
                 else -> error("Not Supported ${coin.chain}")
@@ -399,9 +401,11 @@ constructor(
             Ethereum -> circleDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             MayaChain -> mayaDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             Chain.Tron -> tronDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-            // Terra / TerraClassic share the same address, so the chain is passed explicitly.
+            // Each staking chain has its own LCD (Terra / TerraClassic even share an address), so
+            // the chain is passed explicitly.
             Chain.Terra,
-            Chain.TerraClassic ->
+            Chain.TerraClassic,
+            Chain.Qbtc ->
                 cosmosStakingDeFiBalanceService.getRemoteDeFiBalance(chain, address, vaultId)
             else -> error("Not supported $chain")
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepository.kt
@@ -31,12 +31,13 @@ internal class CryptoConnectionTypeRepositoryImpl @Inject constructor() :
             Chain.ThorChain,
             Chain.MayaChain,
             Chain.Tron,
-            // Terra / TerraClassic surface a staking positions screen (delegate / undelegate /
-            // redelegate / claim). Without these branches they're selectable in the "Select DeFi
+            // Terra / TerraClassic / QBTC surface a staking positions screen (delegate / undelegate
+            // / redelegate / claim). Without these branches they're selectable in the "Select DeFi
             // chains" sheet (isDeFiSupported) but get filtered out of the DeFi portfolio list, so
-            // the user never reaches the LUNA/LUNC staking view.
+            // the user never reaches the staking view.
             Chain.Terra,
-            Chain.TerraClassic -> true
+            Chain.TerraClassic,
+            Chain.Qbtc -> true
             else -> false
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
@@ -163,4 +163,53 @@ class BuildCosmosStakingKeysignPayloadUseCaseTests {
             )
         assertEquals("columbus-5", result.signDirect?.chainId)
     }
+
+    @Test
+    fun `QBTC coin routes through the ML-DSA resolver and stamps the ML-DSA pubkey`() {
+        val mldsaPubKeyHex = "ab".repeat(1312)
+        val mldsaPubKey = ByteArray(1312) { 0xAB.toByte() }
+        val qbtcCoin =
+            Coin(
+                chain = Chain.Qbtc,
+                ticker = "QBTC",
+                logo = "qbtc",
+                address = "qbtc1delegator0000000000000000000000000000",
+                decimal = 8,
+                hexPublicKey = mldsaPubKeyHex,
+                priceProviderID = "",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val qbtcValidator = Bech32TestEncoder.encode("qbtcvaloper", ByteArray(20) { it.toByte() })
+
+        val result =
+            useCase(
+                coin = qbtcCoin,
+                payload =
+                    CosmosStakingPayload.Delegate(
+                        validatorAddress = qbtcValidator,
+                        amount = "100000000",
+                    ),
+                blockChainSpecific = cosmosSpecific,
+                vaultPublicKeyECDSA = "p",
+                vaultLocalPartyID = "l",
+                libType = SigningLibType.DKLS,
+            )
+
+        val signDirect = assertNotNull(result.signDirect)
+        assertEquals("qbtc-testnet", signDirect.chainId)
+        // The AuthInfo must carry the ML-DSA pubkey `Any` and the QBTC base gas/fee — proving the
+        // use case dispatched to `resolveMLDSA`, not the secp256k1 `resolve` (which would have
+        // rejected the 1312-byte key).
+        val expectedAuth =
+            CosmosStakingHelper.buildAuthInfo(
+                pubKey = mldsaPubKey,
+                sequence = cosmosSpecific.sequence.toLong(),
+                gasLimit = 400_000L,
+                feeDenom = "qbtc",
+                feeAmount = 800L,
+                pubKeyTypeUrl = "/cosmos.crypto.mldsa.PubKey",
+            )
+        assertContentEquals(expectedAuth, Base64.getDecoder().decode(signDirect.authInfoBytes))
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingAPYResolverTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingAPYResolverTests.kt
@@ -131,6 +131,18 @@ class CosmosStakingAPYResolverTests {
     }
 
     @Test
+    fun `chainApy short-circuits to null for QBTC without hitting the LCD`() = runTest {
+        // QBTC has no x/mint module, so the fan-out would 501 and collapse to null anyway — it must
+        // skip the four reads entirely so the positions screen isn't slowed by doomed requests.
+        val svc = service()
+        assertNull(resolver(svc).chainApy(Chain.Qbtc, "qbtc"))
+        coVerify(exactly = 0) { svc.fetchMintInflation(any()) }
+        coVerify(exactly = 0) { svc.fetchStakingPool(any()) }
+        coVerify(exactly = 0) { svc.fetchBankSupplyByDenom(any(), any()) }
+        coVerify(exactly = 0) { svc.fetchDistributionParams(any()) }
+    }
+
+    @Test
     fun `chainApy serves from cache within the TTL without re-fetching`() = runTest {
         val svc = service()
         coEvery { svc.fetchMintInflation(Chain.Terra) } returns CosmosMintInflationResponse("0.07")

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
@@ -45,9 +45,28 @@ class CosmosStakingConfigTests {
     }
 
     @Test
-    fun `isStakingSupported returns true for Terra family only`() {
+    fun `QBTC entry matches pinned values`() {
+        val entry = CosmosStakingConfig.entryFor(Chain.Qbtc)
+        assertEquals("qbtc-testnet", entry.chainId)
+        // `qbtc` is lowercase and NOT a micro-denom (8 decimals) — verified on the live
+        // qbtc-testnet LCD `staking/params.bond_denom`.
+        assertEquals("qbtc", entry.bondDenom)
+        assertEquals("qbtc", entry.feeDenom)
+        assertEquals("qbtcvaloper", entry.valoperHrp)
+        // 400_000 matches Terra's post-OoG floor (live MsgDelegate simulate burned 278_759;
+        // redelegate is heavier). feeAmount 800 is the qbtc-testnet `min_tx_fee` floor; since
+        // `min_gas_price` is 0 the higher gas budget does not raise the fee. Mirrors iOS #4481.
+        assertEquals(400_000L, entry.gasLimit)
+        assertEquals(800L, entry.feeAmount)
+        // Live LCD `unbonding_time` = 1814400s = 21 days.
+        assertEquals(21, entry.unbondingDays)
+    }
+
+    @Test
+    fun `isStakingSupported returns true for the staking chains`() {
         assertTrue(CosmosStakingConfig.isStakingSupported(Chain.Terra))
         assertTrue(CosmosStakingConfig.isStakingSupported(Chain.TerraClassic))
+        assertTrue(CosmosStakingConfig.isStakingSupported(Chain.Qbtc))
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingHelperTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingHelperTests.kt
@@ -301,6 +301,30 @@ class CosmosStakingHelperTests {
         assertEquals(FX.GAS_LIMIT, ProtoParser.varint(2, fee))
     }
 
+    @Test
+    fun `AuthInfo stamps the provided pubKey type URL for ML-DSA`() {
+        // QBTC reuses this encoder with the ML-DSA pubkey URL and its ~1312-byte post-quantum key.
+        val mldsaPubKey = ByteArray(1312) { 0xAB.toByte() }
+        val authInfo =
+            CosmosStakingHelper.buildAuthInfo(
+                pubKey = mldsaPubKey,
+                sequence = FX.SEQUENCE,
+                gasLimit = FX.GAS_LIMIT,
+                feeDenom = FX.DENOM,
+                feeAmount = FX.FEE_AMOUNT,
+                pubKeyTypeUrl = "/cosmos.crypto.mldsa.PubKey",
+            )
+        val signerInfo =
+            ProtoParser.parseFields(ProtoParser.bytes(1, ProtoParser.parseFields(authInfo)))
+        val pubKeyAny = ProtoParser.parseFields(ProtoParser.bytes(1, signerInfo))
+        assertEquals("/cosmos.crypto.mldsa.PubKey", ProtoParser.string(1, pubKeyAny))
+        // The full ML-DSA key bytes survive intact in the inner PubKey `{ key(1, bytes) }`.
+        assertContentEquals(
+            mldsaPubKey,
+            ProtoParser.bytes(1, ProtoParser.parseFields(ProtoParser.bytes(2, pubKeyAny))),
+        )
+    }
+
     // MARK: - Proto wire-format parser (test-only)
 
     /**

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
@@ -1,0 +1,301 @@
+package com.vultisig.wallet.data.blockchain.cosmos.staking
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import java.math.BigInteger
+import java.util.Base64
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * Locks down the ML-DSA staking-resolver contract for QBTC. Mirrors iOS
+ * `QBTCStakingSignDataResolverTests.swift` (vultisig-ios PR #4481).
+ *
+ * QBTC signs with ML-DSA (post-quantum), so [CosmosStakingSignDataResolver.resolve] skips the
+ * secp256k1 33-byte pubkey guard and stamps `/cosmos.crypto.mldsa.PubKey` into AuthInfo. The msg
+ * bodies are pubkey-agnostic, so they must still byte-match the shared [CosmosStakingHelper]
+ * encoders. Each test asserts behaviour at the resolver boundary; the secp256k1 `resolve` path is
+ * covered by [CosmosStakingSignDataResolverTests] and pinned here as a regression where it matters.
+ */
+class QbtcStakingSignDataResolverTests {
+
+    private object FX {
+        const val DELEGATOR = "qbtc1delegator0000000000000000000000000000"
+        const val ACCOUNT_NUMBER = 100L
+        const val SEQUENCE = 42L
+        const val DENOM = "qbtc"
+        // ~1312-byte ML-DSA-44 pubkey — far larger than secp256k1's 33 bytes. A deterministic
+        // all-0xAB fill keeps the AuthInfo bytes stable across runs.
+        val MLDSA_PUBKEY_HEX = "ab".repeat(1312)
+        val MLDSA_PUBKEY: ByteArray = ByteArray(1312) { 0xAB.toByte() }
+        const val MLDSA_PUBKEY_TYPE_URL = "/cosmos.crypto.mldsa.PubKey"
+
+        val VALIDATOR_A = makeValoper(seedByte = 0x0A)
+        val VALIDATOR_B = makeValoper(seedByte = 0x0B)
+        val VALIDATOR_C = makeValoper(seedByte = 0x0C)
+
+        private fun makeValoper(seedByte: Int): String {
+            val payload = ByteArray(20) { ((seedByte + it) and 0xFF).toByte() }
+            return Bech32TestEncoder.encode("qbtcvaloper", payload)
+        }
+
+        val COSMOS_SPECIFIC =
+            BlockChainSpecific.Cosmos(
+                accountNumber = BigInteger.valueOf(ACCOUNT_NUMBER),
+                sequence = BigInteger.valueOf(SEQUENCE),
+                gas = BigInteger.ZERO,
+                ibcDenomTraces = null,
+                transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+            )
+    }
+
+    // MARK: - Bodies match the shared, pubkey-agnostic encoders
+
+    @Test
+    fun `delegate body matches the shared encoder and carries qbtc-testnet chainId`() {
+        val result = resolve(CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"))
+        assertEquals("qbtc-testnet", result.chainId)
+        assertEquals(FX.ACCOUNT_NUMBER.toString(), result.accountNumber)
+        val expectedBody =
+            CosmosStakingHelper.buildTxBodyMulti(
+                listOf(
+                    CosmosStakingHelper.encodeDelegate(
+                        delegator = FX.DELEGATOR,
+                        validator = FX.VALIDATOR_A,
+                        amount = "100000000",
+                        denom = FX.DENOM,
+                    )
+                )
+            )
+        assertContentEquals(expectedBody, Base64.getDecoder().decode(result.bodyBytes))
+    }
+
+    @Test
+    fun `undelegate body matches the shared encoder`() {
+        val result = resolve(CosmosStakingPayload.Undelegate(FX.VALIDATOR_A, amount = "50000000"))
+        val expectedBody =
+            CosmosStakingHelper.buildTxBodyMulti(
+                listOf(
+                    CosmosStakingHelper.encodeUndelegate(
+                        delegator = FX.DELEGATOR,
+                        validator = FX.VALIDATOR_A,
+                        amount = "50000000",
+                        denom = FX.DENOM,
+                    )
+                )
+            )
+        assertContentEquals(expectedBody, Base64.getDecoder().decode(result.bodyBytes))
+    }
+
+    @Test
+    fun `redelegate body matches the shared encoder`() {
+        val result =
+            resolve(
+                CosmosStakingPayload.Redelegate(
+                    validatorSrcAddress = FX.VALIDATOR_A,
+                    validatorDstAddress = FX.VALIDATOR_B,
+                    amount = "10000000",
+                )
+            )
+        val expectedBody =
+            CosmosStakingHelper.buildTxBodyMulti(
+                listOf(
+                    CosmosStakingHelper.encodeBeginRedelegate(
+                        delegator = FX.DELEGATOR,
+                        validatorSrc = FX.VALIDATOR_A,
+                        validatorDst = FX.VALIDATOR_B,
+                        amount = "10000000",
+                        denom = FX.DENOM,
+                    )
+                )
+            )
+        assertContentEquals(expectedBody, Base64.getDecoder().decode(result.bodyBytes))
+    }
+
+    @Test
+    fun `withdrawRewards body matches the shared encoder`() {
+        val result =
+            resolve(CosmosStakingPayload.WithdrawRewards(validators = listOf(FX.VALIDATOR_A)))
+        val expectedBody =
+            CosmosStakingHelper.buildTxBodyMulti(
+                listOf(
+                    CosmosStakingHelper.encodeWithdrawDelegatorReward(
+                        delegator = FX.DELEGATOR,
+                        validator = FX.VALIDATOR_A,
+                    )
+                )
+            )
+        assertContentEquals(expectedBody, Base64.getDecoder().decode(result.bodyBytes))
+    }
+
+    // MARK: - AuthInfo carries the ML-DSA pubkey + QBTC gas/fee
+
+    @Test
+    fun `AuthInfo stamps the ML-DSA pubkey URL and QBTC base gas + fee`() {
+        val result = resolve(CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"))
+        val expectedAuth =
+            CosmosStakingHelper.buildAuthInfo(
+                pubKey = FX.MLDSA_PUBKEY,
+                sequence = FX.SEQUENCE,
+                gasLimit = 400_000L,
+                feeDenom = FX.DENOM,
+                feeAmount = 800L,
+                pubKeyTypeUrl = FX.MLDSA_PUBKEY_TYPE_URL,
+            )
+        assertContentEquals(expectedAuth, Base64.getDecoder().decode(result.authInfoBytes))
+    }
+
+    @Test
+    fun `batched claim scales gas + fee linearly with validator count`() {
+        val result =
+            resolve(
+                CosmosStakingPayload.WithdrawRewards(
+                    validators = listOf(FX.VALIDATOR_A, FX.VALIDATOR_B, FX.VALIDATOR_C)
+                )
+            )
+        val expectedAuth =
+            CosmosStakingHelper.buildAuthInfo(
+                pubKey = FX.MLDSA_PUBKEY,
+                sequence = FX.SEQUENCE,
+                gasLimit = 1_200_000L, // 3 × 400_000
+                feeDenom = FX.DENOM,
+                feeAmount = 2_400L, // 3 × 800
+                pubKeyTypeUrl = FX.MLDSA_PUBKEY_TYPE_URL,
+            )
+        assertContentEquals(expectedAuth, Base64.getDecoder().decode(result.authInfoBytes))
+    }
+
+    @Test
+    fun `ML-DSA resolve is deterministic across repeated calls`() {
+        val payload = CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000")
+        assertEquals(resolve(payload), resolve(payload))
+    }
+
+    // MARK: - PubKey guard divergence (the core of the ML-DSA path)
+
+    @Test
+    fun `ML-DSA resolve accepts a 1312-byte ML-DSA pubkey that the secp256k1 guard would reject`() {
+        // Must not throw — the secp256k1 33-byte guard is skipped on the ML-DSA path.
+        resolve(CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"))
+    }
+
+    @Test
+    fun `secp256k1 resolve still rejects the ML-DSA pubkey (guard unchanged)`() {
+        // Regression: the secp256k1 path must keep enforcing the 33-byte compressed-key guard, so
+        // an ML-DSA-sized key fed to `resolve` is rejected up-front.
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.InvalidPublicKey> {
+            CosmosStakingSignDataResolver.resolve(
+                payload = CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"),
+                chain = Chain.Terra,
+                delegatorAddress = FX.DELEGATOR,
+                hexPublicKey = FX.MLDSA_PUBKEY_HEX,
+                chainSpecific = FX.COSMOS_SPECIFIC,
+            )
+        }
+    }
+
+    @Test
+    fun `ML-DSA resolve rejects an empty pubkey`() {
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.InvalidPublicKey> {
+            CosmosStakingSignDataResolver.resolve(
+                payload = CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"),
+                chain = Chain.Qbtc,
+                delegatorAddress = FX.DELEGATOR,
+                hexPublicKey = "",
+                chainSpecific = FX.COSMOS_SPECIFIC,
+            )
+        }
+    }
+
+    @Test
+    fun `ML-DSA resolve rejects a malformed hex pubkey`() {
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.InvalidPublicKey> {
+            CosmosStakingSignDataResolver.resolve(
+                payload = CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"),
+                chain = Chain.Qbtc,
+                delegatorAddress = FX.DELEGATOR,
+                hexPublicKey = "not-hex",
+                chainSpecific = FX.COSMOS_SPECIFIC,
+            )
+        }
+    }
+
+    // MARK: - Preflight + payload guards (shared with the secp256k1 path)
+
+    @Test
+    fun `ML-DSA resolve preflights validators against the QBTC valoper HRP`() {
+        // A terravaloper address has the right structural shape but the wrong HRP for QBTC.
+        val terra = Bech32TestEncoder.encode("terravaloper", ByteArray(20) { it.toByte() })
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.ValidatorPreflightFailed> {
+            resolve(CosmosStakingPayload.Delegate(validatorAddress = terra, amount = "100000000"))
+        }
+    }
+
+    @Test
+    fun `ML-DSA resolve rejects self-redelegation`() {
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.SelfRedelegation> {
+            resolve(
+                CosmosStakingPayload.Redelegate(
+                    validatorSrcAddress = FX.VALIDATOR_A,
+                    validatorDstAddress = FX.VALIDATOR_A,
+                    amount = "10000000",
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `ML-DSA resolve rejects a non-positive amount`() {
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.InvalidAmount> {
+            resolve(CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "0"))
+        }
+    }
+
+    @Test
+    fun `ML-DSA resolve rejects a non-Cosmos blockchain specific`() {
+        val utxo = BlockChainSpecific.UTXO(byteFee = BigInteger.valueOf(10), sendMaxAmount = false)
+        assertFailsWith<CosmosStakingSignDataResolver.ResolverException.MissingChainSpecific> {
+            CosmosStakingSignDataResolver.resolve(
+                payload = CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"),
+                chain = Chain.Qbtc,
+                delegatorAddress = FX.DELEGATOR,
+                hexPublicKey = FX.MLDSA_PUBKEY_HEX,
+                chainSpecific = utxo,
+            )
+        }
+    }
+
+    @Test
+    fun `redelegate swapping src and dst produces different bytes`() {
+        val normal =
+            resolve(
+                CosmosStakingPayload.Redelegate(
+                    validatorSrcAddress = FX.VALIDATOR_A,
+                    validatorDstAddress = FX.VALIDATOR_B,
+                    amount = "10000000",
+                )
+            )
+        val swapped =
+            resolve(
+                CosmosStakingPayload.Redelegate(
+                    validatorSrcAddress = FX.VALIDATOR_B,
+                    validatorDstAddress = FX.VALIDATOR_A,
+                    amount = "10000000",
+                )
+            )
+        assertNotEquals(normal.bodyBytes, swapped.bodyBytes)
+    }
+
+    private fun resolve(payload: CosmosStakingPayload) =
+        CosmosStakingSignDataResolver.resolve(
+            payload = payload,
+            chain = Chain.Qbtc,
+            delegatorAddress = FX.DELEGATOR,
+            hexPublicKey = FX.MLDSA_PUBKEY_HEX,
+            chainSpecific = FX.COSMOS_SPECIFIC,
+        )
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
@@ -7,7 +7,10 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.proto.v1.SignAminoProto
+import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
 import java.math.BigInteger
+import java.util.Base64
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -70,6 +73,8 @@ class QBTCTransactionHelperTest {
         toAmount: BigInteger = BigInteger("1000000"),
         memo: String? = null,
         blockChainSpecific: BlockChainSpecific = cosmosSpecific(),
+        signDirect: SignDirectProto? = null,
+        signAmino: SignAminoProto? = null,
     ) =
         KeysignPayload(
             coin = coin,
@@ -81,6 +86,24 @@ class QBTCTransactionHelperTest {
             vaultLocalPartyID = "party1",
             libType = SigningLibType.DKLS,
             wasmExecuteContractPayload = null,
+            signDirect = signDirect,
+            signAmino = signAmino,
+        )
+
+    // Opaque, deterministic SignDoc artefacts standing in for what `CosmosStakingSignDataResolver`
+    // builds for a QBTC delegate / undelegate / redelegate / claim. The bytes are arbitrary — QBTC
+    // forwards them verbatim, it never re-parses them.
+    private fun signDirect(
+        body: ByteArray = byteArrayOf(1, 2, 3, 4, 5),
+        authInfo: ByteArray = byteArrayOf(9, 8, 7),
+        chainId: String = "qbtc-testnet",
+        accountNumber: String = "42",
+    ) =
+        SignDirectProto(
+            bodyBytes = Base64.getEncoder().encodeToString(body),
+            authInfoBytes = Base64.getEncoder().encodeToString(authInfo),
+            chainId = chainId,
+            accountNumber = accountNumber,
         )
 
     @Test
@@ -375,5 +398,66 @@ class QBTCTransactionHelperTest {
                 )[0]
 
         assertEquals(3, setOf(sendHash, ibcHash, voteHash).size)
+    }
+
+    // MARK: - signDirect consumption (staking co-sign path)
+
+    @Test
+    fun `signDirect drives the presign hash and ignores the MsgSend fields`() {
+        val sd = signDirect()
+        val base = helper.getPreSignedImageHash(payload(signDirect = sd))
+        // With signDirect present the MsgSend path is bypassed, so toAddress / toAmount no longer
+        // affect the hash — both co-signing devices must reach the same SignDoc from the relayed
+        // bytes alone.
+        assertEquals(
+            base,
+            helper.getPreSignedImageHash(
+                payload(signDirect = sd, toAddress = "qbtc1other", toAmount = BigInteger("999"))
+            ),
+        )
+        // ...and the staking hash differs from the default MsgSend-derived hash.
+        assertNotEquals(base, helper.getPreSignedImageHash(payload()))
+    }
+
+    @Test
+    fun `presign hash changes with every signDirect SignDoc input`() {
+        val base = helper.getPreSignedImageHash(payload(signDirect = signDirect()))
+        assertNotEquals(
+            base,
+            helper.getPreSignedImageHash(payload(signDirect = signDirect(body = byteArrayOf(9, 9)))),
+        )
+        assertNotEquals(
+            base,
+            helper.getPreSignedImageHash(
+                payload(signDirect = signDirect(authInfo = byteArrayOf(4, 4)))
+            ),
+        )
+        assertNotEquals(
+            base,
+            helper.getPreSignedImageHash(payload(signDirect = signDirect(chainId = "qbtc-mainnet"))),
+        )
+        assertNotEquals(
+            base,
+            helper.getPreSignedImageHash(payload(signDirect = signDirect(accountNumber = "7"))),
+        )
+    }
+
+    @Test
+    fun `rejects a dApp signAmino payload since ML-DSA has no amino sign mode`() {
+        // A dApp amino-JSON staking request (signAmino, no signDirect) must NOT be rebuilt as a
+        // MsgSend to the validator — it has to fail loudly. QBTC only signs SIGN_MODE_DIRECT.
+        assertThrows<IllegalStateException> {
+            helper.getPreSignedImageHash(payload(signAmino = SignAminoProto()))
+        }
+    }
+
+    @Test
+    fun `signDirect takes priority when a payload carries both signDirect and signAmino`() {
+        // Defensive: signDirect is the valid QBTC form, so it wins and amino is never reached.
+        val sd = signDirect()
+        assertEquals(
+            helper.getPreSignedImageHash(payload(signDirect = sd)),
+            helper.getPreSignedImageHash(payload(signDirect = sd, signAmino = SignAminoProto())),
+        )
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
@@ -460,4 +460,12 @@ class QBTCTransactionHelperTest {
             helper.getPreSignedImageHash(payload(signDirect = sd, signAmino = SignAminoProto())),
         )
     }
+
+    @Test
+    fun `rejects a signDirect with a negative account number`() {
+        // account_number is a uint64; a negative string would mis-encode through encodeVarint.
+        assertThrows<IllegalStateException> {
+            helper.getPreSignedImageHash(payload(signDirect = signDirect(accountNumber = "-1")))
+        }
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/CryptoConnectionTypeRepositoryTest.kt
@@ -11,9 +11,16 @@ internal class CryptoConnectionTypeRepositoryTest {
 
     @Test
     fun `chains with a DeFi positions screen are recognised`() {
-        // Terra / TerraClassic must be present — otherwise the LUNA/LUNC staking view is filtered
-        // out of the DeFi portfolio list and the user can never reach it.
-        listOf(Chain.ThorChain, Chain.MayaChain, Chain.Tron, Chain.Terra, Chain.TerraClassic)
+        // Terra / TerraClassic / QBTC must be present — otherwise the Cosmos staking view is
+        // filtered out of the DeFi portfolio list and the user can never reach it.
+        listOf(
+                Chain.ThorChain,
+                Chain.MayaChain,
+                Chain.Tron,
+                Chain.Terra,
+                Chain.TerraClassic,
+                Chain.Qbtc,
+            )
             .forEach { chain -> assertTrue(repository.hasDeFiPositionsScreen(chain), chain.raw) }
     }
 


### PR DESCRIPTION
## Summary

Adds Cosmos-SDK native staking for QBTC to the DeFi tab — delegate, undelegate, redelegate and claim rewards — reaching parity with the LUNA/LUNC staking shipped in #4687.

QBTC is a Cosmos-SDK chain, so the DeFi-tab surface (screens, view-models, position rows, cooldown gate and LCD read layer) is already chain-generic and is reused unchanged. This change opts QBTC into the DeFi-tab routing and balance wiring.

## Signing layer

QBTC signs with ML-DSA-44 rather than secp256k1, so its staking transactions cannot use the Terra secp256k1 / WalletCore path. The shared encoders are kept and QBTC is routed through its existing ML-DSA path:

- `CosmosStakingHelper.buildAuthInfo` takes an optional `pubKeyTypeUrl` (defaulting to secp256k1). The resolver stamps `/cosmos.crypto.mldsa.PubKey` for QBTC and skips the 33-byte compressed-key guard; the message bodies and gas/fee remain pubkey-agnostic and reuse the existing encoders.
- The staking SignDoc is carried on `KeysignPayload.signDirect` — the same round-trip-safe vehicle Terra uses. `QBTCTransactionHelper` consumes those bytes verbatim, so the initiator and the co-signing peer rebuild an identical SignDoc hash and sign it through the existing ML-DSA ceremony.
- A dApp `signAmino` request is rejected rather than rebuilt as a `MsgSend` to the validator, since ML-DSA has no amino signing mode (consistent with the Terra dApp-amino fix in #4781).

Config values (gas `400000`, fee `800`, 21-day unbonding) are verified against the live `qbtc-testnet` LCD and match vultisig-ios#4481. QBTC has no price feed, so the fiat fee is hidden, as with LUNA/LUNC.

## Co-signing

Fast Vault (server co-sign) and Secure Vault (device co-sign) use the same keysign screen as QBTC send; no new screen is introduced. Both the initiator and the joining peer route `Chain.Qbtc` through `QBTCTransactionHelper`, which consumes the round-tripped `signDirect`, so the hashes match and the ceremony completes. The dApp path (Android joining the QBTC explorer via the browser extension) carries `signDirect` in the byte-identical format the extension produces (`/cosmos.crypto.mldsa.PubKey`, `SIGN_MODE_DIRECT`, `body | authInfo | chainId | accountNumber`).

## Screenshots

<img width="1344" height="2992" alt="Screenshot_20260609_013543" src="https://github.com/user-attachments/assets/49842c55-f508-4ef9-91ac-8d39a410837e" />
<img width="1344" height="2992" alt="Screenshot_20260609_013530" src="https://github.com/user-attachments/assets/8d23b5f0-6d36-44f2-a4b8-d1f8edca4b0d" />
<img width="1344" height="2992" alt="Screenshot_20260609_013515" src="https://github.com/user-attachments/assets/e3b1e620-0de9-4b9d-bbe7-74275f1c3314" />
<img width="1344" height="2992" alt="Screenshot_20260609_013551" src="https://github.com/user-attachments/assets/747d231e-9f0d-4d97-a5e9-a2471324e532" /><img width="1344" height="2992" alt="Screenshot_20260609_013601" src="https://github.com/user-attachments/assets/482e5605-c717-45b1-9f21-8e1235e1cb7a" />
<img width="1344" height="2992" alt="Screenshot_20260609_013917" src="https://github.com/user-attachments/assets/25a19f3d-8f81-4c60-bcec-6e0b1642b0ff" />
<img width="1344" height="2992" alt="Screenshot_20260609_013839" src="https://github.com/user-attachments/assets/024f6ca9-3aae-4f67-b269-f0f19e421778" />
<img width="1344" height="2992" alt="Screenshot_20260609_013740" src="https://github.com/user-attachments/assets/6919970e-208b-4629-a1c7-9c28003400f2" />
<img width="1344" height="2992" alt="Screenshot_20260609_013726" src="https://github.com/user-attachments/assets/bdf75b14-7ab5-497d-a8ef-f256fbe9fd03" />
<img width="1344" height="2992" alt="Screenshot_20260609_013717" src="https://github.com/user-attachments/assets/10bcb4a0-b3ea-40ba-9400-77fec9aba644" />
<img width="1344" height="2992" alt="Screenshot_20260609_013700" src="https://github.com/user-attachments/assets/2f80f9e4-3eac-455c-baf0-f6bb7675211c" />
<img width="1344" height="2992" alt="Screenshot_20260609_013644" src="https://github.com/user-attachments/assets/2a268a79-a5cc-44e6-b74b-c7fb15f094be" />
<img width="1344" height="2992" alt="Screenshot_20260609_013629" src="https://github.com/user-attachments/assets/7db41f52-eaed-4263-98ce-a26ac8cafa63" />



## Testing

- `./gradlew :data:testDebugUnitTest` — full data module, passing
- New tests: `QbtcStakingSignDataResolverTests` (16 cases), plus QBTC cases added to `CosmosStakingConfigTests`, `CosmosStakingHelperTests`, `BuildCosmosStakingKeysignPayloadUseCaseTests` and `QBTCTransactionHelperTest` (signDirect consumption and amino rejection)
- Existing secp256k1 `CosmosStakingSignDataResolverTests` remain green, confirming the shared-encoder change is backward-compatible
- `:data:ktfmtCheck`, `:app:ktfmtCheck`, `:app:installDebug`

Closes #4795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QBTC staking support: delegate, undelegate, redelegate, and reward withdrawal
  * QBTC staking positions now appear in the DeFi/dashboard screens alongside Terra
  * Added QBTC staking preview and verification UI with updated transaction handling

* **Tests**
  * Added extensive QBTC staking/unit tests covering signing, payloads, encoding, and DeFi balance flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->