### PR TITLE
fix(tron): guard cached chain parameters against concurrent fee calculations

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
@@ -18,6 +18,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import wallet.core.jni.Base58
 
@@ -66,7 +68,8 @@ import wallet.core.jni.Base58
  */
 class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeService {
 
-    private var chainParameters: TronChainParametersJson? = null
+    private val chainParametersMutex = Mutex()
+    @Volatile private var chainParameters: TronChainParametersJson? = null
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): TronFees =
         coroutineScope {
@@ -310,12 +313,14 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
     }
 
     private suspend fun getCacheTronChainParameters(): TronChainParametersJson {
-        return if (chainParameters == null) {
-            val params = tronApi.getChainParameters()
-            chainParameters = params
-            params
-        } else {
-            chainParameters!!
+        chainParameters?.let {
+            return it
+        }
+        return chainParametersMutex.withLock {
+            chainParameters?.let {
+                return it
+            }
+            tronApi.getChainParameters().also { chainParameters = it }
         }
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
@@ -1,0 +1,95 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.blockchain.tron
+
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.models.TronAccountJson
+import com.vultisig.wallet.data.api.models.TronAccountResourceJson
+import com.vultisig.wallet.data.api.models.TronChainParameterJson
+import com.vultisig.wallet.data.api.models.TronChainParametersJson
+import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class TronFeeServiceTest {
+
+    private val tronApi: TronApi = mockk(relaxed = true)
+    private val service = TronFeeService(tronApi)
+
+    @Test
+    fun `concurrent fee calculations fetch chain parameters once`() = runTest {
+        // Hold every caller at the chain-parameter fetch until they have all arrived, so the
+        // singleton's shared cache is exercised under genuine concurrency.
+        val gate = CompletableDeferred<TronChainParametersJson>()
+        coEvery { tronApi.getChainParameters() } coAnswers { gate.await() }
+        coEvery { tronApi.getAccountResource(any()) } returns accountResource()
+        coEvery { tronApi.getAccount(any()) } returns existingAccount()
+
+        val calls = List(8) { async { service.calculateFees(nativeTransfer()) } }
+        advanceUntilIdle()
+        gate.complete(chainParameters())
+        advanceUntilIdle()
+        calls.awaitAll()
+
+        coVerify(exactly = 1) { tronApi.getChainParameters() }
+    }
+
+    @Test
+    fun `cached chain parameters are reused across sequential fee calculations`() = runTest {
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+        coEvery { tronApi.getAccountResource(any()) } returns accountResource()
+        coEvery { tronApi.getAccount(any()) } returns existingAccount()
+
+        service.calculateFees(nativeTransfer())
+        service.calculateFees(nativeTransfer())
+
+        coVerify(exactly = 1) { tronApi.getChainParameters() }
+    }
+
+    private fun nativeTransfer() =
+        Transfer(
+            coin =
+                Coin(
+                    chain = Chain.Tron,
+                    ticker = "TRX",
+                    logo = "",
+                    address = "TSenderAddressBase58",
+                    decimal = 6,
+                    hexPublicKey = "pub",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            vault = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain"),
+            amount = BigInteger("1000000"),
+            to = "TRecipientAddressBase58",
+        )
+
+    private fun chainParameters() =
+        TronChainParametersJson(
+            listOf(
+                TronChainParameterJson("getTransactionFee", 1000L),
+                TronChainParameterJson("getCreateAccountFee", 100000L),
+                TronChainParameterJson("getCreateNewAccountFeeInSystemContract", 1000000L),
+                TronChainParameterJson("getMemoFee", 1000000L),
+                TronChainParameterJson("getEnergyFee", 280L),
+                TronChainParameterJson("getDynamicEnergyMaxFactor", 1200L),
+            )
+        )
+
+    private fun accountResource() = TronAccountResourceJson(freeNetLimit = 5000L)
+
+    private fun existingAccount() = TronAccountJson(address = "TRecipientAddressBase58")
+}


### PR DESCRIPTION
## Description

`TronFeeService` is bound as an application-wide `@Singleton` and is shared by every caller that resolves TRON fees — the send form, swap gas calculation, and the join-keysign fee resolver. It memoised the result of `tronApi.getChainParameters()` in a plain `private var` field through an unsynchronised check-then-set, and read it back with a `!!` non-null assertion. When two fee calculations run concurrently they could race on that field: both observe `null`, each issues a redundant network fetch, and the `!!` asserts non-null on state another coroutine can write at the same time.

This guards the cached field with the same double-checked locking pattern already used by `ZcashApi.getConsensusBranchIdHex()` in this module — a `@Volatile` field with a lock-free fast-path read and a `Mutex.withLock` re-check before fetching. The first caller fetches and caches; concurrent callers wait on the mutex and then reuse the cached value, and the `!!` is gone. Fee math and the values read from chain parameters are unchanged.

Fixes #4927

## Which feature is affected?
- [x] Sending  - Please attach a tx link here
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

_TRX/TRC20 fee estimation is part of the send and swap paths, but this change is internal concurrency correctness only — transaction construction and on-chain output are byte-identical, so there is no new tx link to attach._

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

No UI surface — this is a data-layer concurrency fix.

## Additional context

The change only affects how chain parameters are cached and synchronised; the fetched values and the fee they feed into are unchanged, so signing payload construction, server co-signing, and broadcast are unaffected — the fee estimate handed to the keysign flow is identical to before. A regression test launches 8 concurrent `calculateFees` calls against one instance and asserts `getChainParameters()` is invoked exactly once (it fails before the fix, which issues eight fetches); a second test confirms sequential calls still reuse the cache. `./gradlew :data:testDebugUnitTest` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Tron fee calculation reliability with improved concurrency handling and optimized chain parameter caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->