### PR TITLE
fix(cosmos): validate IBC memo and timeout instead of signing a bad packet

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -147,15 +147,14 @@ class CosmosHelper(
         }
         return when (atomData.transactionType) {
             TransactionType.TRANSACTION_TYPE_IBC_TRANSFER -> {
-                val memoParts =
-                    keysignPayload.memo?.split(":")
-                        ?: throw Exception("To send IBC transaction, memo should be specified")
-                val sourceChannel = memoParts.getOrNull(1) ?: ""
-
-                val memo = if (memoParts.size == 4) memoParts[3] else ""
-
-                val timeouts = atomData.ibcDenomTraces?.latestBlock?.split("_") ?: emptyList()
-                val timeout = timeouts.lastOrNull()?.toLongOrNull() ?: 0L
+                val ibc =
+                    parseIbcTransferParams(
+                        memo = keysignPayload.memo,
+                        latestBlock = atomData.ibcDenomTraces?.latestBlock,
+                    )
+                val sourceChannel = ibc.sourceChannel
+                val memo = ibc.forwardMemo
+                val timeout = ibc.timeoutTimestamp
 
                 val transferMessage =
                     Cosmos.Message.Transfer.newBuilder()
@@ -428,4 +427,47 @@ class CosmosHelper(
 
         return inputBuilder.build().toByteArray()
     }
+}
+
+/**
+ * Validated parameters parsed from an IBC-transfer keysign memo.
+ *
+ * The memo grammar (see [com.vultisig.wallet.data.models.DepositMemo.TransferIbc]) is
+ * `dstChain:sourceChannel:dstAddress[:forwardMemo]`, and the timeout timestamp is the trailing
+ * `_`-separated segment of `latestBlock` (`"<block>_<timeout>"`).
+ */
+internal data class IbcTransferParams(
+    val sourceChannel: String,
+    val forwardMemo: String,
+    val timeoutTimestamp: Long,
+)
+
+/**
+ * Parses and validates an IBC-transfer memo/timeout, failing loudly instead of signing a malformed
+ * or never-expiring packet (issue #4849). Previously a missing source channel silently became `""`
+ * (a packet on no channel) and an unparseable timeout silently became `0L` (no effective timeout —
+ * an IBC packet with both timeout height and timestamp zero is invalid and hangs until manual
+ * refund).
+ */
+internal fun parseIbcTransferParams(memo: String?, latestBlock: String?): IbcTransferParams {
+    val memoParts = memo?.split(":") ?: error("To send IBC transaction, memo should be specified")
+
+    val sourceChannel = memoParts.getOrNull(1).orEmpty()
+    require(sourceChannel.isNotBlank()) {
+        "IBC transfer requires a source channel in the memo (dstChain:sourceChannel:dstAddress)"
+    }
+
+    // Forward memo is everything past the dstAddress; rejoin so a memo containing ':' survives.
+    val forwardMemo = if (memoParts.size > 3) memoParts.drop(3).joinToString(":") else ""
+
+    val timeoutTimestamp = latestBlock?.substringAfterLast('_')?.toLongOrNull() ?: 0L
+    require(timeoutTimestamp > 0L) {
+        "IBC transfer requires a non-zero timeout timestamp; latestBlock was missing or unparseable"
+    }
+
+    return IbcTransferParams(
+        sourceChannel = sourceChannel,
+        forwardMemo = forwardMemo,
+        timeoutTimestamp = timeoutTimestamp,
+    )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ParseIbcTransferParamsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ParseIbcTransferParamsTest.kt
@@ -1,0 +1,87 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+
+internal class ParseIbcTransferParamsTest {
+
+    private val validLatestBlock = "19000000_1714000000000000000"
+    private val timeout = 1714000000000000000L
+
+    @Test
+    fun `parses a 3-part memo with no forward memo`() {
+        val result =
+            parseIbcTransferParams(
+                memo = "cosmoshub:channel-141:osmo1dest",
+                latestBlock = validLatestBlock,
+            )
+
+        assertEquals("channel-141", result.sourceChannel)
+        assertEquals("", result.forwardMemo)
+        assertEquals(timeout, result.timeoutTimestamp)
+    }
+
+    @Test
+    fun `parses a 4-part memo with a forward memo`() {
+        val result =
+            parseIbcTransferParams(
+                memo = "cosmoshub:channel-141:osmo1dest:fwd",
+                latestBlock = validLatestBlock,
+            )
+
+        assertEquals("channel-141", result.sourceChannel)
+        assertEquals("fwd", result.forwardMemo)
+    }
+
+    @Test
+    fun `rejoins a forward memo that itself contains colons`() {
+        val result =
+            parseIbcTransferParams(
+                memo = "cosmoshub:channel-141:osmo1dest:wasm:contract:call",
+                latestBlock = validLatestBlock,
+            )
+
+        assertEquals("wasm:contract:call", result.forwardMemo)
+    }
+
+    @Test
+    fun `throws when the memo is null`() {
+        assertFailsWith<IllegalStateException> {
+            parseIbcTransferParams(memo = null, latestBlock = validLatestBlock)
+        }
+    }
+
+    @Test
+    fun `throws when the source channel is missing or blank`() {
+        assertFailsWith<IllegalArgumentException> {
+            parseIbcTransferParams(memo = "cosmoshub::osmo1dest", latestBlock = validLatestBlock)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            parseIbcTransferParams(memo = "cosmoshub", latestBlock = validLatestBlock)
+        }
+    }
+
+    @Test
+    fun `throws when latestBlock is null`() {
+        assertFailsWith<IllegalArgumentException> {
+            parseIbcTransferParams(memo = "cosmoshub:channel-141:osmo1dest", latestBlock = null)
+        }
+    }
+
+    @Test
+    fun `throws when the timeout is zero or unparseable`() {
+        assertFailsWith<IllegalArgumentException> {
+            parseIbcTransferParams(
+                memo = "cosmoshub:channel-141:osmo1dest",
+                latestBlock = "19000000_0",
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            parseIbcTransferParams(
+                memo = "cosmoshub:channel-141:osmo1dest",
+                latestBlock = "19000000_notanumber",
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #4849

## Problem
The IBC branch of `CosmosHelper.getPreSignedInputData()` parsed the keysign memo by **positional split with silent fallbacks**:

```kotlin
val sourceChannel = memoParts.getOrNull(1) ?: ""               // "" → packet on no channel
val memo = if (memoParts.size == 4) memoParts[3] else ""       // forward memo silently dropped
val timeout = timeouts.lastOrNull()?.toLongOrNull() ?: 0L      // 0L → no effective timeout
```

The memo grammar (`DepositMemo.TransferIbc`) is `dstChain:sourceChannel:dstAddress[:forwardMemo]`, and `sourceChannel` is `""` for unsupported chain pairs. So a malformed/unexpected memo silently signed a packet on **no channel**, and an unparseable `latestBlock` signed a **zero-timeout** packet — an IBC packet with both timeout height and timestamp zero is invalid and can hang until manual refund. None of these threw.

## Fix
Extract a pure, testable `parseIbcTransferParams(memo, latestBlock)` that fails loudly:
- `require` a non-blank `sourceChannel` (mirrors the existing guard in `QBTCTransactionHelper`),
- `require` a non-zero, parseable `timeoutTimestamp` instead of signing a no-timeout packet,
- rejoin the forward memo (`drop(3).joinToString(":")`) so a forward memo containing `:` survives instead of being silently dropped.

The valid path (well-formed 3/4-part memo + parseable `latestBlock`) is unchanged — only previously-malformed cases now error instead of broadcasting a bad packet. Extracting the parse to a pure function keeps it unit-testable without the Trust Wallet Core JNI used in the signing path.

## Test plan
- [x] New `ParseIbcTransferParamsTest` (7 cases): 3-part memo, 4-part memo, forward memo containing `:`, null memo, blank/missing channel, null `latestBlock`, zero/unparseable timeout
- [x] `:data:testDebugUnitTest` (new test) — green
- [x] ktfmt clean

Pure validation change (no UI), so no before/after screenshots apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling for IBC (Inter-Blockchain Communication) transfers to ensure memo parameters are correctly parsed with stricter enforcement of required fields and timeout values.

* **Tests**
  * Added comprehensive test coverage for IBC transfer parameter parsing, including validation of edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->