### PR TITLE
fix(swap): clamp inflated destination fiat to source fiat (#4878)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
+import com.vultisig.wallet.ui.models.swap.clampDstFiatToSrcFiat
 import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
@@ -63,6 +64,16 @@ constructor(
 
         val quotesFeesFiat = convertTokenValueToFiat(tokenValue, from.estimatedFees, currency)
 
+        // SwapTransaction carries no destination fiat, so it is recomputed here for the verify and
+        // keysign screens. Apply the same value-preserving clamp the swap form uses (#4878) so an
+        // illiquid token's inflated market mark can't reappear on the screens the user signs from.
+        val srcFiat = convertTokenValueToFiat(from.srcToken, from.srcTokenValue, currency)
+        val dstFiat =
+            clampDstFiatToSrcFiat(
+                srcFiat,
+                convertTokenValueToFiat(from.dstToken, from.expectedDstTokenValue, currency),
+            )
+
         // Display-only label. `provider` below stays the canonical id (the behavioral key that
         // gates SwapKit `/track` settlement); SwapKit collapses every sub-provider onto the
         // canonical `"SwapKit"` id, so render the persisted sub-provider (Chainflip / NEAR /
@@ -87,23 +98,13 @@ constructor(
                 ValuedToken(
                     value = mapTokenValueToDecimalUiString(from.srcTokenValue),
                     token = from.srcToken,
-                    fiatValue =
-                        fiatValueToStringMapper(
-                            convertTokenValueToFiat(from.srcToken, from.srcTokenValue, currency)
-                        ),
+                    fiatValue = fiatValueToStringMapper(srcFiat),
                 ),
             dst =
                 ValuedToken(
                     value = mapTokenValueToDecimalUiString(from.expectedDstTokenValue),
                     token = from.dstToken,
-                    fiatValue =
-                        fiatValueToStringMapper(
-                            convertTokenValueToFiat(
-                                from.dstToken,
-                                from.expectedDstTokenValue,
-                                currency,
-                            )
-                        ),
+                    fiatValue = fiatValueToStringMapper(dstFiat),
                 ),
             hasConsentAllowance = from.isApprovalRequired,
             providerFee =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapDestinationFiat.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapDestinationFiat.kt
@@ -1,0 +1,26 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.models.FiatValue
+import java.math.BigDecimal
+
+/**
+ * Clamps a destination fiat figure to the source fiat for a value-preserving swap (#4878).
+ *
+ * Destination fiat is derived from the destination token's independent market price (e.g.
+ * CoinGecko). For illiquid tokens that mark diverges from the DEX pool rate the quote actually
+ * executes at, inflating the destination above the source — a swap can never yield more fiat than
+ * you put in. So when the market value exceeds the source, fall back to the source value. Genuine
+ * price impact / fees that push the destination *below* the source are real and pass through
+ * unchanged. A non-positive source fiat (cold price) disables the clamp so the destination isn't
+ * zeroed out.
+ *
+ * Applied everywhere the destination fiat is displayed — the swap form, plus the verify and keysign
+ * screens the user signs from (via
+ * [com.vultisig.wallet.ui.models.mappers.SwapTransactionToUiModelMapper]).
+ */
+internal fun clampDstFiatToSrcFiat(srcFiat: FiatValue, marketDstFiat: FiatValue): FiatValue =
+    if (srcFiat.value > BigDecimal.ZERO && marketDstFiat.value > srcFiat.value) {
+        FiatValue(value = srcFiat.value, currency = marketDstFiat.currency)
+    } else {
+        marketDstFiat
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -51,7 +51,9 @@ internal data class QuoteFetchResult(
     val providerUiText: UiText,
     val srcFiatValueText: String,
     val estimatedDstTokenValue: String,
+    // Displayed destination fiat: market value clamped to the source fiat (#4878).
     val estimatedDstFiatValue: String,
+    // Unclamped market value (dstAmount × dstMarketPrice) used only for cross-provider ranking.
     val estimatedDstFiat: FiatValue,
     val feeText: String,
     val swapFeeFiat: FiatValue,
@@ -290,8 +292,25 @@ constructor(
 
         val fiatFees = convertTokenValueToFiat(feeCoin, quote.fees, currency)
         val estimatedDstTokenValue = mapTokenValueToDecimalUiString(quote.expectedDstValue)
+
+        // `expectedDstValue × dstMarketPrice` values the destination at an independent oracle
+        // (e.g. CoinGecko), which for illiquid tokens diverges from the DEX pool rate the quote
+        // actually executes at — inflating the destination fiat above the source (#4878). A swap
+        // is value-preserving, so you can never receive more fiat than you put in; clamp the
+        // *displayed* destination fiat to the source fiat so it reflects the quoted rate. Genuine
+        // price impact / fees that push the destination below the source are real and pass through
+        // unclamped. The unclamped market value is still used for cross-provider ranking below,
+        // where it scales with the destination amount and stays comparable across providers.
+        val marketDstFiatValue = convertTokenValueToFiat(dstToken, quote.expectedDstValue, currency)
         val estimatedDstFiatValue =
-            convertTokenValueToFiat(dstToken, quote.expectedDstValue, currency)
+            if (
+                srcFiatValue.value > BigDecimal.ZERO &&
+                    marketDstFiatValue.value > srcFiatValue.value
+            ) {
+                FiatValue(value = srcFiatValue.value, currency = marketDstFiatValue.currency)
+            } else {
+                marketDstFiatValue
+            }
 
         val rawFees =
             when (quote) {
@@ -350,7 +369,7 @@ constructor(
             srcFiatValueText = srcFiatValueText,
             estimatedDstTokenValue = estimatedDstTokenValue,
             estimatedDstFiatValue = fiatValueToString(estimatedDstFiatValue),
-            estimatedDstFiat = estimatedDstFiatValue,
+            estimatedDstFiat = marketDstFiatValue,
             feeText = resolvedFeeText,
             swapFeeFiat = resolvedSwapFeeFiat,
             outboundFeeText = outboundFeeText,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -295,22 +295,13 @@ constructor(
 
         // `expectedDstValue × dstMarketPrice` values the destination at an independent oracle
         // (e.g. CoinGecko), which for illiquid tokens diverges from the DEX pool rate the quote
-        // actually executes at — inflating the destination fiat above the source (#4878). A swap
-        // is value-preserving, so you can never receive more fiat than you put in; clamp the
-        // *displayed* destination fiat to the source fiat so it reflects the quoted rate. Genuine
-        // price impact / fees that push the destination below the source are real and pass through
-        // unclamped. The unclamped market value is still used for cross-provider ranking below,
-        // where it scales with the destination amount and stays comparable across providers.
+        // actually executes at — inflating the destination fiat above the source (#4878). Clamp the
+        // *displayed* destination fiat to the source fiat so it reflects the quoted rate (see
+        // [clampDstFiatToSrcFiat]). The unclamped market value is still used for cross-provider
+        // ranking below, where it scales with the destination amount and stays comparable across
+        // providers.
         val marketDstFiatValue = convertTokenValueToFiat(dstToken, quote.expectedDstValue, currency)
-        val estimatedDstFiatValue =
-            if (
-                srcFiatValue.value > BigDecimal.ZERO &&
-                    marketDstFiatValue.value > srcFiatValue.value
-            ) {
-                FiatValue(value = srcFiatValue.value, currency = marketDstFiatValue.currency)
-            } else {
-                marketDstFiatValue
-            }
+        val estimatedDstFiatValue = clampDstFiatToSrcFiat(srcFiatValue, marketDstFiatValue)
 
         val rawFees =
             when (quote) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFiatClampTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFiatClampTest.kt
@@ -1,0 +1,158 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The verify and keysign screens build their display off [SwapTransactionToUiModelMapper], which
+ * recomputes the destination fiat from [SwapTransaction.expectedDstTokenValue] (the model carries
+ * no fiat). Without the value-preserving clamp (#4878) an illiquid token's inflated market mark
+ * would reappear on the very screens the user signs from, even though the swap form clamps it.
+ */
+internal class SwapTransactionToUiModelMapperFiatClampTest {
+
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper =
+        mockk(relaxed = true)
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk()
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk()
+    private val appCurrencyRepository: AppCurrencyRepository = mockk()
+    private val tokenRepository: TokenRepository = mockk()
+
+    private fun mapper() =
+        SwapTransactionToUiModelMapperImpl(
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            appCurrencyRepository = appCurrencyRepository,
+            tokenRepository = tokenRepository,
+        )
+
+    @Test
+    fun `clamps an inflated destination fiat to the source fiat`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { tokenRepository.getNativeToken(any()) } returns trx
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        // Accurate source ($5.26) vs an inflated independent dst mark ($13.18).
+        coEvery { convertTokenValueToFiat(trx, srcValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("5.26"), "USD")
+        coEvery { convertTokenValueToFiat(xrp, dstValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("13.18"), "USD")
+
+        val uiModel = mapper().invoke(transaction())
+
+        uiModel.src.fiatValue shouldBe "5.26"
+        // Destination clamps down to the source rather than showing the inflated $13.18.
+        uiModel.dst.fiatValue shouldBe "5.26"
+    }
+
+    @Test
+    fun `keeps a destination fiat that is below the source fiat`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { tokenRepository.getNativeToken(any()) } returns trx
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        coEvery { convertTokenValueToFiat(trx, srcValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("100"), "USD")
+        coEvery { convertTokenValueToFiat(xrp, dstValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("95"), "USD")
+
+        val uiModel = mapper().invoke(transaction())
+
+        uiModel.src.fiatValue shouldBe "100"
+        // Real price impact / fees pass through unclamped.
+        uiModel.dst.fiatValue shouldBe "95"
+    }
+
+    private fun transaction(): RegularSwapTransaction =
+        RegularSwapTransaction(
+            id = "tx-1",
+            vaultId = "vault-1",
+            srcToken = trx,
+            srcTokenValue = srcValue,
+            dstToken = xrp,
+            dstAddress = "rDest",
+            expectedDstTokenValue = dstValue,
+            blockChainSpecific = mockk<BlockChainSpecificAndUtxo>(relaxed = true),
+            estimatedFees = srcValue,
+            gasFees = srcValue,
+            memo = null,
+            payload =
+                SwapPayload.SwapKit(
+                    SwapKitSwapPayloadJson(
+                        fromCoin = trx,
+                        toCoin = xrp,
+                        fromAmount = BigInteger.TEN,
+                        toAmountDecimal = BigDecimal.ONE,
+                        txType = SwapKitSwapPayloadJson.TX_TYPE_TRON,
+                        txPayload = ByteArray(0),
+                        targetAddress = "rDest",
+                        subProvider = "",
+                        swapId = "swap-123",
+                    )
+                ),
+            isApprovalRequired = false,
+            gasFeeFiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+        )
+
+    private companion object {
+        val trx =
+            Coin(
+                chain = Chain.Tron,
+                ticker = "TRX",
+                logo = "trx",
+                address = "Towner",
+                decimal = 6,
+                hexPublicKey = "hex",
+                priceProviderID = "tron",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val xrp =
+            Coin(
+                chain = Chain.Ripple,
+                ticker = "XRP",
+                logo = "xrp",
+                address = "rOwner",
+                decimal = 6,
+                hexPublicKey = "hex",
+                priceProviderID = "ripple",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val srcValue = TokenValue(value = BigInteger.TEN, token = trx)
+        val dstValue = TokenValue(value = BigInteger.ONE, token = xrp)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -299,6 +299,116 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchQuote clamps an inflated destination fiat to the source fiat`() = runTest {
+        // ETH -> BINU on Base (#4878): the destination's CoinGecko mark ($13.18) is ~2.5x the rate
+        // the quote actually executes at, while the source ETH is valued accurately ($5.26). A swap
+        // is value-preserving, so the displayed destination fiat must clamp down to the source fiat
+        // rather than imply a free lunch. The unclamped market value still drives cross-provider
+        // ranking.
+        val eth = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
+        val binu = coin(Chain.Base, "BINU", "0xdst", 18)
+        val srcTokenValue = TokenValue(BigInteger.valueOf(3_174_080_000_000_000L), eth)
+        val dstValue = TokenValue(BigInteger.valueOf(35_900_000L), binu)
+        val quote =
+            SwapQuote.SwapKit(
+                expectedDstValue = dstValue,
+                fees = TokenValue(BigInteger.ZERO, eth),
+                expiredAt = Clock.System.now().plus(5.minutes),
+                data = mockk(relaxed = true),
+                subProvider = null,
+            )
+
+        coEvery { tokenRepository.getNativeToken(any()) } returns eth
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) } returns
+            SwapQuoteResult.Native(quote)
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        coEvery { convertTokenValueToFiat(eth, srcTokenValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("5.26"), "USD")
+        coEvery { convertTokenValueToFiat(binu, dstValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("13.18"), "USD")
+        every { mapTokenValueToDecimalUiString(any()) } returns "35900000"
+        coEvery { fiatValueToString(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+
+        val result =
+            createManager()
+                .fetchQuote(
+                    SwapProvider.SWAPKIT,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    eth,
+                    binu,
+                    BigInteger.ONE,
+                    srcTokenValue,
+                    AppCurrency.USD,
+                    null,
+                    null,
+                    BigDecimal.ONE,
+                )
+
+        // Displayed destination fiat clamps to the source fiat, not the inflated $13.18 mark.
+        assertEquals("5.26", result.estimatedDstFiatValue)
+        // Ranking still sees the unclamped market value.
+        assertEquals(BigDecimal("13.18"), result.estimatedDstFiat.value)
+    }
+
+    @Test
+    fun `fetchQuote keeps a destination fiat that is below the source fiat`() = runTest {
+        // Real price impact / fees legitimately make the destination worth less than the source.
+        // That divergence is honest, so it must pass through unclamped instead of being inflated
+        // back up to the source fiat.
+        val eth = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
+        val usdc = coin(Chain.Base, "USDC", "0xdst", 6)
+        val srcTokenValue = TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), eth)
+        val dstValue = TokenValue(BigInteger.valueOf(95_000_000L), usdc)
+        val quote =
+            SwapQuote.SwapKit(
+                expectedDstValue = dstValue,
+                fees = TokenValue(BigInteger.ZERO, eth),
+                expiredAt = Clock.System.now().plus(5.minutes),
+                data = mockk(relaxed = true),
+                subProvider = null,
+            )
+
+        coEvery { tokenRepository.getNativeToken(any()) } returns eth
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) } returns
+            SwapQuoteResult.Native(quote)
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        coEvery { convertTokenValueToFiat(eth, srcTokenValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("100"), "USD")
+        coEvery { convertTokenValueToFiat(usdc, dstValue, AppCurrency.USD) } returns
+            FiatValue(BigDecimal("95"), "USD")
+        every { mapTokenValueToDecimalUiString(any()) } returns "95"
+        coEvery { fiatValueToString(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+
+        val result =
+            createManager()
+                .fetchQuote(
+                    SwapProvider.SWAPKIT,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    eth,
+                    usdc,
+                    BigInteger.ONE,
+                    srcTokenValue,
+                    AppCurrency.USD,
+                    null,
+                    null,
+                    BigDecimal.ONE,
+                )
+
+        assertEquals("95", result.estimatedDstFiatValue)
+        assertEquals(BigDecimal("95"), result.estimatedDstFiat.value)
+    }
+
+    @Test
     fun `fetchBestQuote prefers higher-priority provider on a near-tie within the 1pct band`() =
         runTest {
             // THORChain (priority 0) prices the dst slightly lower than SwapKit (priority 2), but

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.data.usecases.SearchTokenUseCase
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.utils.UiText
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -350,9 +351,9 @@ internal class SwapQuoteManagerTest {
                 )
 
         // Displayed destination fiat clamps to the source fiat, not the inflated $13.18 mark.
-        assertEquals("5.26", result.estimatedDstFiatValue)
+        result.estimatedDstFiatValue shouldBe "5.26"
         // Ranking still sees the unclamped market value.
-        assertEquals(BigDecimal("13.18"), result.estimatedDstFiat.value)
+        result.estimatedDstFiat.value shouldBe BigDecimal("13.18")
     }
 
     @Test
@@ -404,8 +405,8 @@ internal class SwapQuoteManagerTest {
                     BigDecimal.ONE,
                 )
 
-        assertEquals("95", result.estimatedDstFiatValue)
-        assertEquals(BigDecimal("95"), result.estimatedDstFiat.value)
+        result.estimatedDstFiatValue shouldBe "95"
+        result.estimatedDstFiat.value shouldBe BigDecimal("95")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #4878. In the Swap flow the destination ("To") fiat could read far higher than the source fiat for illiquid tokens (e.g. **ETH → BINU on Base**: source `$5.26` vs destination `$13.18`, ~2.5× apart). A swap is value-preserving, so the two fiat figures should be roughly equal — the destination should never imply a "free lunch."

## Root cause

Destination fiat was computed with an independent market oracle (CoinGecko):

```kotlin
convertTokenValueToFiat(dstToken, quote.expectedDstValue, currency) // dstAmount × dstMarketPrice
```

For illiquid/meme tokens that mark diverges sharply from the DEX pool rate the aggregator actually routes through, inflating the destination fiat above the source.

## Fix

- The **displayed** destination fiat is now **clamped to the source fiat** when the market value exceeds it — it reflects the rate the quote executes at, not a stale independent oracle.
- Genuine price impact / fees that push the destination *below* the source pass through **unclamped** — that divergence is real and shouldn't be hidden (a clamp, not a hard `dst = src` anchor).
- The unclamped market value is preserved on `estimatedDstFiat`, used only for **cross-provider ranking** (`maxBy { estimatedDstFiat.value }`). Anchoring that would make providers tie and break route selection, so display and ranking are kept separate.
- Guarded on `srcFiatValue > 0` so a cold source price doesn't zero out the destination display.

> Note: the alternative of using the provider's own reported USD value isn't viable — none of the quote response models (LI.FI / 1inch / Kyber / THORChain / Maya / SwapKit) return a fiat figure, only the destination token amount.

## Test plan

- Added unit test: inflated destination clamps to source fiat (`$13.18` → displayed `$5.26`) while ranking still sees `$13.18`.
- Added unit test: a legitimately-below-source value (`$95` vs `$100` source) passes through unclamped.
- All existing `SwapQuoteManagerTest` ranking/quote tests still pass (`:app:testDebugUnitTest`).

## Proof (real device)

ETH → BINU on Base — source and destination fiat now match (`$0.84` / `$0.84`):

![proof](https://i.imgur.com/NFlDXDo.png)

On-chain transaction: https://basescan.org/tx/0xad5bcdd55273cfee44f277a36fb1d211316e072a27e92b61558a23c11390aa9e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Displayed destination fiat is clamped to the source fiat when market valuations would otherwise show a higher value; underlying market values remain available for cross-provider ranking.
  * UI/confirmation screens now consistently show the clamped destination fiat to prevent inflated marks from appearing.

* **Tests**
  * Added tests verifying clamped display behavior and preservation of unclamped market values for ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->