### PR TITLE
fix(evm): widen non-swap EIP-1559 maxFee headroom to base×1.5 + tip

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -161,7 +161,14 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
             val bumpPercent = if (chain == Chain.Ethereum) 50 else 10
             return baseNetworkPrice.increaseByPercent(bumpPercent)
         }
-        return baseNetworkPrice
+        // Non-swap transfers: bump the committed base so the broadcast ceiling
+        // (calculateMaxFeePerGas adds a further 20%) lands at baseFee × 1.5 + priorityFee
+        // instead of baseFee × 1.2 + priorityFee. EIP-1559 raises the base fee up to 12.5%
+        // per block, so a flat 20% margin is exhausted after ~1.5 blocks and a send can
+        // stall in the mempool when the base fee climbs across the MPC review + sign window.
+        // The extra headroom only improves inclusion robustness — the amount actually paid
+        // stays near baseFee + priorityFee under EIP-1559.
+        return baseNetworkPrice.increaseByPercent(NON_SWAP_BASE_FEE_BUMP_PERCENT)
     }
 
     private suspend fun calculateMaxPriorityFeePerGas(
@@ -251,6 +258,12 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
 
     companion object {
         private val GWEI = BigInteger.TEN.pow(9)
+
+        // Extra bump applied to the committed base fee on the non-swap send path. With the
+        // further 20% added in calculateMaxFeePerGas this yields a baseFee × 1.5 + priorityFee
+        // ceiling (~3 consecutive max EIP-1559 base-fee increases of 12.5%) so a transfer
+        // survives a base-fee climb during the MPC review + sign window without stalling.
+        private const val NON_SWAP_BASE_FEE_BUMP_PERCENT = 25
 
         private val DEFAULT_MAX_PRIORITY_FEE_PER_GAS_L2 = "20".toBigInteger()
         private val DEFAULT_MAX_PRIORITY_FEE_POLYGON = "30".toBigInteger()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -213,15 +213,19 @@ internal class EthereumFeeServiceTest {
     // ---------- EIP-1559 fee assembly ----------
 
     @Test
-    fun `maxFeePerGas equals baseFee increased by 20 percent plus priority fee`() = runTest {
+    fun `non-swap maxFeePerGas is baseFee times 1_5 plus priority fee`() = runTest {
+        // The committed base is bumped 25% (networkPrice = 125), and calculateMaxFeePerGas
+        // adds a further 20%, so the broadcast ceiling is baseFee × 1.5 + priorityFee. This
+        // gives ~3 blocks of EIP-1559 base-fee headroom across the MPC review + sign window
+        // instead of the ~1.5 blocks a flat 20% margin allowed.
         coEvery { evmApi.getBaseFee() } returns gwei(100)
         stubFeeHistory(listOf(gwei(5)))
 
         val fee = service.calculateDefaultFees(transfer(Chain.Ethereum)) as Eip1559
 
-        assertEquals(gwei(100), fee.networkPrice)
+        assertEquals(gwei(125), fee.networkPrice) // 100 * 1.25
         assertEquals(gwei(5), fee.maxPriorityFeePerGas)
-        assertEquals(gwei(125), fee.maxFeePerGas) // 100 * 1.2 + 5
+        assertEquals(gwei(155), fee.maxFeePerGas) // 100 * 1.25 * 1.2 + 5 = 150 + 5
     }
 
     @Test


### PR DESCRIPTION
Closes #4853

## Problem
On the non-swap EVM send path, the EIP-1559 `maxFeePerGas` was computed as only `base × 1.2 + tip`. EIP-1559 lets the base fee rise up to **12.5% per block**, so a flat 20% margin is exhausted after **~1.5 blocks**. If the base fee climbs between fee estimation and inclusion — common during a busy window or across the MPC review + sign delay — the tx's `maxFeePerGas` falls below the prevailing base fee and it stalls in the mempool until the base fee drops.

The extra base-fee bump previously existed **only** on the swap path (`calculateBaseNetworkPrice` bumps ×1.5 ETH / ×1.1 others when `swap == true`); plain transfers passed the base through unscaled.

## Fix
`EthereumFeeService` now bumps the committed base **25%** on the non-swap path, so with the existing +20% in `calculateMaxFeePerGas` the broadcast ceiling lands at **`base × 1.5 + tip`** (~3 consecutive max base-fee increases of headroom). The swap path is untouched.

Raising the ceiling does **not** overcharge the user: under EIP-1559 the amount actually paid stays near `base + tip` — `maxFeePerGas` is only the cap, so this purely improves inclusion robustness.

## Cross-platform note
iOS (`FeeService.swift`) computes the non-swap ceiling identically (`base × 1.2 + tip`), so this is a **shared** tight ceiling rather than an Android-only divergence. iOS should get the same change for parity — flagging for follow-up, not silently diverging.

## Design choice
Picked **×1.5** (conservative end of the ×1.5–2.0 range suggested in the issue) to roughly double the headroom while minimizing displayed fee-bond inflation. Bumping to ×1.8 (matching the ETH swap ceiling) or ×2.0 is a one-line constant change if preferred.

## Test plan
- [x] Updated `EthereumFeeServiceTest` assertion from `base×1.2` to `base×1.5 + tip` (networkPrice 125, maxFee 155 gwei for base 100 / tip 5)
- [x] `:data:testDebugUnitTest --tests EthereumFeeServiceTest` — all green
- [x] ktfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated base fee calculation for non-swap Ethereum transfers. The base network price now includes a 25% increase, affecting maximum fee per gas estimates for these transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->