### PR TITLE
feat(sui): sign dApp PTBs through the standard keysign pipeline (SignSui)

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -31,10 +31,13 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import java.math.BigInteger
+import java.util.Base64
 import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.digests.Blake2bDigest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import vultisig.keysign.v1.SignSui
 import vultisig.keysign.v1.SignTon
 import vultisig.keysign.v1.TonMessage
 import wallet.core.jni.CoinType
@@ -301,16 +304,16 @@ class ChainHelpersTest {
                 vaultLocalPartyID = "local",
                 libType = null,
                 wasmExecuteContractPayload = null,
-                signSui = vultisig.keysign.v1.SignSui(unsignedTxMsg = ptbBase64),
+                signSui = SignSui(unsignedTxMsg = ptbBase64),
             )
 
         val actual = SuiHelper.getPreSignedImageHash(payload)
 
         // Oracle: Sui signing digest = blake2b_32(intent_prefix(scope=0,version=0,app=0) || ptb),
         // computed independently here so a drift in WalletCore's SignDirect hashing surfaces.
-        val ptbBytes = java.util.Base64.getDecoder().decode(ptbBase64)
+        val ptbBytes = Base64.getDecoder().decode(ptbBase64)
         val intentMessage = byteArrayOf(0x00, 0x00, 0x00) + ptbBytes
-        val blake = org.bouncycastle.crypto.digests.Blake2bDigest(256)
+        val blake = Blake2bDigest(256)
         blake.update(intentMessage, 0, intentMessage.size)
         val expectedDigest = ByteArray(blake.digestSize).also { blake.doFinal(it, 0) }
 

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package com.vultisig.wallet.data.blockchain
 
 import BlockchainSpecific
@@ -257,6 +259,62 @@ class ChainHelpersTest {
 
             assertEquals(preImageHashes, transaction.expectedImageHash)
         }
