### PR TITLE
fix(keygen): surface the real cause on session-start failure (timeout vs. generic)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -39,8 +39,8 @@ import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
 import com.vultisig.wallet.data.utils.NetworkErrorKind
-import com.vultisig.wallet.data.utils.networkErrorKind
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.data.utils.toNetworkErrorKind
 import com.vultisig.wallet.ui.components.errors.ErrorUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
@@ -237,18 +237,18 @@ constructor(
      * copy.
      */
     private fun Throwable.toKeygenErrorUiModel(): ErrorUiModel =
-        when (networkErrorKind()) {
+        when (toNetworkErrorKind()) {
             NetworkErrorKind.Timeout ->
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.keygen_error_timeout_title),
                     description = UiText.StringResource(R.string.keygen_error_timeout_description),
                 )
-            NetworkErrorKind.NoConnectivity,
-            NetworkErrorKind.Transport ->
+            NetworkErrorKind.NoConnectivity ->
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.keygen_error_network_title),
                     description = UiText.StringResource(R.string.keygen_error_network_description),
                 )
+            NetworkErrorKind.Transport,
             NetworkErrorKind.Http,
             null ->
                 ErrorUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -38,6 +38,8 @@ import com.vultisig.wallet.data.usecases.QrShareField
 import com.vultisig.wallet.data.usecases.QrShareInfo
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
+import com.vultisig.wallet.data.utils.NetworkErrorKind
+import com.vultisig.wallet.data.utils.networkErrorKind
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.errors.ErrorUiModel
 import com.vultisig.wallet.ui.navigation.Destination
@@ -224,6 +226,34 @@ constructor(
         }
     }
 
