### PR TITLE
fix(settings): Figma feature-gate popup for tier-locked Custom RPC (#4973)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -111,6 +111,7 @@ import com.vultisig.wallet.ui.screens.referral.EmptyReferralBanner
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.settings.DiscountTiersScreenPreview
 import com.vultisig.wallet.ui.screens.settings.TierType
+import com.vultisig.wallet.ui.screens.settings.bottomsheets.FeatureGateBottomSheet
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.sharelink.TierDiscountBottomSheetContent
 import com.vultisig.wallet.ui.screens.swap.SwapScreen
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
@@ -184,6 +185,7 @@ class PreviewActivity : ComponentActivity() {
                     "swap_quote_loading" -> SwapFormQuoteLoadingPreview()
                     "swap_toolbar" -> SwapToolbarPreview()
                     "swap_advanced_locked" -> SwapAdvancedLockedPreview()
+                    "custom_rpc_gate" -> CustomRpcGatePreview()
                     "swap_advanced_menu" -> AdvancedMenuPreview()
                     "swap_advanced_menu_configured" -> AdvancedMenuConfiguredPreview()
                     "swap_advanced_slippage" -> AdvancedSlippagePreview()
@@ -266,6 +268,23 @@ private fun SwapAdvancedLockedPreview() {
                     thresholdText = "3,000 VULT",
                     isBelowThreshold = true,
                 ),
+            onGetVult = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Composable
+private fun CustomRpcGatePreview() {
+    Box(modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+        FeatureGateBottomSheet(
+            featureIcon = R.drawable.settings_globe,
+            featureTitle = stringResource(R.string.custom_rpc_title),
+            featureDescription = stringResource(R.string.custom_rpc_gate_description),
+            requiredTier = TierType.SILVER,
+            balanceText = "2,340 VULT",
+            thresholdText = "3,000 VULT",
+            isBelowThreshold = true,
             onGetVult = {},
             onDismiss = {},
         )

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GetDiscountBpsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GetDiscountBpsUseCase.kt
@@ -13,12 +13,10 @@ import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.GOL
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.PLATINUM_DISCOUNT_BPS
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_DISCOUNT_BPS
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.ULTIMATE_DISCOUNT_BPS
-import com.vultisig.wallet.data.utils.toUnit
 import com.vultisig.wallet.ui.screens.settings.TierType
 import java.math.BigInteger
 import javax.inject.Inject
 import timber.log.Timber
-import wallet.core.jni.CoinType
 
 /**
  * Use case to calculate the discount in basis points (BPS) based on VULT token balance. Fetches the
@@ -123,12 +121,15 @@ constructor(
         const val DIAMOND_DISCOUNT_BPS = 35
         const val ULTIMATE_DISCOUNT_BPS = 50
 
-        val BRONZE_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("1500".toBigInteger())
-        val SILVER_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("3000".toBigInteger())
-        val GOLD_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("7500".toBigInteger())
-        val PLATINUM_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("15000".toBigInteger())
-        val DIAMOND_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("100000".toBigInteger())
-        val ULTIMATE_TIER_THRESHOLD = CoinType.ETHEREUM.toUnit("1000000".toBigInteger())
+        // VULT has 18 decimals; scale whole-token thresholds to raw units with pure BigInteger
+        // math so they stay usable from unit tests (avoids the TrustWallet Core native lib).
+        private val VULT_UNIT = BigInteger.TEN.pow(Coins.Ethereum.VULT.decimal)
+        val BRONZE_TIER_THRESHOLD = "1500".toBigInteger() * VULT_UNIT
+        val SILVER_TIER_THRESHOLD = "3000".toBigInteger() * VULT_UNIT
+        val GOLD_TIER_THRESHOLD = "7500".toBigInteger() * VULT_UNIT
+        val PLATINUM_TIER_THRESHOLD = "15000".toBigInteger() * VULT_UNIT
+        val DIAMOND_TIER_THRESHOLD = "100000".toBigInteger() * VULT_UNIT
+        val ULTIMATE_TIER_THRESHOLD = "1000000".toBigInteger() * VULT_UNIT
 
         private val supportedProviders =
             setOf(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.models.settings.AppLanguage
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
@@ -14,6 +15,7 @@ import com.vultisig.wallet.data.repositories.CustomRpcConfig
 import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_TIER_THRESHOLD
 import com.vultisig.wallet.ui.models.settings.SettingsItem.AddressBook
 import com.vultisig.wallet.ui.models.settings.SettingsItem.CheckForUpdates
 import com.vultisig.wallet.ui.models.settings.SettingsItem.Currency
@@ -40,6 +42,9 @@ import com.vultisig.wallet.ui.utils.MultipleClicksDetector
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.VsAuxiliaryLinks
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigInteger
+import java.text.NumberFormat
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,6 +57,8 @@ internal data class SettingsUiModel(
     val hasToShowReferralCodeSheet: Boolean = false,
     val showShareBottomSheet: Boolean = false,
     val showCustomRpcUpsell: Boolean = false,
+    val customRpcVultBalance: String = "",
+    val customRpcVultThreshold: String = "",
 )
 
 internal data class SettingsGroupUiModel(val title: UiText, val items: List<SettingsItem>)
@@ -359,7 +366,16 @@ constructor(
                     if (isSilver) {
                         navigator.route(Route.CustomRpcList(vaultId))
                     } else {
-                        state.update { it.copy(showCustomRpcUpsell = true) }
+                        val balanceRaw =
+                            runCatching { getDiscountBps.getVultBalance(vaultId) }.getOrNull()
+                                ?: BigInteger.ZERO
+                        state.update {
+                            it.copy(
+                                showCustomRpcUpsell = true,
+                                customRpcVultBalance = formatVultBalance(balanceRaw),
+                                customRpcVultThreshold = formatVultBalance(SILVER_TIER_THRESHOLD),
+                            )
+                        }
                     }
                 }
             }
@@ -553,4 +569,12 @@ constructor(
         state.update { it.copy(showCustomRpcUpsell = false) }
         viewModelScope.launch { navigator.route(Route.DiscountTiers(vaultId)) }
     }
+}
+
+/** Formats a raw VULT balance (18 decimals) as a grouped, whole-token string e.g. "2,340 VULT". */
+private fun formatVultBalance(raw: BigInteger): String {
+    val whole = raw.toBigDecimal().movePointLeft(Coins.Ethereum.VULT.decimal)
+    val numberFormat = NumberFormat.getNumberInstance(Locale.getDefault())
+    numberFormat.maximumFractionDigits = 0
+    return "${numberFormat.format(whole)} VULT"
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_TIER_THRESHOLD
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.settings.SettingsItem.AddressBook
 import com.vultisig.wallet.ui.models.settings.SettingsItem.CheckForUpdates
 import com.vultisig.wallet.ui.models.settings.SettingsItem.Currency
@@ -59,6 +60,7 @@ internal data class SettingsUiModel(
     val showCustomRpcUpsell: Boolean = false,
     val customRpcVultBalance: String = "",
     val customRpcVultThreshold: String = "",
+    val customRpcIsBelowThreshold: Boolean = false,
 )
 
 internal data class SettingsGroupUiModel(val title: UiText, val items: List<SettingsItem>)
@@ -357,23 +359,22 @@ constructor(
             CustomRpc -> {
                 // Tier gate at the entry point (parity with iOS): below Silver, show the Silver
                 // upsell dialog instead of the editor. Once inside the list the user edits freely.
-                // A failed/unknown tier lookup falls back to the upsell rather than blocking
-                // access.
-                viewModelScope.launch {
-                    val isSilver =
-                        runCatching { getDiscountBps.hasReachedSilverTier(vaultId) }
-                            .getOrDefault(false)
-                    if (isSilver) {
+                // A failed/unknown balance lookup falls back to the upsell rather than blocking
+                // access. The balance is fetched once and the tier is derived locally so we don't
+                // hit the repository twice per tap.
+                viewModelScope.safeLaunch {
+                    val balanceRaw =
+                        runCatching { getDiscountBps.getVultBalance(vaultId) }.getOrNull()
+                            ?: BigInteger.ZERO
+                    if (balanceRaw >= SILVER_TIER_THRESHOLD) {
                         navigator.route(Route.CustomRpcList(vaultId))
                     } else {
-                        val balanceRaw =
-                            runCatching { getDiscountBps.getVultBalance(vaultId) }.getOrNull()
-                                ?: BigInteger.ZERO
                         state.update {
                             it.copy(
                                 showCustomRpcUpsell = true,
                                 customRpcVultBalance = formatVultBalance(balanceRaw),
                                 customRpcVultThreshold = formatVultBalance(SILVER_TIER_THRESHOLD),
+                                customRpcIsBelowThreshold = balanceRaw < SILVER_TIER_THRESHOLD,
                             )
                         }
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
@@ -139,7 +139,7 @@ private fun SettingsScreen(
                 requiredTier = TierType.SILVER,
                 balanceText = state.customRpcVultBalance,
                 thresholdText = state.customRpcVultThreshold,
-                isBelowThreshold = true,
+                isBelowThreshold = state.customRpcIsBelowThreshold,
                 onGetVult = onUnlockCustomRpcTier,
                 onDismiss = onDismissCustomRpcUpsell,
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
@@ -42,8 +42,8 @@ import com.vultisig.wallet.ui.models.settings.SettingsItemUiModel
 import com.vultisig.wallet.ui.models.settings.SettingsUiEvent
 import com.vultisig.wallet.ui.models.settings.SettingsUiModel
 import com.vultisig.wallet.ui.models.settings.SettingsViewModel
+import com.vultisig.wallet.ui.screens.settings.bottomsheets.FeatureGateBottomSheet
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.sharelink.ShareLinkBottomSheet
-import com.vultisig.wallet.ui.screens.settings.bottomsheets.sharelink.TierDiscountBottomSheet
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
 import com.vultisig.wallet.ui.utils.asString
@@ -132,10 +132,16 @@ private fun SettingsScreen(
         }
 
         if (state.showCustomRpcUpsell) {
-            TierDiscountBottomSheet(
-                tier = TierType.SILVER,
-                onContinue = onUnlockCustomRpcTier,
-                onDismissRequest = onDismissCustomRpcUpsell,
+            FeatureGateBottomSheet(
+                featureIcon = R.drawable.settings_globe,
+                featureTitle = stringResource(R.string.custom_rpc_title),
+                featureDescription = stringResource(R.string.custom_rpc_gate_description),
+                requiredTier = TierType.SILVER,
+                balanceText = state.customRpcVultBalance,
+                thresholdText = state.customRpcVultThreshold,
+                isBelowThreshold = true,
+                onGetVult = onUnlockCustomRpcTier,
+                onDismiss = onDismissCustomRpcUpsell,
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.screens.settings.bottomsheets
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -56,7 +57,7 @@ import com.vultisig.wallet.ui.theme.Theme
  */
 @Composable
 internal fun FeatureGateBottomSheet(
-    featureIcon: Int,
+    @DrawableRes featureIcon: Int,
     featureTitle: String,
     featureDescription: String,
     requiredTier: TierType,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
@@ -1,0 +1,269 @@
+package com.vultisig.wallet.ui.screens.settings.bottomsheets
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
+import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
+import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
+import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
+import com.vultisig.wallet.ui.screens.settings.TierType
+import com.vultisig.wallet.ui.screens.settings.getStyleByTier
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Reusable feature-gate popup shown when a user taps a feature locked behind a $VULT tier (Figma
+ * node 77059-110340). It describes the *gated feature*, the tier requirement to unlock it, the
+ * vault's current $VULT balance, and a "Get $VULT" action — parameterized so every gate swaps in
+ * its own feature and required tier.
+ *
+ * This is the single source of truth for the locked-feature design; the Advanced Swap upsell
+ * (#4858) and the Custom RPC upsell (#4787) both render through it.
+ *
+ * @param requiredTier tier required to unlock the feature; drives the badge, name, and CTA accent.
+ * @param balanceText the vault's current $VULT balance, pre-formatted with its unit (e.g. "2,340
+ *   VULT").
+ * @param thresholdText the required $VULT holdings, pre-formatted with its unit (e.g. "3,000
+ *   VULT").
+ * @param isBelowThreshold when true the balance is rendered in the warning accent.
+ */
+@Composable
+internal fun FeatureGateBottomSheet(
+    featureIcon: Int,
+    featureTitle: String,
+    featureDescription: String,
+    requiredTier: TierType,
+    balanceText: String,
+    thresholdText: String,
+    isBelowThreshold: Boolean,
+    onGetVult: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    V2BottomSheet(
+        onDismissRequest = onDismiss,
+        leftAction = {
+            VsCircleButton(
+                onClick = onDismiss,
+                drawableResId = R.drawable.big_close,
+                size = VsCircleButtonSize.Small,
+                type = VsCircleButtonType.Tertiary,
+            )
+        },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(top = 24.dp, bottom = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier =
+                    Modifier.size(56.dp)
+                        .clip(CircleShape)
+                        .background(Theme.v2.colors.backgrounds.secondary)
+                        .border(
+                            width = 1.dp,
+                            color = Theme.v2.colors.primary.accent4.copy(alpha = 0.4f),
+                            shape = CircleShape,
+                        ),
+                contentAlignment = Alignment.Center,
+            ) {
+                UiIcon(
+                    drawableResId = featureIcon,
+                    size = 24.dp,
+                    tint = Theme.v2.colors.primary.accent4,
+                )
+            }
+
+            UiSpacer(24.dp)
+
+            Text(
+                text = featureTitle,
+                style = Theme.brockmann.headings.title2,
+                color = Theme.v2.colors.text.primary,
+                textAlign = TextAlign.Center,
+            )
+
+            UiSpacer(12.dp)
+
+            Text(
+                text = featureDescription,
+                style = Theme.brockmann.body.s.regular,
+                color = Theme.v2.colors.text.tertiary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            UiSpacer(24.dp)
+
+            RequiresCard(
+                requiredTier = requiredTier,
+                balanceText = balanceText,
+                thresholdText = thresholdText,
+                isBelowThreshold = isBelowThreshold,
+                onGetVult = onGetVult,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RequiresCard(
+    requiredTier: TierType,
+    balanceText: String,
+    thresholdText: String,
+    isBelowThreshold: Boolean,
+    onGetVult: () -> Unit,
+) {
+    val tierStyle = getStyleByTier(requiredTier)
+
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(20.dp))
+    ) {
+        Column(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .background(Theme.v2.colors.backgrounds.secondary)
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.feature_gate_requires),
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Image(
+                    painter = painterResource(tierStyle.icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(36.dp),
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.feature_gate_tier_requirement,
+                                tierStyle.titleText,
+                            ),
+                        style = Theme.brockmann.body.s.medium,
+                        color = Theme.v2.colors.text.primary,
+                    )
+                    Text(
+                        text = stringResource(R.string.feature_gate_hold_threshold, thresholdText),
+                        style = Theme.brockmann.supplementary.caption,
+                        color = Theme.v2.colors.text.tertiary,
+                    )
+                }
+            }
+
+            BalanceRow(balanceText = balanceText, isBelowThreshold = isBelowThreshold)
+        }
+
+        // Tier-accent "Get $VULT" footer joined to the card's bottom edge (single rounded
+        // container). Darker accent at the top fading to the bright tier accent at the bottom.
+        Box(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(52.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                lerp(tierStyle.accentColor, Color.Black, 0.4f),
+                                tierStyle.accentColor,
+                            )
+                        )
+                    )
+                    .clickable(onClick = onGetVult),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.feature_gate_get_vult),
+                style = Theme.brockmann.button.semibold.semibold,
+                color = Theme.v2.colors.text.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BalanceRow(balanceText: String, isBelowThreshold: Boolean) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(14.dp))
+                .background(Theme.v2.colors.backgrounds.tertiary)
+                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(14.dp))
+                .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        UiIcon(
+            drawableResId = R.drawable.wallet,
+            size = 16.dp,
+            tint = Theme.v2.colors.text.tertiary,
+        )
+        Text(
+            text = stringResource(R.string.feature_gate_your_balance),
+            style = Theme.brockmann.supplementary.caption,
+            color = Theme.v2.colors.text.tertiary,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = balanceText,
+            style = Theme.brockmann.supplementary.caption,
+            color =
+                if (isBelowThreshold) Theme.v2.colors.alerts.warning
+                else Theme.v2.colors.text.primary,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeatureGateBottomSheetPreview() {
+    FeatureGateBottomSheet(
+        featureIcon = R.drawable.settings_globe,
+        featureTitle = "Custom RPC",
+        featureDescription =
+            "Point Vultisig at your own nodes. Faster queries, higher rate limits, " +
+                "and full privacy per chain.",
+        requiredTier = TierType.SILVER,
+        balanceText = "2,340 VULT",
+        thresholdText = "3,000 VULT",
+        isBelowThreshold = true,
+        onGetVult = {},
+        onDismiss = {},
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapAdvancedSettingsLockedSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapAdvancedSettingsLockedSheet.kt
@@ -1,49 +1,15 @@
 package com.vultisig.wallet.ui.screens.swap.components
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
-import com.vultisig.wallet.ui.components.UiIcon
-import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.models.swap.VultTierGateUiModel
-import com.vultisig.wallet.ui.theme.Theme
-
-// Silver-tier footer gradient (top → bottom). Tier palette isn't in the theme tokens, so the two
-// stops are defined here as private constants per the design (#4858).
-private val SilverGradientTop = Color(0xFF7D8B9E)
-private val SilverGradientBottom = Color(0xFFC9D6E8)
+import com.vultisig.wallet.ui.screens.settings.TierType
+import com.vultisig.wallet.ui.screens.settings.bottomsheets.FeatureGateBottomSheet
 
 /**
  * Tier-locked upsell shown when a vault below the Silver $VULT tier taps Advanced Settings (#4858).
- * Presents the feature, the Silver requirement, the vault's current $VULT balance, and a "Get
- * $VULT" action that routes to a swap pre-filled with VULT — mirroring the iOS LockedFeatureSheet.
+ * Thin wrapper that feeds the Advanced Swap feature copy into the shared [FeatureGateBottomSheet].
  */
 @Composable
 internal fun SwapAdvancedSettingsLockedSheet(
@@ -51,170 +17,15 @@ internal fun SwapAdvancedSettingsLockedSheet(
     onGetVult: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    V2BottomSheet(
-        onDismissRequest = onDismiss,
-        leftAction = {
-            VsCircleButton(
-                onClick = onDismiss,
-                drawableResId = R.drawable.big_close,
-                size = VsCircleButtonSize.Small,
-                type = VsCircleButtonType.Tertiary,
-            )
-        },
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(top = 24.dp, bottom = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Box(
-                modifier =
-                    Modifier.size(56.dp)
-                        .clip(CircleShape)
-                        .background(Theme.v2.colors.backgrounds.secondary)
-                        .border(
-                            width = 1.dp,
-                            color = Theme.v2.colors.primary.accent4.copy(alpha = 0.4f),
-                            shape = CircleShape,
-                        ),
-                contentAlignment = Alignment.Center,
-            ) {
-                UiIcon(
-                    drawableResId = R.drawable.ic_settings_slider_ver,
-                    size = 24.dp,
-                    tint = Theme.v2.colors.primary.accent4,
-                )
-            }
-
-            UiSpacer(24.dp)
-
-            Text(
-                text = stringResource(R.string.swap_advanced_locked_title),
-                style = Theme.brockmann.headings.title2,
-                color = Theme.v2.colors.text.primary,
-                textAlign = TextAlign.Center,
-            )
-
-            UiSpacer(12.dp)
-
-            Text(
-                text = stringResource(R.string.swap_advanced_locked_subtitle),
-                style = Theme.brockmann.body.s.regular,
-                color = Theme.v2.colors.text.tertiary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-
-            UiSpacer(24.dp)
-
-            RequiresCard(gate = gate, onGetVult = onGetVult)
-        }
-    }
-}
-
-@Composable
-private fun RequiresCard(gate: VultTierGateUiModel, onGetVult: () -> Unit) {
-    Column(
-        modifier =
-            Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(20.dp))
-    ) {
-        Column(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .background(Theme.v2.colors.backgrounds.secondary)
-                    .padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.swap_advanced_locked_requires),
-                style = Theme.brockmann.supplementary.caption,
-                color = Theme.v2.colors.text.tertiary,
-            )
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Image(
-                    painter = painterResource(R.drawable.type_silver_tier__size_small),
-                    contentDescription = null,
-                    modifier = Modifier.size(36.dp),
-                )
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.swap_advanced_locked_tier_requirement,
-                                stringResource(R.string.vault_tier_silver),
-                            ),
-                        style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.primary,
-                    )
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.swap_advanced_locked_tier_subtitle,
-                                gate.thresholdText,
-                            ),
-                        style = Theme.brockmann.supplementary.caption,
-                        color = Theme.v2.colors.text.tertiary,
-                    )
-                }
-            }
-
-            BalanceRow(gate = gate)
-        }
-
-        // Gradient "Get $VULT" footer joined to the card's bottom edge (single rounded container).
-        Box(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(52.dp)
-                    .background(
-                        Brush.verticalGradient(listOf(SilverGradientTop, SilverGradientBottom))
-                    )
-                    .clickable(onClick = onGetVult),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = stringResource(R.string.swap_advanced_locked_get_vult),
-                style = Theme.brockmann.button.semibold.semibold,
-                color = Theme.v2.colors.text.primary,
-            )
-        }
-    }
-}
-
-@Composable
-private fun BalanceRow(gate: VultTierGateUiModel) {
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
-                .background(Theme.v2.colors.backgrounds.tertiary)
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(14.dp))
-                .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        UiIcon(
-            drawableResId = R.drawable.wallet,
-            size = 16.dp,
-            tint = Theme.v2.colors.text.tertiary,
-        )
-        Text(
-            text = stringResource(R.string.swap_advanced_locked_your_balance),
-            style = Theme.brockmann.supplementary.caption,
-            color = Theme.v2.colors.text.tertiary,
-            modifier = Modifier.weight(1f),
-        )
-        Text(
-            text = gate.balanceText,
-            style = Theme.brockmann.supplementary.caption,
-            color =
-                if (gate.isBelowThreshold) Theme.v2.colors.alerts.warning
-                else Theme.v2.colors.text.primary,
-        )
-    }
+    FeatureGateBottomSheet(
+        featureIcon = R.drawable.ic_settings_slider_ver,
+        featureTitle = stringResource(R.string.swap_advanced_locked_title),
+        featureDescription = stringResource(R.string.swap_advanced_locked_subtitle),
+        requiredTier = TierType.SILVER,
+        balanceText = gate.balanceText,
+        thresholdText = gate.thresholdText,
+        isBelowThreshold = gate.isBelowThreshold,
+        onGetVult = onGetVult,
+        onDismiss = onDismiss,
+    )
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -591,6 +591,13 @@
     <string name="custom_rpc_wrong_chain">Dieser Endpunkt bedient eine andere Blockchain</string>
     <string name="custom_rpc_invalid_response">Unerwartete Antwort von diesem Endpunkt</string>
     <string name="custom_rpc_unreachable">Endpunkt nicht erreichbar</string>
+    <string name="custom_rpc_gate_description">Richte Vultisig auf deine eigenen Nodes aus. Schnellere Abfragen, höhere Ratenlimits und volle Privatsphäre pro Blockchain.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Erforderlich</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s Stufe oder höher</string>
+    <string name="feature_gate_hold_threshold">Halte mindestens %1$s in deinem Tresor</string>
+    <string name="feature_gate_your_balance">Dein Guthaben</string>
+    <string name="feature_gate_get_vult">$VULT holen</string>
     <string name="swapkit_error_api_key_missing">SwapKit-API-Schlüssel nicht konfiguriert</string>
     <string name="swapkit_error_api_key_invalid">SwapKit-API-Schlüssel ist ungültig</string>
     <string name="swapkit_error_insufficient_balance">Unzureichendes Guthaben für diese Route</string>
@@ -891,11 +898,6 @@
     <string name="swap_advanced_external_recipient_title">Externen Empfänger verwenden</string>
     <string name="swap_advanced_locked_title">Erweiterte Swap-Einstellungen</string>
     <string name="swap_advanced_locked_subtitle">Feinabstimmung von Slippage, Gas, Routing und Empfänger für jeden Swap.</string>
-    <string name="swap_advanced_locked_requires">Erforderlich</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s Stufe oder höher</string>
-    <string name="swap_advanced_locked_tier_subtitle">Halte mindestens %1$s in deinem Tresor</string>
-    <string name="swap_advanced_locked_your_balance">Dein Guthaben</string>
-    <string name="swap_advanced_locked_get_vult">$VULT holen</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Aus</string>
     <string name="swap_slippage_helper">Begrenzt, wie stark sich der Preis vor der Ausführung ändern darf, bevor sie abgebrochen wird.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -593,6 +593,13 @@
     <string name="custom_rpc_wrong_chain">Este endpoint sirve una cadena diferente</string>
     <string name="custom_rpc_invalid_response">Respuesta inesperada de este endpoint</string>
     <string name="custom_rpc_unreachable">Endpoint inaccesible</string>
+    <string name="custom_rpc_gate_description">Conecta Vultisig a tus propios nodos. Consultas más rápidas, mayores límites de tasa y privacidad total por cadena.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Requiere</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s Nivel o superior</string>
+    <string name="feature_gate_hold_threshold">Mantén al menos %1$s en tu bóveda</string>
+    <string name="feature_gate_your_balance">Tu saldo</string>
+    <string name="feature_gate_get_vult">Obtén $VULT</string>
     <string name="swapkit_error_api_key_missing">La clave de API de SwapKit no está configurada</string>
     <string name="swapkit_error_api_key_invalid">La clave de API de SwapKit no es válida</string>
     <string name="swapkit_error_insufficient_balance">Saldo insuficiente para esta ruta</string>
@@ -889,11 +896,6 @@
     <string name="swap_advanced_external_recipient_title">Usar destinatario externo</string>
     <string name="swap_advanced_locked_title">Ajustes avanzados de swap</string>
     <string name="swap_advanced_locked_subtitle">Ajusta el deslizamiento, el gas, la ruta y el destinatario en cada swap.</string>
-    <string name="swap_advanced_locked_requires">Requiere</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s Nivel o superior</string>
-    <string name="swap_advanced_locked_tier_subtitle">Mantén al menos %1$s en tu bóveda</string>
-    <string name="swap_advanced_locked_your_balance">Tu saldo</string>
-    <string name="swap_advanced_locked_get_vult">Obtén $VULT</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Desactivado</string>
     <string name="swap_slippage_helper">Limita cuánto puede cambiar el precio antes de cancelar la ejecución.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -592,6 +592,13 @@
     <string name="custom_rpc_wrong_chain">Ova krajnja točka poslužuje drugi lanac</string>
     <string name="custom_rpc_invalid_response">Neočekivani odgovor s ove krajnje točke</string>
     <string name="custom_rpc_unreachable">Krajnja točka nedostupna</string>
+    <string name="custom_rpc_gate_description">Usmjeri Vultisig na vlastite čvorove. Brži upiti, viša ograničenja zahtjeva i potpuna privatnost po lancu.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Zahtijeva</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s razina ili viša</string>
+    <string name="feature_gate_hold_threshold">Drži barem %1$s u svom trezoru</string>
+    <string name="feature_gate_your_balance">Tvoj saldo</string>
+    <string name="feature_gate_get_vult">Nabavi $VULT</string>
     <string name="swapkit_error_api_key_missing">SwapKit API ključ nije postavljen</string>
     <string name="swapkit_error_api_key_invalid">SwapKit API ključ je neispravan</string>
     <string name="swapkit_error_insufficient_balance">Nedovoljno sredstava za ovu rutu</string>
@@ -894,11 +901,6 @@
     <string name="swap_advanced_external_recipient_title">Koristi vanjskog primatelja</string>
     <string name="swap_advanced_locked_title">Napredne postavke zamjene</string>
     <string name="swap_advanced_locked_subtitle">Precizno podesite slippage, gas, rutu i primatelja za svaku zamjenu.</string>
-    <string name="swap_advanced_locked_requires">Zahtijeva</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s razina ili viša</string>
-    <string name="swap_advanced_locked_tier_subtitle">Drži barem %1$s u svom trezoru</string>
-    <string name="swap_advanced_locked_your_balance">Tvoj saldo</string>
-    <string name="swap_advanced_locked_get_vult">Nabavi $VULT</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Isključeno</string>
     <string name="swap_slippage_helper">Ograničava koliko se cijena može promijeniti prije nego što se izvršenje otkaže.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -591,6 +591,13 @@
     <string name="custom_rpc_wrong_chain">Questo endpoint serve una catena diversa</string>
     <string name="custom_rpc_invalid_response">Risposta imprevista da questo endpoint</string>
     <string name="custom_rpc_unreachable">Endpoint non raggiungibile</string>
+    <string name="custom_rpc_gate_description">Indirizza Vultisig verso i tuoi nodi. Query più veloci, limiti di frequenza più alti e piena privacy per ogni catena.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Richiede</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s livello o superiore</string>
+    <string name="feature_gate_hold_threshold">Detieni almeno %1$s nella tua cassaforte</string>
+    <string name="feature_gate_your_balance">Il tuo saldo</string>
+    <string name="feature_gate_get_vult">Ottieni $VULT</string>
     <string name="swapkit_error_api_key_missing">Chiave API di SwapKit non configurata</string>
     <string name="swapkit_error_api_key_invalid">La chiave API di SwapKit non è valida</string>
     <string name="swapkit_error_insufficient_balance">Saldo insufficiente per questa rotta</string>
@@ -889,11 +896,6 @@
     <string name="swap_advanced_external_recipient_title">Usa destinatario esterno</string>
     <string name="swap_advanced_locked_title">Impostazioni avanzate dello swap</string>
     <string name="swap_advanced_locked_subtitle">Regola slippage, gas, percorso e destinatario per ogni swap.</string>
-    <string name="swap_advanced_locked_requires">Richiede</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s livello o superiore</string>
-    <string name="swap_advanced_locked_tier_subtitle">Detieni almeno %1$s nella tua cassaforte</string>
-    <string name="swap_advanced_locked_your_balance">Il tuo saldo</string>
-    <string name="swap_advanced_locked_get_vult">Ottieni $VULT</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Disattivato</string>
     <string name="swap_slippage_helper">Limita quanto il prezzo può variare prima che l\'esecuzione venga annullata.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -598,11 +598,6 @@
     <string name="swap_advanced_external_recipient_title">외부 수신자 사용</string>
     <string name="swap_advanced_locked_title">고급 스왑 설정</string>
     <string name="swap_advanced_locked_subtitle">모든 스왑에 대해 슬리피지, 가스, 경로, 수신자를 세밀하게 조정하세요.</string>
-    <string name="swap_advanced_locked_requires">필요 조건</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s 등급 이상</string>
-    <string name="swap_advanced_locked_tier_subtitle">볼트에 최소 %1$s 보유</string>
-    <string name="swap_advanced_locked_your_balance">내 잔액</string>
-    <string name="swap_advanced_locked_get_vult">$VULT 받기</string>
     <string name="swap_advanced_value_auto">자동</string>
     <string name="swap_advanced_value_off">끄기</string>
     <string name="swap_slippage_helper">실행이 취소되기 전에 가격이 변동할 수 있는 범위를 제한합니다.</string>
@@ -808,6 +803,13 @@
     <string name="custom_rpc_wrong_chain">이 엔드포인트는 다른 체인을 제공합니다</string>
     <string name="custom_rpc_invalid_response">이 엔드포인트에서 예기치 않은 응답</string>
     <string name="custom_rpc_unreachable">엔드포인트에 연결할 수 없음</string>
+    <string name="custom_rpc_gate_description">Vultisig를 자체 노드에 연결하세요. 더 빠른 쿼리, 더 높은 요청 한도, 체인별 완전한 프라이버시를 제공합니다.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">필요 조건</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s 등급 이상</string>
+    <string name="feature_gate_hold_threshold">볼트에 최소 %1$s 보유</string>
+    <string name="feature_gate_your_balance">내 잔액</string>
+    <string name="feature_gate_get_vult">$VULT 받기</string>
     <string name="swapkit_error_api_key_missing">SwapKit API 키가 구성되지 않았습니다</string>
     <string name="swapkit_error_api_key_invalid">SwapKit API 키가 유효하지 않습니다</string>
     <string name="swapkit_error_insufficient_balance">이 경로에 사용할 잔액이 부족합니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -588,6 +588,13 @@
     <string name="custom_rpc_wrong_chain">Dit endpoint bedient een andere blockchain</string>
     <string name="custom_rpc_invalid_response">Onverwacht antwoord van dit endpoint</string>
     <string name="custom_rpc_unreachable">Endpoint onbereikbaar</string>
+    <string name="custom_rpc_gate_description">Richt Vultisig op je eigen nodes. Snellere query\'s, hogere ratelimieten en volledige privacy per blockchain.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Vereist</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s niveau of hoger</string>
+    <string name="feature_gate_hold_threshold">Houd ten minste %1$s in je kluis</string>
+    <string name="feature_gate_your_balance">Je saldo</string>
+    <string name="feature_gate_get_vult">$VULT kopen</string>
     <string name="swapkit_error_api_key_missing">SwapKit API-sleutel niet geconfigureerd</string>
     <string name="swapkit_error_api_key_invalid">SwapKit API-sleutel is ongeldig</string>
     <string name="swapkit_error_insufficient_balance">Onvoldoende saldo voor deze route</string>
@@ -886,11 +893,6 @@
     <string name="swap_advanced_external_recipient_title">Externe ontvanger gebruiken</string>
     <string name="swap_advanced_locked_title">Geavanceerde swap-instellingen</string>
     <string name="swap_advanced_locked_subtitle">Stem slippage, gas, routering en ontvanger af voor elke swap.</string>
-    <string name="swap_advanced_locked_requires">Vereist</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s niveau of hoger</string>
-    <string name="swap_advanced_locked_tier_subtitle">Houd ten minste %1$s in je kluis</string>
-    <string name="swap_advanced_locked_your_balance">Je saldo</string>
-    <string name="swap_advanced_locked_get_vult">$VULT kopen</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Uit</string>
     <string name="swap_slippage_helper">Beperkt hoeveel de prijs mag veranderen voordat de uitvoering wordt geannuleerd.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -589,6 +589,13 @@
     <string name="custom_rpc_wrong_chain">Este endpoint serve uma cadeia diferente</string>
     <string name="custom_rpc_invalid_response">Resposta inesperada deste endpoint</string>
     <string name="custom_rpc_unreachable">Endpoint inacessível</string>
+    <string name="custom_rpc_gate_description">Aponte o Vultisig para os seus próprios nós. Consultas mais rápidas, limites de taxa maiores e total privacidade por cadeia.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Requer</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s nível ou superior</string>
+    <string name="feature_gate_hold_threshold">Mantenha pelo menos %1$s no seu cofre</string>
+    <string name="feature_gate_your_balance">Seu saldo</string>
+    <string name="feature_gate_get_vult">Obter $VULT</string>
     <string name="swapkit_error_api_key_missing">Chave de API do SwapKit não configurada</string>
     <string name="swapkit_error_api_key_invalid">A chave de API do SwapKit é inválida</string>
     <string name="swapkit_error_insufficient_balance">Saldo insuficiente para esta rota</string>
@@ -888,11 +895,6 @@
     <string name="swap_advanced_external_recipient_title">Usar destinatário externo</string>
     <string name="swap_advanced_locked_title">Configurações avançadas de swap</string>
     <string name="swap_advanced_locked_subtitle">Ajuste slippage, gas, rota e destinatário em cada swap.</string>
-    <string name="swap_advanced_locked_requires">Requer</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s nível ou superior</string>
-    <string name="swap_advanced_locked_tier_subtitle">Mantenha pelo menos %1$s no seu cofre</string>
-    <string name="swap_advanced_locked_your_balance">Seu saldo</string>
-    <string name="swap_advanced_locked_get_vult">Obter $VULT</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Desligado</string>
     <string name="swap_slippage_helper">Limita quanto o preço pode mudar antes de a execução ser cancelada.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -592,6 +592,13 @@
     <string name="custom_rpc_wrong_chain">Эта конечная точка обслуживает другую сеть</string>
     <string name="custom_rpc_invalid_response">Неожиданный ответ от этой конечной точки</string>
     <string name="custom_rpc_unreachable">Конечная точка недоступна</string>
+    <string name="custom_rpc_gate_description">Направьте Vultisig на собственные узлы. Более быстрые запросы, выше лимиты и полная конфиденциальность для каждой сети.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Требуется</string>
+    <string name="feature_gate_tier_requirement">$VULT уровень %1$s или выше</string>
+    <string name="feature_gate_hold_threshold">Держите не менее %1$s в вашем хранилище</string>
+    <string name="feature_gate_your_balance">Ваш баланс</string>
+    <string name="feature_gate_get_vult">Получить $VULT</string>
     <string name="swapkit_error_api_key_missing">API-ключ SwapKit не настроен</string>
     <string name="swapkit_error_api_key_invalid">API-ключ SwapKit недействителен</string>
     <string name="swapkit_error_insufficient_balance">Недостаточно средств для этого маршрута</string>
@@ -894,11 +901,6 @@
     <string name="swap_advanced_external_recipient_title">Использовать внешнего получателя</string>
     <string name="swap_advanced_locked_title">Расширенные настройки обмена</string>
     <string name="swap_advanced_locked_subtitle">Точная настройка проскальзывания, газа, маршрута и получателя для каждого обмена.</string>
-    <string name="swap_advanced_locked_requires">Требуется</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT уровень %1$s или выше</string>
-    <string name="swap_advanced_locked_tier_subtitle">Держите не менее %1$s в вашем хранилище</string>
-    <string name="swap_advanced_locked_your_balance">Ваш баланс</string>
-    <string name="swap_advanced_locked_get_vult">Получить $VULT</string>
     <string name="swap_advanced_value_auto">Авто</string>
     <string name="swap_advanced_value_off">Выкл.</string>
     <string name="swap_slippage_helper">Ограничивает, насколько может измениться цена до отмены исполнения.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -841,6 +841,13 @@
     <string name="custom_rpc_wrong_chain">此端点服务于其他链</string>
     <string name="custom_rpc_invalid_response">此端点返回意外响应</string>
     <string name="custom_rpc_unreachable">端点无法访问</string>
+    <string name="custom_rpc_gate_description">将 Vultisig 指向您自己的节点。更快的查询、更高的速率限制，以及每条链的完全隐私。</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">需要</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s 等级或以上</string>
+    <string name="feature_gate_hold_threshold">在您的金库中持有至少 %1$s</string>
+    <string name="feature_gate_your_balance">您的余额</string>
+    <string name="feature_gate_get_vult">获取 $VULT</string>
     <string name="swapkit_error_api_key_missing">SwapKit API 密钥未配置</string>
     <string name="swapkit_error_api_key_invalid">SwapKit API 密钥无效</string>
     <string name="swapkit_error_insufficient_balance">余额不足,无法完成此路径</string>
@@ -1220,11 +1227,6 @@
     <string name="swap_advanced_external_recipient_title">使用外部接收方</string>
     <string name="swap_advanced_locked_title">高级兑换设置</string>
     <string name="swap_advanced_locked_subtitle">为每次兑换精细调整滑点、Gas、路由和收款人。</string>
-    <string name="swap_advanced_locked_requires">需要</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s 等级或以上</string>
-    <string name="swap_advanced_locked_tier_subtitle">在您的金库中持有至少 %1$s</string>
-    <string name="swap_advanced_locked_your_balance">您的余额</string>
-    <string name="swap_advanced_locked_get_vult">获取 $VULT</string>
     <string name="swap_advanced_value_auto">自动</string>
     <string name="swap_advanced_value_off">关闭</string>
     <string name="swap_slippage_helper">限制价格在执行取消前可变动的幅度。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -607,11 +607,6 @@
     <string name="swap_advanced_external_recipient_title">Use External Recipient</string>
     <string name="swap_advanced_locked_title">Advanced Swap Settings</string>
     <string name="swap_advanced_locked_subtitle">Fine-tune slippage, gas, routing, and recipient for every swap.</string>
-    <string name="swap_advanced_locked_requires">Requires</string>
-    <string name="swap_advanced_locked_tier_requirement">$VULT %1$s Tier or above</string>
-    <string name="swap_advanced_locked_tier_subtitle">Hold at least %1$s in your vault</string>
-    <string name="swap_advanced_locked_your_balance">Your balance</string>
-    <string name="swap_advanced_locked_get_vult">Get $VULT</string>
     <string name="swap_advanced_value_auto">Auto</string>
     <string name="swap_advanced_value_off">Off</string>
     <string name="swap_slippage_helper">Limits how much the price can change before execution is canceled.</string>
@@ -819,6 +814,13 @@
     <string name="custom_rpc_wrong_chain">This endpoint serves a different chain</string>
     <string name="custom_rpc_invalid_response">Unexpected response from this endpoint</string>
     <string name="custom_rpc_unreachable">Endpoint unreachable</string>
+    <string name="custom_rpc_gate_description">Point Vultisig at your own nodes. Faster queries, higher rate limits, and full privacy per chain.</string>
+    <!-- Feature gate (tier-locked feature popup) -->
+    <string name="feature_gate_requires">Requires</string>
+    <string name="feature_gate_tier_requirement">$VULT %1$s Tier or above</string>
+    <string name="feature_gate_hold_threshold">Hold at least %1$s in your vault</string>
+    <string name="feature_gate_your_balance">Your balance</string>
+    <string name="feature_gate_get_vult">Get $VULT</string>
     <string name="swapkit_error_api_key_missing">SwapKit API key not configured</string>
     <string name="swapkit_error_api_key_invalid">SwapKit API key is invalid</string>
     <string name="swapkit_error_insufficient_balance">Insufficient balance for this route</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/settings/SettingsViewModelTest.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.repositories.CustomRpcConfig
 import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_TIER_THRESHOLD
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -23,6 +24,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import java.math.BigInteger
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -123,13 +126,14 @@ internal class SettingsViewModelTest {
             vm.state.value.hasToShowReferralCodeSheet.shouldBeFalse()
         }
 
-    /** Silver-tier users reach the Custom RPC list directly. */
+    /** Silver-tier users (balance at/above the threshold) reach the Custom RPC list directly. */
     @Test
     fun `clicking CustomRpc as Silver navigates to CustomRpcList`() =
         runTest(testDispatcher) {
-            coEvery { getDiscountBps.hasReachedSilverTier(VAULT_ID) } returns true
+            coEvery { getDiscountBps.getVultBalance(VAULT_ID) } returns SILVER_TIER_THRESHOLD
             val vm = createViewModel()
             vm.onSettingsItemClick(SettingsItem.CustomRpc)
+            vm.state.value.showCustomRpcUpsell.shouldBeFalse()
             coVerify { navigator.route(Route.CustomRpcList(VAULT_ID)) }
         }
 
@@ -137,23 +141,46 @@ internal class SettingsViewModelTest {
     @Test
     fun `clicking CustomRpc below Silver shows the upsell dialog`() =
         runTest(testDispatcher) {
-            coEvery { getDiscountBps.hasReachedSilverTier(VAULT_ID) } returns false
+            coEvery { getDiscountBps.getVultBalance(VAULT_ID) } returns
+                SILVER_TIER_THRESHOLD - BigInteger.ONE
+            val vm = createViewModel()
+            vm.onSettingsItemClick(SettingsItem.CustomRpc)
+            vm.state.value.showCustomRpcUpsell.shouldBeTrue()
+            vm.state.value.customRpcIsBelowThreshold.shouldBeTrue()
+            coVerify(exactly = 0) { navigator.route(Route.CustomRpcList(VAULT_ID)) }
+        }
+
+    /** A failed/unknown balance lookup falls back to the upsell rather than opening the list. */
+    @Test
+    fun `clicking CustomRpc with failing balance lookup falls back to the upsell dialog`() =
+        runTest(testDispatcher) {
+            coEvery { getDiscountBps.getVultBalance(VAULT_ID) } throws RuntimeException("boom")
             val vm = createViewModel()
             vm.onSettingsItemClick(SettingsItem.CustomRpc)
             vm.state.value.showCustomRpcUpsell.shouldBeTrue()
             coVerify(exactly = 0) { navigator.route(Route.CustomRpcList(VAULT_ID)) }
         }
 
-    /** A failed tier lookup falls back to the upsell rather than opening the list. */
+    /**
+     * The upsell exposes the balance and threshold as grouped whole-token strings
+     * (formatVultBalance with 18-decimal scaling, no fraction digits). Locale is pinned so grouping
+     * is deterministic.
+     */
     @Test
-    fun `clicking CustomRpc with failing tier lookup falls back to the upsell dialog`() =
+    fun `custom rpc upsell formats balance and threshold as whole VULT tokens`() =
         runTest(testDispatcher) {
-            coEvery { getDiscountBps.hasReachedSilverTier(VAULT_ID) } throws
-                RuntimeException("boom")
-            val vm = createViewModel()
-            vm.onSettingsItemClick(SettingsItem.CustomRpc)
-            vm.state.value.showCustomRpcUpsell.shouldBeTrue()
-            coVerify(exactly = 0) { navigator.route(Route.CustomRpcList(VAULT_ID)) }
+            val previousLocale = Locale.getDefault()
+            Locale.setDefault(Locale.US)
+            try {
+                val balance = BigInteger("2340") * BigInteger.TEN.pow(18)
+                coEvery { getDiscountBps.getVultBalance(VAULT_ID) } returns balance
+                val vm = createViewModel()
+                vm.onSettingsItemClick(SettingsItem.CustomRpc)
+                vm.state.value.customRpcVultBalance shouldBe "2,340 VULT"
+                vm.state.value.customRpcVultThreshold shouldBe "3,000 VULT"
+            } finally {
+                Locale.setDefault(previousLocale)
+            }
         }
 
     /** Verifies clicking PreventScreenshots calls setEnabled with toggled value. */


### PR DESCRIPTION
## Summary

Closes #4973.

Tapping the tier-locked **Custom RPC** entry showed the generic `$VULT` **discount** sheet (_"Unlock <Tier> — receive N bps trading fee discount…"_) instead of a **feature-gate** that explains the gated feature and its tier requirement.

The Figma feature-gate design ([node 77059-110340](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=77059-110340)) was **already implemented** for the Advanced Swap gate (`SwapAdvancedSettingsLockedSheet`, #4969). Rather than add a second near-identical component, this **generalizes it into one reusable `FeatureGateBottomSheet`** — parameterized by feature (icon/title/description), required tier, and the vault's balance/threshold — and routes **both** the Advanced Swap upsell and the Custom RPC upsell through it. The tier badge, name, and CTA accent all derive from the required tier (`getStyleByTier`), so it works for any tier.

## Changes
- **New `FeatureGateBottomSheet`** — single source of truth for the locked-feature design.
- **`SwapAdvancedSettingsLockedSheet`** reduced to a thin wrapper over it (no behavior change).
- **Custom RPC gate** (`SettingsScreen` + `SettingsViewModel`) now renders it with the vault's live `$VULT` balance and the Silver threshold; the required tier stays **Silver** as before.
- **Strings** — added generic `feature_gate_*` + `custom_rpc_gate_description`; removed the now-redundant `swap_advanced_locked_*` label strings. Updated all 10 locales.
- **PreviewActivity** — added a `custom_rpc_gate` case for screenshots.

## Screenshot

Custom RPC feature-gate (below Silver tier), on device:

![custom-rpc-gate](https://i.imgur.com/92BxmCn.png)

## Test plan
- [x] `:app:compileDebugKotlin` builds (incl. debug source set)
- [x] ktfmt applied; locale placeholders consistent across all 10 files
- [x] Device-verified: Settings → Custom RPC (below Silver) shows the new feature-gate popup
- [ ] Advanced Swap → Advanced Settings (below Silver) still shows its upsell unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Custom RPC upsell flow that gates access using your VULT balance vs. a tier threshold, showing current balance and required hold amount.
  * Introduced a reusable “feature gate” bottom sheet for tier-locked features with dismiss/CTA actions and below-threshold warning.
* **Refactor**
  * Updated the swap advanced “locked” bottom sheet to use the shared feature gate component.
* **Localization**
  * Added/updated localized copy for the new Custom RPC and feature gate messaging across multiple languages.
* **Tests**
  * Expanded Custom RPC view-model tests and added balance formatting coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->