### PR TITLE
fix(evm): price OP-stack L1 data fee into EVM tx fees

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.api.models.RpcResponseJson
 import com.vultisig.wallet.data.api.models.SendTransactionJson
 import com.vultisig.wallet.data.api.models.ZkGasFee
 import com.vultisig.wallet.data.chains.helpers.EthereumFunction
+import com.vultisig.wallet.data.chains.helpers.EthereumRlpEncoder
 import com.vultisig.wallet.data.common.convertToBigIntegerOrZero
 import com.vultisig.wallet.data.common.stripHexPrefix
 import com.vultisig.wallet.data.common.toKeccak256
@@ -78,6 +79,23 @@ interface EvmApi {
     suspend fun getERC20Balance(address: String, contractAddress: String): BigInteger
 
     suspend fun getTxStatus(txHash: String): EvmRpcResponseJson<EvmTxStatusJson>?
+
+    /**
+     * Prices the L1 data-availability fee of an OP-stack L2 transaction via the `GasPriceOracle`
+     * predeploy (`0x420…0F`) `getL1Fee(bytes)`. Builds the RLP-encoded unsigned EIP-1559 tx from
+     * the supplied fields (the L1 fee scales with its serialized size) and returns the oracle's
+     * quote in wei, or [BigInteger.ZERO] when the chain has no L1 component or the call fails.
+     */
+    suspend fun getOpStackL1Fee(
+        senderAddress: String,
+        to: String,
+        value: BigInteger,
+        data: ByteArray,
+        gasLimit: BigInteger,
+        maxFeePerGas: BigInteger,
+        maxPriorityFeePerGas: BigInteger,
+        chainId: BigInteger,
+    ): BigInteger
 }
 
 interface EvmApiFactory {
@@ -548,6 +566,46 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         return Numeric.toHexString(data?.copyOfRange(data.size - 20, data.size))
     }
 
