### PR TITLE
fix(swap): use standard EVM swap gas limit on Mantle

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeUtils.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeUtils.kt
@@ -39,9 +39,9 @@ internal fun computeJoinKeysignNetworkFee(
 /**
  * Swap-only fee helper. Only [BlockChainSpecific.Ethereum] and [BlockChainSpecific.THORChain] are
  * reachable in the swap branch — every other subtype goes through `feeServiceComposite`. The
- * Ethereum case uses [defaultEvmSwapGasLimit] for [chain] so joiner output matches the initiator's
- * swap-fee display (see [EthereumFeeService.calculateDefaultFees] for Swap) instead of being ~15×
- * lower for native ETH/Arb transfers.
+ * Ethereum case uses [EthereumFeeService.DEFAULT_SWAP_LIMIT] so joiner output matches the
+ * initiator's swap-fee display (see [EthereumFeeService.calculateDefaultFees] for Swap) instead of
+ * being ~15× lower for native ETH/Arb transfers.
  *
  * The [error] branch is the safety net for [JoinKeysignViewModel.loadTransaction]'s swap path: if a
  * new [BlockChainSpecific] subtype is ever added to that branch's type check, this helper crashes
@@ -50,12 +50,11 @@ internal fun computeJoinKeysignNetworkFee(
 internal fun computeJoinKeysignSwapNetworkFee(
     blockChainSpecific: BlockChainSpecific,
     nativeCoin: Coin,
-    chain: Chain,
 ): TokenValue =
     when (blockChainSpecific) {
         is BlockChainSpecific.Ethereum ->
             TokenValue(
-                value = blockChainSpecific.maxFeePerGasWei * defaultEvmSwapGasLimit(chain),
+                value = blockChainSpecific.maxFeePerGasWei * EthereumFeeService.DEFAULT_SWAP_LIMIT,
                 token = nativeCoin,
             )
         is BlockChainSpecific.THORChain ->
@@ -67,17 +66,6 @@ internal fun computeJoinKeysignSwapNetworkFee(
                     "new swap-branch subtypes"
             )
     }
-
-/**
- * The initiator's swap path always displays `maxFeePerGas * DEFAULT_SWAP_LIMIT` (via
- * [EthereumFeeService.calculateDefaultFees] for Swap), ignoring `BlockChainSpecific.gasLimit` —
- * which can be as low as 40k for native ETH/Arb swaps. Mantle uses
- * [EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT] because its per-gas limit is an order of magnitude
- * higher than other EVM chains.
- */
-internal fun defaultEvmSwapGasLimit(chain: Chain): BigInteger =
-    if (chain == Chain.Mantle) EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
-    else EthereumFeeService.DEFAULT_SWAP_LIMIT
 
 /**
  * The fee a dApp signed in [KeysignPayload.signAmino] or [KeysignPayload.signDirect], or `null` for

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -98,7 +98,6 @@ constructor(
                     computeJoinKeysignSwapNetworkFee(
                         blockChainSpecific = blockChainSpecific,
                         nativeCoin = nativeToken,
-                        chain = chain,
                     )
                 else -> {
                     val (nativeTokenAddress, _) =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -239,10 +239,9 @@ constructor(
                 val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
 
                 val specific = specificAndUtxo.blockChainSpecific
-                // Aggregators can return tx.gas == 0; fall back to the standard EVM swap unit so
-                // the
-                // signed payload never carries a zero gas limit (matches SwapQuoteManager's fee
-                // path).
+                // Aggregators can return tx.gas == 0; fall back to the standard EVM swap unit
+                // so the signed payload never carries a zero gas limit (matches
+                // SwapQuoteManager's fee path).
                 val gasLimit =
                     quote.data.tx.gas.takeIf { it != 0L } ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
                 val quoteData =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -1,7 +1,5 @@
 package com.vultisig.wallet.ui.models.swap
 
-import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
-import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.FiatValue
@@ -240,19 +238,13 @@ constructor(
                 val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
 
                 val specific = specificAndUtxo.blockChainSpecific
-                val gasLimit =
-                    if (srcToken.chain == Chain.Mantle) {
-                        DEFAULT_MANTLE_SWAP_LIMIT.toLong()
-                    } else {
-                        quote.data.tx.gas
-                    }
                 val quoteData =
                     if (specific is BlockChainSpecific.Ethereum) {
                         quote.data.copy(
                             tx =
                                 quote.data.tx.copy(
                                     gasPrice = specific.maxFeePerGasWei.toString(),
-                                    gas = gasLimit,
+                                    gas = quote.data.tx.gas,
                                 )
                         )
                     } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models.swap
 
+import com.vultisig.wallet.data.chains.helpers.EvmHelper
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.FiatValue
@@ -238,13 +239,19 @@ constructor(
                 val isApprovalRequired = allowance != null && allowance < srcTokenValue.value
 
                 val specific = specificAndUtxo.blockChainSpecific
+                // Aggregators can return tx.gas == 0; fall back to the standard EVM swap unit so
+                // the
+                // signed payload never carries a zero gas limit (matches SwapQuoteManager's fee
+                // path).
+                val gasLimit =
+                    quote.data.tx.gas.takeIf { it != 0L } ?: EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT
                 val quoteData =
                     if (specific is BlockChainSpecific.Ethereum) {
                         quote.data.copy(
                             tx =
                                 quote.data.tx.copy(
                                     gasPrice = specific.maxFeePerGasWei.toString(),
-                                    gas = quote.data.tx.gas,
+                                    gas = gasLimit,
                                 )
                         )
                     } else {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignSendGasFeeTest.kt
@@ -170,28 +170,13 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         val result =
-            computeJoinKeysignSwapNetworkFee(
-                blockChainSpecific = specific,
-                nativeCoin = ethCoin,
-                chain = Chain.Ethereum,
-            )
+            computeJoinKeysignSwapNetworkFee(blockChainSpecific = specific, nativeCoin = ethCoin)
 
         result shouldBe
             TokenValue(
                 value = maxFeePerGasWei * EthereumFeeService.DEFAULT_SWAP_LIMIT,
                 token = ethCoin,
             )
-    }
-
-    /**
-     * defaultEvmSwapGasLimit must return DEFAULT_MANTLE_SWAP_LIMIT for Mantle and
-     * DEFAULT_SWAP_LIMIT for every other EVM chain (Mantle has a much higher per-gas limit, so this
-     * branch is the only thing keeping joiner output aligned with the initiator on Mantle swaps).
-     */
-    @Test
-    fun `defaultEvmSwapGasLimit selects Mantle limit for Mantle and default elsewhere`() {
-        defaultEvmSwapGasLimit(Chain.Mantle) shouldBe EthereumFeeService.DEFAULT_MANTLE_SWAP_LIMIT
-        defaultEvmSwapGasLimit(Chain.Ethereum) shouldBe EthereumFeeService.DEFAULT_SWAP_LIMIT
     }
 
     /** Swap helper: THORChain returns blockChainSpecific.fee. */
@@ -208,11 +193,7 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         val result =
-            computeJoinKeysignSwapNetworkFee(
-                blockChainSpecific = specific,
-                nativeCoin = runeCoin,
-                chain = Chain.ThorChain,
-            )
+            computeJoinKeysignSwapNetworkFee(blockChainSpecific = specific, nativeCoin = runeCoin)
 
         result shouldBe TokenValue(value = fee, token = runeCoin)
     }
