### PR TITLE
Remove duplicate manage-positions button on DeFi positions screens

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -38,16 +38,11 @@ import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosUnbondingDelegation
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.ui.components.UiGradientHorizontalDivider
-import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonSize
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
-import com.vultisig.wallet.ui.components.clickOnce
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsViewModel
@@ -108,31 +103,16 @@ internal fun CosmosStakingPositionsScreen(
                     )
                 }
 
-                Row(
+                // Single manage-positions control: the ChainDashboard top-bar action above. The
+                // inline edit-chains button that used to sit here duplicated it (#4821).
+                Box(
                     modifier =
-                        Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+                        Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp)
                 ) {
                     VsTabGroup(index = 0) {
                         COSMOS_STAKING_TABS.forEach { tab ->
                             tab { VsTab(label = stringResource(tab.displayNameRes), onClick = {}) }
                         }
-                    }
-                    V2Container(
-                        type = ContainerType.SECONDARY,
-                        cornerType = CornerType.Circular,
-                        modifier =
-                            Modifier.clickOnce(
-                                onClick = { viewModel.setPositionSelectionDialogVisibility(true) }
-                            ),
-                    ) {
-                        UiIcon(
-                            drawableResId = R.drawable.edit_chain,
-                            size = 16.dp,
-                            modifier = Modifier.padding(all = 12.dp),
-                            tint = Theme.v2.colors.primary.accent4,
-                        )
                     }
                 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/MayachainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/MayachainDefiPositionsScreen.kt
@@ -1,10 +1,8 @@
 package com.vultisig.wallet.ui.screens.v2.defi.maya
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -29,12 +27,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.VaultId
-import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.clickOnce
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
 import com.vultisig.wallet.ui.models.defi.MayachainDefiPositionsUiModel
@@ -164,11 +157,9 @@ internal fun MayachainDefiPositionsScreenContent(
 
             UiSpacer(16.dp)
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+            // Single manage-positions control: the ChainDashboard top-bar action above. The inline
+            // edit-chains button that used to sit here duplicated it (#4821).
+            Box(modifier = Modifier.fillMaxWidth()) {
                 VsTabGroup(index = tabs.indexOfFirst { it.displayNameRes == state.selectedTab }) {
                     tabs.forEach { tab ->
                         tab {
@@ -178,19 +169,6 @@ internal fun MayachainDefiPositionsScreenContent(
                             )
                         }
                     }
-                }
-
-                V2Container(
-                    type = ContainerType.SECONDARY,
-                    cornerType = CornerType.Circular,
-                    modifier = Modifier.clickOnce(onClick = onEditPositionClick),
-                ) {
-                    UiIcon(
-                        drawableResId = R.drawable.edit_chain,
-                        size = 16.dp,
-                        modifier = Modifier.padding(all = 12.dp),
-                        tint = Theme.v2.colors.primary.accent4,
-                    )
                 }
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
@@ -1,9 +1,8 @@
 package com.vultisig.wallet.ui.screens.v2.defi.thorchain
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,12 +27,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.VaultId
-import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.clickOnce
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
 import com.vultisig.wallet.ui.models.defi.BondedNodeUiModel
@@ -148,11 +141,9 @@ internal fun ThorchainDefiPositionScreenContent(
 
             UiSpacer(16.dp)
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+            // Single manage-positions control: the ChainDashboard top-bar action above. The inline
+            // edit-chains button that used to sit here duplicated it (#4821).
+            Box(modifier = Modifier.fillMaxWidth()) {
                 VsTabGroup(index = tabs.indexOfFirst { it.displayNameRes == state.selectedTab }) {
                     tabs.forEach { tab ->
                         tab {
@@ -162,19 +153,6 @@ internal fun ThorchainDefiPositionScreenContent(
                             )
                         }
                     }
-                }
-
-                V2Container(
-                    type = ContainerType.SECONDARY,
-                    cornerType = CornerType.Circular,
-                    modifier = Modifier.clickOnce(onClick = onEditPositionClick),
-                ) {
-                    UiIcon(
-                        drawableResId = R.drawable.edit_chain,
-                        size = 16.dp,
-                        modifier = Modifier.padding(all = 12.dp),
-                        tint = Theme.v2.colors.primary.accent4,
-                    )
                 }
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -38,10 +38,6 @@ import com.vultisig.wallet.data.api.models.ResourceUsage
 import com.vultisig.wallet.data.blockchain.tron.TronResourceType
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.ui.components.UiIcon
-import com.vultisig.wallet.ui.components.clickOnce
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
 import com.vultisig.wallet.ui.models.defi.TronAction
@@ -107,7 +103,6 @@ internal fun TronDeFiPositionsScreen(
             viewModel.refresh()
         },
         onTabSelected = viewModel::onTabSelected,
-        onEditPositionClick = { viewModel.setPositionSelectionDialogVisibility(true) },
         onCancelEditPositionClick = { viewModel.setPositionSelectionDialogVisibility(false) },
         onDonePositionClick = viewModel::onPositionSelectionDone,
         onPositionSelectionChange = viewModel::onPositionSelectionChange,
@@ -124,7 +119,6 @@ private fun TronDeFiPositionsScreenContent(
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onTabSelected: (DeFiTab) -> Unit = {},
-    onEditPositionClick: () -> Unit = {},
     onCancelEditPositionClick: () -> Unit = {},
     onDonePositionClick: () -> Unit = {},
     onPositionSelectionChange: (String, Boolean) -> Unit = { _, _ -> },
@@ -161,12 +155,11 @@ private fun TronDeFiPositionsScreenContent(
 
                 if (state is TronDeFiUiState.Success || state is TronDeFiUiState.Loading) {
                     val isLoading = state is TronDeFiUiState.Loading
-                    Row(
+                    // Single manage-positions control: the ChainDashboard top-bar action above. The
+                    // inline edit-chains button that used to sit here duplicated it (#4821).
+                    Box(
                         modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(start = 16.dp, end = 16.dp, top = 16.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
+                            Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp)
                     ) {
                         VsTabGroup(index = 0) {
                             TRON_DEFI_TABS.forEach { tab ->
@@ -178,25 +171,6 @@ private fun TronDeFiPositionsScreenContent(
                                     )
                                 }
                             }
-                        }
-
-                        V2Container(
-                            type = ContainerType.SECONDARY,
-                            cornerType = CornerType.Circular,
-                            modifier =
-                                Modifier.clickOnce(
-                                    enabled = !isLoading,
-                                    onClick = onEditPositionClick,
-                                ),
-                        ) {
-                            UiIcon(
-                                drawableResId = R.drawable.edit_chain,
-                                size = 16.dp,
-                                modifier = Modifier.padding(all = 12.dp),
-                                tint =
-                                    if (isLoading) Theme.v2.colors.text.tertiary
-                                    else Theme.v2.colors.primary.accent4,
-                            )
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #4821.

The Cosmos, Tron, Maya and Thorchain DeFi positions screens each register a `ChainDashboard` top-bar action **and** rendered an inline edit-chains button next to the Staked tab — two controls that open the same position-selection dialog. This removes the inline button on all four so the top-bar action is the single manage-positions control, which is also what `BaseDeFiPositionsScreen` (Circle etc.) does when its inline button is gated off.

The ticket described this as a Cosmos-only issue, but the same duplicate exists on Tron/Maya/Thorchain (each is a custom screen that registers the top-bar action and draws its own inline button), so all four are aligned here.

## Changes

- Removed the inline `edit_chain` button (and its now-unused imports) from `CosmosStakingPositionsScreen`, `TronDeFiPositionsScreen`, `MayachainDefiPositionsScreen`, `ThorchainDefiPositionsScreen`.
- Tron's content no longer needs the `onEditPositionClick` param (only the inline button used it) — dropped. Maya/Thorchain keep it (their empty-state "Manage positions" still uses it).
- The `edit_chain` drawable stays (still used by `BaseDeFiPositionsScreen`, `HomePageTabMenu`, `ChainTokensTabMenuAndSearchBar`).

## Screenshots

Cosmos staking positions (representative; the inline edit button beside the Staked tab is removed — the top-bar manage action, host chrome not shown in this content render, is unchanged):

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/lkfw2OT.png) | ![after](https://i.imgur.com/ClVOOtU.png) |

## Testing

- `./gradlew :app:compileDebugKotlin` — builds.
- `./gradlew :app:assembleDebug` — built; screenshots captured from `PreviewActivity`.

No behavior change beyond removing the duplicate control; signing is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined the layout of DeFi position screens (Cosmos, Mayachain, Thorchain, and Tron) by consolidating position management controls to a single, unified location in the top action bar, removing redundant inline controls for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->