### PR TITLE
refactor(address-book): return null from getEntry instead of throwing on a miss

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -340,12 +340,9 @@ constructor(
                         }
                     }
                     ?.name
-            val dstInAddressBook =
-                dstVaultName == null && addressBookRepository.entryExists(chain.id, tx.dstAddress)
             val dstAddressBookTitle =
-                if (dstInAddressBook) {
-                    runCatching { addressBookRepository.getEntry(chain.id, tx.dstAddress).title }
-                        .getOrNull()
+                if (dstVaultName == null) {
+                    addressBookRepository.getEntry(chain.id, tx.dstAddress)?.title
                 } else null
 
             val memo = tx.memo

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
@@ -193,12 +193,9 @@ constructor(
                     }
                 }
                 ?.name
-        val isSavedInAddressBook =
-            dstVaultName == null && addressBookRepository.entryExists(chain.id, payload.toAddress)
         val dstAddressBookTitle =
-            if (isSavedInAddressBook) {
-                runCatching { addressBookRepository.getEntry(chain.id, payload.toAddress).title }
-                    .getOrNull()
+            if (dstVaultName == null) {
+                addressBookRepository.getEntry(chain.id, payload.toAddress)?.title
             } else null
 
         val isUnlimitedApproval =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -359,10 +359,7 @@ constructor(
 
                 val dstAddressBookTitle =
                     if (dstVaultName == null && isSavedBefore) {
-                        runCatching {
-                                addressBookRepository.getEntry(chain.id, tx.dstAddress).title
-                            }
-                            .getOrNull()
+                        addressBookRepository.getEntry(chain.id, tx.dstAddress)?.title
                     } else null
 
                 _state.update {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -143,7 +143,7 @@ constructor(
             addressBookRepository.getEntry(
                 chainId = addressBookEntryChainId,
                 address = addressBookEntryAddress,
-            )
+            ) ?: return
         state.update {
             it.copy(
                 titleRes = R.string.edit_address_title,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/AddressBookEntryDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/AddressBookEntryDao.kt
@@ -12,14 +12,14 @@ interface AddressBookEntryDao {
     suspend fun getEntries(): List<AddressBookEntryEntity>
 
     @Query("SELECT * FROM address_book_entry WHERE chainId = :chainId AND address = :address")
-    suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity
+    suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity?
 
     // COLLATE NOCASE folds ASCII case, which is exactly what EIP-55 checksum casing varies, so an
     // EVM entry is matched regardless of how the address was capitalized when saved or looked up.
     @Query(
         "SELECT * FROM address_book_entry WHERE chainId = :chainId AND address = :address COLLATE NOCASE"
     )
-    suspend fun getEntryIgnoringCase(chainId: String, address: String): AddressBookEntryEntity
+    suspend fun getEntryIgnoringCase(chainId: String, address: String): AddressBookEntryEntity?
 
     @Upsert suspend fun upsert(entry: AddressBookEntryEntity)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
@@ -11,7 +11,7 @@ interface AddressBookRepository {
 
     suspend fun getEntries(): List<AddressBookEntry>
 
-    suspend fun getEntry(chainId: String, address: String): AddressBookEntry
+    suspend fun getEntry(chainId: String, address: String): AddressBookEntry?
 
     suspend fun add(entry: AddressBookEntry)
 
@@ -31,14 +31,14 @@ constructor(private val addressBookEntryDao: AddressBookEntryDao) : AddressBookR
         addressBookEntryDao.upsert(entry.toEntity())
     }
 
-    override suspend fun getEntry(chainId: String, address: String): AddressBookEntry {
+    override suspend fun getEntry(chainId: String, address: String): AddressBookEntry? {
         val entity =
             if (isEvm(chainId)) {
                 addressBookEntryDao.getEntryIgnoringCase(chainId, address)
             } else {
                 addressBookEntryDao.getEntry(chainId, address)
             }
-        return entity.toAddressBookEntry()
+        return entity?.toAddressBookEntry()
     }
 
     override suspend fun delete(chainId: String, address: String) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
@@ -6,6 +6,8 @@ import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -39,8 +41,15 @@ internal class AddressBookRepositoryImplTest {
 
         val entry = repository.getEntry(Chain.Ethereum.id, LOWERCASED)
 
+        assertNotNull(entry)
         assertEquals(CHECKSUMMED, entry.address)
         assertEquals("Alice", entry.title)
+    }
+
+    @Test
+    fun `getEntry returns null when the address is not saved`() = runTest {
+        assertNull(repository.getEntry(Chain.Ethereum.id, CHECKSUMMED))
+        assertNull(repository.getEntry(Chain.Bitcoin.id, BTC_ADDRESS))
     }
 
     @Test
@@ -111,14 +120,16 @@ private class FakeAddressBookEntryDao : AddressBookEntryDao {
 
     override suspend fun getEntries(): List<AddressBookEntryEntity> = entries.toList()
 
-    override suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity =
-        entries.first { it.chainId == chainId && it.address == address }
+    override suspend fun getEntry(chainId: String, address: String): AddressBookEntryEntity? =
+        entries.firstOrNull { it.chainId == chainId && it.address == address }
 
     override suspend fun getEntryIgnoringCase(
         chainId: String,
         address: String,
-    ): AddressBookEntryEntity =
-        entries.first { it.chainId == chainId && it.address.equals(address, ignoreCase = true) }
+    ): AddressBookEntryEntity? =
+        entries.firstOrNull {
+            it.chainId == chainId && it.address.equals(address, ignoreCase = true)
+        }
 
     override suspend fun upsert(entry: AddressBookEntryEntity) {
         entries.removeAll { it.chainId == entry.chainId && it.address == entry.address }


### PR DESCRIPTION
## Description

Fixes #4934

`AddressBookEntryDao.getEntry(...)` returned a non-null entity and threw when no row matched, so the verify and keysign screens compensated by pairing an `entryExists(...)` pre-check with `runCatching { getEntry(...).title }.getOrNull()`. That contract is fragile — a future caller that forgets the wrapper would crash on an ordinary "address not saved" miss — and the exists-then-read pair issues two queries for one lookup.

This makes `getEntry` (and its case-insensitive variant) return a nullable entity through the DAO and repository, and reads `getEntry(...)?.title` at the call sites. The existence pre-check is dropped where it only gated the read; `entryExists` stays where its boolean result is independently used (the "save to address book" hint on the keysign screen and the edit-vs-create branch in the address entry screen). No change to stored values/casing, the case-insensitive matching from #4917, or any signing/keysign payload — only the recipient display title.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — no UI surface change. The address-book lookup only resolves the recipient display label and the "save to address book" hint; both are covered by unit tests.

## Additional context

Co-sign is unaffected. The lookup feeds only the displayed address-book title and the "save to address book" flag on the verify/keysign screens; it does not influence the signing payload, session, approval, or broadcast. The keysign path keeps a graceful fallback — if the entry is removed between the existence check and the read, `getEntry(...)?.title` now yields `null` instead of throwing, exactly as the old `runCatching` did.

Verification: `./gradlew :data:testDebugUnitTest` and `./gradlew :app:testDebugUnitTest --tests "*AddressEntryViewModelTest" --tests "*VerifyTransactionViewModelTest" --tests "*KeysignViewModel*Test"` pass; a new repository test asserts `getEntry` returns null for an address that is not saved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address book lookup handling to properly handle missing address entries instead of suppressing errors.

* **Refactor**
  * Simplified address resolution logic across transaction verification and keysign flows for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->