### PR TITLE
fix(swap): clear sticky error on percentage tap & stop logging zero-amount

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -334,6 +334,12 @@ constructor(
 
         val srcToken = selectedSrcAccount.token
 
+        // Each tap supersedes the previous one: clear any sticky error from an earlier tap so it
+        // can't outlive the condition that raised it. The screen renders `error ?: formError`, so a
+        // stale `error` (only ever cleared by an explicit dismiss) would otherwise pin a one-off
+        // "insufficient balance" warning on a now-valid amount and mask the live quote/formError.
+        _uiState.update { it.copy(error = null) }
+
         val swapFee =
             quoteState.quote?.fees?.value.takeIf { quoteState.provider == SwapProvider.LIFI }
                 ?: BigInteger.ZERO
@@ -346,7 +352,10 @@ constructor(
                 } ?: BigInteger.ZERO)
 
         if (maxUsableTokenAmount <= BigInteger.ZERO) {
-            srcAmountState.setTextAndPlaceCursorAtEnd("0")
+            // Empty (not "0"): the empty-field path clears the stale quote silently, whereas a
+            // literal "0" reaches the quote pipeline and throws/logs AmountCannotBeZero at ERROR
+            // for an expected condition. The error set below stays visible to explain why.
+            srcAmountState.setTextAndPlaceCursorAtEnd("")
             val errorRes =
                 if (srcToken.isNativeToken) {
                     R.string.swap_error_insufficient_balance_and_fees

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -567,7 +567,7 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
-    fun `selectSrcPercentage with zero balance sets zero`() =
+    fun `selectSrcPercentage with zero balance clears the amount and shows an error`() =
         runTest(mainDispatcher) {
             val addresses = listOf(ethAddressWithBalance(BigInteger.ZERO))
             val vm = createViewModelWithAddresses(addresses)
@@ -575,7 +575,10 @@ internal class SwapFormViewModelTest {
 
             vm.selectSrcPercentage(1.0f)
 
-            assertEquals("0", vm.srcAmountState.text.toString())
+            // Empty (not "0") so the empty-field path clears the quote silently instead of feeding
+            // "0" into the pipeline and logging AmountCannotBeZero; the error explains why.
+            assertEquals("", vm.srcAmountState.text.toString())
+            assertNotNull(vm.uiState.value.error)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Tapping a swap percentage / Max button could leave a stale **"Insufficient ETH balance for the swap and gas fees"** popup pinned on screen even after a valid amount was set — the error showed alongside a perfectly valid MAX amount and masked the live quote.

Root cause: the swap screen renders `error ?: formError` (`SwapScreen.kt:149`), and `state.error` (set by `selectSrcPercentage`'s `showError`) was **only ever cleared by an explicit dismiss** (`hideError`). It was never reset by a new tap, a fresh amount, or a successful quote, so a one-off "insufficient for fees" warning outlived the condition that raised it.

Secondarily, the insufficient branch wrote a literal `"0"` into the amount field. That `"0"` reached the quote pipeline and threw/logged `SwapException.AmountCannotBeZero: Amount must be positive` at **ERROR** with a full stack trace for an expected condition (visible repeatedly in logcat).

## Changes

- **Clear `state.error` at the start of `selectSrcPercentage`** so a stale transient error can't outlive its condition and mask a fresh tap's result.
- **Write `""` (the silent-clear sentinel) instead of `"0"`** in the insufficient branch, so the quote clears silently without logging `AmountCannotBeZero`; the error set below stays visible to explain why.
- Updated the `selectSrcPercentage with zero balance` unit test to assert the empty field + error.

## Not in scope

- The static-table vs live-routability gap (#4685): pairs like `BASE.ETH → BASE.SNX` are marked routable by the static provider table but can return `noRoutesFound` / be rate-limited at runtime. With this fix the failure surfaces as a clean "no route" `formError` instead of a masked-out one.
- A user *typing* `0` still logs `AmountCannotBeZero` at ERROR (pre-existing, by design).

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapFormViewModelTest"` passes
- [ ] Manual: open Swap, pick a pair where a percentage tap can't cover fees, tap a percentage → error shows; tap a valid percentage/Max → error clears and the amount/quote render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where swap percentage selection could leave an earlier error message visible after changing the amount.
  * Improved the “insufficient/zero usable balance” behavior by clearing the source amount field in the appropriate case while keeping the explicit balance error shown.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->