### PR TITLE
fix(tx): unverified-function caution box at bottom of done screen (#4974)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -28,7 +28,10 @@ import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsOverviewToken
+import com.vultisig.wallet.ui.components.banners.Banner
+import com.vultisig.wallet.ui.components.banners.BannerVariant
 import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.components.hero.TransactionHero
 import com.vultisig.wallet.ui.components.library.form.FormCard
 import com.vultisig.wallet.ui.components.library.form.FormDetails
@@ -55,6 +58,13 @@ internal fun TransactionDoneView(
 ) {
     BackHandler(onBack = onBack)
 
+    // #4974: on the completed-transaction screen the signature is already on chain, so the
+    // pre-signing "Unverified function" warning hero is wrong. Drop it to the plain function-name
+    // title and surface the caution as the Figma caution box (amber banner) pinned at the bottom.
+    val isUnverifiedFunction =
+        (transactionTypeUiModel as? TransactionTypeUiModel.Send)?.tx?.heroContent ==
+            HeroContent.Unverified
+
     V2Scaffold(
         applyDefaultPaddings = true,
         applyScaffoldPaddings = true,
@@ -80,7 +90,10 @@ internal fun TransactionDoneView(
                         if (transactionTypeUiModel is TransactionTypeUiModel.Send) {
                             val transaction = transactionTypeUiModel.tx
                             TransactionHero(
-                                heroContent = transaction.heroContent,
+                                heroContent =
+                                    transaction.heroContent.takeUnless {
+                                        it == HeroContent.Unverified
+                                    },
                                 functionName = transaction.functionName,
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
@@ -127,11 +140,20 @@ internal fun TransactionDoneView(
             }
         },
         bottomBar = {
-            VsButton(
-                label = stringResource(R.string.transaction_done_complete),
-                onClick = onComplete,
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
-            )
+            Column {
+                if (isUnverifiedFunction) {
+                    Banner(
+                        text = stringResource(R.string.dapp_unverified_function_done_caution),
+                        variant = BannerVariant.Warning,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    )
+                }
+                VsButton(
+                    label = stringResource(R.string.transaction_done_complete),
+                    onClick = onComplete,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
+                )
+            }
         },
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -30,6 +30,8 @@ import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsOverviewToken
+import com.vultisig.wallet.ui.components.banners.Banner
+import com.vultisig.wallet.ui.components.banners.BannerVariant
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonSize
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
@@ -63,6 +65,11 @@ internal fun SendTxOverviewScreen(
     onTransactionDetailVisibleChange: (Boolean) -> Unit,
     dappMetadata: DAppMetadata? = null,
 ) {
+    // #4974: the transaction is already signed on the completed screen, so the pre-signing
+    // "Unverified function" warning hero is wrong here. Drop it to the plain function-name title
+    // and surface the caution as the Figma caution box (amber banner) pinned at the bottom.
+    val isUnverifiedFunction = tx.heroContent == HeroContent.Unverified
+
     TxDoneScaffold(
         transactionHash = transactionHash,
         transactionLink = transactionLink,
@@ -73,17 +80,28 @@ internal fun SendTxOverviewScreen(
         onTransactionDetailVisibleChange = onTransactionDetailVisibleChange,
         dappMetadata = dappMetadata,
         bottomBarContent = {
-            VsButton(
-                label = stringResource(R.string.transaction_done_title),
-                variant = VsButtonVariant.Primary,
-                size = VsButtonSize.Medium,
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
-                onClick = onComplete,
-            )
+            Column {
+                if (isUnverifiedFunction) {
+                    Banner(
+                        text = stringResource(R.string.dapp_unverified_function_done_caution),
+                        variant = BannerVariant.Warning,
+                        modifier =
+                            Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 4.dp),
+                    )
+                }
+                VsButton(
+                    label = stringResource(R.string.transaction_done_title),
+                    variant = VsButtonVariant.Primary,
+                    size = VsButtonSize.Medium,
+                    modifier =
+                        Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
+                    onClick = onComplete,
+                )
+            }
         },
         tokenContent = {
             TransactionHero(
-                heroContent = tx.heroContent,
+                heroContent = tx.heroContent.takeUnless { it == HeroContent.Unverified },
                 functionName = tx.functionName,
                 modifier = Modifier.fillMaxWidth(),
             ) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -419,6 +419,7 @@
     <string name="verify_transaction_function_inputs_title">Funktionsargumente</string>
     <string name="dapp_hero_unverified_function_title">Nicht verifizierte Funktion</string>
     <string name="dapp_hero_unverified_function_subtitle">Überprüfen Sie die Details unten, bevor Sie signieren</string>
+    <string name="dapp_unverified_function_done_caution">Nicht verifizierte Funktion. Überprüfen Sie die Transaktionsdetails.</string>
     <string name="request_from">Anfrage von</string>
     <string name="send_shares_currency_hint">Anteile eingeben</string>
     <string name="send_error_max_shares">Betrag darf den Kontostand nicht überschreiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -419,6 +419,7 @@
     <string name="verify_transaction_function_inputs_title">Argumentos de función</string>
     <string name="dapp_hero_unverified_function_title">Función no verificada</string>
     <string name="dapp_hero_unverified_function_subtitle">Revisa los detalles antes de firmar</string>
+    <string name="dapp_unverified_function_done_caution">Función no verificada. Revisa los detalles de la transacción.</string>
     <string name="request_from">Solicitud de</string>
     <string name="send_shares_currency_hint">Introduce acciones</string>
     <string name="send_error_max_shares">La cantidad no debe exceder el saldo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -420,6 +420,7 @@
     <string name="verify_transaction_function_inputs_title">Argumenti funkcije</string>
     <string name="dapp_hero_unverified_function_title">Neprovjerena funkcija</string>
     <string name="dapp_hero_unverified_function_subtitle">Pregledajte detalje prije potpisivanja</string>
+    <string name="dapp_unverified_function_done_caution">Neprovjerena funkcija. Pregledajte detalje transakcije.</string>
     <string name="request_from">Zahtjev od</string>
     <string name="send_shares_currency_hint">Unesite udjele</string>
     <string name="send_error_max_shares">Iznos ne smije premašiti stanje</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -419,6 +419,7 @@
     <string name="verify_transaction_function_inputs_title">Argomenti della funzione</string>
     <string name="dapp_hero_unverified_function_title">Funzione non verificata</string>
     <string name="dapp_hero_unverified_function_subtitle">Controlla i dettagli prima di firmare</string>
+    <string name="dapp_unverified_function_done_caution">Funzione non verificata. Controlla i dettagli della transazione.</string>
     <string name="request_from">Richiesta da</string>
     <string name="send_shares_currency_hint">Inserisci quote</string>
     <string name="send_error_max_shares">L\'importo non deve superare il saldo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -619,6 +619,7 @@
     <string name="verify_transaction_function_inputs_title">함수 인수</string>
     <string name="dapp_hero_unverified_function_title">확인되지 않은 함수</string>
     <string name="dapp_hero_unverified_function_subtitle">서명 전에 아래 세부정보를 확인하세요</string>
+    <string name="dapp_unverified_function_done_caution">확인되지 않은 함수입니다. 거래 세부정보를 확인하세요.</string>
     <string name="request_from">요청 출처</string>
     <string name="fast_vault_password_reminder_title">비밀번호를 확인하세요:</string>
     <string name="fast_vault_password_reminder_done_button">완료</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -418,6 +418,7 @@
     <string name="verify_transaction_function_inputs_title">Functie-argumenten</string>
     <string name="dapp_hero_unverified_function_title">Niet-geverifieerde functie</string>
     <string name="dapp_hero_unverified_function_subtitle">Bekijk de details hieronder voordat je ondertekent</string>
+    <string name="dapp_unverified_function_done_caution">Niet-geverifieerde functie. Bekijk de transactiedetails.</string>
     <string name="request_from">Verzoek van</string>
     <string name="send_shares_currency_hint">Voer aandelen in</string>
     <string name="send_error_max_shares">Bedrag mag het saldo niet overschrijden</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -419,6 +419,7 @@
     <string name="verify_transaction_function_inputs_title">Argumentos de função</string>
     <string name="dapp_hero_unverified_function_title">Função não verificada</string>
     <string name="dapp_hero_unverified_function_subtitle">Reveja os detalhes antes de assinar</string>
+    <string name="dapp_unverified_function_done_caution">Função não verificada. Reveja os detalhes da transação.</string>
     <string name="request_from">Pedido de</string>
     <string name="send_shares_currency_hint">Insira cotas</string>
     <string name="send_error_max_shares">O valor não deve exceder o saldo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -420,6 +420,7 @@
     <string name="verify_transaction_function_inputs_title">Аргументы функции</string>
     <string name="dapp_hero_unverified_function_title">Непроверенная функция</string>
     <string name="dapp_hero_unverified_function_subtitle">Просмотрите детали ниже перед подписанием</string>
+    <string name="dapp_unverified_function_done_caution">Непроверенная функция. Просмотрите детали транзакции.</string>
     <string name="request_from">Запрос от</string>
     <string name="send_shares_currency_hint">Введите доли</string>
     <string name="send_error_max_shares">Сумма не должна превышать баланс</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -695,6 +695,7 @@
     <string name="verify_transaction_function_inputs_title">函数参数</string>
     <string name="dapp_hero_unverified_function_title">未验证的功能</string>
     <string name="dapp_hero_unverified_function_subtitle">请在签名前查看下方详情</string>
+    <string name="dapp_unverified_function_done_caution">未验证的功能。请查看交易详情。</string>
     <string name="request_from">请求来自</string>
 
     <!-- Fast Vault Password Reminder -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,6 +628,7 @@
     <string name="verify_transaction_function_inputs_title">Function Arguments</string>
     <string name="dapp_hero_unverified_function_title">Unverified function</string>
     <string name="dapp_hero_unverified_function_subtitle">Review the details below before signing</string>
+    <string name="dapp_unverified_function_done_caution">Unverified function. Review the transaction details.</string>
     <string name="request_from">Request from</string>
     <string name="fast_vault_password_reminder_title">Verify your password for:</string>
     <string name="fast_vault_password_reminder_done_button">Done</string>


### PR DESCRIPTION
## Summary
Fixes #4974. On the completed-transaction screens, a Blockaid `Unverified` result rendered as a **centered triangle-alert hero** ("Unverified function — Review the details below before signing") in the middle of the card. That centered treatment isn't in Figma, and "before signing" is contextually wrong on an already-signed transaction.

This change:
- **Drops `HeroContent.Unverified` from the hero slot** on the done screens, so it falls back to the plain function-name title (no warning glyph) and reads as a contract call.
- **Surfaces the caution as the Figma caution box** ([node 26558-90550](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=26558-90550)) — the amber `Banner(variant = Warning)` (info icon + text) pinned at the **bottom**, above the Complete button.
- **Fixes the copy** for the post-signing context — new `dapp_unverified_function_done_caution` ("Unverified function. Review the transaction details.") added to all 10 locales, reusing each locale's established "Unverified function" term.

Applies to both `SendTxOverviewScreen` (Transaction complete) and `TransactionDoneView` (Keysign done). The verify/sign screens are unchanged — the pre-signing warning glyph is correct there.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/w3w5sJC.png) | ![after](https://i.imgur.com/EMSZfJC.png) |

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds
- [x] ktfmt clean
- [x] Device-verified via PreviewActivity (`blockaid_hero_done_unverified`): centered warning gone; amber caution box renders at the bottom with corrected copy
- [ ] Reviewer: confirm caution box copy across locales reads naturally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an amber warning banner for Send transactions with unverified functions. The caution message appears during transaction review and completion, reminding users to verify transaction details before confirming.

* **Documentation**
  * Added multilingual caution messages across 11 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->