### PR TITLE
fix(swap): clear stale UTXO fee on plan-fee miss / cleared network fee (#4810)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -795,7 +795,7 @@ constructor(
                             networkFeeFiat = fee.formattedFiatValue,
                         )
                     NetworkFeeUpdate.Clear ->
-                        it.feeBreakdown.copy(networkFee = "", networkFeeFiat = "")
+                        it.feeBreakdown.copy(networkFee = "", networkFeeFiat = "", totalFee = "")
                     null -> it.feeBreakdown
                 }
             it.copy(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -417,6 +417,8 @@ internal class SwapQuotePipeline(
                         isSwapDisabled = false
                     }
                     UtxoPlanFeeResult.InsufficientUtxos -> {
+                        networkFee = NetworkFeeUpdate.Clear
+                        effectiveNetworkFeeTokenValue = null
                         isSwapDisabled = true
                         formError = UiText.StringResource(R.string.insufficient_utxos_error)
                     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -2195,6 +2195,52 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
+    fun `InsufficientUtxos after a successful plan fee clears the stale fee and total`() =
+        runTest(mainDispatcher) {
+            // Regression for #4810: an earlier successful plan fee leaves the network-fee row and
+            // totalFee populated; a later quote that hits InsufficientUtxos must blank both rather
+            // than leaving a stale fee on screen alongside the insufficient-utxos error.
+            val vm = setupUtxoPlanFeeTest(SwapProvider.THORCHAIN, createThorChainQuote())
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.01")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            // The successful plan fee is shown and the swap is enabled.
+            assertFalse(vm.uiState.value.isSwapDisabled)
+            assertEquals("0.00000816 BTC", vm.uiState.value.feeBreakdown.networkFee)
+
+            // A later quote can no longer afford the plan: the fee must be cleared.
+            coEvery {
+                swapGasCalculator.resolveUtxoPlanFee(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns UtxoPlanFeeResult.InsufficientUtxos
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.02")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.isSwapDisabled)
+            assertEquals(
+                UiText.StringResource(R.string.insufficient_utxos_error),
+                vm.uiState.value.formError,
+            )
+            assertEquals("", vm.uiState.value.feeBreakdown.networkFee)
+            assertEquals("", vm.uiState.value.feeBreakdown.networkFeeFiat)
+            assertEquals("", vm.uiState.value.feeBreakdown.totalFee)
+        }
+
+    @Test
     fun `calculateFees for UTXO chain clears fee and disables swap on plan network error`() =
         runTest(mainDispatcher) {
             coEvery { swapGasCalculator.calculateGasFee(any(), any()) } returns


### PR DESCRIPTION
## Summary

Two related spots in the swap form left stale fee state after a UTXO plan-fee miss. Both are behavior-preserving cleanups split out of #4808. Closes #4810.

### 1. `InsufficientUtxos` didn't clear the previous UTXO fee
In `SwapQuotePipeline.resolveNetworkFee()`, the `UtxoPlanFeeResult.InsufficientUtxos` branch set `isSwapDisabled` + the error but — unlike `Unavailable` — left the previously resolved network fee on screen and in the balance check. It now emits `NetworkFeeUpdate.Clear` and nulls `effectiveNetworkFeeTokenValue`, matching the `Unavailable` branch.

### 2. Stale `totalFee` when the network fee is cleared
`collectTotalFee()` combines the network-fee and swap-fee fiat flows with `filterNotNull()` on both sides. When the network fee is cleared, `estimatedNetworkFeeFiatValue` goes null and the `combine` stops emitting, so `feeBreakdown.totalFee` kept its previous value — a blank network-fee row alongside a non-zero total.

Fixed by blanking `totalFee` in the `NetworkFeeUpdate.Clear` branch of `applyNetworkFeeOutcome()`, right where `networkFee`/`networkFeeFiat` are already cleared. This is preferred over dropping `filterNotNull()` because the short-circuit on `swapFeeFiat` is intentional and documented (avoids a `newGas + staleSwap` race on flip/reset).

## Impact
Cosmetic / transitional only — the affected states are swap-disabled and self-correct on the next successful quote. This makes the fee breakdown internally consistent during those windows.

## Test plan
- Added a regression test in `SwapFormViewModelTest`: drives a successful plan fee (asserts fee row populated, swap enabled), then a later quote returns `InsufficientUtxos` and asserts `networkFee` / `networkFeeFiat` / `totalFee` all blank with the swap disabled and the insufficient-utxos error shown.
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapFormViewModelTest"` → green
- ktfmt applied

## Files
- `SwapQuotePipeline.kt` (`resolveNetworkFee()`)
- `SwapFormViewModel.kt` (`applyNetworkFeeOutcome()`)
- `SwapFormViewModelTest.kt` (regression test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where stale network fee values would persist in the swap form UI after being cleared
* Improved error handling when insufficient UTXOs are available for a transaction, ensuring the swap form properly disables the swap and clears outdated fee information
* Added test coverage to prevent regression of UTXO fee resolution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->