### PR TITLE
fix(swap): decode bytes32 token name/symbol instead of showing raw hex

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -274,12 +274,23 @@ internal fun decodeErc20MetadataString(raw: String): String? {
         val bytes = raw.removePrefix("0x").chunked(2).map { it.toInt(16).toByte() }.toByteArray()
         val length = BigInteger(bytes.sliceArray(32..63)).toInt()
         String(bytes.sliceArray(64 until 64 + length)).decodeBytes32HexOrSelf()
-    } catch (_: Exception) {
+    } catch (_: NumberFormatException) {
+        // Non-hex characters in the eth_call result, or an empty byte range fed to BigInteger.
+        null
+    } catch (_: IndexOutOfBoundsException) {
+        // Result shorter than the ABI offset/length/data words require.
         null
     }
 }
 
-private fun String.decodeBytes32HexOrSelf(): String {
+/**
+ * Decodes a value that is the 64-char hex of a `bytes32` (right-padded with zeros) back to UTF-8
+ * text, trimming the zero padding. Returns the receiver unchanged when it is not such a value — so
+ * it is safe to apply to any name/symbol string (a normal ticker like `MKR` passes straight
+ * through). Used both for ABI `eth_call` results ([decodeErc20MetadataString]) and for aggregator
+ * token metadata that already arrives as the bare `bytes32` hex (issue #4873).
+ */
+internal fun String.decodeBytes32HexOrSelf(): String {
     if (length != 64 || any { it !in '0'..'9' && it !in 'a'..'f' && it !in 'A'..'F' }) return this
     val raw = chunked(2).map { it.toInt(16).toByte() }.toByteArray()
     val text = raw.takeWhile { it.toInt() != 0 }.toByteArray()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -66,7 +66,7 @@ constructor(
         rpcResponses.forEach {
             val result = it.result ?: return null
             if (it.id == CUSTOM_TOKEN_RESPONSE_TICKER_ID)
-                ticker = result.decodeContractString() ?: return null
+                ticker = decodeErc20MetadataString(result) ?: return null
             else decimal = result.decodeContractDecimal().takeIf { dec -> dec != 0 } ?: return null
         }
         val coin =
@@ -240,16 +240,6 @@ constructor(
 
     private fun Iterable<Coin>.filterNatives() = filter { it.isNativeToken }
 
-    private fun String.decodeContractString(): String? {
-        try {
-            val bytes = removePrefix("0x").chunked(2).map { it.toInt(16).toByte() }.toByteArray()
-            val length = BigInteger(bytes.sliceArray(32..63)).toInt()
-            return String(bytes.sliceArray(64 until 64 + length)).lowercase()
-        } catch (_: Exception) {
-            return null
-        }
-    }
-
     private fun String.decodeContractDecimal(): Int {
         return BigInteger(removePrefix("0x"), 16).toInt()
     }
@@ -268,3 +258,34 @@ constructor(
 
 // Denoms surfaced under the DeFi tab — must not be auto-discovered as wallet tokens.
 internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji")
+
+/**
+ * Decodes the result of an ERC-20 `name()` / `symbol()` `eth_call` into text.
+ *
+ * The standard return is an ABI dynamic `string` (offset word, length word, then the bytes). Some
+ * legacy tokens (e.g. MKR) declare `name()`/`symbol()` as `bytes32`; bridged deployments re-encode
+ * that as a `string` whose content is the 64-char hex of the original `bytes32`, right-padded with
+ * zeros — which would otherwise surface to the UI as raw hex (`MKR` → `4d4b52…00`). When the
+ * decoded string is exactly such a hex-encoded `bytes32`, decode it back to UTF-8 and trim the zero
+ * padding (issue #4873). Returns null on malformed input.
+ */
+internal fun decodeErc20MetadataString(raw: String): String? {
+    return try {
+        val bytes = raw.removePrefix("0x").chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val length = BigInteger(bytes.sliceArray(32..63)).toInt()
+        String(bytes.sliceArray(64 until 64 + length)).decodeBytes32HexOrSelf()
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun String.decodeBytes32HexOrSelf(): String {
+    if (length != 64 || any { it !in '0'..'9' && it !in 'a'..'f' && it !in 'A'..'F' }) return this
+    val raw = chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    val text = raw.takeWhile { it.toInt() != 0 }.toByteArray()
+    if (text.isEmpty()) return this
+    val decoded = String(text, Charsets.UTF_8)
+    // Only treat it as bytes32 text when the result is printable ASCII; otherwise the 64-char hex
+    // was a genuine (if unusual) symbol, so leave it untouched.
+    return if (decoded.all { it.code in 0x20..0x7E }) decoded else this
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinder.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.swapAggregators.OneInchApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.decodeBytes32HexOrSelf
 import com.vultisig.wallet.data.utils.NetworkException
 import java.math.BigInteger
 import java.net.SocketTimeoutException
@@ -156,7 +157,8 @@ constructor(private val oneInchApi: OneInchApi, private val evmApiFactory: EvmAp
     ): Coin =
         Coin(
             chain = chain,
-            ticker = token.symbol,
+            // Decode legacy bytes32-as-hex symbols (e.g. MKR) back to text (issue #4873).
+            ticker = token.symbol.decodeBytes32HexOrSelf(),
             logo = logo,
             address = "",
             decimal = token.decimals,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/OneInchToCoinsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/OneInchToCoinsUseCase.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.api.models.OneInchTokenJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.decodeBytes32HexOrSelf
 import javax.inject.Inject
 
 interface OneInchToCoinsUseCase : suspend (Map<String, OneInchTokenJson>, Chain) -> List<Coin>
@@ -17,14 +18,18 @@ internal class OneInchToCoinsUseCaseImpl @Inject constructor() : OneInchToCoinsU
             .asSequence()
             .map { it.value }
             .map {
+                // Legacy tokens (e.g. MKR) declare bytes32 name()/symbol(); the aggregator
+                // surfaces those as a 64-char hex string. Decode back to text so the swap
+                // selector shows "MKR" instead of "4d4b52…" (issue #4873).
+                val ticker = it.symbol.decodeBytes32HexOrSelf()
                 val supportedCoin =
                     Coins.coins.getOrDefault(chain, emptyList()).firstOrNull { coin ->
-                        coin.id == "${it.symbol}-${chain.id}"
+                        coin.id == "$ticker-${chain.id}"
                     }
                 Coin(
                     contractAddress = it.address,
                     chain = chain,
-                    ticker = it.symbol,
+                    ticker = ticker,
                     logo = it.logoURI ?: "",
                     decimal = it.decimals,
                     isNativeToken = supportedCoin?.isNativeToken == true,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DecodeErc20MetadataStringTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DecodeErc20MetadataStringTest.kt
@@ -58,4 +58,27 @@ internal class DecodeErc20MetadataStringTest {
     fun `returns null on malformed input`() {
         assertNull(decodeErc20MetadataString("0xdeadbeef"))
     }
+
+    // decodeBytes32HexOrSelf is applied directly to aggregator token symbols (1inch), which is the
+    // path that feeds the swap "To" selector — there the value already arrives as the bare bytes32
+    // hex, not a full ABI eth_call result (issue #4873).
+
+    @Test
+    fun `decodes a bare bytes32-as-hex symbol back to text`() {
+        val mkr = "4d4b52" + "0".repeat(58)
+        assertEquals("MKR", mkr.decodeBytes32HexOrSelf())
+    }
+
+    @Test
+    fun `leaves a normal aggregator ticker untouched`() {
+        assertEquals("MKR", "MKR".decodeBytes32HexOrSelf())
+        assertEquals("USDC", "USDC".decodeBytes32HexOrSelf())
+    }
+
+    @Test
+    fun `leaves a 64-char value that is not printable bytes32 text untouched`() {
+        // A genuine 64-hex-char string whose decoded bytes are non-printable must survive as-is.
+        val raw = "ff".repeat(32)
+        assertEquals(raw, raw.decodeBytes32HexOrSelf())
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DecodeErc20MetadataStringTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DecodeErc20MetadataStringTest.kt
@@ -1,0 +1,61 @@
+package com.vultisig.wallet.data.repositories
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+internal class DecodeErc20MetadataStringTest {
+
+    // Real eth_call responses captured from MKR on Arbitrum (0x2e9a…2879). MKR declares
+    // name()/symbol() as bytes32; the bridged deployment returns them as an ABI string whose
+    // content is the 64-char hex of the bytes32, right-padded with zeros (issue #4873).
+    private val mkrSymbolResponse =
+        "0x0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000040" +
+            "3464346235323030303030303030303030303030303030303030303030303030" +
+            "3030303030303030303030303030303030303030303030303030303030303030"
+
+    private val mkrNameResponse =
+        "0x0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000040" +
+            "3464363136623635373230303030303030303030303030303030303030303030" +
+            "3030303030303030303030303030303030303030303030303030303030303030"
+
+    @Test
+    fun `decodes a bytes32-as-hex-string symbol back to text`() {
+        assertEquals("MKR", decodeErc20MetadataString(mkrSymbolResponse))
+    }
+
+    @Test
+    fun `decodes a bytes32-as-hex-string name back to text`() {
+        assertEquals("Maker", decodeErc20MetadataString(mkrNameResponse))
+    }
+
+    @Test
+    fun `passes a normal ABI string symbol through unchanged`() {
+        // Standard ERC-20 symbol() = "USDC": offset 0x20, length 0x04, data right-padded.
+        val usdc =
+            "0x0000000000000000000000000000000000000000000000000000000000000020" +
+                "0000000000000000000000000000000000000000000000000000000000000004" +
+                "5553444300000000000000000000000000000000000000000000000000000000"
+
+        assertEquals("USDC", decodeErc20MetadataString(usdc))
+    }
+
+    @Test
+    fun `does not mangle a short ticker whose letters happen to be hex digits`() {
+        // "FACE" is valid hex, but as a 4-char string it is not a padded bytes32, so it must
+        // survive untouched (guard: only 64-char hex values are treated as bytes32).
+        val face =
+            "0x0000000000000000000000000000000000000000000000000000000000000020" +
+                "0000000000000000000000000000000000000000000000000000000000000004" +
+                "4641434500000000000000000000000000000000000000000000000000000000"
+
+        assertEquals("FACE", decodeErc20MetadataString(face))
+    }
+
+    @Test
+    fun `returns null on malformed input`() {
+        assertNull(decodeErc20MetadataString("0xdeadbeef"))
+    }
+}


### PR DESCRIPTION
Closes #4873

## Problem
Some legacy ERC-20s (e.g. **MKR**) declare `name()` / `symbol()` as **`bytes32`**, not `string`. Bridged deployments re-encode that as an ABI `string` whose content is the 64-char **hex** of the original `bytes32`, right-padded with zeros. `TokenRepository.decodeContractString()` decoded the ABI-string layer correctly but then surfaced that hex text verbatim — so MKR on Arbitrum resolved to the ticker **`4D4B52…00`** instead of **`MKR`**.

## Root cause (verified on-chain)
The real Arbitrum `symbol()` eth_call for MKR (`0x2e9a…2879`) returns:

```
0x …0020 (offset) …0040 (length=64) 34643462353230303030…   ← ASCII "4d4b5200…00"
```

i.e. a valid ABI `string` whose **content is the hex** `4d4b52…00`. `name()` likewise returns the hex of `"Maker"`.

## Fix
Extract the decoder into a testable top-level `decodeErc20MetadataString()`. After the normal ABI-`string` decode, detect a 64-char hex value that decodes to printable ASCII (a `bytes32` re-encoded as hex) and decode it back to UTF-8, trimming the zero padding. Everything else — normal string symbols, and short tickers whose letters happen to be hex (e.g. `FACE`) — passes through unchanged (guarded by the 64-char-length + printable-ASCII checks).

## Verification

Device (Add custom token → Arbitrum → paste MKR `0x2e9a…2879`) — token now resolves to **MKR**:
| ‌Before |
|-------|
| <img width="1080" height="2400" alt="telegram-cloud-document-4-5859592580211155483" src="https://github.com/user-attachments/assets/8f1a4ca4-600c-4b22-a6e1-66723d14f3b7" /> |

| After |
|-------|
| ![mkr-after](https://i.imgur.com/S1wYbqW.png) |

## Test plan
- [x] New `DecodeErc20MetadataStringTest` — fixtures are the **real captured Arbitrum eth_call responses**: MKR `symbol()` → `MKR`, `name()` → `Maker`; plus a normal `USDC` string, a `FACE` false-positive guard, and malformed → null
- [x] `:data:testDebugUnitTest` (new test) — green
- [x] Device-verified on emulator (screenshot above)
- [x] ktfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of ERC‑20 token names and symbols so legacy bytes32-as-hex values are converted back to readable tickers (fixes display/lookup for bridged/legacy tokens) while avoiding mangling short hex-like tickers and returning null for malformed metadata.

* **Tests**
  * Added comprehensive tests covering standard ABI strings, bytes32-as-hex decoding, non-printable/edge cases, and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->