### PR TITLE
fix(keygen): reveal Scan QR only after its Rive frame renders (#4954)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/RiveInitializer.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/RiveInitializer.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.app
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import app.rive.runtime.kotlin.core.Rive
+import com.vultisig.wallet.BuildConfig
+import timber.log.Timber
+
+internal var isRiveInitialized: Boolean = false
+    private set
+
+@VisibleForTesting
+internal fun resetRiveInitialized() {
+    isRiveInitialized = false
+}
+
+private const val RIVE_GUARD_PREFS = "rive_init_guard"
+private const val KEY_RIVE_INIT_IN_FLIGHT_VERSION = "rive_init_in_flight_version"
+internal const val NO_IN_FLIGHT_VERSION = -1
+
+/**
+ * Returns the [SharedPreferences] backing the Rive crash-loop guard.
+ *
+ * Kept as a plain (unencrypted) prefs file — the only stored value is an int "init attempted"
+ * marker keyed by app version — and resolved synchronously so [initializeRive] can read/write
+ * before invoking the native Rive entry point.
+ */
+@VisibleForTesting
+internal fun riveGuardPrefs(context: Context): SharedPreferences =
+    context.getSharedPreferences(RIVE_GUARD_PREFS, Context.MODE_PRIVATE)
+
+/**
+ * Initializes the Rive SDK behind a device-agnostic crash-loop guard.
+ *
+ * Mitigates the native `SIGABRT` in `librive-android.so` (see issue #4656) without keying on
+ * manufacturer/model strings. Before [Rive.init] we store the current [BuildConfig.VERSION_CODE];
+ * the `finally` block clears it on any normal return (success or catchable throw). Only an
+ * uncatchable process death inside the native call leaves the stored version set, causing the next
+ * launch at the *same* version to short-circuit and leave [isRiveInitialized] `false` so
+ * composables fall back to a [androidx.compose.foundation.layout.Spacer]. A later install that
+ * bumps `versionCode` (e.g. ships a fixed Rive lib) will not match the stored version, so Rive is
+ * re-attempted automatically without a manual reset.
+ */
+internal fun initializeRive(context: Context) {
+    val prefs = riveGuardPrefs(context)
+    val storedVersion = prefs.getInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, NO_IN_FLIGHT_VERSION)
+    if (storedVersion == BuildConfig.VERSION_CODE) {
+        Timber.w(
+            "Skipping Rive init: previous launch at version %d did not complete Rive.init " +
+                "(likely native crash)",
+            BuildConfig.VERSION_CODE,
+        )
+        return
+    }
+    // commit() (not apply()) so the marker is durable on disk before we cross the JNI boundary —
+    // an async write would race a SIGABRT and lose the signal we rely on next launch.
+    prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, BuildConfig.VERSION_CODE).commit()
+    try {
+        Rive.init(context)
+        isRiveInitialized = true
+    } catch (e: Throwable) {
+        Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
+    } finally {
+        // apply() is fine on the clear path — we only need durability for the *set* (which races
+        // SIGABRT). On normal return the next read happens after this process writes, so async is
+        // safe and keeps the cold-start path off a second blocking disk write.
+        prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, NO_IN_FLIGHT_VERSION).apply()
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/app/RiveInitializer.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/RiveInitializer.kt
@@ -54,12 +54,24 @@ internal fun initializeRive(context: Context) {
         return
     }
     // commit() (not apply()) so the marker is durable on disk before we cross the JNI boundary —
