### PR TITLE
Raise QBTC staking gas limit to fix redelegate out-of-gas

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
@@ -69,7 +69,9 @@ object CosmosStakingConfig {
                     feeAmount = 133_333_334L,
                     unbondingDays = 21,
                 ),
-            // Values verified against the live qbtc-testnet LCD; mirrors iOS #4481.
+            // Chain identity (chainId / denom / valoper / unbonding) mirrors iOS #4481; the gas
+            // and fee are tuned to the live qbtc-testnet instead — iOS's 300_000 gas OoGs on
+            // redelegate (see below) and its 7_500 fee overpays the verified 800 min_tx_fee.
             Chain.Qbtc to
                 Entry(
                     chainId = "qbtc-testnet",
@@ -77,9 +79,16 @@ object CosmosStakingConfig {
                     bondDenom = "qbtc",
                     feeDenom = "qbtc",
                     valoperHrp = "qbtcvaloper",
-                    // Terra's post-OoG floor — a MsgDelegate simulate burned 278_759; redelegate
-                    // (dual-record write + ~2.4 KB ML-DSA sig) is heavier.
-                    gasLimit = 400_000L,
+                    // Redelegate OoG'd at the borrowed 400_000 Terra floor: on-chain
+                    // MsgBeginRedelegate burned 400_832 gas (qbtc-testnet tx 67B85E1C…, sdk code
+                    // 11 "ReadPerByte"). It's the heaviest single-msg path — the dual-record
+                    // x/staking write plus the per-byte read of QBTC's ~2.4 KB ML-DSA signature
+                    // outruns the floor a single MsgDelegate (simulate burned 278_759) fits in.
+                    // Raised to 800_000 (~2x the observed burn). Free here: qbtc-testnet has no
+                    // minimum gas price and block.max_gas is -1, so a larger budget moves neither
+                    // the fee nor the block-limit risk. Batched claims scale this per-msg in the
+                    // resolver, keeping the same headroom.
+                    gasLimit = 800_000L,
                     // qbtc-testnet min_tx_fee floor (min_gas_price is 0, so gas can't raise it).
                     feeAmount = 800L,
                     unbondingDays = 21,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
@@ -205,7 +205,7 @@ class BuildCosmosStakingKeysignPayloadUseCaseTests {
             CosmosStakingHelper.buildAuthInfo(
                 pubKey = mldsaPubKey,
                 sequence = cosmosSpecific.sequence.toLong(),
-                gasLimit = 400_000L,
+                gasLimit = 800_000L,
                 feeDenom = "qbtc",
                 feeAmount = 800L,
                 pubKeyTypeUrl = "/cosmos.crypto.mldsa.PubKey",

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
@@ -53,10 +53,12 @@ class CosmosStakingConfigTests {
         assertEquals("qbtc", entry.bondDenom)
         assertEquals("qbtc", entry.feeDenom)
         assertEquals("qbtcvaloper", entry.valoperHrp)
-        // 400_000 matches Terra's post-OoG floor (live MsgDelegate simulate burned 278_759;
-        // redelegate is heavier). feeAmount 800 is the qbtc-testnet `min_tx_fee` floor; since
-        // `min_gas_price` is 0 the higher gas budget does not raise the fee. Mirrors iOS #4481.
-        assertEquals(400_000L, entry.gasLimit)
+        // 800_000 after MsgBeginRedelegate OoG'd at the prior 400_000 floor on-chain (tx
+        // 67B85E1C…, gasUsed 400_832, sdk code 11 ReadPerByte) — the heaviest single-msg path. It
+        // must stay above that observed burn. feeAmount 800 is the qbtc-testnet `min_tx_fee` floor;
+        // `min_gas_price` is 0 so the higher gas budget does not raise the fee (#4820).
+        assertEquals(800_000L, entry.gasLimit)
+        assertTrue(entry.gasLimit > 400_832L, "gas must exceed the observed redelegate OoG burn")
         assertEquals(800L, entry.feeAmount)
         // Live LCD `unbonding_time` = 1814400s = 21 days.
         assertEquals(21, entry.unbondingDays)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
@@ -141,7 +141,7 @@ class QbtcStakingSignDataResolverTests {
             CosmosStakingHelper.buildAuthInfo(
                 pubKey = FX.MLDSA_PUBKEY,
                 sequence = FX.SEQUENCE,
-                gasLimit = 400_000L,
+                gasLimit = 800_000L,
                 feeDenom = FX.DENOM,
                 feeAmount = 800L,
                 pubKeyTypeUrl = FX.MLDSA_PUBKEY_TYPE_URL,
@@ -161,7 +161,7 @@ class QbtcStakingSignDataResolverTests {
             CosmosStakingHelper.buildAuthInfo(
                 pubKey = FX.MLDSA_PUBKEY,
                 sequence = FX.SEQUENCE,
-                gasLimit = 1_200_000L, // 3 × 400_000
+                gasLimit = 2_400_000L, // 3 × 800_000
                 feeDenom = FX.DENOM,
                 feeAmount = 2_400L, // 3 × 800
                 pubKeyTypeUrl = FX.MLDSA_PUBKEY_TYPE_URL,


### PR DESCRIPTION
Fixes #4820.

A QBTC staking **redelegate (Move)** fails on-chain with out-of-gas.

- Failing tx: https://explorer.qbtc.net/qbtc/tx/67B85E1C2EE74480495B330DCB2D07383BDC988039A458E45B2A7AE327BCC109
- `code: 11`, `raw_log: "out of gas in location: ReadPerByte; gasWanted: 400000, gasUsed: 400832: out of gas"` (verified against the live LCD)

## Root cause

The QBTC staking gas limit was `400000`, borrowed from the Terra entry. QBTC signs with **ML-DSA** (~2.4 KB signature), and `MsgBeginRedelegate` is the heaviest single-message path — the dual-record `x/staking` write plus the per-byte read of that large signature pushes gas just over the floor (400832 > 400000). Delegate / undelegate / claim are lighter single-message paths and fit; redelegate doesn't.

The gas model is per-message (`gasLimit = entry.gasLimit × msgCount`), so redelegate (1 msg) gets exactly the base limit while batched claims already scale.

## Change

Raise the QBTC staking gas limit `400000 → 800000` (~2× the observed burn). It's free here: the live qbtc-testnet node reports no minimum gas price (`minimum_gas_price: ""`) and enforces a flat `800` `min_tx_fee`, and `block.max_gas` is `-1`, so the larger budget moves neither the fee (stays `800`) nor any block limit. Batched claims keep the same headroom via the per-message multiplier.

## Cross-platform note

iOS (#4481) and Windows have no native QBTC staking gas config that matches Android's — iOS's `CosmosStakingConfig` ships QBTC at `gasLimit: 300_000`, which is *lower* than the old Android value and would OoG on redelegate as well (a latent iOS bug). Android intentionally diverges here with the empirically-verified `800000`; iOS should be aligned separately. The gas *model* (per-msg × count, redelegate = heaviest single msg) is identical across platforms.


## Success Redelegate Tx sample

https://explorer.qbtc.net/qbtc/tx/97B4D0562378A3F25D6B3485888F0DD694EB5049371C4F8A059220EE1D627943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased gas limits for QBTC staking transactions to prevent out-of-gas failures during redelegate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->