### PR TITLE
fix(tokens): dedup chain tokens by Coin.id to stop duplicate LazyColumn key crash

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCase.kt
@@ -86,6 +86,12 @@ constructor(
                 .flatten()
                 .asSequence()
                 .distinctBy { it.contractAddress to it.chain.id }
+                // The UI keys each row on Coin.id (ticker-chainId). Collapse any remaining
+                // collisions on that key so the same ticker sourced with two different contract
+                // addresses on one chain can't produce duplicate LazyColumn keys and crash on
+                // scroll (issue #4869). Built-in/refreshed tokens are ordered first, so the
+                // canonical entry wins over a searchable/provider duplicate.
+                .distinctBy { it.id }
                 .toList()
                 .modifyIfNeeded()
         emit(coins)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCaseTest.kt
@@ -1,0 +1,79 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.usecases.chaintokens
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.TokenRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class GetChainTokensUseCaseTest {
+
+    private val tokenRepository: TokenRepository = mockk()
+    private val vault: Vault = mockk()
+
+    private val useCase =
+        GetChainTokensUseCaseImpl(
+            tokenRepository = tokenRepository,
+            splTokenRepository = mockk(relaxed = true),
+            oneInchApi = mockk(relaxed = true),
+            oneInchToCoins = mockk(relaxed = true),
+        )
+
+    @Test
+    fun `collapses a ticker sourced with two contract addresses on one chain to one row`() =
+        runTest {
+            // Regression for #4869: the LazyColumn keys on Coin.id (ticker-chainId), so two coins
+            // with the same ticker but different contracts on one chain must not both survive —
+            // otherwise the list crashes with a duplicate-key IllegalArgumentException on scroll.
+            val chain = Chain.Bitcoin
+            val builtIn = coin(chain, ticker = "cbETH", contractAddress = "0xA")
+            val provider = coin(chain, ticker = "cbETH", contractAddress = "0xB")
+            every { tokenRepository.builtInTokens } returns flowOf(listOf(builtIn, provider))
+            coEvery { tokenRepository.getRefreshTokens(any(), any()) } returns emptyList()
+
+            val emitted = useCase(chain, vault).toList().last()
+
+            val key = "cbETH-${chain.id}"
+            assertEquals(1, emitted.count { it.id == key })
+            // No two emitted coins ever share a LazyColumn key.
+            assertEquals(emitted.size, emitted.distinctBy { it.id }.size)
+            // The canonical built-in entry (ordered first) wins over the provider duplicate.
+            assertEquals("0xA", emitted.first { it.id == key }.contractAddress)
+        }
+
+    @Test
+    fun `keeps distinct tickers on the same chain`() = runTest {
+        val chain = Chain.Bitcoin
+        val a = coin(chain, ticker = "AAA", contractAddress = "0x1")
+        val b = coin(chain, ticker = "BBB", contractAddress = "0x2")
+        every { tokenRepository.builtInTokens } returns flowOf(listOf(a, b))
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } returns emptyList()
+
+        val emitted = useCase(chain, vault).toList().last()
+
+        assertEquals(setOf("AAA-${chain.id}", "BBB-${chain.id}"), emitted.map { it.id }.toSet())
+    }
+
+    private fun coin(chain: Chain, ticker: String, contractAddress: String) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = "addr",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contractAddress,
+            isNativeToken = false,
+        )
+}


### PR DESCRIPTION
Closes #4869

## Problem
The app crashes with a fatal `IllegalArgumentException: Key "cbETH-Base" was already used` while scrolling a token list, because the LazyColumn key and the de-dup key are derived from **different** fields:

- The list keys each row on `Coin.id` = `"${ticker}-${chain.id}"` (`SelectAssetScreen`, `ChainTokensScreen`, `SelectAssetPopup`).
- `GetChainTokensUseCase.emitUniqueTokens` deduped only by `(contractAddress, chain.id)`.

So when the same ticker is sourced with two different contract addresses on one chain (a built-in/refreshed `cbETH-Base` plus a searchable/provider `cbETH-Base`), both survive `distinctBy`, then collide on the identical key `"cbETH-Base"` and crash the LazyColumn on scroll.

## Fix
Add a final `.distinctBy { it.id }` after the existing contract-based collapse, so the de-dup key matches the LazyColumn key exactly and the emitted list can never contain two coins with the same key. The contract-based `distinctBy` is kept, so the only behavior change is collapsing the previously-crashing duplicate.

Built-in/refreshed tokens are flattened **first** in every `emitUniqueTokens(...)` call, so the canonical entry wins over the provider duplicate.

## Test plan
- [x] New `GetChainTokensUseCaseTest`:
  - same ticker / two contract addresses on one chain → emitted once, no duplicate `id`, built-in entry (`0xA`) survives
  - distinct tickers on the same chain are all kept
- [x] `:data:testDebugUnitTest` (new test) — green
- [x] ktfmt clean

Pure data-layer fix (no UI render change), so no before/after screenshots apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate tokens appearing in the token list that could cause display rendering issues. Tokens are now properly de-duplicated to ensure a cleaner, conflict-free interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->