### PR TITLE
fix(address-book): match EVM addresses case-insensitively

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/AddressBookEntryDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/AddressBookEntryDao.kt
@@ -14,13 +14,30 @@ interface AddressBookEntryDao {
     @Query("SELECT * FROM address_book_entry WHERE chainId = :chainId AND address = :address")
     suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity
 
+    // COLLATE NOCASE folds ASCII case, which is exactly what EIP-55 checksum casing varies, so an
+    // EVM entry is matched regardless of how the address was capitalized when saved or looked up.
+    @Query(
+        "SELECT * FROM address_book_entry WHERE chainId = :chainId AND address = :address COLLATE NOCASE"
+    )
+    suspend fun getEntryIgnoringCase(chainId: String, address: String): AddressBookEntryEntity
+
     @Upsert suspend fun upsert(entry: AddressBookEntryEntity)
 
     @Query("DELETE FROM address_book_entry WHERE chainId = :chainId AND address = :address")
     suspend fun delete(chainId: String, address: String)
 
     @Query(
+        "DELETE FROM address_book_entry WHERE chainId = :chainId AND address = :address COLLATE NOCASE"
+    )
+    suspend fun deleteIgnoringCase(chainId: String, address: String)
+
+    @Query(
         "SELECT EXISTS(SELECT 1 FROM address_book_entry WHERE chainId = :chainId AND address = :address)"
     )
     suspend fun entryExists(chainId: String, address: String): Boolean
+
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM address_book_entry WHERE chainId = :chainId AND address = :address COLLATE NOCASE)"
+    )
+    suspend fun entryExistsIgnoringCase(chainId: String, address: String): Boolean
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.db.dao.AddressBookEntryDao
 import com.vultisig.wallet.data.db.models.AddressBookEntryEntity
 import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
 import javax.inject.Inject
 
 interface AddressBookRepository {
@@ -31,16 +32,37 @@ constructor(private val addressBookEntryDao: AddressBookEntryDao) : AddressBookR
     }
 
     override suspend fun getEntry(chainId: String, address: String): AddressBookEntry {
-        return addressBookEntryDao.getEntry(chainId, address).toAddressBookEntry()
+        val entity =
+            if (isEvm(chainId)) {
+                addressBookEntryDao.getEntryIgnoringCase(chainId, address)
+            } else {
+                addressBookEntryDao.getEntry(chainId, address)
+            }
+        return entity.toAddressBookEntry()
     }
 
     override suspend fun delete(chainId: String, address: String) {
-        addressBookEntryDao.delete(chainId, address)
+        if (isEvm(chainId)) {
+            addressBookEntryDao.deleteIgnoringCase(chainId, address)
+        } else {
+            addressBookEntryDao.delete(chainId, address)
+        }
     }
 
-    override suspend fun entryExists(chainId: String, address: String): Boolean {
-        return addressBookEntryDao.entryExists(chainId, address)
-    }
+    override suspend fun entryExists(chainId: String, address: String): Boolean =
+        if (isEvm(chainId)) {
+            addressBookEntryDao.entryExistsIgnoringCase(chainId, address)
+        } else {
+            addressBookEntryDao.entryExists(chainId, address)
+        }
+
+    // EVM addresses use EIP-55 checksum casing, so the same account can be written with different
+    // capitalization; matching them case-insensitively keeps one logical entry. Other chains use
+    // case-sensitive address encodings (base58, bech32, base64), so they stay exact-match. Unknown
+    // chain ids fall back to exact-match, matching the pre-existing behavior.
+    private fun isEvm(chainId: String): Boolean =
+        Chain.entries.firstOrNull { it.raw.equals(chainId, ignoreCase = true) }?.standard ==
+            TokenStandard.EVM
 
     private fun AddressBookEntryEntity.toAddressBookEntry() =
         AddressBookEntry(chain = Chain.fromRaw(chainId), address = address, title = title)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