+    override suspend fun getOpStackL1Fee(
+        senderAddress: String,
+        to: String,
+        value: BigInteger,
+        data: ByteArray,
+        gasLimit: BigInteger,
+        maxFeePerGas: BigInteger,
+        maxPriorityFeePerGas: BigInteger,
+        chainId: BigInteger,
+    ): BigInteger {
+        val rlpEncodedTx =
+            EthereumRlpEncoder.encodeUnsignedEip1559(
+                chainId = chainId,
+                nonce = getNonce(senderAddress),
+                maxPriorityFeePerGas = maxPriorityFeePerGas,
+                maxFeePerGas = maxFeePerGas,
+                gasLimit = gasLimit,
+                to = to,
+                value = value,
+                data = data,
+            )
+        val callData = EthereumFunction.getL1FeeEncoder(rlpEncodedTx)
+        val rpcResp =
+            fetch<RpcResponse>(
+                "eth_call",
+                buildJsonArray {
+                    addJsonObject {
+                        put("to", OP_STACK_GAS_PRICE_ORACLE)
+                        put("data", callData)
+                    }
+                    add("latest")
+                },
+            )
+        if (rpcResp.error != null) {
+            Timber.d("get l1 fee error: %s", rpcResp.error.message)
+            return BigInteger.ZERO
+        }
+        return rpcResp.result.convertToBigIntegerOrZero()
+    }
+
     override suspend fun getTxStatus(txHash: String): EvmRpcResponseJson<EvmTxStatusJson>? {
         val rpcResp =
             try {
@@ -582,5 +640,8 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
         private const val ERROR_EXISTING_TX = "existing tx"
         private const val ERROR_TX_IN_CACHE = "tx already exists in cache"
         private const val ERROR_CODE_10055 = "code=10055"
+
+        // OP-stack GasPriceOracle predeploy, identical across all OP-stack L2s.
+        private const val OP_STACK_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -142,7 +142,17 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
                 L1CallContext(
                     to = transaction.to,
                     value = if (coin.isNativeToken) transaction.amount else BigInteger.ZERO,
-                    data = Numeric.hexStringToByteArray(transaction.callData),
+                    // The router calldata is the dominant part of a swap's L1 data fee, but it is
+                    // not known here: gas estimation runs in parallel with the quote fetch, so
+                    // every
+                    // live caller builds the Swap with an empty callData. Pricing the empty payload
+                    // would drop almost the entire L1 cost, so we fall back to a representative
+                    // swap-calldata payload. If a caller ever supplies real calldata, we honour it.
+                    data =
+                        transaction.callData
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { Numeric.hexStringToByteArray(it) }
+                            ?: REPRESENTATIVE_SWAP_CALLDATA,
                 )
             else ->
                 error("Unsupported transaction type for L1 fee: ${transaction::class.simpleName}")
@@ -331,6 +341,18 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
 
     companion object {
         private val GWEI = BigInteger.TEN.pow(9)
+
+        // Stand-in calldata used to price a swap's OP-stack L1 data fee when the real router
+        // calldata is unavailable at estimation time (see resolveL1CallContext). Sized to a typical
+        // DEX/router swap payload (~512 bytes covers a 1inch/Kyber route or a THORChain
+        // depositWithExpiry memo) and filled with non-zero bytes, which the OP-stack fee formula
+        // charges at the higher 16-gas/byte rate — a deliberately conservative estimate so the
+        // reserved fee does not under-cover the real L1 cost. Post-Ecotone/Fjord L1 fees are small
+        // in absolute terms, so the conservative sizing adds negligible cost while avoiding a gross
+        // underestimate.
+        const val REPRESENTATIVE_SWAP_CALLDATA_BYTES = 512
+        private val REPRESENTATIVE_SWAP_CALLDATA =
+            ByteArray(REPRESENTATIVE_SWAP_CALLDATA_BYTES) { 1 }
 
         // Extra bump applied to the committed base fee on the non-swap send path. With the
         // further 20% added in calculateMaxFeePerGas this yields a baseFee × 1.5 + priorityFee

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -91,8 +91,12 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         if (!chain.isOpStackL2) return BigInteger.ZERO
         if (fees !is Eip1559) return BigInteger.ZERO
 
+        // Resolve the call context outside the try so a genuine programming error (unsupported
+        // transaction type) surfaces instead of being masked as a zero L1 fee. Only the best-effort
+        // oracle call below degrades to zero on failure.
+        val context = resolveL1CallContext(transaction)
+
         return try {
-            val context = resolveL1CallContext(transaction)
             evmApi.getOpStackL1Fee(
                 senderAddress = transaction.coin.address,
                 to = context.to,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -10,11 +10,14 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.isLayer2
+import com.vultisig.wallet.data.models.isOpStackL2
+import com.vultisig.wallet.data.models.oneInchChainId
 import com.vultisig.wallet.data.models.supportsLegacyGas
+import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.increaseByPercent
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import timber.log.Timber
@@ -40,12 +43,7 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
                 calculateEip1559Fees(limit, chain, false, evmApi)
             }
 
-        val l1Fees =
-            if (chain.isLayer2) {
-                calculateLayer1Fees()
-            } else {
-                BigInteger.ZERO
-            }
+        val l1Fees = calculateLayer1Fees(transaction, fees, evmApi)
 
         return fees.addL1Amount(l1Fees)
     }
@@ -79,9 +77,85 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         return maxOf(calculatedLimit, getDefaultLimit(transaction))
     }
 
-    private fun calculateLayer1Fees(): BigInteger {
-        return BigInteger.ZERO
+    // OP-stack L2s charge an L1 data-availability fee on top of L2 execution gas. We price it via
+    // the chain's GasPriceOracle predeploy so the displayed/reserved fee (and any max-send
+    // headroom) reflects the true cost. Non-OP-stack chains — including the other L2s Arbitrum and
+    // ZkSync, which fold their L1 component in elsewhere — contribute zero here. Estimation is
+    // best-effort: a failed oracle call degrades to zero rather than blocking the whole fee calc.
+    private suspend fun calculateLayer1Fees(
+        transaction: BlockchainTransaction,
+        fees: Fee,
+        evmApi: EvmApi,
+    ): BigInteger {
+        val chain = transaction.coin.chain
+        if (!chain.isOpStackL2) return BigInteger.ZERO
+        if (fees !is Eip1559) return BigInteger.ZERO
+
+        return try {
+            val context = resolveL1CallContext(transaction)
+            evmApi.getOpStackL1Fee(
+                senderAddress = transaction.coin.address,
+                to = context.to,
+                value = context.value,
+                data = context.data,
+                gasLimit = fees.limit,
+                maxFeePerGas = fees.maxFeePerGas,
+                maxPriorityFeePerGas = fees.maxPriorityFeePerGas,
+                chainId = chain.oneInchChainId().toBigInteger(),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "L1 data fee estimation failed for %s; treating as zero", chain)
+            BigInteger.ZERO
+        }
     }
+
+    // Mirrors what each transaction type actually broadcasts (the L1 fee scales with calldata
+    // size):
+    // native sends carry the memo, ERC-20 sends carry the transfer calldata to the token contract,
+    // and swaps carry the router calldata.
+    private fun resolveL1CallContext(transaction: BlockchainTransaction): L1CallContext {
+        val coin = transaction.coin
+        return when (transaction) {
+            is Transfer ->
+                if (coin.isNativeToken) {
+                    L1CallContext(
+                        to = transaction.to,
+                        value = transaction.amount,
+                        data =
+                            transaction.memo?.takeIf { it.isNotEmpty() }?.toByteArray()
+                                ?: ByteArray(0),
+                    )
+                } else {
+                    L1CallContext(
+                        to = coin.contractAddress,
+                        value = BigInteger.ZERO,
+                        data = erc20TransferCallData(transaction.to, transaction.amount),
+                    )
+                }
+            is Swap ->
+                L1CallContext(
+                    to = transaction.to,
+                    value = if (coin.isNativeToken) transaction.amount else BigInteger.ZERO,
+                    data = Numeric.hexStringToByteArray(transaction.callData),
+                )
+            else ->
+                error("Unsupported transaction type for L1 fee: ${transaction::class.simpleName}")
+        }
+    }
+
+    // ERC-20 transfer(address,uint256) calldata, built with plain hex concatenation (no JNI) so
+    // this
+    // class stays unit-testable. Matches EvmApi.constructERC20TransferData.
+    private fun erc20TransferCallData(recipient: String, amount: BigInteger): ByteArray {
+        val methodId = "a9059cbb"
+        val paddedAddress = recipient.removePrefix("0x").padStart(64, '0')
+        val paddedValue = amount.toString(16).padStart(64, '0')
+        return Numeric.hexStringToByteArray(methodId + paddedAddress + paddedValue)
+    }
+
+    private data class L1CallContext(val to: String, val value: BigInteger, val data: ByteArray)
 
     override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee {
         val chain = transaction.coin.chain
@@ -96,12 +170,7 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
                 calculateEip1559Fees(defaultLimit, chain, isSwap, evmApi)
             }
 
-        val l1Fees =
-            if (chain.isLayer2) {
-                calculateLayer1Fees()
-            } else {
-                BigInteger.ZERO
-            }
+        val l1Fees = calculateLayer1Fees(transaction, fees, evmApi)
 
         return fees.addL1Amount(l1Fees)
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumFunctions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumFunctions.kt
@@ -52,6 +52,19 @@ object EthereumFunction {
         }
     }
 
+    // ABI-encodes the OP-stack `GasPriceOracle.getL1Fee(bytes)` call where `rlpEncodedUnsignedTx`
+    // is
+    // the RLP-encoded unsigned transaction whose L1 data fee we want priced.
+    fun getL1FeeEncoder(rlpEncodedUnsignedTx: ByteArray): String {
+        try {
+            val encodedFunction =
+                EthereumAbiFunction("getL1Fee").apply { addParamBytes(rlpEncodedUnsignedTx, false) }
+            return EthereumAbi.encode(encodedFunction).toHexString().add0x()
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Failed to encode getL1Fee call: ${e.message}", e)
+        }
+    }
+
     fun balanceErc20Decoder(hexBalance: String): BigInteger {
         val fn = EthereumAbiFunction("balanceOf")
         fn.addParamUInt256(ByteArray(32), true)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumRlpEncoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/EthereumRlpEncoder.kt
@@ -1,0 +1,64 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.utils.toSafeByteArray
+import java.math.BigInteger
+import wallet.core.jni.CoinType
+import wallet.core.jni.EthereumRlp
+import wallet.core.jni.proto.EthereumRlp.EncodingInput
+import wallet.core.jni.proto.EthereumRlp.EncodingOutput
+import wallet.core.jni.proto.EthereumRlp.RlpItem
+import wallet.core.jni.proto.EthereumRlp.RlpList
+
+/**
+ * Builds the RLP-encoded, **unsigned** EIP-1559 (type-2) transaction payload that OP-stack chains'
+ * `GasPriceOracle.getL1Fee(bytes)` expects in order to price the L1 data-availability component of
+ * an L2 transaction. The L1 fee scales with the serialized byte size of this payload, so the fields
+ * mirror what will actually be broadcast.
+ *
+ * The envelope is `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to,
+ * value, data, accessList])` with an empty access list.
+ */
+object EthereumRlpEncoder {
+
+    private const val EIP1559_TX_TYPE: Byte = 0x02
+
+    fun encodeUnsignedEip1559(
+        chainId: BigInteger,
+        nonce: BigInteger,
+        maxPriorityFeePerGas: BigInteger,
+        maxFeePerGas: BigInteger,
+        gasLimit: BigInteger,
+        to: String,
+        value: BigInteger,
+        data: ByteArray,
+    ): ByteArray {
+        val txList =
+            RlpList.newBuilder()
+                .addItems(u256(chainId))
+                .addItems(u256(nonce))
+                .addItems(u256(maxPriorityFeePerGas))
+                .addItems(u256(maxFeePerGas))
+                .addItems(u256(gasLimit))
+                .addItems(RlpItem.newBuilder().setAddress(to))
+                .addItems(u256(value))
+                .addItems(RlpItem.newBuilder().setData(ByteString.copyFrom(data)))
+                // empty access list
+                .addItems(RlpItem.newBuilder().setList(RlpList.newBuilder()))
+                .build()
+
+        val input = EncodingInput.newBuilder().setItem(RlpItem.newBuilder().setList(txList)).build()
+
+        val output =
+            EncodingOutput.parseFrom(EthereumRlp.encode(CoinType.ETHEREUM, input.toByteArray()))
+        val encoded = output.encoded.toByteArray()
+
+        return ByteArray(encoded.size + 1).apply {
+            this[0] = EIP1559_TX_TYPE
+            System.arraycopy(encoded, 0, this, 1, encoded.size)
+        }
+    }
+
+    private fun u256(value: BigInteger): RlpItem.Builder =
+        RlpItem.newBuilder().setNumberU256(ByteString.copyFrom(value.toSafeByteArray()))
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -314,15 +314,20 @@ val Chain.isLayer2: Boolean
             else -> false
         }
 
-// OP-stack–derived L2s that expose the GasPriceOracle predeploy (0x420…0F) and charge a separate
-// L1 data fee on top of L2 execution gas. Arbitrum and ZkSync are L2s too (isLayer2) but price
+// OP-stack–derived L2s that expose the GasPriceOracle predeploy (0x420…0F), charge a separate L1
+// data fee on top of L2 execution gas, and denominate that L1 fee in the same token as L2 gas (ETH)
+// so it can be summed directly into the tx fee. Arbitrum and ZkSync are L2s too (isLayer2) but
+// price
 // their L1 component differently, so they are deliberately excluded from the OP-stack oracle path.
+// Mantle is also OP-stack–derived, but its getL1Fee is denominated in ETH while its L2 gas (and our
+// fee amount) is denominated in MNT; without the chain's ETH/MNT tokenRatio the two are not
+// additive,
+// so Mantle is excluded here rather than have its L1 cost mis-summed against an MNT amount.
 val Chain.isOpStackL2: Boolean
     get() =
         when (this) {
             Chain.Base,
             Chain.Blast,
-            Chain.Mantle,
             Chain.Optimism -> true
             else -> false
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -308,8 +308,22 @@ val Chain.isLayer2: Boolean
             Chain.Arbitrum,
             Chain.Base,
             Chain.Blast,
+            Chain.Mantle,
             Chain.Optimism,
             Chain.ZkSync -> true
+            else -> false
+        }
+
+// OP-stack–derived L2s that expose the GasPriceOracle predeploy (0x420…0F) and charge a separate
+// L1 data fee on top of L2 execution gas. Arbitrum and ZkSync are L2s too (isLayer2) but price
+// their L1 component differently, so they are deliberately excluded from the OP-stack oracle path.
+val Chain.isOpStackL2: Boolean
+    get() =
+        when (this) {
+            Chain.Base,
+            Chain.Blast,
+            Chain.Mantle,
+            Chain.Optimism -> true
             else -> false
         }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_MANTLE_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT
+import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.REPRESENTATIVE_SWAP_CALLDATA_BYTES
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
@@ -475,9 +476,7 @@ internal class EthereumFeeServiceTest {
     }
 
     @Test
-    fun `Mantle swap prices L1 against the router target with the swap calldata`() = runTest {
-        coEvery { evmApi.getBaseFee() } returns gwei(100)
-        stubFeeHistory(listOf(gwei(5)))
+    fun `swap with empty calldata prices L1 against the representative swap payload`() = runTest {
         val dataSlot = slot<ByteArray>()
         coEvery {
             evmApi.getOpStackL1Fee(
@@ -492,32 +491,38 @@ internal class EthereumFeeServiceTest {
             )
         } returns BigInteger.ZERO
 
-        val swap =
-            Swap(
-                coin = coin(Chain.Mantle, isNative = true),
-                vault = VAULT,
-                amount = BigInteger("1000000000000000000"),
-                to = "0xRouter",
-                callData = "0xabcdef",
-                approvalData = null,
-            )
-
-        service.calculateDefaultFees(swap)
+        // Mirrors production: every live swap caller builds the Swap with an empty callData because
+        // the real router calldata is fetched in parallel and is not available at estimation time.
+        service.calculateDefaultFees(swap(Chain.Base))
 
         coVerify(exactly = 1) {
             evmApi.getOpStackL1Fee(
                 senderAddress = "0xSender",
-                to = "0xRouter",
-                value = swap.amount,
+                to = "0xRecipient",
+                value = BigInteger("1000000000000000000"),
                 data = any(),
                 gasLimit = any(),
                 maxFeePerGas = any(),
                 maxPriorityFeePerGas = any(),
-                chainId = BigInteger("5000"),
+                chainId = BigInteger("8453"),
             )
         }
-        // 0xabcdef = 3 bytes
-        assertEquals(3, dataSlot.captured.size)
+        // Empty calldata falls back to the representative payload rather than pricing zero bytes.
+        assertEquals(REPRESENTATIVE_SWAP_CALLDATA_BYTES, dataSlot.captured.size)
+    }
+
+    @Test
+    fun `Mantle does not query the OP-stack L1 oracle`() = runTest {
+        coEvery { evmApi.getBaseFee() } returns gwei(100)
+        stubFeeHistory(listOf(gwei(5)))
+
+        // Mantle is OP-stack–derived but its L1 fee is ETH-denominated; summing it into the MNT fee
+        // would understate the cost, so it is excluded from the oracle path entirely.
+        service.calculateDefaultFees(swap(Chain.Mantle))
+
+        coVerify(exactly = 0) {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -20,6 +20,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -39,6 +40,9 @@ internal class EthereumFeeServiceTest {
         every { evmApiFactory.createEvmApi(any()) } returns evmApi
         coEvery { evmApi.getBaseFee() } returns BigInteger.ZERO
         coEvery { evmApi.getFeeHistory() } returns emptyList()
+        coEvery {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns BigInteger.ZERO
     }
 
     // ---------- Bug #6 regression: empty fee history must not crash ----------
@@ -400,6 +404,158 @@ internal class EthereumFeeServiceTest {
 
         assertEquals(DEFAULT_MANTLE_SWAP_LIMIT, fee.limit)
         assertEquals(gwei(110), fee.networkPrice)
+    }
+
+    // ---------- OP-stack L1 data fee (issue #4844) ----------
+
+    @Test
+    fun `Optimism adds the OP-stack L1 data fee to the amount`() = runTest {
+        coEvery {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns BigInteger("777")
+
+        val fee = service.calculateDefaultFees(transfer(Chain.Optimism)) as Eip1559
+
+        assertEquals(fee.maxFeePerGas.multiply(fee.limit).add(BigInteger("777")), fee.amount)
+    }
+
+    @Test
+    fun `Base prices L1 against the recipient, amount and chain id for a native transfer`() =
+        runTest {
+            val tx = transfer(Chain.Base)
+
+            service.calculateDefaultFees(tx)
+
+            coVerify(exactly = 1) {
+                evmApi.getOpStackL1Fee(
+                    senderAddress = "0xSender",
+                    to = "0xRecipient",
+                    value = tx.amount,
+                    data = any(),
+                    gasLimit = any(),
+                    maxFeePerGas = any(),
+                    maxPriorityFeePerGas = any(),
+                    chainId = BigInteger("8453"),
+                )
+            }
+        }
+
+    @Test
+    fun `ERC-20 transfer prices L1 against the token contract with 68-byte calldata`() = runTest {
+        val dataSlot = slot<ByteArray>()
+        coEvery {
+            evmApi.getOpStackL1Fee(
+                any(),
+                any(),
+                any(),
+                capture(dataSlot),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns BigInteger.ZERO
+
+        service.calculateDefaultFees(transfer(Chain.Base, isNative = false))
+
+        coVerify(exactly = 1) {
+            evmApi.getOpStackL1Fee(
+                senderAddress = "0xSender",
+                to = "0xContract",
+                value = BigInteger.ZERO,
+                data = any(),
+                gasLimit = any(),
+                maxFeePerGas = any(),
+                maxPriorityFeePerGas = any(),
+                chainId = BigInteger("8453"),
+            )
+        }
+        // 4-byte selector + 32-byte address + 32-byte amount
+        assertEquals(4 + 32 + 32, dataSlot.captured.size)
+    }
+
+    @Test
+    fun `Mantle swap prices L1 against the router target with the swap calldata`() = runTest {
+        coEvery { evmApi.getBaseFee() } returns gwei(100)
+        stubFeeHistory(listOf(gwei(5)))
+        val dataSlot = slot<ByteArray>()
+        coEvery {
+            evmApi.getOpStackL1Fee(
+                any(),
+                any(),
+                any(),
+                capture(dataSlot),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns BigInteger.ZERO
+
+        val swap =
+            Swap(
+                coin = coin(Chain.Mantle, isNative = true),
+                vault = VAULT,
+                amount = BigInteger("1000000000000000000"),
+                to = "0xRouter",
+                callData = "0xabcdef",
+                approvalData = null,
+            )
+
+        service.calculateDefaultFees(swap)
+
+        coVerify(exactly = 1) {
+            evmApi.getOpStackL1Fee(
+                senderAddress = "0xSender",
+                to = "0xRouter",
+                value = swap.amount,
+                data = any(),
+                gasLimit = any(),
+                maxFeePerGas = any(),
+                maxPriorityFeePerGas = any(),
+                chainId = BigInteger("5000"),
+            )
+        }
+        // 0xabcdef = 3 bytes
+        assertEquals(3, dataSlot.captured.size)
+    }
+
+    @Test
+    fun `Arbitrum does not query the OP-stack L1 oracle`() = runTest {
+        service.calculateDefaultFees(transfer(Chain.Arbitrum))
+
+        coVerify(exactly = 0) {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `ZkSync does not query the OP-stack L1 oracle`() = runTest {
+        service.calculateDefaultFees(transfer(Chain.ZkSync))
+
+        coVerify(exactly = 0) {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `Ethereum does not query the OP-stack L1 oracle`() = runTest {
+        service.calculateDefaultFees(transfer(Chain.Ethereum))
+
+        coVerify(exactly = 0) {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `failed L1 oracle call degrades to zero and keeps the base amount`() = runTest {
+        coEvery {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        } throws RuntimeException("rpc down")
+
+        val fee = service.calculateDefaultFees(transfer(Chain.Base)) as Eip1559
+
+        assertEquals(fee.maxFeePerGas.multiply(fee.limit), fee.amount)
     }
 
     // ---------- Helpers ----------


### PR DESCRIPTION
## Summary

Fixes #4844.

On OP-stack L2s (Optimism, Base, Blast, Mantle) the **L1 data fee** — often the dominant cost of an L2 transaction — was never added to the displayed/reserved fee, so the app under-estimated cost and a max-send could leave too little to cover the real L1 portion. `EthereumFeeService.calculateLayer1Fees()` was a stub returning `BigInteger.ZERO`, and **Mantle wasn't even classified as an L2**.

## What changed

- **`Chain.kt`** — add `Chain.Mantle` to `isLayer2`; introduce `Chain.isOpStackL2` (`Optimism, Base, Blast, Mantle`), the set that actually exposes the OP-stack `GasPriceOracle`. Arbitrum and ZkSync are L2s but price their L1 component differently, so they stay out of the oracle path.
- **`EvmApi.getOpStackL1Fee(...)`** — builds the RLP-encoded unsigned EIP-1559 tx from the supplied fields, ABI-encodes `getL1Fee(bytes)`, `eth_call`s the `GasPriceOracle` predeploy (`0x420…0F`) and decodes the wei result.
- **`EthereumRlpEncoder.kt`** (new) — encodes the `0x02 || rlp([chainId, nonce, …, accessList])` unsigned type-2 payload via Wallet Core's `EthereumRlp`.
- **`EthereumFeeService`** — gates the L1 path on `isOpStackL2`, resolves the real broadcast call context per tx type (native = memo, ERC-20 = transfer calldata to the token contract, swap = router calldata), prices the L1 fee **best-effort** (a failed oracle call degrades to zero rather than blocking the whole fee calc), and adds it to the amount.

The JNI-dependent RLP/ABI/oracle work lives behind the `EvmApi` boundary so `EthereumFeeService` stays pure-JVM unit-testable.

## Testing

- `:data:testDebugUnitTest` green — **9 new tests** in `EthereumFeeServiceTest`: L1 fee added to amount; correct `to`/`value`/`chainId`/calldata size for native, ERC-20 and swap txs; Arbitrum/ZkSync/Ethereum do **not** query the oracle; graceful degradation when the oracle call fails.
- `:data:compileDebugKotlin` and `:app:compileDebugKotlin` succeed; ktfmt applied.
- The exact `getL1Fee(bytes)` call this code makes was verified against the production RPCs the app uses (`/base/`, `/opt/`, `/mantle/`) and returns real non-zero values, confirming the RLP envelope + ABI encoding + oracle address are correct.

## Test plan (device)

1. Build/install debug, open **Send** or **Swap** on Base / Optimism / Blast / Mantle with the native token.
2. The network fee on the verify screen now includes the L1 data fee (higher than `main`, where it was always 0).
3. Confirm Arbitrum / ZkSync / Ethereum are unaffected.

## Note

Adding Mantle to `isLayer2` also makes the Mantle native token show the chain-logo overlay on the swap/send verify screens, consistent with the other L2s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OP-stack L1 data-availability fee estimation for eligible L2 transactions to improve total fee calculations (Base, Blast, Optimism).

* **Bug Fixes**
  * Updated total fee computation to include the OP-stack L1 component for native transfers, ERC-20 transfers, and swaps, with a safe fallback to the standard EIP-1559 fee when estimation fails.
  * Ensured Mantle and non-OP-stack chains don’t use OP-stack L1 fee estimation.

* **Tests**
  * Expanded coverage for oracle call behavior, calldata sizing/handling, and fallback behavior across transaction types and chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->