### PR TITLE
fix(qbtc): accurate error when co-sign vault lacks Bitcoin/QBTC account

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -169,7 +169,18 @@ sealed class JoinKeysignError(val message: UiText) {
     /** Relay server is unavailable after exhausting all retry attempts. */
     data object RelayUnavailable :
         JoinKeysignError(R.string.join_keysign_relay_unavailable.asUiText())
+
+    /**
+     * This vault is missing the Bitcoin or QBTC account the claim hash is derived from, so it
+     * cannot co-sign the QBTC claim.
+     */
+    data object MissingQbtcClaimAccount :
+        JoinKeysignError(R.string.join_keysign_qbtc_claim_missing_account.asUiText())
 }
+
+/** Thrown when a QBTC claim co-sign cannot find the [chain] account it needs in this vault. */
+private class MissingQbtcClaimAccountException(chain: Chain) :
+    Exception("Missing ${chain.raw} account for QBTC claim co-sign")
 
 sealed interface JoinKeysignState {
     data object DiscoveringSessionID : JoinKeysignState
@@ -1566,15 +1577,21 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.e(e, "QBTC claim co-sign failed")
-                currentState.value = JoinKeysignState.Error(JoinKeysignError.FailedConnectToServer)
+                val error =
+                    when (e) {
+                        is MissingQbtcClaimAccountException ->
+                            JoinKeysignError.MissingQbtcClaimAccount
+                        else -> JoinKeysignError.FailedConnectToServer
+                    }
+                currentState.value = JoinKeysignState.Error(error)
             }
         ) {
             val btc =
                 _currentVault.coins.firstOrNull { it.chain == Chain.Bitcoin }
-                    ?: error("Missing Bitcoin account for QBTC claim co-sign")
+                    ?: throw MissingQbtcClaimAccountException(Chain.Bitcoin)
             val qbtc =
                 _currentVault.coins.firstOrNull { it.chain == Chain.Qbtc }
-                    ?: error("Missing QBTC account for QBTC claim co-sign")
+                    ?: throw MissingQbtcClaimAccountException(Chain.Qbtc)
             val messageHashHex =
                 computeQbtcClaimMessageHash(btc.address, btc.hexPublicKey, qbtc.address)
             val session =

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -356,6 +356,7 @@
     <string name="edit_address_title">Adresse bearbeiten</string>
     <string name="join_keysign_failed_connect_to_server">Verbindung zum Server fehlgeschlagen</string>
     <string name="join_keysign_relay_unavailable">Relay-Server nicht verfügbar, bitte versuchen Sie es erneut</string>
+    <string name="join_keysign_qbtc_claim_missing_account">Diesem Tresor fehlt das zum Mitsignieren des Claims erforderliche Bitcoin- oder QBTC-Konto</string>
     <string name="network_connection_lost">Netzwerkverbindung verloren. Bitte überprüfen Sie Ihre Internetverbindung</string>
     <string name="send_form_polka_reaping_warning">Stellen Sie sicher, dass Sie genügend Geld übrig lassen, um die Gebühren zu decken. Wenn ein Kontostand unter 1 DOT (Existential Deposit) fällt, wird das Konto deaktiviert (geerntet) und alle verbleibenden Gelder gehen verloren. Sie können die Adresse jederzeit mit einer neuen Einzahlung reaktivieren, die größer als die Existenzeinzahlung ist. Dadurch werden die verlorenen Gelder jedoch nicht wiederhergestellt.</string>
     <!-- Push Notifications -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Error en el cálculo de cotización</string>
     <string name="join_keysign_failed_connect_to_server">Error al conectar con el servidor</string>
     <string name="join_keysign_relay_unavailable">Servidor de retransmisión no disponible, inténtalo de nuevo</string>
+    <string name="join_keysign_qbtc_claim_missing_account">A esta bóveda le falta la cuenta de Bitcoin o QBTC necesaria para cofirmar la reclamación</string>
     <string name="network_connection_lost">Se perdió la conexión a la red. Verifique su conexión a Internet.</string>
     <string name="send_form_polka_reaping_warning">Asegúrese de dejar fondos suficientes para cubrir las tarifas. Si el saldo de una cuenta cae por debajo de 1 DOT (depósito existencial), la cuenta se desactivará (se recuperará) y se perderán los fondos restantes. Puede reactivar la dirección con un nuevo depósito mayor que el depósito existencial en cualquier momento. Sin embargo, esto no recuperará los fondos perdidos.</string>
     <string name="edit_address_title">Editar dirección</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Izračun ponude nije uspio</string>
     <string name="join_keysign_failed_connect_to_server">Povezivanje s poslužiteljem nije uspjelo</string>
     <string name="join_keysign_relay_unavailable">Relay poslužitelj nije dostupan, pokušajte ponovo</string>
+    <string name="join_keysign_qbtc_claim_missing_account">Ovom trezoru nedostaje Bitcoin ili QBTC račun potreban za supotpisivanje zahtjeva</string>
     <string name="network_connection_lost">Mrežna veza izgubljena. Provjerite svoju internetsku vezu</string>
     <string name="send_form_polka_reaping_warning">Ostavite dovoljno sredstava za pokrivanje naknada. Ako stanje na računu padne ispod 1 DOT (egzistencijalni depozit), račun će biti deaktiviran (požnjet) i sva preostala sredstva bit će izgubljena. Adresu možete ponovno aktivirati s novim pologom većim od egzistencijalnog pologa u bilo kojem trenutku. Međutim, to neće vratiti izgubljena sredstva.</string>
     <string name="edit_address_title">Uredi adresu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Calcolo preventivo fallito</string>
     <string name="join_keysign_failed_connect_to_server">Connessione al server non riuscita</string>
     <string name="join_keysign_relay_unavailable">Server relay non disponibile, riprova</string>
+    <string name="join_keysign_qbtc_claim_missing_account">A questo caveau manca l\'account Bitcoin o QBTC necessario per cofirmare il claim</string>
     <string name="network_connection_lost">Connessione di rete persa. Controlla la tua connessione Internet</string>
     <string name="send_form_polka_reaping_warning">Assicurati di lasciare fondi sufficienti per coprire le commissioni. Se il saldo di un account scende sotto 1 DOT (deposito esistenziale), l\'account verrà disattivato (raccolto) e tutti i fondi rimanenti andranno persi. Puoi riattivare l\'indirizzo con un nuovo deposito superiore al deposito esistenziale in qualsiasi momento. Tuttavia, questo non recupererà i fondi persi.</string>
     <string name="edit_address_title">Modifica indirizzo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -446,6 +446,7 @@
     <string name="edit_address_title">주소 수정</string>
     <string name="join_keysign_failed_connect_to_server">서버 연결 실패</string>
     <string name="join_keysign_relay_unavailable">릴레이 서버를 사용할 수 없습니다. 다시 시도해 주세요</string>
+    <string name="join_keysign_qbtc_claim_missing_account">이 볼트에는 클레임을 공동 서명하는 데 필요한 Bitcoin 또는 QBTC 계정이 없습니다</string>
     <string name="network_connection_lost">네트워크 연결이 끊어졌습니다. 인터넷 연결을 확인해 주세요</string>
     <string name="send_form_polka_reaping_warning">수수료를 충당할 충분한 자금을 남겨두세요. 계정 잔액이 1 DOT(최소 예치금) 아래로 떨어지면 계정이 비활성화(수확)되고 남은 자금이 손실됩니다. 언제든지 최소 예치금보다 큰 새 입금으로 주소를 재활성화할 수 있습니다. 그러나 손실된 자금은 복구되지 않습니다.</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -354,6 +354,7 @@
     <string name="swap_screen_invalid_quote_calculation">Berekening offerte mislukt</string>
     <string name="join_keysign_failed_connect_to_server">Verbinding met server mislukt</string>
     <string name="join_keysign_relay_unavailable">Relayserver niet beschikbaar, probeer het opnieuw</string>
+    <string name="join_keysign_qbtc_claim_missing_account">Deze kluis mist het Bitcoin- of QBTC-account dat nodig is om de claim mede te ondertekenen</string>
     <string name="network_connection_lost">Netwerkverbinding verbroken. Controleer uw internetverbinding.</string>
     <string name="send_form_polka_reaping_warning">Zorg ervoor dat u voldoende geld achterlaat om de kosten te dekken. Als een rekeningsaldo onder 1 DOT (Existential Deposit) zakt, wordt de rekening gedeactiveerd (gereapeerd) en gaan alle resterende fondsen verloren. U kunt het adres op elk gewenst moment reactiveren met een nieuwe storting die groter is dan de existentiële storting. Dit zal echter niet de verloren fondsen terugkrijgen.</string>
     <string name="edit_address_title">Adres bewerken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -356,6 +356,7 @@
     <string name="edit_address_title">Editar endereço</string>
     <string name="join_keysign_failed_connect_to_server">Falha ao ligar ao servidor</string>
     <string name="join_keysign_relay_unavailable">Servidor de retransmissão indisponível, tente novamente</string>
+    <string name="join_keysign_qbtc_claim_missing_account">Falta a este cofre a conta Bitcoin ou QBTC necessária para coassinar a reivindicação</string>
     <string name="network_connection_lost">Ligação de rede perdida. Verifique a sua ligação com a Internet</string>
     <string name="send_form_polka_reaping_warning">Certifique-se de que deixa fundos suficientes para cobrir as taxas. Se o saldo de uma conta cair abaixo de 1 DOT (Depósito Existencial), a conta será desativada (recolhida) e quaisquer fundos remanescentes serão perdidos. Pode reativar o endereço com um novo depósito maior do que o depósito existencial a qualquer momento. No entanto, isto não recuperará os fundos perdidos.</string>
     <!-- Push Notifications -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -355,6 +355,7 @@
     <string name="edit_address_title">Изменить адрес</string>
     <string name="join_keysign_failed_connect_to_server">Не удалось подключиться к серверу</string>
     <string name="join_keysign_relay_unavailable">Ретранслятор недоступен, повторите попытку</string>
+    <string name="join_keysign_qbtc_claim_missing_account">В этом хранилище отсутствует учётная запись Bitcoin или QBTC, необходимая для совместного подписания заявки</string>
     <string name="network_connection_lost">Сетевое соединение потеряно. Проверьте подключение к интернету</string>
     <string name="send_form_polka_reaping_warning">Убедитесь, что вы оставили достаточно средств для покрытия сборов. Если баланс счета опустится ниже 1 DOT (экзистенциальный депозит), счет будет деактивирован (изъят), а все оставшиеся средства будут потеряны. Вы можете повторно активировать адрес с новым депозитом, превышающим экзистенциальный депозит, в любое время. Однако это не вернет потерянные средства.</string>
     <!-- Push Notifications -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -651,6 +651,7 @@
     <!-- Join Keysign Failed -->
     <string name="join_keysign_failed_connect_to_server">连接服务器失败</string>
     <string name="join_keysign_relay_unavailable">中继服务器不可用，请重试</string>
+    <string name="join_keysign_qbtc_claim_missing_account">此保险库缺少联合签署领取所需的 Bitcoin 或 QBTC 账户</string>
 
     <!-- Network Connection -->
     <string name="network_connection_lost">网络连接丢失。请检查您的互联网连接</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,7 @@
     <string name="edit_address_title">Edit Address</string>
     <string name="join_keysign_failed_connect_to_server">Failed to connect to server</string>
     <string name="join_keysign_relay_unavailable">Relay server unavailable, please try again</string>
+    <string name="join_keysign_qbtc_claim_missing_account">This vault is missing the Bitcoin or QBTC account required to co-sign the claim</string>
     <string name="network_connection_lost">Network connection lost. Please check your internet connection</string>
     <string name="send_form_polka_reaping_warning">Ensure you leave enough funds to cover the fees. If an account balance falls below 1 DOT (Existential Deposit), the account will be deactivated (reaped) and any remaining funds will be lost. You can reactivate the address with a new deposit larger than the existential deposit at any time. However, this will not recover the lost funds.</string>
 


### PR DESCRIPTION
## Summary
- QBTC claim co-sign recomputes the claim hash from the co-signing vault's own Bitcoin + QBTC accounts. When either account was absent, `startQbtcClaimCosign()` threw a bare `IllegalStateException`, and the `safeLaunch` `onError` handler mapped **every** failure to `FailedConnectToServer`.
- Result: an account-derivation problem surfaced as a misleading **"Signing Error. Please try again. Failed to connect to server"** — retrying never helped.
- Now a dedicated `MissingQbtcClaimAccountException` is thrown and mapped to a new `JoinKeysignError.MissingQbtcClaimAccount`, so the UI shows an accurate, actionable message: *"This vault is missing the Bitcoin or QBTC account required to co-sign the claim."*
- Added the new string to `values/strings.xml` and all 9 locale files (de, es, hr, it, ko, nl, pt, ru, zh-rCN), using each locale's established term for "vault".

## Issue
Closes #4827

## Test Plan
- [ ] Co-sign a QBTC claim on a second device whose vault has **no** Bitcoin account → verify the accurate missing-account message is shown (not "Failed to connect to server")
- [ ] Co-sign a QBTC claim on a device with both Bitcoin + QBTC accounts → verify co-sign still completes normally
- [ ] Trigger a genuine relay/connection failure during co-sign → verify it still shows "Failed to connect to server"
- [x] Lint passes (`./gradlew lint`)
- [x] Debug Kotlin compiles (`./gradlew :app:compileDebugKotlin`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specific error handling and user-facing messaging for QBTC claim co-signing when a vault is missing the required Bitcoin or QBTC accounts.

* **Documentation**
  * Added localized error messages across 10 languages (English, German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese) to clearly communicate the missing account requirement to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->