### PR TITLE
fix(swap): take a plain fraction of the balance for 25/50/75% chips

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -339,16 +339,21 @@ constructor(
         // "insufficient balance" warning on a now-valid amount and mask the live quote/formError.
         _uiState.update { it.copy(error = null) }
 
-        // Only the source-chain network fee may be deducted from the source balance, and only for a
-        // native source on its own gas chain. The provider swap fee is taken from the destination
-        // amount (for LI.FI it is denominated in the destination token's units), so subtracting it
-        // here would mix decimals and could wrongly drive the usable amount negative for a
-        // low-decimal source into a high-decimal destination.
-        val maxUsableTokenAmount =
-            srcTokenValue.value -
-                (quotePipeline.estimatedNetworkFeeTokenValue.value?.value?.takeIf {
+        // The 25/50/75 chips take a plain fraction of the full balance, matching iOS and the
+        // desktop app. Only MAX reserves the source-chain network fee, and only for a native source
+        // on its own gas chain. The provider swap fee is taken from the destination amount (for
+        // LI.FI it is denominated in the destination token's units), so it is never deducted from
+        // the source balance here — that would mix decimals and could wrongly drive the usable
+        // amount negative for a low-decimal source into a high-decimal destination.
+        val reservedNetworkFee =
+            if (percentage >= 1f) {
+                quotePipeline.estimatedNetworkFeeTokenValue.value?.value?.takeIf {
                     srcToken.isNativeToken && quotePipeline.gasFeeChain.value == srcToken.chain
-                } ?: BigInteger.ZERO)
+                } ?: BigInteger.ZERO
+            } else {
+                BigInteger.ZERO
+            }
+        val maxUsableTokenAmount = srcTokenValue.value - reservedNetworkFee
 
         if (maxUsableTokenAmount <= BigInteger.ZERO) {
             // Empty (not "0"): the empty-field path clears the stale quote silently, whereas a

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -553,8 +553,11 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
-    fun `selectSrcPercentage with 50 percent sets half amount`() =
+    fun `selectSrcPercentage with 50 percent takes half of the full balance without subtracting the fee`() =
         runTest(mainDispatcher) {
+            // 2 ETH native source on its own gas chain. The 50% chip must take half of the FULL
+            // balance (1 ETH), not half of (balance - network fee): the source-chain network fee is
+            // reserved only for MAX, matching iOS and the desktop app.
             val balance = BigInteger("2000000000000000000") // 2 ETH
             val addresses = listOf(ethAddressWithBalance(balance))
             val vm = createViewModelWithAddresses(addresses)
@@ -562,8 +565,7 @@ internal class SwapFormViewModelTest {
 
             vm.selectSrcPercentage(0.5f)
 
-            val amountText = vm.srcAmountState.text.toString()
-            assertTrue(amountText.isNotEmpty(), "Expected non-empty amount")
+            assertEquals("1", vm.srcAmountState.text.toString())
         }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #4933

On the swap form, the 25%/50%/75% chips and MAX run through one handler that computed a single "max usable" amount (balance minus the source-chain network fee for a native source) and then multiplied it by the fraction. After PR #4903 stopped the provider swap fee from being subtracted here, the source-chain network fee was still subtracted before the fraction was applied — so a 50% tap on a native source produced half of (balance − network fee) instead of half of the balance. iOS and the desktop app take a plain fraction of the full balance for 25/50/75 and reserve the network fee only for MAX, so the same balance produced a different amount on Android.

This gates the network-fee deduction on the MAX selection; the 25/50/75 fractions now take a plain fraction of the full balance, matching manual entry and the other clients. MAX (native source on its own gas chain) still reserves the network fee, and the insufficient-balance handling is unchanged.

## Which feature is affected?
- [x] Swap - amount-input fix only (the computed source amount before quoting); the resulting swap is identical to typing the same amount, so there is no new on-chain behavior to link
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — this is a ViewModel computation fix. The visible effect (the amount field holding a plain fraction of the balance) is produced by runtime logic against a live quote, which the static preview harness can't reproduce faithfully. The behavior is pinned by a unit test that fails before the change (`expected: <1> but was: <0.9995>`) and passes after.

## Additional context

Co-sign is unaffected. `selectSrcPercentage` only writes to the shared source-amount field — the same channel manual typing uses — so the staged swap amount, payload construction, session, approval, and broadcast are all identical to entering the value by hand. No signing/co-sign code is touched.

Verification: `./gradlew :app:testDebugUnitTest --tests "*SwapFormViewModelTest"` → all passing (the existing MAX test still pins the native network-fee reservation; the 50% test now pins the plain-fraction behavior).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted swap percentage selection behavior: network fees are now only deducted when selecting the maximum amount. Selecting 50%, 75%, or other partial percentages now reserves the full selected amount without fee deduction.

* **Tests**
  * Updated test cases to reflect revised percentage selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->