### PR TITLE
fix(keygen): skip QR flash and blank frame in Fast Vault peer discovery

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -160,17 +160,15 @@ constructor(
                 deviceCount = args?.deviceCount,
                 allowsMoreDevices =
                     (args?.deviceCount ?: MIN_KEYGEN_DEVICES) >= UNBOUNDED_KEYGEN_DEVICE_COUNT,
-                // Seed the connecting state for Fast Vault so the QR/devices branch is never
-                // composed during the async loadData() window (it would otherwise flash before
-                // startVultiServerConnection() flips this to non-null). Excludes Migrate: the
-                // active-vault migrate (signers > 2) path intentionally shows peer discovery, and
-                // we can't know the signer count synchronously here.
+                // Seed the connecting state for every Fast Vault flow (credentials present) so the
+                // QR/devices branch is never composed during the async loadData() window (it would
+                // otherwise flash before startVultiServerConnection() flips this to non-null).
+                // loadData() clears this back to null for the only Fast Vault path that shows peer
+                // discovery instead of connecting to the server (active-vault migrate, signers >
+                // 2),
+                // which we cannot detect synchronously here.
                 connectingToServer =
-                    if (
-                        !args?.email.isNullOrBlank() &&
-                            !args.password.isNullOrBlank() &&
-                            args.action != TssAction.Migrate
-                    )
+                    if (!args?.email.isNullOrBlank() && !args.password.isNullOrBlank())
                         ConnectingToServerUiModel(false)
                     else null,
                 enableNotification = false,
@@ -487,6 +485,10 @@ constructor(
                 // join
                 // Also need to request the server to join the upgrade process
                 if (args.action == TssAction.Migrate && signers.count() > 2) {
+                    // This is the only Fast Vault path that shows peer discovery rather than the
+                    // connecting screen, so undo the connecting state seeded in the initial UI
+                    // model.
+                    state.update { it.copy(connectingToServer = null) }
                     startPeerDiscovery()
                     requestVultiServerConnection()
                 } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -160,6 +160,19 @@ constructor(
                 deviceCount = args?.deviceCount,
                 allowsMoreDevices =
                     (args?.deviceCount ?: MIN_KEYGEN_DEVICES) >= UNBOUNDED_KEYGEN_DEVICE_COUNT,
+                // Seed the connecting state for Fast Vault so the QR/devices branch is never
+                // composed during the async loadData() window (it would otherwise flash before
+                // startVultiServerConnection() flips this to non-null). Excludes Migrate: the
+                // active-vault migrate (signers > 2) path intentionally shows peer discovery, and
+                // we can't know the signer count synchronously here.
+                connectingToServer =
+                    if (
+                        !args?.email.isNullOrBlank() &&
+                            !args.password.isNullOrBlank() &&
+                            args.action != TssAction.Migrate
+                    )
+                        ConnectingToServerUiModel(false)
+                    else null,
                 enableNotification = false,
             )
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -133,13 +133,17 @@ internal fun KeygenPeerDiscoveryScreen(model: KeygenPeerDiscoveryViewModel = hil
                 showRive = true
             }
 
-            if (showRive) {
-                RiveAnimation(
-                    file = riveFile,
-                    viewModelInstance = vmi,
-                    modifier = Modifier.fillMaxSize(),
-                    fit = Fit.Cover(),
-                )
+            // Solid backdrop so the 300ms pre-Rive window renders the app background rather than
+            // an empty/blank frame between the password screen and the connecting animation.
+            Box(modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+                if (showRive) {
+                    RiveAnimation(
+                        file = riveFile,
+                        viewModelInstance = vmi,
+                        modifier = Modifier.fillMaxSize(),
+                        fit = Fit.Cover(),
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4922.

## Problem

In the **Fast Vault (standard) creation flow**, tapping **Next** on the "Choose a password" screen briefly flashed the **Peer Discovery ("Scan QR" / "Devices (1/1)") screen**, then a **blank dark frame**, before the "Connecting…" animation appeared. In the Fast Vault flow the VultiServer is the second party, so the peer-discovery / QR screen should never be shown.

## Root cause

1. **QR/devices flash** — the initial `PeerDiscoveryUiModel` is created with `connectingToServer = null`, so the very first composition renders the `else` branch (the full QR / "Devices" screen). `connectingToServer` is only set non-null inside `startVultiServerConnection()`, reached after `loadData()` finishes its async work (DKLS secret setup, feature-flags fetch, optional vault lookup). The QR screen is on-screen during that window.
2. **Blank frame** — the connecting branch defers its Rive animation by 300ms (`showRive`), drawing nothing in the meantime.

## Fix

- **`KeygenPeerDiscoveryViewModel`** — seed `connectingToServer = ConnectingToServerUiModel(false)` in the initial state when it's a Fast Vault flow (`email` + `password` present), so the QR/devices `else` branch is never composed. Excludes `Migrate`: the active-vault migrate (`signers > 2`) path intentionally shows peer discovery, and the signer count isn't knowable synchronously at construction.
- **`PeerDiscoveryScreen`** — wrap the connecting branch in a `Box` filled with `Theme.v2.colors.backgrounds.primary`, so the 300ms pre-Rive window renders the app backdrop rather than a blank dark frame.

## Test plan

- [ ] Fast Vault (standard, email + password) → password screen → **Next**: transitions directly into "Connecting…" with no QR flash and no blank frame.
- [ ] Secure vault (2/2, 3/3, 4+) keygen still shows the QR / peer-discovery screen.
- [ ] Active-vault migrate (vault with > 2 signers) still shows the QR / peer-discovery screen.
- [ ] Reshare / KeyImport Fast Vault flows go straight to "Connecting…".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a blank/empty peer discovery screen during connection initialization by ensuring the initial UI state is properly set before async loading completes.
  * Removed visual gaps during peer discovery startup by rendering a solid background behind the loading animation until it appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->