@@ -1,0 +1,141 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.db.dao.AddressBookEntryDao
+import com.vultisig.wallet.data.db.models.AddressBookEntryEntity
+import com.vultisig.wallet.data.models.AddressBookEntry
+import com.vultisig.wallet.data.models.Chain
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AddressBookRepositoryImplTest {
+
+    private lateinit var dao: FakeAddressBookEntryDao
+    private lateinit var repository: AddressBookRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        dao = FakeAddressBookEntryDao()
+        repository = AddressBookRepositoryImpl(dao)
+    }
+
+    @Test
+    fun `EVM entry is found when looked up with a different checksum casing`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Ethereum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        assertTrue(repository.entryExists(Chain.Ethereum.id, LOWERCASED))
+    }
+
+    @Test
+    fun `EVM entry is fetched by a different casing while keeping the stored casing`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Ethereum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        val entry = repository.getEntry(Chain.Ethereum.id, LOWERCASED)
+
+        assertEquals(CHECKSUMMED, entry.address)
+        assertEquals("Alice", entry.title)
+    }
+
+    @Test
+    fun `EVM entry is deleted when removed with a different casing`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Ethereum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        repository.delete(Chain.Ethereum.id, LOWERCASED)
+
+        assertFalse(repository.entryExists(Chain.Ethereum.id, CHECKSUMMED))
+    }
+
+    @Test
+    fun `deleting an EVM entry clears case-variant duplicates saved before this change`() =
+        runTest {
+            // Two rows for the same account, as could have been stored when matching was
+            // case-sensitive; a single case-insensitive delete removes both.
+            repository.add(
+                AddressBookEntry(chain = Chain.Ethereum, address = CHECKSUMMED, title = "Alice")
+            )
+            repository.add(
+                AddressBookEntry(chain = Chain.Ethereum, address = LOWERCASED, title = "Alice")
+            )
+
+            repository.delete(Chain.Ethereum.id, LOWERCASED)
+
+            assertFalse(repository.entryExists(Chain.Ethereum.id, CHECKSUMMED))
+        }
+
+    @Test
+    fun `non-EVM entry is matched case-sensitively`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Bitcoin, address = BTC_ADDRESS, title = "Cold storage")
+        )
+
+        assertFalse(repository.entryExists(Chain.Bitcoin.id, BTC_ADDRESS.lowercase()))
+        assertTrue(repository.entryExists(Chain.Bitcoin.id, BTC_ADDRESS))
+    }
+
+    @Test
+    fun `non-EVM entry is not deleted by a different casing`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Bitcoin, address = BTC_ADDRESS, title = "Cold storage")
+        )
+
+        repository.delete(Chain.Bitcoin.id, BTC_ADDRESS.lowercase())
+
+        assertTrue(repository.entryExists(Chain.Bitcoin.id, BTC_ADDRESS))
+    }
+
+    private companion object {
+        // EIP-55 checksummed reference address and its all-lowercase canonical form.
+        const val CHECKSUMMED = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+        const val LOWERCASED = "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"
+        const val BTC_ADDRESS = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
+    }
+}
+
+/**
+ * In-memory [AddressBookEntryDao] that mirrors SQLite semantics: the exact methods compare with the
+ * default binary collation, and the `IgnoringCase` methods compare with `COLLATE NOCASE` (ASCII
+ * case-folding), so the repository's per-chain routing can be exercised without a real database.
+ */
+private class FakeAddressBookEntryDao : AddressBookEntryDao {
+
+    private val entries = mutableListOf<AddressBookEntryEntity>()
+
+    override suspend fun getEntries(): List<AddressBookEntryEntity> = entries.toList()
+
+    override suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity =
+        entries.first { it.chainId == chainId && it.address == address }
+
+    override suspend fun getEntryIgnoringCase(
+        chainId: String,
+        address: String,
+    ): AddressBookEntryEntity =
+        entries.first { it.chainId == chainId && it.address.equals(address, ignoreCase = true) }
+
+    override suspend fun upsert(entry: AddressBookEntryEntity) {
+        entries.removeAll { it.chainId == entry.chainId && it.address == entry.address }
+        entries.add(entry)
+    }
+
+    override suspend fun delete(chainId: String, address: String) {
+        entries.removeAll { it.chainId == chainId && it.address == address }
+    }
+
+    override suspend fun deleteIgnoringCase(chainId: String, address: String) {
+        entries.removeAll { it.chainId == chainId && it.address.equals(address, ignoreCase = true) }
+    }
+
+    override suspend fun entryExists(chainId: String, address: String): Boolean =
+        entries.any { it.chainId == chainId && it.address == address }
+
+    override suspend fun entryExistsIgnoringCase(chainId: String, address: String): Boolean =
+        entries.any { it.chainId == chainId && it.address.equals(address, ignoreCase = true) }
+}


### PR DESCRIPTION
## Description

Fixes #4916

EVM addresses use EIP-55 checksum casing, so the same recipient saved under one capitalization (e.g. a checksummed address copied from an explorer) was treated as a different entry when looked up under another (e.g. the same address pasted in lowercase). The saved contact's title was not shown on the Verify/Sign screen and "Save to address book" was offered as if the recipient were unknown, and the same account could be saved twice.

This matches the address-book existence/fetch/delete by case for EVM chains only — scoped by the chain's token standard — using `COLLATE NOCASE` query variants, while leaving non-EVM chains (Bitcoin, Solana, Cosmos, TON, …), whose address encodings are case-sensitive, on exact matching. The stored value is left exactly as the user entered it, so the displayed casing is unchanged and no database migration or schema-version bump is required. This brings Android in line with iOS and Windows, which both compare EVM addresses case-insensitively while storing them verbatim.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — no UI surface changes. The fix is in the data layer (address-book repository/DAO); the only user-visible effect is that an already-saved EVM recipient's name now resolves regardless of address casing, which is covered by unit tests.

## Additional context

The address-book lookups feed only the recipient display label and the "Save to address book" hint on the Verify/Keysign screens; they do not influence the signing payload, session, or broadcast, so co-signing is unaffected. The neighbouring vault-name match on those same screens already lowercases EVM addresses via `normalizeAddressForLookup`; this change makes the address-book lookup consistent with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address book now treats EVM chain addresses as case-insensitive for lookups and deletion, accommodating EIP-55 checksum variations.
  * Non-EVM chains continue using exact case-sensitive matching.

* **Tests**
  * Added comprehensive test suite validating case-insensitive address matching for EVM chains and case-sensitive matching for other chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->