### PR TITLE
refactor(swap): extract calculateFees() pipeline into SwapQuoteOrchestrator (#4735)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -8,24 +8,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
-import com.vultisig.wallet.data.IoDispatcher
-import com.vultisig.wallet.data.api.errors.SwapException
-import com.vultisig.wallet.data.api.errors.SwapKitError
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
-import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
-import com.vultisig.wallet.data.repositories.AppCurrencyRepository
-import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
-import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.SwapTransactionRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
-import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
-import com.vultisig.wallet.data.usecases.getTierType
-import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.findCurrentSrc
 import com.vultisig.wallet.ui.models.firstSendSrc
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
@@ -44,28 +34,16 @@ import java.math.BigInteger
 import java.math.RoundingMode
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import timber.log.Timber
 
 @HiltViewModel
@@ -76,18 +54,13 @@ constructor(
     private val navigator: Navigator<Destination>,
     private val fiatValueToString: FiatValueToStringMapper,
     private val convertTokenAndValueToTokenValue: ConvertTokenAndValueToTokenValueUseCase,
-    private val swapQuoteRepository: SwapQuoteRepository,
-    private val appCurrencyRepository: AppCurrencyRepository,
     private val swapTransactionRepository: SwapTransactionRepository,
-    private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
-    private val referralRepository: ReferralCodeSettingsRepository,
     private val swapValidator: SwapValidator,
-    private val swapDiscountChecker: SwapDiscountChecker,
     private val swapGasCalculator: SwapGasCalculator,
     private val swapTokenSelector: SwapTokenSelector,
     private val swapQuoteManager: SwapQuoteManager,
     private val swapTransactionBuilder: SwapTransactionBuilder,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val swapQuoteOrchestrator: SwapQuoteOrchestrator,
 ) : ViewModel() {
 
     private val args = savedStateHandle.toRoute<Route.Swap>()
@@ -108,7 +81,6 @@ constructor(
     private val selectedDst = MutableStateFlow<SendSrc?>(null)
     private val selectedSrcId = MutableStateFlow<String?>(null)
     private val selectedDstId = MutableStateFlow<String?>(null)
-    private val referralCode = MutableStateFlow<String?>(null)
 
     private val estimatedNetworkFeeTokenValue = MutableStateFlow<TokenValue?>(null)
     private val gasFee = MutableStateFlow<TokenValue?>(null)
@@ -121,36 +93,6 @@ constructor(
     private val refreshQuoteState = MutableStateFlow(0)
 
     private var selectTokensJob: Job? = null
-
-    private var refreshQuoteJob: Job? = null
-
-    private data class PreFlipState(
-        val srcAmount: String,
-        val srcTokenId: String,
-        val dstTokenId: String,
-        val flippedAmount: String,
-    )
-
-    private data class QuoteInput(
-        val address: Pair<SendSrc, SendSrc>,
-        val amount: BigDecimal?,
-        // True when the change should bypass the typing debounce (percentage / Max / paste).
-        val immediate: Boolean,
-    )
-
-    /**
-     * Mutable swap-quote state confined to the main thread.
-     *
-     * Every read/write happens from Main.immediate-dispatched code (the quote pipeline, the flip
-     * gesture, and the reset paths), so these plain `var`s need no synchronization. Grouping them
-     * here keeps that threading invariant explicit in one place instead of scattering it across
-     * fields.
-     */
-    private class QuoteStateHolder {
-        var quote: SwapQuote? = null
-        var provider: SwapProvider? = null
-        var preFlipState: PreFlipState? = null
-    }
 
     private var isLoading: Boolean
         get() = uiState.value.isLoading
@@ -402,7 +344,7 @@ constructor(
                     ?.decimal
                     ?.formatFlippedAmount(selectedDst.value?.account?.token?.decimal)
 
-        resetQuoteState()
+        swapQuoteOrchestrator.resetQuoteState()
 
         // Fall back to the raw ID when the resolved SendSrc hasn't loaded yet, so a race between
         // the flip gesture and token resolution never silently clobbers both slots with null.
@@ -450,10 +392,6 @@ constructor(
             dstToken.address,
             currentAmount,
         )
-    }
-
-    private fun resetQuoteState() {
-        resetQuoteState(error = null, cause = null, tag = null)
     }
 
     fun selectSrcPercentage(percentage: Float) {
@@ -617,489 +555,28 @@ constructor(
             .launchIn(viewModelScope)
     }
 
-    @OptIn(FlowPreview::class)
     private fun calculateFees() {
-        viewModelScope.safeLaunch {
-            // Emits once per source-amount change carrying whether the quote should fetch
-            // immediately (percentage / Max / paste) instead of waiting out the typing debounce.
-            // Empty input still flows through so collectLatest hits the zero-amount branch and
-            // resetQuoteState() clears the stale quote (#4712).
-            val amountChanges = swapQuoteManager.amountChanges(srcAmountState.textAsFlow())
-
-            combine(selectedSrc.filterNotNull(), selectedDst.filterNotNull()) { src, dst ->
-                    src to dst
-                }
-                .distinctUntilChanged()
-                .onEach {
-                    // A freshly selected pair has no quote yet, and a token switch never clears the
-                    // previous pair's destination value. Reset it so the skeleton shows while the
-                    // new quote loads instead of the stale amount reading as a firm quote for the
-                    // new pair (#4712 review).
-                    uiState.update {
-                        it.copy(
-                            quoteDisplay =
-                                it.quoteDisplay.copy(
-                                    estimatedDstTokenValue = "0",
-                                    isDstEstimated = false,
-                                )
-                        )
-                    }
-                }
-                .combine(amountChanges) { address, immediate ->
-                    QuoteInput(address = address, amount = srcAmount, immediate = immediate)
-                }
-                // Fires on real user intent (typing, paste, percentage, token change) but not on
-                // the
-                // silent refreshes combined in below — so the spinner appears immediately ahead of
-                // the debounce and an instant indicative estimate fills the destination field while
-                // we wait, without flashing on background refreshes (#4712).
-                .onEach { input ->
-                    isLoading = true
-                    showIndicativeRate(input)
-                }
-                .combine(refreshQuoteState) { input, _ -> input }
-                // Percentage / Max / paste skip the debounce (0ms); free typing still coalesces at
-                // 300ms so rapid edits fire a single quote fetch.
-                .debounce { input -> swapQuoteManager.quoteDebounceMillis(input.immediate) }
-                // collectLatest so newer input cancels an in-flight fetch instead of letting a
-                // stale fetch write isLoading = false after the user has already typed again.
-                .collectLatest { input ->
-                    val (src, dst) = input.address
-                    val amount = input.amount
-
-                    val srcToken = src.account.token
-                    val dstToken = dst.account.token
-
-                    val srcTokenValue =
-                        amount?.movePointRight(src.account.token.decimal)?.toBigInteger()
-
-                    // An empty field (the initial state on entry, or a cleared field) is not an
-                    // error. The empty-input filter was removed so clearing the field clears the
-                    // stale quote (#4712); without this guard that same empty emission would throw
-                    // AmountCannotBeZero and flash "Invalid amount" the moment the screen opens.
-                    // Clear the quote silently and wait for a real amount instead. An explicitly
-                    // entered zero still falls through to the AmountCannotBeZero error below.
-                    if (srcAmountState.text.isEmpty()) {
-                        resetQuoteState(error = null, cause = null, tag = null)
-                        return@collectLatest
-                    }
-
-                    try {
-                        if (srcTokenValue == null || srcTokenValue <= BigInteger.ZERO) {
-                            throw SwapException.AmountCannotBeZero("Amount must be positive")
-                        }
-                        if (srcToken == dstToken) {
-                            throw SwapException.SameAssets("Can't swap same assets ${srcToken.id})")
-                        }
-
-                        val tokenValue = convertTokenAndValueToTokenValue(srcToken, srcTokenValue)
-
-                        val eligibleProviders =
-                            swapQuoteRepository.getEligibleProviders(srcToken, dstToken)
-                        if (eligibleProviders.isEmpty()) {
-                            throw SwapException.SwapIsNotSupported(
-                                "Swap is not supported for this pair"
-                            )
-                        }
-
-                        val currency = appCurrencyRepository.currency.first()
-
-                        val baselineReferral =
-                            referralCode.value
-                                ?: vaultId?.let { referralRepository.getExternalReferralBy(it) }
-
-                        val candidates = coroutineScope {
-                            eligibleProviders
-                                .map { p ->
-                                    async {
-                                        val discount =
-                                            vaultId?.let { id ->
-                                                getDiscountBpsUseCase.invoke(id, p).takeIf { bps ->
-                                                    bps != 0
-                                                }
-                                            }
-                                        QuoteCandidate(
-                                            provider = p,
-                                            vultBPSDiscount = discount,
-                                            referral = baselineReferral,
-                                        )
-                                    }
-                                }
-                                .awaitAll()
-                        }
-
-                        val resolution =
-                            swapQuoteManager.resolveBestQuote(
-                                candidates = candidates,
-                                src = src,
-                                dst = dst,
-                                srcToken = srcToken,
-                                dstToken = dstToken,
-                                srcTokenValue = srcTokenValue,
-                                tokenValue = tokenValue,
-                                currency = currency,
-                                amount = amount,
-                                selectedSrcTokenTitle = uiState.value.selectedSrcToken?.title,
-                            )
-                        // Map the sealed result: a typed fetch failure resets the quote state with
-                        // its already-mapped error; only a Success continues into fee processing.
-                        val bestQuote =
-                            when (resolution) {
-                                is QuoteResolution.Failure -> {
-                                    resetQuoteState(
-                                        error = resolution.formError,
-                                        cause = resolution.cause,
-                                        tag = resolution.tag,
-                                    )
-                                    return@collectLatest
-                                }
-                                is QuoteResolution.Success -> resolution.best
-                            }
-
-                        val quoteResult = bestQuote.result
-                        val provider = quoteResult.provider
-                        quoteState.provider = provider
-
-                        val vultBPSDiscount = bestQuote.candidate.vultBPSDiscount
-                        val referral = bestQuote.candidate.referral
-
-                        if (provider == SwapProvider.THORCHAIN) {
-                            referral?.let { code ->
-                                val tierType = vultBPSDiscount?.getTierType()
-                                val result =
-                                    swapDiscountChecker.checkReferralBpsDiscount(
-                                        tierType,
-                                        srcToken,
-                                        tokenValue,
-                                        code,
-                                    )
-                                result.referralCode?.let { rc -> referralCode.update { rc } }
-                                uiState.update {
-                                    it.copy(
-                                        discountInfo =
-                                            it.discountInfo.copy(
-                                                referralBpsDiscount = result.referralBpsDiscount,
-                                                referralBpsDiscountFiatValue =
-                                                    result.referralBpsDiscountFiatValue,
-                                            )
-                                    )
-                                }
-                            }
-                        } else {
-                            uiState.update {
-                                it.copy(
-                                    discountInfo =
-                                        it.discountInfo.copy(
-                                            referralBpsDiscount = null,
-                                            referralBpsDiscountFiatValue = null,
-                                        )
-                                )
-                            }
-                        }
-
-                        val vultResult =
-                            swapDiscountChecker.checkVultBpsDiscount(
-                                srcToken,
-                                tokenValue,
-                                vultBPSDiscount,
-                            )
-                        uiState.update {
-                            it.copy(
-                                discountInfo =
-                                    it.discountInfo.copy(
-                                        vultBpsDiscount = vultResult.vultBpsDiscount,
-                                        vultBpsDiscountFiatValue =
-                                            vultResult.vultBpsDiscountFiatValue,
-                                        tierType = vultResult.tierType,
-                                    )
-                            )
-                        }
-
-                        quoteState.quote = quoteResult.quote
-                        // SwapKit BTC settles by broadcasting the provider's PSBT, whose miner fee
-                        // is the only network cost — and it is already surfaced as the UTXO plan
-                        // network fee below. SwapKit reports that same deposit cost as its inbound
-                        // fee, so counting it again as a swap fee would double-count the BTC
-                        // network
-                        // cost in the headline total (iOS shows it once). Zero the swap-fee
-                        // contribution and the breakdown row so Total reconciles to Network Fee
-                        // alone; the affiliate fee is already baked into expectedDstValue.
-                        val isSwapKitUtxoSwap =
-                            quoteResult.quote is SwapQuote.SwapKit &&
-                                srcToken.chain.standard == TokenStandard.UTXO
-                        val effectiveSwapFeeFiat =
-                            if (isSwapKitUtxoSwap)
-                                FiatValue(BigDecimal.ZERO, quoteResult.swapFeeFiat.currency)
-                            else quoteResult.swapFeeFiat
-                        val feeText =
-                            if (isSwapKitUtxoSwap)
-                                fiatValueToString(effectiveSwapFeeFiat, asFee = true)
-                            else quoteResult.feeText
-                        swapFeeFiat.value = effectiveSwapFeeFiat
-
-                        // Determine destination address and memo for UTXO plan fee computation.
-                        // Must be computed before the uiState.update so the button stays
-                        // disabled for UTXO swaps until the plan fee is verified.
-                        val utxoFeeData: Pair<String, String?>? =
-                            when (val q = quoteResult.quote) {
-                                is SwapQuote.ThorChain ->
-                                    (q.data.router
-                                        ?: q.data.inboundAddress
-                                        ?: src.address.address) to q.data.memo
-                                is SwapQuote.MayaChain ->
-                                    (q.data.inboundAddress ?: src.address.address) to q.data.memo
-                                // SwapKit BTC is a PSBT deposit to targetAddress; route it through
-                                // the same UTXO plan-fee path so the network fee is computed and
-                                // swap() doesn't abort with invalid_gas_fee_calculation.
-                                is SwapQuote.SwapKit ->
-                                    if (srcToken.chain.standard == TokenStandard.UTXO) {
-                                        q.data.targetAddress to q.data.memo
-                                    } else null
-                                else -> null
-                            }
-                        val isUtxoSwap =
-                            utxoFeeData != null &&
-                                srcToken.chain.standard == TokenStandard.UTXO &&
-                                srcToken.chain != Chain.Cardano
-
-                        // For UTXO swaps keep isSwapDisabled=true until plan fee is verified
-                        // so a tap between this update and the plan-fee write never submits
-                        // with sats/byte as the total fee.
-                        uiState.update {
-                            it.copy(
-                                srcFiatValue = quoteResult.srcFiatValueText,
-                                quoteDisplay =
-                                    it.quoteDisplay.copy(
-                                        provider = quoteResult.providerUiText,
-                                        estimatedDstTokenValue = quoteResult.estimatedDstTokenValue,
-                                        estimatedDstFiatValue = quoteResult.estimatedDstFiatValue,
-                                        isDstEstimated = false,
-                                        hasQuote = true,
-                                        expiredAt = quoteState.quote?.expiredAt,
-                                    ),
-                                feeBreakdown =
-                                    it.feeBreakdown.copy(
-                                        fee = feeText,
-                                        outboundFee = quoteResult.outboundFeeText,
-                                        swapFeePercent = quoteResult.swapFeePercent,
-                                    ),
-                                formError = null,
-                                isSwapDisabled = isUtxoSwap,
-                                isLoading = false,
-                            )
-                        }
-
-                        if (isUtxoSwap) {
-                            val currentGasFee =
-                                gasFee.value?.takeIf { gasFeeChain.value == srcToken.chain }
-                            val currentVaultId = vaultId
-                            if (currentGasFee != null && currentVaultId != null) {
-                                val (utxoDstAddress, utxoMemo) = utxoFeeData!!
-                                when (
-                                    val planFee =
-                                        swapGasCalculator.resolveUtxoPlanFee(
-                                            vaultId = currentVaultId,
-                                            srcToken = srcToken,
-                                            srcAddress = src.address.address,
-                                            dstAddress = utxoDstAddress,
-                                            memo = utxoMemo,
-                                            tokenAmountInt = srcTokenValue,
-                                            gasFee = currentGasFee,
-                                        )
-                                ) {
-                                    is UtxoPlanFeeResult.Success -> {
-                                        estimatedNetworkFeeFiatValue.value =
-                                            planFee.estimated.fiatValue
-                                        estimatedNetworkFeeTokenValue.value =
-                                            planFee.estimated.tokenValue
-                                        uiState.update {
-                                            it.copy(
-                                                feeBreakdown =
-                                                    it.feeBreakdown.copy(
-                                                        networkFee =
-                                                            planFee.estimated.formattedTokenValue,
-                                                        networkFeeFiat =
-                                                            planFee.estimated.formattedFiatValue,
-                                                    ),
-                                                isSwapDisabled = false,
-                                            )
-                                        }
-                                    }
-                                    UtxoPlanFeeResult.InsufficientUtxos -> {
-                                        uiState.update {
-                                            it.copy(
-                                                isSwapDisabled = true,
-                                                formError =
-                                                    UiText.StringResource(
-                                                        R.string.insufficient_utxos_error
-                                                    ),
-                                            )
-                                        }
-                                    }
-                                    UtxoPlanFeeResult.Unavailable -> {
-                                        estimatedNetworkFeeTokenValue.value = null
-                                        estimatedNetworkFeeFiatValue.value = null
-                                        uiState.update {
-                                            it.copy(
-                                                isSwapDisabled = true,
-                                                feeBreakdown =
-                                                    it.feeBreakdown.copy(
-                                                        networkFee = "",
-                                                        networkFeeFiat = "",
-                                                    ),
-                                            )
-                                        }
-                                    }
-                                }
-                            } else {
-                                // gasFeeChain lags srcToken.chain after a token switch:
-                                // clear any stale fee from the previous chain.
-                                estimatedNetworkFeeTokenValue.value = null
-                                estimatedNetworkFeeFiatValue.value = null
-                                uiState.update {
-                                    it.copy(
-                                        feeBreakdown =
-                                            it.feeBreakdown.copy(
-                                                networkFee = "",
-                                                networkFeeFiat = "",
-                                            )
-                                    )
-                                }
-                            }
-                        }
-
-                        val balanceError =
-                            swapValidator.validateBalanceForSwap(
-                                src,
-                                srcTokenValue,
-                                estimatedNetworkFeeTokenValue.value,
-                            )
-                        if (balanceError != null) {
-                            uiState.update {
-                                it.copy(isSwapDisabled = true, formError = balanceError.formError)
-                            }
-                        }
-                    } catch (e: SwapException) {
-                        resetQuoteState(
-                            error =
-                                swapQuoteManager.mapSwapExceptionToFormError(
-                                    e,
-                                    srcToken,
-                                    uiState.value.selectedSrcToken?.title,
-                                ),
-                            cause = e,
-                            tag = "swapError",
-                        )
-                    } catch (e: SwapKitError) {
-                        resetQuoteState(
-                            error = swapQuoteManager.mapSwapKitErrorToFormError(e),
-                            cause = e,
-                            tag = "swapKitError",
-                        )
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        resetQuoteState(
-                            error = UiText.StringResource(R.string.swap_error_quote_failed),
-                            cause = e,
-                            tag = "swapUnexpectedError",
-                        )
-                    }
-
-                    quoteState.quote?.expiredAt?.let { launchRefreshQuoteTimer(it) }
-                }
-        }
-    }
-
-    /**
-     * Fill the destination field with an instant indicative estimate from cached spot prices while
-     * the firm quote resolves, so it never blanks on input or while refetching (#4712). Cached-only
-     * and display-only: a cold price leaves the previous value untouched, and the firm quote always
-     * overwrites this with [SwapFormUiModel.isDstEstimated] = false.
-     */
-    private suspend fun showIndicativeRate(input: QuoteInput) {
-        // This runs in an onEach upstream of (and outside) the collectLatest try/catch, so any
-        // throw from the suspending price read would escape into safeLaunch and end the whole quote
-        // collection while isLoading stays stuck true. Contain it here (#4712 review).
-        try {
-            val (src, dst) = input.address
-            val srcToken = src.account.token
-            val dstToken = dst.account.token
-            val amount = input.amount ?: return
-            if (amount <= BigDecimal.ZERO || srcToken == dstToken) return
-
-            // Skip pairs we can't actually quote: showing an indicative estimate for an
-            // unsupported pair only to wipe it back to "0" once the firm fetch fails flashes a
-            // receivable amount, which is jumpier than a steady "0" (#4712 review).
-            // getEligibleProviders is a local table lookup, so this stays instant.
-            if (swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isEmpty()) return
-
-            val currency = appCurrencyRepository.currency.first()
-            val indicative =
-                swapQuoteManager.computeIndicativeQuote(srcToken, dstToken, amount, currency)
-                    ?: return
-
-            uiState.update {
-                it.copy(
-                    quoteDisplay =
-                        it.quoteDisplay.copy(
-                            estimatedDstTokenValue = indicative.estimatedDstTokenValue,
-                            estimatedDstFiatValue = indicative.estimatedDstFiatValue,
-                            isDstEstimated = true,
-                        )
-                )
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.e(e, "showIndicativeRate")
-        }
-    }
-
-    private fun launchRefreshQuoteTimer(expiredAt: Instant) {
-        refreshQuoteJob?.cancel()
-        refreshQuoteJob =
-            viewModelScope.launch(ioDispatcher) {
-                delay(expiredAt - Clock.System.now())
-                refreshQuoteState.value++
-            }
-    }
-
-    private fun resetQuoteState(error: UiText?, cause: Throwable?, tag: String?) {
-        // The prior quote's refresh timer would otherwise fire mid-flip/mid-error and re-run
-        // calculateFees against the same invalid amount, briefly re-exposing the fee block.
-        refreshQuoteJob?.cancel()
-        refreshQuoteJob = null
-        quoteState.quote = null
-        quoteState.provider = null
-        // collectTotalFee() combines this with estimatedNetworkFeeFiatValue. Resetting it
-        // to null lets filterNotNull() short-circuit so a later calculateGas() update can't
-        // write a (newGas + staleSwap) combination back into state.totalFee — the same race
-        // that triggers on flipSelectedTokens since selectedSrc changes synchronously.
-        swapFeeFiat.value = null
-        // networkFee/networkFeeFiat are tied to the source token (calculateGas), not to a
-        // specific quote, so we deliberately leave them alone — resetting them would leave
-        // them empty until selectedSrc changes again.
-        uiState.update {
-            it.copy(
-                srcFiatValue = "0",
-                quoteDisplay = QuoteDisplay(),
-                feeBreakdown =
-                    it.feeBreakdown.copy(
-                        fee = "0",
-                        totalFee = "0",
-                        outboundFee = null,
-                        swapFeePercent = null,
-                    ),
-                discountInfo = DiscountInfo(),
-                isSwapDisabled = true,
-                formError = error,
-                isLoading = false,
-            )
-        }
-        if (cause != null) {
-            Timber.e(cause, tag)
-        }
+        swapQuoteOrchestrator.start(
+            viewModelScope,
+            SwapQuoteContext(
+                uiState = uiState,
+                quoteState = quoteState,
+                swapFeeFiat = swapFeeFiat,
+                estimatedNetworkFeeTokenValue = estimatedNetworkFeeTokenValue,
+                estimatedNetworkFeeFiatValue = estimatedNetworkFeeFiatValue,
+                gasFee = gasFee,
+                gasFeeChain = gasFeeChain,
+                refreshQuoteState = refreshQuoteState,
+                selectedSrc = selectedSrc,
+                selectedDst = selectedDst,
+                srcAmountTextFlow = srcAmountState.textAsFlow(),
+                swapQuoteManager = swapQuoteManager,
+                srcAmount = { srcAmount },
+                isSrcAmountEmpty = { srcAmountState.text.isEmpty() },
+                vaultId = { vaultId },
+                selectedSrcTokenTitle = { uiState.value.selectedSrcToken?.title },
+            ),
+        )
     }
 
     fun hideError() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteOrchestrator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteOrchestrator.kt
@@ -1,0 +1,661 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.errors.SwapKitError
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.usecases.getTierType
+import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.send.SendSrc
+import com.vultisig.wallet.ui.utils.UiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import timber.log.Timber
+
+internal data class PreFlipState(
+    val srcAmount: String,
+    val srcTokenId: String,
+    val dstTokenId: String,
+    val flippedAmount: String,
+)
+
+/**
+ * Mutable swap-quote state confined to the main thread.
+ *
+ * Every read/write happens from Main.immediate-dispatched code (the quote pipeline, the flip
+ * gesture, and the reset paths), so these plain `var`s need no synchronization. Grouping them here
+ * keeps that threading invariant explicit in one place instead of scattering it across fields.
+ *
+ * Shared between [SwapFormViewModel] (which reads [quote]/[provider] and owns [preFlipState] for
+ * the flip gesture) and [SwapQuoteOrchestrator] (which writes [quote]/[provider] from the quote
+ * pipeline).
+ */
+internal class QuoteStateHolder {
+    var quote: SwapQuote? = null
+    var provider: SwapProvider? = null
+    var preFlipState: PreFlipState? = null
+}
+
+/**
+ * Shared, ViewModel-owned state and read accessors the [SwapQuoteOrchestrator] pipeline both reads
+ * and writes. Bundling them keeps the orchestrator's launch surface a single argument instead of a
+ * dozen flows/lambdas, and keeps every write target pointing at the exact same [MutableStateFlow]
+ * instances [SwapFormViewModel] exposes — so relocating the pipeline changes nothing about which
+ * state it mutates or in what order.
+ */
+internal class SwapQuoteContext(
+    val uiState: MutableStateFlow<SwapFormUiModel>,
+    val quoteState: QuoteStateHolder,
+    val swapFeeFiat: MutableStateFlow<FiatValue?>,
+    val estimatedNetworkFeeTokenValue: MutableStateFlow<TokenValue?>,
+    val estimatedNetworkFeeFiatValue: MutableStateFlow<FiatValue?>,
+    val gasFee: MutableStateFlow<TokenValue?>,
+    val gasFeeChain: MutableStateFlow<Chain?>,
+    val refreshQuoteState: MutableStateFlow<Int>,
+    val selectedSrc: MutableStateFlow<SendSrc?>,
+    val selectedDst: MutableStateFlow<SendSrc?>,
+    val srcAmountTextFlow: Flow<CharSequence>,
+    val swapQuoteManager: SwapQuoteManager,
+    val srcAmount: () -> BigDecimal?,
+    val isSrcAmountEmpty: () -> Boolean,
+    val vaultId: () -> String?,
+    val selectedSrcTokenTitle: () -> String?,
+)
+
+/**
+ * Owns the reactive quote/fee orchestration that used to live inline in [SwapFormViewModel] as the
+ * `calculateFees()` god-method: a single `combine`/`debounce`/`collectLatest` pipeline wiring token
+ * + amount + refresh-timer inputs to quote fetching and fee/UI updates (#4735).
+ *
+ * The ViewModel stays a thin coordinator: it builds a [SwapQuoteContext] over its own state flows
+ * and calls [start]. Every state write the pipeline performs targets the ViewModel's flows
+ * verbatim, preserving the UTXO plan-fee race, the `isLoading` spinner timing (#4712), and the
+ * `isSwapDisabled` gating exactly as before.
+ */
+internal class SwapQuoteOrchestrator
+@Inject
+constructor(
+    private val swapQuoteRepository: SwapQuoteRepository,
+    private val appCurrencyRepository: AppCurrencyRepository,
+    private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
+    private val referralRepository: ReferralCodeSettingsRepository,
+    private val convertTokenAndValueToTokenValue: ConvertTokenAndValueToTokenValueUseCase,
+    private val swapDiscountChecker: SwapDiscountChecker,
+    private val swapGasCalculator: SwapGasCalculator,
+    private val swapValidator: SwapValidator,
+    private val fiatValueToString: FiatValueToStringMapper,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var context: SwapQuoteContext
+
+    private val referralCode = MutableStateFlow<String?>(null)
+
+    private var refreshQuoteJob: Job? = null
+
+    private data class QuoteInput(
+        val address: Pair<SendSrc, SendSrc>,
+        val amount: BigDecimal?,
+        // True when the change should bypass the typing debounce (percentage / Max / paste).
+        val immediate: Boolean,
+    )
+
+    /**
+     * Launches the quote/fee pipeline on [scope], reading and writing the flows in [context]. Call
+     * once during ViewModel initialization (mirroring the original inline `calculateFees()` call).
+     */
+    @OptIn(FlowPreview::class)
+    fun start(scope: CoroutineScope, context: SwapQuoteContext) {
+        this.scope = scope
+        this.context = context
+
+        val swapQuoteManager = context.swapQuoteManager
+        val uiState = context.uiState
+        val quoteState = context.quoteState
+        val swapFeeFiat = context.swapFeeFiat
+        val estimatedNetworkFeeTokenValue = context.estimatedNetworkFeeTokenValue
+        val estimatedNetworkFeeFiatValue = context.estimatedNetworkFeeFiatValue
+        val gasFee = context.gasFee
+        val gasFeeChain = context.gasFeeChain
+        val refreshQuoteState = context.refreshQuoteState
+        val selectedSrc = context.selectedSrc
+        val selectedDst = context.selectedDst
+
+        scope.safeLaunch {
+            // Emits once per source-amount change carrying whether the quote should fetch
+            // immediately (percentage / Max / paste) instead of waiting out the typing debounce.
+            // Empty input still flows through so collectLatest hits the zero-amount branch and
+            // resetQuoteState() clears the stale quote (#4712).
+            val amountChanges = swapQuoteManager.amountChanges(context.srcAmountTextFlow)
+
+            combine(selectedSrc.filterNotNull(), selectedDst.filterNotNull()) { src, dst ->
+                    src to dst
+                }
+                .distinctUntilChanged()
+                .onEach {
+                    // A freshly selected pair has no quote yet, and a token switch never clears the
+                    // previous pair's destination value. Reset it so the skeleton shows while the
+                    // new quote loads instead of the stale amount reading as a firm quote for the
+                    // new pair (#4712 review).
+                    uiState.update {
+                        it.copy(
+                            quoteDisplay =
+                                it.quoteDisplay.copy(
+                                    estimatedDstTokenValue = "0",
+                                    isDstEstimated = false,
+                                )
+                        )
+                    }
+                }
+                .combine(amountChanges) { address, immediate ->
+                    QuoteInput(
+                        address = address,
+                        amount = context.srcAmount(),
+                        immediate = immediate,
+                    )
+                }
+                // Fires on real user intent (typing, paste, percentage, token change) but not on
+                // the
+                // silent refreshes combined in below — so the spinner appears immediately ahead of
+                // the debounce and an instant indicative estimate fills the destination field while
+                // we wait, without flashing on background refreshes (#4712).
+                .onEach { input ->
+                    uiState.update { it.copy(isLoading = true) }
+                    showIndicativeRate(input)
+                }
+                .combine(refreshQuoteState) { input, _ -> input }
+                // Percentage / Max / paste skip the debounce (0ms); free typing still coalesces at
+                // 300ms so rapid edits fire a single quote fetch.
+                .debounce { input -> swapQuoteManager.quoteDebounceMillis(input.immediate) }
+                // collectLatest so newer input cancels an in-flight fetch instead of letting a
+                // stale fetch write isLoading = false after the user has already typed again.
+                .collectLatest { input ->
+                    val (src, dst) = input.address
+                    val amount = input.amount
+
+                    val srcToken = src.account.token
+                    val dstToken = dst.account.token
+
+                    val srcTokenValue =
+                        amount?.movePointRight(src.account.token.decimal)?.toBigInteger()
+
+                    // An empty field (the initial state on entry, or a cleared field) is not an
+                    // error. The empty-input filter was removed so clearing the field clears the
+                    // stale quote (#4712); without this guard that same empty emission would throw
+                    // AmountCannotBeZero and flash "Invalid amount" the moment the screen opens.
+                    // Clear the quote silently and wait for a real amount instead. An explicitly
+                    // entered zero still falls through to the AmountCannotBeZero error below.
+                    if (context.isSrcAmountEmpty()) {
+                        resetQuoteState(error = null, cause = null, tag = null)
+                        return@collectLatest
+                    }
+
+                    try {
+                        if (srcTokenValue == null || srcTokenValue <= BigInteger.ZERO) {
+                            throw SwapException.AmountCannotBeZero("Amount must be positive")
+                        }
+                        if (srcToken == dstToken) {
+                            throw SwapException.SameAssets("Can't swap same assets ${srcToken.id})")
+                        }
+
+                        val tokenValue = convertTokenAndValueToTokenValue(srcToken, srcTokenValue)
+
+                        val eligibleProviders =
+                            swapQuoteRepository.getEligibleProviders(srcToken, dstToken)
+                        if (eligibleProviders.isEmpty()) {
+                            throw SwapException.SwapIsNotSupported(
+                                "Swap is not supported for this pair"
+                            )
+                        }
+
+                        val currency = appCurrencyRepository.currency.first()
+
+                        val baselineReferral =
+                            referralCode.value
+                                ?: context.vaultId()?.let {
+                                    referralRepository.getExternalReferralBy(it)
+                                }
+
+                        val candidates = coroutineScope {
+                            eligibleProviders
+                                .map { p ->
+                                    async {
+                                        val discount =
+                                            context.vaultId()?.let { id ->
+                                                getDiscountBpsUseCase.invoke(id, p).takeIf { bps ->
+                                                    bps != 0
+                                                }
+                                            }
+                                        QuoteCandidate(
+                                            provider = p,
+                                            vultBPSDiscount = discount,
+                                            referral = baselineReferral,
+                                        )
+                                    }
+                                }
+                                .awaitAll()
+                        }
+
+                        val resolution =
+                            swapQuoteManager.resolveBestQuote(
+                                candidates = candidates,
+                                src = src,
+                                dst = dst,
+                                srcToken = srcToken,
+                                dstToken = dstToken,
+                                srcTokenValue = srcTokenValue,
+                                tokenValue = tokenValue,
+                                currency = currency,
+                                amount = amount,
+                                selectedSrcTokenTitle = context.selectedSrcTokenTitle(),
+                            )
+                        // Map the sealed result: a typed fetch failure resets the quote state with
+                        // its already-mapped error; only a Success continues into fee processing.
+                        val bestQuote =
+                            when (resolution) {
+                                is QuoteResolution.Failure -> {
+                                    resetQuoteState(
+                                        error = resolution.formError,
+                                        cause = resolution.cause,
+                                        tag = resolution.tag,
+                                    )
+                                    return@collectLatest
+                                }
+                                is QuoteResolution.Success -> resolution.best
+                            }
+
+                        val quoteResult = bestQuote.result
+                        val provider = quoteResult.provider
+                        quoteState.provider = provider
+
+                        val vultBPSDiscount = bestQuote.candidate.vultBPSDiscount
+                        val referral = bestQuote.candidate.referral
+
+                        if (provider == SwapProvider.THORCHAIN) {
+                            referral?.let { code ->
+                                val tierType = vultBPSDiscount?.getTierType()
+                                val result =
+                                    swapDiscountChecker.checkReferralBpsDiscount(
+                                        tierType,
+                                        srcToken,
+                                        tokenValue,
+                                        code,
+                                    )
+                                result.referralCode?.let { rc -> referralCode.update { rc } }
+                                uiState.update {
+                                    it.copy(
+                                        discountInfo =
+                                            it.discountInfo.copy(
+                                                referralBpsDiscount = result.referralBpsDiscount,
+                                                referralBpsDiscountFiatValue =
+                                                    result.referralBpsDiscountFiatValue,
+                                            )
+                                    )
+                                }
+                            }
+                        } else {
+                            uiState.update {
+                                it.copy(
+                                    discountInfo =
+                                        it.discountInfo.copy(
+                                            referralBpsDiscount = null,
+                                            referralBpsDiscountFiatValue = null,
+                                        )
+                                )
+                            }
+                        }
+
+                        val vultResult =
+                            swapDiscountChecker.checkVultBpsDiscount(
+                                srcToken,
+                                tokenValue,
+                                vultBPSDiscount,
+                            )
+                        uiState.update {
+                            it.copy(
+                                discountInfo =
+                                    it.discountInfo.copy(
+                                        vultBpsDiscount = vultResult.vultBpsDiscount,
+                                        vultBpsDiscountFiatValue =
+                                            vultResult.vultBpsDiscountFiatValue,
+                                        tierType = vultResult.tierType,
+                                    )
+                            )
+                        }
+
+                        quoteState.quote = quoteResult.quote
+                        // SwapKit BTC settles by broadcasting the provider's PSBT, whose miner fee
+                        // is the only network cost — and it is already surfaced as the UTXO plan
+                        // network fee below. SwapKit reports that same deposit cost as its inbound
+                        // fee, so counting it again as a swap fee would double-count the BTC
+                        // network
+                        // cost in the headline total (iOS shows it once). Zero the swap-fee
+                        // contribution and the breakdown row so Total reconciles to Network Fee
+                        // alone; the affiliate fee is already baked into expectedDstValue.
+                        val isSwapKitUtxoSwap =
+                            quoteResult.quote is SwapQuote.SwapKit &&
+                                srcToken.chain.standard == TokenStandard.UTXO
+                        val effectiveSwapFeeFiat =
+                            if (isSwapKitUtxoSwap)
+                                FiatValue(BigDecimal.ZERO, quoteResult.swapFeeFiat.currency)
+                            else quoteResult.swapFeeFiat
+                        val feeText =
+                            if (isSwapKitUtxoSwap)
+                                fiatValueToString(effectiveSwapFeeFiat, asFee = true)
+                            else quoteResult.feeText
+                        swapFeeFiat.value = effectiveSwapFeeFiat
+
+                        // Determine destination address and memo for UTXO plan fee computation.
+                        // Must be computed before the uiState.update so the button stays
+                        // disabled for UTXO swaps until the plan fee is verified.
+                        val utxoFeeData: Pair<String, String?>? =
+                            when (val q = quoteResult.quote) {
+                                is SwapQuote.ThorChain ->
+                                    (q.data.router
+                                        ?: q.data.inboundAddress
+                                        ?: src.address.address) to q.data.memo
+                                is SwapQuote.MayaChain ->
+                                    (q.data.inboundAddress ?: src.address.address) to q.data.memo
+                                // SwapKit BTC is a PSBT deposit to targetAddress; route it through
+                                // the same UTXO plan-fee path so the network fee is computed and
+                                // swap() doesn't abort with invalid_gas_fee_calculation.
+                                is SwapQuote.SwapKit ->
+                                    if (srcToken.chain.standard == TokenStandard.UTXO) {
+                                        q.data.targetAddress to q.data.memo
+                                    } else null
+                                else -> null
+                            }
+                        val isUtxoSwap =
+                            utxoFeeData != null &&
+                                srcToken.chain.standard == TokenStandard.UTXO &&
+                                srcToken.chain != Chain.Cardano
+
+                        // For UTXO swaps keep isSwapDisabled=true until plan fee is verified
+                        // so a tap between this update and the plan-fee write never submits
+                        // with sats/byte as the total fee.
+                        uiState.update {
+                            it.copy(
+                                srcFiatValue = quoteResult.srcFiatValueText,
+                                quoteDisplay =
+                                    it.quoteDisplay.copy(
+                                        provider = quoteResult.providerUiText,
+                                        estimatedDstTokenValue = quoteResult.estimatedDstTokenValue,
+                                        estimatedDstFiatValue = quoteResult.estimatedDstFiatValue,
+                                        isDstEstimated = false,
+                                        hasQuote = true,
+                                        expiredAt = quoteState.quote?.expiredAt,
+                                    ),
+                                feeBreakdown =
+                                    it.feeBreakdown.copy(
+                                        fee = feeText,
+                                        outboundFee = quoteResult.outboundFeeText,
+                                        swapFeePercent = quoteResult.swapFeePercent,
+                                    ),
+                                formError = null,
+                                isSwapDisabled = isUtxoSwap,
+                                isLoading = false,
+                            )
+                        }
+
+                        if (isUtxoSwap) {
+                            val currentGasFee =
+                                gasFee.value?.takeIf { gasFeeChain.value == srcToken.chain }
+                            val currentVaultId = context.vaultId()
+                            if (currentGasFee != null && currentVaultId != null) {
+                                val (utxoDstAddress, utxoMemo) = utxoFeeData!!
+                                when (
+                                    val planFee =
+                                        swapGasCalculator.resolveUtxoPlanFee(
+                                            vaultId = currentVaultId,
+                                            srcToken = srcToken,
+                                            srcAddress = src.address.address,
+                                            dstAddress = utxoDstAddress,
+                                            memo = utxoMemo,
+                                            tokenAmountInt = srcTokenValue,
+                                            gasFee = currentGasFee,
+                                        )
+                                ) {
+                                    is UtxoPlanFeeResult.Success -> {
+                                        estimatedNetworkFeeFiatValue.value =
+                                            planFee.estimated.fiatValue
+                                        estimatedNetworkFeeTokenValue.value =
+                                            planFee.estimated.tokenValue
+                                        uiState.update {
+                                            it.copy(
+                                                feeBreakdown =
+                                                    it.feeBreakdown.copy(
+                                                        networkFee =
+                                                            planFee.estimated.formattedTokenValue,
+                                                        networkFeeFiat =
+                                                            planFee.estimated.formattedFiatValue,
+                                                    ),
+                                                isSwapDisabled = false,
+                                            )
+                                        }
+                                    }
+                                    UtxoPlanFeeResult.InsufficientUtxos -> {
+                                        uiState.update {
+                                            it.copy(
+                                                isSwapDisabled = true,
+                                                formError =
+                                                    UiText.StringResource(
+                                                        R.string.insufficient_utxos_error
+                                                    ),
+                                            )
+                                        }
+                                    }
+                                    UtxoPlanFeeResult.Unavailable -> {
+                                        estimatedNetworkFeeTokenValue.value = null
+                                        estimatedNetworkFeeFiatValue.value = null
+                                        uiState.update {
+                                            it.copy(
+                                                isSwapDisabled = true,
+                                                feeBreakdown =
+                                                    it.feeBreakdown.copy(
+                                                        networkFee = "",
+                                                        networkFeeFiat = "",
+                                                    ),
+                                            )
+                                        }
+                                    }
+                                }
+                            } else {
+                                // gasFeeChain lags srcToken.chain after a token switch:
+                                // clear any stale fee from the previous chain.
+                                estimatedNetworkFeeTokenValue.value = null
+                                estimatedNetworkFeeFiatValue.value = null
+                                uiState.update {
+                                    it.copy(
+                                        feeBreakdown =
+                                            it.feeBreakdown.copy(
+                                                networkFee = "",
+                                                networkFeeFiat = "",
+                                            )
+                                    )
+                                }
+                            }
+                        }
+
+                        val balanceError =
+                            swapValidator.validateBalanceForSwap(
+                                src,
+                                srcTokenValue,
+                                estimatedNetworkFeeTokenValue.value,
+                            )
+                        if (balanceError != null) {
+                            uiState.update {
+                                it.copy(isSwapDisabled = true, formError = balanceError.formError)
+                            }
+                        }
+                    } catch (e: SwapException) {
+                        resetQuoteState(
+                            error =
+                                swapQuoteManager.mapSwapExceptionToFormError(
+                                    e,
+                                    srcToken,
+                                    context.selectedSrcTokenTitle(),
+                                ),
+                            cause = e,
+                            tag = "swapError",
+                        )
+                    } catch (e: SwapKitError) {
+                        resetQuoteState(
+                            error = swapQuoteManager.mapSwapKitErrorToFormError(e),
+                            cause = e,
+                            tag = "swapKitError",
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        resetQuoteState(
+                            error = UiText.StringResource(R.string.swap_error_quote_failed),
+                            cause = e,
+                            tag = "swapUnexpectedError",
+                        )
+                    }
+
+                    quoteState.quote?.expiredAt?.let { launchRefreshQuoteTimer(it) }
+                }
+        }
+    }
+
+    /**
+     * Resets the quote state to its pristine, no-quote form: cancels the refresh timer, drops the
+     * cached quote/provider/swap-fee, and clears the quote-related UI. Called by the pipeline on
+     * empty input / fetch failure, and by [SwapFormViewModel] from the flip gesture.
+     */
+    fun resetQuoteState() {
+        resetQuoteState(error = null, cause = null, tag = null)
+    }
+
+    /**
+     * Fill the destination field with an instant indicative estimate from cached spot prices while
+     * the firm quote resolves, so it never blanks on input or while refetching (#4712). Cached-only
+     * and display-only: a cold price leaves the previous value untouched, and the firm quote always
+     * overwrites this with [SwapFormUiModel.isDstEstimated] = false.
+     */
+    private suspend fun showIndicativeRate(input: QuoteInput) {
+        // This runs in an onEach upstream of (and outside) the collectLatest try/catch, so any
+        // throw from the suspending price read would escape into safeLaunch and end the whole quote
+        // collection while isLoading stays stuck true. Contain it here (#4712 review).
+        try {
+            val (src, dst) = input.address
+            val srcToken = src.account.token
+            val dstToken = dst.account.token
+            val amount = input.amount ?: return
+            if (amount <= BigDecimal.ZERO || srcToken == dstToken) return
+
+            // Skip pairs we can't actually quote: showing an indicative estimate for an
+            // unsupported pair only to wipe it back to "0" once the firm fetch fails flashes a
+            // receivable amount, which is jumpier than a steady "0" (#4712 review).
+            // getEligibleProviders is a local table lookup, so this stays instant.
+            if (swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isEmpty()) return
+
+            val currency = appCurrencyRepository.currency.first()
+            val indicative =
+                context.swapQuoteManager.computeIndicativeQuote(
+                    srcToken,
+                    dstToken,
+                    amount,
+                    currency,
+                ) ?: return
+
+            context.uiState.update {
+                it.copy(
+                    quoteDisplay =
+                        it.quoteDisplay.copy(
+                            estimatedDstTokenValue = indicative.estimatedDstTokenValue,
+                            estimatedDstFiatValue = indicative.estimatedDstFiatValue,
+                            isDstEstimated = true,
+                        )
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "showIndicativeRate")
+        }
+    }
+
+    private fun launchRefreshQuoteTimer(expiredAt: Instant) {
+        refreshQuoteJob?.cancel()
+        refreshQuoteJob =
+            scope.launch(ioDispatcher) {
+                delay(expiredAt - Clock.System.now())
+                context.refreshQuoteState.value++
+            }
+    }
+
+    private fun resetQuoteState(error: UiText?, cause: Throwable?, tag: String?) {
+        // The prior quote's refresh timer would otherwise fire mid-flip/mid-error and re-run
+        // calculateFees against the same invalid amount, briefly re-exposing the fee block.
+        refreshQuoteJob?.cancel()
+        refreshQuoteJob = null
+        context.quoteState.quote = null
+        context.quoteState.provider = null
+        // collectTotalFee() combines this with estimatedNetworkFeeFiatValue. Resetting it
+        // to null lets filterNotNull() short-circuit so a later calculateGas() update can't
+        // write a (newGas + staleSwap) combination back into state.totalFee — the same race
+        // that triggers on flipSelectedTokens since selectedSrc changes synchronously.
+        context.swapFeeFiat.value = null
+        // networkFee/networkFeeFiat are tied to the source token (calculateGas), not to a
+        // specific quote, so we deliberately leave them alone — resetting them would leave
+        // them empty until selectedSrc changes again.
+        context.uiState.update {
+            it.copy(
+                srcFiatValue = "0",
+                quoteDisplay = QuoteDisplay(),
+                feeBreakdown =
+                    it.feeBreakdown.copy(
+                        fee = "0",
+                        totalFee = "0",
+                        outboundFee = null,
+                        swapFeePercent = null,
+                    ),
+                discountInfo = DiscountInfo(),
+                isSwapDisabled = true,
+                formError = error,
+                isLoading = false,
+            )
+        }
+        if (cause != null) {
+            Timber.e(cause, tag)
+        }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -215,19 +215,26 @@ internal class SwapFormViewModelTest {
                 navigator = navigator,
                 fiatValueToString = fiatValueToString,
                 convertTokenAndValueToTokenValue = convertTokenAndValueToTokenValue,
-                swapQuoteRepository = swapQuoteRepository,
-                appCurrencyRepository = appCurrencyRepository,
                 swapTransactionRepository = swapTransactionRepository,
-                getDiscountBpsUseCase = getDiscountBpsUseCase,
-                referralRepository = referralRepository,
                 swapValidator = swapValidator,
-                swapDiscountChecker = swapDiscountChecker,
                 swapGasCalculator = swapGasCalculator,
                 swapTokenSelector = swapTokenSelector,
                 swapQuoteManager = swapQuoteManager,
                 swapTransactionBuilder =
                     SwapTransactionBuilder(swapGasCalculator, allowanceRepository),
-                ioDispatcher = ioDispatcher,
+                swapQuoteOrchestrator =
+                    SwapQuoteOrchestrator(
+                        swapQuoteRepository = swapQuoteRepository,
+                        appCurrencyRepository = appCurrencyRepository,
+                        getDiscountBpsUseCase = getDiscountBpsUseCase,
+                        referralRepository = referralRepository,
+                        convertTokenAndValueToTokenValue = convertTokenAndValueToTokenValue,
+                        swapDiscountChecker = swapDiscountChecker,
+                        swapGasCalculator = swapGasCalculator,
+                        swapValidator = swapValidator,
+                        fiatValueToString = fiatValueToString,
+                        ioDispatcher = ioDispatcher,
+                    ),
             )
             .also { createdViewModels += it }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteOrchestratorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteOrchestratorTest.kt
@@ -1,0 +1,265 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.swap
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.send.SendSrc
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.textAsFlow
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Focused unit tests for the [SwapQuoteOrchestrator] collaborator extracted from
+ * `SwapFormViewModel.calculateFees()` (#4735). The full success/UTXO/discount matrix is already
+ * covered end-to-end through `SwapFormViewModelTest`, which now drives this orchestrator; these
+ * tests assert the orchestrator's behaviour in isolation behind its own [SwapQuoteContext].
+ */
+internal class SwapQuoteOrchestratorTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+    // Inert: its scheduler is never advanced, so the refresh-quote timer's delay never fires.
+    private val inertIoDispatcher = StandardTestDispatcher()
+
+    private lateinit var pipelineScope: CoroutineScope
+
+    private lateinit var swapQuoteRepository: SwapQuoteRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var getDiscountBpsUseCase: GetDiscountBpsUseCase
+    private lateinit var referralRepository: ReferralCodeSettingsRepository
+    private lateinit var convertTokenAndValueToTokenValue: ConvertTokenAndValueToTokenValueUseCase
+    private lateinit var swapDiscountChecker: SwapDiscountChecker
+    private lateinit var swapGasCalculator: SwapGasCalculator
+    private lateinit var fiatValueToString: FiatValueToStringMapper
+    private lateinit var swapQuoteManager: SwapQuoteManager
+
+    private val srcAmountState = TextFieldState()
+    private val uiState = MutableStateFlow(SwapFormUiModel())
+    private val quoteState = QuoteStateHolder()
+    private val swapFeeFiat = MutableStateFlow<FiatValue?>(null)
+    private val estimatedNetworkFeeTokenValue = MutableStateFlow<TokenValue?>(null)
+    private val estimatedNetworkFeeFiatValue = MutableStateFlow<FiatValue?>(null)
+    private val gasFee = MutableStateFlow<TokenValue?>(null)
+    private val gasFeeChain = MutableStateFlow<Chain?>(null)
+    private val refreshQuoteState = MutableStateFlow(0)
+    private val selectedSrc = MutableStateFlow<SendSrc?>(null)
+    private val selectedDst = MutableStateFlow<SendSrc?>(null)
+
+    @BeforeEach
+    fun setUp() {
+        pipelineScope = CoroutineScope(mainDispatcher)
+
+        swapQuoteRepository = mockk(relaxed = true)
+        appCurrencyRepository = mockk(relaxed = true)
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        getDiscountBpsUseCase = mockk(relaxed = true)
+        referralRepository = mockk(relaxed = true)
+        convertTokenAndValueToTokenValue = mockk(relaxed = true)
+        every { convertTokenAndValueToTokenValue(any(), any()) } answers
+            {
+                TokenValue(value = secondArg(), token = firstArg())
+            }
+        swapDiscountChecker = mockk(relaxed = true)
+        coEvery { swapDiscountChecker.checkVultBpsDiscount(any(), any(), any()) } returns
+            VultDiscountResult(null, null, null)
+        coEvery { swapDiscountChecker.checkReferralBpsDiscount(any(), any(), any(), any()) } returns
+            ReferralDiscountResult(null, null, null)
+        swapGasCalculator = mockk(relaxed = true)
+        fiatValueToString = mockk(relaxed = true)
+        coEvery { fiatValueToString(any(), any()) } returns "$0.00"
+
+        // Real manager: the orchestrator delegates amountChanges/debounce/quote-resolution and
+        // error mapping to it, and the failure-mapping test asserts on its real
+        // mapSwapExceptionToFormError output. Its network-touching collaborators stay mocked.
+        swapQuoteManager =
+            SwapQuoteManager(
+                swapQuoteRepository = swapQuoteRepository,
+                tokenRepository = mockk(relaxed = true),
+                tokenPriceRepository = mockk(relaxed = true),
+                convertTokenValueToFiat = mockk(relaxed = true),
+                mapTokenValueToDecimalUiString = mockk(relaxed = true),
+                fiatValueToString = fiatValueToString,
+                searchToken = mockk(relaxed = true),
+                convertTokenToTokenUseCase = mockk(relaxed = true),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        pipelineScope.cancel()
+    }
+
+    private fun createOrchestrator() =
+        SwapQuoteOrchestrator(
+            swapQuoteRepository = swapQuoteRepository,
+            appCurrencyRepository = appCurrencyRepository,
+            getDiscountBpsUseCase = getDiscountBpsUseCase,
+            referralRepository = referralRepository,
+            convertTokenAndValueToTokenValue = convertTokenAndValueToTokenValue,
+            swapDiscountChecker = swapDiscountChecker,
+            swapGasCalculator = swapGasCalculator,
+            swapValidator = SwapValidator(),
+            fiatValueToString = fiatValueToString,
+            ioDispatcher = inertIoDispatcher,
+        )
+
+    private fun context() =
+        SwapQuoteContext(
+            uiState = uiState,
+            quoteState = quoteState,
+            swapFeeFiat = swapFeeFiat,
+            estimatedNetworkFeeTokenValue = estimatedNetworkFeeTokenValue,
+            estimatedNetworkFeeFiatValue = estimatedNetworkFeeFiatValue,
+            gasFee = gasFee,
+            gasFeeChain = gasFeeChain,
+            refreshQuoteState = refreshQuoteState,
+            selectedSrc = selectedSrc,
+            selectedDst = selectedDst,
+            srcAmountTextFlow = srcAmountState.textAsFlow(),
+            swapQuoteManager = swapQuoteManager,
+            srcAmount = { srcAmountState.text.toString().toBigDecimalOrNull() },
+            isSrcAmountEmpty = { srcAmountState.text.isEmpty() },
+            vaultId = { TEST_VAULT_ID },
+            selectedSrcTokenTitle = { null },
+        )
+
+    @Test
+    fun `resetQuoteState clears cached quote, swap fee, and resets the UI to pristine`() =
+        runTest(mainDispatcher) {
+            val orchestrator = createOrchestrator()
+            orchestrator.start(pipelineScope, context())
+
+            // Seed non-pristine state as a successful quote would have.
+            quoteState.quote = mockk(relaxed = true)
+            quoteState.provider = com.vultisig.wallet.data.models.SwapProvider.THORCHAIN
+            swapFeeFiat.value = FiatValue(BigDecimal("1.23"), "USD")
+            uiState.value =
+                uiState.value.copy(
+                    srcFiatValue = "$100.00",
+                    isSwapDisabled = false,
+                    isLoading = true,
+                    formError = UiText.DynamicString("stale"),
+                )
+
+            orchestrator.resetQuoteState()
+
+            assertNull(quoteState.quote)
+            assertNull(quoteState.provider)
+            assertNull(swapFeeFiat.value)
+            val state = uiState.value
+            assertEquals("0", state.srcFiatValue)
+            assertTrue(state.isSwapDisabled)
+            assertEquals(false, state.isLoading)
+            assertNull(state.formError)
+            assertEquals("0", state.feeBreakdown.fee)
+            assertEquals("0", state.feeBreakdown.totalFee)
+            assertEquals(false, state.quoteDisplay.hasQuote)
+        }
+
+    @Test
+    fun `unsupported pair surfaces the route-not-available form error and disables swap`() =
+        runTest(mainDispatcher) {
+            // No eligible provider for the pair -> the pipeline throws SwapIsNotSupported, which
+            // the
+            // orchestrator maps via the real SwapQuoteManager and writes as the form error.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns emptyList()
+
+            val orchestrator = createOrchestrator()
+            orchestrator.start(pipelineScope, context())
+
+            selectedSrc.value = sendSrc(ETH_COIN)
+            selectedDst.value = sendSrc(USDC_COIN)
+            advanceUntilIdle()
+
+            srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            val state = uiState.value
+            assertEquals(UiText.StringResource(R.string.swap_route_not_available), state.formError)
+            assertTrue(state.isSwapDisabled)
+            assertEquals(false, state.isLoading)
+            assertNull(quoteState.quote)
+        }
+
+    private fun sendSrc(coin: Coin): SendSrc {
+        val account =
+            Account(
+                token = coin,
+                tokenValue = TokenValue(value = BigInteger("1000000000000000000"), token = coin),
+                fiatValue = null,
+                price = null,
+            )
+        val address =
+            Address(chain = coin.chain, address = coin.address, accounts = listOf(account))
+        return SendSrc(address = address, account = account)
+    }
+
+    companion object {
+        private const val TEST_VAULT_ID = "test-vault-id"
+
+        private val ETH_COIN =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "ETH",
+                logo = "eth",
+                address = "0xethaddress",
+                decimal = 18,
+                hexPublicKey = "hex",
+                priceProviderID = "ethereum",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+
+        private val USDC_COIN =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "USDC",
+                logo = "usdc",
+                address = "0xethaddress",
+                decimal = 6,
+                hexPublicKey = "hex",
+                priceProviderID = "usd-coin",
+                contractAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                isNativeToken = false,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #4723 / #4778. Extracts the reactive quote/fee orchestration (`calculateFees()`, ~380 lines) out of `SwapFormViewModel` into a new **`SwapQuoteOrchestrator`** collaborator behind a single flow, so the ViewModel goes back to being a thin coordinator. Closes #4735.

- **`SwapQuoteOrchestrator`** owns the `combine`/`debounce`/`collectLatest` pipeline plus `showIndicativeRate()`, `launchRefreshQuoteTimer()`, and `resetQuoteState()`.
- The pipeline is moved **verbatim** over a shared **`SwapQuoteContext`** (the same `StateFlow` instances the VM exposes), so every state-write site and its ordering is byte-for-byte preserved — the UTXO plan-fee race, the `isLoading` spinner timing (#4712), and the `isSwapDisabled` gating all behave exactly as before.
- `SwapFormViewModel.calculateFees()` is now a thin delegator (`swapQuoteOrchestrator.start(scope, context)`); the flip path calls `swapQuoteOrchestrator.resetQuoteState()`.
- Six pipeline-only dependencies (`swapQuoteRepository`, `appCurrencyRepository`, `referralRepository`, `getDiscountBpsUseCase`, `swapDiscountChecker`, `ioDispatcher`) plus `referralCode`/`refreshQuoteJob` moved to the orchestrator — a genuine slim-down, not net-additive churn.

**`SwapFormViewModel.kt`: 1145 → 622 lines** (acceptance: well under 1,000).

## Notes for reviewers

- `SwapQuoteManager` stays a single shared instance (passed via the context, not re-injected) so the quote cache and the percentage/Max immediate-fetch flag keep working across the VM (`cacheQuote`, `markImmediateFetch`) and the orchestrator's pipeline.
- No behavior, fee-display ordering, validation messages, or UI were changed; quote provider integrations are untouched.

## Test plan

- **New** `SwapQuoteOrchestratorTest` — drives the orchestrator in isolation behind its own `SwapQuoteContext`: pristine `resetQuoteState()`, and unsupported-pair failure-mapping through the real flow.
- The existing `SwapFormViewModelTest` (~40 `calculateFees …` cases) now exercises the extracted orchestrator end-to-end — verifies the move is behavior-preserving.
- `./gradlew assembleDebug` → BUILD SUCCESSFUL
- `./gradlew :app:testDebugUnitTest` (full suite) → BUILD SUCCESSFUL
- ktfmt applied to all modified/new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of swap fee calculations, particularly for UTXO-based swaps
  * Improved balance validation for swap operations

* **Tests**
  * Added tests for swap quote processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->