### PR TITLE
fix(onboarding): add vertical padding to vault setup Get started button

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt
@@ -103,7 +103,8 @@ private fun SetupVaultInfoScreen(
             OnboardingResponsiveBottomBar {
                 VsButton(
                     label = stringResource(R.string.key_import_device_count_get_started),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
                     onClick = { onEvent(SetupVaultInfoEvent.Next) },
                 )
             }


### PR DESCRIPTION
## Summary

On the **Your vault setup** screen (Secure Vault, 2-device setup), the bottom **Get started** button sat flush against the bottom edge of the screen — directly against the gesture navigation bar — with no breathing room above or below it.

The button passed only `Modifier.fillMaxWidth()` into `OnboardingResponsiveBottomBar`, which on compact width wraps the content in a `fillMaxWidth()` box with no padding of its own.

## Fix

Added `.padding(horizontal = 16.dp, vertical = 24.dp)` to the button — the exact same bottom-bar padding already used by every sibling onboarding screen (`NameVaultScreen`, `FastVaultPasswordScreen`, `FastVaultEmailScreen`), so the spacing is now consistent across the onboarding flow.

## Files Modified

- `app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/SetupVaultInfoScreen.kt`

## Test Plan

- Start vault setup → select Secure Vault (2-device) → observe the **Get started** button now has vertical/horizontal breathing room, consistent with the other onboarding screens.

Closes #4935