### PR TITLE
fix(network): retry transport errors only for idempotent methods

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
@@ -15,6 +15,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import java.io.IOException
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 
 /**
@@ -27,8 +28,10 @@ import kotlinx.serialization.json.Json
  * 3. **HttpCallValidator** — converts transport-level [IOException]s into [NetworkException] with
  *    `httpStatusCode = 0` (client-side error). This runs *after* [HttpRequestRetry] exhausts its
  *    retries.
- * 4. **HttpRequestRetry** — retries on [IOException] (up to 3 times with exponential backoff) and
- *    on 5xx/429/408 responses for safe HTTP methods.
+ * 4. **HttpRequestRetry** — retries idempotent (GET/HEAD/OPTIONS) requests up to 3 times with
+ *    exponential backoff: on transport [IOException]s/read-timeouts and on 5xx/429/408 responses.
+ *    Non-idempotent requests (e.g. POST broadcasts) are never auto-retried, so a write the server
+ *    received but slow-ACKed is not silently resent.
  *
  * The retry plugin fires first: if all retries fail, the [IOException] propagates to
  * [HttpCallValidator], which wraps it in a [NetworkException].
@@ -59,16 +62,18 @@ class HttpClientConfigurator @Inject constructor(private val json: Json) {
 
             install(HttpRequestRetry) {
                 exponentialDelay()
-                retryOnException(maxRetries = 3, retryOnTimeout = true)
+
+                // Retry transport failures (IOException, read-timeout) only for idempotent
+                // methods. A non-idempotent request — e.g. a transaction broadcast the node
+                // already received but slow-ACKed — must not be silently resent. The
+                // CancellationException guard is required because HttpRequestRetry passes the
+                // cause straight to this predicate without filtering out coroutine cancellation.
+                retryOnExceptionIf(maxRetries = 3) { request, cause ->
+                    isSafeMethod(request.method) && cause !is CancellationException
+                }
 
                 retryIf { request, response ->
-                    val method = request.method
                     val status = response.status.value
-
-                    val isSafeMethod =
-                        method == HttpMethod.Get ||
-                            method == HttpMethod.Head ||
-                            method == HttpMethod.Options
 
                     val isServerError = status >= 500
                     val isRetriableStatus =
@@ -76,9 +81,13 @@ class HttpClientConfigurator @Inject constructor(private val json: Json) {
                             status == HttpStatusCode.TooManyRequests.value ||
                             status == HttpStatusCode.RequestTimeout.value
 
-                    isSafeMethod && isRetriableStatus
+                    isSafeMethod(request.method) && isRetriableStatus
                 }
             }
         }
     }
 }
+
+/** Idempotent HTTP methods that are safe to retry automatically. */
+private fun isSafeMethod(method: HttpMethod): Boolean =
+    method == HttpMethod.Get || method == HttpMethod.Head || method == HttpMethod.Options

--- a/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfiguratorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfiguratorTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import java.io.IOException
+import java.net.SocketTimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
@@ -137,12 +138,13 @@ class HttpClientConfiguratorTest {
     }
 
     /**
-     * Pins the documented behavior that [retryOnException] applies to every HTTP method, including
-     * unsafe ones like POST. This is intentional — transport-level retries on IOException are safe
-     * because the request never made it onto the wire.
+     * Verifies a non-idempotent POST request is NOT resent on IOException. A retry could duplicate
+     * a side effect (e.g. a transaction broadcast the node already received), so transport-level
+     * retries are restricted to idempotent methods. The IOException surfaces as a NetworkException
+     * on the very first failure via HttpCallValidator.
      */
     @Test
