### PR TITLE
fix(send): convert EVM priority fee Gwei/Wei in advanced gas settings

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
@@ -77,7 +77,9 @@ constructor(
                 val baseFeeGwei = convertWeiToGwei(baseFeeWei)
 
                 baseFeeState.setTextAndPlaceCursorAtEnd(baseFeeGwei.toPlainString())
-                priorityFeeState.setTextAndPlaceCursorAtEnd(spec.priorityFeeWei.toString())
+                priorityFeeState.setTextAndPlaceCursorAtEnd(
+                    convertWeiToGwei(spec.priorityFeeWei).toPlainString()
+                )
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 Timber.e(e)
@@ -104,9 +106,12 @@ constructor(
                 val baseFeeWei =
                     convertGweiToWei(baseFeeState.text.toString().toBigDecimalOrZero())
                         .toBigInteger()
+                val priorityFeeWei =
+                    convertGweiToWei(priorityFeeState.text.toString().toBigDecimalOrZero())
+                        .toBigInteger()
                 GasSettings.Eth(
                     baseFee = baseFeeWei,
-                    priorityFee = priorityFeeState.text.toString().toBigInteger(),
+                    priorityFee = priorityFeeWei,
                     gasLimit = gasLimitState.text.toString().toBigInteger(),
                 )
             }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
@@ -1,0 +1,132 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.api.EvmApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.blockchain.utxo.UtxoFeeService
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.usecases.ConvertGweiToWeiUseCase
+import com.vultisig.wallet.data.usecases.ConvertWeiToGweiUseCase
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GasSettingsViewModelTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val mainDispatcher = UnconfinedTestDispatcher(scheduler)
+
+    private val weiPerGwei = BigDecimal(1_000_000_000L)
+    private val convertWeiToGwei =
+        object : ConvertWeiToGweiUseCase {
+            override fun invoke(wei: BigInteger): BigDecimal = wei.toBigDecimal().divide(weiPerGwei)
+        }
+    private val convertGweiToWei =
+        object : ConvertGweiToWeiUseCase {
+            override fun invoke(gwei: BigDecimal): BigDecimal = gwei.multiply(weiPerGwei)
+        }
+
+    private val evmApi: EvmApi = mockk(relaxed = true)
+    private val evmApiFactory: EvmApiFactory = mockk()
+    private val utxoFeeService: UtxoFeeService = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+        every { evmApiFactory.createEvmApi(any()) } returns evmApi
+        coEvery { evmApi.getBaseFee() } returns BigInteger("3000000000")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() =
+        GasSettingsViewModel(
+            evmApiFactory = evmApiFactory,
+            utxoFeeService = utxoFeeService,
+            convertWeiToGwei = convertWeiToGwei,
+            convertGweiToWei = convertGweiToWei,
+        )
+
+    private fun ethSpec(priorityFeeWei: BigInteger, gasLimit: BigInteger = BigInteger("21000")) =
+        BlockChainSpecificAndUtxo(
+            blockChainSpecific =
+                BlockChainSpecific.Ethereum(
+                    maxFeePerGasWei = BigInteger.ZERO,
+                    priorityFeeWei = priorityFeeWei,
+                    nonce = BigInteger.ZERO,
+                    gasLimit = gasLimit,
+                )
+        )
+
+    @Test
+    fun `loads stored wei priority fee into the field as gwei`() = runTest {
+        val vm = viewModel()
+
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        assertEquals("1", vm.priorityFeeState.text.toString())
+    }
+
+    @Test
+    fun `saves gwei priority fee input back as wei`() = runTest {
+        val vm = viewModel()
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        vm.priorityFeeState.setTextAndPlaceCursorAtEnd("2")
+        val settings = vm.save() as GasSettings.Eth
+
+        assertEquals(BigInteger("2000000000"), settings.priorityFee)
+    }
+
+    @Test
+    fun `eth gas settings round-trip through load and save without an edit`() = runTest {
+        val vm = viewModel()
+        vm.loadData(
+            Chain.Ethereum,
+            ethSpec(priorityFeeWei = BigInteger("1500000000"), gasLimit = BigInteger("21000")),
+        )
+        advanceUntilIdle()
+
+        assertEquals("1.5", vm.priorityFeeState.text.toString())
+
+        val settings = vm.save() as GasSettings.Eth
+        assertEquals(BigInteger("1500000000"), settings.priorityFee)
+        assertEquals(BigInteger("3000000000"), settings.baseFee)
+        assertEquals(BigInteger("21000"), settings.gasLimit)
+    }
+
+    @Test
+    fun `blank priority fee saves as zero`() = runTest {
+        val vm = viewModel()
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        vm.priorityFeeState.setTextAndPlaceCursorAtEnd("")
+        val settings = vm.save() as GasSettings.Eth
+
+        assertEquals(BigInteger.ZERO, settings.priorityFee)
+    }
+}


### PR DESCRIPTION
## Description

Fixes #4904

The EVM advanced gas-settings dialog labels its priority-fee input **Priority fee (GWEI)**, but `GasSettingsViewModel` loaded and saved that field as raw **Wei** — unlike the sibling base-fee field, which already converts Wei→Gwei on load and Gwei→Wei on save. As a result the field showed a value ~1e9 too large (a 1-Gwei tip rendered as `1000000000`), and editing it per the displayed unit (e.g. typing `2` for 2 Gwei) stored a 2-Wei tip, producing an EVM transaction with a near-zero priority fee that miners deprioritize or drop.

This applies the same conversion the base-fee field uses, so the displayed and entered values match the GWEI label while the stored `priorityFee` stays in Wei (as required by `DefaultSendStrategy.applyGasSettings` → `spec.priorityFeeWei` and `EthereumGasHelper`'s `maxInclusionFeePerGas`).

- Load: `convertWeiToGwei(spec.priorityFeeWei)` for display, matching the base fee.
- Save: `convertGweiToWei(...).toBigInteger()`, matching the base fee (also using the existing `toBigDecimalOrZero` helper, so a cleared field saves `0` rather than throwing).

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — this is a value-conversion fix in the ViewModel with no layout or visual change; the only visible effect is the numeric magnitude/unit shown in the existing priority-fee field. The exact before/after values are pinned by unit tests (a 1,000,000,000-Wei tip now displays as `1`, and entering `2` saves `2,000,000,000` Wei).

## Additional context

The priority fee lives on the single shared `BlockChainSpecific.Ethereum` carried by one keysign payload and is hashed once into the messages to sign, so this change only corrects the fee magnitude — it does not alter payload structure or the signing flow, and it applies identically to local-device and server co-signing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ethereum priority fee unit conversion to ensure gas settings are displayed and saved correctly across different scales.

* **Tests**
  * Added comprehensive unit test suite validating gas settings functionality, including fee conversions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->