### PR TITLE
fix(swap): surface "no route" guidance on token selection instead of at quote time (#4710)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -134,6 +134,14 @@ constructor(
 
     private var refreshQuoteJob: Job? = null
 
+    // Whether the currently selected source/destination pair has any eligible swap provider.
+    // Resolved up front on every pair change (#4710) so an unroutable pair surfaces guidance the
+    // moment it is selected and never reaches the quote pipeline (which would throw
+    // SwapIsNotSupported only after the user typed an amount and waited out the debounce).
+    private var isPairSupported = true
+
+    private val pairNotSupportedError = UiText.StringResource(R.string.swap_route_not_available)
+
     private data class PreFlipState(
         val srcAmount: String,
         val srcTokenId: String,
@@ -656,7 +664,7 @@ constructor(
                     src to dst
                 }
                 .distinctUntilChanged()
-                .onEach {
+                .onEach { (src, dst) ->
                     // A freshly selected pair has no quote yet, and a token switch never clears the
                     // previous pair's destination value. Reset it so the skeleton shows while the
                     // new quote loads instead of the stale amount reading as a firm quote for the
@@ -670,6 +678,7 @@ constructor(
                                 )
                         )
                     }
+                    updatePairSupport(src, dst)
                 }
                 .combine(amountChanges) { address, immediate ->
                     QuoteInput(address = address, amount = srcAmount, immediate = immediate)
@@ -680,6 +689,9 @@ constructor(
                 // the debounce and an instant indicative estimate fills the destination field while
                 // we wait, without flashing on background refreshes (#4712).
                 .onEach { input ->
+                    // Unroutable pair: the "no route" guidance already showed on selection (#4710),
+                    // so don't spin or fetch an indicative estimate for a pair we can't quote.
+                    if (!isPairSupported) return@onEach
                     isLoading = true
                     showIndicativeRate(input)
                 }
@@ -690,6 +702,13 @@ constructor(
                 // collectLatest so newer input cancels an in-flight fetch instead of letting a
                 // stale fetch write isLoading = false after the user has already typed again.
                 .collectLatest { input ->
+                    // Never request a quote for a pair with no eligible provider — that path throws
+                    // SwapIsNotSupported. The guidance set on selection stands; just keep the
+                    // spinner off and wait for the next pair change (#4710).
+                    if (!isPairSupported) {
+                        isLoading = false
+                        return@collectLatest
+                    }
                     when (
                         val result =
                             swapQuotePipeline.resolveQuote(
@@ -858,6 +877,31 @@ constructor(
                 delay(expiredAt - Clock.System.now())
                 refreshQuoteState.value++
             }
+    }
+
+    /**
+     * Resolves whether the selected source/destination pair has any eligible provider and surfaces
+     * the "no route" guidance immediately on selection, instead of letting the quote pipeline throw
+     * SwapIsNotSupported only after the user has typed an amount and waited for a quote (#4710).
+     *
+     * Same-token pairs are treated as supported here — the zero-amount / same-asset guards handle
+     * those — so we never flash "no route" while the user is mid-pick. Eligibility stays driven by
+     * the static [com.vultisig.wallet.data.repositories.swap.SwapProviderTable] (a local lookup, so
+     * this is instant); moving it to live provider/token data is deferred (#4685).
+     */
+    private fun updatePairSupport(src: SendSrc, dst: SendSrc) {
+        val srcToken = src.account.token
+        val dstToken = dst.account.token
+        isPairSupported =
+            srcToken == dstToken ||
+                swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isNotEmpty()
+        if (!isPairSupported) {
+            resetQuoteState(error = pairNotSupportedError, cause = null, tag = null)
+        } else if (uiState.value.formError == pairNotSupportedError) {
+            // Moving from an unroutable pair to a routable one clears the stale guidance at once,
+            // ahead of the debounced quote that would otherwise clear it ~300ms later.
+            uiState.update { it.copy(formError = null) }
+        }
     }
 
     private fun resetQuoteState(error: UiText?, cause: Throwable?, tag: String?) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -764,6 +764,76 @@ internal class SwapFormViewModelTest {
 
     // endregion
 
+    // region pair eligibility (#4710)
+
+    @Test
+    fun `unsupported pair surfaces route guidance on selection before any amount is entered`() =
+        runTest(mainDispatcher) {
+            // No eligible provider for the chosen pair — e.g. a thin-coverage chain like Sui.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns emptyList()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            // The guidance appears from token selection alone — no amount typed, no quote
+            // requested.
+            assertEquals(
+                UiText.StringResource(R.string.swap_route_not_available),
+                vm.uiState.value.formError,
+            )
+            assertTrue(vm.uiState.value.isSwapDisabled)
+            assertFalse(vm.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `unsupported pair never requests a quote even after an amount is entered`() =
+        runTest(mainDispatcher) {
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns emptyList()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("100")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            // The quote pipeline (which would throw SwapIsNotSupported) is never reached, and the
+            // pre-quote guidance still stands.
+            coVerify(exactly = 0) {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
+            assertEquals(
+                UiText.StringResource(R.string.swap_route_not_available),
+                vm.uiState.value.formError,
+            )
+            assertFalse(vm.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `routable pair does not show route guidance`() =
+        runTest(mainDispatcher) {
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.formError)
+        }
+
+    // endregion
+
     @Test
     fun `selectSrcPercentage fetches a quote immediately, bypassing the typing debounce`() =
         runTest(mainDispatcher) {


### PR DESCRIPTION
## Summary

The swap form filtered selectable tokens by **chain** but not by **pair**. A user could pick a source + destination, type an amount, wait for the quote, and only then hit a dead end — *"Swap route not available"* — because `getEligibleProviders(src, dst)` returned empty and the pipeline threw `SwapException.SwapIsNotSupported` at quote time. On thin-coverage chains (e.g. Sui), or a non-Thor/Maya ERC-20 swapped to a THORChain-only chain, this is easy to trip and reads as a failure rather than guidance.

This implements the issue's **option 1** (the lower-risk first step): resolve provider eligibility **up front on token selection** and surface the existing guidance immediately, before any quote is requested.

## What changed

`SwapFormViewModel` only (no UI, no new strings):

- Added an `isPairSupported` flag, resolved by `updatePairSupport(src, dst)` on every pair change.
- When the selected pair has no eligible provider, the `swap_route_not_available` guidance shows **the moment the destination is selected** (red flip button + warning icon, swap disabled) — no amount required, no spinner.
- The indicative-rate `onEach` and the quote `collectLatest` early-return for an unroutable pair, so the pipeline path that throws `SwapIsNotSupported` is **never reached** as a user-visible failure.
- Switching back to a routable pair clears the guidance immediately (ahead of the debounced quote that would otherwise clear it).
- Same-token pairs are treated as supported, so the hint never flashes mid-pick.

## Design decision

Eligibility stays driven by the static `SwapProviderTable` (a local lookup, so this is instant). Moving "supported pairs" to live provider/token data is a separate, larger change — **explicitly deferred to #4685**.

## Test plan

**Unit** — 3 new tests in `SwapFormViewModelTest.kt` (full class: 89 tests, 0 failures):
- guidance appears on selection before any amount is entered
- no quote is ever fetched for an unsupported pair, even after typing an amount
- a routable pair shows no guidance

`:app:compileDebugKotlin` green, ktfmt applied.

**Manual (device)** — unsupported pair: **VULT → ATOM (Cosmos)** (`{1INCH, LIFI, KYBER, SWAPKIT}` ∩ `{THORCHAIN}` = ∅):
- [ ] Selecting ATOM as destination shows "Swap route not available" instantly, before typing an amount; swap disabled; no spinner.
- [ ] Typing an amount keeps the guidance and never spins or late-errors.
- [ ] Control pair **VULT → BTC** (share SWAPKIT) still quotes normally.
- [ ] Switching the destination from ATOM back to BTC clears the guidance immediately.

Closes #4710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap pair validation to display route-unavailable errors immediately upon selection, eliminating unnecessary loading states and quote-fetch attempts for unsupported token pairs.

* **Tests**
  * Added test coverage for swap pair eligibility validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->