### PR TITLE
fix(keygen): deliver mediator service-started broadcast to not-exported receiver

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mediator/MediatorService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mediator/MediatorService.kt
@@ -61,6 +61,11 @@ class MediatorService : Service() {
     private fun broadcastServiceStarted() {
         val intent = Intent()
         intent.setAction(SERVICE_ACTION)
+        // Scope the broadcast to our own package. The receiver is registered RECEIVER_NOT_EXPORTED,
+        // and from Android 14+ an implicit (package-less) broadcast is treated as cross-app and is
+        // not delivered to a not-exported receiver — so without this the onServiceStarted callback
+        // never fires and Local mode never starts its session/peer discovery.
+        intent.setPackage(packageName)
         sendBroadcast(intent)
         Timber.d("broadcast service started")
     }


### PR DESCRIPTION
## Summary

Local-mode (Wi-Fi/LAN) peer discovery never started — the initiator's `MediatorServiceController.start()` ran, but the service-started `BroadcastReceiver.onReceive` was never called back, so `onServiceStarted` never fired and the local session / participant discovery was never kicked off.

**Root cause:** `MediatorService.broadcastServiceStarted()` sends an **implicit** broadcast (action only, no package). The mediator-controller refactor registers the receiver with `RECEIVER_NOT_EXPORTED` (the correct, secure choice). From **Android 14+**, an implicit (package-less) broadcast is treated as potentially cross-app and is **not delivered** to a `RECEIVER_NOT_EXPORTED` receiver. `Server.startMediator()` swallows its own exceptions, so `start()` still appeared to succeed with no error — masking the dropped broadcast.

**Fix:** scope the broadcast to our own package via `intent.setPackage(packageName)`. This delivers it to the not-exported receiver while keeping it inaccessible to other apps — no need to weaken the flag back to `RECEIVER_EXPORTED`.

## Changes
- `MediatorService.broadcastServiceStarted()` — set the package on the service-started broadcast intent.

## Test plan
- Pixel 8, Android 16: start keygen, switch to **Local** mode, join from a second device.
- Verified in logcat: `onStartCommand` → `broadcast service started` → `onReceive: Mediator service started`, followed by the local session starting against `127.0.0.1:18080` and the peer appearing.
- Internet mode unaffected (relay path doesn't use the mediator broadcast).

## Notes
- This is a regression from the `MediatorServiceController` refactor (`RECEIVER_EXPORTED` → `RECEIVER_NOT_EXPORTED`) without scoping the broadcast to the package.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of local session and peer discovery on Android by ensuring the app’s internal service-start notifications are correctly targeted, particularly on Android 14+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->