-    fun `retryOnIOException forPostMethod alsoRetriesThreeTimes`() = runTest {
+    fun `retryOnIOException forPostMethod doesNotRetry`() = runTest {
         var callCount = 0
         configuredClient(
                 MockEngine {
@@ -152,7 +154,48 @@ class HttpClientConfiguratorTest {
             )
             .use { client ->
                 assertFailsWith<NetworkException> { client.post("http://localhost/test") }
-                // 1 original call + 3 retries — the IOException retry policy is method-agnostic.
+                assertEquals(1, callCount)
+            }
+    }
+
+    /**
+     * Verifies a non-idempotent POST request is NOT resent on a read-timeout
+     * ([SocketTimeoutException], an IOException subclass). This is the core idempotency guard: a
+     * broadcast the node accepted but slow-ACKed must not be auto-rebroadcast. The failure surfaces
+     * as a NetworkException on the first attempt.
+     */
+    @Test
+    fun `retryOnSocketTimeout forPostMethod doesNotRetry`() = runTest {
+        var callCount = 0
+        configuredClient(
+                MockEngine {
+                    callCount++
+                    throw SocketTimeoutException("Read timed out")
+                }
+            )
+            .use { client ->
+                assertFailsWith<NetworkException> { client.post("http://localhost/test") }
+                assertEquals(1, callCount)
+            }
+    }
+
+    /**
+     * Verifies a safe GET request IS still retried three times on a read-timeout
+     * ([SocketTimeoutException]) before throwing NetworkException — idempotent-method transport
+     * retries are unchanged.
+     */
+    @Test
+    fun `retryOnSocketTimeout forSafeMethod retriesThreeTimes`() = runTest {
+        var callCount = 0
+        configuredClient(
+                MockEngine {
+                    callCount++
+                    throw SocketTimeoutException("Read timed out")
+                }
+            )
+            .use { client ->
+                assertFailsWith<NetworkException> { client.get("http://localhost/test") }
+                // 1 original call + 3 retries
                 assertEquals(4, callCount)
             }
     }


### PR DESCRIPTION
## Description

Fixes #4932

The shared `HttpClient`'s `HttpRequestRetry` retried every request on `IOException`/read-timeout via `retryOnException(maxRetries = 3, retryOnTimeout = true)`, including non-idempotent `POST`s. The status-based predicate (`retryIf`) already restricted 5xx/429/408 retries to safe methods, but the transport-exception/timeout retry applied to every method. A `POST` the node already received but slow-ACKed — e.g. a transaction broadcast — could be resent up to three times once the 15s read timeout fired.

This replaces `retryOnException` with a method-gated `retryOnExceptionIf` so transport/timeout retries apply only to idempotent methods (GET/HEAD/OPTIONS), reusing one `isSafeMethod` helper shared with the status predicate. The `CancellationException` guard is kept because `HttpRequestRetry` hands the cause straight to the predicate without filtering coroutine cancellation, so a blanket retry would break structured concurrency. Retry count, exponential backoff, the status predicate, and OkHttp's `retryOnConnectionFailure` are unchanged. It mirrors the dedicated QBTC proof client, which already disables implicit retry for its non-idempotent `/prove` POST.

## Which feature is affected?
- [x] Sending  — broadcast POSTs (timeout-failure path only)
- [x] Swap  — broadcast POSTs (timeout-failure path only)

No happy-path change to attach a tx link for: a successful broadcast is unaffected; only the retry behavior on a transport timeout changes, which is covered by unit tests.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — networking/transport-layer change, no UI surface.

## Additional context

Co-sign / keysign: the relay POSTs in `SessionApi` (`startSession`, `sendTssMessage`, the completion markers, `uploadSetupMessage`) and the FastVault co-sign POSTs use the same shared client, so they are also no longer auto-retried on a transport timeout. They are idempotent (session/party-set keyed with server-side dedup), `startSession`/`startWithCommittee` keep their own app-level `withRelayRetry`, OkHttp still retries genuine pre-send connection failures, and the keygen/keysign flow is user-retryable — so correctness is unaffected. This matches iOS, where broadcasts are single-shot and a timeout is treated as inconclusive (verified on-chain, never auto-rebroadcast) rather than resent.

Most broadcast paths already recover a transaction that actually landed via `BroadcastTxUseCase.recoverIfAlreadyBroadcast` (BTC, Solana, Ton, Tron, Ripple, Cardano, Polkadot). For the few without a precomputed-hash recovery path (EVM, Cosmos/THORChain/Maya, Sui, Bittensor), a read-timeout now surfaces an error the user retries — the node then rejects the duplicate (nonce-too-low / mempool-cache / "already known"), which is mapped to success — instead of an implicit resend. Extending `recoverIfAlreadyBroadcast` to those chains is a reasonable follow-up, out of scope here.

Tests: `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.networkutils.HttpClientConfiguratorTest"` is green (8 tests) — the test that pinned POST-being-retried is inverted, and a read-timeout pair is added (POST not resent; GET still retried three times). The full `:data:testDebugUnitTest` suite is green and `:data:ktfmtCheck` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request retry logic to prevent unnecessary retries of non-idempotent requests (POST, PUT, DELETE)
  * Enhanced timeout and cancellation exception handling to avoid redundant operation retries
  * Safe HTTP methods (GET, HEAD, OPTIONS) continue to retry appropriately for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->