### PR TITLE
fix(swap): send TON.TON for native GRAM coin in SwapKit quotes

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.repositories.swap
 
+import androidx.annotation.VisibleForTesting
 import com.vultisig.wallet.data.api.errors.SwapKitError
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
@@ -879,13 +880,22 @@ constructor(
                 ?: throw SwapKitError.NoRoutes(
                     "SwapKit asset identifier missing chain prefix for ${coin.chain.raw}"
                 )
-        val ticker = coin.ticker
+        val ticker = swapSymbol(coin)
         return if (coin.isNativeToken || coin.contractAddress.isBlank()) {
             "$prefix.$ticker"
         } else {
             "$prefix.$ticker-${coin.contractAddress}"
         }
     }
+
+    /**
+     * SwapKit lists the native TON asset as "TON"; the Toncoin → GRAM rebrand (#4984) renamed only
+     * the display ticker, so a GRAM-ticker'd native must still swap as TON. Mirrors iOS'
+     * `SwapKitService.swapSymbol(chain:ticker:isNativeToken:)`.
+     */
+    @VisibleForTesting
+    internal fun swapSymbol(coin: Coin): String =
+        if (coin.chain == Chain.Ton && coin.isNativeToken) "TON" else coin.ticker
 
     private fun chainPrefix(chain: Chain): String? =
         when (chain) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -639,6 +639,62 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `swapSymbol maps the GRAM-ticker'd native TON coin back to the TON protocol symbol`() {
+        // After the Toncoin -> GRAM rebrand (#4984) the native coin's display ticker is "GRAM", but
+        // SwapKit only knows the native TON asset as "TON" — sending GRAM yields noRoutesFound for
+        // TON.GRAM -> .... Mirrors iOS' SwapKitService.swapSymbol (vultisig-ios#4629).
+        val gram = tonCoin().copy(ticker = "GRAM")
+
+        assertEquals("TON", source().swapSymbol(gram))
+    }
+
+    @Test
+    fun `swapSymbol leaves an already-TON native TON coin unchanged`() {
+        assertEquals("TON", source().swapSymbol(tonCoin()))
+    }
+
+    @Test
+    fun `swapSymbol leaves a non-native TON jetton ticker unchanged`() {
+        // The remap is native-only: a TON jetton (e.g. USDT) keeps its own ticker so the
+        // CHAIN.TICKER-CONTRACT identifier still resolves.
+        val usdtJetton =
+            tonCoin()
+                .copy(
+                    ticker = "USDT",
+                    isNativeToken = false,
+                    contractAddress = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sD",
+                )
+
+        assertEquals("USDT", source().swapSymbol(usdtJetton))
+    }
+
+    @Test
+    fun `swapSymbol leaves non-TON native coins unchanged`() {
+        assertEquals("ETH", source().swapSymbol(ethCoin()))
+        assertEquals("BTC", source().swapSymbol(btcCoin()))
+    }
+
+    @Test
+    fun `fetch sends TON-TON sellAsset for the GRAM-ticker'd native TON coin`() = runTest {
+        // End-to-end pin of the noRoutesFound fix: a GRAM-ticker'd native must hit the wire as
+        // TON.TON, not TON.GRAM.
+        every { config.isFeatureEnabled } returns flowOf(true)
+
+        val captured = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(captured)) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r", providers = listOf("CHAINFLIP"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        val gram = tonCoin().copy(ticker = "GRAM")
+        source().fetch(request(srcToken = gram))
+
+        assertEquals("TON.TON", captured.captured.sellAsset)
+    }
+
+    @Test
     fun `fetch passes affiliateBps from the request through to the SwapKit quote call`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
 


### PR DESCRIPTION
## Summary
SwapKit swaps for the native TON-chain coin fail with `noRoutesFound` after the Toncoin → GRAM rebrand (#4984). The quote request sent the display ticker `GRAM` as the SwapKit asset symbol, but SwapKit only knows the native TON asset as `TON`:

```
SwapKitError$NoRoutes: {"error":"noRoutesFound","message":"No routes found for TON.GRAM -> TON.USDT-EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs", ...}
```

The asset id must be `TON.TON`, not `TON.GRAM`.

## Root cause
`data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt` → `assetIdentifier(coin: Coin)` built the symbol part from `coin.ticker` (now `GRAM`). The chain prefix (`chainPrefix(Chain.Ton)` → `"TON"`) was already correct — only the symbol leaked the display ticker onto the wire request. `TON` is a third-party/protocol identifier SwapKit still uses; #4984 deliberately kept SwapKit/Banxa codes as `TON` and renamed only the display ticker.

## Fix
- Added a native-only helper `swapSymbol(coin)` that maps the native TON coin back to its `TON` protocol symbol; all other coins (including TON jettons) keep `coin.ticker`.
- Used `swapSymbol(coin)` instead of `coin.ticker` in both return branches of `assetIdentifier`.
- No change to the coin's display ticker (stays `GRAM`), `priceProviderID`, decimals, or the `Chain.Ton` enum. SwapKit-only — the THORChain native-quote path (derives from chain ticker) and EVM aggregators are untouched.

Mirrors the iOS fix in vultisig-ios#4629 (`SwapKitService.swapSymbol(chain:ticker:isNativeToken:)`).

Closes #5009
Cross-platform: vultisig-ios#4629

## Test Plan
Added 5 unit tests to `SwapKitQuoteSourceTest`:
- native TON coin (ticker `GRAM`, isNative) → `TON`
- native TON coin already `TON` → `TON`
- non-native TON jetton (USDT, with contract) → `USDT` (unchanged)
- ETH/BTC natives → unchanged
- end-to-end `fetch` pins the wire request `sellAsset` = `TON.TON` for a GRAM-ticker'd native

## Build / verification
Ran locally and green in this dev env:
- `./gradlew :data:testDebugUnitTest --tests '*SwapKitQuoteSourceTest*'` → BUILD SUCCESSFUL (all 5 new tests pass)
- `./gradlew :data:ktfmtCheck` → BUILD SUCCESSFUL

The full app build (`assembleDebug`/`lint`) requires `wallet-core` from GitHub Packages (a valid `TRUSTWALLET_PAT`); the `:data` unit-test path did not need it here. CI should run the complete build/lint to be safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TON native token identification in swap quotes. GRAM-branded native tokens on the TON chain now correctly resolve to the TON protocol identifier, ensuring accurate and consistent swap quote processing.

* **Tests**
  * Added comprehensive unit tests validating TON native token ticker normalization, protocol identifier mapping, and swap asset encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->