-    // an async write would race a SIGABRT and lose the signal we rely on next launch.
-    prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, BuildConfig.VERSION_CODE).commit()
+    // an async write would race a SIGABRT and lose the signal we rely on next launch. If the
+    // durable write fails (full disk, I/O error, thread interruption) we skip Rive.init entirely:
+    // the guard could not detect a native crash next launch, so running unguarded risks a crash
+    // loop. We leave isRiveInitialized false and composables fall back gracefully.
+    val committed =
+        prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, BuildConfig.VERSION_CODE).commit()
+    if (!committed) {
+        Timber.w("Skipping Rive init: failed to durably persist the in-flight crash-loop marker")
+        return
+    }
     try {
         Rive.init(context)
         isRiveInitialized = true
-    } catch (e: Throwable) {
+    } catch (e: LinkageError) {
+        // Native library load/link failure (e.g. UnsatisfiedLinkError) — Rive can't run on this
+        // device. Catchable, so the finally clears the marker and Rive is retried next launch.
+        Timber.e(e, "Failed to load Rive SDK native components, animations will be disabled")
+    } catch (e: RuntimeException) {
         Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
     } finally {
         // apply() is fine on the clear path — we only need durability for the *set* (which races

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -1,76 +1,10 @@
 package com.vultisig.wallet.app
 
 import android.app.Application
-import android.content.Context
-import android.content.SharedPreferences
-import androidx.annotation.VisibleForTesting
-import app.rive.runtime.kotlin.core.Rive
 import com.vultisig.wallet.BuildConfig
 import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
-
-internal var isRiveInitialized: Boolean = false
-    private set
-
-@VisibleForTesting
-internal fun resetRiveInitialized() {
-    isRiveInitialized = false
-}
-
-private const val RIVE_GUARD_PREFS = "rive_init_guard"
-private const val KEY_RIVE_INIT_IN_FLIGHT_VERSION = "rive_init_in_flight_version"
-internal const val NO_IN_FLIGHT_VERSION = -1
-
-/**
- * Returns the [SharedPreferences] backing the Rive crash-loop guard.
- *
- * Kept as a plain (unencrypted) prefs file — the only stored value is an int "init attempted"
- * marker keyed by app version — and resolved synchronously so [initializeRive] can read/write
- * before invoking the native Rive entry point.
- */
-@VisibleForTesting
-internal fun riveGuardPrefs(context: Context): SharedPreferences =
-    context.getSharedPreferences(RIVE_GUARD_PREFS, Context.MODE_PRIVATE)
-
-/**
- * Initializes the Rive SDK behind a device-agnostic crash-loop guard.
- *
- * Mitigates the native `SIGABRT` in `librive-android.so` (see issue #4656) without keying on
- * manufacturer/model strings. Before [Rive.init] we store the current [BuildConfig.VERSION_CODE];
- * the `finally` block clears it on any normal return (success or catchable throw). Only an
- * uncatchable process death inside the native call leaves the stored version set, causing the next
- * launch at the *same* version to short-circuit and leave [isRiveInitialized] `false` so
- * composables fall back to a [androidx.compose.foundation.layout.Spacer]. A later install that
- * bumps `versionCode` (e.g. ships a fixed Rive lib) will not match the stored version, so Rive is
- * re-attempted automatically without a manual reset.
- */
-internal fun initializeRive(context: Context) {
-    val prefs = riveGuardPrefs(context)
-    val storedVersion = prefs.getInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, NO_IN_FLIGHT_VERSION)
-    if (storedVersion == BuildConfig.VERSION_CODE) {
-        Timber.w(
-            "Skipping Rive init: previous launch at version %d did not complete Rive.init " +
-                "(likely native crash)",
-            BuildConfig.VERSION_CODE,
-        )
-        return
-    }
-    // commit() (not apply()) so the marker is durable on disk before we cross the JNI boundary —
-    // an async write would race a SIGABRT and lose the signal we rely on next launch.
-    prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, BuildConfig.VERSION_CODE).commit()
-    try {
-        Rive.init(context)
-        isRiveInitialized = true
-    } catch (e: Throwable) {
-        Timber.e(e, "Failed to initialize Rive SDK, animations will be disabled")
-    } finally {
-        // apply() is fine on the clear path — we only need durability for the *set* (which races
-        // SIGABRT). On normal return the next read happens after this process writes, so async is
-        // safe and keeps the cold-start path off a second blocking disk write.
-        prefs.edit().putInt(KEY_RIVE_INIT_IN_FLIGHT_VERSION, NO_IN_FLIGHT_VERSION).apply()
-    }
-}
 
 internal open class VsBaseApplication : Application() {
     override fun onCreate() {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/rive/RiveAnimation.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
@@ -22,7 +23,9 @@ import app.rive.ViewModelInstance
 import app.rive.rememberRiveFile
 import app.rive.rememberRiveWorkerOrNull
 import app.rive.runtime.kotlin.RiveAnimationView
+import app.rive.runtime.kotlin.controllers.RiveFileController
 import app.rive.runtime.kotlin.core.Alignment
+import app.rive.runtime.kotlin.core.PlayableInstance
 import com.vultisig.wallet.app.isRiveInitialized
 
 @Composable
@@ -34,21 +37,49 @@ fun RiveAnimation(
     fit: app.rive.runtime.kotlin.core.Fit = app.rive.runtime.kotlin.core.Fit.FIT_WIDTH,
     autoPlay: Boolean = true,
     onInit: (RiveAnimationView) -> Unit = {},
+    onFirstFrame: () -> Unit = {},
 ) {
     if (LocalInspectionMode.current || !isRiveInitialized) {
         Spacer(modifier)
     } else {
+        // Read the latest callback without re-running the one-shot factory below.
+        val currentOnFirstFrame = rememberUpdatedState(onFirstFrame)
         key(animation) {
             AndroidView(
                 modifier = modifier,
                 factory = { context ->
-                    RiveAnimationView(context).also {
-                        it.setRiveResource(
+                    RiveAnimationView(context).also { view ->
+                        view.setRiveResource(
                             resId = animation,
                             stateMachineName = stateMachineName,
                             alignment = alignment,
                             autoplay = autoPlay,
                             fit = fit,
+                        )
+                        // The view inflates and renders its first frame a few hundred ms after it
+                        // is composed. Callers that overlay their own content (e.g. a QR code) use
+                        // this to reveal it only once the Rive frame is actually on screen, so the
+                        // two appear together instead of the overlay flashing in first (#4954).
+                        view.registerListener(
+                            object : RiveFileController.Listener {
+                                override fun notifyPlay(animation: PlayableInstance) {}
+
+                                override fun notifyPause(animation: PlayableInstance) {}
+
+                                override fun notifyStop(animation: PlayableInstance) {}
+
+                                override fun notifyLoop(animation: PlayableInstance) {}
+
+                                override fun notifyStateChanged(
+                                    stateMachineName: String,
+                                    stateName: String,
+                                ) {}
+
+                                override fun notifyAdvance(elapsedTime: Float) {
+                                    currentOnFirstFrame.value()
+                                    view.unregisterListener(this)
+                                }
+                            }
                         )
                     }
                 },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -62,6 +62,7 @@ import app.rive.Fit
 import app.rive.ViewModelSource
 import app.rive.rememberViewModelInstance
 import com.vultisig.wallet.R
+import com.vultisig.wallet.app.isRiveInitialized
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
 import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.ShowQrHelperBottomSheet
@@ -486,6 +487,12 @@ private fun QrCodeContainer(
     devicesSize: Int = 0,
     qrCode: BitmapPainter? = null,
 ) {
+    // The QR bitmap is ready well before the Rive frame's AndroidView renders its first frame, so
+    // revealing it immediately shows a bare, un-styled QR that the branded frame then pops in
+    // around (#4954). Wait for the frame's first render before fading the QR in so both appear
+    // together. When Rive is unavailable there is no frame to wait for, so reveal it right away.
+    var frameReady by remember { mutableStateOf(!isRiveInitialized) }
+
     Box(modifier = modifier.aspectRatio(1f)) {
         RiveAnimation(
             animation = R.raw.riv_qr_scanned,
@@ -496,10 +503,11 @@ private fun QrCodeContainer(
                         inputName = "isSucces",
                     )
             },
+            onFirstFrame = { frameReady = true },
         )
         AnimatedVisibility(
             modifier = Modifier.padding(28.dp),
-            visible = qrCode != null,
+            visible = qrCode != null && frameReady,
             enter = fadeIn(),
         ) {
             if (qrCode != null) {

--- a/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
@@ -110,6 +110,18 @@ internal class RiveInitializationTest {
     }
 
     @Test
+    fun `init is skipped when the in-flight marker commit fails`() {
+        // A failed durable write (full disk, I/O error, thread interruption) means the crash-loop
+        // guard could not record this attempt, so running Rive.init unguarded risks a crash loop.
+        every { editor.commit() } returns false
+
+        initializeRive(context)
+
+        isRiveInitialized.shouldBeFalse()
+        verify(exactly = 0) { Rive.init(any(), any()) }
+    }
+
+    @Test
     fun `init is skipped when stored version matches current version from a previous crash`() {
         // We cannot kill the JVM inside a unit test, so we simulate the post-crash state directly:
         // the stored version equals the current versionCode, which is exactly the on-disk shape a

--- a/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/RiveInitializationTest.kt
@@ -31,7 +31,7 @@ internal class RiveInitializationTest {
     fun setUp() {
         resetRiveInitialized()
         mockkObject(Rive)
-        mockkStatic("com.vultisig.wallet.app.VoltixApplicationKt")
+        mockkStatic("com.vultisig.wallet.app.RiveInitializerKt")
         every { riveGuardPrefs(context) } returns prefs
         // Read from / write to a single in-memory backing variable so the test can observe what
         // the production code commits.
@@ -52,7 +52,7 @@ internal class RiveInitializationTest {
     @AfterEach
     fun tearDown() {
         unmockkObject(Rive)
-        unmockkStatic("com.vultisig.wallet.app.VoltixApplicationKt")
+        unmockkStatic("com.vultisig.wallet.app.RiveInitializerKt")
         resetRiveInitialized()
         storedVersion = NO_IN_FLIGHT_VERSION
     }


### PR DESCRIPTION
Closes #4954

## Summary

On the Secure-vault **Scan QR** (peer-discovery) screen the QR code first rendered in a bare, un-styled form and only "beautified" into the branded frame ~1s later (#4954).

**Root cause:** the QR `Image` is pure Compose and faded in the instant its bitmap was ready, while the decorative `riv_qr_scanned` frame is a Rive `AndroidView` whose first frame renders a few hundred ms after composition. So the QR appeared before its frame — there is no second QR generation; it's purely a render-ordering race.

## Fix

- `RiveAnimation.kt` — add an optional `onFirstFrame: () -> Unit` to the `@RawRes` overload. It registers a `RiveFileController.Listener` once in the view `factory` and fires the callback on the first `notifyAdvance` (first rendered frame), then unregisters. Default no-op, so all other callers are unaffected.
- `PeerDiscoveryScreen.kt` (`QrCodeContainer`) — gate the QR's `AnimatedVisibility` on `qrCode != null && frameReady`, where `frameReady` flips on `onFirstFrame`. It is seeded to `!isRiveInitialized` so the QR still shows immediately when Rive is unavailable or in previews. The existing `fireState("isSucces")` device-joined animation is untouched.

The QR and its branded frame now appear together.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/JYWxWUz.png) | ![after](https://i.imgur.com/MbBsri5.png) |

## Test plan

- Start Secure-vault creation → name the vault → tap **Next** → observe the **Scan QR** screen: the QR appears already inside its branded frame, with no intermediate un-styled flash.
- Confirm a second device joining still triggers the success animation (`isSucces`).
- Confirm previews / Rive-disabled fallback still render the QR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Enhancements**
  - Improved coordination between the first rendered Rive frame and QR code visibility during peer discovery.
  - Added a one-time “first frame” callback for Rive animations to support initial UI actions.

- **Bug Fixes**
  - Introduced a guarded Rive initialization flow to prevent repeated crash loops across app restarts.

- **Tests**
  - Updated Rive initialization tests to mock the new initialization entry point and added coverage for when the in-flight marker write fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->