### PR TITLE
fix(defi): show selected currency symbol in DeFi tabs, not device locale

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
@@ -4,9 +4,11 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.sources.AppDataStore
 import java.text.NumberFormat
+import java.util.Currency
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,6 +33,7 @@ internal class AppCurrencyRepositoryImpl @Inject constructor(private val dataSto
 
     private val mutex = Mutex()
     private var cachedLocale: Locale? = null
+    private var cachedCurrency: AppCurrency? = null
     private var cachedCurrencyFormat: NumberFormat? = null
 
     override val currency: Flow<AppCurrency>
@@ -49,18 +52,31 @@ internal class AppCurrencyRepositoryImpl @Inject constructor(private val dataSto
         return CURRENCY_LIST
     }
 
-    override suspend fun getCurrencyFormat(): NumberFormat =
-        mutex.withLock {
+    override suspend fun getCurrencyFormat(): NumberFormat {
+        val appCurrency = currency.first()
+        return mutex.withLock {
             val currentLocale = Locale.getDefault()
-            // Update the currency format in a thread-safe manner when the locale changes or the
-            // value is
-            // null
-            if (cachedLocale != currentLocale || cachedCurrencyFormat == null) {
+            // Rebuild when either the device locale or the selected app currency changes. The
+            // locale
+            // drives grouping/decimal conventions while the selected currency drives the symbol, so
+            // a USD vault always renders "$" even when the device locale would otherwise default to
+            // another currency (e.g. en_GB defaults to "£").
+            if (
+                cachedLocale != currentLocale ||
+                    cachedCurrency != appCurrency ||
+                    cachedCurrencyFormat == null
+            ) {
                 cachedLocale = currentLocale
-                cachedCurrencyFormat = NumberFormat.getCurrencyInstance(currentLocale)
+                cachedCurrency = appCurrency
+                cachedCurrencyFormat =
+                    NumberFormat.getCurrencyInstance(currentLocale).apply {
+                        currency = Currency.getInstance(appCurrency.ticker)
+                    }
             }
-            requireNotNull(cachedCurrencyFormat)
+            // Return a clone so concurrent callers never share a mutable NumberFormat instance.
+            requireNotNull(cachedCurrencyFormat).clone() as NumberFormat
         }
+    }
 
     companion object {
         private const val CURRENCY_KEY = "currency_key"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
@@ -70,7 +70,14 @@ internal class AppCurrencyRepositoryImpl @Inject constructor(private val dataSto
                 cachedCurrency = appCurrency
                 cachedCurrencyFormat =
                     NumberFormat.getCurrencyInstance(currentLocale).apply {
-                        currency = Currency.getInstance(appCurrency.ticker)
+                        val selectedCurrency = Currency.getInstance(appCurrency.ticker)
+                        currency = selectedCurrency
+                        // Pin fraction digits to the selected currency's default. Otherwise they
+                        // stay at the device-locale default currency, so a USD vault on a ja_JP /
+                        // ko_KR device (JPY/KRW have 0 fraction digits) would render "$1,235" and
+                        // drop the cents.
+                        minimumFractionDigits = selectedCurrency.defaultFractionDigits
+                        maximumFractionDigits = selectedCurrency.defaultFractionDigits
                     }
             }
             // Return a clone so concurrent callers never share a mutable NumberFormat instance.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
@@ -50,6 +50,22 @@ class AppCurrencyRepositoryImplTest {
     }
 
     @Test
+    fun `format keeps the selected currency fraction digits on a zero-decimal device locale`() =
+        runTest {
+            // On ja_JP the device-locale default currency is JPY (0 fraction digits). Without
+            // pinning the fraction digits to the selected currency, a USD vault would render
+            // "$1,235" and drop the cents (#4982 review).
+            Locale.setDefault(Locale.JAPAN)
+            val repository =
+                AppCurrencyRepositoryImpl(FakeCurrencyDataStore(AppCurrency.USD.ticker))
+
+            val formatted = repository.getCurrencyFormat().format(1234.5)
+
+            val usdSymbol = Currency.getInstance("USD").getSymbol(Locale.JAPAN)
+            assertEquals("${usdSymbol}1,234.50", formatted)
+        }
+
+    @Test
     fun `format reflects a currency change between calls`() = runTest {
         Locale.setDefault(Locale.US)
         val dataStore = FakeCurrencyDataStore(AppCurrency.USD.ticker)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
@@ -1,0 +1,81 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.sources.AppDataStore
+import java.util.Currency
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class AppCurrencyRepositoryImplTest {
+
+    private val originalLocale: Locale = Locale.getDefault()
+
+    @AfterEach
+    fun restoreLocale() {
+        Locale.setDefault(originalLocale)
+    }
+
+    @Test
+    fun `format uses selected currency symbol not the device locale currency`() = runTest {
+        // A UK device locale would otherwise default the currency symbol to GBP (£) — the bug
+        // reported in #4967 where a USD vault showed amounts in £ on the THORChain DeFi tab.
+        Locale.setDefault(Locale.UK)
+        val repository = AppCurrencyRepositoryImpl(FakeCurrencyDataStore(AppCurrency.USD.ticker))
+
+        val formatted = repository.getCurrencyFormat().format(1234.5)
+
+        val gbpSymbol = Currency.getInstance("GBP").getSymbol(Locale.UK)
+        val usdSymbol = Currency.getInstance("USD").getSymbol(Locale.UK)
+        assertFalse(formatted.contains(gbpSymbol), "Should not use the device locale currency (£)")
+        assertTrue(formatted.contains(usdSymbol), "Should use the selected currency (USD)")
+    }
+
+    @Test
+    fun `format renders the selected non-USD currency`() = runTest {
+        Locale.setDefault(Locale.US)
+        val repository = AppCurrencyRepositoryImpl(FakeCurrencyDataStore(AppCurrency.EUR.ticker))
+
+        val formatted = repository.getCurrencyFormat().format(1000)
+
+        assertEquals("€1,000.00", formatted)
+    }
+
+    @Test
+    fun `format reflects a currency change between calls`() = runTest {
+        Locale.setDefault(Locale.US)
+        val dataStore = FakeCurrencyDataStore(AppCurrency.USD.ticker)
+        val repository = AppCurrencyRepositoryImpl(dataStore)
+
+        val usd = repository.getCurrencyFormat().format(1)
+        dataStore.ticker = AppCurrency.GBP.ticker
+        val gbp = repository.getCurrencyFormat().format(1)
+
+        assertEquals("$1.00", usd)
+        assertEquals("£1.00", gbp)
+    }
+
+    private class FakeCurrencyDataStore(var ticker: String) : AppDataStore {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =
+            flowOf(ticker as T)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> readData(key: Preferences.Key<T>): Flow<T?> = flowOf(ticker as? T)
+
+        override suspend fun editData(
+            transform: suspend (MutablePreferences) -> Unit
+        ): Preferences = throw UnsupportedOperationException()
+
+        override suspend fun <T> set(key: Preferences.Key<T>, value: T) =
+            throw UnsupportedOperationException()
+    }
+}


### PR DESCRIPTION
Fixes #4967

## Problem

The vault currency was set to USD, but the THORChain DeFi tab displayed amounts in £ instead of $.

## Root cause

`AppCurrencyRepositoryImpl.getCurrencyFormat()` built its `NumberFormat` from the **device locale only**:

```kotlin
cachedCurrencyFormat = NumberFormat.getCurrencyInstance(currentLocale)
```

So the currency **symbol** followed the device locale's default currency, ignoring the user's selected vault currency. On a UK device (`en_GB`) that default is GBP → £. The numeric values were already correct (prices are fetched in the selected currency); only the symbol was wrong.

The correct path elsewhere (`FiatValueToStringMapperImpl`) compensates by cloning the format and setting `currency = Currency.getInstance(...)`. But the DeFi tab ViewModels (THORChain, Maya, Tron, Circle, Cosmos) call `getCurrencyFormat()` → `format()` directly, so they all inherited the wrong symbol. THORChain was the one reported.

## Fix

Apply the selected `AppCurrency` to the format at the root, so every direct caller is correct:

- Set `currency = Currency.getInstance(appCurrency.ticker)` on the format.
- Key the cache on `(locale, currency)` so it rebuilds when the user changes currency.
- Return a clone so concurrent callers never share a mutable `NumberFormat` (thread safety).
- `FiatValueToStringMapperImpl` is unaffected — it still clones and overrides the currency.

One change fixes the reported THORChain bug **and** the identical latent defect in the Maya/Tron/Circle/Cosmos DeFi tabs.

## Test plan

- [x] New `AppCurrencyRepositoryImplTest` (3 cases, all green):
  - UK locale + USD selected → uses `$`, never `£` (the #4967 regression)
  - US locale + EUR selected → `€1,000.00`
  - currency change between calls is reflected
- [x] `./gradlew :data:testDebugUnitTest` passes
- [x] ktfmt applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed currency formatting to match the currently selected app currency, including correct symbols and fraction digits across different device locales.

- **Tests**
  - Added multi-locale and multi-currency formatting tests to ensure output updates when the selected ticker changes and that zero-decimal locales still render the selected currency’s expected decimals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->