+    /**
+     * Maps a session-start failure to a cause-specific [ErrorUiModel]. A socket/read timeout or a
+     * connectivity loss gets a network-specific message so the user knows to check their connection
+     * and retry, instead of the opaque generic "Something went wrong" (issue #4956). Anything that
+     * isn't a recognisable transport failure (server error, app bug) falls back to the generic
+     * copy.
+     */
+    private fun Throwable.toKeygenErrorUiModel(): ErrorUiModel =
+        when (networkErrorKind()) {
+            NetworkErrorKind.Timeout ->
+                ErrorUiModel(
+                    title = UiText.StringResource(R.string.keygen_error_timeout_title),
+                    description = UiText.StringResource(R.string.keygen_error_timeout_description),
+                )
+            NetworkErrorKind.NoConnectivity,
+            NetworkErrorKind.Transport ->
+                ErrorUiModel(
+                    title = UiText.StringResource(R.string.keygen_error_network_title),
+                    description = UiText.StringResource(R.string.keygen_error_network_description),
+                )
+            NetworkErrorKind.Http,
+            null ->
+                ErrorUiModel(
+                    title = UiText.StringResource(R.string.error_view_default_title),
+                    description = UiText.StringResource(R.string.error_view_default_description),
+                )
+        }
+
     private fun showNetworkWarning() {
         _state.update {
             it.copy(
@@ -323,16 +353,7 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { e ->
                 Timber.e(e, "Failed to start keygen session")
-                _state.update {
-                    it.copy(
-                        warning =
-                            ErrorUiModel(
-                                title = UiText.StringResource(R.string.error_view_default_title),
-                                description =
-                                    UiText.StringResource(R.string.error_view_default_description),
-                            )
-                    )
-                }
+                _state.update { it.copy(warning = e.toKeygenErrorUiModel()) }
             }
         ) {
             val session = session
@@ -588,21 +609,7 @@ constructor(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e(e, "Failed to connect to Vultiserver")
-            _state.update {
-                it.copy(
-                    error =
-                        ErrorUiModel(
-                            title = UiText.StringResource(R.string.error_view_default_title),
-                            description =
-                                UiText.DynamicString(
-                                    e.message
-                                        ?: context.getString(
-                                            R.string.error_view_default_description
-                                        )
-                                ),
-                        )
-                )
-            }
+            _state.update { it.copy(error = e.toKeygenErrorUiModel()) }
         }
     }
 
@@ -699,22 +706,10 @@ constructor(
                 return
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                Timber.tag("startSessionAndDiscovery").e(e, "Attempt ${attempt + 1} failed")
+                Timber.tag("startSessionAndDiscovery").e(e, "Attempt %d failed", attempt + 1)
                 if (attempt >= 2) {
                     Timber.tag("startSessionAndDiscovery").e("All attempts to start session failed")
-                    _state.update {
-                        it.copy(
-                            error =
-                                ErrorUiModel(
-                                    title =
-                                        UiText.StringResource(R.string.error_view_default_title),
-                                    description =
-                                        UiText.StringResource(
-                                            R.string.error_view_default_description
-                                        ),
-                                )
-                        )
-                    }
+                    _state.update { it.copy(error = e.toKeygenErrorUiModel()) }
                 }
             }
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -810,6 +810,10 @@
     <string name="onboarding_intro_back">Zurück</string>
     <string name="error_view_default_title">Etwas ist schiefgelaufen</string>
     <string name="error_view_default_description">Ein Fehler ist aufgetreten</string>
+    <string name="keygen_error_timeout_title">Zeitüberschreitung der Verbindung</string>
+    <string name="keygen_error_timeout_description">Der Server konnte nicht rechtzeitig erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
+    <string name="keygen_error_network_title">Verbindungsproblem</string>
+    <string name="keygen_error_network_description">Der Server konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
     <string name="migration_onboarding_step_1_text_emphasized">das weltweit schnellste MPC-Protokoll</string>
     <string name="migration_onboarding_step_1_text_end">und schneller als je zuvor signieren</string>
     <string name="keygen_benefit_5_template">Lassen Sie sich nicht erneut betrügen!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -810,6 +810,10 @@
     <string name="migration_onboarding_step_1_text_end">y firma más rápido que nunca</string>
     <string name="error_view_default_title">Algo salió mal</string>
     <string name="error_view_default_description">Ocurrió un error</string>
+    <string name="keygen_error_timeout_title">Se agotó el tiempo de conexión</string>
+    <string name="keygen_error_timeout_description">No se pudo conectar con el servidor a tiempo. Verifique su conexión e inténtelo de nuevo.</string>
+    <string name="keygen_error_network_title">Problema de conexión</string>
+    <string name="keygen_error_network_description">No se pudo conectar con el servidor. Verifique su conexión e inténtelo de nuevo.</string>
     <string name="keygen_benefit_5_template">No vuelvas a caer en estafas.</string>
     <string name="keygen_benefit_5_emphasized">Una cartera sin semilla</string>
     <string name="keygen_vault_created_success_part_1">Bóveda creada</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -814,6 +814,10 @@
     <string name="migration_onboarding_step_1_text_end">i prijavite se brže nego ikad prije</string>
     <string name="error_view_default_title">Nešto je pošlo po zlu</string>
     <string name="error_view_default_description">Dogodila se pogreška</string>
+    <string name="keygen_error_timeout_title">Isteklo je vrijeme veze</string>
+    <string name="keygen_error_timeout_description">Poslužitelj nije dosegnut na vrijeme. Provjerite svoju vezu i pokušajte ponovno.</string>
+    <string name="keygen_error_network_title">Problem s vezom</string>
+    <string name="keygen_error_network_description">Poslužitelj nije dosegnut. Provjerite svoju vezu i pokušajte ponovno.</string>
     <string name="keygen_benefit_5_template">Ne dajte se ponovno prevariti</string>
     <string name="keygen_benefit_5_emphasized">Novčanik bez sjemena,</string>
     <string name="keygen_vault_created_success_part_1">Trezor kreiran</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -810,6 +810,10 @@
     <string name="migration_onboarding_step_1_text_end">e firma più velocemente che mai</string>
     <string name="error_view_default_title">Qualcosa è andato storto</string>
     <string name="error_view_default_description">Si è verificato un errore</string>
+    <string name="keygen_error_timeout_title">Connessione scaduta</string>
+    <string name="keygen_error_timeout_description">Impossibile raggiungere il server in tempo. Controlla la tua connessione e riprova.</string>
+    <string name="keygen_error_network_title">Problema di connessione</string>
+    <string name="keygen_error_network_description">Impossibile raggiungere il server. Controlla la tua connessione e riprova.</string>
     <string name="keygen_benefit_5_template">Non farti più truffare</string>
     <string name="keygen_benefit_5_emphasized">Un portafoglio seedless,</string>
     <string name="keygen_vault_created_success_part_1">Vault creato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -569,6 +569,10 @@
     <string name="enter_email_screen_next">다음</string>
     <string name="error_view_default_title">문제가 발생했습니다</string>
     <string name="error_view_default_description">오류가 발생했습니다</string>
+    <string name="keygen_error_timeout_title">연결 시간 초과</string>
+    <string name="keygen_error_timeout_description">서버에 제때 연결하지 못했습니다. 연결을 확인하고 다시 시도해 주세요.</string>
+    <string name="keygen_error_network_title">연결 문제</string>
+    <string name="keygen_error_network_description">서버에 연결하지 못했습니다. 연결을 확인하고 다시 시도해 주세요.</string>
     <string name="keygen_vault_created_success_part_1">볼트가</string>
     <string name="vault_created_success_part_2">성공적으로 생성되었습니다</string>
     <string name="vault_backup_screen_paste">붙여넣기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -807,6 +807,10 @@
     <string name="migration_onboarding_step_1_text_end">en onderteken sneller dan ooit tevoren</string>
     <string name="error_view_default_title">Er is iets misgegaan</string>
     <string name="error_view_default_description">Er is een fout opgetreden</string>
+    <string name="keygen_error_timeout_title">Time-out van verbinding</string>
+    <string name="keygen_error_timeout_description">Kon de server niet op tijd bereiken. Controleer uw verbinding en probeer het opnieuw.</string>
+    <string name="keygen_error_network_title">Verbindingsprobleem</string>
+    <string name="keygen_error_network_description">Kon de server niet bereiken. Controleer uw verbinding en probeer het opnieuw.</string>
     <string name="keygen_benefit_5_template">Word niet opnieuw opgelicht</string>
     <string name="keygen_benefit_5_emphasized">Een seedless wallet,</string>
     <string name="keygen_vault_created_success_part_1">Kluis aangemaakt</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -809,6 +809,10 @@
     <string name="migration_onboarding_step_1_text_end">e assine mais depressa do que nunca</string>
     <string name="error_view_default_title">Ocorreu um erro</string>
     <string name="error_view_default_description">Um erro ocorreu</string>
+    <string name="keygen_error_timeout_title">Tempo de ligação esgotado</string>
+    <string name="keygen_error_timeout_description">Não foi possível contactar o servidor a tempo. Verifique a sua ligação e tente novamente.</string>
+    <string name="keygen_error_network_title">Problema de ligação</string>
+    <string name="keygen_error_network_description">Não foi possível contactar o servidor. Verifique a sua ligação e tente novamente.</string>
     <string name="keygen_benefit_5_template">Não caia novamente em golpes</string>
     <string name="keygen_benefit_5_emphasized">Uma carteira sem semente,</string>
     <string name="keygen_vault_created_success_part_1">Cofre criado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -813,6 +813,10 @@
     <string name="migration_onboarding_step_1_text_end">и подпишите быстрее, чем когда-либо прежде</string>
     <string name="error_view_default_title">Что-то пошло не так</string>
     <string name="error_view_default_description">Произошла ошибка</string>
+    <string name="keygen_error_timeout_title">Превышено время ожидания</string>
+    <string name="keygen_error_timeout_description">Не удалось вовремя связаться с сервером. Проверьте подключение и попробуйте снова.</string>
+    <string name="keygen_error_network_title">Проблема с подключением</string>
+    <string name="keygen_error_network_description">Не удалось связаться с сервером. Проверьте подключение и попробуйте снова.</string>
     <string name="keygen_benefit_5_template">Не дайте себя обмануть снова!</string>
     <string name="keygen_benefit_5_emphasized">Кошелёк без сид-фразы,</string>
     <string name="keygen_vault_created_success_part_1">Хранилище создано</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1142,6 +1142,10 @@
     <string name="migration_onboarding_step_1_text_end">签名速度前所未有</string>
     <string name="error_view_default_title">出错了</string>
     <string name="error_view_default_description">发生错误</string>
+    <string name="keygen_error_timeout_title">连接超时</string>
+    <string name="keygen_error_timeout_description">未能及时连接到服务器。请检查您的网络连接并重试。</string>
+    <string name="keygen_error_network_title">连接问题</string>
+    <string name="keygen_error_network_description">未能连接到服务器。请检查您的网络连接并重试。</string>
     <string name="keygen_vault_created_success_part_1">保险库已创建</string>
     <string name="vault_created_success_part_2">成功</string>
     <string name="backup_password_request_no_password_action">无需密码备份</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,6 +578,10 @@
     <string name="enter_email_screen_next">Next</string>
     <string name="error_view_default_title">Something went wrong</string>
     <string name="error_view_default_description">An error occurred</string>
+    <string name="keygen_error_timeout_title">Connection timed out</string>
+    <string name="keygen_error_timeout_description">Couldn\'t reach the server in time. Check your connection and try again.</string>
+    <string name="keygen_error_network_title">Connection problem</string>
+    <string name="keygen_error_network_description">Couldn\'t reach the server. Check your connection and try again.</string>
     <string name="keygen_vault_created_success_part_1">Vault created</string>
     <string name="vault_created_success_part_2">successfully</string>
     <string name="vault_backup_screen_paste">Paste</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.networkutils
 
+import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
@@ -14,6 +15,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
@@ -26,8 +29,9 @@ import kotlinx.serialization.json.Json
  * 1. **ContentNegotiation** — JSON serialization/deserialization.
  * 2. **DefaultRequest** — default headers for all requests.
  * 3. **HttpCallValidator** — converts transport-level [IOException]s into [NetworkException] with
- *    `httpStatusCode = 0` (client-side error). This runs *after* [HttpRequestRetry] exhausts its
- *    retries.
+ *    `httpStatusCode = 0` (client-side error) and a [NetworkErrorKind] identifying the specific
+ *    transport cause (timeout vs. no connectivity vs. other). This runs *after* [HttpRequestRetry]
+ *    exhausts its retries.
  * 4. **HttpRequestRetry** — retries idempotent (GET/HEAD/OPTIONS) requests up to 3 times with
  *    exponential backoff: on transport [IOException]s/read-timeouts and on 5xx/429/408 responses.
  *    Non-idempotent requests (e.g. POST broadcasts) are never auto-retried, so a write the server
@@ -51,11 +55,7 @@ class HttpClientConfigurator @Inject constructor(private val json: Json) {
             install(HttpCallValidator) {
                 handleResponseExceptionWithRequest { cause, _ ->
                     if (cause is IOException) {
-                        throw NetworkException(
-                            httpStatusCode = 0,
-                            message = "No internet connection",
-                            cause = cause,
-                        )
+                        throw cause.toNetworkException()
                     }
                 }
             }
@@ -91,3 +91,17 @@ class HttpClientConfigurator @Inject constructor(private val json: Json) {
 /** Idempotent HTTP methods that are safe to retry automatically. */
 private fun isSafeMethod(method: HttpMethod): Boolean =
     method == HttpMethod.Get || method == HttpMethod.Head || method == HttpMethod.Options
+
+/**
+ * Maps a transport-level [IOException] to a classified [NetworkException]. A read/socket timeout is
+ * reported as a timeout rather than a lack of connectivity — wrapping every [IOException] as "No
+ * internet connection" was misleading both to users and when triaging logs (see issue #4956).
+ */
+private fun IOException.toNetworkException(): NetworkException =
+    when (this) {
+        is SocketTimeoutException ->
+            NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout, this)
+        is UnknownHostException ->
+            NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity, this)
+        else -> NetworkException(0, "Network request failed", NetworkErrorKind.Transport, this)
+    }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/RpcExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/RpcExtensions.kt
@@ -141,7 +141,7 @@ class NetworkException(
  * server HTTP error or an application bug). Used by the UI layer to pick a cause-specific error
  * message.
  */
-fun Throwable.networkErrorKind(): NetworkErrorKind? {
+fun Throwable.toNetworkErrorKind(): NetworkErrorKind? {
     var current: Throwable? = this
     while (current != null) {
         when (current) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/RpcExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/RpcExtensions.kt
@@ -90,20 +90,66 @@ private fun findValueRecursively(element: JsonElement, key: String): String? {
 }
 
 /**
+ * Categorises a [NetworkException] so callers can show a cause-specific message instead of a single
+ * generic "something went wrong". Transport failures are no longer collapsed into one bucket: a
+ * read/socket timeout ([Timeout]) is distinct from a genuine lack of connectivity
+ * ([NoConnectivity]).
+ */
+enum class NetworkErrorKind {
+    /** Read/socket timeout — the server was reachable but did not respond in time. */
+    Timeout,
+    /** No connectivity — DNS resolution failed / host unreachable, typically offline. */
+    NoConnectivity,
+    /** Other transport-level failure (connection refused, SSL handshake, generic I/O). */
+    Transport,
+    /** The server returned an HTTP error response (4xx / 5xx). */
+    Http,
+}
+
+/**
  * Represents a network-related error — either a transport failure or an HTTP error response.
  *
  * [httpStatusCode] semantics:
  * - `0` — transport-level failure (no HTTP response was received). Thrown by
  *   [HttpClientConfigurator][com.vultisig.wallet.data.networkutils.HttpClientConfigurator]'s
  *   `HttpCallValidator` when an [java.io.IOException] occurs (DNS failure, timeout, SSL error,
- *   etc.).
+ *   etc.). [kind] then carries the specific transport cause.
  * - `4xx / 5xx` — the server returned an error response. Thrown by [bodyOrThrow] when the HTTP
- *   status is not successful.
+ *   status is not successful; [kind] defaults to [NetworkErrorKind.Http].
  *
  * Extends [RuntimeException] so it is caught by existing `catch(Exception)` blocks.
  */
 class NetworkException(
     val httpStatusCode: Int,
     override val message: String,
+    val kind: NetworkErrorKind = NetworkErrorKind.Http,
     cause: Throwable? = null,
-) : RuntimeException(message, cause)
+) : RuntimeException(message, cause) {
+    /**
+     * Backwards-compatible constructor for callers that don't classify the failure (HTTP errors).
+     */
+    constructor(
+        httpStatusCode: Int,
+        message: String,
+        cause: Throwable?,
+    ) : this(httpStatusCode, message, NetworkErrorKind.Http, cause)
+}
+
+/**
+ * Walks this throwable's cause chain and returns the first transport-level [NetworkErrorKind] it
+ * can identify, or `null` when the failure isn't a recognisable network/transport error (e.g. a
+ * server HTTP error or an application bug). Used by the UI layer to pick a cause-specific error
+ * message.
+ */
+fun Throwable.networkErrorKind(): NetworkErrorKind? {
+    var current: Throwable? = this
+    while (current != null) {
+        when (current) {
+            is NetworkException -> if (current.kind != NetworkErrorKind.Http) return current.kind
+            is java.net.SocketTimeoutException -> return NetworkErrorKind.Timeout
+            is java.net.UnknownHostException -> return NetworkErrorKind.NoConnectivity
+        }
+        current = current.cause
+    }
+    return null
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfiguratorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfiguratorTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.networkutils
 
+import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -12,6 +13,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import java.io.IOException
 import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
@@ -198,5 +200,40 @@ class HttpClientConfiguratorTest {
                 // 1 original call + 3 retries
                 assertEquals(4, callCount)
             }
+    }
+
+    /**
+     * A read/socket timeout must surface as [NetworkErrorKind.Timeout] with a timeout message, not
+     * as a generic "No internet connection" — collapsing distinct transport failures into one
+     * message misled both users and log triage (issue #4956).
+     */
+    @Test
+    fun `socketTimeout isClassifiedAsTimeout`() = runTest {
+        configuredClient(MockEngine { throw SocketTimeoutException("Read timed out") }).use { client
+            ->
+            val ex = assertFailsWith<NetworkException> { client.post("http://localhost/test") }
+            assertEquals(NetworkErrorKind.Timeout, ex.kind)
+            assertEquals("Connection timed out", ex.message)
+            assertEquals(0, ex.httpStatusCode)
+        }
+    }
+
+    /** A DNS failure (host unreachable) is classified as a connectivity loss. */
+    @Test
+    fun `unknownHost isClassifiedAsNoConnectivity`() = runTest {
+        configuredClient(MockEngine { throw UnknownHostException("no host") }).use { client ->
+            val ex = assertFailsWith<NetworkException> { client.post("http://localhost/test") }
+            assertEquals(NetworkErrorKind.NoConnectivity, ex.kind)
+            assertEquals("No internet connection", ex.message)
+        }
+    }
+
+    /** Any other transport-level IOException maps to the generic [NetworkErrorKind.Transport]. */
+    @Test
+    fun `genericIOException isClassifiedAsTransport`() = runTest {
+        configuredClient(MockEngine { throw IOException("connection refused") }).use { client ->
+            val ex = assertFailsWith<NetworkException> { client.post("http://localhost/test") }
+            assertEquals(NetworkErrorKind.Transport, ex.kind)
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/NetworkStateInterceptorContractTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/networkutils/NetworkStateInterceptorContractTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.networkutils
 
 import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.call.body
@@ -33,7 +34,8 @@ import org.junit.Test
  * 3. `bodyOrThrow()` must report network failures as client-side errors (code 0).
  * 4. Callers using status-code checks must not confuse network failures with server rejections.
  * 5. Existing `catch(Exception)` patterns must still catch network errors.
- * 6. All `IOException` subtypes (SSL, timeout, DNS, connection) are handled uniformly.
+ * 6. All `IOException` subtypes (SSL, timeout, DNS, connection) become a transport-level
+ *    `NetworkException` (httpStatusCode=0), classified by subtype into a `NetworkErrorKind`.
  * 7. Non-network errors (deserialization, business logic) are NOT swallowed.
  */
 class NetworkStateInterceptorContractTest {
@@ -62,33 +64,49 @@ class NetworkStateInterceptorContractTest {
     // ================================================================
 
     @Test
-    fun ioException_becomesNetworkExceptionWithCode0() = runBlocking {
-        assertTransportExceptionBecomesNetworkException(IOException("Connection reset"))
-    }
-
-    @Test
-    fun sslHandshakeException_becomesNetworkExceptionWithCode0() = runBlocking {
-        assertTransportExceptionBecomesNetworkException(SSLHandshakeException("Handshake failed"))
-    }
-
-    @Test
-    fun socketTimeoutException_becomesNetworkExceptionWithCode0() = runBlocking {
-        assertTransportExceptionBecomesNetworkException(SocketTimeoutException("Read timed out"))
-    }
-
-    @Test
-    fun connectException_becomesNetworkExceptionWithCode0() = runBlocking {
-        assertTransportExceptionBecomesNetworkException(ConnectException("Connection refused"))
-    }
-
-    @Test
-    fun unknownHostException_becomesNetworkExceptionWithCode0() = runBlocking {
+    fun ioException_becomesTransportNetworkException() = runBlocking {
         assertTransportExceptionBecomesNetworkException(
-            UnknownHostException("Unable to resolve host")
+            IOException("Connection reset"),
+            expectedKind = NetworkErrorKind.Transport,
         )
     }
 
-    private suspend fun assertTransportExceptionBecomesNetworkException(ioException: IOException) {
+    @Test
+    fun sslHandshakeException_becomesTransportNetworkException() = runBlocking {
+        assertTransportExceptionBecomesNetworkException(
+            SSLHandshakeException("Handshake failed"),
+            expectedKind = NetworkErrorKind.Transport,
+        )
+    }
+
+    @Test
+    fun socketTimeoutException_becomesTimeoutNetworkException() = runBlocking {
+        assertTransportExceptionBecomesNetworkException(
+            SocketTimeoutException("Read timed out"),
+            expectedKind = NetworkErrorKind.Timeout,
+        )
+    }
+
+    @Test
+    fun connectException_becomesTransportNetworkException() = runBlocking {
+        assertTransportExceptionBecomesNetworkException(
+            ConnectException("Connection refused"),
+            expectedKind = NetworkErrorKind.Transport,
+        )
+    }
+
+    @Test
+    fun unknownHostException_becomesNoConnectivityNetworkException() = runBlocking {
+        assertTransportExceptionBecomesNetworkException(
+            UnknownHostException("Unable to resolve host"),
+            expectedKind = NetworkErrorKind.NoConnectivity,
+        )
+    }
+
+    private suspend fun assertTransportExceptionBecomesNetworkException(
+        ioException: IOException,
+        expectedKind: NetworkErrorKind,
+    ) {
         val client = MockHttpClient.throwingIOException(ioException)
         try {
             client.get("https://api.vultisig.com/test")
@@ -99,7 +117,7 @@ class NetworkStateInterceptorContractTest {
                 0,
                 e.httpStatusCode,
             )
-            assertEquals("No internet connection", e.message)
+            assertEquals("transport failure must be classified by subtype", expectedKind, e.kind)
             assertTrue(
                 "cause must be the original IOException (${ioException::class.simpleName})",
                 e.cause is IOException,
@@ -153,7 +171,7 @@ class NetworkStateInterceptorContractTest {
             fail("Expected NetworkException")
         } catch (e: NetworkException) {
             assertEquals(0, e.httpStatusCode)
-            assertEquals("No internet connection", e.message)
+            assertEquals(NetworkErrorKind.Transport, e.kind)
         }
 
         client.close()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.testutils
 
+import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -14,6 +15,8 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import kotlinx.serialization.json.Json
 
 /**
@@ -108,13 +111,24 @@ object MockHttpClient {
         install(HttpCallValidator) {
             handleResponseExceptionWithRequest { cause, _ ->
                 if (cause is IOException) {
-                    throw NetworkException(
-                        httpStatusCode = 0,
-                        message = "No internet connection",
-                        cause = cause,
-                    )
+                    throw cause.toNetworkException()
                 }
             }
         }
     }
+
+    /**
+     * Mirrors the production
+     * [HttpClientConfigurator][com.vultisig.wallet.data.networkutils.HttpClientConfigurator]
+     * classification so transport failures map to the same [NetworkErrorKind] in tests as in
+     * production.
+     */
+    private fun IOException.toNetworkException(): NetworkException =
+        when (this) {
+            is SocketTimeoutException ->
+                NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout, this)
+            is UnknownHostException ->
+                NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity, this)
+            else -> NetworkException(0, "Network request failed", NetworkErrorKind.Transport, this)
+        }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/NetworkErrorKindTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/NetworkErrorKindTest.kt
@@ -1,0 +1,53 @@
+package com.vultisig.wallet.data.utils
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+/** Pins the cause-chain classification used to pick a cause-specific keygen error (issue #4956). */
+class NetworkErrorKindTest {
+
+    @Test
+    fun `directNetworkException returnsItsKind`() {
+        val ex = NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout)
+        assertEquals(NetworkErrorKind.Timeout, ex.networkErrorKind())
+    }
+
+    @Test
+    fun `wrappedNetworkException isFoundThroughCauseChain`() {
+        val root = NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity)
+        val wrapped = IllegalStateException("start failed", RuntimeException(root))
+        assertEquals(NetworkErrorKind.NoConnectivity, wrapped.networkErrorKind())
+    }
+
+    @Test
+    fun `rawSocketTimeout isClassifiedAsTimeout`() {
+        val ex = RuntimeException("boom", SocketTimeoutException("timeout"))
+        assertEquals(NetworkErrorKind.Timeout, ex.networkErrorKind())
+    }
+
+    @Test
+    fun `rawUnknownHost isClassifiedAsNoConnectivity`() {
+        assertEquals(
+            NetworkErrorKind.NoConnectivity,
+            UnknownHostException("dns").networkErrorKind(),
+        )
+    }
+
+    @Test
+    fun `httpServerError isNotTreatedAsTransportFailure`() {
+        // A 500 from the server is an Http-kind NetworkException; the keygen UI keeps the generic
+        // message for it rather than claiming a connectivity problem.
+        val ex = NetworkException(500, "Internal Server Error")
+        assertNull(ex.networkErrorKind())
+    }
+
+    @Test
+    fun `nonNetworkError returnsNull`() {
+        assertNull(IllegalArgumentException("bad arg").networkErrorKind())
+        assertNull(IOException("disk").networkErrorKind())
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/NetworkErrorKindTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/NetworkErrorKindTest.kt
@@ -13,27 +13,27 @@ class NetworkErrorKindTest {
     @Test
     fun `directNetworkException returnsItsKind`() {
         val ex = NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout)
-        assertEquals(NetworkErrorKind.Timeout, ex.networkErrorKind())
+        assertEquals(NetworkErrorKind.Timeout, ex.toNetworkErrorKind())
     }
 
     @Test
     fun `wrappedNetworkException isFoundThroughCauseChain`() {
         val root = NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity)
         val wrapped = IllegalStateException("start failed", RuntimeException(root))
-        assertEquals(NetworkErrorKind.NoConnectivity, wrapped.networkErrorKind())
+        assertEquals(NetworkErrorKind.NoConnectivity, wrapped.toNetworkErrorKind())
     }
 
     @Test
     fun `rawSocketTimeout isClassifiedAsTimeout`() {
         val ex = RuntimeException("boom", SocketTimeoutException("timeout"))
-        assertEquals(NetworkErrorKind.Timeout, ex.networkErrorKind())
+        assertEquals(NetworkErrorKind.Timeout, ex.toNetworkErrorKind())
     }
 
     @Test
     fun `rawUnknownHost isClassifiedAsNoConnectivity`() {
         assertEquals(
             NetworkErrorKind.NoConnectivity,
-            UnknownHostException("dns").networkErrorKind(),
+            UnknownHostException("dns").toNetworkErrorKind(),
         )
     }
 
@@ -42,12 +42,12 @@ class NetworkErrorKindTest {
         // A 500 from the server is an Http-kind NetworkException; the keygen UI keeps the generic
         // message for it rather than claiming a connectivity problem.
         val ex = NetworkException(500, "Internal Server Error")
-        assertNull(ex.networkErrorKind())
+        assertNull(ex.toNetworkErrorKind())
     }
 
     @Test
     fun `nonNetworkError returnsNull`() {
-        assertNull(IllegalArgumentException("bad arg").networkErrorKind())
-        assertNull(IOException("disk").networkErrorKind())
+        assertNull(IllegalArgumentException("bad arg").toNetworkErrorKind())
+        assertNull(IOException("disk").toNetworkErrorKind())
     }
 }


### PR DESCRIPTION
## Summary

Closes #4956.

When starting a keygen session failed due to a network/server timeout, the UI showed the generic **"Something went wrong / An error occurred"** screen and the failure was logged as `NetworkException: No internet connection` — even though the device had connectivity and the real cause was a `SocketTimeoutException` on `router/start`. Two layers contributed, and both are fixed here.

### Layer 1 — transport-failure classification (`data`)
- `HttpClientConfigurator` no longer wraps every `IOException` as `NetworkException("No internet connection")`. It classifies the subtype:
  - `SocketTimeoutException` → **Timeout** ("Connection timed out")
  - `UnknownHostException` → **NoConnectivity** ("No internet connection")
  - everything else → **Transport** ("Network request failed")
- New `NetworkErrorKind` enum + `kind` field on `NetworkException` (with a back-compat constructor, so existing call sites are untouched).
- New `Throwable.networkErrorKind()` walks the cause chain so the UI can pick a cause-specific message.

### Layer 2 — keygen error surfacing (`app`)
- `startSessionWithRetry()`, `startVultiServerConnection()` and `next()` in `KeygenPeerDiscoveryViewModel` now map the actual failure to a cause-specific `ErrorUiModel`. A timeout or connectivity loss tells the user to check their connection and retry; anything that isn't a recognisable transport failure keeps the generic copy.
- New `keygen_error_timeout_*` and `keygen_error_network_*` strings across **all 10 locales**.

## Test plan
- `./gradlew :data:testDebugUnitTest` — extended `HttpClientConfiguratorTest` (timeout/DNS/generic kinds), updated `NetworkStateInterceptorContractTest` to assert `kind`, updated `MockHttpClient` to mirror prod classification, added `NetworkErrorKindTest` (cause-chain walking). ✅
- `./gradlew :app:testDebugUnitTest --tests "*.peer.*"` — keygen peer-discovery suite green. ✅
- `./gradlew :app:compileDebugKotlin` — ✅
- ktfmt applied; all 10 `strings.xml` validated as well-formed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key generation error handling by classifying failures as connection timeout, no connectivity, or other network issues, and showing clearer user-facing warnings/errors.
* **Localization**
  * Added localized Keygen network error message strings (timeout and general connectivity problems) for German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->