### PR TITLE
fix: replace dead Hyperliquid explorer liquidscan.io with hypurrscan.io

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -143,7 +143,7 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
                 Chain.Cardano -> "https://cardanoscan.io/"
                 Chain.Mantle -> "https://mantlescan.xyz/"
                 Chain.Sei -> "https://seiscan.io/"
-                Chain.Hyperliquid -> "https://liquidscan.io/"
+                Chain.Hyperliquid -> "https://hypurrscan.io/"
                 Chain.Qbtc -> "" // no public explorer yet
             }
 }


### PR DESCRIPTION
## Summary
- `liquidscan.io` (Hyperliquid explorer) is dead — DNS no longer resolves, so Hyperliquid tx/address explorer links 404 at the network level
- Replace base URL with `hypurrscan.io`; Hyperliquid uses the default `${explorerUrl}tx/` / `${explorerUrl}address/` composition, so the base swap is sufficient

## Changes
| File | Change |
|------|--------|
| `data/.../repositories/ExplorerLinkRepository.kt` | `Chain.Hyperliquid` explorer base → `https://hypurrscan.io/` |

## Context
Closes #4888. Dead link example: https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF → working replacement: https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF

## Test plan
- [x] ktfmt dry-run: no new formatting issues introduced (file's drift is pre-existing on main)
- [x] Old/new explorer reachability verified via curl (see receipts)
- [ ] Tap explorer link from a Hyperliquid tx on device

## receipts
```bash
$ curl -sS -o /dev/null -w "%{http_code}\n" "https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
curl: (6) Could not resolve host: liquidscan.io

$ curl -sS -o /dev/null -w "address: %{http_code}\n" -L "https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
address: 200
```
URL-constant-only change; no logic touched.

Generated with [Claude Code](https://claude.com/claude-code)