### PR TITLE
fix(send): reject amounts with more decimals than the token supports

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -81,6 +81,13 @@ internal class AmountManager(
         if (decimal == null || decimal <= BigDecimal.ZERO) {
             return UiText.StringResource(R.string.send_error_no_amount)
         }
+        val tokenDecimals = selectedToken.value?.decimal
+        if (tokenDecimals != null && decimal.hasExcessDecimals(tokenDecimals)) {
+            return UiText.FormattedText(
+                R.string.send_error_too_many_decimals,
+                listOf(tokenDecimals),
+            )
+        }
         return null
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendAmountExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendAmountExtensions.kt
@@ -1,0 +1,13 @@
+package com.vultisig.wallet.ui.models.send
+
+import java.math.BigDecimal
+
+/**
+ * True when this amount carries more fractional digits than the token's [decimals] precision.
+ *
+ * Converting to base units with `movePointRight(decimals).toBigInteger()` rounds toward zero, so
+ * any digit past [decimals] would be dropped silently. Trailing zeros are not real precision —
+ * `1.5000000` fits a 6-decimal token — so they are stripped before the scale is compared.
+ */
+internal fun BigDecimal.hasExcessDecimals(decimals: Int): Boolean =
+    stripTrailingZeros().scale() > decimals

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.allowZeroGas
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.hasExcessDecimals
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asAddressInput
 import java.math.BigDecimal
@@ -55,6 +56,13 @@ internal class AccountValidator(
         if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val tokenDecimals = selectedAccount.token.decimal
+        if (tokenAmount.hasExcessDecimals(tokenDecimals)) {
+            throw InvalidTransactionDataException(
+                UiText.FormattedText(R.string.send_error_too_many_decimals, listOf(tokenDecimals))
             )
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,6 +90,7 @@
     <string name="ok">OK</string>
     <string name="dialog_default_error_title">Fehler</string>
     <string name="send_error_no_amount">Die Menge muss eine positive Zahl sein</string>
+    <string name="send_error_too_many_decimals">Die Menge darf höchstens %1$d Dezimalstellen haben</string>
     <string name="send_error_invalid_operator_fee">Die Betreibergebühr muss eine gültige Zahl zwischen 0 und 10000 Basispunkten sein</string>
     <string name="settings_screen_language">Sprache</string>
     <string name="settings_screen_currency">Währung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -105,6 +105,7 @@
     <string name="send_error_no_token">No se ha seleccionado ningún token</string>
     <string name="send_error_no_gas_fee">Sin cargos por gas</string>
     <string name="send_error_no_amount">La cantidad debe ser un número positivo</string>
+    <string name="send_error_too_many_decimals">La cantidad puede tener como máximo %1$d decimales</string>
     <string name="send_error_invalid_operator_fee">La comisión del operador debe ser un número válido entre 0 y 10000 puntos base</string>
     <string name="send_error_insufficient_balance">Fondos insuficientes</string>
     <string name="send_error_msca_not_deployed">La cuenta MSCA aún no está desplegada, por favor inténtelo de nuevo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -88,6 +88,7 @@
     <string name="ok">U redu</string>
     <string name="dialog_default_error_title">Greška</string>
     <string name="send_error_no_amount">Iznos mora biti pozitivan broj. Pokušajte ponovno.</string>
+    <string name="send_error_too_many_decimals">Iznos može imati najviše %1$d decimalnih mjesta.</string>
     <string name="send_error_invalid_operator_fee">Naknada operatora mora biti valjani broj između 0 i 10000 baznih bodova</string>
     <string name="settings_screen_language">Jezik</string>
     <string name="settings_screen_currency">Valuta</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -88,6 +88,7 @@
     <string name="ok">OK</string>
     <string name="dialog_default_error_title">Errore</string>
     <string name="send_error_no_amount">La quantità deve essere un numero positivo.</string>
+    <string name="send_error_too_many_decimals">La quantità può avere al massimo %1$d cifre decimali.</string>
     <string name="send_error_invalid_operator_fee">La commissione dell\'operatore deve essere un numero valido tra 0 e 10000 punti base</string>
     <string name="settings_screen_language">Lingua</string>
     <string name="settings_screen_currency">Valuta</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -176,6 +176,7 @@
     <string name="send_error_no_gas_fee">가스 수수료 없음</string>
     <string name="send_error_no_address">주소가 유효하지 않습니다</string>
     <string name="send_error_no_amount">금액은 양수여야 합니다</string>
+    <string name="send_error_too_many_decimals">금액은 소수점 이하 최대 %1$d자리까지 입력할 수 있습니다</string>
     <string name="send_error_invalid_operator_fee">운영자 수수료는 0에서 10000 베이시스 포인트 사이의 유효한 숫자여야 합니다</string>
     <string name="send_error_max_shares">금액이 잔액을 초과할 수 없습니다</string>
     <string name="send_error_insufficient_balance">잔액 부족</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -103,6 +103,7 @@
     <string name="send_error_no_gas_fee">Geen gasvergoeding</string>
     <string name="send_error_no_address">Adres is ongeldig</string>
     <string name="send_error_no_amount">Het bedrag moet een positief getal zijn</string>
+    <string name="send_error_too_many_decimals">Het bedrag mag maximaal %1$d decimalen hebben</string>
     <string name="send_error_invalid_operator_fee">Operatorkosten moeten een geldig getal tussen 0 en 10000 basispunten zijn</string>
     <string name="send_error_insufficient_balance">Onvoldoende saldo</string>
     <string name="send_error_msca_not_deployed">MSCA-account nog niet geïmplementeerd, probeer het opnieuw</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -92,6 +92,7 @@
     <string name="select_chain_chain_title">Cadeia</string>
     <string name="select_chain_balance_title">Saldo</string>
     <string name="send_error_no_amount">A quantidade deve ser um número positivo.</string>
+    <string name="send_error_too_many_decimals">A quantidade pode ter no máximo %1$d casas decimais.</string>
     <string name="send_error_invalid_operator_fee">A taxa do operador deve ser um número válido entre 0 e 10000 pontos base</string>
     <string name="settings_screen_language">Idioma</string>
     <string name="settings_screen_currency">Moeda</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -103,6 +103,7 @@
     <string name="send_error_no_gas_fee">Нет платы за газ</string>
     <string name="send_error_no_address">Адрес недействителен</string>
     <string name="send_error_no_amount">Сумма должна быть положительным числом</string>
+    <string name="send_error_too_many_decimals">Сумма может содержать не более %1$d знаков после запятой</string>
     <string name="send_error_invalid_operator_fee">Комиссия оператора должна быть действительным числом от 0 до 10000 базисных пунктов</string>
     <string name="send_error_insufficient_balance">Недостаточно средств</string>
     <string name="send_error_msca_not_deployed">Аккаунт MSCA ещё не развёрнут, пожалуйста, попробуйте снова</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -196,6 +196,7 @@
     <string name="send_error_no_gas_fee">无燃料费</string>
     <string name="send_error_no_address">地址无效</string>
     <string name="send_error_no_amount">金额必须是正数</string>
+    <string name="send_error_too_many_decimals">金额最多可保留 %1$d 位小数</string>
     <string name="send_error_invalid_operator_fee">运营商费用必须是0到10000基点之间的有效数字</string>
     <string name="send_error_max_shares">金额不应超过余额</string>
     <string name="send_error_insufficient_balance">资金不足</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,7 @@
     <string name="send_error_no_gas_fee">No gas fees</string>
     <string name="send_error_no_address">Address is invalid</string>
     <string name="send_error_no_amount">Amount must be a positive number</string>
+    <string name="send_error_too_many_decimals">Amount can have at most %1$d decimal places</string>
     <string name="send_error_invalid_operator_fee">Operator fee must be a valid number between 0 and 10000 basis points</string>
     <string name="send_error_max_shares">Amount should not exceed balance</string>
     <string name="send_error_insufficient_balance">Insufficient funds</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
@@ -98,6 +98,31 @@ internal class AmountManagerTest {
         assertNull(manager.validateTokenAmount("1.5"))
     }
 
+    @Test
+    fun `validateTokenAmount over-precision returns too_many_decimals error`() {
+        selectedToken.value = usdcToken() // 6 decimals
+        val manager = build(emptyScope())
+
+        val error = manager.validateTokenAmount("1.1234567") as? UiText.FormattedText
+
+        assertEquals(R.string.send_error_too_many_decimals, error?.resId)
+        assertEquals(listOf(6), error?.formatArgs)
+    }
+
+    @Test
+    fun `validateTokenAmount at exact precision returns null`() {
+        selectedToken.value = usdcToken() // 6 decimals
+        val manager = build(emptyScope())
+        assertNull(manager.validateTokenAmount("1.123456"))
+    }
+
+    @Test
+    fun `validateTokenAmount ignores trailing zeros beyond precision`() {
+        selectedToken.value = usdcToken() // 6 decimals
+        val manager = build(emptyScope())
+        assertNull(manager.validateTokenAmount("1.5000000"))
+    }
+
     // ──────── markMax ────────
 
     @Test
@@ -340,6 +365,19 @@ internal class AmountManagerTest {
             priceProviderID = "polkadot",
             contractAddress = "",
             isNativeToken = true,
+        )
+
+    private fun usdcToken(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "USDC",
+            logo = "",
+            address = "0xself",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNativeToken = false,
         )
 
     /** Convenience: pull the StringResource id out of a UiText for terse assertions. */

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/AccountValidatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/AccountValidatorTest.kt
@@ -108,6 +108,31 @@ internal class AccountValidatorTest {
     }
 
     @Test
+    fun `validate throws too_many_decimals when amount exceeds token precision`() = runTest {
+        account = usdcAccount() // 6 decimals
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.1234567")
+        val ex = assertFailsWith<InvalidTransactionDataException> { build().validate() }
+        assertEquals(
+            R.string.send_error_too_many_decimals,
+            (ex.text as? UiText.FormattedText)?.resId,
+        )
+    }
+
+    @Test
+    fun `validate accepts amount at exact token precision`() = runTest {
+        account = usdcAccount() // 6 decimals
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.123456")
+        addressFieldState.setTextAndPlaceCursorAtEnd("0xabc123")
+        gasFee.value = TokenValue(value = BigInteger.valueOf(21000), token = usdcCoin())
+        coEvery { addressParserRepository.resolveName("0xabc123", Chain.Ethereum) } returns
+            "0xresolved"
+
+        val result = build().validate()
+
+        assertEquals("0xresolved", result.dstAddress)
+    }
+
+    @Test
     fun `validate wraps resolveName failure in failed_to_resolve_address`() = runTest {
         account = ethAccount()
         tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
@@ -157,6 +182,27 @@ internal class AccountValidatorTest {
             priceProviderID = "ethereum",
             contractAddress = "",
             isNativeToken = true,
+        )
+
+    private fun usdcAccount(): Account =
+        Account(
+            token = usdcCoin(),
+            tokenValue = TokenValue(BigInteger.valueOf(1_000_000), usdcCoin()),
+            fiatValue = null,
+            price = null,
+        )
+
+    private fun usdcCoin(): Coin =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "USDC",
+            logo = "",
+            address = "0xself",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNativeToken = false,
         )
 
     private fun UiText?.stringId(): Int? = (this as? UiText.StringResource)?.resId


### PR DESCRIPTION
## Description

On the Send screen, entering an amount with more fractional digits than the selected token's precision (e.g. `1.1234567` for a 6-decimal token) silently dropped the surplus when the amount was converted to base units for signing — `movePointRight(decimals).toBigInteger()` truncates toward zero — so the signed/broadcast amount differed from what the user typed, with no warning.

This validates the entered amount's fractional-digit count against the token's decimals and rejects over-precision with a clear, localized message instead of silently truncating:

- `AccountValidator.validate()` — the shared pre-submit check that every send strategy (plain send and the send-form DeFi actions) runs before building the payload, so the truncated amount can never reach signing or the co-signer.
- `AmountManager.validateTokenAmount()` — mirrors the check inline on the amount field for early feedback, alongside the existing positivity/length checks.

Trailing zeros are not treated as real precision, so `1.5000000` on a 6-decimal token is still accepted. The fiat↔token conversion and percentage/MAX buttons already clamp to the token's precision and are unaffected.

Fixes #4925

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

No tx link applies: the change only blocks an over-precision amount before any transaction is built or signed. Valid amounts (within the token's precision) are unchanged, so existing sends sign and broadcast exactly as before.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — no layout or component change. The new message renders in the Send form's existing amount-error slot (the same one that already shows "Amount must be a positive number" / "Invalid amount"). The prior behavior had no visual manifestation: the amount was silently truncated with the form looking unchanged, so there is no before/after visual to compare.

## Additional context

Co-sign: the precision check runs in `AccountValidator.validate()` before `BlockChainSpecificRepository.getSpecific` and the `KeysignPayload` are built, so the VultiServer co-signer can never receive an over-precision-truncated `toAmount`. No co-sign behavior changes for valid amounts.

Scope is limited to the Send screen. The Deposit screen uses a separate validator (`DepositFieldValidator`) and flow; it is left untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added decimal precision validation for token amounts during the send process. The app now prevents users from entering amounts that exceed the token's supported decimal precision and displays clear error messages.
  * Error messages are localized across German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->