### PR TITLE
fix(swap): don't deduct LI.FI fee from source balance on percentage tap

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -10,7 +10,6 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.SwapTransactionRepository
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -340,13 +339,13 @@ constructor(
         // "insufficient balance" warning on a now-valid amount and mask the live quote/formError.
         _uiState.update { it.copy(error = null) }
 
-        val swapFee =
-            quoteState.quote?.fees?.value.takeIf { quoteState.provider == SwapProvider.LIFI }
-                ?: BigInteger.ZERO
-
+        // Only the source-chain network fee may be deducted from the source balance, and only for a
+        // native source on its own gas chain. The provider swap fee is taken from the destination
+        // amount (for LI.FI it is denominated in the destination token's units), so subtracting it
+        // here would mix decimals and could wrongly drive the usable amount negative for a
+        // low-decimal source into a high-decimal destination.
         val maxUsableTokenAmount =
             srcTokenValue.value -
-                swapFee -
                 (quotePipeline.estimatedNetworkFeeTokenValue.value?.value?.takeIf {
                     srcToken.isNativeToken && quotePipeline.gasFeeChain.value == srcToken.chain
                 } ?: BigInteger.ZERO)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.AllowanceRepository
@@ -630,6 +631,69 @@ internal class SwapFormViewModelTest {
             vm.selectSrcPercentage(1.0f)
 
             assertEquals("0.00553297", vm.srcAmountState.text.toString())
+        }
+
+    @Test
+    fun `selectSrcPercentage does not subtract the LIFI destination-denominated swap fee`() =
+        runTest(mainDispatcher) {
+            // LI.FI's integrator fee is denominated in the destination token's raw units, so
+            // deducting it from a low-decimal source balance underflows: here the 0.1 ETH fee
+            // (1e17) far exceeds the 1000 USDC balance (1e9), which used to clear the field with
+            // an insufficient-balance error.
+            val usdcBalance = BigInteger("1000000000") // 1000 USDC (6 decimals)
+            val usdcAddress =
+                Address(
+                    chain = Chain.Ethereum,
+                    address = "0xethaddress",
+                    accounts =
+                        listOf(
+                            createAccount(USDC_COIN, usdcBalance),
+                            createAccount(ETH_COIN, BigInteger("1000000000000000000")),
+                        ),
+                )
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.LIFI)
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns
+                createDefaultQuoteFetchResult(
+                    quote =
+                        createLiFiQuote(
+                            fees = TokenValue(BigInteger("100000000000000000"), ETH_COIN)
+                        ),
+                    provider = SwapProvider.LIFI,
+                    providerUiText = R.string.swap_for_provider_li_fi.asUiText(),
+                )
+
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(usdcAddress, btcAddress()),
+                    srcTokenId = USDC_COIN.id,
+                    dstTokenId = ETH_COIN.id,
+                )
+            advanceUntilIdle()
+
+            // Land a LI.FI quote so quoteState carries the destination-denominated fee.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("100")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            vm.selectSrcPercentage(0.25f)
+
+            // 25% of the full 1000 USDC balance, with no destination-fee subtraction.
+            assertEquals("250", vm.srcAmountState.text.toString())
+            assertNull(vm.uiState.value.error)
         }
 
     // endregion
@@ -2810,6 +2874,19 @@ internal class SwapFormViewModelTest {
             expiredAt = Clock.System.now() + 1.minutes,
             data = mockk(relaxed = true),
             subProvider = "NEAR",
+        )
+
+    private fun createLiFiQuote(
+        expectedDstValue: TokenValue =
+            TokenValue(value = BigInteger("1000000000000000000"), token = ETH_COIN),
+        fees: TokenValue = TokenValue(value = BigInteger("100000000000000000"), token = ETH_COIN),
+    ): SwapQuote.OneInch =
+        SwapQuote.OneInch(
+            expectedDstValue = expectedDstValue,
+            fees = fees,
+            expiredAt = Clock.System.now() + 1.minutes,
+            data = mockk(relaxed = true),
+            provider = SwapProvider.LIFI.getSwapProviderId(),
         )
 
     /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -546,11 +546,10 @@ internal class SwapFormViewModelTest {
 
             vm.selectSrcPercentage(1.0f)
 
-            val amountText = vm.srcAmountState.text.toString()
-            assertTrue(
-                amountText.isNotEmpty() && amountText != "0",
-                "Expected non-zero amount but got: $amountText",
-            )
+            // 1 ETH balance minus the 0.001 ETH source-chain gas fee (native source on its own gas
+            // chain). Pins the network-fee subtraction so a regression that stops deducting it is
+            // caught instead of slipping through a non-empty/non-zero check.
+            assertEquals("0.999", vm.srcAmountState.text.toString())
         }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #4902

On the Swap form, the percentage chips (25/50/75) and MAX read the active quote's swap fee and subtracted it from the source-token balance before computing the amount. For LI.FI the quote fee is denominated in the **destination** token's raw units, so subtracting it from a source-token raw balance mixes decimals. For a low-decimal source into a high-decimal destination (e.g. USDC, 6dp, into an 18-decimal ERC-20) the destination-denominated fee can far exceed the source balance, driving the usable amount negative — which cleared the field and showed a false "insufficient balance" error.

The swap fee is taken out of the destination amount and is already reflected in the quoted output, so it must not be deducted from the source balance — iOS and the desktop app never deduct it. The existing source-chain network-fee handling for a native source is unchanged. Manual amount entry was already correct, so this only brings the buttons in line with it.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - amount-input fix only (computed source amount before quoting); the resulting swap is identical to manually typing the same amount, so there is no new on-chain behavior to link
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — this is a ViewModel computation fix. The visible effect (the amount field holding a fraction of the balance instead of clearing with an error) is produced by runtime logic against a live LI.FI quote, which the static preview harness can't reproduce faithfully. The behavior is pinned by a unit test that fails before the change (`expected: <250> but was: <>`) and passes after.

## Additional context

Co-sign is unaffected. `selectSrcPercentage` only writes to the shared source-amount field — the same channel manual typing uses — so the staged swap amount, payload construction, session, approval, and broadcast are all identical to entering the value by hand (which already worked). No signing/co-sign code is touched.

Verification: `./gradlew :app:testDebugUnitTest --tests "*SwapFormViewModelTest"` → 90 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected swap “max usable” calculations to subtract only the source-chain network fee (when the source is native on its own gas chain), preventing incorrect provider fee deductions that could lead to negative or insufficient balances.
  * Refined fee handling to avoid decimal-mixing and ensure the insufficient-balance check is based on the updated usable amount.

* **Tests**
  * Updated swap quote construction to use LI.FI provider-id mapping.
  * Strengthened and added assertions covering source percentage selection and ensuring LI.FI destination-denominated fees aren’t subtracted from low-decimal sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->