### PR TITLE
fix(evm): align ERC-20 signed gas limit with displayed fee bond

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -244,7 +244,7 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
             transaction is Swap -> DEFAULT_SWAP_LIMIT
             chain == Chain.Arbitrum -> DEFAULT_ARBITRUM_TRANSFER
             transaction is Transfer && transaction.coin.isNativeToken -> DEFAULT_COIN_TRANSFER_LIMIT
-            transaction is Transfer -> DEFAULT_TOKEN_TRANSFER_LIMIT.increaseByPercent(40)
+            transaction is Transfer -> DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
             else -> error("Transaction type not supported: ${transaction::class.simpleName}")
         }
     }
@@ -274,6 +274,12 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         val DEFAULT_SWAP_LIMIT = "600000".toBigInteger()
         val DEFAULT_COIN_TRANSFER_LIMIT = "23000".toBigInteger()
         val DEFAULT_TOKEN_TRANSFER_LIMIT = "150000".toBigInteger()
+
+        // ERC-20 transfer gas-limit floor: the 150k base plus a 40% safety margin. Single
+        // source of truth shared with BlockChainSpecificRepository so the signed gasLimit and
+        // the displayed fee bond use the same floor and cannot drift (issue #4857).
+        val DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN =
+            DEFAULT_TOKEN_TRANSFER_LIMIT.increaseByPercent(40)
 
         val DEFAULT_ARBITRUM_TRANSFER = "160000".toBigInteger()
         val DEFAULT_MANTLE_SWAP_LIMIT = "3000000000".toBigInteger()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -19,7 +19,7 @@ import com.vultisig.wallet.data.blockchain.FeeServiceComposite
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_ARBITRUM_TRANSFER
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
-import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
@@ -171,7 +171,9 @@ constructor(
                             isSwap -> DEFAULT_SWAP_LIMIT
                             chain == Chain.Arbitrum -> DEFAULT_ARBITRUM_TRANSFER
                             token.isNativeToken -> DEFAULT_COIN_TRANSFER_LIMIT
-                            else -> DEFAULT_TOKEN_TRANSFER_LIMIT
+                            // ERC-20 floor mirrors EthereumFeeService.getDefaultLimit so the
+                            // signed gasLimit equals the displayed fee bond (issue #4857).
+                            else -> DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
                         }
 
                     // ERC-20 router deposits need depositWithExpiry headroom, but
@@ -212,7 +214,11 @@ constructor(
 
                     val nonce = evmApi.getNonce(address)
 
-                    val gasLimitFee = gasLimit ?: max(defaultGasLimit, estimateGasLimit)
+                    // Router deposits use their hardcoded headroom verbatim — the raised ERC-20
+                    // default floor must not bump it up via max(). Everything else floors the
+                    // on-chain estimate at the chain default.
+                    val gasLimitFee =
+                        gasLimit ?: routerDepositGasLimit ?: max(defaultGasLimit, estimateGasLimit)
                     val fees =
                         if (isSwap) {
                             feeServiceComposite.calculateDefaultFees(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -139,8 +139,8 @@ internal class BlockChainSpecificRepositoryImplTest {
                     isThorchainRouterDeposit = true,
                 )
 
-        // eth_estimateGas reverts without prior router approval, so we hardcode 200k —
-        // higher than the 150k DEFAULT_TOKEN_TRANSFER_LIMIT used for bare ERC-20 sends.
+        // eth_estimateGas reverts without prior router approval, so we hardcode 200k and use
+        // it verbatim — the bare ERC-20 default floor (210k) must not bump it up via max().
         assertEthereumSpecific(
             result = result,
             gasLimit = BigInteger("200000"),
@@ -180,10 +180,12 @@ internal class BlockChainSpecificRepositoryImplTest {
                     memo = "+:something-the-user-typed",
                 )
 
-        // ERC-20 path: max(150k DEFAULT_TOKEN_TRANSFER_LIMIT, 50k*1.5=75k) = 150k.
+        // ERC-20 path: max(210k DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN, 50k*1.5=75k) = 210k.
+        // The floor mirrors EthereumFeeService so the signed gasLimit equals the displayed
+        // fee bond (issue #4857).
         assertEthereumSpecific(
             result = result,
-            gasLimit = BigInteger("150000"),
+            gasLimit = BigInteger("210000"),
             maxFeePerGas = BigInteger("111"),
             priorityFee = BigInteger("22"),
         )


### PR DESCRIPTION
Closes #4857

## Problem
For ERC-20 transfers the gas limit was computed in two independent places with **different default floors**:

| | Location | ERC-20 floor |
|---|---|---|
| **Signed** limit | `BlockChainSpecificRepository.getSpecific()` | `DEFAULT_TOKEN_TRANSFER_LIMIT` = **150k** |
| **Displayed** fee bond | `EthereumFeeService.getDefaultLimit()` | `DEFAULT_TOKEN_TRANSFER_LIMIT.increaseByPercent(40)` = **210k** |

Both apply the same `estimate × 1.5`, so whenever the estimate falls below 210k (the common case — a plain ERC-20 transfer estimates ~45–65k) the floor decides the limit, and the two diverge: the user is shown a **210k**-based fee but the tx is signed with a **150k** limit. The fee consented to does not match the limit committed.

## Fix
- Extract the 210k floor into a single shared constant `DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN` in `EthereumFeeService`, and have `BlockChainSpecificRepository` use it as the ERC-20 default. The signed `defaultGasLimit` `when` now mirrors `getDefaultLimit` exactly for every case (Arbitrum 160k, native 23k, swap 600k, ERC-20 210k) — one source of truth, can't drift.
- Aligning **up** to 210k matches the value already displayed to the user and gives the tx more headroom. Gas limit is only a cap — actual cost is gas *used* × price — so this does not increase what the user pays.

## Router-deposit guard
`gasLimitFee = max(defaultGasLimit, estimateGasLimit)` applies the floor to **everything**, so naively raising the ERC-20 default to 210k would have silently bumped the deliberate THORChain router-deposit hardcode (`THORCHAIN_ROUTER_DEPOSIT_GAS_LIMIT` = 200k) up to 210k via `max()`. Short-circuited it:

```kotlin
val gasLimitFee = gasLimit ?: routerDepositGasLimit ?: max(defaultGasLimit, estimateGasLimit)
```

Router deposits now use their 200k headroom verbatim — unchanged behavior.

## Test plan
- [x] Updated `BlockChainSpecificRepositoryImplTest`: bare ERC-20 (75k estimate) floor assertion 150k → 210k; router-deposit assertion stays 200k with a clarified comment
- [x] `:data:testDebugUnitTest` full suite — green
- [x] EVM/fee `:app` tests (`*GasFee*`, `*EvmActualFee*`, `*SwapTransactionBuilder*`, `*SwapGasCalculator*`, `*DefaultSendStrategy*`, `*SelectGasFee*`) — green
- [x] ktfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized ERC-20 transfer gas limit calculations to ensure consistency between displayed fee estimates and signed transactions.
  * Improved router deposit gas limit handling to prevent unnecessary fee adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->