### PR TITLE
Prefill Unstake/Move staking forms to avoid the 0 Token flash

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -55,6 +56,7 @@ import com.vultisig.wallet.ui.components.SignTonDisplayView
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
 import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
 import com.vultisig.wallet.ui.components.hero.HeroContent
@@ -63,6 +65,7 @@ import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBottomSh
 import com.vultisig.wallet.ui.components.v2.fastselection.SelectPopupUiModel
 import com.vultisig.wallet.ui.components.v2.fastselection.components.ChainSelectorPickerItem
 import com.vultisig.wallet.ui.components.v2.fastselection.components.SelectPopup
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.ChainTokenUiModel
@@ -93,6 +96,10 @@ import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.screens.TransactionDoneView
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
+import com.vultisig.wallet.ui.screens.cosmosstaking.StakingAmountCard
+import com.vultisig.wallet.ui.screens.cosmosstaking.UnbondingLockNotice
+import com.vultisig.wallet.ui.screens.cosmosstaking.UnstakeAmountCard
+import com.vultisig.wallet.ui.screens.cosmosstaking.ValidatorReadonlyBlock
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
@@ -128,6 +135,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import java.math.BigDecimal
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -218,6 +226,10 @@ class PreviewActivity : ComponentActivity() {
                         CosmosStakingVerifyCtaPreview(newButtons = true, qbtc = true)
                     "sign_message_before" -> VerifySignMessageCtaPreview(newButtons = false)
                     "sign_message_after" -> VerifySignMessageCtaPreview(newButtons = true)
+                    "unstake_form_before" -> CosmosUnstakeFormPreview(prefilled = false)
+                    "unstake_form_after" -> CosmosUnstakeFormPreview(prefilled = true)
+                    "move_form_before" -> CosmosMoveFormPreview(prefilled = false)
+                    "move_form_after" -> CosmosMoveFormPreview(prefilled = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1800,6 +1812,95 @@ private fun KeysignSigningLuncPreview() {
         showSaveToAddressBook = false,
         coinLogoRes = R.drawable.lunc,
     )
+}
+
+@Composable
+private fun CosmosUnstakeFormPreview(prefilled: Boolean) {
+    // BEFORE (#4822): the route carried no ticker/amount, so the form opened on "Unstake Token"
+    // with a 0 balance and empty amount. AFTER: the tapped position's ticker + staked amount seed
+    // the form on the first frame.
+    val ticker = if (prefilled) "LUNC" else ""
+    val staked = if (prefilled) BigDecimal("1200000") else BigDecimal.ZERO
+    val amount = rememberTextFieldState(if (prefilled) "1200000" else "")
+    V2Scaffold(
+        title =
+            stringResource(
+                R.string.cosmos_staking_undelegate_title,
+                ticker.ifEmpty { stringResource(R.string.cosmos_staking_token_fallback) },
+            ),
+        onBackClick = {},
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                ValidatorReadonlyBlock(
+                    moniker = "Allnodes",
+                    address = "terravaloper1allnodes00000000000000000000000000",
+                )
+                UnstakeAmountCard(
+                    ticker = ticker,
+                    amountFieldState = amount,
+                    available = staked,
+                    percentageSelected = 100,
+                    onPercentage = {},
+                    modifier = Modifier.weight(1f),
+                )
+                UnbondingLockNotice(
+                    message = "Funds are locked for 21 days. Available on Jun 30, 2026."
+                )
+            }
+            VsButton(
+                label = stringResource(R.string.cosmos_staking_continue),
+                variant = VsButtonVariant.CTA,
+                state = VsButtonState.Enabled,
+                onClick = {},
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CosmosMoveFormPreview(prefilled: Boolean) {
+    // BEFORE (#4822): "Move Token" with a 0 balance and empty amount until the LCD load landed.
+    // AFTER: the tapped position's ticker + staked amount seed the form immediately.
+    val ticker = if (prefilled) "LUNC" else ""
+    val staked = if (prefilled) BigDecimal("1200000") else BigDecimal.ZERO
+    val amount = rememberTextFieldState(if (prefilled) "1200000" else "")
+    V2Scaffold(
+        title =
+            stringResource(R.string.cosmos_staking_redelegate_title, ticker.ifEmpty { "Token" }),
+        onBackClick = {},
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                ValidatorReadonlyBlock(
+                    moniker = "Allnodes",
+                    address = "terravaloper1allnodes00000000000000000000000000",
+                )
+                StakingAmountCard(
+                    ticker = ticker,
+                    amountFieldState = amount,
+                    available = staked,
+                    percentageSelected = 100,
+                    onPercentage = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            VsButton(
+                label = stringResource(R.string.cosmos_staking_continue),
+                variant = VsButtonVariant.CTA,
+                state = VsButtonState.Enabled,
+                onClick = {},
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModel.kt
@@ -136,10 +136,25 @@ constructor(
     val amountFieldState: TextFieldState = TextFieldState()
 
     private val _state =
-        MutableStateFlow(CosmosRedelegateUiState(srcValidatorAddress = route.validatorSrcAddress))
+        MutableStateFlow(
+            CosmosRedelegateUiState(
+                // Seeded from the tapped position row so the title, amount field and balance row
+                // render the real values on the first frame; the async load refreshes them (#4822).
+                ticker = route.ticker,
+                srcValidatorAddress = route.validatorSrcAddress,
+                stakedBalance = route.stakedAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            )
+        )
     val state: StateFlow<CosmosRedelegateUiState> = _state.asStateFlow()
 
     private var coin: Coin? = null
+
+    /**
+     * The amount the VM last auto-filled (seed or post-load refresh). The async refresh only
+     * overwrites the field while it still holds this value, so a user who moves the slider during
+     * the ~1s load doesn't have their input clobbered when the fetch lands.
+     */
+    private var lastAutoFilledAmount: String = ""
 
     /**
      * The delegator's outstanding redelegations, fetched once by [loadCooldown]. Retained so the
@@ -154,6 +169,8 @@ constructor(
         // only assigned after that coroutine suspends on the vault read, so a parallel cooldown
         // fetch would observe `coin == null`, bail at its guard, and silently skip the 21-day
         // redelegation gate on first open. It is chained from loadCoinAndStakedBalance() instead.
+        // Pre-fill the amount to 100% of the seeded balance so the field shows it immediately.
+        prefillAmount(_state.value.stakedBalance)
         loadCoinAndStakedBalance()
         loadValidators()
     }
@@ -394,9 +411,10 @@ constructor(
                 matching?.balance?.amount?.toBigDecimalOrNull()?.movePointLeft(nativeCoin.decimal)
                     ?: BigDecimal.ZERO
 
-            // Default amount = 100% of staked, matching iOS pattern (slider type defaults to max).
-            amountFieldState.edit {
-                replace(0, length, stakedBalance.stripTrailingZeros().toPlainString())
+            // Refresh the 100% pre-fill from the authoritative on-chain balance, but only while the
+            // field still holds the value we seeded — never stomp an amount the user just entered.
+            if (amountFieldState.text.toString() == lastAutoFilledAmount) {
+                prefillAmount(stakedBalance)
             }
 
             val spendableBalance =
@@ -517,7 +535,16 @@ constructor(
                 .divide(BigDecimal(100), 8, java.math.RoundingMode.DOWN)
                 .stripTrailingZeros()
                 .toPlainString()
+        // User-driven (slider), so don't mark this as an auto-fill — that lets the in-flight load's
+        // refresh detect the field as user-touched and leave it alone.
         amountFieldState.edit { replace(0, length, amount) }
+    }
+
+    /** Writes [value] into the amount field and records it as the latest auto-fill. */
+    private fun prefillAmount(value: BigDecimal) {
+        val text = value.stripTrailingZeros().toPlainString()
+        amountFieldState.edit { replace(0, length, text) }
+        lastAutoFilledAmount = text
     }
 
     private fun setError(message: String) {
@@ -531,4 +558,6 @@ private fun SavedStateHandle.toRoute(): Route.CosmosStakingRedelegate =
         chainId = checkNotNull(get<String>("chainId")) { "chainId is required" },
         validatorSrcAddress =
             checkNotNull(get<String>("validatorSrcAddress")) { "validatorSrcAddress is required" },
+        ticker = get<String>("ticker").orEmpty(),
+        stakedAmount = get<String>("stakedAmount").orEmpty(),
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingPositionsViewModel.kt
@@ -430,6 +430,10 @@ constructor(
                     vaultId = vaultId,
                     chainId = chainId,
                     validatorAddress = position.validatorAddress,
+                    // Prefill so the form shows the real ticker + staked balance on the first frame
+                    // instead of flashing `0 Token` while the LCD load runs (#4822).
+                    ticker = coin?.ticker.orEmpty(),
+                    stakedAmount = position.stakedAmount.toPlainString(),
                 ),
                 popOptionsForStaking(Route.CosmosStakingUndelegate::class.java),
             )
@@ -446,6 +450,10 @@ constructor(
                     vaultId = vaultId,
                     chainId = chainId,
                     validatorSrcAddress = position.validatorAddress,
+                    // Prefill so the form shows the real ticker + staked balance on the first frame
+                    // instead of flashing `0 Token` while the LCD load runs (#4822).
+                    ticker = coin?.ticker.orEmpty(),
+                    stakedAmount = position.stakedAmount.toPlainString(),
                 ),
                 popOptionsForStaking(Route.CosmosStakingRedelegate::class.java),
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModel.kt
@@ -122,12 +122,29 @@ constructor(
     val amountFieldState: TextFieldState = TextFieldState()
 
     private val _state =
-        MutableStateFlow(CosmosUndelegateUiState(validatorAddress = route.validatorAddress))
+        MutableStateFlow(
+            CosmosUndelegateUiState(
+                // Seeded from the tapped position row so the title, amount field and balance row
+                // render the real values on the first frame; the async load refreshes them (#4822).
+                ticker = route.ticker,
+                validatorAddress = route.validatorAddress,
+                stakedBalance = route.stakedAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            )
+        )
     val state: StateFlow<CosmosUndelegateUiState> = _state.asStateFlow()
 
     private var coin: Coin? = null
 
+    /**
+     * The amount the VM last auto-filled (seed or post-load refresh). The async refresh only
+     * overwrites the field while it still holds this value, so a user who moves the slider during
+     * the ~1s load doesn't have their input clobbered when the fetch lands.
+     */
+    private var lastAutoFilledAmount: String = ""
+
     init {
+        // Pre-fill the amount to 100% of the seeded balance so the field shows it immediately.
+        prefillAmount(_state.value.stakedBalance)
         loadCoinAndStakedBalance()
     }
 
@@ -319,10 +336,10 @@ constructor(
                     activeUnbondingEntryCount(chain, nativeCoin.address, route.validatorAddress)
                 }
 
-            // Default to 100% selected (iOS pattern) — pre-fill the amount field so the user can
-            // confirm with one tap if they want to unstake everything.
-            amountFieldState.edit {
-                replace(0, length, stakedBalance.stripTrailingZeros().toPlainString())
+            // Refresh the 100% pre-fill from the authoritative on-chain balance, but only while the
+            // field still holds the value we seeded — never stomp an amount the user just entered.
+            if (amountFieldState.text.toString() == lastAutoFilledAmount) {
+                prefillAmount(stakedBalance)
             }
 
             _state.update {
@@ -400,7 +417,16 @@ constructor(
                 .divide(BigDecimal(100), 8, java.math.RoundingMode.DOWN)
                 .stripTrailingZeros()
                 .toPlainString()
+        // User-driven (slider), so don't mark this as an auto-fill — that lets the in-flight load's
+        // refresh detect the field as user-touched and leave it alone.
         amountFieldState.edit { replace(0, length, amount) }
+    }
+
+    /** Writes [value] into the amount field and records it as the latest auto-fill. */
+    private fun prefillAmount(value: BigDecimal) {
+        val text = value.stripTrailingZeros().toPlainString()
+        amountFieldState.edit { replace(0, length, text) }
+        lastAutoFilledAmount = text
     }
 
     private fun setError(message: String) {
@@ -414,4 +440,6 @@ private fun SavedStateHandle.toRoute(): Route.CosmosStakingUndelegate =
         chainId = checkNotNull(get<String>("chainId")) { "chainId is required" },
         validatorAddress =
             checkNotNull(get<String>("validatorAddress")) { "validatorAddress is required" },
+        ticker = get<String>("ticker").orEmpty(),
+        stakedAmount = get<String>("stakedAmount").orEmpty(),
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -462,23 +462,34 @@ internal sealed class Route {
      */
     @Serializable data class CosmosStakingDelegate(val vaultId: String, val chainId: String)
 
-    /** Undelegate flow — validator address comes from the active-delegation card. */
+    /**
+     * Undelegate flow — validator address comes from the active-delegation card. [ticker] and
+     * [stakedAmount] (human-decimal, plain string) are carried from the tapped position row so the
+     * form renders the real values on the first frame instead of flashing `0 Token`; the VM's async
+     * load then refreshes them from the LCD (#4822).
+     */
     @Serializable
     data class CosmosStakingUndelegate(
         val vaultId: String,
         val chainId: String,
         val validatorAddress: String,
+        val ticker: String = "",
+        val stakedAmount: String = "",
     )
 
     /**
      * Redelegate flow — src is fixed (the current delegation), dst is picked. The 21-day cooldown
-     * gate runs at submit-time inside the VM.
+     * gate runs at submit-time inside the VM. [ticker] and [stakedAmount] (human-decimal, plain
+     * string) are carried from the tapped position row to prefill the form and avoid the `0 Token`
+     * flash; the VM's async load then refreshes them (#4822).
      */
     @Serializable
     data class CosmosStakingRedelegate(
         val vaultId: String,
         val chainId: String,
         val validatorSrcAddress: String,
+        val ticker: String = "",
+        val stakedAmount: String = "",
     )
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -131,8 +131,9 @@ internal fun CosmosUndelegateScreen(viewModel: CosmosUndelegateViewModel = hiltV
  * subline and a 0–100% drag slider (with 25/50/75 tick stops), rather than the 25/50/75/Max chips
  * the Stake form uses. The slider is the primary control; the percentage drives the amount field.
  */
+// internal (not private) so PreviewActivity can render this card with mock state.
 @Composable
-private fun UnstakeAmountCard(
+internal fun UnstakeAmountCard(
     ticker: String,
     amountFieldState: TextFieldState,
     available: BigDecimal,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosRedelegateViewModelTest.kt
@@ -27,9 +27,11 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -106,15 +108,17 @@ internal class CosmosRedelegateViewModelTest {
             votingPower = power,
         )
 
-    private fun vm(): CosmosRedelegateViewModel =
+    private fun vm(ticker: String = "", stakedAmount: String = ""): CosmosRedelegateViewModel =
         CosmosRedelegateViewModel(
             savedStateHandle =
                 SavedStateHandle(
-                    mapOf(
-                        "vaultId" to "v1",
-                        "chainId" to "Terra",
-                        "validatorSrcAddress" to srcValidator,
-                    )
+                    buildMap {
+                        put("vaultId", "v1")
+                        put("chainId", "Terra")
+                        put("validatorSrcAddress", srcValidator)
+                        if (ticker.isNotEmpty()) put("ticker", ticker)
+                        if (stakedAmount.isNotEmpty()) put("stakedAmount", stakedAmount)
+                    }
                 ),
             vaultRepository = vaultRepository,
             cosmosStakingService = cosmosStakingService,
@@ -167,5 +171,55 @@ internal class CosmosRedelegateViewModelTest {
         assertTrue(visible.none { it.operatorAddress == srcValidator })
         // Dest 2 (900) before Dest 1 (300).
         assertEquals("terravaloper1dst2", visible.first().operatorAddress)
+    }
+
+    @Test
+    fun `route ticker and staked amount seed the form before the LCD load resolves`() = runTest {
+        // Hold the coin load open so we observe the first frame — the values carried on the route
+        // must already render (real ticker + staked balance + amount), not 0 / Token.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "5")
+        assertEquals("LUNA", model.state.value.ticker)
+        assertEquals(0, BigDecimal("5").compareTo(model.state.value.stakedBalance))
+        assertEquals("5", model.amountFieldState.text.toString())
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun `the async refresh keeps an amount the user typed during the load`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "5")
+        model.amountFieldState.edit { replace(0, length, "2.5") }
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("2.5", model.amountFieldState.text.toString())
+    }
+
+    @Test
+    fun `the async refresh updates an untouched amount to the on-chain balance`() = runTest {
+        // A slightly stale seed must be refreshed to the authoritative on-chain balance (5 LUNA
+        // from setUp) when the user hasn't touched the field.
+        coEvery { cosmosStakingService.fetchRedelegations(any(), any()) } returns emptyList()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "1")
+        assertEquals("1", model.amountFieldState.text.toString())
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("5", model.amountFieldState.text.toString())
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosUndelegateViewModelTest.kt
@@ -23,9 +23,11 @@ import io.mockk.mockk
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -98,15 +100,17 @@ internal class CosmosUndelegateViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun vm() =
+    private fun vm(ticker: String = "", stakedAmount: String = "") =
         CosmosUndelegateViewModel(
             savedStateHandle =
                 SavedStateHandle(
-                    mapOf(
-                        "vaultId" to "v1",
-                        "chainId" to "Terra",
-                        "validatorAddress" to validatorAddr,
-                    )
+                    buildMap {
+                        put("vaultId", "v1")
+                        put("chainId", "Terra")
+                        put("validatorAddress", validatorAddr)
+                        if (ticker.isNotEmpty()) put("ticker", ticker)
+                        if (stakedAmount.isNotEmpty()) put("stakedAmount", stakedAmount)
+                    }
                 ),
             vaultRepository = vaultRepository,
             cosmosStakingService = cosmosStakingService,
@@ -135,5 +139,56 @@ internal class CosmosUndelegateViewModelTest {
         model.submit()
         assertNotNull(model.state.value.errorMessage)
         coVerify(exactly = 0) { navigator.route(any<Route.VerifyDeposit>()) }
+    }
+
+    @Test
+    fun `route ticker and staked amount seed the form before the LCD load resolves`() = runTest {
+        // Hold the coin load open so we observe the very first frame — the values carried on the
+        // route must already be rendered (real ticker + staked balance + amount), not 0 / Token.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "2")
+        assertEquals("LUNA", model.state.value.ticker)
+        assertEquals(0, BigDecimal("2").compareTo(model.state.value.stakedBalance))
+        assertEquals("2", model.amountFieldState.text.toString())
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun `the async refresh keeps an amount the user typed during the load`() = runTest {
+        // With the form interactive from the first frame, a user can edit the amount before the LCD
+        // load lands. The refresh must not stomp that input back to 100%.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "2")
+        model.amountFieldState.edit { replace(0, length, "1.5") }
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("1.5", model.amountFieldState.text.toString())
+    }
+
+    @Test
+    fun `the async refresh updates an untouched amount to the on-chain balance`() = runTest {
+        // The route can carry a slightly stale staked amount; if the user hasn't touched the field,
+        // the LCD load must refresh it to the authoritative on-chain balance (2 LUNA from setUp).
+        val gate = CompletableDeferred<Unit>()
+        coEvery { vaultRepository.get(any()) } coAnswers
+            {
+                gate.await()
+                Vault("v1", "v", "pk", "lp", coins = listOf(coin))
+            }
+        val model = vm(ticker = "LUNA", stakedAmount = "1")
+        assertEquals("1", model.amountFieldState.text.toString())
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("2", model.amountFieldState.text.toString())
     }
 }


### PR DESCRIPTION
Fixes #4822.

Opening Unstake or Move on a staking position briefly showed `0 Token` before the real ticker and staked balance loaded, because the routes carried only the validator address and the view-models initialized `stakedBalance = 0` / `ticker = ""` until an async LCD fetch landed.

## Changes

- `Route.CosmosStakingUndelegate` / `Route.CosmosStakingRedelegate` carry the tapped row's `ticker` and `stakedAmount` (human-decimal, optional with empty defaults — backward compatible).
- The positions VM passes those when navigating; the Undelegate/Redelegate VMs seed their initial state and pre-fill the amount field to 100% on the first frame.
- The async load still refreshes from the LCD, but a `lastAutoFilledAmount` guard only re-fills the amount while it still holds the auto-filled value — so a balance that drifts gets refreshed, while an amount the user typed during the load is never overwritten.

Applies to LUNA / LUNC / QBTC (shared screens); most visible on QBTC's slower LCD.

## Screenshots

| | Before | After |
|---|--------|-------|
| Unstake | ![](https://i.imgur.com/RgYiknu.png) | ![](https://i.imgur.com/pNZxqVx.png) |
| Move | ![](https://i.imgur.com/iuSDCe4.png) | ![](https://i.imgur.com/RgSRQBo.png) |

## Co-sign / signing

Untouched — the seed only affects what the form renders on the first frame. The signed amount still comes from the amount field, and `KeysignPayload` / `signDirect` construction is unchanged.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "*CosmosUndelegateViewModelTest" --tests "*CosmosRedelegateViewModelTest"` — passes, with new coverage: the route seeds the form before the LCD load resolves, the refresh keeps a user-typed amount, and the refresh updates an untouched amount to the on-chain balance.
- `./gradlew :app:assembleDebug` — built; screenshots captured from `PreviewActivity`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cosmos staking unstake and redelegate forms now display the correct token ticker and staked amount immediately upon opening, eliminating temporary placeholder states during data loading.

* **Tests**
  * Added test coverage for form prefilling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->