### PR TITLE
fix(keygen): fix non-compiling state.update on main (semantic merge conflict)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -512,7 +512,7 @@ constructor(
                     // This is the only Fast Vault path that shows peer discovery rather than the
                     // connecting screen, so undo the connecting state seeded in the initial UI
                     // model.
-                    state.update { it.copy(connectingToServer = null) }
+                    _state.update { it.copy(connectingToServer = null) }
                     startPeerDiscovery()
                     requestVultiServerConnection()
                 } else {


### PR DESCRIPTION
## Summary

`main` does not compile. `KeygenPeerDiscoveryViewModel` reset the connecting state with `state.update { ... }` on the **read-only** `StateFlow` instead of the mutable `_state` backing field:

```
e: KeygenPeerDiscoveryViewModel.kt:515 Unresolved reference. None of the following candidates is applicable because of a receiver type mismatch:
   fun <T> MutableStateFlow<T>.update(function: (T) -> T): Unit
e: KeygenPeerDiscoveryViewModel.kt:515 Unresolved reference 'copy'.
```

`update {}`/`copy` only resolve on `MutableStateFlow`. Fixed to use `_state`, matching every other mutation in the file.

This was introduced and merged in #4942.

## Why CI didn't catch it

`build-and-test` runs `assembleDebug testDebugUnitTest --parallel --build-cache`. The build cache restored across runs by `setup-gradle`, combined with `--build-cache`, served a **stale `compileDebugKotlin` output** instead of recompiling the changed file — so the broken code landed on `main` with a green build.

## Fix

- **Code:** `state.update` → `_state.update` in `KeygenPeerDiscoveryViewModel`.
- **CI:** add a cache-independent compile gate to `build-and-test` that compiles main + unit-test + instrumented-test sources with `--no-build-cache`, before the assemble/test step. A stale/false cache hit can no longer mask a compile error, and it covers all source sets (the old `assembleDebug` only covered main). It is compile-only, so it stays fast and fails fast.

## Test plan

- [ ] `build-and-test` passes on this branch (the new compile gate runs `compileDebug{,UnitTest,AndroidTest}Sources --no-build-cache`).
- [ ] Confirm the gate fails the job when a compile error is present (verified by the nature of this fix — the prior broken state would now be rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed peer discovery UI not displaying correctly during the vault migration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->