### PR TITLE
fix: swap kujira publicnode lcd endpoint for polkachu

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -73,7 +73,7 @@ constructor(
         val defaultApiUrl =
             when (chain) {
                 Chain.GaiaChain -> "https://cosmos-rest.publicnode.com"
-                Chain.Kujira -> "https://kujira-rest.publicnode.com"
+                Chain.Kujira -> "https://kujira-api.polkachu.com"
                 Chain.Dydx -> "https://dydx-rest.publicnode.com"
                 Chain.Osmosis -> "https://osmosis-rest.publicnode.com"
                 Chain.Terra -> "https://terra-lcd.publicnode.com"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchKujiraTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchKujiraTokenUseCase.kt
@@ -18,7 +18,7 @@ constructor(private val httpClient: HttpClient) : SearchKujiraTokenUseCase {
 
     companion object {
         private const val findKujiraUrl =
-            "https://kujira-rest.publicnode.com/cosmwasm/wasm/v1/contract/"
+            "https://kujira-api.polkachu.com/cosmwasm/wasm/v1/contract/"
     }
 
     override suspend operator fun invoke(contractAddress: String): CoinAndPrice? {


### PR DESCRIPTION
Closes vultisig/vultisig-android#4913

## what

Swap the Kujira REST/LCD host from `kujira-rest.publicnode.com` to `kujira-api.polkachu.com` in two places:
- `CosmosApi.kt` - balance queries
- `SearchKujiraTokenUseCase.kt` - cw20 token lookups (`/cosmwasm/wasm/v1/contract/`)

Path shapes unchanged, host only. No logic touched.

## why

publicnode now returns HTTP 403 "unsupported platform" for the kujira endpoint, making KUJI balance reads and cw20 token searches dead. polkachu serves the same paths and is already the provider for Noble in this codebase.

## receipts

**old host (publicnode) - 403:**
```
$ curl -s -o /dev/null -w "%{http_code}" "https://kujira-rest.publicnode.com/cosmos/bank/v1beta1/balances/kujira18c8ca2h8a3pcwc5j0vd26kfwl2fch5xl8tdxmk"
403
```

**new host (polkachu) - 200 + ukuji balance:**
```
$ curl -s "https://kujira-api.polkachu.com/cosmos/bank/v1beta1/balances/kujira18c8ca2h8a3pcwc5j0vd26kfwl2fch5xl8tdxmk"
{"balances":[{"denom":"ukuji","amount":"195561951"}],"pagination":{"next_key":null,"total":"1"}}
```

**new host cosmwasm path - 200:**
```
$ curl -s -o /dev/null -w "%{http_code}" "https://kujira-api.polkachu.com/cosmwasm/wasm/v1/contract/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7"
200
```

🤖 Agent-generated