### PR TITLE
fix(home/chain-detail/staking): pull-to-refresh from anywhere + whole-screen scroll (#4752, #4761)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
@@ -3,8 +3,8 @@
 package com.vultisig.wallet.ui.components.v2.scaffold
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
@@ -25,9 +25,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
@@ -41,7 +39,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 
 @Composable
 fun VsExpandableTopBar(
@@ -107,34 +104,27 @@ fun VsExpandableTopBar(
             }
         val offsetLimit = remember(heightDiffPx) { -heightDiffPx }
 
-        val animatedOffset = remember { Animatable(0f) }
-
+        // Single source of truth for the bar height: scrollBehavior.state.heightOffset. Both the
+        // direct drag below and the nested-scroll from the list write this same value, so they can
+        // never diverge (no separate Animatable that goes stale when the list scrolls the bar).
         val previousOffsetLimit = remember { mutableFloatStateOf(offsetLimit) }
 
         LaunchedEffect(offsetLimit) {
             val oldLimit = previousOffsetLimit.floatValue
-            val currentOffset = animatedOffset.value
+            val currentOffset = scrollBehavior.state.heightOffset
 
-            animatedOffset.updateBounds(lowerBound = offsetLimit, upperBound = 0f)
+            // Update the limit first so the coercing setter below accepts the rescaled offset.
+            scrollBehavior.state.heightOffsetLimit = offsetLimit
 
             if (oldLimit != 0f && oldLimit != offsetLimit && currentOffset != 0f) {
                 val collapsePercentage = (currentOffset / oldLimit).coerceIn(0f, 1f)
                 val newOffset = (offsetLimit * collapsePercentage).coerceIn(offsetLimit, 0f)
-                animatedOffset.snapTo(newOffset)
+                scrollBehavior.state.heightOffset = newOffset
             } else {
-                val clampedValue = currentOffset.coerceIn(offsetLimit, 0f)
-                if (clampedValue != currentOffset) {
-                    animatedOffset.snapTo(clampedValue)
-                }
+                scrollBehavior.state.heightOffset = currentOffset.coerceIn(offsetLimit, 0f)
             }
 
-            scrollBehavior.state.heightOffsetLimit = offsetLimit
             previousOffsetLimit.floatValue = offsetLimit
-        }
-
-        LaunchedEffect(Unit) {
-            snapshotFlow { animatedOffset.value }
-                .collect { value -> scrollBehavior.state.heightOffset = value }
         }
 
         val offset by remember { derivedStateOf { scrollBehavior.state.heightOffset } }
@@ -154,8 +144,6 @@ fun VsExpandableTopBar(
                 collapsedHeightPx + (expandedHeightPx - collapsedHeightPx) * expandedFraction
             }
 
-        val coroutineScope = rememberCoroutineScope()
-
         // Bridges the bar's own drag gesture into the nested-scroll system. When the bar is at a
         // bound (fully expanded and over-dragged downward), the unused delta is dispatched to the
         // surrounding parents so a downward pull that starts on the top bar reaches the enclosing
@@ -164,14 +152,13 @@ fun VsExpandableTopBar(
         val noOpConnection = remember { object : NestedScrollConnection {} }
 
         val dragState = rememberDraggableState { delta ->
-            val current = animatedOffset.value
+            val current = scrollBehavior.state.heightOffset
             val target = (current + delta).coerceIn(offsetLimit, 0f)
-            val consumed = target - current
-            coroutineScope.launch { animatedOffset.snapTo(target) }
-            val leftover = delta - consumed
+            scrollBehavior.state.heightOffset = target
+            val leftover = delta - (target - current)
             if (leftover != 0f) {
                 nestedScrollDispatcher.dispatchPostScroll(
-                    consumed = Offset(0f, consumed),
+                    consumed = Offset(0f, target - current),
                     available = Offset(0f, leftover),
                     source = NestedScrollSource.UserInput,
                 )
@@ -187,21 +174,33 @@ fun VsExpandableTopBar(
                         orientation = Orientation.Vertical,
                         state = dragState,
                         onDragStopped = { velocity ->
-                            // Hand the release to the nested-scroll parents first so a downward
-                            // over-drag of the top bar lets PullToRefreshBox settle / trigger.
-                            val available = Velocity(0f, velocity)
-                            val consumedVelocity =
-                                nestedScrollDispatcher.dispatchPreFling(available)
-                            nestedScrollDispatcher.dispatchPostFling(
-                                consumedVelocity,
-                                available - consumedVelocity,
-                            )
-                            val target = if (expandedFraction < 0.5f) offsetLimit else 0f
-                            animatedOffset.animateTo(
-                                targetValue = target,
-                                animationSpec =
-                                    tween(durationMillis = 300, easing = FastOutSlowInEasing),
-                            )
+                            if (scrollBehavior.state.heightOffset >= 0f) {
+                                // The bar is fully expanded and the user kept over-dragging
+                                // downward: hand the release velocity to the nested-scroll parents
+                                // so PullToRefreshBox can settle / trigger. The bar itself does not
+                                // move, so there is nothing for us to settle.
+                                val available = Velocity(0f, velocity)
+                                val consumedVelocity =
+                                    nestedScrollDispatcher.dispatchPreFling(available)
+                                nestedScrollDispatcher.dispatchPostFling(
+                                    consumedVelocity,
+                                    available - consumedVelocity,
+                                )
+                            } else {
+                                // The bar is partially dragged: settle it to the nearest state.
+                                // We do NOT dispatch the fling to the parent here — doing so would
+                                // let exitUntilCollapsed.onPostFling settle the bar too, producing
+                                // a settle-then-jump-back double animation on the shared offset.
+                                val target = if (expandedFraction < 0.5f) offsetLimit else 0f
+                                animate(
+                                    initialValue = scrollBehavior.state.heightOffset,
+                                    targetValue = target,
+                                    animationSpec =
+                                        tween(durationMillis = 300, easing = FastOutSlowInEasing),
+                                ) { value, _ ->
+                                    scrollBehavior.state.heightOffset = value
+                                }
+                            }
                         },
                     ),
             tonalElevation = 0.dp,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
@@ -30,10 +30,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
@@ -150,9 +156,25 @@ fun VsExpandableTopBar(
 
         val coroutineScope = rememberCoroutineScope()
 
+        // Bridges the bar's own drag gesture into the nested-scroll system. When the bar is at a
+        // bound (fully expanded and over-dragged downward), the unused delta is dispatched to the
+        // surrounding parents so a downward pull that starts on the top bar reaches the enclosing
+        // PullToRefreshBox instead of being swallowed by this draggable (#4752).
+        val nestedScrollDispatcher = remember { NestedScrollDispatcher() }
+        val noOpConnection = remember { object : NestedScrollConnection {} }
+
         val dragState = rememberDraggableState { delta ->
-            coroutineScope.launch {
-                animatedOffset.snapTo((animatedOffset.value + delta).coerceIn(offsetLimit, 0f))
+            val current = animatedOffset.value
+            val target = (current + delta).coerceIn(offsetLimit, 0f)
+            val consumed = target - current
+            coroutineScope.launch { animatedOffset.snapTo(target) }
+            val leftover = delta - consumed
+            if (leftover != 0f) {
+                nestedScrollDispatcher.dispatchPostScroll(
+                    consumed = Offset(0f, consumed),
+                    available = Offset(0f, leftover),
+                    source = NestedScrollSource.UserInput,
+                )
             }
         }
 
@@ -160,10 +182,20 @@ fun VsExpandableTopBar(
             modifier =
                 modifier
                     .height(with(density) { currentHeightPx.toDp() })
+                    .nestedScroll(connection = noOpConnection, dispatcher = nestedScrollDispatcher)
                     .draggable(
                         orientation = Orientation.Vertical,
                         state = dragState,
-                        onDragStopped = {
+                        onDragStopped = { velocity ->
+                            // Hand the release to the nested-scroll parents first so a downward
+                            // over-drag of the top bar lets PullToRefreshBox settle / trigger.
+                            val available = Velocity(0f, velocity)
+                            val consumedVelocity =
+                                nestedScrollDispatcher.dispatchPreFling(available)
+                            nestedScrollDispatcher.dispatchPostFling(
+                                consumedVelocity,
+                                available - consumedVelocity,
+                            )
                             val target = if (expandedFraction < 0.5f) offsetLimit else 0f
                             animatedOffset.animateTo(
                                 targetValue = target,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
@@ -1,8 +1,5 @@
 package com.vultisig.wallet.ui.components.v2.scaffold
 
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
@@ -16,23 +13,14 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.unit.Velocity
 import com.vultisig.wallet.ui.components.v2.snackbar.VSSnackbarState
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.theme.Theme
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,77 +36,16 @@ internal fun ScaffoldWithExpandableTopBar(
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
 ) {
-    val expandScope = rememberCoroutineScope()
-    val expandJob = remember { mutableStateOf<Job?>(null) }
-
-    // A downward over-scroll at the top must reach the enclosing PullToRefreshBox to arm a refresh.
-    // The default exitUntilCollapsed connection instead consumes that over-scroll frame-by-frame to
-    // re-grow the collapsed top bar, which starved pull-to-refresh — so a pull made while the bar
-    // was collapsed never triggered a refresh (#4752). This wrapper keeps collapse-on-scroll-up,
-    // but
-    // when the user over-scrolls down at the top with the bar collapsed it animates the bar open
-    // once
-    // and lets the over-scroll pass through, so the bar reappears and the refresh arms in the same
-    // gesture.
-    val pullRefreshAwareConnection =
-        remember(scrollBehavior, expandScope) {
-            object : NestedScrollConnection {
-                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                    if (available.y < 0f) {
-                        expandJob.value?.cancel()
-                        expandJob.value = null
-                    }
-                    return scrollBehavior.nestedScrollConnection.onPreScroll(available, source)
-                }
-
-                override fun onPostScroll(
-                    consumed: Offset,
-                    available: Offset,
-                    source: NestedScrollSource,
-                ): Offset {
-                    val barCollapsed = scrollBehavior.state.heightOffset < 0f
-                    if (
-                        available.y > 0f && source == NestedScrollSource.UserInput && barCollapsed
-                    ) {
-                        if (expandJob.value?.isActive != true) {
-                            expandJob.value =
-                                expandScope.launch {
-                                    animate(
-                                        initialValue = scrollBehavior.state.heightOffset,
-                                        targetValue = 0f,
-                                        animationSpec =
-                                            tween(
-                                                durationMillis = 250,
-                                                easing = FastOutSlowInEasing,
-                                            ),
-                                    ) { value, _ ->
-                                        scrollBehavior.state.heightOffset = value
-                                    }
-                                }
-                        }
-                        // Don't consume: hand the over-scroll to PullToRefreshBox so it can arm.
-                        return Offset.Zero
-                    }
-                    return scrollBehavior.nestedScrollConnection.onPostScroll(
-                        consumed,
-                        available,
-                        source,
-                    )
-                }
-
-                override suspend fun onPreFling(available: Velocity): Velocity =
-                    scrollBehavior.nestedScrollConnection.onPreFling(available)
-
-                override suspend fun onPostFling(
-                    consumed: Velocity,
-                    available: Velocity,
-                ): Velocity = scrollBehavior.nestedScrollConnection.onPostFling(consumed, available)
-            }
-        }
-
+    // The bar collapses/re-grows entirely through the standard exitUntilCollapsed nested-scroll
+    // connection. When the bar is collapsed and the user pulls down at the top, that connection
+    // re-grows the bar with the leading over-scroll and, once it reaches its fully-expanded bound,
+    // stops consuming — the remaining over-scroll then flows up to the enclosing PullToRefreshBox
+    // and arms the refresh in the same gesture (#4752). Driving it through this single connection
+    // (rather than a side animation on the shared height offset) keeps one writer to the offset, so
+    // a non-monotonic pull can no longer make the bar oscillate.
     PullToRefreshBox(onRefresh = onRefresh, isRefreshing = isRefreshing) {
         Scaffold(
-            modifier = modifier.nestedScroll(pullRefreshAwareConnection),
+            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
             containerColor = backgroundColor,
             topBar = {
                 VsExpandableTopBar(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
@@ -1,21 +1,38 @@
 package com.vultisig.wallet.ui.components.v2.scaffold
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Velocity
 import com.vultisig.wallet.ui.components.v2.snackbar.VSSnackbarState
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.theme.Theme
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,10 +48,77 @@ internal fun ScaffoldWithExpandableTopBar(
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
 ) {
+    val expandScope = rememberCoroutineScope()
+    val expandJob = remember { mutableStateOf<Job?>(null) }
+
+    // A downward over-scroll at the top must reach the enclosing PullToRefreshBox to arm a refresh.
+    // The default exitUntilCollapsed connection instead consumes that over-scroll frame-by-frame to
+    // re-grow the collapsed top bar, which starved pull-to-refresh — so a pull made while the bar
+    // was collapsed never triggered a refresh (#4752). This wrapper keeps collapse-on-scroll-up,
+    // but
+    // when the user over-scrolls down at the top with the bar collapsed it animates the bar open
+    // once
+    // and lets the over-scroll pass through, so the bar reappears and the refresh arms in the same
+    // gesture.
+    val pullRefreshAwareConnection =
+        remember(scrollBehavior, expandScope) {
+            object : NestedScrollConnection {
+                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    if (available.y < 0f) {
+                        expandJob.value?.cancel()
+                        expandJob.value = null
+                    }
+                    return scrollBehavior.nestedScrollConnection.onPreScroll(available, source)
+                }
+
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource,
+                ): Offset {
+                    val barCollapsed = scrollBehavior.state.heightOffset < 0f
+                    if (
+                        available.y > 0f && source == NestedScrollSource.UserInput && barCollapsed
+                    ) {
+                        if (expandJob.value?.isActive != true) {
+                            expandJob.value =
+                                expandScope.launch {
+                                    animate(
+                                        initialValue = scrollBehavior.state.heightOffset,
+                                        targetValue = 0f,
+                                        animationSpec =
+                                            tween(
+                                                durationMillis = 250,
+                                                easing = FastOutSlowInEasing,
+                                            ),
+                                    ) { value, _ ->
+                                        scrollBehavior.state.heightOffset = value
+                                    }
+                                }
+                        }
+                        // Don't consume: hand the over-scroll to PullToRefreshBox so it can arm.
+                        return Offset.Zero
+                    }
+                    return scrollBehavior.nestedScrollConnection.onPostScroll(
+                        consumed,
+                        available,
+                        source,
+                    )
+                }
+
+                override suspend fun onPreFling(available: Velocity): Velocity =
+                    scrollBehavior.nestedScrollConnection.onPreFling(available)
+
+                override suspend fun onPostFling(
+                    consumed: Velocity,
+                    available: Velocity,
+                ): Velocity = scrollBehavior.nestedScrollConnection.onPostFling(consumed, available)
+            }
+        }
 
     PullToRefreshBox(onRefresh = onRefresh, isRefreshing = isRefreshing) {
         Scaffold(
-            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = modifier.nestedScroll(pullRefreshAwareConnection),
             containerColor = backgroundColor,
             topBar = {
                 VsExpandableTopBar(
@@ -45,8 +129,31 @@ internal fun ScaffoldWithExpandableTopBar(
                 )
             },
             bottomBar = bottomBarContent,
-            content = content,
-        )
+        ) { paddingValues ->
+            // A downward drag that starts on a non-scrollable region of the content (the empty area
+            // below a short list, headers, banners) would otherwise never reach PullToRefreshBox,
+            // so
+            // pull-to-refresh only worked when the drag began on the list itself (#4752). This
+            // gesture-only `scrollable` (it consumes nothing and does NOT change layout, unlike
+            // verticalScroll) forwards those drags into the nested-scroll system. Drags that land
+            // on
+            // the real list are handled by the list first; only the otherwise-dead regions fall
+            // through to here.
+            Box(
+                modifier =
+                    Modifier.fillMaxSize()
+                        .scrollable(
+                            orientation = Orientation.Vertical,
+                            state = rememberScrollableState { 0f },
+                            // No overscroll effect: this gesture-only scrollable must forward the
+                            // list's over-scroll up to PullToRefreshBox, not absorb it as a
+                            // stretch.
+                            overscrollEffect = null,
+                        )
+            ) {
+                content(paddingValues)
+            }
+        }
         VsSnackBar(
             snackbarState = snackbarState,
             modifier = Modifier.align(alignment = Alignment.BottomCenter),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -94,33 +94,34 @@ internal fun CosmosStakingPositionsScreen(
             Column(
                 modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)
             ) {
-                Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
-                    CosmosStakingBalanceBanner(
-                        chainName = chainId,
-                        coinLogo = state.coinLogo,
-                        balanceFiat = state.totalAmountPrice,
-                        isBalanceVisible = state.isBalanceVisible,
-                    )
-                }
-
-                // Single manage-positions control: the ChainDashboard top-bar action above. The
-                // inline edit-chains button that used to sit here duplicated it (#4821).
-                Box(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                ) {
-                    VsTabGroup(index = 0) {
-                        COSMOS_STAKING_TABS.forEach { tab ->
-                            tab { VsTab(label = stringResource(tab.displayNameRes), onClick = {}) }
-                        }
-                    }
-                }
-
                 LazyColumn(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
+                    // Banner + tab row scroll with the list as part of the whole screen (mirrors
+                    // iOS) rather than staying pinned above it (#4761).
+                    item {
+                        CosmosStakingBalanceBanner(
+                            chainName = chainId,
+                            coinLogo = state.coinLogo,
+                            balanceFiat = state.totalAmountPrice,
+                            isBalanceVisible = state.isBalanceVisible,
+                        )
+                    }
+
+                    // Single manage-positions control: the ChainDashboard top-bar action above. The
+                    // inline edit-chains button that used to sit here duplicated it (#4821).
+                    item {
+                        VsTabGroup(index = 0) {
+                            COSMOS_STAKING_TABS.forEach { tab ->
+                                tab {
+                                    VsTab(label = stringResource(tab.displayNameRes), onClick = {})
+                                }
+                            }
+                        }
+                    }
+
                     if (!state.isPositionEnabled) {
                         item {
                             NoPositionsContainer(


### PR DESCRIPTION
## Summary

Fixes #4752 and fixes #4761 — two closely-related scroll/refresh issues on the screens built around `ScaffoldWithExpandableTopBar`, plus the staking positions screen.

### #4752 — pull-to-refresh works from anywhere

On the home and chain/token-detail screens, pull-to-refresh only fired when the drag **started on the asset list itself**. A pull that began on the balance card, the header, or the empty area below a short list did nothing — so on a sparse chain-detail screen (tiny list, mostly card + empty space) refresh felt broken.

`PullToRefreshBox` only arms from a scrollable child's over-scroll, so three distinct gaps had to be closed in the shared `ScaffoldWithExpandableTopBar` (used by both `VaultAccountsScreen` and `ChainTokensScreen`):

- **Top card** — `VsExpandableTopBar`'s own `draggable` swallowed vertical drags on the card. It's now bridged into the nested-scroll system via a `NestedScrollDispatcher`, so a downward over-drag of the fully-expanded card flows to `PullToRefreshBox`.
- **Empty / non-scrollable content regions** — the Scaffold content is wrapped in a gesture-only `scrollable` (consumes nothing, `overscrollEffect = null`, and — unlike `verticalScroll` — does **not** change layout) so drags on otherwise-dead regions forward into the nested-scroll system. Real list drags are still handled by the list first.
- **Collapsed top bar** — the bar collapses/re-grows entirely through the standard `exitUntilCollapsed` connection; a single source of truth on `heightOffset` (the direct drag writes it; no side `Animatable`/`snapshotFlow` bridge) means a non-monotonic pull can no longer make the bar oscillate. Once the bar is fully expanded it stops consuming and the remaining over-scroll flows up to `PullToRefreshBox` in the same gesture.

### #4761 — scroll the whole screen, don't pin the top card

The header should scroll away as part of the whole screen (mirroring iOS), not stay pinned while only the list moves.

- **Chain detail** — already handled by the `ScaffoldWithExpandableTopBar` nested-scroll rework above: the expanded top bar collapses/scrolls away with the content.
- **Staking positions** (`CosmosStakingPositionsScreen`) — the balance banner and the "Staked" tab row sat in the outer `Column` above the `LazyColumn`, so they stayed pinned. They're now leading `item {}`s inside the `LazyColumn` (and the list went from `weight(1f)` to `fillMaxSize()`), so the top card scrolls away with the rest of the screen.

## Notes for reviewers

- No behavior/visual change to the card, the list, or collapse-on-scroll-up — only otherwise-dead gestures now reach the refresh.
- The gesture-only `scrollable` is intentionally not a `verticalScroll`: it adds gesture detection + nested-scroll dispatch without altering layout or the list's virtualization.
- The staking change is layout-only (banner/tabs become list items); no data, validation, or action wiring changed.

## Test plan

Verified on a device/emulator (home + chain detail). Refresh fires when pulling from:
- the balance card / header area
- the empty space below a short list
- the asset list itself — with the card both **expanded** and **collapsed**

Staking screen: the banner + "Staked" tab now scroll up with the delegation list instead of staying pinned.

Regression checks: list scrolling, card collapse/expand by scroll and by direct drag, and the snackbar overlay all still work. `./gradlew assembleDebug` and `./gradlew :app:ktfmtCheckMain` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expandable top bar drag/scroll responsiveness with smoother fling handoff to parent scrollers and proper behavior at bounds.
  * Pull-to-refresh now arms reliably from non-scrollable regions by forwarding downward gestures.

* **Refactor**
  * Banner and tab row now scroll together with the main list for a unified scrolling experience.

* **Documentation**
  * Expanded comments clarifying top bar nested-scroll and pull-to-refresh interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->