### PR TITLE
fix(swap): guard null "To" token balance while loading

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/TokenInput.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/TokenInput.kt
@@ -210,7 +210,10 @@ internal fun TokenInput(
             }
 
             Text(
-                text = selectedToken?.let { "${it.balance} ${it.title}" } ?: "",
+                text =
+                    selectedToken?.let { token ->
+                        token.balance?.let { balance -> "$balance ${token.title}" }
+                    } ?: "",
                 style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.text.tertiary,
                 textAlign = TextAlign.End,


### PR DESCRIPTION
## Summary
- The Swap screen's "To" token balance label showed the literal text `null <ticker>` (e.g. `null GRT`) for a few seconds after selecting a destination token, until the balance finished loading.
- Root cause: in `TokenInput.kt` the label was built as `selectedToken?.let { "${it.balance} ${it.title}" }`. The `?.let` only guarded `selectedToken` — not its nullable `balance` (`String?`, null until loaded). Kotlin string interpolation then emitted the literal `"null"`.
- Fix: guard `balance` as well, so the label stays empty while the balance is null/loading and only renders `"<balance> <ticker>"` once it resolves.

## Issue
Closes #4963

## Test Plan
- [x] Lint passes (`./gradlew lint`)
- [x] Debug Kotlin compiles (`:app:compileDebugKotlin`)
- [ ] Manual: Swap → From ETH → To GRT (uncached balance); confirm the "To" balance label is empty while loading and never shows `null`, then resolves to the real balance.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token balance display in token input to properly handle cases where balance information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->