### PR TITLE
fix(keysign): bound join-keysign wait so a joiner can't spin forever

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -192,7 +192,10 @@ private class MissingQbtcClaimAccountException(chain: Chain) :
     Exception("Missing ${chain.raw} account for QBTC claim co-sign")
 
 /** Raised when the messages to sign cannot be prepared once the ceremony starts. */
-private class KeysignMessagesException(message: String) : Exception(message)
+internal class KeysignMessagesException(message: String) : Exception(message)
+
+/** Raised when polling the relay for committee membership fails (network/relay error). */
+internal class KeysignCheckException(message: String) : Exception(message)
 
 /** How [awaitKeysignStart] finished polling for the initiator to start the ceremony. */
 internal sealed interface KeysignStartOutcome {
@@ -202,6 +205,9 @@ internal sealed interface KeysignStartOutcome {
     /** Preparing the messages to sign failed; carries the reason for the error state. */
     data class FailedToPrepare(val message: String) : KeysignStartOutcome
 
+    /** Polling the relay for the committee failed; carries the reason for the error state. */
+    data class FailedToCheck(val message: String) : KeysignStartOutcome
+
     /** The deadline elapsed without the ceremony starting (initiator likely abandoned). */
     data object TimedOut : KeysignStartOutcome
 }
@@ -209,8 +215,11 @@ internal sealed interface KeysignStartOutcome {
 /**
  * Polls [checkStarted] every [pollInterval] until it reports the ceremony has started, bounded by
  * [timeout]. Without the bound a joiner spins forever when the initiator abandons the keysign
- * (issue #4856). A [KeysignMessagesException] thrown by [checkStarted] ends the wait with
- * [KeysignStartOutcome.FailedToPrepare]; exceeding [timeout] yields [KeysignStartOutcome.TimedOut].
+ * (issue #4856). Only a plain `false` ("not started yet") keeps the loop running. A
+ * [KeysignMessagesException] ends the wait with [KeysignStartOutcome.FailedToPrepare] and a
+ * [KeysignCheckException] with [KeysignStartOutcome.FailedToCheck], so a real poll failure surfaces
+ * immediately instead of being masked by the timeout; exceeding [timeout] yields
+ * [KeysignStartOutcome.TimedOut].
  */
 internal suspend fun awaitKeysignStart(
     timeout: Duration,
@@ -227,10 +236,14 @@ internal suspend fun awaitKeysignStart(
                 return@withTimeoutOrNull KeysignStartOutcome.FailedToPrepare(
                     e.message ?: "Failed to prepare messages to sign"
                 )
+            } catch (e: KeysignCheckException) {
+                return@withTimeoutOrNull KeysignStartOutcome.FailedToCheck(
+                    e.message ?: "Failed to check keysign start"
+                )
             }
             delay(pollInterval)
         }
-        @Suppress("UNREACHABLE_CODE") KeysignStartOutcome.TimedOut
+        error("unreachable") // the loop only exits via return@withTimeoutOrNull
     } ?: KeysignStartOutcome.TimedOut
 
 /** Bounds how long a joiner waits for the initiator to start the ceremony before failing. */
@@ -1757,33 +1770,44 @@ constructor(
     }
 
     private fun waitForKeysignToStart() {
-        _jobWaitingForKeysignStart = viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                when (
-                    val outcome =
-                        awaitKeysignStart(
-                            timeout = WAIT_FOR_KEYSIGN_START_TIMEOUT,
-                            pollInterval = KEYSIGN_START_POLL_INTERVAL,
-                            checkStarted = ::checkKeygenStarted,
-                        )
-                ) {
-                    KeysignStartOutcome.Started -> currentState.value = JoinKeysignState.Keysign
+        _jobWaitingForKeysignStart =
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    when (
+                        val outcome =
+                            awaitKeysignStart(
+                                timeout = WAIT_FOR_KEYSIGN_START_TIMEOUT,
+                                pollInterval = KEYSIGN_START_POLL_INTERVAL,
+                                checkStarted = ::checkKeygenStarted,
+                            )
+                    ) {
+                        KeysignStartOutcome.Started -> currentState.value = JoinKeysignState.Keysign
 
-                    is KeysignStartOutcome.FailedToPrepare -> {
-                        Timber.e("Failed to prepare messages to sign")
-                        currentState.value =
-                            JoinKeysignState.Error(JoinKeysignError.FailedToCheck(outcome.message))
-                    }
+                        is KeysignStartOutcome.FailedToPrepare -> {
+                            Timber.e("Failed to prepare messages to sign")
+                            currentState.value =
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToCheck(outcome.message)
+                                )
+                        }
 
-                    KeysignStartOutcome.TimedOut -> {
-                        Timber.w("Timed out waiting for the initiator to start the keysign")
-                        // Allow tryAgain() to re-register and re-poll the session.
-                        isJoiningKeysign.set(false)
-                        currentState.value = JoinKeysignState.Error(JoinKeysignError.Timeout)
+                        is KeysignStartOutcome.FailedToCheck -> {
+                            Timber.e("Failed to check keysign start: %s", outcome.message)
+                            currentState.value =
+                                JoinKeysignState.Error(
+                                    JoinKeysignError.FailedToCheck(outcome.message)
+                                )
+                        }
+
+                        KeysignStartOutcome.TimedOut -> {
+                            Timber.w("Timed out waiting for the initiator to start the keysign")
+                            // Allow tryAgain() to re-register and re-poll the session.
+                            isJoiningKeysign.set(false)
+                            currentState.value = JoinKeysignState.Error(JoinKeysignError.Timeout)
+                        }
                     }
                 }
             }
-        }
     }
 
     private suspend fun checkKeygenStarted(): Boolean {
@@ -1801,8 +1825,9 @@ constructor(
             throw ce
         } catch (e: Exception) {
             Timber.e(e, "Failed to check keysign start")
-            currentState.value =
-                JoinKeysignState.Error(JoinKeysignError.FailedToCheck(e.message.toString()))
+            // Surface as a terminal outcome rather than a "not started yet" false, so a real
+            // relay failure ends the wait instead of being masked by the timeout (issue #4856).
+            throw KeysignCheckException(e.message ?: "Failed to check keysign start")
         }
         return false
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -116,6 +116,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -125,9 +128,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.json.Json
@@ -171,6 +174,12 @@ sealed class JoinKeysignError(val message: UiText) {
         JoinKeysignError(R.string.join_keysign_relay_unavailable.asUiText())
 
     /**
+     * The initiator never started the signing ceremony within the timeout — it likely abandoned the
+     * keysign (closed the app or lost connectivity). Retryable.
+     */
+    data object Timeout : JoinKeysignError(R.string.join_keysign_start_timeout.asUiText())
+
+    /**
      * This vault is missing the Bitcoin or QBTC account the claim hash is derived from, so it
      * cannot co-sign the QBTC claim.
      */
@@ -181,6 +190,52 @@ sealed class JoinKeysignError(val message: UiText) {
 /** Thrown when a QBTC claim co-sign cannot find the [chain] account it needs in this vault. */
 private class MissingQbtcClaimAccountException(chain: Chain) :
     Exception("Missing ${chain.raw} account for QBTC claim co-sign")
+
+/** Raised when the messages to sign cannot be prepared once the ceremony starts. */
+private class KeysignMessagesException(message: String) : Exception(message)
+
+/** How [awaitKeysignStart] finished polling for the initiator to start the ceremony. */
+internal sealed interface KeysignStartOutcome {
+    /** The local party is in the committee — the ceremony has begun. */
+    data object Started : KeysignStartOutcome
+
+    /** Preparing the messages to sign failed; carries the reason for the error state. */
+    data class FailedToPrepare(val message: String) : KeysignStartOutcome
+
+    /** The deadline elapsed without the ceremony starting (initiator likely abandoned). */
+    data object TimedOut : KeysignStartOutcome
+}
+
+/**
+ * Polls [checkStarted] every [pollInterval] until it reports the ceremony has started, bounded by
+ * [timeout]. Without the bound a joiner spins forever when the initiator abandons the keysign
+ * (issue #4856). A [KeysignMessagesException] thrown by [checkStarted] ends the wait with
+ * [KeysignStartOutcome.FailedToPrepare]; exceeding [timeout] yields [KeysignStartOutcome.TimedOut].
+ */
+internal suspend fun awaitKeysignStart(
+    timeout: Duration,
+    pollInterval: Duration,
+    checkStarted: suspend () -> Boolean,
+): KeysignStartOutcome =
+    withTimeoutOrNull(timeout) {
+        while (true) {
+            try {
+                if (checkStarted()) {
+                    return@withTimeoutOrNull KeysignStartOutcome.Started
+                }
+            } catch (e: KeysignMessagesException) {
+                return@withTimeoutOrNull KeysignStartOutcome.FailedToPrepare(
+                    e.message ?: "Failed to prepare messages to sign"
+                )
+            }
+            delay(pollInterval)
+        }
+        @Suppress("UNREACHABLE_CODE") KeysignStartOutcome.TimedOut
+    } ?: KeysignStartOutcome.TimedOut
+
+/** Bounds how long a joiner waits for the initiator to start the ceremony before failing. */
+private val WAIT_FOR_KEYSIGN_START_TIMEOUT = 2.minutes
+private val KEYSIGN_START_POLL_INTERVAL = 1.seconds
 
 sealed interface JoinKeysignState {
     data object DiscoveringSessionID : JoinKeysignState
@@ -265,8 +320,6 @@ constructor(
 
         private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
     }
-
-    private class KeysignMessagesException(message: String) : Exception(message)
 
     private val args = savedStateHandle.toRoute<Route.Keysign.Join>()
     private val vaultId: String = args.vaultId
@@ -1687,7 +1740,8 @@ constructor(
                         opts = NavigationOptions(clearBackStack = true),
                     )
 
-                JoinKeysignError.RelayUnavailable -> {
+                JoinKeysignError.RelayUnavailable,
+                JoinKeysignError.Timeout -> {
                     currentState.value = JoinKeysignState.JoinKeysign
                     joinKeysign()
                 }
@@ -1703,29 +1757,33 @@ constructor(
     }
 
     private fun waitForKeysignToStart() {
-        _jobWaitingForKeysignStart =
-            viewModelScope.launch {
-                withContext(Dispatchers.IO) {
-                    while (isActive) {
-                        try {
-                            if (checkKeygenStarted()) {
-                                currentState.value = JoinKeysignState.Keysign
-                                return@withContext
-                            }
-                        } catch (e: KeysignMessagesException) {
-                            Timber.e(e, "Failed to prepare messages to sign")
-                            currentState.value =
-                                JoinKeysignState.Error(
-                                    JoinKeysignError.FailedToCheck(
-                                        e.message ?: "Failed to prepare messages to sign"
-                                    )
-                                )
-                            return@withContext
-                        }
-                        delay(1000)
+        _jobWaitingForKeysignStart = viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                when (
+                    val outcome =
+                        awaitKeysignStart(
+                            timeout = WAIT_FOR_KEYSIGN_START_TIMEOUT,
+                            pollInterval = KEYSIGN_START_POLL_INTERVAL,
+                            checkStarted = ::checkKeygenStarted,
+                        )
+                ) {
+                    KeysignStartOutcome.Started -> currentState.value = JoinKeysignState.Keysign
+
+                    is KeysignStartOutcome.FailedToPrepare -> {
+                        Timber.e("Failed to prepare messages to sign")
+                        currentState.value =
+                            JoinKeysignState.Error(JoinKeysignError.FailedToCheck(outcome.message))
+                    }
+
+                    KeysignStartOutcome.TimedOut -> {
+                        Timber.w("Timed out waiting for the initiator to start the keysign")
+                        // Allow tryAgain() to re-register and re-poll the session.
+                        isJoiningKeysign.set(false)
+                        currentState.value = JoinKeysignState.Error(JoinKeysignError.Timeout)
                     }
                 }
             }
+        }
     }
 
     private suspend fun checkKeygenStarted(): Boolean {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -356,6 +356,7 @@
     <string name="edit_address_title">Adresse bearbeiten</string>
     <string name="join_keysign_failed_connect_to_server">Verbindung zum Server fehlgeschlagen</string>
     <string name="join_keysign_relay_unavailable">Relay-Server nicht verfügbar, bitte versuchen Sie es erneut</string>
+    <string name="join_keysign_start_timeout">Das andere Gerät hat das Signieren nicht rechtzeitig gestartet</string>
     <string name="join_keysign_qbtc_claim_missing_account">Diesem Tresor fehlt das zum Mitsignieren des Claims erforderliche Bitcoin- oder QBTC-Konto</string>
     <string name="network_connection_lost">Netzwerkverbindung verloren. Bitte überprüfen Sie Ihre Internetverbindung</string>
     <string name="send_form_polka_reaping_warning">Stellen Sie sicher, dass Sie genügend Geld übrig lassen, um die Gebühren zu decken. Wenn ein Kontostand unter 1 DOT (Existential Deposit) fällt, wird das Konto deaktiviert (geerntet) und alle verbleibenden Gelder gehen verloren. Sie können die Adresse jederzeit mit einer neuen Einzahlung reaktivieren, die größer als die Existenzeinzahlung ist. Dadurch werden die verlorenen Gelder jedoch nicht wiederhergestellt.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Error en el cálculo de cotización</string>
     <string name="join_keysign_failed_connect_to_server">Error al conectar con el servidor</string>
     <string name="join_keysign_relay_unavailable">Servidor de retransmisión no disponible, inténtalo de nuevo</string>
+    <string name="join_keysign_start_timeout">El otro dispositivo no comenzó a firmar a tiempo</string>
     <string name="join_keysign_qbtc_claim_missing_account">A esta bóveda le falta la cuenta de Bitcoin o QBTC necesaria para cofirmar la reclamación</string>
     <string name="network_connection_lost">Se perdió la conexión a la red. Verifique su conexión a Internet.</string>
     <string name="send_form_polka_reaping_warning">Asegúrese de dejar fondos suficientes para cubrir las tarifas. Si el saldo de una cuenta cae por debajo de 1 DOT (depósito existencial), la cuenta se desactivará (se recuperará) y se perderán los fondos restantes. Puede reactivar la dirección con un nuevo depósito mayor que el depósito existencial en cualquier momento. Sin embargo, esto no recuperará los fondos perdidos.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Izračun ponude nije uspio</string>
     <string name="join_keysign_failed_connect_to_server">Povezivanje s poslužiteljem nije uspjelo</string>
     <string name="join_keysign_relay_unavailable">Relay poslužitelj nije dostupan, pokušajte ponovo</string>
+    <string name="join_keysign_start_timeout">Drugi uređaj nije započeo potpisivanje na vrijeme</string>
     <string name="join_keysign_qbtc_claim_missing_account">Ovom trezoru nedostaje Bitcoin ili QBTC račun potreban za supotpisivanje zahtjeva</string>
     <string name="network_connection_lost">Mrežna veza izgubljena. Provjerite svoju internetsku vezu</string>
     <string name="send_form_polka_reaping_warning">Ostavite dovoljno sredstava za pokrivanje naknada. Ako stanje na računu padne ispod 1 DOT (egzistencijalni depozit), račun će biti deaktiviran (požnjet) i sva preostala sredstva bit će izgubljena. Adresu možete ponovno aktivirati s novim pologom većim od egzistencijalnog pologa u bilo kojem trenutku. Međutim, to neće vratiti izgubljena sredstva.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -355,6 +355,7 @@
     <string name="swap_screen_invalid_quote_calculation">Calcolo preventivo fallito</string>
     <string name="join_keysign_failed_connect_to_server">Connessione al server non riuscita</string>
     <string name="join_keysign_relay_unavailable">Server relay non disponibile, riprova</string>
+    <string name="join_keysign_start_timeout">L\'altro dispositivo non ha avviato la firma in tempo</string>
     <string name="join_keysign_qbtc_claim_missing_account">A questo caveau manca l\'account Bitcoin o QBTC necessario per cofirmare il claim</string>
     <string name="network_connection_lost">Connessione di rete persa. Controlla la tua connessione Internet</string>
     <string name="send_form_polka_reaping_warning">Assicurati di lasciare fondi sufficienti per coprire le commissioni. Se il saldo di un account scende sotto 1 DOT (deposito esistenziale), l\'account verrà disattivato (raccolto) e tutti i fondi rimanenti andranno persi. Puoi riattivare l\'indirizzo con un nuovo deposito superiore al deposito esistenziale in qualsiasi momento. Tuttavia, questo non recupererà i fondi persi.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -446,6 +446,7 @@
     <string name="edit_address_title">주소 수정</string>
     <string name="join_keysign_failed_connect_to_server">서버 연결 실패</string>
     <string name="join_keysign_relay_unavailable">릴레이 서버를 사용할 수 없습니다. 다시 시도해 주세요</string>
+    <string name="join_keysign_start_timeout">다른 기기가 제때 서명을 시작하지 않았습니다</string>
     <string name="join_keysign_qbtc_claim_missing_account">이 볼트에는 클레임을 공동 서명하는 데 필요한 Bitcoin 또는 QBTC 계정이 없습니다</string>
     <string name="network_connection_lost">네트워크 연결이 끊어졌습니다. 인터넷 연결을 확인해 주세요</string>
     <string name="send_form_polka_reaping_warning">수수료를 충당할 충분한 자금을 남겨두세요. 계정 잔액이 1 DOT(최소 예치금) 아래로 떨어지면 계정이 비활성화(수확)되고 남은 자금이 손실됩니다. 언제든지 최소 예치금보다 큰 새 입금으로 주소를 재활성화할 수 있습니다. 그러나 손실된 자금은 복구되지 않습니다.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -354,6 +354,7 @@
     <string name="swap_screen_invalid_quote_calculation">Berekening offerte mislukt</string>
     <string name="join_keysign_failed_connect_to_server">Verbinding met server mislukt</string>
     <string name="join_keysign_relay_unavailable">Relayserver niet beschikbaar, probeer het opnieuw</string>
+    <string name="join_keysign_start_timeout">Het andere apparaat is niet op tijd begonnen met ondertekenen</string>
     <string name="join_keysign_qbtc_claim_missing_account">Deze kluis mist het Bitcoin- of QBTC-account dat nodig is om de claim mede te ondertekenen</string>
     <string name="network_connection_lost">Netwerkverbinding verbroken. Controleer uw internetverbinding.</string>
     <string name="send_form_polka_reaping_warning">Zorg ervoor dat u voldoende geld achterlaat om de kosten te dekken. Als een rekeningsaldo onder 1 DOT (Existential Deposit) zakt, wordt de rekening gedeactiveerd (gereapeerd) en gaan alle resterende fondsen verloren. U kunt het adres op elk gewenst moment reactiveren met een nieuwe storting die groter is dan de existentiële storting. Dit zal echter niet de verloren fondsen terugkrijgen.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -356,6 +356,7 @@
     <string name="edit_address_title">Editar endereço</string>
     <string name="join_keysign_failed_connect_to_server">Falha ao ligar ao servidor</string>
     <string name="join_keysign_relay_unavailable">Servidor de retransmissão indisponível, tente novamente</string>
+    <string name="join_keysign_start_timeout">O outro dispositivo não começou a assinar a tempo</string>
     <string name="join_keysign_qbtc_claim_missing_account">Falta a este cofre a conta Bitcoin ou QBTC necessária para coassinar a reivindicação</string>
     <string name="network_connection_lost">Ligação de rede perdida. Verifique a sua ligação com a Internet</string>
     <string name="send_form_polka_reaping_warning">Certifique-se de que deixa fundos suficientes para cobrir as taxas. Se o saldo de uma conta cair abaixo de 1 DOT (Depósito Existencial), a conta será desativada (recolhida) e quaisquer fundos remanescentes serão perdidos. Pode reativar o endereço com um novo depósito maior do que o depósito existencial a qualquer momento. No entanto, isto não recuperará os fundos perdidos.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -355,6 +355,7 @@
     <string name="edit_address_title">Изменить адрес</string>
     <string name="join_keysign_failed_connect_to_server">Не удалось подключиться к серверу</string>
     <string name="join_keysign_relay_unavailable">Ретранслятор недоступен, повторите попытку</string>
+    <string name="join_keysign_start_timeout">Другое устройство не начало подписание вовремя</string>
     <string name="join_keysign_qbtc_claim_missing_account">В этом хранилище отсутствует учётная запись Bitcoin или QBTC, необходимая для совместного подписания заявки</string>
     <string name="network_connection_lost">Сетевое соединение потеряно. Проверьте подключение к интернету</string>
     <string name="send_form_polka_reaping_warning">Убедитесь, что вы оставили достаточно средств для покрытия сборов. Если баланс счета опустится ниже 1 DOT (экзистенциальный депозит), счет будет деактивирован (изъят), а все оставшиеся средства будут потеряны. Вы можете повторно активировать адрес с новым депозитом, превышающим экзистенциальный депозит, в любое время. Однако это не вернет потерянные средства.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -651,6 +651,7 @@
     <!-- Join Keysign Failed -->
     <string name="join_keysign_failed_connect_to_server">连接服务器失败</string>
     <string name="join_keysign_relay_unavailable">中继服务器不可用，请重试</string>
+    <string name="join_keysign_start_timeout">另一台设备未及时开始签名</string>
     <string name="join_keysign_qbtc_claim_missing_account">此保险库缺少联合签署领取所需的 Bitcoin 或 QBTC 账户</string>
 
     <!-- Network Connection -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,7 @@
     <string name="edit_address_title">Edit Address</string>
     <string name="join_keysign_failed_connect_to_server">Failed to connect to server</string>
     <string name="join_keysign_relay_unavailable">Relay server unavailable, please try again</string>
+    <string name="join_keysign_start_timeout">The other device didn\'t start signing in time</string>
     <string name="join_keysign_qbtc_claim_missing_account">This vault is missing the Bitcoin or QBTC account required to co-sign the claim</string>
     <string name="network_connection_lost">Network connection lost. Please check your internet connection</string>
     <string name="send_form_polka_reaping_warning">Ensure you leave enough funds to cover the fees. If an account balance falls below 1 DOT (Existential Deposit), the account will be deactivated (reaped) and any remaining funds will be lost. You can reactivate the address with a new deposit larger than the existential deposit at any time. However, this will not recover the lost funds.</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/AwaitKeysignStartTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/AwaitKeysignStartTest.kt
@@ -60,4 +60,30 @@ internal class AwaitKeysignStartTest {
         // The wait is bounded by the timeout rather than spinning forever.
         assertEquals(timeout.inWholeMilliseconds, currentTime)
     }
+
+    @Test
+    fun `surfaces a poll failure immediately instead of masking it with the timeout`() = runTest {
+        var calls = 0
+
+        val outcome =
+            awaitKeysignStart(timeout = timeout, pollInterval = pollInterval) {
+                calls++
+                throw KeysignCheckException("relay unreachable")
+            }
+
+        assertEquals(KeysignStartOutcome.FailedToCheck("relay unreachable"), outcome)
+        assertEquals(1, calls) // the loop ends on the first real failure
+        assertEquals(0L, currentTime) // no waiting for the timeout deadline
+    }
+
+    @Test
+    fun `surfaces a message-preparation failure as FailedToPrepare`() = runTest {
+        val outcome =
+            awaitKeysignStart(timeout = timeout, pollInterval = pollInterval) {
+                throw KeysignMessagesException("cannot prepare messages")
+            }
+
+        assertEquals(KeysignStartOutcome.FailedToPrepare("cannot prepare messages"), outcome)
+        assertEquals(0L, currentTime)
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/AwaitKeysignStartTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/AwaitKeysignStartTest.kt
@@ -1,0 +1,63 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class AwaitKeysignStartTest {
+
+    private val timeout = 2.minutes
+    private val pollInterval = 1.seconds
+
+    @Test
+    fun `returns Started immediately when the ceremony has already begun`() = runTest {
+        var calls = 0
+
+        val outcome =
+            awaitKeysignStart(timeout = timeout, pollInterval = pollInterval) {
+                calls++
+                true
+            }
+
+        assertEquals(KeysignStartOutcome.Started, outcome)
+        assertEquals(1, calls)
+        assertEquals(0L, currentTime) // no polling delay consumed
+    }
+
+    @Test
+    fun `keeps polling until the ceremony starts`() = runTest {
+        var calls = 0
+
+        val outcome =
+            awaitKeysignStart(timeout = timeout, pollInterval = pollInterval) {
+                calls++
+                calls >= 3 // false, false, then true
+            }
+
+        assertEquals(KeysignStartOutcome.Started, outcome)
+        assertEquals(3, calls)
+        // Two failed checks → two poll intervals waited before success.
+        assertEquals(2 * pollInterval.inWholeMilliseconds, currentTime)
+    }
+
+    @Test
+    fun `times out when the initiator never starts`() = runTest {
+        var calls = 0
+
+        val outcome =
+            awaitKeysignStart(timeout = timeout, pollInterval = pollInterval) {
+                calls++
+                false // never starts
+            }
+
+        assertEquals(KeysignStartOutcome.TimedOut, outcome)
+        // The wait is bounded by the timeout rather than spinning forever.
+        assertEquals(timeout.inWholeMilliseconds, currentTime)
+    }
+}


### PR DESCRIPTION
Closes #4856

## Problem
`JoinKeysignViewModel.waitForKeysignToStart()` polled the relay every second with **no elapsed-time bound** — the loop exited only on success, a `KeysignMessagesException`, or coroutine cancellation:

```kotlin
while (isActive) {
    try { if (checkKeygenStarted()) { ...; return@withContext } }
    catch (e: KeysignMessagesException) { ...; return@withContext }
    delay(1000)
}
```

If the initiator abandons the ceremony (closes the app, loses connectivity), `checkCommittee` keeps returning a committee that never includes this party, so the joining device holds the user on a spinner **indefinitely** with no failure or abort until they manually back out.

## Fix
- Extract the polling loop into a small, testable top-level `awaitKeysignStart(timeout, pollInterval, checkStarted)` returning a `KeysignStartOutcome` (`Started` / `FailedToPrepare` / `TimedOut`), wrapped in `withTimeoutOrNull(2.minutes)` and polling every `1.second`. Mirrors the existing `JoinKeygenViewModel.DiscoveryTimeout` pattern.
- New retryable `JoinKeysignError.Timeout`. The error View's existing branch already renders any error with a **Try Again** button; `tryAgain()` routes `Timeout` through the same re-join path as `RelayUnavailable` (and the timeout handler resets `isJoiningKeysign` so the retry isn't blocked).
- `KeysignMessagesException` moved from a private nested class to a file-level declaration so the extracted helper can reference it (behavior-preserving).
- Added `join_keysign_start_timeout` across all 10 locales.

## Cross-platform note
iOS (`JoinKeysignViewModel.swift`) has the **same** unbounded loop (`while status == .WaitingForKeysignToStart`, `Task.sleep(1s)`), so this is a shared gap rather than an Android divergence — flagging for an iOS follow-up.

## Design choice
2-minute deadline: long enough not to cut off a slow-but-alive initiator, and a false timeout recovers gracefully because **Try Again** just re-polls the still-valid session. Easy to tune via the named constant.

## Test plan
- [x] New `AwaitKeysignStartTest` — `Started` immediately, poll-then-`Started`, and `TimedOut` bounded by the deadline (asserted via `runTest` virtual `currentTime`)
- [x] Full `*keysign*` `:app` unit-test suite — green
- [x] ktfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keysign start polling with clearer timeout handling and distinct error outcomes so users receive precise feedback when a signing session fails to begin.

* **Localization**
  * Added timeout error message translations in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, Chinese, and English.

* **Tests**
  * Added tests covering immediate start, polling-to-start, timeout, and distinct failure scenarios to ensure accurate user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->