### PR TITLE
fix(thorchain): resolve native tx status via node when Midgard has no action

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.models.cosmos.CosmosEnvelopedTxResponse
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
@@ -7,6 +8,7 @@ import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.http.HttpStatusCode
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.SerialName
@@ -34,6 +36,15 @@ import timber.log.Timber
  * that's the user-facing answer regardless of whether the outbound leg has landed yet — observing
  * the outbound is the network's bookkeeping, not new information for the user. `type == "failed"`
  * carries no such commitment, which is why it gates on the outbound being observed.
+ *
+ * Midgard only indexes recognized *actions* (swap/addLiquidity/withdraw/savers/loan/bond/…). A
+ * plain native transfer (e.g. sending a secured asset) or a native deposit the node rejected during
+ * execution never becomes an action, so `/v2/actions` returns an empty array for it. Treating that
+ * as [TransactionResult.Pending] left such txs stuck "in progress" forever while the app kept
+ * polling Midgard. When no action is found we therefore fall back to the native node's
+ * `cosmos/tx/v1beta1/txs/{hash}` endpoint, which reports the committed tx's result code directly:
+ * code 0 → [TransactionResult.Confirmed], non-zero → [TransactionResult.Failed] with the node's
+ * `raw_log`, and 404/not-yet-committed → [TransactionResult.Pending] so polling continues.
  */
 class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: HttpClient) :
     TransactionStatusProvider {
@@ -44,18 +55,41 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
             Chain.MayaChain to MAYACHAIN_MIDGARD_ACTIONS_URL,
         )
 
+    private val nativeTxUrls =
+        mapOf(
+            Chain.ThorChain to THORCHAIN_NATIVE_TX_URL,
+            Chain.MayaChain to MAYACHAIN_NATIVE_TX_URL,
+        )
+
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
         val baseUrl = midgardUrls[chain] ?: return TransactionResult.Failed("Unknown chain")
         return try {
             val response: MidgardActionsResponse =
                 httpClient.get(baseUrl) { parameter(MIDGARD_TXID_PARAM, txHash) }.bodyOrThrow()
-            val action = response.actions.firstOrNull() ?: return TransactionResult.Pending
+            val action = response.actions.firstOrNull() ?: return checkNativeStatus(txHash, chain)
             mapAction(action)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Timber.w(e, "THOR/Maya status check failed for %s on %s", txHash, chain)
             TransactionResult.Pending
+        }
+    }
+
+    /**
+     * Resolve a native THORChain/MayaChain tx that Midgard doesn't index (plain transfers, rejected
+     * deposits) via the node's `cosmos/tx/v1beta1/txs/{hash}` endpoint. The node returns 404 until
+     * the tx is committed in a block, then a non-null result code (0 = success).
+     */
+    private suspend fun checkNativeStatus(txHash: String, chain: Chain): TransactionResult {
+        val nativeTxUrl = nativeTxUrls[chain] ?: return TransactionResult.Pending
+        val response = httpClient.get("$nativeTxUrl/$txHash")
+        if (response.status == HttpStatusCode.NotFound) return TransactionResult.Pending
+        val txResponse = response.bodyOrThrow<CosmosEnvelopedTxResponse>().txResponse
+        return when (txResponse.code) {
+            0 -> TransactionResult.Confirmed
+            null -> TransactionResult.Pending
+            else -> TransactionResult.Failed(nonBlankOr(txResponse.rawLog, DEFAULT_FAILED_REASON))
         }
     }
 
@@ -83,6 +117,9 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
         const val THORCHAIN_MIDGARD_ACTIONS_URL =
             "https://gateway.liquify.com/chain/thorchain_midgard/v2/actions"
         const val MAYACHAIN_MIDGARD_ACTIONS_URL = "https://midgard.mayachain.info/v2/actions"
