### PR TITLE
fix(banner): single dismiss motion on swipe-to-dismiss (#5001)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -172,6 +172,7 @@ private fun MainActivityContent(
                         qrCodeData = notification.qrCodeData,
                         vaultName = notification.vaultName,
                         transactionSummary = notification.transactionSummary,
+                        isActive = foregroundNotification != null,
                         onTap = onBannerTap,
                         onDismiss = onBannerDismiss,
                     )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
@@ -83,6 +83,7 @@ internal fun ForegroundNotificationBanner(
     qrCodeData: String,
     vaultName: String,
     transactionSummary: UiText,
+    isActive: Boolean,
     onTap: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
@@ -97,9 +98,12 @@ internal fun ForegroundNotificationBanner(
     val offsetX = remember { Animatable(0f) }
     val scope = rememberCoroutineScope()
 
-    // Reset any residual swipe offset when a new (or re-shown) request is bound,
-    // so a previously dismissed banner doesn't reappear off-screen.
-    LaunchedEffect(qrCodeData) { offsetX.snapTo(0f) }
+    // Re-center only when a live request (re)enters. A new or re-broadcast push produces a fresh
+    // state instance, so `isActive` flips true and resets any residual swipe offset. Crucially we
+    // do NOT reset on dismissal: after a successful swipe the banner must stay off-screen while the
+    // parent's vertical exit transition plays out, otherwise the snap-back rides that exit and the
+    // banner visibly re-centers then slides up (#5001).
+    LaunchedEffect(qrCodeData, isActive) { if (isActive) offsetX.snapTo(0f) }
 
     Box(
         modifier =
@@ -120,12 +124,11 @@ internal fun ForegroundNotificationBanner(
                                         if (offsetX.value > 0) size.width.toFloat()
                                         else -size.width.toFloat()
                                     offsetX.animateTo(target)
+                                    // Leave the banner off-screen and clear the request; the
+                                    // retained offset keeps it hidden through the parent's vertical
+                                    // exit transition. The LaunchedEffect above re-centers it only
+                                    // when a fresh request next (re)enters.
                                     onDismiss()
-                                    // Reset the retained offset: when the same signing session
-                                    // re-broadcasts, MainActivityContent reuses this subtree
-                                    // (keyed by qrCodeData), so LaunchedEffect(qrCodeData) won't
-                                    // re-fire and the banner would otherwise reappear off-screen.
-                                    offsetX.snapTo(0f)
                                 } else {
                                     offsetX.animateTo(0f)
                                 }
@@ -214,6 +217,7 @@ private fun ForegroundNotificationBannerPreview() {
         qrCodeData = "preview",
         vaultName = "Vault #2",
         transactionSummary = UiText.DynamicString("Swap 10 ETH → USDC"),
+        isActive = true,
         onTap = {},
         onDismiss = {},
     )


### PR DESCRIPTION
## Summary

Fixes #5001 — the foreground "Join transaction" notification banner double-animated when swiped away. After the horizontal swipe-to-dismiss flicked the banner off-screen, it **re-appeared centered and slid upward** before disappearing.

## Root cause

Two independent dismiss animations were firing, plus an offset reset that re-centered the banner mid-exit:

1. The horizontal swipe animated `offsetX` off-screen (`ForegroundNotificationBanner.kt`).
2. `onDismiss()` cleared the state, flipping the parent `AnimatedVisibility` to its vertical `slideOutVertically { -it }` exit (`MainActivityContent.kt`). The banner subtree keeps composing for the exit's duration.
3. `offsetX.snapTo(0f)` then **re-centered** the still-composing banner, so it rode the vertical exit back into view.

Net: horizontal flick → re-center → vertical slide-up.

## Fix

Drive the offset reset off "is there a live request" instead of an inline post-dismiss snap:

- Removed the inline `offsetX.snapTo(0f)`. After a successful swipe the banner now stays off-screen, so the parent's vertical exit transition plays out invisibly — a single, consistent motion in the swipe direction.
- Reset the offset only on (re)entry: `LaunchedEffect(qrCodeData, isActive) { if (isActive) offsetX.snapTo(0f) }`, with `isActive = foregroundNotification != null` passed from `MainActivityContent`.

This preserves the re-broadcast guard the old inline snap provided: a new or re-broadcast push produces a fresh `ForegroundNotificationState` instance, flipping `isActive` true, which re-centers the banner before it re-enters. Crucially the reset never fires during the exit, so the glitch is gone.

## Test plan

- [ ] Trigger the foreground signing banner (join a transaction).
- [ ] Swipe horizontally past ~35% of its width — banner slides off in the swipe direction in a single motion, with no re-center or vertical slide-up.
- [ ] Swipe below the threshold — banner springs back to center.
- [ ] Receive a new signing request after dismissing — banner re-appears centered and slides in normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced foreground notification banner dismissal behavior—the banner now correctly remains dismissed after swiping until a new notification arrives, improving the experience during screen transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->