### PR TITLE
Refresh Cosmos staking positions after a tx; skeleton cold-load

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimBlockedReason
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
+import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
@@ -70,6 +71,7 @@ import com.vultisig.wallet.ui.models.ChainTokensUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
+import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorRow
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
@@ -92,6 +94,7 @@ import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.screens.TransactionDoneView
+import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsContent
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
@@ -128,6 +131,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import java.math.BigDecimal
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -212,6 +216,8 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_detail_claim" -> QbtcDetailClaimPreview()
                     "keysign_devices_plus_before" -> KeysignDevicesCountPreview(allowsMore = true)
                     "keysign_devices_plus_after" -> KeysignDevicesCountPreview(allowsMore = false)
+                    "staking_positions_loading" -> CosmosStakingPositionsLoadingPreview()
+                    "staking_positions_loaded" -> CosmosStakingPositionsLoadedPreview()
                     "staking_verify_before" -> CosmosStakingVerifyCtaPreview(newButtons = false)
                     "staking_verify_after" -> CosmosStakingVerifyCtaPreview(newButtons = true)
                     "staking_verify_qbtc" ->
@@ -1799,6 +1805,63 @@ private fun KeysignSigningLuncPreview() {
         hasBackClick = false,
         showSaveToAddressBook = false,
         coinLogoRes = R.drawable.lunc,
+    )
+}
+
+@Composable
+private fun CosmosStakingPositionsLoadingPreview() {
+    // Cold load (#4815): positions empty + isLoading renders the skeleton delegation cards.
+    CosmosStakingPositionsContent(
+        chainId = "TerraClassic",
+        state =
+            CosmosStakingPositionsUiState(
+                ticker = "LUNC",
+                coinLogo = Coins.TerraClassic.LUNC.logo,
+                isLoading = true,
+                selectedPositions = listOf("LUNC"),
+            ),
+    )
+}
+
+@Composable
+private fun CosmosStakingPositionsLoadedPreview() {
+    CosmosStakingPositionsContent(
+        chainId = "TerraClassic",
+        state =
+            CosmosStakingPositionsUiState(
+                ticker = "LUNC",
+                coinLogo = Coins.TerraClassic.LUNC.logo,
+                positions =
+                    listOf(
+                        CosmosStakePositionRow(
+                            validatorAddress = "terravaloper1allnodes00000000000000000000000000",
+                            validatorMoniker = "Allnodes",
+                            validatorIdentity = null,
+                            stakedAmount = BigDecimal("1200000"),
+                            stakedFiatDisplay = "$0.14",
+                            pendingReward = BigDecimal("45.231"),
+                            apyPercent = BigDecimal("0.182"),
+                            validatorStatus = CosmosStakePositionRow.ValidatorStatus.Active,
+                            pendingUnbondingUnlockDate = null,
+                        ),
+                        CosmosStakePositionRow(
+                            validatorAddress = "terravaloper1legacy000000000000000000000000000",
+                            validatorMoniker = "Legacy Node",
+                            validatorIdentity = null,
+                            stakedAmount = BigDecimal("300000"),
+                            stakedFiatDisplay = "$0.03",
+                            pendingReward = BigDecimal.ZERO,
+                            apyPercent = null,
+                            validatorStatus = CosmosStakePositionRow.ValidatorStatus.ChurnedOut,
+                            pendingUnbondingUnlockDate = null,
+                        ),
+                    ),
+                hasClaimableRewards = true,
+                totalStaked = BigDecimal("1500000"),
+                totalStakedFiat = "$0.17",
+                totalAmountPrice = "$0.17",
+                selectedPositions = listOf("LUNC"),
+            ),
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
@@ -12,12 +12,15 @@ import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingService
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosUnbondingDelegation
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosValidator
 import com.vultisig.wallet.data.blockchain.cosmos.staking.KeybaseAvatarService
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.CosmosStakingSnapshot
 import com.vultisig.wallet.data.repositories.CosmosStakingSnapshotCache
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -113,6 +116,7 @@ constructor(
     private val tokenPriceRepository: TokenPriceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val snapshotCache: CosmosStakingSnapshotCache,
+    private val stakingDetailsRepository: StakingDetailsRepository,
     private val navigator: Navigator<Destination>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -146,19 +150,34 @@ constructor(
 
     private var coin: Coin? = null
 
-    /** Idempotent — re-invoking with the same args is a no-op so recomposition doesn't re-fetch. */
+    /**
+     * Wires the screen's vault + chain and loads. Driven by a `LifecycleResumeEffect`, so it runs
+     * on the first open AND every time the user returns to the retained screen — e.g. after signing
+     * a delegate / undelegate / redelegate / claim. The first call resolves the native coin then
+     * loads ([loadCoin] chains into [load] once `coin` is assigned); a re-entry silently refreshes
+     * so the Total Staked card reflects the just-signed tx without a manual pull (#4815). A
+     * re-entry fired while the first load is still resolving the coin is a no-op — that load's own
+     * tail refresh already covers it.
+     */
     fun setData(vaultId: String, chainId: String) {
-        if (this.vaultId == vaultId && this.chainId == chainId) return
+        val isReentry = this.vaultId == vaultId && this.chainId == chainId
         this.vaultId = vaultId
         this.chainId = chainId
-        // [loadCoin] resolves the native coin then chains into [refresh] from the SAME coroutine.
-        // We must NOT call refresh() here in parallel: loadCoin only assigns `coin` after it
-        // suspends on the vault read, so a parallel refresh() would observe `coin == null`, bail at
-        // its `coin ?: return` guard, and the delegations list would never load on first open.
-        loadCoin()
+        when {
+            !isReentry -> loadCoin()
+            coin != null -> load(userInitiated = false)
+        }
     }
 
-    fun refresh() {
+    /** Pull-to-refresh: re-runs the fan-out and drives the pull-to-refresh spinner. */
+    fun refresh() = load(userInitiated = true)
+
+    /**
+     * @param userInitiated true only for an explicit pull-to-refresh, which owns the [isRefreshing]
+     *   spinner. The first load and the resume refresh pass false so they update in the background
+     *   (seeded from the cached snapshot) without spinning the pull indicator.
+     */
+    private fun load(userInitiated: Boolean) {
         val chainId = chainId ?: return
         val chain =
             Chain.entries.firstOrNull { it.raw.equals(chainId, ignoreCase = true) }
@@ -172,7 +191,7 @@ constructor(
                     onRefreshFailed("Failed to load staking positions")
                 }
             ) {
-                _isRefreshing.value = true
+                if (userInitiated) _isRefreshing.value = true
                 try {
                     val coin = coin ?: return@safeLaunch
                     val cacheKey = snapshotKey(chain, coin.address)
@@ -361,6 +380,15 @@ constructor(
                         )
                     }
 
+                    // Keep the persisted staking total — the cache the global DeFi/portfolio page
+                    // reads through StakingDetailsRepository — in sync with these fresh on-chain
+                    // numbers. Without it the portfolio Total Staked keeps serving the pre-tx value
+                    // (AccountsRepository only does a remote pass on an explicit refresh), so a
+                    // delegate/undelegate/redelegate/claim wouldn't surface there until a manual
+                    // pull (#4815). Mirrors CosmosStakingDeFiBalanceService: delegated base units +
+                    // floored bond-denom rewards.
+                    persistStakedTotal(coin, delegations, rewardsByValidator)
+
                     // Cache the display-ready result so the next open within this session renders
                     // instantly — but only when the snapshot is actually trustworthy. A degraded
                     // validators
@@ -399,12 +427,11 @@ constructor(
                     // in as the network catches up.
                     resolveAvatarsAsync(positions)
                 } finally {
-                    // Only the still-current run clears the spinner. A superseded run reaches this
-                    // block via cancellation (isActive == false) and must leave the flag for
-                    // whichever
-                    // refresh replaced it; a normally-completing run is still active here and
-                    // resets it.
-                    if (isActive) _isRefreshing.value = false
+                    // Only a still-current, user-initiated run clears the spinner. A superseded run
+                    // reaches this block via cancellation (isActive == false) and must leave the
+                    // flag for whichever refresh replaced it; background (resume / first) loads
+                    // never raised it, so there is nothing to reset.
+                    if (isActive && userInitiated) _isRefreshing.value = false
                 }
             }
     }
@@ -565,6 +592,51 @@ constructor(
     }
 
     /**
+     * Persists the staked total in base units (delegated + floored bond-denom rewards) for the
+     * native coin, so the global DeFi/portfolio Total Staked stays in step with this screen. The
+     * definition matches
+     * [com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingDeFiBalanceService] so
+     * whichever source writes last leaves the same value. A write failure is non-fatal — the
+     * positions view is already up to date and the portfolio repairs itself on its next remote
+     * pass.
+     */
+    private suspend fun persistStakedTotal(
+        coin: Coin,
+        delegations: List<CosmosDelegation>,
+        rewardsByValidator: Map<String, BigDecimal>,
+    ) {
+        val vaultId = vaultId ?: return
+        val delegated =
+            delegations.fold(BigInteger.ZERO) { acc, d ->
+                acc + (d.balance.amount.toBigIntegerOrNull() ?: BigInteger.ZERO)
+            }
+        val rewards =
+            rewardsByValidator.values.fold(BigInteger.ZERO) { acc, r -> acc + r.toBigInteger() }
+        val total = delegated + rewards
+        runCatching {
+                val details =
+                    StakingDetails(
+                        id = coin.generateId(),
+                        coin = coin,
+                        stakeAmount = total,
+                        apr = null,
+                        estimatedRewards = null,
+                        nextPayoutDate = null,
+                        rewards = null,
+                        rewardsCoin = null,
+                    )
+                val existing = stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, coin.id)
+                when {
+                    existing == null ->
+                        stakingDetailsRepository.saveStakingDetails(vaultId, details)
+                    existing.stakeAmount != total ->
+                        stakingDetailsRepository.updateStakingDetails(vaultId, details)
+                }
+            }
+            .onFailure { Timber.e(it, "Failed to persist staking total for %s", coin.chain.raw) }
+    }
+
+    /**
      * Fires off Keybase avatar lookups for any row that has a non-empty identity. Lookups are
      * deduped per-identity by the [KeybaseAvatarService] cache, so concurrent rows with the same
      * identity share a single network call.
@@ -650,7 +722,9 @@ constructor(
                 )
             }
             // Now that `coin` is resolved, load the delegations / unbondings / rewards fan-out.
-            refresh()
+            // The first open shows the skeleton (no cache yet), so it must not also raise the
+            // pull-to-refresh spinner.
+            load(userInitiated = false)
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -21,7 +22,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import coil.compose.AsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
@@ -45,11 +46,13 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonSize
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
+import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsViewModel
 import com.vultisig.wallet.ui.screens.RegisterChainDashboardTopBarAction
 import com.vultisig.wallet.ui.screens.v2.defi.NoPositionsContainer
@@ -62,6 +65,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 private val COSMOS_STAKING_TABS = listOf(com.vultisig.wallet.ui.screens.v2.defi.DeFiTab.STAKED)
+
+/** Placeholder delegation cards shown during the first cold load (no cached snapshot). */
+private const val SKELETON_ROW_COUNT = 3
 
 /**
  * LUNA / LUNC active-delegations view — reuses the shared DeFi-chain chrome (balance banner +
@@ -87,14 +93,60 @@ internal fun CosmosStakingPositionsScreen(
     // load. Collect it directly instead.
     val isRefreshing by viewModel.isRefreshing.collectAsState()
 
-    LaunchedEffect(vaultId, chainId) { viewModel.setData(vaultId = vaultId, chainId = chainId) }
+    // Reload on every resume, not just first composition, mirroring TronDeFiPositionsScreen: the
+    // retained screen's keyed LaunchedEffect would not re-run, so returning from a signed
+    // delegate/undelegate/redelegate/claim wouldn't refresh the Total Staked card or positions
+    // without a manual pull (#4815).
+    LifecycleResumeEffect(vaultId, chainId) {
+        viewModel.setData(vaultId = vaultId, chainId = chainId)
+        onPauseOrDispose {}
+    }
 
     RegisterChainDashboardTopBarAction(
         icon = R.drawable.ic_shapes_plus_x_square_circle,
         onClick = { viewModel.setPositionSelectionDialogVisibility(true) },
     )
 
-    PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = { viewModel.refresh() }) {
+    CosmosStakingPositionsContent(
+        chainId = chainId,
+        state = state,
+        isRefreshing = isRefreshing,
+        onRefresh = viewModel::refresh,
+        onManagePositions = { viewModel.setPositionSelectionDialogVisibility(true) },
+        onClaim = viewModel::claimAll,
+        onDelegateToNewValidator = viewModel::stakeMore,
+        onUnstake = viewModel::unstake,
+        onMove = viewModel::move,
+        onStakeMore = viewModel::stakeMore,
+        onPositionSelectionChange = viewModel::onPositionSelectionChange,
+        onPositionSelectionDone = viewModel::onPositionSelectionDone,
+        onDismissDialog = { viewModel.setPositionSelectionDialogVisibility(false) },
+    )
+}
+
+/**
+ * Stateless content for the staking-positions screen. Split out from the ViewModel-bound entry
+ * point so [PreviewActivity] (and tests) can render every state — cold-load skeleton, populated,
+ * empty — with mock data. Mirrors `TronDeFiPositionsScreenContent`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun CosmosStakingPositionsContent(
+    chainId: String,
+    state: CosmosStakingPositionsUiState,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
+    onManagePositions: () -> Unit = {},
+    onClaim: () -> Unit = {},
+    onDelegateToNewValidator: () -> Unit = {},
+    onUnstake: (CosmosStakePositionRow) -> Unit = {},
+    onMove: (CosmosStakePositionRow) -> Unit = {},
+    onStakeMore: () -> Unit = {},
+    onPositionSelectionChange: (String, Boolean) -> Unit = { _, _ -> },
+    onPositionSelectionDone: () -> Unit = {},
+    onDismissDialog: () -> Unit = {},
+) {
+    PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = onRefresh) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
                 modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)
@@ -122,10 +174,7 @@ internal fun CosmosStakingPositionsScreen(
                     V2Container(
                         type = ContainerType.SECONDARY,
                         cornerType = CornerType.Circular,
-                        modifier =
-                            Modifier.clickOnce(
-                                onClick = { viewModel.setPositionSelectionDialogVisibility(true) }
-                            ),
+                        modifier = Modifier.clickOnce(onClick = onManagePositions),
                     ) {
                         UiIcon(
                             drawableResId = R.drawable.edit_chain,
@@ -142,13 +191,7 @@ internal fun CosmosStakingPositionsScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     if (!state.isPositionEnabled) {
-                        item {
-                            NoPositionsContainer(
-                                onManagePositionsClick = {
-                                    viewModel.setPositionSelectionDialogVisibility(true)
-                                }
-                            )
-                        }
+                        item { NoPositionsContainer(onManagePositionsClick = onManagePositions) }
                     } else {
                         item {
                             TotalStakedCard(
@@ -157,8 +200,8 @@ internal fun CosmosStakingPositionsScreen(
                                 totalStaked = formatStakeAmount(state.totalStaked),
                                 totalFiat = state.totalStakedFiat,
                                 hasClaimableRewards = state.hasClaimableRewards,
-                                onClaim = viewModel::claimAll,
-                                onDelegateToNewValidator = viewModel::stakeMore,
+                                onClaim = onClaim,
+                                onDelegateToNewValidator = onDelegateToNewValidator,
                             )
                         }
 
@@ -183,29 +226,25 @@ internal fun CosmosStakingPositionsScreen(
                                     position = position,
                                     ticker = state.ticker,
                                     fiat = position.stakedFiatDisplay,
-                                    onUnstake = { viewModel.unstake(position) },
-                                    onMove = { viewModel.move(position) },
-                                    onStakeMore = viewModel::stakeMore,
+                                    onUnstake = { onUnstake(position) },
+                                    onMove = { onMove(position) },
+                                    onStakeMore = onStakeMore,
                                 )
                             }
+                        } else if (state.isLoading) {
+                            // Cold load, nothing cached: skeleton delegation cards (the shared
+                            // UiPlaceholderLoader used on the other DeFi tabs) rather than a
+                            // "Loading…" line that reads as stuck while the fan-out runs (#4815).
+                            items(SKELETON_ROW_COUNT) { PositionRowSkeleton() }
                         } else {
-                            // No delegations yet: surface a loading hint while the first fetch is
-                            // in
-                            // flight, then an empty-state once it settles (the screen would
-                            // otherwise
-                            // render only the zeroed Total Staked card).
+                            // Settled with no delegations — the genuine empty state.
                             item {
                                 Text(
                                     text =
-                                        if (state.isLoading)
-                                            stringResource(
-                                                R.string.cosmos_staking_loading_positions
-                                            )
-                                        else
-                                            stringResource(
-                                                R.string.cosmos_staking_empty_positions,
-                                                state.ticker,
-                                            ),
+                                        stringResource(
+                                            R.string.cosmos_staking_empty_positions,
+                                            state.ticker,
+                                        ),
                                     style = Theme.brockmann.body.s.medium,
                                     color = Theme.v2.colors.text.secondary,
                                 )
@@ -249,9 +288,9 @@ internal fun CosmosStakingPositionsScreen(
                     stakePositions = state.stakePositionsDialog,
                     selectedPositions = state.tempSelectedPositions,
                     searchTextFieldState = searchTextFieldState,
-                    onPositionSelectionChange = viewModel::onPositionSelectionChange,
-                    onDoneClick = viewModel::onPositionSelectionDone,
-                    onCancelClick = { viewModel.setPositionSelectionDialogVisibility(false) },
+                    onPositionSelectionChange = onPositionSelectionChange,
+                    onDoneClick = onPositionSelectionDone,
+                    onCancelClick = onDismissDialog,
                 )
             }
         }
@@ -528,6 +567,44 @@ private fun PositionRow(
                 style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.text.secondary,
             )
+        }
+    }
+}
+
+/**
+ * Cold-load placeholder for a delegation card — the same bordered shell as [PositionRow] with its
+ * validator, staked-amount and action rows redacted to [UiPlaceholderLoader] bars, so the first
+ * load reads as "loading" rather than "stuck" (#4815).
+ */
+@Composable
+private fun PositionRowSkeleton() {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.normal,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            UiPlaceholderLoader(modifier = Modifier.size(40.dp))
+            UiSpacer(size = 12.dp)
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                UiPlaceholderLoader(modifier = Modifier.height(16.dp).width(140.dp))
+                UiPlaceholderLoader(modifier = Modifier.height(12.dp).width(96.dp))
+            }
+        }
+        UiPlaceholderLoader(modifier = Modifier.height(16.dp).width(120.dp))
+        UiGradientHorizontalDivider()
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            repeat(3) { UiPlaceholderLoader(modifier = Modifier.weight(1f).height(36.dp)) }
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1293,7 +1293,6 @@
     <string name="cosmos_staking_continue">Weiter</string>
     <string name="cosmos_staking_amount">Betrag</string>
     <string name="cosmos_staking_loading_validators">Validatoren werden geladen…</string>
-    <string name="cosmos_staking_loading_positions">Positionen werden geladen…</string>
     <string name="cosmos_staking_loading_rewards">Belohnungen werden geladen…</string>
     <string name="cosmos_staking_no_rewards">Keine einforderbaren Belohnungen auf dieser Chain</string>
     <string name="cosmos_staking_empty_positions">Du hast noch keine aktiven %1$s-Positionen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1291,7 +1291,6 @@
     <string name="cosmos_staking_continue">Continuar</string>
     <string name="cosmos_staking_amount">Cantidad</string>
     <string name="cosmos_staking_loading_validators">Cargando validadores…</string>
-    <string name="cosmos_staking_loading_positions">Cargando posiciones…</string>
     <string name="cosmos_staking_loading_rewards">Cargando recompensas…</string>
     <string name="cosmos_staking_no_rewards">Sin recompensas reclamables en esta cadena</string>
     <string name="cosmos_staking_empty_positions">Aún no tienes posiciones activas de %1$s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1301,7 +1301,6 @@
     <string name="cosmos_staking_continue">Nastavi</string>
     <string name="cosmos_staking_amount">Iznos</string>
     <string name="cosmos_staking_loading_validators">Učitavanje validatora…</string>
-    <string name="cosmos_staking_loading_positions">Učitavanje pozicija…</string>
     <string name="cosmos_staking_loading_rewards">Učitavanje nagrada…</string>
     <string name="cosmos_staking_no_rewards">Nema nagrada za preuzimanje na ovom lancu</string>
     <string name="cosmos_staking_empty_positions">Još nemate aktivnih %1$s pozicija</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1294,7 +1294,6 @@
     <string name="cosmos_staking_continue">Continua</string>
     <string name="cosmos_staking_amount">Importo</string>
     <string name="cosmos_staking_loading_validators">Caricamento validatori…</string>
-    <string name="cosmos_staking_loading_positions">Caricamento posizioni…</string>
     <string name="cosmos_staking_loading_rewards">Caricamento ricompense…</string>
     <string name="cosmos_staking_no_rewards">Nessuna ricompensa riscattabile su questa chain</string>
     <string name="cosmos_staking_empty_positions">Non hai ancora posizioni %1$s attive</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1310,7 +1310,6 @@
     <string name="cosmos_staking_continue">계속</string>
     <string name="cosmos_staking_amount">금액</string>
     <string name="cosmos_staking_loading_validators">검증인 로드 중…</string>
-    <string name="cosmos_staking_loading_positions">포지션 로드 중…</string>
     <string name="cosmos_staking_loading_rewards">보상 로드 중…</string>
     <string name="cosmos_staking_no_rewards">이 체인에 청구 가능한 보상이 없습니다</string>
     <string name="cosmos_staking_empty_positions">아직 활성 %1$s 포지션이 없습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1285,7 +1285,6 @@
     <string name="cosmos_staking_continue">Doorgaan</string>
     <string name="cosmos_staking_amount">Bedrag</string>
     <string name="cosmos_staking_loading_validators">Validators laden…</string>
-    <string name="cosmos_staking_loading_positions">Posities laden…</string>
     <string name="cosmos_staking_loading_rewards">Beloningen laden…</string>
     <string name="cosmos_staking_no_rewards">Geen claimbare beloningen op deze keten</string>
     <string name="cosmos_staking_empty_positions">Je hebt nog geen actieve %1$s-posities</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1289,7 +1289,6 @@
     <string name="cosmos_staking_continue">Continuar</string>
     <string name="cosmos_staking_amount">Quantia</string>
     <string name="cosmos_staking_loading_validators">Carregando validadores…</string>
-    <string name="cosmos_staking_loading_positions">Carregando posições…</string>
     <string name="cosmos_staking_loading_rewards">Carregando recompensas…</string>
     <string name="cosmos_staking_no_rewards">Sem recompensas reivindicáveis nesta cadeia</string>
     <string name="cosmos_staking_empty_positions">Você ainda não tem posições %1$s ativas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1303,7 +1303,6 @@
     <string name="cosmos_staking_continue">Продолжить</string>
     <string name="cosmos_staking_amount">Сумма</string>
     <string name="cosmos_staking_loading_validators">Загрузка валидаторов…</string>
-    <string name="cosmos_staking_loading_positions">Загрузка позиций…</string>
     <string name="cosmos_staking_loading_rewards">Загрузка наград…</string>
     <string name="cosmos_staking_no_rewards">Нет наград к получению в этой сети</string>
     <string name="cosmos_staking_empty_positions">У вас пока нет активных позиций %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1616,7 +1616,6 @@
     <string name="cosmos_staking_continue">继续</string>
     <string name="cosmos_staking_amount">金额</string>
     <string name="cosmos_staking_loading_validators">正在加载验证人…</string>
-    <string name="cosmos_staking_loading_positions">正在加载仓位…</string>
     <string name="cosmos_staking_loading_rewards">正在加载奖励…</string>
     <string name="cosmos_staking_no_rewards">此链上没有可领取的奖励</string>
     <string name="cosmos_staking_empty_positions">您还没有活跃的 %1$s 仓位</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1344,7 +1344,6 @@
     <string name="cosmos_staking_continue">Continue</string>
     <string name="cosmos_staking_amount">Amount</string>
     <string name="cosmos_staking_loading_validators">Loading validators…</string>
-    <string name="cosmos_staking_loading_positions">Loading positions…</string>
     <string name="cosmos_staking_loading_rewards">Loading rewards…</string>
     <string name="cosmos_staking_no_rewards">No claimable rewards on this chain</string>
     <string name="cosmos_staking_empty_positions">You have no active %1$s positions yet</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModelTest.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.CosmosStakingSnapshotCache
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
@@ -29,6 +30,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.text.NumberFormat
 import java.time.Instant
 import java.util.Locale
@@ -58,6 +60,7 @@ internal class CosmosStakingPositionsViewModelTest {
     private val tokenPriceRepository: TokenPriceRepository = mockk(relaxed = true)
     private val appCurrencyRepository: AppCurrencyRepository = mockk()
     private val snapshotCache = CosmosStakingSnapshotCache()
+    private val stakingDetailsRepository: StakingDetailsRepository = mockk(relaxed = true)
     private val navigator: Navigator<Destination> = mockk(relaxed = true)
 
     private val activeVal = "terravaloper1active"
@@ -130,6 +133,8 @@ internal class CosmosStakingPositionsViewModelTest {
             NumberFormat.getCurrencyInstance(Locale.US)
         coEvery { tokenPriceRepository.refresh(any()) } returns Unit
         coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns BigDecimal("0.058")
+        // No persisted staking detail yet → the VM takes the save (not update) path.
+        coEvery { stakingDetailsRepository.getStakingDetailsByCoindId(any(), any()) } returns null
     }
 
     @AfterEach
@@ -146,6 +151,7 @@ internal class CosmosStakingPositionsViewModelTest {
                 tokenPriceRepository = tokenPriceRepository,
                 appCurrencyRepository = appCurrencyRepository,
                 snapshotCache = snapshotCache,
+                stakingDetailsRepository = stakingDetailsRepository,
                 navigator = navigator,
                 ioDispatcher = testDispatcher,
             )
@@ -396,5 +402,42 @@ internal class CosmosStakingPositionsViewModelTest {
         assertNotNull(s.errorMessage)
         assertEquals(true, s.positions.isEmpty())
         assertNull(snapshotCache.read("Terra:terra1delegator"))
+    }
+
+    @Test
+    fun `returning to the screen re-runs the fan-out so a just-signed tx is reflected`() = runTest {
+        // The screen drives setData from a LifecycleResumeEffect, so a re-entry with the same
+        // vault+chain (returning after a signed delegate/undelegate/redelegate/claim) must trigger
+        // a fresh load — not the old idempotent no-op — so Total Staked + positions update without
+        // a manual pull (#4815).
+        val model = vm()
+        model.setData(vaultId = "v1", chainId = "Terra")
+        coVerify(exactly = 2) { cosmosStakingService.fetchDelegations(any(), any()) }
+        // The coin is resolved only once: a re-entry must not re-run loadCoin, which would reset
+        // the Manage Positions selection back to the default.
+        coVerify(exactly = 1) { vaultRepository.get(any()) }
+    }
+
+    @Test
+    fun `the resume refresh does not raise the pull-to-refresh spinner`() = runTest {
+        // Only an explicit pull owns the spinner; the background resume refresh stays silent so the
+        // pull indicator does not flash on every return to the screen.
+        val model = vm()
+        model.setData(vaultId = "v1", chainId = "Terra")
+        assertEquals(false, model.isRefreshing.value)
+    }
+
+    @Test
+    fun `the staked total is persisted so the global DeFi balance stays in sync`() = runTest {
+        // delegated 3 + 1 = 4 LUNA (4_000_000 uluna) plus 250_000 uluna claimable rewards =
+        // 4_250_000 base units, persisted to StakingDetailsRepository so the portfolio Total Staked
+        // reflects the stake on its next read instead of serving the pre-tx cached value (#4815).
+        vm()
+        coVerify {
+            stakingDetailsRepository.saveStakingDetails(
+                "v1",
+                match { it.stakeAmount == BigInteger.valueOf(4_250_000) },
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #4815.

After a Cosmos-SDK staking transaction (delegate / undelegate / redelegate / claim) the shared positions screen and the global DeFi total stayed stale until a manual pull, and the cold-load state was plain text.

## Changes

- The positions screen reloads on every resume via `LifecycleResumeEffect` (matching `TronDeFiPositionsScreen`), so returning from a signed tx refreshes the Total Staked card and the delegations list without a pull. The reload is seeded from the in-memory snapshot and runs silently — the pull-to-refresh spinner is reserved for explicit pulls, the first load, and the resume refresh stay silent.
- On each successful load the screen persists the staked total (delegated + bond-denom rewards, base units) to `StakingDetailsRepository`, which is the cache the portfolio/DeFi page reads. `AccountsRepository.loadDeFiAddresses` only hits the network on an explicit refresh, so without this the global Total Staked kept serving the pre-tx value. The total uses the same definition as `CosmosStakingDeFiBalanceService`, mirroring how `CircleDeFiPositionsViewModel` already persists its position.
- The cold-load state renders skeleton delegation cards (`UiPlaceholderLoader`, as on the other DeFi tabs) instead of a "Loading positions…" line. The now-unused string was removed from all locales.
- Extracted a stateless `CosmosStakingPositionsContent` (mirroring `TronDeFiPositionsScreenContent`) so each state can be previewed and tested.

Applies to LUNA / LUNC / QBTC since these screens are shared.


## Screenshots

Cold-load state (same TerraClassic / LUNC mock):

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/EsWPlrX.png) | ![after](https://i.imgur.com/VS26c0m.png) |

Populated state, rendered through the extracted content (layout unchanged):

![loaded](https://i.imgur.com/jPpmHWG.png)

## Testing

- `./gradlew :app:testDebugUnitTest --tests "*CosmosStakingPositionsViewModelTest"` — passes, with new coverage for the resume re-fetch, the silent (non-spinner) resume refresh, and the persisted staked total.
- `./gradlew :app:assembleDebug` — built; the screenshots above were captured from `PreviewActivity`.

Lint was not run locally; CI covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staking positions display animated skeleton card loaders during data loading for enhanced visual feedback
  * Total staked amounts automatically persist across app sessions to maintain accurate portfolio totals

* **Improvements**
  * Staking screen data now automatically refreshes when you return to the screen
  * Pull-to-refresh spinner only displays during manual refreshes, not for background updates
  * Improved loading state with skeleton cards instead of text messages

* **Localization**
  * Updated loading state terminology from "positions" to "validators" across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->