### PR TITLE
fix(peer-discovery): center resend pill and refine notification-sent copy

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -296,6 +296,7 @@ internal fun PeerDiscoveryScreen(
 
                     Column(
                         modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(24.dp),
                     ) {
                         WaitingForDevicesHeader()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -367,7 +367,7 @@
         <item quantity="one">%1$d von %2$d Tresoren aktualisiert, %3$d fehlgeschlagen</item>
         <item quantity="other">%1$d von %2$d Tresoren aktualisiert, %3$d fehlgeschlagen</item>
     </plurals>
-    <string name="push_notifications_sent">Benachrichtigung erfolgreich gesendet</string>
+    <string name="push_notifications_sent">Benachrichtigung erfolgreich gesendet!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Erhalten Sie eine Benachrichtigung, wenn Ihre Unterschrift erforderlich ist oder ein Gerät Zugriff anfordert.</string>
     <string name="keysign_notification_channel_name">Keysign-Anfragen</string>
     <string name="keysign_notification_title">Transaktion signieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -367,7 +367,7 @@
         <item quantity="one">%1$d de %2$d bóveda actualizada, %3$d fallida</item>
         <item quantity="other">%1$d de %2$d bóvedas actualizadas, %3$d fallidas</item>
     </plurals>
-    <string name="push_notifications_sent">Notificación enviada correctamente</string>
+    <string name="push_notifications_sent">¡Notificación enviada correctamente!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Recibe una notificación cuando se requiera tu firma o un dispositivo solicite acceso.</string>
     <string name="keysign_notification_channel_name">Solicitudes de firma</string>
     <string name="keysign_notification_title">Firmar transacción</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -368,7 +368,7 @@
         <item quantity="few">%1$d od %2$d trezora ažurirano, %3$d neuspješno</item>
         <item quantity="other">%1$d od %2$d trezora ažurirano, %3$d neuspješno</item>
     </plurals>
-    <string name="push_notifications_sent">Obavijest je uspješno poslana</string>
+    <string name="push_notifications_sent">Obavijest je uspješno poslana!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Primite obavijest kada je potreban vaš potpis ili uređaj zatraži pristup.</string>
     <string name="keysign_notification_channel_name">Zahtjevi za potpisivanje</string>
     <string name="keysign_notification_title">Potpiši transakciju</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -367,7 +367,7 @@
         <item quantity="one">%1$d cassaforti su %2$d aggiornate, %3$d non riuscite</item>
         <item quantity="other">%1$d cassaforti su %2$d aggiornate, %3$d non riuscite</item>
     </plurals>
-    <string name="push_notifications_sent">Notifica inviata con successo</string>
+    <string name="push_notifications_sent">Notifica inviata con successo!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Ricevi una notifica quando è richiesta la tua firma o un dispositivo richiede l\'accesso.</string>
     <string name="keysign_notification_channel_name">Richieste di firma</string>
     <string name="keysign_notification_title">Firma transazione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -11,7 +11,7 @@
     <plurals name="push_notification_partial_failure">
         <item quantity="other">%1$d / %2$d 볼트 업데이트됨, %3$d 실패</item>
     </plurals>
-    <string name="push_notifications_sent">알림이 성공적으로 전송되었습니다</string>
+    <string name="push_notifications_sent">알림이 성공적으로 전송되었습니다!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">서명이 필요하거나 기기가 접근을 요청할 때 알림을 받으세요.</string>
     <string name="keysign_notification_channel_name">서명 요청</string>
     <string name="keysign_notification_title">거래 서명</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -366,7 +366,7 @@
         <item quantity="one">%1$d van %2$d kluizen bijgewerkt, %3$d mislukt</item>
         <item quantity="other">%1$d van %2$d kluizen bijgewerkt, %3$d mislukt</item>
     </plurals>
-    <string name="push_notifications_sent">Melding succesvol verzonden</string>
+    <string name="push_notifications_sent">Melding succesvol verzonden!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Ontvang een melding wanneer uw handtekening vereist is of een apparaat toegang aanvraagt.</string>
     <string name="keysign_notification_channel_name">Ondertekeningsverzoeken</string>
     <string name="keysign_notification_title">Transactie ondertekenen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -367,7 +367,7 @@
         <item quantity="one">%1$d de %2$d cofres atualizados, %3$d falhou</item>
         <item quantity="other">%1$d de %2$d cofres atualizados, %3$d falharam</item>
     </plurals>
-    <string name="push_notifications_sent">Notificação enviada com sucesso</string>
+    <string name="push_notifications_sent">Notificação enviada com sucesso!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Receba uma notificação quando a sua assinatura for necessária ou um dispositivo solicitar acesso.</string>
     <string name="keysign_notification_channel_name">Solicitações de assinatura</string>
     <string name="keysign_notification_title">Assinar transação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -368,7 +368,7 @@
         <item quantity="many">Обновлено %1$d из %2$d хранилищ, %3$d не удалось</item>
         <item quantity="other">Обновлено %1$d из %2$d хранилищ, %3$d не удалось</item>
     </plurals>
-    <string name="push_notifications_sent">Уведомление успешно отправлено</string>
+    <string name="push_notifications_sent">Уведомление успешно отправлено!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Получайте уведомления, когда требуется ваша подпись или устройство запрашивает доступ.</string>
     <string name="keysign_notification_channel_name">Запросы на подписание</string>
     <string name="keysign_notification_title">Подписать транзакцию</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@
     <plurals name="push_notification_partial_failure">
         <item quantity="other">已更新 %2$d 个保险库中的 %1$d 个，%3$d 个失败</item>
     </plurals>
-    <string name="push_notifications_sent">通知发送成功</string>
+    <string name="push_notifications_sent">通知发送成功！</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">当需要您的签名或设备请求访问时，您将收到通知。</string>
     <string name="keysign_notification_channel_name">签名请求</string>
     <string name="keysign_notification_title">签署交易</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
         <item quantity="one">%1$d of %2$d vaults updated, %3$d failed</item>
         <item quantity="other">%1$d of %2$d vaults updated, %3$d failed</item>
     </plurals>
-    <string name="push_notifications_sent">Notification sent successfully</string>
+    <string name="push_notifications_sent">Notification was successfully sent!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Get notified when your signature is required or a device requests access.</string>
     <string name="keysign_notification_channel_name">Keysign Requests</string>
     <string name="keysign_notification_title">Sign transaction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
         <item quantity="one">%1$d of %2$d vaults updated, %3$d failed</item>
         <item quantity="other">%1$d of %2$d vaults updated, %3$d failed</item>
     </plurals>
-    <string name="push_notifications_sent">Notification was successfully sent!</string>
+    <string name="push_notifications_sent">Notification sent successfully!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Get notified when your signature is required or a device requests access.</string>
     <string name="keysign_notification_channel_name">Keysign Requests</string>
     <string name="keysign_notification_title">Sign transaction</string>


### PR DESCRIPTION
## Summary
- Center the **Resend notification** pill horizontally on the Scan QR (peer discovery) screen. The inner column used `fillMaxWidth()` without a `horizontalAlignment`, so the wrap-content pill fell back to `Start` and rendered left-aligned, while the full-width header and device cards looked centered.
- Update the `push_notifications_sent` copy to **"Notification was successfully sent!"** across all 10 locales, matching each locale's established phrasing (e.g. Spanish `¡…!`, Chinese full-width `！`).

## Changes
| Property | Before | After |
|----------|--------|-------|
| Resend pill horizontal alignment | `Start` (default) | `CenterHorizontally` |
| `push_notifications_sent` (en) | Notification sent successfully | Notification was successfully sent! |

## Test Plan
- [ ] Resend pill is horizontally centered on the Scan QR screen
- [ ] Notification toast/banner reads "Notification was successfully sent!"
- [ ] No regression to the waiting header or device cards (still full width)
- [ ] All locale strings render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment of the peer discovery screen layout for better visual consistency.

* **Style**
  * Updated the push notification success message text across all supported languages to include exclamation marks for clearer emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->