+    }
+
+    /**
+     * Parity for issue #4881: a dApp-supplied Sui PTB (`signSui`) signed through WalletCore's
+     * SignDirect path must produce the same intent-prefixed digest the existing
+     * [com.vultisig.wallet.data.chains.helpers.SwapKitSuiSigner] computes by hand
+     * (`blake2b_32([0x00,0x00,0x00] || ptb)`). The SignDirect input carries the verbatim base64
+     * `TransactionData` BCS bytes — no Pay/PaySui rebuild — and the resulting sighash must match
+     * the cross-platform (iOS / extension / SDK) digest so co-signing converges.
+     */
+    @Test
+    fun signSuiSignDirectMatchesIntentPrefixedDigest() {
+        // base64 TransactionData BCS bytes. The digest is taken over these opaque bytes under the
+        // Sui transaction intent, so the exact contents are irrelevant to the parity assertion.
+        val ptbBase64 = "AAACAAgA4fUFAAAAAAAgWqQ5q8s0e0kq0a7s3w2QxJYwq7XmZ1pL0c1d8s2f3g4="
+        val suiCoin =
+            com.vultisig.wallet.data.models.Coin(
+                chain = Chain.Sui,
+                ticker = "SUI",
+                logo = "sui",
+                address = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef",
+                decimal = 9,
+                hexPublicKey = HEX_PUBLIC_KEY_EDDSA,
+                priceProviderID = "sui",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val payload =
+            com.vultisig.wallet.data.models.payload.KeysignPayload(
+                coin = suiCoin,
+                toAddress = "",
+                toAmount = BigInteger.ZERO,
+                blockChainSpecific =
+                    com.vultisig.wallet.data.models.payload.BlockChainSpecific.Sui(
+                        referenceGasPrice = BigInteger.ZERO,
+                        gasBudget = BigInteger.ZERO,
+                        coins = emptyList(),
+                    ),
+                vaultPublicKeyECDSA = HEX_PUBLIC_KEY,
+                vaultLocalPartyID = "local",
+                libType = null,
+                wasmExecuteContractPayload = null,
+                signSui = vultisig.keysign.v1.SignSui(unsignedTxMsg = ptbBase64),
+            )
+
+        val actual = SuiHelper.getPreSignedImageHash(payload)
+
+        // Oracle: Sui signing digest = blake2b_32(intent_prefix(scope=0,version=0,app=0) || ptb),
+        // computed independently here so a drift in WalletCore's SignDirect hashing surfaces.
+        val ptbBytes = java.util.Base64.getDecoder().decode(ptbBase64)
+        val intentMessage = byteArrayOf(0x00, 0x00, 0x00) + ptbBytes
+        val blake = org.bouncycastle.crypto.digests.Blake2bDigest(256)
+        blake.update(intentMessage, 0, intentMessage.size)
+        val expectedDigest = ByteArray(blake.digestSize).also { blake.doFinal(it, 0) }
+
+        assertEquals(listOf(expectedDigest.toHexString()), actual)
     }
 
     @Test

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignSuiDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignSuiDisplayView.kt
@@ -1,0 +1,123 @@
+package com.vultisig.wallet.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Verify-screen card for a dApp-supplied Sui Programmable Transaction Block (SignSui). The PTB's
+ * `TransactionData` is signed verbatim from its BCS bytes, so there is no `to_address` /
+ * `to_amount` to render as a normal send. Instead we show the signer and the raw base64 bytes that
+ * will be signed, mirroring [SignSolanaDisplayView]'s raw-transaction display.
+ *
+ * @param sender the vault address signing the PTB.
+ * @param unsignedTxMsg base64-encoded `TransactionData` BCS bytes.
+ */
+@Composable
+fun SignSuiDisplayView(
+    sender: String,
+    unsignedTxMsg: String,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        modifier = modifier.fillMaxWidth().padding(vertical = 10.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Absolute.SpaceBetween,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(R.string.sui_raw_transaction),
+                style = Theme.brockmann.button.medium.regular,
+                color = Theme.v2.colors.text.tertiary,
+            )
+
+            IconButton(onClick = { isExpanded = !isExpanded }, modifier = Modifier.size(10.dp)) {
+                UiIcon(
+                    drawableResId = R.drawable.chevron,
+                    tint = Theme.v2.colors.neutrals.n100,
+                    size = 8.dp,
+                    modifier = Modifier.graphicsLayer(rotationZ = if (isExpanded) 180f else 0f),
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = isExpanded) {
+            Column(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (sender.isNotBlank()) {
+                    VerifyCardJsonDetails(
+                        title = stringResource(R.string.sui_sender),
+                        subtitle = sender,
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .background(
+                                    color = Theme.v2.colors.variables.bordersLight,
+                                    shape = RoundedCornerShape(12.dp),
+                                )
+                                .padding(horizontal = 12.dp),
+                    )
+                }
+                VerifyCardJsonDetails(
+                    title = stringResource(R.string.raw_transaction_data),
+                    subtitle = unsignedTxMsg,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .background(
+                                color = Theme.v2.colors.variables.bordersLight,
+                                shape = RoundedCornerShape(12.dp),
+                            )
+                            .padding(horizontal = 12.dp),
+                )
+            }
+        }
+    }
+}
+
+private const val PREVIEW_SUI_PTB =
+    "AAACAAgA4fUFAAAAAAAgWqQ5q8s0e0kq0a7s3w2QxJYwq7XmZ1pL0c1d8s2f3g4FAQEBAQABAAA" +
+        "x2QxJYwq7XmZ1pL0c1d8s2f3g4Aq7XmZ1pL0c1d8s2f3g4Fy0kq0a7s3w2QxJYwq7XmZ1AQ=="
+
+@Preview
+@Composable
+private fun PreviewSignSuiDisplayView() {
+    SignSuiDisplayView(
+        sender = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef",
+        unsignedTxMsg = PREVIEW_SUI_PTB,
+        initiallyExpanded = true,
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -77,6 +77,10 @@ internal data class TransactionDetailsUiModel(
     val signDirect: String? = null,
     val signSolana: String? = null,
     /**
+     * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB (SignSui), for verify display.
+     */
+    val signSui: String? = null,
+    /**
      * Per-message rows for a TonConnect signing request, each decoded from its BOC body into an
      * operation label, real recipient, forward amount, and the raw payload. Empty for non-TON or
      * undecodable requests. Built in [com.vultisig.wallet.ui.models.keysign.mapTonMessages].

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
@@ -158,6 +158,7 @@ constructor(
             payload.signDirect?.let { json.encodeToString(parseCosmosMessage(it)) } ?: ""
 
         val signSolana = payload.signSolana?.rawTransactions?.firstOrNull() ?: ""
+        val signSui = payload.signSui?.unsignedTxMsg?.takeIf { it.isNotEmpty() }
         val transaction =
             Transaction(
                 id = UUID.randomUUID().toString(),
@@ -176,6 +177,7 @@ constructor(
                 signAmino = normalizedSignAmino,
                 signDirect = signDirect,
                 signSolana = signSolana,
+                signSui = signSui,
             )
 
         val transactionToUiModel = mapTransactionToUiModel(transaction)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -31,6 +31,7 @@ constructor(
             signAmino = from.signAmino,
             signDirect = from.signDirect,
             signSolana = from.signSolana,
+            signSui = from.signSui,
             networkFeeFiatValue = from.estimatedFee,
             networkFeeTokenValue = from.totalGas,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -37,6 +37,7 @@ import com.vultisig.wallet.data.models.monoToneLogo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.ui.components.SignSolanaDisplayView
+import com.vultisig.wallet.ui.components.SignSuiDisplayView
 import com.vultisig.wallet.ui.components.SignTonDisplayView
 import com.vultisig.wallet.ui.components.TokenAndChainLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
@@ -303,6 +304,18 @@ internal fun VerifySendScreen(
 
                             SignSolanaDisplayView(
                                 signSolana = SignSolana(rawTransactions = listOf(it))
+                            )
+                        }
+
+                    tx.signSui
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let {
+                            VerifyCardDivider(0.dp)
+
+                            SignSuiDisplayView(
+                                sender = tx.srcAddress,
+                                unsignedTxMsg = it,
+                                initiallyExpanded = initiallyExpandedDetails,
                             )
                         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -991,7 +991,7 @@
     <string name="transaction_status_notification_title">Transaktionsstatus</string>
     <string name="transaction_status_checking_transaction">Transaktion wird geprüft…</string>
     <string name="raw_transaction_data">Rohdaten der Transaktion</string>
-        <string name="sui_raw_transaction">Sui-Transaktion</string>
+    <string name="sui_raw_transaction">Sui-Transaktion</string>
     <string name="sui_sender">Von</string>
     <string name="solana_raw_transaction">Solana-Rohdaten der Transaktion</string>
     <string name="solana_instructions_summary">Transaktionsanweisungen – Übersicht</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -991,6 +991,8 @@
     <string name="transaction_status_notification_title">Transaktionsstatus</string>
     <string name="transaction_status_checking_transaction">Transaktion wird geprüft…</string>
     <string name="raw_transaction_data">Rohdaten der Transaktion</string>
+        <string name="sui_raw_transaction">Sui-Transaktion</string>
+    <string name="sui_sender">Von</string>
     <string name="solana_raw_transaction">Solana-Rohdaten der Transaktion</string>
     <string name="solana_instructions_summary">Transaktionsanweisungen – Übersicht</string>
     <string name="solana_instruction_number">Anweisung %1$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -989,6 +989,8 @@
     <string name="transaction_status_notification_title">Estado de la transacción</string>
     <string name="transaction_status_checking_transaction">Comprobando transacción…</string>
     <string name="raw_transaction_data">Datos de transacciones sin procesar</string>
+        <string name="sui_raw_transaction">Transacción de Sui</string>
+    <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transacción sin procesar de Solana</string>
     <string name="solana_instructions_summary">Resumen de instrucciones de transacción</string>
     <string name="solana_instruction_number">Instrucción %1$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -989,7 +989,7 @@
     <string name="transaction_status_notification_title">Estado de la transacción</string>
     <string name="transaction_status_checking_transaction">Comprobando transacción…</string>
     <string name="raw_transaction_data">Datos de transacciones sin procesar</string>
-        <string name="sui_raw_transaction">Transacción de Sui</string>
+    <string name="sui_raw_transaction">Transacción de Sui</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transacción sin procesar de Solana</string>
     <string name="solana_instructions_summary">Resumen de instrucciones de transacción</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -994,7 +994,7 @@
     <string name="transaction_status_notification_title">Status transakcije</string>
     <string name="transaction_status_checking_transaction">Provjera transakcije…</string>
     <string name="raw_transaction_data">Sirovi podaci o transakciji</string>
-        <string name="sui_raw_transaction">Sui transakcija</string>
+    <string name="sui_raw_transaction">Sui transakcija</string>
     <string name="sui_sender">Od</string>
     <string name="solana_raw_transaction">Solana Sirova transakcija</string>
     <string name="solana_instructions_summary">Sažetak uputa transakcije</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -994,6 +994,8 @@
     <string name="transaction_status_notification_title">Status transakcije</string>
     <string name="transaction_status_checking_transaction">Provjera transakcije…</string>
     <string name="raw_transaction_data">Sirovi podaci o transakciji</string>
+        <string name="sui_raw_transaction">Sui transakcija</string>
+    <string name="sui_sender">Od</string>
     <string name="solana_raw_transaction">Solana Sirova transakcija</string>
     <string name="solana_instructions_summary">Sažetak uputa transakcije</string>
     <string name="solana_instruction_number">Uputa %1$d</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -991,7 +991,7 @@
     <string name="transaction_status_notification_title">Stato della transazione</string>
     <string name="transaction_status_checking_transaction">Verifica della transazione in corso…</string>
     <string name="raw_transaction_data">Dati grezzi sulle transazioni</string>
-        <string name="sui_raw_transaction">Transazione Sui</string>
+    <string name="sui_raw_transaction">Transazione Sui</string>
     <string name="sui_sender">Da</string>
     <string name="solana_raw_transaction">Transazioni grezze Solana</string>
     <string name="solana_instructions_summary">Riepilogo istruzioni della transazione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -991,6 +991,8 @@
     <string name="transaction_status_notification_title">Stato della transazione</string>
     <string name="transaction_status_checking_transaction">Verifica della transazione in corso…</string>
     <string name="raw_transaction_data">Dati grezzi sulle transazioni</string>
+        <string name="sui_raw_transaction">Transazione Sui</string>
+    <string name="sui_sender">Da</string>
     <string name="solana_raw_transaction">Transazioni grezze Solana</string>
     <string name="solana_instructions_summary">Riepilogo istruzioni della transazione</string>
     <string name="solana_instruction_number">Istruzione %1$d</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1021,6 +1021,8 @@
     <string name="transaction_status_notification_title">거래 상태</string>
     <string name="transaction_status_checking_transaction">거래 확인 중…</string>
     <string name="raw_transaction_data">원시 거래 데이터</string>
+        <string name="sui_raw_transaction">Sui 거래</string>
+    <string name="sui_sender">보내는 주소</string>
     <string name="solana_raw_transaction">Solana 원시 거래</string>
     <string name="solana_instructions_summary">거래 명령어 요약</string>
     <string name="solana_instruction_number">명령어 %1$d</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1021,7 +1021,7 @@
     <string name="transaction_status_notification_title">거래 상태</string>
     <string name="transaction_status_checking_transaction">거래 확인 중…</string>
     <string name="raw_transaction_data">원시 거래 데이터</string>
-        <string name="sui_raw_transaction">Sui 거래</string>
+    <string name="sui_raw_transaction">Sui 거래</string>
     <string name="sui_sender">보내는 주소</string>
     <string name="solana_raw_transaction">Solana 원시 거래</string>
     <string name="solana_instructions_summary">거래 명령어 요약</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -986,7 +986,7 @@
     <string name="transaction_status_notification_title">Transactiestatus</string>
     <string name="transaction_status_checking_transaction">Transactie controleren…</string>
     <string name="raw_transaction_data">Ruwe transactiegegevens</string>
-        <string name="sui_raw_transaction">Sui-transactie</string>
+    <string name="sui_raw_transaction">Sui-transactie</string>
     <string name="sui_sender">Van</string>
     <string name="solana_raw_transaction">Solana Ruwe transactie</string>
     <string name="solana_instructions_summary">Overzicht transactie-instructies</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -986,6 +986,8 @@
     <string name="transaction_status_notification_title">Transactiestatus</string>
     <string name="transaction_status_checking_transaction">Transactie controleren…</string>
     <string name="raw_transaction_data">Ruwe transactiegegevens</string>
+        <string name="sui_raw_transaction">Sui-transactie</string>
+    <string name="sui_sender">Van</string>
     <string name="solana_raw_transaction">Solana Ruwe transactie</string>
     <string name="solana_instructions_summary">Overzicht transactie-instructies</string>
     <string name="solana_instruction_number">Instructie %1$d</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -990,7 +990,7 @@
     <string name="transaction_status_notification_title">Estado da transação</string>
    <string name="transaction_status_checking_transaction">A verificar transação…</string>
     <string name="raw_transaction_data">Dados brutos de transação</string>
-        <string name="sui_raw_transaction">Transação Sui</string>
+    <string name="sui_raw_transaction">Transação Sui</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transação bruta de Solana</string>
     <string name="solana_instructions_summary">Resumo das instruções da transação</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -990,6 +990,8 @@
     <string name="transaction_status_notification_title">Estado da transação</string>
    <string name="transaction_status_checking_transaction">A verificar transação…</string>
     <string name="raw_transaction_data">Dados brutos de transação</string>
+        <string name="sui_raw_transaction">Transação Sui</string>
+    <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transação bruta de Solana</string>
     <string name="solana_instructions_summary">Resumo das instruções da transação</string>
     <string name="solana_instruction_number">Instrução %1$d</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -994,7 +994,7 @@
     <string name="transaction_status_notification_title">Статус транзакции</string>
     <string name="transaction_status_checking_transaction">Проверка транзакции…</string>
     <string name="raw_transaction_data">Исходные данные транзакции</string>
-        <string name="sui_raw_transaction">Транзакция Sui</string>
+    <string name="sui_raw_transaction">Транзакция Sui</string>
     <string name="sui_sender">От</string>
     <string name="solana_raw_transaction">Исходные данные транзакции Соланы</string>
     <string name="solana_instructions_summary">Сводка инструкций транзакции</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -994,6 +994,8 @@
     <string name="transaction_status_notification_title">Статус транзакции</string>
     <string name="transaction_status_checking_transaction">Проверка транзакции…</string>
     <string name="raw_transaction_data">Исходные данные транзакции</string>
+        <string name="sui_raw_transaction">Транзакция Sui</string>
+    <string name="sui_sender">От</string>
     <string name="solana_raw_transaction">Исходные данные транзакции Соланы</string>
     <string name="solana_instructions_summary">Сводка инструкций транзакции</string>
     <string name="solana_instruction_number">Инструкция %1$d</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1322,6 +1322,8 @@
     <string name="transaction_status_notification_title">交易状态</string>
     <string name="transaction_status_checking_transaction">正在检查交易……</string>
     <string name="raw_transaction_data">原始交易数据</string>
+        <string name="sui_raw_transaction">Sui 交易</string>
+    <string name="sui_sender">从</string>
     <string name="solana_raw_transaction">Solana 原始交易数据</string>
     <string name="solana_instructions_summary">交易指令摘要</string>
     <string name="solana_instruction_number">指令 %1$d</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1322,7 +1322,7 @@
     <string name="transaction_status_notification_title">交易状态</string>
     <string name="transaction_status_checking_transaction">正在检查交易……</string>
     <string name="raw_transaction_data">原始交易数据</string>
-        <string name="sui_raw_transaction">Sui 交易</string>
+    <string name="sui_raw_transaction">Sui 交易</string>
     <string name="sui_sender">从</string>
     <string name="solana_raw_transaction">Solana 原始交易数据</string>
     <string name="solana_instructions_summary">交易指令摘要</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1048,7 +1048,7 @@
     <string name="transaction_status_checking_transaction">Checking transaction…</string>
     <string name="raw_transaction_data">Raw Transaction Data</string>
     <string name="sui_raw_transaction">Sui Transaction</string>
-    <string name="sui_sender">Sender</string>
+    <string name="sui_sender">From</string>
     <string name="solana_raw_transaction">Solana Raw Transaction</string>
     <string name="solana_instructions_summary">Transaction Instructions Summary</string>
     <string name="solana_instruction_number">Instruction %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1047,6 +1047,8 @@
     <string name="transaction_status_notification_title">Transaction Status</string>
     <string name="transaction_status_checking_transaction">Checking transaction…</string>
     <string name="raw_transaction_data">Raw Transaction Data</string>
+    <string name="sui_raw_transaction">Sui Transaction</string>
+    <string name="sui_sender">Sender</string>
     <string name="solana_raw_transaction">Solana Raw Transaction</string>
     <string name="solana_instructions_summary">Transaction Instructions Summary</string>
     <string name="solana_instruction_number">Instruction %1$d</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -28,6 +28,17 @@ object SuiHelper {
     private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
         require(keysignPayload.coin.chain == Chain.Sui) { "Coin is not SUI" }
 
+        // dApp-supplied Programmable Transaction Block (Sui Wallet Standard): the base64
+        // `TransactionData` BCS bytes are already complete (coins, gas budget, recipients baked
+        // in), so we sign them verbatim via WalletCore's SignDirect path rather than rebuilding a
+        // Pay / PaySui. WalletCore hashes the bytes under the Sui transaction intent.
+        keysignPayload.signSui?.let { signSui ->
+            return buildSignDirectInputData(
+                signer = keysignPayload.coin.address,
+                unsignedTxMsg = signSui.unsignedTxMsg,
+            )
+        }
+
         val (referenceGasPrice, gasBudget, coins) =
             keysignPayload.blockChainSpecific as? BlockChainSpecific.Sui
                 ?: throw RuntimeException(
@@ -119,6 +130,21 @@ object SuiHelper {
         val tx = preSigningOutput.data.toByteArray().drop(3).toByteArray()
 
         return Base64.encode(tx)
+    }
+
+    /**
+     * Builds the WalletCore `Sui.SigningInput` bytes for a dApp-supplied PTB ([SignSui]). The
+     * `SignDirect` payload carries the base64 `TransactionData` BCS bytes verbatim — no `Pay` /
+     * `PaySui`, gas budget, or reference gas price, since those are already encoded in the bytes.
+     * Pure protobuf assembly (no JNI), so it is unit-testable.
+     */
+    internal fun buildSignDirectInputData(signer: String, unsignedTxMsg: String): ByteArray {
+        require(unsignedTxMsg.isNotEmpty()) { "SignSui unsignedTxMsg is empty" }
+        return Sui.SigningInput.newBuilder()
+            .setSignDirectMessage(Sui.SignDirect.newBuilder().setUnsignedTxMsg(unsignedTxMsg))
+            .setSigner(signer)
+            .build()
+            .toByteArray()
     }
 
     internal fun selectSuiGasCoin(coins: List<SuiCoin>, gasBudget: BigInteger): SuiCoin? =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -52,6 +52,7 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             signDirect = from.signDirect,
             signSolana = from.signSolana,
             signTon = from.signTon,
+            signSui = from.signSui,
             signBitcoin = from.signBitcoin,
             swapPayload =
                 when {
@@ -132,6 +133,19 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                     // would leave `blockChainSpecific` reading stale `byteFee`/`sendMaxAmount` data
                     // while sighashes dispatch through the PSBT helper.
                     from.signBitcoin != null -> BlockChainSpecific.BitcoinPSBT
+
+                    // A dApp-supplied Sui PTB (`signSui`) is signed verbatim from its BCS bytes via
+                    // WalletCore's SignDirect path, so the initiator omits the SUI RPC-derived
+                    // `suicheSpecific` (coins / gas price). Stand in an empty placeholder here so
+                    // [SuiHelper] — which casts `blockChainSpecific` to `Sui` — has a value to
+                    // read;
+                    // every field is already baked into the signed bytes and goes unused.
+                    from.signSui != null ->
+                        BlockChainSpecific.Sui(
+                            referenceGasPrice = BigInteger.ZERO,
+                            gasBudget = BigInteger.ZERO,
+                            coins = emptyList(),
+                        )
 
                     from.ethereumSpecific != null ->
                         from.ethereumSpecific.let {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
@@ -21,6 +21,10 @@ data class Transaction(
     val signAmino: String? = null,
     val signDirect: String? = null,
     val signSolana: String? = null,
+    /**
+     * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB, surfaced for verify display.
+     */
+    val signSui: String? = null,
     val estimatedFee: String,
     val blockChainSpecific: BlockChainSpecific,
     val utxos: List<UtxoInfo> = emptyList(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
@@ -7,6 +7,7 @@ import java.math.BigInteger
 import vultisig.keysign.v1.SignAmino
 import vultisig.keysign.v1.SignBitcoin
 import vultisig.keysign.v1.SignSolana
+import vultisig.keysign.v1.SignSui
 import vultisig.keysign.v1.SignTon
 import vultisig.keysign.v1.TronTransferAssetContractPayload
 import vultisig.keysign.v1.TronTransferContractPayload
@@ -30,6 +31,14 @@ data class KeysignPayload(
     val signDirect: SignDirectProto? = null,
     val signSolana: SignSolana? = null,
     val signTon: SignTon? = null,
+    /**
+     * Pre-built Sui Programmable Transaction Block (PTB) supplied by an external dApp via the Sui
+     * Wallet Standard. Carries the base64-encoded `TransactionData` BCS bytes to sign verbatim;
+     * when present, [SuiHelper] signs through WalletCore's `SignDirect` path instead of rebuilding
+     * a `Pay`/`PaySui`, and the Sui [blockChainSpecific] slot is an empty placeholder (the coins,
+     * gas budget and recipients are already baked into the bytes).
+     */
+    val signSui: SignSui? = null,
     /**
      * Structured Bitcoin PSBT payload supplied by an external dApp for co-signing. When present,
      * the UTXO signing path uses these inputs/outputs directly and bypasses WalletCore tx planning;

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
@@ -195,6 +195,32 @@ class SuiHelperTest {
         }
     }
 
+    @Test
+    fun `buildSignDirectInputData sets SignDirect payload with the verbatim PTB and signer`() {
+        val signer = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef"
+        val ptb = "AAACAAgA4fUFAAAAAA==" // base64 TransactionData BCS, opaque to the builder
+
+        val input = Sui.SigningInput.parseFrom(SuiHelper.buildSignDirectInputData(signer, ptb))
+
+        // SignDirect path — must NOT fall into Pay / PaySui (those rebuild from RPC coins).
+        assertEquals(
+            Sui.SigningInput.TransactionPayloadCase.SIGN_DIRECT_MESSAGE,
+            input.transactionPayloadCase,
+        )
+        assertEquals(ptb, input.signDirectMessage.unsignedTxMsg)
+        assertEquals(signer, input.signer)
+        // No gas budget / reference gas price — they are baked into the signed bytes.
+        assertEquals(0L, input.gasBudget)
+        assertEquals(0L, input.referenceGasPrice)
+    }
+
+    @Test
+    fun `buildSignDirectInputData rejects an empty PTB`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SuiHelper.buildSignDirectInputData(signer = "0xabc", unsignedTxMsg = "")
+        }
+    }
+
     private fun objectRef(
         id: String,
         version: Long = 1,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
@@ -1,0 +1,110 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.proto.v1.CoinProto
+import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignSui
+import vultisig.keysign.v1.SuiSpecific
+
+/**
+ * Pins the inbound mapping of a dApp-supplied Sui PTB (`signSui`).
+ *
+ * A `SignSui` payload is signed verbatim from its base64 `TransactionData` BCS bytes via
+ * WalletCore's SignDirect path, so the initiator omits the SUI RPC-derived `suicheSpecific` (coins
+ * / gas price). The inbound mapper must (1) carry `signSui` onto the domain payload so [SuiHelper]
+ * takes the SignDirect branch, and (2) stand in an empty [BlockChainSpecific.Sui] placeholder so
+ * the helper — which casts `blockChainSpecific` to `Sui` — has a value to read. This mirrors how
+ * `signBitcoin` short-circuits to [BlockChainSpecific.BitcoinPSBT].
+ */
+class KeysignPayloadProtoMapperSignSuiTest {
+
+    private val inbound = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `signSui is copied and blockChainSpecific becomes an empty Sui placeholder`() {
+        val ptb = "AAACAAgA4fUFAAAAAA==" // arbitrary base64, opaque to the mapper
+
+        val payload = inbound(basePayload(signSui = SignSui(unsignedTxMsg = ptb)))
+
+        assertEquals(ptb, payload.signSui?.unsignedTxMsg)
+        val specific = payload.blockChainSpecific
+        check(specific is BlockChainSpecific.Sui) { "expected empty Sui placeholder" }
+        assertEquals(BigInteger.ZERO, specific.referenceGasPrice)
+        assertEquals(BigInteger.ZERO, specific.gasBudget)
+        assertEquals(emptyList<Any>(), specific.coins)
+    }
+
+    @Test
+    fun `signSui takes precedence over a present suicheSpecific`() {
+        // Defensive: even if an initiator wrongly attaches both, the SignDirect bytes win so the
+        // helper never rebuilds a Pay/PaySui from RPC coins it shouldn't use.
+        val payload =
+            inbound(
+                basePayload(
+                    signSui = SignSui(unsignedTxMsg = "AAEC"),
+                    suicheSpecific =
+                        SuiSpecific(
+                            referenceGasPrice = "750",
+                            gasBudget = "3000000",
+                            coins = emptyList(),
+                        ),
+                )
+            )
+
+        val specific = payload.blockChainSpecific
+        check(specific is BlockChainSpecific.Sui)
+        assertEquals(BigInteger.ZERO, specific.referenceGasPrice)
+        assertEquals(BigInteger.ZERO, specific.gasBudget)
+    }
+
+    @Test
+    fun `absent signSui maps the suicheSpecific normally`() {
+        val payload =
+            inbound(
+                basePayload(
+                    suicheSpecific =
+                        SuiSpecific(
+                            referenceGasPrice = "750",
+                            gasBudget = "3000000",
+                            coins = emptyList(),
+                        )
+                )
+            )
+
+        assertNull(payload.signSui)
+        val specific = payload.blockChainSpecific
+        check(specific is BlockChainSpecific.Sui)
+        assertEquals(BigInteger("750"), specific.referenceGasPrice)
+        assertEquals(BigInteger("3000000"), specific.gasBudget)
+    }
+
+    private fun basePayload(signSui: SignSui? = null, suicheSpecific: SuiSpecific? = null) =
+        KeysignPayloadProto(
+            coin = SUI_COIN,
+            toAddress = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef",
+            toAmount = "0",
+            vaultPublicKeyEcdsa = "pubkey",
+            vaultLocalPartyId = "party-1",
+            signSui = signSui,
+            suicheSpecific = suicheSpecific,
+        )
+
+    private companion object {
+        val SUI_COIN =
+            CoinProto(
+                chain = "Sui",
+                ticker = "SUI",
+                address = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef",
+                contractAddress = "",
+                decimals = 9,
+                priceProviderId = "sui",
+                isNativeToken = true,
+                hexPublicKey = "",
+                logo = "sui",
+            )
+    }
+}


### PR DESCRIPTION
Closes #4881

## Summary
Lets a pre-built Sui Programmable Transaction Block (PTB) — supplied by a dApp via the Sui Wallet Standard — be signed through the **standard keysign pipeline** via the new `KeysignPayload.signData → SignSui` variant, instead of a parallel custom-message path. This device co-signs the verbatim `TransactionData` BCS bytes, so a session initiated on desktop/extension converges on every platform. Cross-platform with SDK [#705](https://github.com/vultisig/vultisig-sdk/pull/705) and windows [#4105](https://github.com/vultisig/vultisig-windows/pull/4105).

## ⚠️ Requires commondata bump
This PR forwards the `commondata` submodule **5a72a86 → 955cfa7** (linear, one commit — adds only `SignSui`). `955cfa7` is merged on commondata `main` (PR [#89](https://github.com/vultisig/commondata/pull/89)). Reviewers/CI must `git submodule update --init` to regenerate the protobufs.

## What changed
- **Signing** — `SuiHelper` branches on `signSui` into `buildSignDirectInputData()`, building `Sui.SigningInput.signDirectMessage` (`SignDirect.unsignedTxMsg`) + signer with no `Pay`/`PaySui` rebuild and no `getAllCoins`/gas-price RPC. WalletCore (4.3.22) hashes the bytes under the Sui transaction intent. `getSignedTransaction` is unchanged and returns the Wallet-Standard Ed25519 signature.
- **Mapping** — `KeysignPayloadProtoMapper` copies `signSui` inbound and short-circuits `blockChainSpecific` to an empty `BlockChainSpecific.Sui` placeholder (the initiator omits `suicheSpecific`), mirroring the `signBitcoin → BitcoinPSBT` precedence. Inbound-only, matching the `signSolana`/`signTon`/`signBitcoin` precedent.
- **Verify UI** — `SignSui` carries no `to_address`/`to_amount`, so the new `SignSuiDisplayView` renders the sender + raw PTB bytes (mirrors `SignSolanaDisplayView`) instead of a "0 SUI / no recipient" send card. `sui_raw_transaction`/`sui_sender` added across all 10 locales.

## Tests
- `SuiHelperTest` — `buildSignDirectInputData` sets the `SIGN_DIRECT_MESSAGE` case with the verbatim PTB + signer, no gas budget (pure protobuf, no JNI).
- `KeysignPayloadProtoMapperSignSuiTest` — field copy + empty-`Sui` placeholder precedence over `suicheSpecific`.
- `ChainHelpersTest` (instrumented) — the SignDirect sighash equals `blake2b_32(intent_prefix ‖ ptb)`, i.e. parity with the existing `SwapKitSuiSigner` digest so co-signing converges.
- `:data` + `:app` debug build and unit suites green; ktfmt applied.

## On-device verification
Co-signed a real **Aftermath Finance** SUI→USDC spot swap (Sui Wallet-Standard PTB) initiated from the Vultisig extension; the verify screen rendered the decoded request and the tx broadcast on-chain.

- **Broadcast tx:** https://suivision.xyz/txblock/HXfTXBYRm6rac1i5UZB19affmYArHbZ1se9SvU92DWN1

| Before (without fix) | After (this PR) |
|---|---|
| Keysign fails to build a `Pay`/`PaySui` (payload has no `suicheSpecific`) — no valid signature, swap can't broadcast | ![after](https://i.imgur.com/bnTJAQA.jpeg) |

## Test plan
- [x] Unit + instrumented tests pass; debug build succeeds
- [x] Native Sui `Pay`/`PaySui` send flow unchanged (only `signSui != null` diverts)
- [x] Cross-device co-sign with extension produces a valid Wallet-Standard signature and broadcasts (tx above)