### PR TITLE
fix(qbtc): set chain id to qbtc

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcClaimConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcClaimConfig.kt
@@ -7,7 +7,7 @@ package com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim
  */
 object QbtcClaimConfig {
     /** Cosmos chain id, also hashed into the claim message hash. */
-    const val CHAIN_ID = "qbtc-testnet"
+    const val CHAIN_ID = "qbtc"
 
     const val MAX_CLAIM_UTXOS = 50
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfig.kt
@@ -74,7 +74,7 @@ object CosmosStakingConfig {
             // redelegate (see below) and its 7_500 fee overpays the verified 800 min_tx_fee.
             Chain.Qbtc to
                 Entry(
-                    chainId = "qbtc-testnet",
+                    chainId = "qbtc",
                     // Lowercase, not a micro-denom — QBTC's bond_denom is the bare `qbtc` (8 dp).
                     bondDenom = "qbtc",
                     feeDenom = "qbtc",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelper.kt
@@ -16,7 +16,7 @@ class QBTCTransactionHelper {
 
     companion object {
         // This is the actual on-chain ID; the network launched with this name
-        private const val CHAIN_ID = "qbtc-testnet"
+        private const val CHAIN_ID = "qbtc"
         private const val DENOM = "qbtc"
         // Higher than typical Cosmos chains — ML-DSA-44 signatures are ~2.4 KB
         internal const val GAS_LIMIT = 300_000L

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcProofModelsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/QbtcProofModelsTest.kt
@@ -62,7 +62,7 @@ class QbtcProofModelsTest {
         assertEquals("0".repeat(40) + "deadbeef", request.signatureR)
         assertEquals("0".repeat(56) + "cafebabe", request.signatureS)
         assertTrue(request.broadcast)
-        assertEquals("qbtc-testnet", request.chainId)
+        assertEquals("qbtc", request.chainId)
         assertEquals(1, request.utxos.size)
         assertEquals(0, request.utxos.first().vout)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/BuildCosmosStakingKeysignPayloadUseCaseTests.kt
@@ -197,7 +197,7 @@ class BuildCosmosStakingKeysignPayloadUseCaseTests {
             )
 
         val signDirect = assertNotNull(result.signDirect)
-        assertEquals("qbtc-testnet", signDirect.chainId)
+        assertEquals("qbtc", signDirect.chainId)
         // The AuthInfo must carry the ML-DSA pubkey `Any` and the QBTC base gas/fee — proving the
         // use case dispatched to `resolveMLDSA`, not the secp256k1 `resolve` (which would have
         // rejected the 1312-byte key).

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/CosmosStakingConfigTests.kt
@@ -47,7 +47,7 @@ class CosmosStakingConfigTests {
     @Test
     fun `QBTC entry matches pinned values`() {
         val entry = CosmosStakingConfig.entryFor(Chain.Qbtc)
-        assertEquals("qbtc-testnet", entry.chainId)
+        assertEquals("qbtc", entry.chainId)
         // `qbtc` is lowercase and NOT a micro-denom (8 decimals) — verified on the live
         // qbtc-testnet LCD `staking/params.bond_denom`.
         assertEquals("qbtc", entry.bondDenom)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/staking/QbtcStakingSignDataResolverTests.kt
@@ -56,9 +56,9 @@ class QbtcStakingSignDataResolverTests {
     // MARK: - Bodies match the shared, pubkey-agnostic encoders
 
     @Test
-    fun `delegate body matches the shared encoder and carries qbtc-testnet chainId`() {
+    fun `delegate body matches the shared encoder and carries qbtc chainId`() {
         val result = resolve(CosmosStakingPayload.Delegate(FX.VALIDATOR_A, amount = "100000000"))
-        assertEquals("qbtc-testnet", result.chainId)
+        assertEquals("qbtc", result.chainId)
         assertEquals(FX.ACCOUNT_NUMBER.toString(), result.accountNumber)
         val expectedBody =
             CosmosStakingHelper.buildTxBodyMulti(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/QBTCTransactionHelperTest.kt
@@ -96,7 +96,7 @@ class QBTCTransactionHelperTest {
     private fun signDirect(
         body: ByteArray = byteArrayOf(1, 2, 3, 4, 5),
         authInfo: ByteArray = byteArrayOf(9, 8, 7),
-        chainId: String = "qbtc-testnet",
+        chainId: String = "qbtc",
         accountNumber: String = "42",
     ) =
         SignDirectProto(


### PR DESCRIPTION
## Summary
- Change the QBTC Cosmos `chain_id` from `qbtc-testnet` to the bare `qbtc` across all functional paths:
  - **Keysign** — `QBTCTransactionHelper.CHAIN_ID`
  - **Staking** — `CosmosStakingConfig` QBTC entry `chainId`
  - **Claim** — `QbtcClaimConfig.CHAIN_ID` (also folded into the claim message hash via `SHA256(chainId)`)
- Update the corresponding unit tests to assert `qbtc`.
- Descriptive comments that reference the live `qbtc-testnet` deployment (where gas/fee values were observed) are left intact as provenance notes.

## Test Plan
- [ ] `./gradlew test` (QBTC keysign / staking / claim test suites)
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)
- [ ] Verify on-chain QBTC node actually expects `qbtc` (not `qbtc-testnet`) — signatures will be rejected if the chain id does not match exactly, since it is part of the signed message

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QBTC chain identifier configuration across blockchain operations and staking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->