### PR TITLE
fix(solana): confirmed blockhash commitment + client-side rebroadcast loop

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -33,16 +33,21 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import timber.log.Timber
 
@@ -135,7 +140,11 @@ constructor(
             RpcPayload(
                 jsonrpc = "2.0",
                 method = "getLatestBlockhash",
-                params = buildJsonArray { addJsonObject { put("commitment", "finalized") } },
+                // `confirmed` is the standard commitment for sending: it tracks the tip closely,
+                // whereas `finalized` lags ~32 slots (~13s) behind and burns that much of the
+                // ~60-90s blockhash validity window before the keysign ceremony even starts
+                // (issue #4863).
+                params = buildJsonArray { addJsonObject { put("commitment", "confirmed") } },
                 id = 1,
             )
         val response = httpClient.post(rpcEndpoint) { setBody(payload) }
@@ -186,14 +195,38 @@ constructor(
                     params = buildJsonArray { add(tx) },
                     id = 1,
                 )
-            val response = httpClient.post(rpcEndpoint) { setBody(requestBody) }
-            val responseRawString = response.bodyAsText()
-            val result = response.bodyOrThrow<BroadcastTransactionRespJson>()
-            result.error?.let { error ->
-                Timber.tag("SolanaApiImp").d("Error broadcasting transaction: $responseRawString")
-                error(error["message"].toString())
+            repeat(BROADCAST_MAX_ATTEMPTS) { index ->
+                val attempt = index + 1
+                val response = httpClient.post(rpcEndpoint) { setBody(requestBody) }
+                val responseRawString = response.bodyAsText()
+                val result = response.bodyOrThrow<BroadcastTransactionRespJson>()
+                val error =
+                    result.error ?: return result.result ?: error("broadcastTransaction error")
+
+                val message = error["message"]?.jsonPrimitive?.contentOrNull ?: error.toString()
+                Timber.tag("SolanaApiImp")
+                    .d("Error broadcasting transaction: %s", responseRawString)
+
+                when (solanaBroadcastAction(message, attempt, BROADCAST_MAX_ATTEMPTS)) {
+                    // Propagation lag: the RPC node hasn't observed our confirmed blockhash yet.
+                    // Resending the same signed tx after a short backoff typically clears it.
+                    SolanaBroadcastAction.RESEND -> {
+                        Timber.tag("SolanaApiImp")
+                            .w(
+                                "Transient blockhash-not-found on broadcast attempt %d/%d; resending after backoff",
+                                attempt,
+                                BROADCAST_MAX_ATTEMPTS,
+                            )
+                        delay(BROADCAST_RETRY_BACKOFF)
+                    }
+                    // True expiry (or exhausted resends): the same tx can no longer land, so
+                    // surface it as expired. Re-signing with a fresh blockhash is a deferred
+                    // follow-up (needs a cross-device KeysignMessage proto change).
+                    SolanaBroadcastAction.EXPIRED -> throw SolanaBlockhashExpiredException(message)
+                    SolanaBroadcastAction.FATAL -> error(message)
+                }
             }
-            return result.result ?: error("broadcastTransaction error")
+            error("broadcastTransaction failed after $BROADCAST_MAX_ATTEMPTS attempts")
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.tag("SolanaApiImp").e("Error broadcasting transaction: ${e.message}")
@@ -414,5 +447,44 @@ constructor(
         // 100x the floor — caps priority fee at ~0.01 SOL per tx to prevent overpayment
         // during congestion spikes or compromised RPC proxy
         private const val MAX_PRIORITY_FEE_PRICE = 100_000_000L
+    }
+}
+
+/** Max times a signed Solana tx is (re)sent when the RPC node hasn't yet seen our blockhash. */
+private const val BROADCAST_MAX_ATTEMPTS = 3
+
+/** Backoff between rebroadcast attempts, giving the confirmed blockhash time to propagate. */
+private val BROADCAST_RETRY_BACKOFF: Duration = 2.seconds
+
+/** Thrown when a Solana broadcast fails because the blockhash has expired (issue #4863). */
+class SolanaBlockhashExpiredException(message: String) : Exception(message)
+
+/** What to do with a Solana `sendTransaction` RPC error on a given attempt. */
+internal enum class SolanaBroadcastAction {
+    /** Transient blockhash-not-found (propagation lag) with retries left — resend the same tx. */
+    RESEND,
+    /** Blockhash expired (height exceeded, or blockhash-not-found after exhausting retries). */
+    EXPIRED,
+    /** Any other RPC error — not recoverable by resending. */
+    FATAL,
+}
+
+/**
+ * Classifies a Solana `sendTransaction` error message into the action to take. `-32002` is Solana's
+ * generic preflight-failure code, not specific to expired blockhashes, so we match on the message
+ * text (mirrors vultisig-ios#4551).
+ */
+internal fun solanaBroadcastAction(
+    errorMessage: String,
+    attempt: Int,
+    maxAttempts: Int,
+): SolanaBroadcastAction {
+    val lowered = errorMessage.lowercase()
+    return when {
+        lowered.contains("blockhash not found") && attempt < maxAttempts ->
+            SolanaBroadcastAction.RESEND
+        lowered.contains("blockhash not found") || lowered.contains("block height exceeded") ->
+            SolanaBroadcastAction.EXPIRED
+        else -> SolanaBroadcastAction.FATAL
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 
 /**
@@ -90,6 +91,41 @@ class SolanaApiBodyReadTest {
         val result = api.broadcastTransaction("fakeTxBase64Encoded")
 
         assertEquals("5xFakeTransactionHashABCDE1234", result)
+    }
+
+    @Test
+    fun `broadcastTransaction surfaces an expired blockhash as SolanaBlockhashExpiredException`() =
+        runTest {
+            val body =
+                """
+                {
+                  "error": { "code": -32002, "message": "Transaction simulation failed: Block height exceeded" },
+                  "result": null
+                }
+                """
+                    .trimIndent()
+            val api = newApi(body)
+
+            val error = runCatching { api.broadcastTransaction("tx") }.exceptionOrNull()
+
+            assertInstanceOf(SolanaBlockhashExpiredException::class.java, error)
+        }
+
+    @Test
+    fun `broadcastTransaction rethrows a non-recoverable rpc error`() = runTest {
+        val body =
+            """
+            {
+              "error": { "code": -32002, "message": "Transaction simulation failed: insufficient funds for rent" },
+              "result": null
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        val error = runCatching { api.broadcastTransaction("tx") }.exceptionOrNull()
+
+        assertInstanceOf(IllegalStateException::class.java, error)
     }
 
     // ── getSPLTokensInfo2 ───────────────────────────────────────────────────────

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaBroadcastActionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaBroadcastActionTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.api
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SolanaBroadcastActionTest {
+
+    private val maxAttempts = 3
+
+    @Test
+    fun `blockhash not found with retries left resends`() {
+        assertEquals(
+            SolanaBroadcastAction.RESEND,
+            solanaBroadcastAction("Blockhash not found", attempt = 1, maxAttempts = maxAttempts),
+        )
+        assertEquals(
+            SolanaBroadcastAction.RESEND,
+            solanaBroadcastAction("Blockhash not found", attempt = 2, maxAttempts = maxAttempts),
+        )
+    }
+
+    @Test
+    fun `blockhash not found on the final attempt is treated as expired`() {
+        assertEquals(
+            SolanaBroadcastAction.EXPIRED,
+            solanaBroadcastAction("Blockhash not found", attempt = 3, maxAttempts = maxAttempts),
+        )
+    }
+
+    @Test
+    fun `block height exceeded is expired and never resent`() {
+        assertEquals(
+            SolanaBroadcastAction.EXPIRED,
+            solanaBroadcastAction(
+                "Transaction simulation failed: block height exceeded",
+                attempt = 1,
+                maxAttempts = maxAttempts,
+            ),
+        )
+    }
+
+    @Test
+    fun `other rpc errors are fatal`() {
+        assertEquals(
+            SolanaBroadcastAction.FATAL,
+            solanaBroadcastAction(
+                "Transaction simulation failed: insufficient funds for rent",
+                attempt = 1,
+                maxAttempts = maxAttempts,
+            ),
+        )
+    }
+
+    @Test
+    fun `matching is case insensitive`() {
+        assertEquals(
+            SolanaBroadcastAction.RESEND,
+            solanaBroadcastAction("BLOCKHASH NOT FOUND", attempt = 1, maxAttempts = maxAttempts),
+        )
+        assertEquals(
+            SolanaBroadcastAction.EXPIRED,
+            solanaBroadcastAction("BLOCK HEIGHT EXCEEDED", attempt = 1, maxAttempts = maxAttempts),
+        )
+    }
+}


### PR DESCRIPTION
Closes #4863

## Problem
Two avoidable Solana broadcast failure modes:

1. `getRecentBlockHash()` fetched the blockhash with the **`finalized`** commitment. `finalized` lags the tip by ~32 slots (~13s), burning that much of the ~60–90s blockhash validity window before the keysign ceremony even starts — so a slightly slow ceremony can broadcast against an already-near-expired blockhash.
2. `broadcastTransaction()` was **one-shot**: any RPC error threw immediately, including a transient `"blockhash not found"` that just means the RPC node we hit hasn't observed our (confirmed) blockhash yet (propagation lag).

## Fix (ports vultisig-ios#4551, items 1–2)
- Switch the blockhash commitment to **`confirmed`** — the standard for sending; it tracks the tip closely.
- Add a bounded **client-side rebroadcast loop** (3 attempts, 2s backoff):
  - `"blockhash not found"` with retries left → resend the same signed tx after a backoff.
  - `"block height exceeded"`, or an exhausted blockhash-not-found retry → throw `SolanaBlockhashExpiredException` (true expiry; resending can't help).
  - Any other RPC error → rethrown unchanged.
- The error classification is a pure, unit-tested `solanaBroadcastAction(message, attempt, maxAttempts)` returning `RESEND` / `EXPIRED` / `FATAL`. `-32002` is Solana's generic preflight code, so we match on the message text (same as iOS).

## Scope (matches iOS)
Threading `lastValidBlockHeight` for a precise expiry-bounded loop and having the ceremony **re-sign** with a fresh blockhash on expiry is deferred — it needs a cross-device `KeysignMessage` proto change (and Android has no re-sign hook today). The new `SolanaBlockhashExpiredException` is the typed signal that follow-up will consume.

## Test plan
- [x] `SolanaBroadcastActionTest` — classifier: resend-with-retries, exhausted→expired, height-exceeded→expired, generic→fatal, case-insensitivity
- [x] `SolanaApiBodyReadTest` — added end-to-end error paths: expired→`SolanaBlockhashExpiredException`, generic→`IllegalStateException`; existing success path still green
- [x] full `:data:testDebugUnitTest` — green
- [x] ktfmt clean
- [ ] Manual: Solana send + swap broadcast end-to-end (cannot mainnet-test from here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry mechanism for transaction broadcasting with exponential backoff between attempts
  * Enhanced error handling to classify network failures into recoverable and terminal error types
  * Added specific exception for blockhash expiration scenarios

* **Improvements**
  * Updated block confirmation strategy for faster transaction validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->