@@ -231,11 +212,7 @@ internal class JoinKeysignSendGasFeeTest {
             )
 
         shouldThrow<IllegalStateException> {
-            computeJoinKeysignSwapNetworkFee(
-                blockChainSpecific = specific,
-                nativeCoin = solCoin,
-                chain = Chain.Solana,
-            )
+            computeJoinKeysignSwapNetworkFee(blockChainSpecific = specific, nativeCoin = solCoin)
         }
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -5,7 +5,6 @@ package com.vultisig.wallet.ui.models.swap
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
-import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
@@ -403,7 +402,7 @@ internal class SwapTransactionBuilderTest {
         }
 
     @Test
-    fun `builds OneInch swap overriding the gas limit on Mantle`() = runTest {
+    fun `builds OneInch swap keeping the quote gas limit on Mantle`() = runTest {
         val srcToken =
             coin(Chain.Mantle, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
         val dstToken = coin(Chain.Mantle, "MNT", "0xdst", 18, isNative = true)
@@ -443,8 +442,8 @@ internal class SwapTransactionBuilderTest {
             )
 
         val payload = assertIs<SwapPayload.EVM>(tx.payload)
-        // Mantle overrides the quote's gas limit with the dedicated swap limit.
-        assertEquals(DEFAULT_MANTLE_SWAP_LIMIT.toLong(), payload.data.quote.tx.gas)
+        // Mantle now keeps the quote's original gas limit like every other EVM chain.
+        assertEquals(21_000L, payload.data.quote.tx.gas)
         // The gas price is still patched from the EVM plan.
         assertEquals("7", payload.data.quote.tx.gasPrice)
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -5,6 +5,7 @@ package com.vultisig.wallet.ui.models.swap
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.chains.helpers.EvmHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
@@ -446,6 +447,51 @@ internal class SwapTransactionBuilderTest {
         assertEquals(21_000L, payload.data.quote.tx.gas)
         // The gas price is still patched from the EVM plan.
         assertEquals("7", payload.data.quote.tx.gasPrice)
+    }
+
+    @Test
+    fun `builds OneInch swap falling back to default gas unit when quote gas is zero`() = runTest {
+        val srcToken =
+            coin(Chain.Mantle, "USDC", "0xsrc", 6, isNative = false, contract = "0xtoken")
+        val dstToken = coin(Chain.Mantle, "MNT", "0xdst", 18, isNative = true)
+        coEvery { swapGasCalculator.getSpecificAndUtxo(any(), any(), any()) } returns
+            ethereumSpecificAndUtxo(maxFeePerGasWei = BigInteger.valueOf(7))
+        val tx0 =
+            OneInchSwapTxJson(
+                from = "0xsrc",
+                to = "0xrouter",
+                allowanceTarget = "0xproxy",
+                gas = 0,
+                data = "0xdata",
+                value = "0",
+                gasPrice = "1",
+            )
+        val quote =
+            SwapQuote.OneInch(
+                expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
+                fees = TokenValue(BigInteger.valueOf(9), dstToken),
+                expiredAt = Clock.System.now(),
+                data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
+                provider = "1inch",
+            )
+
+        val tx =
+            builder.build(
+                vaultId = "vault-5",
+                srcToken = srcToken,
+                dstToken = dstToken,
+                srcAddress = "0xsrc",
+                srcTokenValue = TokenValue(BigInteger.valueOf(1_000), srcToken),
+                quote = quote,
+                gasFee = TokenValue(BigInteger.valueOf(8), srcToken),
+                gasFeeFiatValue = FiatValue(BigDecimal("2.00"), "USD"),
+                estimatedNetworkFeeTokenValue = null,
+                estimatedNetworkFeeFiatValue = null,
+            )
+
+        val payload = assertIs<SwapPayload.EVM>(tx.payload)
+        // A zero-gas quote must never reach the signed payload — fall back to the standard unit.
+        assertEquals(EvmHelper.DEFAULT_ETH_SWAP_GAS_UNIT, payload.data.quote.tx.gas)
     }
 
     /** Plan fixture whose [BlockChainSpecific] is a real [BlockChainSpecific.Ethereum]. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -247,7 +247,6 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         val chain = transaction.coin.chain
 
         return when {
-            transaction is Swap && chain == Chain.Mantle -> DEFAULT_MANTLE_SWAP_LIMIT
             transaction is Swap -> DEFAULT_SWAP_LIMIT
             chain == Chain.Arbitrum -> DEFAULT_ARBITRUM_TRANSFER
             transaction is Transfer && transaction.coin.isNativeToken -> DEFAULT_COIN_TRANSFER_LIMIT
@@ -295,7 +294,6 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
             DEFAULT_TOKEN_TRANSFER_LIMIT.increaseByPercent(40)
 
         val DEFAULT_ARBITRUM_TRANSFER = "160000".toBigInteger()
-        val DEFAULT_MANTLE_SWAP_LIMIT = "3000000000".toBigInteger()
     }
 }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -6,7 +6,6 @@ import com.vultisig.wallet.data.api.EvmApi
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_ARBITRUM_TRANSFER
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
-import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.model.Eip1559
@@ -392,13 +391,13 @@ internal class EthereumFeeServiceTest {
     }
 
     @Test
-    fun `calculateFees uses Mantle-specific limit for Mantle swap transactions`() = runTest {
+    fun `calculateFees uses the standard swap limit for Mantle swap transactions`() = runTest {
         coEvery { evmApi.getBaseFee() } returns gwei(100)
         stubFeeHistory(listOf(gwei(5)))
 
         val fee = service.calculateFees(swap(Chain.Mantle)) as Eip1559
 
-        assertEquals(DEFAULT_MANTLE_SWAP_LIMIT, fee.limit)
+        assertEquals(DEFAULT_SWAP_LIMIT, fee.limit)
         assertEquals(gwei(110), fee.networkPrice)
     }
 


### PR DESCRIPTION
## Summary

Mantle swaps used a dedicated `DEFAULT_MANTLE_SWAP_LIMIT = 3,000,000,000` gas limit in three places, while every other EVM chain uses the standard `DEFAULT_SWAP_LIMIT` (600,000). This PR removes the Mantle special-casing so Mantle is treated like the other EVM chains:

- **`EthereumFeeService.getDefaultLimit`** — Mantle swaps now use `DEFAULT_SWAP_LIMIT` for the fee estimate/bond.
- **`SwapTransactionBuilder`** — the signed swap tx keeps the aggregator's quoted gas (`quote.data.tx.gas`) instead of overriding it on Mantle.
- **`JoinKeysignFeeUtils`** — the joiner fee uses `DEFAULT_SWAP_LIMIT`; the now-redundant `defaultEvmSwapGasLimit(chain)` helper and its `chain` plumbing are removed.
- Dropped the unused `DEFAULT_MANTLE_SWAP_LIMIT` constant.

## ⚠️ Note / risk

The removed code was deliberate: Mantle's per-gas units run ~an order of magnitude higher than other EVM chains, and the 3B limit existed to keep the **displayed fee bond** consistent with the actual on-chain swap cost (and to keep the joiner aligned with the initiator). With this change the displayed network fee on Mantle swaps is sized off 600k, so it may understate the real cost. Proceeding per request to standardize Mantle.

## Test plan

- [x] `:data:testDebugUnitTest --tests EthereumFeeServiceTest` — green
- [x] `:app:testDebugUnitTest --tests SwapTransactionBuilderTest --tests JoinKeysignSendGasFeeTest` — green
- Updated the three affected tests to assert the standard limit / quoted gas for Mantle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated join-keysign and swap fee estimation to use the standard Ethereum default swap limit for Ethereum-based swaps, including Mantle (removing Mantle-specific swap gas handling).
  * Improved OneInch swap gas handling: the staged transaction now uses the quote’s gas limit, with a fallback default when the quote gas is zero.
* **Tests**
  * Updated and added unit tests to match the new standard swap-limit behavior and the revised staged gas-limit logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->