+        const val THORCHAIN_NATIVE_TX_URL =
+            "https://gateway.liquify.com/chain/thorchain_api/cosmos/tx/v1beta1/txs"
+        const val MAYACHAIN_NATIVE_TX_URL = "https://mayanode.mayachain.info/cosmos/tx/v1beta1/txs"
         const val MIDGARD_TXID_PARAM = "txid"
         const val ACTION_TYPE_REFUND = "refund"
         const val ACTION_TYPE_FAILED = "failed"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test
  * - `type == "failed"` with no outbound tx yet → [TransactionResult.Failed] (network rejected the
  *   action; refund is a separate outbound that hasn't been observed).
  * - `status == "success"` (non-refund/failed) → [TransactionResult.Confirmed].
- * - empty actions array → [TransactionResult.Pending] (indexer lag).
+ * - empty actions array → native node `cosmos/tx/v1beta1/txs/{hash}` fallback (Midgard doesn't
+ *   index plain transfers or rejected deposits): code 0 → Confirmed, non-zero → Failed, 404 →
+ *   Pending.
  * - network/parse failure → [TransactionResult.Pending] (so polling keeps running).
  */
 class ThorMayaChainStatusProviderTest {
@@ -235,13 +237,84 @@ class ThorMayaChainStatusProviderTest {
     }
 
     @Test
-    fun `empty actions returns Pending`() = runTest {
-        val client = MockHttpClient.respondingWith(HttpStatusCode.OK, """{ "actions": [] }""")
+    fun `no midgard action falls back to native node and maps failed code to Failed`() = runTest {
+        // The reported bug: a native THORChain tx (secured-asset send / rejected wasm deposit) is
+        // never indexed by Midgard, so `/v2/actions` is empty. Previously this stayed Pending
+        // forever; now we resolve it via the node's cosmos/tx endpoint, which reports the failure.
+        val nativeFailed =
+            """
+            {
+              "tx_response": {
+                "code": 11,
+                "codespace": "wasm",
+                "raw_log": "Zeroamount: execute wasm contract failed"
+              }
+            }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeFailed,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        val result = provider.checkStatus("hash", Chain.ThorChain)
+
+        result shouldBe TransactionResult.Failed("Zeroamount: execute wasm contract failed")
+    }
+
+    @Test
+    fun `no midgard action falls back to native node and maps code 0 to Confirmed`() = runTest {
+        val nativeSuccess =
+            """
+            { "tx_response": { "code": 0, "codespace": "", "raw_log": "" } }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        val result = provider.checkStatus("hash", Chain.MayaChain)
+
+        result shouldBe TransactionResult.Confirmed
+    }
+
+    @Test
+    fun `no midgard action and native node 404 stays Pending`() = runTest {
+        // Node returns 404 until the tx is committed in a block — keep polling.
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.NotFound to "",
+            )
         val provider = ThorMayaChainStatusProvider(client)
 
         val result = provider.checkStatus("hash", Chain.ThorChain)
 
         result shouldBe TransactionResult.Pending
+    }
+
+    @Test
+    fun `failed native code with blank raw_log falls back to default failed reason`() = runTest {
+        val nativeFailed =
+            """
+            { "tx_response": { "code": 5, "codespace": "sdk", "raw_log": "" } }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeFailed,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        val result = provider.checkStatus("hash", Chain.ThorChain)
+
+        result shouldBe TransactionResult.Failed("Transaction failed")
     }
 
     @Test


### PR DESCRIPTION
## Problem

Native THORChain/MayaChain transactions stay stuck **"In progress"** in transaction history forever — even after they've clearly succeeded or failed on-chain — while the app keeps polling Midgard in the background.

Observed case: a native THORChain tx that **failed** on-chain (explorer shows `Error — Zeroamount: execute wasm contract failed`) still displays "In progress…" days later. Logcat shows the app repeatedly hitting Midgard and getting an empty result:

```
GET …/thorchain_midgard/v2/actions?txid=1f14…
→ 200 {"actions": [], "count": "0"}
```

## Root cause

`ThorMayaChainStatusProvider` resolves status **only** through Midgard's `/v2/actions`. Midgard only indexes recognized *actions* (swap / addLiquidity / withdraw / savers / loan / bond). A plain native transfer (e.g. sending a secured asset) or a native deposit the node **rejects during execution** never becomes a Midgard action, so `/v2/actions` returns `actions: []`. The provider treated that as `Pending`, so the tx never reached a terminal state and was polled indefinitely.

This affected **all** native THORChain/MayaChain transfers, not just failed ones — a successful native send would also have been stuck "In progress".

## Fix

When Midgard returns no action, fall back to the native node's `cosmos/tx/v1beta1/txs/{hash}` endpoint, which reports the committed tx's result code directly:

- `code == 0` → **Confirmed**
- `code != 0` → **Failed** (surfacing the node's `raw_log`, e.g. "Zeroamount: execute wasm contract failed")
- `404` / not yet committed → **Pending** (keep polling)

Midgard remains the primary source so refund/failed-action semantics are unchanged; the native query is a fallback only used when no action exists. Reuses the provider's existing `HttpClient`, so the constructor and DI wiring are unchanged.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*ThorMayaChainStatusProviderTest"` — 18 tests, 0 failures
- Added native-fallback cases: failed code → Failed (with `raw_log`), code 0 → Confirmed, 404 → Pending, blank `raw_log` → default reason
- Existing Midgard action mapping (refund / failed / success / pending) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction status detection with an improved fallback mechanism to native chain endpoints, providing more reliable and accurate determination of transaction states (confirmed, pending, or failed). Better edge case handling ensures transactions are properly classified even when not immediately indexed on THORChain and MayaChain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->