### PR TITLE
fix(swap): price tokens via contract address when priceProviderID misses

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -126,6 +126,21 @@ constructor(
 
         savePrices(pricesWithProviderIds, currency)
 
+        // Fall back to the contract-address lookup for tokens whose priceProviderID returned no
+        // price but which have a valid contract address (e.g. ezETH on Base, whose priceProviderID
+        // is not a CoinGecko-recognized id). Without this, such tokens would never be priced.
+        val pricedTokenIds = pricesWithProviderIds.keys
+        tokens.forEach { token ->
+            if (
+                token.priceProviderID.isNotEmpty() &&
+                    token.contractAddress.isNotEmpty() &&
+                    token.id !in pricedTokenIds
+            ) {
+                val existingChain = chainContractAddresses.getOrPut(token.chain) { mutableListOf() }
+                chainContractAddresses[token.chain] = existingChain + token
+            }
+        }
+
         chainContractAddresses.map { (chain, tokens) ->
             val pricesWithContractAddress =
                 fetchPricesWithContractAddress(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenId
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -78,7 +79,6 @@ constructor(
         val currencies = listOf(currency)
 
         val tokensByPriceProviderIds = tokens.groupBy { it.priceProviderID.lowercase() }
-        val tokensByContractAddress = tokens.associateBy { it.contractAddress.lowercase() }
 
         val priceProviderIds = mutableListOf<String>()
         val chainContractAddresses = mutableMapOf<Chain, List<Coin>>()
@@ -126,13 +126,16 @@ constructor(
 
         savePrices(pricesWithProviderIds, currency)
 
-        // Fall back to the contract-address lookup for tokens whose priceProviderID returned no
+        // Fall back to the contract-address lookup for EVM tokens whose priceProviderID returned no
         // price but which have a valid contract address (e.g. ezETH on Base, whose priceProviderID
         // is not a CoinGecko-recognized id). Without this, such tokens would never be priced.
+        // Restricted to EVM so non-EVM contract formats (e.g. THORChain x/… tokens handled by
+        // fetchThorContractPrices) aren't fanned out to CoinGecko/LI.FI per-contract calls.
         val pricedTokenIds = pricesWithProviderIds.keys
         tokens.forEach { token ->
             if (
-                token.priceProviderID.isNotEmpty() &&
+                token.chain.standard == TokenStandard.EVM &&
+                    token.priceProviderID.isNotEmpty() &&
                     token.contractAddress.isNotEmpty() &&
                     token.id !in pricedTokenIds
             ) {
@@ -142,6 +145,11 @@ constructor(
         }
 
         chainContractAddresses.map { (chain, tokens) ->
+            // Resolve ids from this chain's tokens only: the same contractAddress can exist on
+            // multiple chains (e.g. ezETH on Arbitrum, Base and Optimism), so a global
+            // address->token map would collapse them onto a single id and leave the rest at $0.00.
+            val tokenIdsByContractAddress =
+                tokens.associate { it.contractAddress.lowercase() to it.id }
             val pricesWithContractAddress =
                 fetchPricesWithContractAddress(
                         chain = chain,
@@ -150,7 +158,7 @@ constructor(
                     )
                     .asSequence()
                     .mapNotNull { (contractAddress, value) ->
-                        val tokenId = tokensByContractAddress[contractAddress.lowercase()]?.id
+                        val tokenId = tokenIdsByContractAddress[contractAddress.lowercase()]
                         if (
                             tokenId != null &&
                                 value.filter { it.value != BigDecimal.ZERO }.isNotEmpty()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -1,0 +1,105 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.CoinGeckoApi
+import com.vultisig.wallet.data.api.LiQuestApi
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.db.dao.TokenPriceDao
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class TokenPriceRepositoryImplTest {
+
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var coinGeckoApi: CoinGeckoApi
+    private lateinit var liQuestApi: LiQuestApi
+    private lateinit var thorApi: ThorChainApi
+    private lateinit var mayaApi: MayaChainApi
+    private lateinit var tokenPriceDao: TokenPriceDao
+    private lateinit var repository: TokenPriceRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        appCurrencyRepository = mockk()
+        coinGeckoApi = mockk()
+        liQuestApi = mockk()
+        thorApi = mockk()
+        mayaApi = mockk()
+        tokenPriceDao = mockk(relaxed = true)
+
+        coEvery { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        // No thor/maya tokens in these tests, so pool fetches are not exercised.
+
+        repository =
+            TokenPriceRepositoryImpl(
+                appCurrencyRepository = appCurrencyRepository,
+                coinGeckoApi = coinGeckoApi,
+                liQuestApi = liQuestApi,
+                thorApi = thorApi,
+                mayaApi = mayaApi,
+                tokenPriceDao = tokenPriceDao,
+            )
+    }
+
+    private val ezEth =
+        Coin(
+            chain = Chain.Base,
+            ticker = "ezETH",
+            logo = "ezeth",
+            address = "",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ezETH",
+            contractAddress = "0x2416092f143378750bb29b79eD961ab195CcEea5",
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `falls back to contract-address lookup when priceProviderID returns no price`() = runTest {
+        // CoinGecko does not recognize the "ezETH" id, so the provider-id lookup is empty.
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        // The contract-address lookup returns a valid price.
+        coEvery { coinGeckoApi.getContractsPrice(eq(Chain.Base), any(), any()) } returns
+            mapOf(ezEth.contractAddress to mapOf("usd" to BigDecimal("3500.0")))
+
+        repository.refresh(listOf(ezEth))
+
+        // The contract-address fallback must have been attempted for ezETH's contract.
+        coVerify {
+            coinGeckoApi.getContractsPrice(
+                Chain.Base,
+                match { it.contains(ezEth.contractAddress) },
+                any(),
+            )
+        }
+
+        val price = repository.getPrice(ezEth, AppCurrency.USD).first()
+        assertEquals(BigDecimal("3500.0"), price)
+    }
+
+    @Test
+    fun `does not call contract-address lookup when priceProviderID returns a price`() = runTest {
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns
+            mapOf("ezETH" to mapOf("usd" to BigDecimal("3400.0")))
+
+        repository.refresh(listOf(ezEth))
+
+        coVerify(exactly = 0) { coinGeckoApi.getContractsPrice(any(), any(), any()) }
+
+        val price = repository.getPrice(ezEth, AppCurrency.USD).first()
+        assertEquals(BigDecimal("3400.0"), price)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4874 — in the Swap flow, the destination token showed a fiat value of **$0.00** despite a non-zero amount (reproduced swapping ETH → ezETH on Base).

### Tranaction hash
https://basescan.org/tx/0x1a484b0fc706cf6741f359661494df60db18746e9275f4ef50b9ecbd9640b5a8

**Root cause:** `TokenPriceRepository.refresh()` routed any token with a non-empty `priceProviderID` to the CoinGecko `/simple/price?ids=...` lookup and never to the contract-address lookup — the two branches were mutually exclusive. `ezETH` is defined with `priceProviderID = "ezETH"` (not a CoinGecko-recognized id) **and** a valid Base `contractAddress`, so the provider-id lookup returned nothing and the contract-address path — which does return a price (CoinGecko, with a LI.FI fallback) — was never reached. No price was cached, so `convertTokenValueToFiat` yielded `$0.00`.

**Fix:** After the provider-id lookup completes, any token that has a `contractAddress` but didn't get a price from its `priceProviderID` now falls back to the contract-address lookup. This is generic — it covers ezETH and any other token with an unrecognized `priceProviderID` but a valid contract.

## Changes

- `TokenPriceRepository.refresh()`: add contract-address fallback for tokens whose `priceProviderID` returned no price.
- Add `TokenPriceRepositoryImplTest` covering both the fallback and the no-regression case.

## Test plan

- `./gradlew :data:testDebugUnitTest --tests "*.TokenPriceRepositoryImplTest"` — passes:
  - Falls back to contract-address lookup when `priceProviderID` returns no price → price cached.
  - Does **not** call the contract-address lookup when `priceProviderID` succeeds (no extra network call for working tokens).
- Verified in the running app: destination ezETH now shows a non-zero fiat value.

## After

| Swap screen (ETH → ezETH on Base) |
|---|
| <img width="530" height="328" alt="image" src="https://github.com/user-attachments/assets/dd08709c-189c-4f61-91eb-eb2957a3db51" /> |

ezETH destination now shows `$1.28` (was `$0.00`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token price refresh by adding an EVM-specific fallback to ensure tokens are priced via contract-address lookup when provider-id pricing is missing.

* **Tests**
  * Added unit tests covering both fallback and non-fallback behaviors for token price retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->