### PR TITLE
feat(errors): friendly error screen with Show exact error / Copy / Report Bug (#4996)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -57,6 +57,9 @@ import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
+import com.vultisig.wallet.ui.components.errors.ErrorState
+import com.vultisig.wallet.ui.components.errors.ErrorView
+import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
 import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.components.securityscanner.SecurityScannerBottomSheetContent
@@ -249,11 +252,35 @@ class PreviewActivity : ComponentActivity() {
                     "sign_message_before" -> VerifySignMessageCtaPreview(newButtons = false)
                     "sign_message_after" -> VerifySignMessageCtaPreview(newButtons = true)
                     "review_vault_devices" -> ReviewVaultDevicesPreview()
+                    "error_screen_after" -> ErrorScreenAfterPreview()
                     else -> SwapConfirmPreview()
                 }
             }
         }
     }
+}
+
+// Redesigned shared error screen (#4996): neutral title + subtitle, red-cross critical hero, and
+// the
+// "Show exact error" disclosure that opens the raw-trace sheet. Rendered as the "Transaction
+// failed"
+// critical case with a real stack trace so the disclosure row is visible.
+@Composable
+private fun ErrorScreenAfterPreview() {
+    ErrorView(
+        title = stringResource(R.string.signing_error_transaction_failed_title),
+        description = stringResource(R.string.signing_error_transaction_failed_description),
+        errorState = ErrorState.CRITICAL,
+        rawError =
+            "javax.crypto.AEADBadTagException: error:1e000065:Cipher functions:" +
+                "OPENSSL_internal:BAD_DECRYPT\n" +
+                "  at java.lang.reflect.Constructor.newInstance0(Native Method)\n" +
+                "  at com.android.org.conscrypt.OpenSSLAeadCipher.engineDoFinal" +
+                "(OpenSSLAeadCipher.java:283)",
+        buttonUiModel =
+            ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
+        onBack = {},
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorMessageBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorMessageBottomSheet.kt
@@ -1,0 +1,93 @@
+package com.vultisig.wallet.ui.components.errors
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
+import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.VsAuxiliaryLinks
+import com.vultisig.wallet.ui.utils.VsClipboardService
+
+/**
+ * Full-screen sheet showing the raw technical error behind a friendly [ErrorView]. The trace is
+ * copyable ([VsClipboardService]) and reportable — "Report Bug" copies the trace and opens the
+ * Vultisig Discord support channel so the user can paste it.
+ */
+@Composable
+internal fun ErrorMessageBottomSheet(rawError: String, onDismissRequest: () -> Unit) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+
+    VsModalBottomSheet(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.error_message_sheet_title),
+                style = Theme.brockmann.headings.title2,
+                color = Theme.v2.colors.text.primary,
+            )
+
+            Text(
+                text = rawError,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.tertiary,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .heightIn(max = 420.dp)
+                        .background(
+                            color = Theme.v2.colors.backgrounds.disabled,
+                            shape = RoundedCornerShape(24.dp),
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = Theme.v2.colors.border.light,
+                            shape = RoundedCornerShape(24.dp),
+                        )
+                        .verticalScroll(rememberScrollState())
+                        .padding(20.dp),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                VsButton(
+                    label = stringResource(R.string.error_message_copy),
+                    iconLeft = R.drawable.ic_copy,
+                    variant = VsButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                    onClick = { VsClipboardService.copy(context, rawError) },
+                )
+                VsButton(
+                    label = stringResource(R.string.error_message_report_bug),
+                    variant = VsButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        VsClipboardService.copy(context, rawError)
+                        uriHandler.openUri(VsAuxiliaryLinks.DISCORD)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorUiModel.kt
@@ -2,4 +2,19 @@ package com.vultisig.wallet.ui.components.errors
 
 import com.vultisig.wallet.ui.utils.UiText
 
-data class ErrorUiModel(val title: UiText, val description: UiText)
+/**
+ * UI model for the shared full-screen [ErrorView].
+ *
+ * @param title human-readable error name (never a raw trace).
+ * @param description plain-language explanation plus the action the user should take.
+ * @param errorState selects the hero icon variant — [ErrorState.CRITICAL] (red ✕, hard failure) or
+ *   [ErrorState.WARNING] (amber ⚠, recoverable / precondition error).
+ * @param rawError the underlying technical error text. When non-null, the screen shows a "Show
+ *   exact error" disclosure that opens a sheet with this text, copyable and reportable.
+ */
+data class ErrorUiModel(
+    val title: UiText,
+    val description: UiText,
+    val errorState: ErrorState = ErrorState.WARNING,
+    val rawError: String? = null,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -2,15 +2,23 @@ package com.vultisig.wallet.ui.components.errors
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -22,7 +30,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
-import com.vultisig.wallet.ui.components.AppVersionText
+import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
@@ -42,11 +50,14 @@ internal fun ErrorView(
     errorState: ErrorState = ErrorState.WARNING,
     buttonUiModel: ErrorViewButtonUiModel?,
     secondaryButtonUiModel: ErrorViewButtonUiModel? = null,
+    rawError: String? = null,
     onBack: (() -> Unit)? = null,
 ) {
+    var showRawError by remember { mutableStateOf(false) }
+
     Box(modifier = modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
+            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
@@ -54,18 +65,24 @@ internal fun ErrorView(
 
             ErrorWaves(title = title, description = description, errorState = errorState)
 
-            buttonUiModel?.let {
-                UiSpacer(30.dp)
+            if (rawError != null) {
+                UiSpacer(37.dp)
+                ShowExactErrorRow(onClick = { showRawError = true })
+            }
+
+            UiSpacer(weight = 1f)
+
+            secondaryButtonUiModel?.let {
                 VsButton(
                     variant = VsButtonVariant.Secondary,
                     label = it.text,
                     modifier = Modifier.fillMaxWidth(),
                     onClick = it.onClick,
                 )
+                UiSpacer(12.dp)
             }
 
-            secondaryButtonUiModel?.let {
-                UiSpacer(if (buttonUiModel != null) 12.dp else 30.dp)
+            buttonUiModel?.let {
                 VsButton(
                     variant = VsButtonVariant.CTA,
                     label = it.text,
@@ -74,11 +91,7 @@ internal fun ErrorView(
                 )
             }
 
-            UiSpacer(weight = 1f)
-
-            AppVersionText()
-
-            UiSpacer(size = 50.dp)
+            UiSpacer(size = 24.dp)
         }
 
         if (onBack != null) {
@@ -92,6 +105,43 @@ internal fun ErrorView(
             )
         }
     }
+
+    if (showRawError && rawError != null) {
+        ErrorMessageBottomSheet(rawError = rawError, onDismissRequest = { showRawError = false })
+    }
+}
+
+@Composable
+private fun ShowExactErrorRow(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(
+                    color = Theme.v2.colors.backgrounds.surface1,
+                    shape = RoundedCornerShape(16.dp),
+                )
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.light,
+                    shape = RoundedCornerShape(16.dp),
+                )
+                .clickable(onClick = onClick)
+                .padding(20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.error_message_show_exact),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.secondary,
+        )
+        UiIcon(
+            drawableResId = R.drawable.ic_chevron_down_small,
+            size = 24.dp,
+            tint = Theme.v2.colors.text.secondary,
+        )
+    }
 }
 
 @Composable
@@ -101,10 +151,9 @@ internal fun ErrorWaves(
     description: String? = null,
     errorState: ErrorState = ErrorState.WARNING,
 ) {
-
     val waveCircleColor = Theme.v2.colors.border.light
     Column(
-        modifier = modifier.padding(bottom = 56.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -142,21 +191,17 @@ internal fun ErrorWaves(
 
         Text(
             text = title,
-            style = Theme.brockmann.headings.title2,
-            color =
-                when (errorState) {
-                    ErrorState.CRITICAL -> Theme.v2.colors.alerts.error
-                    ErrorState.WARNING -> Theme.v2.colors.alerts.warning
-                },
+            style = Theme.brockmann.headings.title3,
+            color = Theme.v2.colors.text.primary,
             textAlign = TextAlign.Center,
         )
 
         description?.let {
-            UiSpacer(12.dp)
+            UiSpacer(8.dp)
             Text(
                 text = description,
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.tertiary,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.secondary,
                 textAlign = TextAlign.Center,
             )
         }
@@ -170,33 +215,25 @@ enum class ErrorState {
 
 @Preview
 @Composable
-fun WarningErrorViewPreview() {
+private fun CriticalErrorViewPreview() {
     ErrorView(
-        title = "Something went wrong",
-        description = "Please try again later",
+        title = "Transaction failed",
+        description =
+            "One of your devices didn't respond in time. Check your connection and try again.",
+        errorState = ErrorState.CRITICAL,
+        rawError = "javax.crypto.AEADBadTagException: error:1e000065:Cipher functions",
+        buttonUiModel = ErrorViewButtonUiModel(text = "Try Again", onClick = {}),
+        onBack = {},
+    )
+}
+
+@Preview
+@Composable
+private fun WarningErrorViewPreview() {
+    ErrorView(
+        title = "Insufficient funds",
+        description = "Insufficient funds to execute the swap. Please fund the wallet.",
         errorState = ErrorState.WARNING,
-        buttonUiModel =
-            ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
-    )
-}
-
-@Preview
-@Composable
-fun WarningErrorViewPreview2() {
-    ErrorView(
-        title = "Something went wrong",
-        errorState = ErrorState.CRITICAL,
-        buttonUiModel =
-            ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
-    )
-}
-
-@Preview
-@Composable
-fun WarningErrorViewPreview3() {
-    ErrorView(
-        title = "Something went wrong",
-        errorState = ErrorState.CRITICAL,
-        buttonUiModel = null,
+        buttonUiModel = ErrorViewButtonUiModel(text = "Try Again", onClick = {}),
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
@@ -59,6 +59,7 @@ import com.vultisig.wallet.data.usecases.Encryption
 import com.vultisig.wallet.data.usecases.ExtractMasterKeysUseCase
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
 import com.vultisig.wallet.ui.components.canAuthenticateBiometric
+import com.vultisig.wallet.ui.components.errors.ErrorState
 import com.vultisig.wallet.ui.components.errors.ErrorUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
@@ -1034,11 +1035,15 @@ constructor(
                     title = UiText.StringResource(R.string.import_seedphrase_already_imported),
                     description =
                         UiText.StringResource(R.string.import_seedphrase_duplicate_description),
+                    errorState = ErrorState.WARNING,
+                    rawError = e.message,
                 )
             } else {
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.generating_key_screen_keygen_failed),
                     description = e.message or R.string.unknown_error,
+                    errorState = ErrorState.CRITICAL,
+                    rawError = e.message,
                 )
             }
         }
@@ -1059,6 +1064,8 @@ constructor(
                 } else {
                     e.message or R.string.unknown_error
                 },
+            errorState = if (isThresholdError) ErrorState.WARNING else ErrorState.CRITICAL,
+            rawError = e.message,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/peer/KeygenPeerDiscoveryViewModel.kt
@@ -41,6 +41,7 @@ import com.vultisig.wallet.data.usecases.tss.ParticipantName
 import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.data.utils.toNetworkErrorKind
+import com.vultisig.wallet.ui.components.errors.ErrorState
 import com.vultisig.wallet.ui.components.errors.ErrorUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
@@ -242,11 +243,15 @@ constructor(
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.keygen_error_timeout_title),
                     description = UiText.StringResource(R.string.keygen_error_timeout_description),
+                    errorState = ErrorState.WARNING,
+                    rawError = message,
                 )
             NetworkErrorKind.NoConnectivity ->
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.keygen_error_network_title),
                     description = UiText.StringResource(R.string.keygen_error_network_description),
+                    errorState = ErrorState.WARNING,
+                    rawError = message,
                 )
             NetworkErrorKind.Transport,
             NetworkErrorKind.Http,
@@ -254,6 +259,8 @@ constructor(
                 ErrorUiModel(
                     title = UiText.StringResource(R.string.error_view_default_title),
                     description = UiText.StringResource(R.string.error_view_default_description),
+                    errorState = ErrorState.CRITICAL,
+                    rawError = message,
                 )
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/JoinKeygenScreen.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
+import com.vultisig.wallet.ui.models.keygen.JoinKeygenError
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenUiModel
 import com.vultisig.wallet.ui.models.keygen.JoinKeygenViewModel
 import com.vultisig.wallet.ui.screens.v3.onboarding.components.OnboardingResponsiveContainer
@@ -52,15 +53,23 @@ internal fun JoinKeygenScreen(model: JoinKeygenViewModel = hiltViewModel()) {
                     ),
             )
 
-        error != null ->
+        error != null -> {
+            val isDuplicateName = error is JoinKeygenError.DuplicateVaultName
             ErrorView(
-                title = error.message.asString(),
+                title =
+                    if (isDuplicateName) stringResource(R.string.error_vault_name_in_use_title)
+                    else error.message.asString(),
+                description =
+                    if (isDuplicateName)
+                        stringResource(R.string.error_vault_name_in_use_description)
+                    else null,
                 buttonUiModel =
                     ErrorViewButtonUiModel(
                         text = stringResource(R.string.scan_qr_code_error_button),
                         onClick = model::navigateBack,
                     ),
             )
+        }
 
         else -> JoinKeygenScreen(state = state)
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
@@ -147,6 +147,8 @@ private fun KeygenScreen(state: KeygenUiModel, onTryAgainClick: () -> Unit) {
                         ErrorView(
                             title = error.title.asString(),
                             description = error.description.asString(),
+                            errorState = error.errorState,
+                            rawError = error.rawError,
                             modifier = Modifier.fillMaxWidth(),
                             buttonUiModel =
                                 ErrorViewButtonUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.errors.ErrorState
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
@@ -186,12 +187,27 @@ internal fun JoinKeysignView() {
 
             is Error -> {
                 val error = state as Error
-                val errorLabel: String
+                val title: String
+                val description: String?
+                val errorState: ErrorState
                 val buttonText: String
+                var rawError: String? = null
                 when (error.errorType) {
-                    is JoinKeysignError.WrongVaultShare,
-                    is JoinKeysignError.WrongVault -> {
-                        errorLabel = error.errorType.message.asString()
+                    is JoinKeysignError.WrongVaultShare -> {
+                        title = stringResource(R.string.error_same_vault_share_title)
+                        description = stringResource(R.string.error_same_vault_share_description)
+                        errorState = ErrorState.WARNING
+                        buttonText =
+                            stringResource(
+                                R.string.join_keysign_error_wrong_vault_share_try_again_button
+                            )
+                    }
+
+                    is JoinKeysignError.WrongVault,
+                    is JoinKeysignError.MissingRequiredVault -> {
+                        title = stringResource(R.string.error_vault_not_loaded_title)
+                        description = stringResource(R.string.error_vault_not_loaded_description)
+                        errorState = ErrorState.WARNING
                         buttonText =
                             stringResource(
                                 R.string.join_keysign_error_wrong_vault_share_try_again_button
@@ -199,17 +215,20 @@ internal fun JoinKeysignView() {
                     }
 
                     else -> {
-                        errorLabel =
-                            stringResource(
-                                R.string.signing_error_please_try_again_s,
-                                error.errorType.message.asString(),
-                            )
+                        val rawMessage = error.errorType.message.asString()
+                        val signingError = resolveSigningError(rawMessage)
+                        title = signingError.title
+                        description = signingError.description
+                        errorState = signingError.errorState
+                        rawError = rawMessage.ifBlank { null }
                         buttonText = stringResource(R.string.try_again)
                     }
                 }
                 ErrorView(
-                    title = errorLabel,
-                    description = null,
+                    title = title,
+                    description = description,
+                    errorState = errorState,
+                    rawError = rawError,
                     buttonUiModel =
                         ErrorViewButtonUiModel(text = buttonText, onClick = viewModel::tryAgain),
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -6,41 +6,68 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.chains.helpers.SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX
+import com.vultisig.wallet.ui.components.errors.ErrorState
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
 
+internal data class SigningError(
+    val title: String,
+    val description: String?,
+    val errorState: ErrorState,
+)
+
+/**
+ * Maps a raw keysign error message to friendly title/subtitle + icon variant. Leads with a
+ * human-readable message; the raw text is kept one tap away via the "Show exact error" disclosure
+ * on [ErrorView]. Recoverable / precondition errors use the amber warning variant; hard failures
+ * use the red critical variant.
+ */
 @Composable
-internal fun KeysignErrorScreen(
-    errorMessage: UiText = UiText.Empty,
-    tryAgain: () -> Unit,
-    onBack: (() -> Unit)? = null,
-) {
-    val errorMessageString = errorMessage.asString()
-    val errorLabel: String
+internal fun resolveSigningError(rawMessage: String): SigningError =
     when {
-        errorMessageString.contains("Blockhash not found") ->
-            errorLabel = stringResource(R.string.signing_error_transaction_timeout)
-        errorMessageString.contains("insufficient funds") ->
-            errorLabel = stringResource(R.string.signing_error_insufficient_funds)
-        errorMessageString.contains(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX) -> {
-            val ticker =
-                errorMessageString.substringAfter(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX).trim()
-            errorLabel = stringResource(R.string.signing_error_token_account_not_found_s, ticker)
+        rawMessage.contains("Blockhash not found") ->
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description = stringResource(R.string.signing_error_transaction_timeout),
+                errorState = ErrorState.CRITICAL,
+            )
+        rawMessage.contains("insufficient funds") ->
+            SigningError(
+                title = stringResource(R.string.error_insufficient_funds_title),
+                description = stringResource(R.string.signing_error_insufficient_funds),
+                errorState = ErrorState.WARNING,
+            )
+        rawMessage.contains(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX) -> {
+            val ticker = rawMessage.substringAfter(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX).trim()
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description =
+                    stringResource(R.string.signing_error_token_account_not_found_s, ticker),
+                errorState = ErrorState.CRITICAL,
+            )
         }
-        errorMessageString.contains("failed to calculate bob mid and bob_mic_mc") ->
-            errorLabel = stringResource(R.string.signing_error_mixed_reshare)
-        errorMessageString.contains(CosmosBroadcastException.BROADCAST_FAILURE_MARKER) -> {
+        rawMessage.contains("failed to calculate bob mid and bob_mic_mc") ->
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description = stringResource(R.string.signing_error_mixed_reshare),
+                errorState = ErrorState.WARNING,
+            )
+        rawMessage.contains(CosmosBroadcastException.BROADCAST_FAILURE_MARKER) -> {
             // SEQUENCE_MISMATCH_MARKER is itself prefixed with BROADCAST_FAILURE_MARKER, so the
             // sequence-mismatch check has to live inside the broadcast-failure branch — otherwise
             // a future reorder of these two branches would silently route every sequence mismatch
             // into the generic "rejected" copy.
-            if (errorMessageString.contains(CosmosBroadcastException.SEQUENCE_MISMATCH_MARKER)) {
-                errorLabel = stringResource(R.string.signing_error_sequence_mismatch)
+            if (rawMessage.contains(CosmosBroadcastException.SEQUENCE_MISMATCH_MARKER)) {
+                SigningError(
+                    title = stringResource(R.string.signing_error_transaction_failed_title),
+                    description = stringResource(R.string.signing_error_sequence_mismatch),
+                    errorState = ErrorState.WARNING,
+                )
             } else {
                 val detail =
-                    errorMessageString
+                    rawMessage
                         .substringAfter(CosmosBroadcastException.BROADCAST_FAILURE_MARKER)
                         .trimStart(':', ' ')
                         .let { raw ->
@@ -48,22 +75,40 @@ internal fun KeysignErrorScreen(
                                 raw.take(BROADCAST_DETAIL_MAX_LENGTH).trimEnd() + "…"
                             } else raw
                         }
-                errorLabel =
-                    if (detail.isBlank()) {
-                        stringResource(R.string.signing_error_broadcast_rejected)
-                    } else {
-                        stringResource(R.string.signing_error_broadcast_rejected_s, detail)
-                    }
+                SigningError(
+                    title = stringResource(R.string.signing_error_transaction_failed_title),
+                    description =
+                        if (detail.isBlank()) {
+                            stringResource(R.string.signing_error_broadcast_rejected)
+                        } else {
+                            stringResource(R.string.signing_error_broadcast_rejected_s, detail)
+                        },
+                    errorState = ErrorState.CRITICAL,
+                )
             }
         }
         else ->
-            errorLabel =
-                stringResource(R.string.signing_error_please_try_again_s, errorMessageString)
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description = stringResource(R.string.signing_error_transaction_failed_description),
+                errorState = ErrorState.CRITICAL,
+            )
     }
 
+@Composable
+internal fun KeysignErrorScreen(
+    errorMessage: UiText = UiText.Empty,
+    tryAgain: () -> Unit,
+    onBack: (() -> Unit)? = null,
+) {
+    val rawMessage = errorMessage.asString()
+    val signingError = resolveSigningError(rawMessage)
+
     ErrorView(
-        title = errorLabel,
-        description = null,
+        title = signingError.title,
+        description = signingError.description,
+        errorState = signingError.errorState,
+        rawError = rawMessage.ifBlank { null },
         buttonUiModel =
             ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = tryAgain),
         onBack = onBack,
@@ -81,8 +126,10 @@ private const val BROADCAST_DETAIL_MAX_LENGTH = 120
 @Composable
 private fun PreviewKeysignError() {
     ErrorView(
-        title = stringResource(R.string.signing_error_please_try_again_s, "some errors"),
-        description = null,
+        title = stringResource(R.string.signing_error_transaction_failed_title),
+        description = stringResource(R.string.signing_error_transaction_failed_description),
+        errorState = ErrorState.CRITICAL,
+        rawError = "javax.crypto.AEADBadTagException: BAD_DECRYPT",
         buttonUiModel =
             ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -111,6 +111,8 @@ internal fun KeygenPeerDiscoveryScreen(model: KeygenPeerDiscoveryViewModel = hil
             ErrorView(
                 title = warning.title.asString(),
                 description = warning.description.asString(),
+                errorState = warning.errorState,
+                rawError = warning.rawError,
                 buttonUiModel =
                     ErrorViewButtonUiModel(
                         text = stringResource(R.string.try_again),
@@ -773,6 +775,8 @@ private fun Error(state: ErrorUiModel, onTryAgainClick: () -> Unit) {
         ErrorView(
             title = state.title.asString(),
             description = state.description.asString(),
+            errorState = state.errorState,
+            rawError = state.rawError,
             modifier = Modifier.fillMaxWidth(),
             buttonUiModel =
                 ErrorViewButtonUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/scan/ScanQrScreen.kt
@@ -278,7 +278,8 @@ private fun ScanQrScreen(
                 }
             } else {
                 ErrorView(
-                    title = stringResource(R.string.camera_permission_denied),
+                    title = stringResource(R.string.error_camera_permission_title),
+                    description = stringResource(R.string.error_camera_permission_description),
                     buttonUiModel =
                         ErrorViewButtonUiModel(
                             text = stringResource(R.string.camera_permission_open_settings),

--- a/app/src/main/res/drawable/error_critical.xml
+++ b/app/src/main/res/drawable/error_critical.xml
@@ -7,7 +7,7 @@
       android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
       android:fillColor="#FF5C5C"/>
   <path
-      android:pathData="M12,8V12M12,16H12.01M22,12C22,17.523 17.523,22 12,22C6.477,22 2,17.523 2,12C2,6.477 6.477,2 12,2C17.523,2 22,6.477 22,12Z"
+      android:pathData="M7.5,7.5L16.5,16.5M16.5,7.5L7.5,16.5"
       android:strokeLineJoin="round"
       android:strokeWidth="2"
       android:fillColor="#00000000"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -185,7 +185,6 @@
     <string name="vault_accounts_account_assets">%1$s Vermögenswerte</string>
     <string name="chain_token_screen_address_copied">%1$s in die Zwischenablage kopiert</string>
     <string name="s_of_s_vault">%1$s von %2$s Tresor</string>
-    <string name="camera_permission_denied">Kameraberechtigung nicht erteilt. Bitte aktivieren Sie sie in den Einstellungen.</string>
     <string name="camera_permission_open_settings">Einstellungen öffnen</string>
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
@@ -811,6 +810,22 @@
     <string name="onboarding_intro_back">Zurück</string>
     <string name="error_view_default_title">Etwas ist schiefgelaufen</string>
     <string name="error_view_default_description">Ein Fehler ist aufgetreten</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transaktion fehlgeschlagen</string>
+    <string name="signing_error_transaction_failed_description">Eines deiner Geräte hat nicht rechtzeitig geantwortet. Überprüfe deine Verbindung und versuche es erneut.</string>
+    <string name="error_insufficient_funds_title">Unzureichendes Guthaben</string>
+    <string name="error_same_vault_share_title">Dieselbe Tresorfreigabe</string>
+    <string name="error_same_vault_share_description">Bitte ändern Sie die Freigabe zum Signieren. Zwei Geräte können nicht dieselbe Tresorfreigabe zum gemeinsamen Signieren verwenden.</string>
+    <string name="error_vault_not_loaded_title">Tresor ist nicht geladen</string>
+    <string name="error_vault_not_loaded_description">Bitte importieren Sie die richtige Freigabe.</string>
+    <string name="error_vault_name_in_use_title">Tresorname bereits vergeben</string>
+    <string name="error_vault_name_in_use_description">Bitte wählen Sie einen anderen Tresornamen.</string>
+    <string name="error_camera_permission_title">Kameraberechtigung nicht erteilt</string>
+    <string name="error_camera_permission_description">Kameraberechtigung ist erforderlich, um fortzufahren. Bitte aktivieren Sie sie in den Einstellungen.</string>
+    <string name="error_message_sheet_title">Fehlermeldung</string>
+    <string name="error_message_copy">Kopieren</string>
+    <string name="error_message_report_bug">Fehler melden</string>
+    <string name="error_message_show_exact">Genauen Fehler anzeigen</string>
     <string name="keygen_error_timeout_title">Zeitüberschreitung der Verbindung</string>
     <string name="keygen_error_timeout_description">Der Server konnte nicht rechtzeitig erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
     <string name="keygen_error_network_title">Verbindungsproblem</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -185,7 +185,6 @@
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
     <string name="send_error_no_address">La dirección no es válida</string>
     <string name="verify_transaction_value">Valor</string>
-    <string name="camera_permission_denied">No se ha concedido el permiso para la cámara. Habilítelo en la configuración.</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>
     <string name="vault_accounts_account_assets">%1$s activos</string>
     <string name="chain_token_screen_address_copied">%1$s copiada al portapapeles</string>
@@ -811,6 +810,22 @@
     <string name="migration_onboarding_step_1_text_end">y firma más rápido que nunca</string>
     <string name="error_view_default_title">Algo salió mal</string>
     <string name="error_view_default_description">Ocurrió un error</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transacción fallida</string>
+    <string name="signing_error_transaction_failed_description">Uno de tus dispositivos no respondió a tiempo. Comprueba tu conexión e inténtalo de nuevo.</string>
+    <string name="error_insufficient_funds_title">Fondos insuficientes</string>
+    <string name="error_same_vault_share_title">Misma bóveda compartida</string>
+    <string name="error_same_vault_share_description">Cambie la compartición para firmar. Dos dispositivos no pueden usar la misma bóveda compartida para firmar conjuntamente.</string>
+    <string name="error_vault_not_loaded_title">La bóveda no está cargada</string>
+    <string name="error_vault_not_loaded_description">Por favor, importe la compartición correcta.</string>
+    <string name="error_vault_name_in_use_title">Nombre de bóveda ya en uso</string>
+    <string name="error_vault_name_in_use_description">Por favor, elija un nombre de bóveda diferente.</string>
+    <string name="error_camera_permission_title">Permiso de cámara no concedido</string>
+    <string name="error_camera_permission_description">Se requiere permiso de cámara para continuar. Habilítelo en la configuración.</string>
+    <string name="error_message_sheet_title">Mensaje de error</string>
+    <string name="error_message_copy">Copiar</string>
+    <string name="error_message_report_bug">Reportar error</string>
+    <string name="error_message_show_exact">Mostrar el error exacto</string>
     <string name="keygen_error_timeout_title">Se agotó el tiempo de conexión</string>
     <string name="keygen_error_timeout_description">No se pudo conectar con el servidor a tiempo. Verifique su conexión e inténtelo de nuevo.</string>
     <string name="keygen_error_network_title">Problema de conexión</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -185,7 +185,6 @@
     <string name="vault_accounts_account_assets">%1$s sredstva</string>
     <string name="chain_token_screen_address_copied">%1$s kopirano u međuspremnik</string>
     <string name="s_of_s_vault">%1$s od %2$s trezora</string>
-    <string name="camera_permission_denied">Dopuštenje za kameru nije odobreno. Omogućite ga u postavkama.</string>
     <string name="camera_permission_open_settings">Otvori postavke</string>
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
@@ -815,6 +814,22 @@
     <string name="migration_onboarding_step_1_text_end">i prijavite se brže nego ikad prije</string>
     <string name="error_view_default_title">Nešto je pošlo po zlu</string>
     <string name="error_view_default_description">Dogodila se pogreška</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transakcija nije uspjela</string>
+    <string name="signing_error_transaction_failed_description">Jedan od tvojih uređaja nije odgovorio na vrijeme. Provjeri vezu i pokušaj ponovno.</string>
+    <string name="error_insufficient_funds_title">Nedovoljno sredstava</string>
+    <string name="error_same_vault_share_title">Isti dio trezora</string>
+    <string name="error_same_vault_share_description">Molimo promijenite dionicu za potpis. Dva uređaja ne mogu koristiti isti dio trezora za zajedničko potpisivanje.</string>
+    <string name="error_vault_not_loaded_title">Trezor nije učitan</string>
+    <string name="error_vault_not_loaded_description">Molimo uvezite ispravnu dionicu.</string>
+    <string name="error_vault_name_in_use_title">Naziv trezora već se koristi</string>
+    <string name="error_vault_name_in_use_description">Molimo odaberite drugi naziv trezora.</string>
+    <string name="error_camera_permission_title">Dopuštenje za kameru nije odobreno</string>
+    <string name="error_camera_permission_description">Dopuštenje za kameru potrebno je za nastavak. Omogućite ga u postavkama.</string>
+    <string name="error_message_sheet_title">Poruka o pogrešci</string>
+    <string name="error_message_copy">Kopiraj</string>
+    <string name="error_message_report_bug">Prijavi grešku</string>
+    <string name="error_message_show_exact">Prikaži točnu pogrešku</string>
     <string name="keygen_error_timeout_title">Isteklo je vrijeme veze</string>
     <string name="keygen_error_timeout_description">Poslužitelj nije dosegnut na vrijeme. Provjerite svoju vezu i pokušajte ponovno.</string>
     <string name="keygen_error_network_title">Problem s vezom</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -185,7 +185,6 @@
     <string name="vault_accounts_account_assets">%1$s risorse</string>
     <string name="chain_token_screen_address_copied">%1$s copiato negli appunti</string>
     <string name="s_of_s_vault">%1$s del caveau %2$s</string>
-    <string name="camera_permission_denied">Autorizzazione della telecamera non concessa. Abilitala nelle impostazioni.</string>
     <string name="camera_permission_open_settings">Apri impostazioni</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
@@ -811,6 +810,22 @@
     <string name="migration_onboarding_step_1_text_end">e firma più velocemente che mai</string>
     <string name="error_view_default_title">Qualcosa è andato storto</string>
     <string name="error_view_default_description">Si è verificato un errore</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transazione fallita</string>
+    <string name="signing_error_transaction_failed_description">Uno dei tuoi dispositivi non ha risposto in tempo. Controlla la connessione e riprova.</string>
+    <string name="error_insufficient_funds_title">Fondi insufficienti</string>
+    <string name="error_same_vault_share_title">Stessa condivisione del vault</string>
+    <string name="error_same_vault_share_description">Modifica la condivisione per firmare. Due dispositivi non possono usare la stessa condivisione del vault per la co-firma.</string>
+    <string name="error_vault_not_loaded_title">Il vault non è caricato</string>
+    <string name="error_vault_not_loaded_description">Importa la condivisione corretta.</string>
+    <string name="error_vault_name_in_use_title">Nome del vault già in uso</string>
+    <string name="error_vault_name_in_use_description">Scegli un nome del vault diverso.</string>
+    <string name="error_camera_permission_title">Autorizzazione della telecamera non concessa</string>
+    <string name="error_camera_permission_description">L\'autorizzazione della telecamera è necessaria per procedere. Abilitala nelle impostazioni.</string>
+    <string name="error_message_sheet_title">Messaggio di errore</string>
+    <string name="error_message_copy">Copia</string>
+    <string name="error_message_report_bug">Segnala bug</string>
+    <string name="error_message_show_exact">Mostra l\'errore esatto</string>
     <string name="keygen_error_timeout_title">Connessione scaduta</string>
     <string name="keygen_error_timeout_description">Impossibile raggiungere il server in tempo. Controlla la tua connessione e riprova.</string>
     <string name="keygen_error_network_title">Problema di connessione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -199,7 +199,6 @@
     <string name="verify_transaction_consent_address">올바른 주소로 보내고 있습니다</string>
     <string name="verify_transaction_consent_amount">금액이 정확합니다</string>
     <string name="verify_transaction_error_not_enough_consent">모든 동의 항목을 확인해 주세요</string>
-    <string name="camera_permission_denied">카메라 권한이 부여되지 않았습니다. 설정에서 활성화해 주세요.</string>
     <string name="camera_permission_open_settings">설정 열기</string>
     <string name="join_keysign_discovering_session_id">세션 ID 검색 중</string>
     <string name="transaction_done_title">완료</string>
@@ -569,6 +568,22 @@
     <string name="enter_email_screen_next">다음</string>
     <string name="error_view_default_title">문제가 발생했습니다</string>
     <string name="error_view_default_description">오류가 발생했습니다</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">거래 실패</string>
+    <string name="signing_error_transaction_failed_description">기기 중 하나가 제때 응답하지 않았습니다. 연결을 확인하고 다시 시도해 주세요.</string>
+    <string name="error_insufficient_funds_title">잔액 부족</string>
+    <string name="error_same_vault_share_title">동일한 볼트 공유</string>
+    <string name="error_same_vault_share_description">서명할 공유를 변경해 주세요. 두 기기는 공동 서명에 동일한 볼트 공유를 사용할 수 없습니다.</string>
+    <string name="error_vault_not_loaded_title">볼트가 로드되지 않았습니다</string>
+    <string name="error_vault_not_loaded_description">올바른 공유를 가져와 주세요.</string>
+    <string name="error_vault_name_in_use_title">이미 사용 중인 볼트 이름</string>
+    <string name="error_vault_name_in_use_description">다른 볼트 이름을 선택해 주세요.</string>
+    <string name="error_camera_permission_title">카메라 권한이 부여되지 않음</string>
+    <string name="error_camera_permission_description">계속하려면 카메라 권한이 필요합니다. 설정에서 활성화해 주세요.</string>
+    <string name="error_message_sheet_title">오류 메시지</string>
+    <string name="error_message_copy">복사</string>
+    <string name="error_message_report_bug">버그 신고</string>
+    <string name="error_message_show_exact">정확한 오류 보기</string>
     <string name="keygen_error_timeout_title">연결 시간 초과</string>
     <string name="keygen_error_timeout_description">서버에 제때 연결하지 못했습니다. 연결을 확인하고 다시 시도해 주세요.</string>
     <string name="keygen_error_network_title">연결 문제</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -124,7 +124,6 @@
     <string name="verify_transaction_consent_address">Ik stuur naar het juiste adres</string>
     <string name="verify_transaction_consent_amount">Het bedrag is correct</string>
     <string name="verify_transaction_error_not_enough_consent">Controleer alle toestemmingen</string>
-    <string name="camera_permission_denied">Cameratoestemming niet verleend. Schakel deze in de instellingen in.</string>
     <string name="camera_permission_open_settings">Instellingen openen</string>
     <string name="join_keysign_discovering_session_id">Sessienummer ontdekken</string>
     <string name="transaction_done_title">Gedaan</string>
@@ -808,6 +807,22 @@
     <string name="migration_onboarding_step_1_text_end">en onderteken sneller dan ooit tevoren</string>
     <string name="error_view_default_title">Er is iets misgegaan</string>
     <string name="error_view_default_description">Er is een fout opgetreden</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transactie mislukt</string>
+    <string name="signing_error_transaction_failed_description">Een van je apparaten reageerde niet op tijd. Controleer je verbinding en probeer het opnieuw.</string>
+    <string name="error_insufficient_funds_title">Onvoldoende saldo</string>
+    <string name="error_same_vault_share_title">Zelfde kluisshare</string>
+    <string name="error_same_vault_share_description">Verander de share om te ondertekenen. Twee apparaten kunnen niet dezelfde kluisshare gebruiken voor mede-ondertekening.</string>
+    <string name="error_vault_not_loaded_title">Kluis is niet geladen</string>
+    <string name="error_vault_not_loaded_description">Importeer de juiste share.</string>
+    <string name="error_vault_name_in_use_title">Kluisnaam al in gebruik</string>
+    <string name="error_vault_name_in_use_description">Kies een andere kluisnaam.</string>
+    <string name="error_camera_permission_title">Cameratoestemming niet verleend</string>
+    <string name="error_camera_permission_description">Cameratoestemming is vereist om door te gaan. Schakel deze in de instellingen in.</string>
+    <string name="error_message_sheet_title">Foutmelding</string>
+    <string name="error_message_copy">Kopiëren</string>
+    <string name="error_message_report_bug">Bug melden</string>
+    <string name="error_message_show_exact">Toon exacte fout</string>
     <string name="keygen_error_timeout_title">Time-out van verbinding</string>
     <string name="keygen_error_timeout_description">Kon de server niet op tijd bereiken. Controleer uw verbinding en probeer het opnieuw.</string>
     <string name="keygen_error_network_title">Verbindingsprobleem</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -185,7 +185,6 @@
     <string name="vault_accounts_account_assets">Ativos de %1$s</string>
     <string name="chain_token_screen_address_copied">%1$s copiado para a área de transferência</string>
     <string name="s_of_s_vault">%1$s do cofre %2$s</string>
-    <string name="camera_permission_denied">Permissão de câmera não concedida. Por favor, habilite-a nas configurações.</string>
     <string name="camera_permission_open_settings">Abrir configurações</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
@@ -810,6 +809,22 @@
     <string name="migration_onboarding_step_1_text_end">e assine mais depressa do que nunca</string>
     <string name="error_view_default_title">Ocorreu um erro</string>
     <string name="error_view_default_description">Um erro ocorreu</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transação falhou</string>
+    <string name="signing_error_transaction_failed_description">Um dos seus dispositivos não respondeu a tempo. Verifique a sua conexão e tente novamente.</string>
+    <string name="error_insufficient_funds_title">Fundos insuficientes</string>
+    <string name="error_same_vault_share_title">A mesma partilha do cofre</string>
+    <string name="error_same_vault_share_description">Por favor, altere a partilha para assinar. Dois dispositivos não podem usar a mesma partilha do cofre para co-assinar.</string>
+    <string name="error_vault_not_loaded_title">O cofre não está carregado</string>
+    <string name="error_vault_not_loaded_description">Por favor, importe a partilha correta.</string>
+    <string name="error_vault_name_in_use_title">Nome do cofre já em uso</string>
+    <string name="error_vault_name_in_use_description">Por favor, escolha um nome de cofre diferente.</string>
+    <string name="error_camera_permission_title">Permissão de câmera não concedida</string>
+    <string name="error_camera_permission_description">A permissão de câmera é necessária para continuar. Por favor, habilite-a nas configurações.</string>
+    <string name="error_message_sheet_title">Mensagem de erro</string>
+    <string name="error_message_copy">Copiar</string>
+    <string name="error_message_report_bug">Reportar bug</string>
+    <string name="error_message_show_exact">Mostrar erro exato</string>
     <string name="keygen_error_timeout_title">Tempo de ligação esgotado</string>
     <string name="keygen_error_timeout_description">Não foi possível contactar o servidor a tempo. Verifique a sua ligação e tente novamente.</string>
     <string name="keygen_error_network_title">Problema de ligação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -124,7 +124,6 @@
     <string name="verify_transaction_consent_address">Я отправляю на правильный адрес</string>
     <string name="verify_transaction_consent_amount">Сумма верна</string>
     <string name="verify_transaction_error_not_enough_consent">Пожалуйста, проверьте все согласия</string>
-    <string name="camera_permission_denied">Разрешение на камеру не предоставлено. Пожалуйста, включите его в настройках.</string>
     <string name="camera_permission_open_settings">Открыть настройки</string>
     <string name="join_keysign_discovering_session_id">Обнаружение ID сессии</string>
     <string name="transaction_done_title">Готово</string>
@@ -814,6 +813,22 @@
     <string name="migration_onboarding_step_1_text_end">и подпишите быстрее, чем когда-либо прежде</string>
     <string name="error_view_default_title">Что-то пошло не так</string>
     <string name="error_view_default_description">Произошла ошибка</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Транзакция не удалась</string>
+    <string name="signing_error_transaction_failed_description">Одно из ваших устройств не ответило вовремя. Проверьте соединение и попробуйте снова.</string>
+    <string name="error_insufficient_funds_title">Недостаточно средств</string>
+    <string name="error_same_vault_share_title">Тот же общий доступ к хранилищу</string>
+    <string name="error_same_vault_share_description">Пожалуйста, измените общий доступ для подписи. Два устройства не могут использовать один и тот же общий доступ к хранилищу для совместной подписи.</string>
+    <string name="error_vault_not_loaded_title">Хранилище не загружено</string>
+    <string name="error_vault_not_loaded_description">Пожалуйста, импортируйте правильный общий доступ.</string>
+    <string name="error_vault_name_in_use_title">Имя хранилища уже используется</string>
+    <string name="error_vault_name_in_use_description">Пожалуйста, выберите другое имя хранилища.</string>
+    <string name="error_camera_permission_title">Разрешение на камеру не предоставлено</string>
+    <string name="error_camera_permission_description">Для продолжения требуется разрешение на камеру. Пожалуйста, включите его в настройках.</string>
+    <string name="error_message_sheet_title">Сообщение об ошибке</string>
+    <string name="error_message_copy">Копировать</string>
+    <string name="error_message_report_bug">Сообщить об ошибке</string>
+    <string name="error_message_show_exact">Показать точную ошибку</string>
     <string name="keygen_error_timeout_title">Превышено время ожидания</string>
     <string name="keygen_error_timeout_description">Не удалось вовремя связаться с сервером. Проверьте подключение и попробуйте снова.</string>
     <string name="keygen_error_network_title">Проблема с подключением</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -227,7 +227,6 @@
     <string name="verify_transaction_error_not_enough_consent">请检查所有同意项</string>
 
     <!-- Camera & QR -->
-    <string name="camera_permission_denied">相机权限未授予。请在设置中启用。</string>
     <string name="camera_permission_open_settings">打开设置</string>
     <string name="join_keysign_discovering_session_id">发现会话 ID</string>
 
@@ -1143,6 +1142,22 @@
     <string name="migration_onboarding_step_1_text_end">签名速度前所未有</string>
     <string name="error_view_default_title">出错了</string>
     <string name="error_view_default_description">发生错误</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">交易失败</string>
+    <string name="signing_error_transaction_failed_description">您的某个设备未及时响应。请检查您的连接并重试。</string>
+    <string name="error_insufficient_funds_title">余额不足</string>
+    <string name="error_same_vault_share_title">相同的保险库份额</string>
+    <string name="error_same_vault_share_description">请更改份额以签名。两台设备不能使用相同的保险库份额进行联合签名。</string>
+    <string name="error_vault_not_loaded_title">保险库未加载</string>
+    <string name="error_vault_not_loaded_description">请导入正确的份额。</string>
+    <string name="error_vault_name_in_use_title">保险库名称已被使用</string>
+    <string name="error_vault_name_in_use_description">请选择其他保险库名称。</string>
+    <string name="error_camera_permission_title">相机权限未授予</string>
+    <string name="error_camera_permission_description">需要相机权限才能继续。请在设置中启用。</string>
+    <string name="error_message_sheet_title">错误信息</string>
+    <string name="error_message_copy">复制</string>
+    <string name="error_message_report_bug">报告错误</string>
+    <string name="error_message_show_exact">显示具体错误</string>
     <string name="keygen_error_timeout_title">连接超时</string>
     <string name="keygen_error_timeout_description">未能及时连接到服务器。请检查您的网络连接并重试。</string>
     <string name="keygen_error_network_title">连接问题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,7 +200,6 @@
     <string name="verify_transaction_consent_address">I’m sending to the right address</string>
     <string name="verify_transaction_consent_amount">The amount is correct</string>
     <string name="verify_transaction_error_not_enough_consent">Please check all consents</string>
-    <string name="camera_permission_denied">Camera permission not granted. Please, enable it in the settings.</string>
     <string name="camera_permission_open_settings">Open Settings</string>
     <string name="join_keysign_discovering_session_id">Discovering Session ID</string>
     <string name="transaction_done_title">Done</string>
@@ -578,6 +577,22 @@
     <string name="enter_email_screen_next">Next</string>
     <string name="error_view_default_title">Something went wrong</string>
     <string name="error_view_default_description">An error occurred</string>
+    <!-- Friendly error screen (issue #4996) -->
+    <string name="signing_error_transaction_failed_title">Transaction failed</string>
+    <string name="signing_error_transaction_failed_description">One of your devices didn\'t respond in time. Check your connection and try again.</string>
+    <string name="error_insufficient_funds_title">Insufficient funds</string>
+    <string name="error_same_vault_share_title">Same vault share</string>
+    <string name="error_same_vault_share_description">Please change the share to sign. Two devices cannot use the same vault share for co-signing.</string>
+    <string name="error_vault_not_loaded_title">Vault is not loaded</string>
+    <string name="error_vault_not_loaded_description">Please import the correct share.</string>
+    <string name="error_vault_name_in_use_title">Vault name already in use</string>
+    <string name="error_vault_name_in_use_description">Please choose a different Vault name.</string>
+    <string name="error_camera_permission_title">Camera permission not granted</string>
+    <string name="error_camera_permission_description">Camera permission is required to proceed. Please enable it in Settings.</string>
+    <string name="error_message_sheet_title">Error message</string>
+    <string name="error_message_copy">Copy</string>
+    <string name="error_message_report_bug">Report Bug</string>
+    <string name="error_message_show_exact">Show exact error</string>
     <string name="keygen_error_timeout_title">Connection timed out</string>
     <string name="keygen_error_timeout_description">Couldn\'t reach the server in time. Check your connection and try again.</string>
     <string name="keygen_error_network_title">Connection problem</string>


### PR DESCRIPTION
## Summary

Redesigns the shared full-screen error UX to match the new Figma (CW 24/25). Instead of dumping a raw exception as the primary message, the screen now leads with a **human-readable title + fix-it action** and tucks the technical trace one tap away behind a copyable / reportable disclosure.

Closes #4996.

## What changed

- **`ErrorView` redesigned** — neutral title + subtitle, concentric-circle hero with **red-✕ (critical)** / **amber-⚠ (warning)** icon variants, a **"Show exact error"** disclosure card, and a bottom-pinned primary CTA.
- **`ErrorMessageBottomSheet` (new)** — full-screen sheet with the scrollable raw trace, **Copy** (clipboard) and **Report Bug** (copies the trace, then opens the Vultisig Discord support channel).
- **`ErrorUiModel`** gains `errorState` + `rawError`.
- **Error catalogue** maps real triggers across flows to the 8 named cases:
  - **Transaction failed** (✕) — generic keysign failure / device timeout / blockhash
  - **Insufficient funds** (⚠) — keysign insufficient funds
  - **Same vault share** (⚠) — `JoinKeysignError.WrongVaultShare`
  - **Vault is not loaded** (⚠) — `WrongVault` / `MissingRequiredVault`
  - **Network unstable** (⚠) — keygen `NetworkErrorKind.Timeout` / `NoConnectivity`
  - **Vault name already in use** (⚠) — `JoinKeygenError.DuplicateVaultName`
  - **Seed phrase already imported** (⚠) — `DuplicateVaultException` (KeyImport)
  - **Camera permission not granted** (⚠) — scan permission denial
- Swap/Send **execution** failures flow through the redesigned keysign error screen; inline as-you-type form validation is unchanged.
- `error_critical` icon switched to a cross per Figma.
- 15 new strings across all 10 locales; removed the now-orphaned `camera_permission_denied`.

## Screenshots

| Error screen | Error message sheet |
|--------------|---------------------|
| ![error screen](https://i.imgur.com/7vj3Bip.png) | ![error message sheet](https://i.imgur.com/NKLrSUc.png) |

## Test plan

- [x] `:app:compileDebugKotlin` builds (offline)
- [x] ktfmt formatted
- [x] Rendered on emulator via `PreviewActivity` (`error_screen_after`) — see screenshots
- [ ] Manual smoke: trigger a real keysign/keygen/import/camera error and confirm friendly copy + Show exact error → Copy / Report Bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to view and copy detailed error messages for troubleshooting
  * Introduced "Show exact error" feature for technical error details
  * Enhanced error screens with improved messaging and categorization

* **Improvements**
  * Updated error messaging for better clarity across various scenarios
  * Improved camera permission error messaging
  * Added multilingual error message support across 10+ languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->