### PR TITLE
fix(swap): min-output limit on THORChain/Maya swaps via tolerance_bps

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -101,6 +101,10 @@ constructor(
                                 routerAddress = quote.data.router,
                                 fromAmount = srcTokenValue.value,
                                 toAmountDecimal = dstTokenValue.decimal,
+                                // The on-chain min-output floor is enforced by the `:LIM` field
+                                // the node bakes into `quote.data.memo` (signed verbatim) when the
+                                // quote request carries `tolerance_bps`; this proto field is not
+                                // read at sign time, so it stays "0".
                                 toAmountLimit = "0",
                                 streamingInterval = "1",
                                 streamingQuantity = "0",
@@ -171,6 +175,9 @@ constructor(
                                 routerAddress = quote.data.router,
                                 fromAmount = srcTokenValue.value,
                                 toAmountDecimal = dstTokenValue.decimal,
+                                // See ThorChain branch: the real floor is the memo `:LIM` the node
+                                // adds from `tolerance_bps`; this proto field is unused at sign
+                                // time.
                                 toAmountLimit = "0",
                                 streamingInterval = "3",
                                 streamingQuantity = "0",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -52,6 +52,7 @@ interface MayaChainApi {
         isAffiliate: Boolean,
         bpsDiscount: Int,
         referralCode: String,
+        toleranceBps: Int? = null,
     ): THORChainSwapQuoteDeserialized
 
     suspend fun broadcastTransaction(tx: String): String?
@@ -188,6 +189,7 @@ constructor(
         isAffiliate: Boolean,
         bpsDiscount: Int,
         referralCode: String,
+        toleranceBps: Int?,
     ): THORChainSwapQuoteDeserialized {
         try {
             val affiliateFeeRate =
@@ -202,6 +204,7 @@ constructor(
                     parameter("streaming_interval", MAYA_STREAMING_INTERVAL)
                     parameter("affiliate", THORChainSwaps.AFFILIATE_FEE_ADDRESS)
                     parameter("affiliate_bps", if (isAffiliate) affiliateFeeRate else "0")
+                    toleranceBps?.let { parameter("tolerance_bps", it) }
                     header(xClientID, xClientIDValue)
                 }
             val responseRawString = response.bodyAsText()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -235,6 +235,7 @@ constructor(
                 parameter("destination", request.address)
                 parameter("streaming_interval", request.interval)
                 request.streamingQuantity?.let { parameter("streaming_quantity", it) }
+                request.toleranceBps?.let { parameter("tolerance_bps", it) }
                 if (affiliateParams.isNotEmpty()) {
                     affiliateParams.forEach { (key, value) ->
                         when (key) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/ThorChainSwapQuoteRequest.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/ThorChainSwapQuoteRequest.kt
@@ -9,4 +9,10 @@ data class ThorChainSwapQuoteRequest(
     val referralCode: String,
     val bpsDiscount: Int,
     val streamingQuantity: Int? = null,
+    /**
+     * Minimum-output tolerance in basis points. When set, the node bakes a real `LIM` into the
+     * returned swap memo (`expected_amount_out × (1 − toleranceBps/10_000)`). When null/omitted the
+     * memo carries no limit, i.e. the swap accepts any output (unbounded slippage).
+     */
+    val toleranceBps: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/MayaQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/MayaQuoteSource.kt
@@ -32,6 +32,7 @@ internal class MayaQuoteSource @Inject constructor(private val mayaChainApi: May
                     isAffiliate = request.isAffiliate,
                     bpsDiscount = request.bpsDiscount,
                     referralCode = request.referralCode,
+                    toleranceBps = DEFAULT_THORCHAIN_TOLERANCE_BPS,
                 )
             }
         val data = response.unwrapOrThrow()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -61,6 +61,16 @@ sealed class SwapQuoteResult {
         }
 }
 
+/**
+ * Minimum-output tolerance (basis points) sent on every THORChain/Maya quote request as
+ * `tolerance_bps`. The node bakes a real `LIM` into the returned swap memo — `expected_amount_out ×
+ * (1 − toleranceBps/10_000)` — protecting the user from adverse pool moves and front-running
+ * between quote and execution. Without it the memo carries no limit (unbounded slippage). 100 bps
+ * (1%) is a conservative default aligned with the streaming-upgrade threshold; there is no per-swap
+ * user slippage control yet. Mirrors iOS `SwapService.defaultThorchainToleranceBps`.
+ */
+internal const val DEFAULT_THORCHAIN_TOLERANCE_BPS = 100
+
 /** Common contract for every per-provider quote source. */
 interface SwapQuoteSource {
     suspend fun fetch(request: SwapQuoteRequest): SwapQuoteResult

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
@@ -37,6 +37,7 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
                 interval = Interval.Rapid.wireValue,
                 referralCode = request.referralCode,
                 bpsDiscount = request.bpsDiscount,
+                toleranceBps = DEFAULT_THORCHAIN_TOLERANCE_BPS,
             )
 
         val finalData = fetchWithStreamingFallback(rapidRequest)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -176,7 +176,7 @@ class SwapQuoteRepositoryProvidersTest {
     fun `maya happy path returns SwapQuote MayaChain with mapped fields`() = runTest {
         val quote = mayaQuote(expectedAmountOut = "12000000000", feesTotal = "100000000")
         coEvery {
-            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any())
+            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any(), any())
         } returns THORChainSwapQuoteDeserialized.Result(quote)
 
         val srcToken = coin(Chain.Bitcoin, "BTC", decimal = 8)
@@ -207,7 +207,7 @@ class SwapQuoteRepositoryProvidersTest {
     fun `maya source MayaChain keeps original tokenValue as recommendedMin`() = runTest {
         val quote = mayaQuote(recommendedMinAmountIn = "999999")
         coEvery {
-            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any())
+            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any(), any())
         } returns THORChainSwapQuoteDeserialized.Result(quote)
 
         val srcToken = coin(Chain.MayaChain, "CACAO", decimal = 10)
@@ -232,7 +232,7 @@ class SwapQuoteRepositoryProvidersTest {
     @Test
     fun `maya deserialization error throws SwapException`() = runTest {
         coEvery {
-            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any())
+            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any(), any())
         } returns THORChainSwapQuoteDeserialized.Error(THORChainSwapQuoteError("pool unavailable"))
 
         val srcToken = coin(Chain.Bitcoin, "BTC")
@@ -254,7 +254,7 @@ class SwapQuoteRepositoryProvidersTest {
     @Test
     fun `maya inner quote error throws SwapException`() = runTest {
         coEvery {
-            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any())
+            mayaChainApi.getSwapQuotes(any(), any(), any(), any(), any(), any(), any(), any())
         } returns THORChainSwapQuoteDeserialized.Result(mayaQuote(error = "trading halted"))
 
         val srcToken = coin(Chain.Bitcoin, "BTC")

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryThorChainStreamingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryThorChainStreamingTest.kt
@@ -231,6 +231,39 @@ class SwapQuoteRepositoryThorChainStreamingTest {
     }
 
     @Test
+    fun `rapid request carries 1 percent tolerance_bps so the memo gets a real limit`() = runTest {
+        coEvery { thorChainApi.getSwapQuotes(match { it.interval == "0" }) } returns
+            THORChainSwapQuoteDeserialized.Result(
+                thorQuote(expectedAmountOut = "9950", feesTotal = "50")
+            )
+
+        fetchQuote()
+
+        coVerify(exactly = 1) {
+            thorChainApi.getSwapQuotes(match { it.interval == "0" && it.toleranceBps == 100 })
+        }
+    }
+
+    @Test
+    fun `streaming fallback request also carries tolerance_bps`() = runTest {
+        // High slippage forces a streaming fetch; the .copy() must preserve toleranceBps.
+        val rapidData =
+            thorQuote(expectedAmountOut = "6000", feesTotal = "4000", maxStreamingQuantity = 5)
+        val streamingData = thorQuote(expectedAmountOut = "7500", feesTotal = "500")
+
+        coEvery { thorChainApi.getSwapQuotes(match { it.interval == "0" }) } returns
+            THORChainSwapQuoteDeserialized.Result(rapidData)
+        coEvery { thorChainApi.getSwapQuotes(match { it.interval == "1" }) } returns
+            THORChainSwapQuoteDeserialized.Result(streamingData)
+
+        fetchQuote()
+
+        coVerify(exactly = 1) {
+            thorChainApi.getSwapQuotes(match { it.interval == "1" && it.toleranceBps == 100 })
+        }
+    }
+
+    @Test
     fun `both rapid and streaming fail throws rapid error`() = runTest {
         coEvery { thorChainApi.getSwapQuotes(match { it.interval == "0" }) } returns
             THORChainSwapQuoteDeserialized.Error(THORChainSwapQuoteError("pool suspended"))


### PR DESCRIPTION
## Problem

THORChain and MayaChain swaps were signed and broadcast with **no minimum-output (slippage) floor**. If the pool moved adversely between quote and execution — or a sandwich bot front-ran the inbound — the swap still executed at whatever the pool gave, with no on-chain revert. The user could receive materially less than the quoted `expected_amount_out`. (#4840)

## Root cause

The on-chain floor is the `:LIM` field the node bakes into the swap **memo**, which Android signs verbatim (`quote.data.memo`). Neither `ThorChainApi.getSwapQuotes` nor `MayaChainApi.getSwapQuotes` sent `tolerance_bps`, so the returned memo carried **no limit** (= accept any output).

The hardcoded `toAmountLimit = "0"` in `SwapTransactionBuilder` flagged in the issue is a red herring — verified that nothing in the signing helpers (`THORChainSwaps`, chain/crypto helpers) reads that proto field. The limit lives in the memo.

## Fix

Send `tolerance_bps = 100` (1%) on every THORChain/Maya quote request, mirroring iOS (`SwapService.defaultThorchainToleranceBps`). The node then bakes `LIM = expected_amount_out × (1 − tolerance_bps/10_000)` into the memo we sign.

- `ThorChainSwapQuoteRequest` → add `toleranceBps` (preserved through the streaming `.copy()`)
- `ThorChainApi` / `MayaChainApi` → emit `tolerance_bps` when present
- `DEFAULT_THORCHAIN_TOLERANCE_BPS = 100` shared constant (aligned with the existing `STREAMING_SLIPPAGE_THRESHOLD_BPS`)
- Clarifying comments on the now-cosmetic `toAmountLimit = "0"`

The 1% default matches the existing streaming-upgrade threshold; there is no per-swap user slippage control yet (a follow-up could surface one).

## Test plan

- [x] New unit tests assert both the **rapid** and **streaming-fallback** THORChain requests carry `toleranceBps == 100`
- [x] Updated Maya provider-test mock stubs for the new param
- [x] `:data` affected suites green (`SwapQuoteRepositoryThorChainStreamingTest`, `SwapQuoteRepositoryProvidersTest`, `MayaChainApiBodyReadTest`)
- [x] ktfmt applied
- [ ] Manual mainnet smoke: confirm a THORChain and a Maya swap memo now contains a non-zero `:LIM`

Closes #4840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slippage protection to swap transactions with a configurable tolerance parameter that enforces a minimum output floor.
  * Default tolerance is set to 100 basis points (1%) to guard against adverse pool price movements between quote and execution.

* **Tests**
  * Added test coverage verifying tolerance parameters are correctly included in swap quote requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->