### PR TITLE
fix(terra): charge Terra Classic burn tax on USTC/LUNC sends

### DIFF
--- a/app/src/androidTest/assets/terra.json
+++ b/app/src/androidTest/assets/terra.json
@@ -155,6 +155,6 @@
       "vault_public_key_ecdsa": "0342d6eb3e536bd1d6f57a8388afb09936aa64160c5e2ebee76d791b4844a06770",
       "lib_type": "DKLS"
     },
-    "expected_image_hash": ["4fa9c4d76019a96e166890d2cbbbd93ccd03aa7926924f9c74ef51aae239a56c"]
+    "expected_image_hash": ["b96a418417af1532b9d0705323bf013b5c6ca6aca840efef872a3047caf47e18"]
   }
 ]

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountFractionManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountFractionManager.kt
@@ -3,9 +3,11 @@ package com.vultisig.wallet.ui.models.send
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.cosmos.TerraClassicTax
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
@@ -180,14 +182,22 @@ internal class AmountFractionManager(
         val chain = token.chain
 
         // Skip the fresh-fee round-trip when it cannot change the percentage amount:
-        //   - Non-native tokens pay chain gas in the native coin (see
+        //   - Most non-native tokens pay chain gas in the native coin (see
         //     GetAvailableTokenBalanceUseCase), so the fee never reduces the
         //     selected balance and the cached estimate is already accurate.
         //   - EVM gas is amount-independent once collectGasFees has run, so the
         //     cached fee is reusable.
         // GasFeeOrchestrator still refreshes gasFee in the background when the
         // amount field updates, so the fee display reflects the new amount.
-        if (!token.isNativeToken || (gasFee.value != null && chain.standard == TokenStandard.EVM)) {
+        //
+        // Terra Classic bank denoms (USTC/uusd) are the exception: their fee is paid in their OWN
+        // denom AND includes an amount-proportional burn tax, so the fee genuinely reduces the
+        // selectable balance and must be recomputed against the candidate amount below.
+        val feeReservedInToken =
+            token.isNativeToken ||
+                (chain == Chain.TerraClassic &&
+                    TerraClassicTax.isBankDenom(token.contractAddress, token.isNativeToken))
+        if (!feeReservedInToken || (gasFee.value != null && chain.standard == TokenStandard.EVM)) {
             return amount
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.models.send.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.cosmos.TerraClassicTax
 import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Chain
@@ -242,6 +243,26 @@ internal class DefaultSendStrategy(
                                 tokenAmountInt,
                                 chain,
                                 planBtc.value,
+                            )
+                        }
+                    } else if (
+                        chain == Chain.TerraClassic &&
+                            TerraClassicTax.isBankDenom(
+                                selectedToken.contractAddress,
+                                selectedToken.isNativeToken,
+                            )
+                    ) {
+                        // Terra Classic bank denoms (USTC/uusd) pay gas + burn tax in their OWN
+                        // denom, not in native LUNC, so gate on the token's own balance covering
+                        // amount + fee. Requiring a LUNC balance here (as the generic non-native
+                        // branch below does) would wrongly block a USTC send from a vault with ~0
+                        // LUNC, even though the chain deducts the fee from the USTC being sent.
+                        if (selectedTokenValue.value < tokenAmountInt + gasFee.value) {
+                            throw InvalidTransactionDataException(
+                                UiText.FormattedText(
+                                    R.string.send_error_insufficient_native_balance_with_fees,
+                                    listOf(selectedToken.ticker),
+                                )
                             )
                         }
                     } else {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -55,6 +55,14 @@ interface CosmosApi {
     suspend fun getLatestBlock(): String
 
     suspend fun getTxStatus(txHash: String): CosmosTxStatusJson?
+
+    /**
+     * Terra Classic's live proportional burn-tax rate from the `x/tax` module
+     * (`/terra/tax/v1beta1/params` → `params.burn_tax_rate`, currently 0.5%). Returns the raw
+     * decimal string, or `null` on any failure so the caller can fail closed to a conservative
+     * fallback rather than signing an under-funded tx. Only meaningful for [Chain.TerraClassic].
+     */
+    suspend fun getTerraClassicBurnTaxRate(): String?
 }
 
 interface CosmosApiFactory {
@@ -214,5 +222,25 @@ internal class CosmosApiImp(
         val response = httpClient.get("$rpcEndpoint/cosmos/tx/v1beta1/txs/$txHash")
         if (response.status.value == 404) return null
         return response.bodyOrThrow<CosmosTxStatusJson>()
+    }
+
+    override suspend fun getTerraClassicBurnTaxRate(): String? {
+        // The proportional burn tax lives in the x/tax module, not the legacy treasury module
+        // (whose tax_rate is 0). Fail closed (return null) so the caller applies its conservative
+        // fallback rate instead of signing an under-funded tx.
+        return try {
+            httpClient
+                .get("$rpcEndpoint/terra/tax/v1beta1/params")
+                .bodyOrThrow<JsonObject>()["params"]
+                ?.jsonObject
+                ?.get("burn_tax_rate")
+                ?.jsonPrimitive
+                ?.content
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to fetch Terra Classic burn_tax_rate; falling back to default")
+            null
+        }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/FeeServiceProvidersModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/FeeServiceProvidersModule.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.blockchain
 
 import com.vultisig.wallet.data.api.BittensorApi
 import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.PolkadotApi
 import com.vultisig.wallet.data.api.RippleApi
@@ -83,7 +84,11 @@ object FeeServiceProvidersModule {
     fun provideThorchainService(thorChainApi: ThorChainApi): FeeService =
         ThorchainFeeService(thorChainApi)
 
-    @Provides @Singleton @CosmosFee fun provideCosmosService(): FeeService = CosmosFeeService()
+    @Provides
+    @Singleton
+    @CosmosFee
+    fun provideCosmosService(cosmosApiFactory: CosmosApiFactory): FeeService =
+        CosmosFeeService(cosmosApiFactory)
 
     @Provides
     @Singleton

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -1,12 +1,15 @@
 package com.vultisig.wallet.data.blockchain.cosmos
 
+import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.blockchain.FeeService
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
+import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.models.Chain
+import java.math.BigInteger
 
-class CosmosFeeService : FeeService {
+class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeService {
 
     companion object {
         internal const val OSMOSIS_MIN_FEE_UOSMO = 25_000L
@@ -55,12 +58,39 @@ class CosmosFeeService : FeeService {
                 GasFees(limit = gasLimit.toBigInteger(), amount = 20000L.toBigInteger())
             }
             Chain.TerraClassic -> {
-                GasFees(limit = gasLimit.toBigInteger(), amount = 10000000L.toBigInteger())
+                GasFees(
+                    limit = gasLimit.toBigInteger(),
+                    amount = terraClassicFeeAmount(transaction),
+                )
             }
             Chain.Dydx -> {
                 GasFees(limit = gasLimit.toBigInteger(), amount = 2500000000000000L.toBigInteger())
             }
             else -> error("Chain Not Supported: ${chain.name}")
         }
+    }
+
+    /**
+     * Terra Classic fee = base gas + proportional burn tax. The base gas is denominated in the same
+     * denom the signer uses for the fee (uluna for native LUNC / CW20 / IBC, uusd for the USTC bank
+     * denom — see [TerraClassicTax.baseGas] and `TerraHelper`). The burn tax (~0.5%, fetched live
+     * with a conservative fallback) is folded into this single fee field only when it is paid in
+     * the send denom (native LUNC or USTC); CW20/IBC sends, whose fee is in uluna while the send is
+     * in the token's own denom, get base gas only to avoid mixing denoms.
+     */
+    private suspend fun terraClassicFeeAmount(transaction: BlockchainTransaction): BigInteger {
+        val coin = transaction.coin
+        val base = TerraClassicTax.baseGas(coin.contractAddress, coin.isNativeToken).toBigInteger()
+
+        val taxable =
+            transaction is Transfer &&
+                TerraClassicTax.taxPaidInSendDenom(coin.contractAddress, coin.isNativeToken) &&
+                transaction.amount > BigInteger.ZERO
+        if (!taxable) return base
+
+        val rawRate =
+            cosmosApiFactory.createCosmosApi(Chain.TerraClassic).getTerraClassicBurnTaxRate()
+        val rate = TerraClassicTax.parseRate(rawRate)
+        return base + TerraClassicTax.burnTax(transaction.amount, rate)
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -7,12 +7,25 @@ import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.models.Chain
+import java.math.BigDecimal
 import java.math.BigInteger
 
 class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeService {
 
+    /**
+     * Terra Classic burn rate only changes via governance, but [calculateFees] runs on every
+     * debounced keystroke during fee display. Cache the parsed rate for a short TTL so the hot path
+     * doesn't hit `/terra/tax/v1beta1/params` on each keypress. A single `@Volatile` reference
+     * makes the read/publish atomic; concurrent refreshes are harmless (idempotent fetch).
+     */
+    @Volatile private var cachedBurnTaxRate: CachedBurnTaxRate? = null
+
+    private data class CachedBurnTaxRate(val rate: BigDecimal, val fetchedAtMs: Long)
+
     companion object {
         internal const val OSMOSIS_MIN_FEE_UOSMO = 25_000L
+
+        private const val BURN_TAX_RATE_TTL_MS = 5 * 60 * 1000L
 
         // `gasLimit * gasPrice` lands below what Akash's validators accept: the
         // chain-registry price (0.025 uakt/gas) on a ~300k-gas delegation yields
@@ -88,9 +101,16 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 transaction.amount > BigInteger.ZERO
         if (!taxable) return base
 
+        return base + TerraClassicTax.burnTax(transaction.amount, burnTaxRate())
+    }
+
+    private suspend fun burnTaxRate(): BigDecimal {
+        val now = System.currentTimeMillis()
+        cachedBurnTaxRate?.let { if (now - it.fetchedAtMs < BURN_TAX_RATE_TTL_MS) return it.rate }
         val rawRate =
             cosmosApiFactory.createCosmosApi(Chain.TerraClassic).getTerraClassicBurnTaxRate()
         val rate = TerraClassicTax.parseRate(rawRate)
-        return base + TerraClassicTax.burnTax(transaction.amount, rate)
+        cachedBurnTaxRate = CachedBurnTaxRate(rate, now)
+        return rate
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTax.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTax.kt
@@ -1,0 +1,89 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+
+/**
+ * Terra Classic (columbus-5) charges a proportional **burn tax** on every `MsgSend`, paid in the
+ * send denom on top of the gas fee. The rate lives in the chain's `x/tax` module (`burn_tax_rate`,
+ * currently 0.5%) and is fetched live; this helper holds the conservative fallback and the pure tax
+ * math so the signed fee, the validated fee, and the displayed fee stay consistent.
+ *
+ * Ported from vultisig-ios `TerraClassicTax`.
+ */
+object TerraClassicTax {
+
+    /**
+     * Conservative fallback burn-tax rate used when the live `x/tax` params can't be
+     * fetched/decoded. Matches current governance (0.5%). Failing closed (taxing) rather than open
+     * (0%) avoids signing a tx the chain then rejects at broadcast.
+     */
+    val fallbackBurnTaxRate: BigDecimal = BigDecimal("0.005")
+
+    /**
+     * Base gas fee for an `uluna`-denominated Terra Classic send (300k gas × 28.325 uluna/gas =
+     * 8,497,500 uluna ≈ 8.5 LUNC). Paid by native LUNC, CW20 (`terra1…`) and IBC (`ibc/…`) tokens,
+     * whose fee the signer denominates in `uluna`.
+     */
+    const val ULUNA_BASE_GAS: Long = 8_497_500L
+
+    /**
+     * Base gas fee for a `uusd`-denominated Terra Classic send (300k gas × 0.75 uusd/gas = 225,000
+     * uusd). Paid only by the USTC bank denom, whose fee the signer denominates in `uusd`.
+     */
+    const val UUSD_BASE_GAS: Long = 225_000L
+
+    /**
+     * Burn tax on a send [amount] (in the denom's smallest unit) at [rate], rounded **up** so the
+     * signed fee never undershoots the chain's check. Returns 0 for a non-positive amount or rate.
+     */
+    fun burnTax(amount: BigInteger, rate: BigDecimal): BigInteger {
+        if (amount <= BigInteger.ZERO || rate <= BigDecimal.ZERO) return BigInteger.ZERO
+        return BigDecimal(amount).multiply(rate).setScale(0, RoundingMode.CEILING).toBigInteger()
+    }
+
+    /**
+     * Parse a decimal-string `burn_tax_rate` from the LCD into a [BigDecimal], falling back to the
+     * conservative default on null input or any parse failure / negative value.
+     */
+    fun parseRate(raw: String?): BigDecimal {
+        if (raw == null) return fallbackBurnTaxRate
+        return runCatching { BigDecimal(raw.trim()) }.getOrNull()?.takeIf { it >= BigDecimal.ZERO }
+            ?: fallbackBurnTaxRate
+    }
+
+    /**
+     * Whether a Terra Classic coin is a **bank denom** (e.g. USTC's `uusd`) that pays its gas +
+     * burn tax in its OWN denom, as opposed to a CW20 contract token (`terra1…`) or an IBC token
+     * (`ibc/…`) that pays the fee in native LUNC (`uluna`). Mirrors the bank-denom branch selection
+     * in `TerraHelper.getPreSignedInputData` so the signed fee, the validated fee, and the max-send
+     * math all agree on which tokens are taxed in their own denom. The native coin (LUNC) is
+     * intentionally excluded — it is handled by its own native-balance branch.
+     */
+    fun isBankDenom(contractAddress: String, isNativeToken: Boolean): Boolean {
+        if (isNativeToken) return false
+        val denom = contractAddress.lowercase()
+        return !denom.contains("terra1") &&
+            !denom.startsWith("ibc/") &&
+            !denom.startsWith("factory/")
+    }
+
+    /**
+     * Base gas number for a Terra Classic send, in the SAME denom the signer uses for the fee (see
+     * `TerraHelper.getPreSignedInputData`). Bank denoms (USTC / `uusd`) get the `uusd` base;
+     * everything else — native LUNC, CW20 and IBC — gets the `uluna` base. Gating both this and the
+     * signed fee denom on [isBankDenom] keeps the gas number and the fee denom in lockstep.
+     */
+    fun baseGas(contractAddress: String, isNativeToken: Boolean): Long =
+        if (isBankDenom(contractAddress, isNativeToken)) UUSD_BASE_GAS else ULUNA_BASE_GAS
+
+    /**
+     * Whether the burn tax can be folded into the single fee field for this coin: only when the fee
+     * is denominated in the same denom as the send (native LUNC → uluna, USTC bank denom → uusd).
+     * CW20/IBC pay the fee in uluna while the send is in the token's own denom, so folding a
+     * token-unit tax there would mix denoms; they are excluded.
+     */
+    fun taxPaidInSendDenom(contractAddress: String, isNativeToken: Boolean): Boolean =
+        isNativeToken || isBankDenom(contractAddress, isNativeToken)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTax.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTax.kt
@@ -22,6 +22,14 @@ object TerraClassicTax {
     val fallbackBurnTaxRate: BigDecimal = BigDecimal("0.005")
 
     /**
+     * Sanity ceiling for a parsed burn-tax rate. The live rate is governance-controlled and has
+     * historically been ≤ 1.2%, so any value above this (e.g. a malformed `"5"` meaning 500%) is
+     * treated as garbage and replaced by [fallbackBurnTaxRate] — keeping the fail-safe symmetric
+     * with the lower bound so a bad endpoint can neither under- nor massively over-charge.
+     */
+    val maxBurnTaxRate: BigDecimal = BigDecimal("0.1")
+
+    /**
      * Base gas fee for an `uluna`-denominated Terra Classic send (300k gas × 28.325 uluna/gas =
      * 8,497,500 uluna ≈ 8.5 LUNC). Paid by native LUNC, CW20 (`terra1…`) and IBC (`ibc/…`) tokens,
      * whose fee the signer denominates in `uluna`.
@@ -45,12 +53,15 @@ object TerraClassicTax {
 
     /**
      * Parse a decimal-string `burn_tax_rate` from the LCD into a [BigDecimal], falling back to the
-     * conservative default on null input or any parse failure / negative value.
+     * conservative default on null/blank input, any parse failure, a negative value, or a value
+     * above [maxBurnTaxRate] (a parseable-but-garbage rate like `"5"` would otherwise be applied as
+     * a 500% tax).
      */
     fun parseRate(raw: String?): BigDecimal {
         if (raw == null) return fallbackBurnTaxRate
-        return runCatching { BigDecimal(raw.trim()) }.getOrNull()?.takeIf { it >= BigDecimal.ZERO }
-            ?: fallbackBurnTaxRate
+        return runCatching { BigDecimal(raw.trim()) }
+            .getOrNull()
+            ?.takeIf { it >= BigDecimal.ZERO && it <= maxBurnTaxRate } ?: fallbackBurnTaxRate
     }
 
     /**
@@ -74,6 +85,11 @@ object TerraClassicTax {
      * `TerraHelper.getPreSignedInputData`). Bank denoms (USTC / `uusd`) get the `uusd` base;
      * everything else — native LUNC, CW20 and IBC — gets the `uluna` base. Gating both this and the
      * signed fee denom on [isBankDenom] keeps the gas number and the fee denom in lockstep.
+     *
+     * NOTE: among bank denoms only `uusd` is supported — it is the only non-native bank token in
+     * the Terra Classic coin list. A different bank denom (e.g. `ukrw`) would be billed the `uusd`
+     * gas price in its own denom and be mis-priced; add per-denom gas prices here before listing
+     * one.
      */
     fun baseGas(contractAddress: String, isNativeToken: Boolean): Long =
         if (isBankDenom(contractAddress, isNativeToken)) UUSD_BASE_GAS else ULUNA_BASE_GAS

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
@@ -110,6 +110,11 @@ class TerraHelper(
                 !keysignPayload.coin.contractAddress.contains("terra1") &&
                     !keysignPayload.coin.contractAddress.contains("ibc/")
             ) {
+                // Terra Classic bank-denom tokens (e.g. USTC / uusd) pay the base gas fee plus a
+                // proportional burn tax in the send denom itself. The total (gas + burn tax) is
+                // precomputed upstream in CosmosFeeService and carried in atomData.gas, so the fee
+                // is a single coin in the token's own denom. Mirrors vultisig-ios
+                // TerraHelperStruct.
                 val input =
                     Cosmos.SigningInput.newBuilder()
                         .setPublicKey(ByteString.copyFrom(publicKey.data()))
@@ -139,17 +144,11 @@ class TerraHelper(
                         )
                         .setFee(
                             Cosmos.Fee.newBuilder()
-                                .setGas(1000000)
+                                .setGas(gasLimit)
                                 .addAmounts(
                                     Cosmos.Amount.newBuilder()
-                                        .setDenom("uluna")
+                                        .setDenom(keysignPayload.coin.contractAddress)
                                         .setAmount(atomData.gas.toString())
-                                        .build()
-                                )
-                                .addAmounts(
-                                    Cosmos.Amount.newBuilder()
-                                        .setDenom("uusd")
-                                        .setAmount("1000000")
                                         .build()
                                 )
                                 .build()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetAvailableTokenBalanceUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetAvailableTokenBalanceUseCase.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.data.usecases
 
+import com.vultisig.wallet.data.blockchain.cosmos.TerraClassicTax
 import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.TokenValue
 import java.math.BigInteger
 import javax.inject.Inject
@@ -13,7 +15,15 @@ internal class GetAvailableTokenBalanceUseCaseImpl @Inject constructor() :
     override suspend fun invoke(account: Account, gasCost: BigInteger): TokenValue? {
         val token = account.token
         val tokenValue = account.tokenValue
-        return if (token.isNativeToken) {
+        // Terra Classic bank denoms (e.g. USTC/uusd) pay gas + burn tax in their OWN denom, not in
+        // native LUNC — so, like native tokens, the fee must be reserved out of the token's own
+        // balance. Without this a MAX send signs amount+fee > balance and the chain rejects it.
+        // Mirrors iOS terraClassicMaxValue. CW20/IBC still pay in native LUNC and reserve nothing.
+        val feePaidInThisToken =
+            token.isNativeToken ||
+                (token.chain == Chain.TerraClassic &&
+                    TerraClassicTax.isBankDenom(token.contractAddress, token.isNativeToken))
+        return if (feePaidInThisToken) {
             tokenValue?.copy(value = tokenValue.value.minus(gasCost).coerceAtLeast(BigInteger.ZERO))
         } else {
             tokenValue

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
@@ -115,6 +115,41 @@ class CosmosApiTest {
         assertNull(api.getDenomMetadata("uluna"))
     }
 
+    @Test
+    fun `getTerraClassicBurnTaxRate parses burn_tax_rate from x-tax params`() = runTest {
+        var capturedPath: String? = null
+        val api =
+            cosmosApi(
+                MockEngine { request ->
+                    capturedPath = request.url.encodedPath
+                    respond(
+                        content =
+                            """{"params":{"burn_tax_rate":"0.005000000000000000",""" +
+                                """"gas_prices":[]}}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val rate = api.getTerraClassicBurnTaxRate()
+
+        assertEquals("/terra/tax/v1beta1/params", capturedPath)
+        assertEquals("0.005000000000000000", rate)
+    }
+
+    @Test
+    fun `getTerraClassicBurnTaxRate returns null on failure so caller can fall back`() = runTest {
+        val api =
+            cosmosApi(
+                MockEngine {
+                    respond(content = "boom", status = HttpStatusCode.InternalServerError)
+                }
+            )
+
+        assertNull(api.getTerraClassicBurnTaxRate())
+    }
+
     private fun cosmosApi(engine: MockEngine): CosmosApi {
         val json = Json { ignoreUnknownKeys = true }
         return CosmosApiImp(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -1,10 +1,15 @@
 package com.vultisig.wallet.data.blockchain.cosmos
 
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -13,9 +18,24 @@ import org.junit.jupiter.api.Test
 
 class CosmosFeeServiceTest {
 
-    private val feeService = CosmosFeeService()
+    private val cosmosApi: CosmosApi = mockk(relaxed = true)
+    private val cosmosApiFactory: CosmosApiFactory = mockk {
+        every { createCosmosApi(any()) } returns cosmosApi
+    }
 
-    private fun transfer(chain: Chain) =
+    private val feeService = CosmosFeeService(cosmosApiFactory)
+
+    init {
+        // Default live burn-tax rate (0.5%) for Terra Classic taxable sends.
+        coEvery { cosmosApi.getTerraClassicBurnTaxRate() } returns "0.005"
+    }
+
+    private fun transfer(
+        chain: Chain,
+        amount: BigInteger = BigInteger("1000000"),
+        contractAddress: String = "",
+        isNativeToken: Boolean = true,
+    ) =
         Transfer(
             coin =
                 Coin(
@@ -26,11 +46,11 @@ class CosmosFeeServiceTest {
                     decimal = 8,
                     hexPublicKey = "test_pub_key",
                     priceProviderID = "",
-                    contractAddress = "",
-                    isNativeToken = true,
+                    contractAddress = contractAddress,
+                    isNativeToken = isNativeToken,
                 ),
             vault = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain"),
-            amount = BigInteger("1000000"),
+            amount = amount,
             to = "recipient_address",
         )
 
@@ -88,6 +108,59 @@ class CosmosFeeServiceTest {
     fun `QBTC returns GasFees type`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Qbtc))
         assertTrue(fee is GasFees)
+    }
+
+    @Test
+    fun `TerraClassic native LUNC fee is uluna base gas plus burn tax`() = runTest {
+        // amount 1_000_000 × 0.5% = 5_000 tax + 8_497_500 base = 8_502_500 uluna.
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(Chain.TerraClassic, amount = BigInteger("1000000"))
+            ) as GasFees
+        assertEquals(BigInteger("300000"), fee.limit)
+        assertEquals(TerraClassicTax.ULUNA_BASE_GAS.toBigInteger() + BigInteger("5000"), fee.amount)
+    }
+
+    @Test
+    fun `TerraClassic USTC bank denom fee is uusd base gas plus burn tax`() = runTest {
+        // USTC (uusd) is a bank denom: base 225_000 uusd + 0.5% of 2_000_000 = 10_000 → 235_000.
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(
+                    Chain.TerraClassic,
+                    amount = BigInteger("2000000"),
+                    contractAddress = "uusd",
+                    isNativeToken = false,
+                )
+            ) as GasFees
+        assertEquals(TerraClassicTax.UUSD_BASE_GAS.toBigInteger() + BigInteger("10000"), fee.amount)
+    }
+
+    @Test
+    fun `TerraClassic CW20 token gets uluna base gas with no burn tax`() = runTest {
+        // CW20 (terra1…) pays its fee in uluna while the send is in the token denom, so no tax
+        // fold.
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(
+                    Chain.TerraClassic,
+                    amount = BigInteger("9999999999"),
+                    contractAddress = "terra1abcdef",
+                    isNativeToken = false,
+                )
+            ) as GasFees
+        assertEquals(TerraClassicTax.ULUNA_BASE_GAS.toBigInteger(), fee.amount)
+    }
+
+    @Test
+    fun `TerraClassic falls back to default rate when live fetch returns null`() = runTest {
+        coEvery { cosmosApi.getTerraClassicBurnTaxRate() } returns null
+        // Fallback 0.5%: 1_000_000 × 0.005 = 5_000 tax on top of the uluna base.
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(Chain.TerraClassic, amount = BigInteger("1000000"))
+            ) as GasFees
+        assertEquals(TerraClassicTax.ULUNA_BASE_GAS.toBigInteger() + BigInteger("5000"), fee.amount)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTaxTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTaxTest.kt
@@ -44,8 +44,20 @@ class TerraClassicTaxTest {
     @Test
     fun `parseRate falls back on null, blank, garbage and negative`() {
         assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate(null))
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate(""))
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("   "))
         assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("not-a-number"))
         assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("-0.1"))
+    }
+
+    @Test
+    fun `parseRate falls back when the rate exceeds the sanity ceiling`() {
+        // A malformed "5" would otherwise be applied as a 500% tax and massively overcharge.
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("5"))
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("0.2"))
+        // A plausible governance rate at/under the ceiling is accepted as-is.
+        assertEquals(BigDecimal("0.012"), TerraClassicTax.parseRate("0.012"))
+        assertEquals(TerraClassicTax.maxBurnTaxRate, TerraClassicTax.parseRate("0.1"))
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTaxTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/TerraClassicTaxTest.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class TerraClassicTaxTest {
+
+    @Test
+    fun `burnTax rounds up so the signed fee never undershoots`() {
+        // 333 × 0.005 = 1.665 → ceil → 2.
+        assertEquals(
+            BigInteger("2"),
+            TerraClassicTax.burnTax(BigInteger("333"), BigDecimal("0.005")),
+        )
+    }
+
+    @Test
+    fun `burnTax exact multiple is not rounded up`() {
+        // 1_000_000 × 0.005 = 5_000 exactly.
+        assertEquals(
+            BigInteger("5000"),
+            TerraClassicTax.burnTax(BigInteger("1000000"), BigDecimal("0.005")),
+        )
+    }
+
+    @Test
+    fun `burnTax is zero for non-positive amount or rate`() {
+        assertEquals(BigInteger.ZERO, TerraClassicTax.burnTax(BigInteger.ZERO, BigDecimal("0.005")))
+        assertEquals(BigInteger.ZERO, TerraClassicTax.burnTax(BigInteger("100"), BigDecimal.ZERO))
+    }
+
+    @Test
+    fun `parseRate parses a high-precision decimal string`() {
+        assertEquals(
+            BigDecimal("0.005000000000000000"),
+            TerraClassicTax.parseRate("0.005000000000000000"),
+        )
+    }
+
+    @Test
+    fun `parseRate falls back on null, blank, garbage and negative`() {
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate(null))
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("not-a-number"))
+        assertEquals(TerraClassicTax.fallbackBurnTaxRate, TerraClassicTax.parseRate("-0.1"))
+    }
+
+    @Test
+    fun `isBankDenom only true for non-native non-contract non-ibc denoms`() {
+        assertTrue(TerraClassicTax.isBankDenom("uusd", isNativeToken = false))
+        assertFalse(TerraClassicTax.isBankDenom("uusd", isNativeToken = true))
+        assertFalse(TerraClassicTax.isBankDenom("terra1abc", isNativeToken = false))
+        assertFalse(TerraClassicTax.isBankDenom("ibc/ABC123", isNativeToken = false))
+        assertFalse(TerraClassicTax.isBankDenom("factory/terra1/foo", isNativeToken = false))
+    }
+
+    @Test
+    fun `baseGas picks uusd for bank denom and uluna otherwise`() {
+        assertEquals(
+            TerraClassicTax.UUSD_BASE_GAS,
+            TerraClassicTax.baseGas("uusd", isNativeToken = false),
+        )
+        assertEquals(
+            TerraClassicTax.ULUNA_BASE_GAS,
+            TerraClassicTax.baseGas("", isNativeToken = true),
+        )
+        assertEquals(
+            TerraClassicTax.ULUNA_BASE_GAS,
+            TerraClassicTax.baseGas("terra1abc", isNativeToken = false),
+        )
+    }
+
+    @Test
+    fun `taxPaidInSendDenom is true for native LUNC and USTC bank denom only`() {
+        assertTrue(TerraClassicTax.taxPaidInSendDenom("", isNativeToken = true)) // LUNC
+        assertTrue(TerraClassicTax.taxPaidInSendDenom("uusd", isNativeToken = false)) // USTC
+        assertFalse(TerraClassicTax.taxPaidInSendDenom("terra1abc", isNativeToken = false)) // CW20
+        assertFalse(TerraClassicTax.taxPaidInSendDenom("ibc/ABC", isNativeToken = false)) // IBC
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetAvailableTokenBalanceUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetAvailableTokenBalanceUseCaseTest.kt
@@ -1,0 +1,101 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class GetAvailableTokenBalanceUseCaseTest {
+
+    private val useCase = GetAvailableTokenBalanceUseCaseImpl()
+
+    private fun coin(
+        chain: Chain,
+        ticker: String,
+        contractAddress: String,
+        isNativeToken: Boolean,
+    ) =
+        Coin(
+            chain = chain,
+            ticker = ticker,
+            logo = "",
+            address = "",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contractAddress,
+            isNativeToken = isNativeToken,
+        )
+
+    private fun account(coin: Coin, balance: BigInteger) =
+        Account(
+            token = coin,
+            tokenValue = TokenValue(value = balance, unit = coin.ticker, decimals = coin.decimal),
+            fiatValue = null,
+            price = null,
+        )
+
+    @Test
+    fun `native token reserves the gas cost`() = runTest {
+        val acc =
+            account(coin(Chain.TerraClassic, "LUNC", "", isNativeToken = true), BigInteger("1000"))
+        val result = useCase(acc, BigInteger("250"))
+        assertEquals(BigInteger("750"), result?.value)
+    }
+
+    @Test
+    fun `terra classic bank denom reserves the fee from its own balance`() = runTest {
+        // USTC pays gas + burn tax in uusd, so the fee must be reserved out of the USTC balance
+        // or a MAX send would sign amount+fee > balance and the chain would reject it.
+        val acc =
+            account(
+                coin(Chain.TerraClassic, "USTC", "uusd", isNativeToken = false),
+                BigInteger("1000"),
+            )
+        val result = useCase(acc, BigInteger("250"))
+        assertEquals(BigInteger("750"), result?.value)
+    }
+
+    @Test
+    fun `terra classic cw20 token reserves nothing (fee paid in native LUNC)`() = runTest {
+        val acc =
+            account(
+                coin(Chain.TerraClassic, "ASTROC", "terra1xyz", isNativeToken = false),
+                BigInteger("1000"),
+            )
+        val result = useCase(acc, BigInteger("250"))
+        assertEquals(BigInteger("1000"), result?.value)
+    }
+
+    @Test
+    fun `non-native token on another chain reserves nothing`() = runTest {
+        // An ERC20 contract address must NOT be mistaken for a Terra Classic bank denom.
+        val acc =
+            account(
+                coin(
+                    Chain.Ethereum,
+                    "USDC",
+                    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    isNativeToken = false,
+                ),
+                BigInteger("1000"),
+            )
+        val result = useCase(acc, BigInteger("250"))
+        assertEquals(BigInteger("1000"), result?.value)
+    }
+
+    @Test
+    fun `reserved balance is floored at zero when the fee exceeds the balance`() = runTest {
+        val acc =
+            account(
+                coin(Chain.TerraClassic, "USTC", "uusd", isNativeToken = false),
+                BigInteger("100"),
+            )
+        val result = useCase(acc, BigInteger("250"))
+        assertEquals(BigInteger.ZERO, result?.value)
+    }
+}


### PR DESCRIPTION
## Problem

Terra Classic (columbus-5) charges a proportional **burn tax** (~0.5%, `x/tax` module) on every `MsgSend`, paid in the send denom on top of the gas fee. `CosmosFeeService` returned a flat `10,000,000 uluna` with no reference to the send amount, so any non-trivial USTC/LUNC send **under-paid and was rejected** by validators (`insufficient fee`). Users could not send USTC/LUNC. (#4843)

## Fix

Fold the burn tax into the single Cosmos fee field, mirroring `vultisig-ios` (`TerraClassicTax` / `BlockChainService`):

- **`TerraClassicTax`** (new) — pure helper: ceil-rounded tax math (so the signed fee never undershoots), fail-closed `0.5%` fallback rate, bank-denom classification, and per-denom base gas (`uluna` 8,497,500 / `uusd` 225,000).
- **`CosmosApi.getTerraClassicBurnTaxRate()`** — live rate from `/terra/tax/v1beta1/params` → `params.burn_tax_rate`; returns `null` on any failure so the caller falls back conservatively rather than signing an under-funded tx.
- **`CosmosFeeService`** — TerraClassic fee = `baseGas(coin) + burnTax(amount, rate)`, folding the tax only when it is paid in the send denom (native LUNC → uluna, USTC bank denom → uusd). CW20 (`terra1…`) / IBC (`ibc/…`) pay the fee in uluna while the send is in the token's own denom, so they get base gas only to avoid mixing denoms.
- **`TerraHelper`** — sign the USTC bank-denom fee as a **single `uusd` coin = tax-folded `gas`** (was a two-coin `uluna=gas` + hardcoded `uusd=1_000_000`), so the signed fee denom matches the base-gas denom. Native LUNC / CW20 branches already read `gas` and pick up the tax automatically.

The displayed fee and signed fee both derive from `CosmosFeeService`, so they stay consistent. MAX-send estimates the tax on a slightly larger amount than is ultimately sent, so the fee always covers the real tax (fail-safe — sends marginally less rather than over-committing).

## Test plan

- [x] `TerraClassicTaxTest` — tax math, ceil rounding, fallback (null/garbage/negative), denom classification, base-gas selection
- [x] `CosmosFeeServiceTest` — LUNC (uluna base + tax), USTC (uusd base + tax), CW20 (base only, no tax), null-rate fallback; updated for the new constructor
- [x] `CosmosApiTest` — endpoint path + `burn_tax_rate` parse, and null-on-failure
- [x] Full `:data` unit suite green; `:app` compiles; ktfmt applied
- [ ] Manual mainnet smoke: send LUNC and USTC, confirm broadcast succeeds (no `insufficient fee` / tax rejection)

Note: for USTC the fee is now correctly paid in `uusd`; the fee *display* still labels in the native LUNC token (pre-existing single-gas-field display nuance, same as iOS) — out of scope for this rejection fix.

Closes #4843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terra Classic transactions now use a live-fetched burn tax rate when estimating fees.

* **Bug Fixes**
  * Improved Terra Classic fee calculations for LUNC vs USTC bank denoms, including correct proportional burn tax behavior and safer burn-tax rate handling.
  * Fee reservation and balance checks now account for fee-paying tokens more accurately.
  * Better fallback to a conservative default rate when live data isn’t available.

* **Tests**
  * Added/updated unit tests for Terra Classic tax rate parsing and fee computations, and refreshed the related expected image hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->