### PR TITLE
fix(swap): charge VULT-discounted LiFi integrator fee on Solana routes

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
@@ -93,10 +93,6 @@ constructor(
                         BigDecimal(it).movePointLeft(4).stripTrailingZeros().toPlainString(),
                     )
                 }
-                // Always collect the (VULT-discounted) integrator fee, Solana routes included.
-                // LI.FI rejected the `integrator`/`fee` params on Solana routes when Solana support
-                // landed (#1535, Jan 2025), so they were omitted there; LI.FI has since added fee
-                // support for Solana, so the fee + discount now apply uniformly across all chains.
                 parameter("integrator", LiFiChainApi.INTEGRATOR_ACCOUNT)
                 parameter("fee", updatedFeeIntegrator)
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
@@ -2,8 +2,6 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteError
-import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.oneInchChainId
 import com.vultisig.wallet.data.utils.LiFiSwapQuoteResponseSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -69,10 +67,6 @@ constructor(
         bpsDiscount: Int,
         slippageBps: Int?,
     ): LiFiSwapQuoteDeserialized {
-        val isSolanaChainInvolved =
-            fromChain.toLong() == Chain.Solana.oneInchChainId() ||
-                toChain.toLong() == Chain.Solana.oneInchChainId()
-
         val bpsDiscountFee = round(bpsDiscount.toDouble()) / LiFiChainApi.BPS_DENOMINATOR_INT
         val updatedFeeIntegrator =
             (round(
@@ -99,10 +93,12 @@ constructor(
                         BigDecimal(it).movePointLeft(4).stripTrailingZeros().toPlainString(),
                     )
                 }
-                if (!isSolanaChainInvolved) {
-                    parameter("integrator", LiFiChainApi.INTEGRATOR_ACCOUNT)
-                    parameter("fee", updatedFeeIntegrator)
-                }
+                // Always collect the (VULT-discounted) integrator fee, Solana routes included.
+                // LI.FI rejected the `integrator`/`fee` params on Solana routes when Solana support
+                // landed (#1535, Jan 2025), so they were omitted there; LI.FI has since added fee
+                // support for Solana, so the fee + discount now apply uniformly across all chains.
+                parameter("integrator", LiFiChainApi.INTEGRATOR_ACCOUNT)
+                parameter("fee", updatedFeeIntegrator)
             }
         return try {
             json.decodeFromString(liFiSwapQuoteResponseSerializer, response.bodyAsText())

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiImplRequestTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiImplRequestTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.utils.LiFiSwapQuoteResponseSerializerImpl
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlin.test.assertContains
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins that the LI.FI quote request always carries the integrator + (VULT-discounted) fee params,
+ * including on Solana-involving routes. LI.FI rejected those params on Solana when Solana support
+ * first landed (#1535); it now supports them, so the affiliate fee + discount apply uniformly.
+ */
+class LiFiChainApiImplRequestTest {
+
+    // Arbitrum / Solana LI.FI (1inch-style) chain ids.
+    private val arbitrumChainId = "42161"
+    private val solanaChainId = "1151111081099710"
+
+    @Test
+    fun `sends integrator and fee on a Solana-destination route`() = runBlocking {
+        val url = captureQuoteUrl(toChain = solanaChainId, bpsDiscount = 0)
+
+        assertContains(url, "integrator=vultisig-android")
+        // 50 bps, no discount -> fee fraction 0.005.
+        assertContains(url, "fee=0.005")
+    }
+
+    @Test
+    fun `applies the VULT discount to the fee on a Solana route`() = runBlocking {
+        val url = captureQuoteUrl(toChain = solanaChainId, bpsDiscount = 20)
+
+        assertContains(url, "integrator=vultisig-android")
+        // 50 bps - 20 bps discount -> 30 bps -> fee fraction 0.003.
+        assertContains(url, "fee=0.003")
+    }
+
+    private suspend fun captureQuoteUrl(toChain: String, bpsDiscount: Int): String {
+        lateinit var requestedUrl: String
+        val json = Json { ignoreUnknownKeys = true }
+        val engine = MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(content = "", status = HttpStatusCode.OK)
+        }
+        val api =
+            LiFiChainApiImpl(HttpClient(engine), LiFiSwapQuoteResponseSerializerImpl(json), json)
+
+        api.getSwapQuote(
+            fromChain = arbitrumChainId,
+            toChain = toChain,
+            fromToken = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+            toToken = "SOL",
+            fromAmount = "2000000",
+            fromAddress = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+            toAddress = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+            bpsDiscount = bpsDiscount,
+            slippageBps = null,
+        )
+        return requestedUrl
+    }
+}


### PR DESCRIPTION
Fixes #5012

## Problem

LiFi swaps that involve **Solana** were not charging the Vultisig integrator fee, and VULT holders got **no discount** on those routes — while EVM and native THOR/Maya swaps did. This is the LiFi side of #5012.

Root cause: `LiFiChainApiImpl.getSwapQuote()` omitted the `integrator`/`fee` params whenever Solana was the source or destination:

```kotlin
if (!isSolanaChainInvolved) {
    parameter("integrator", INTEGRATOR_ACCOUNT)
    parameter("fee", updatedFeeIntegrator)
}
```

That guard was added in **#1535 (Jan 2025)** because LiFi *rejected* those params on Solana routes at the time. A side effect: the UI still computed and displayed a ~0.5% fee via `integratorFeeAmount()` that was never actually collected (a display/charge mismatch).

## Fix

**LiFi now supports integrator fees on Solana routes** — verified against the live `li.quest/v1/quote` API: with `integrator=vultisig-android&fee=…` on USDC(Arbitrum)→SOL(Solana), the quote's `LIFI Fixed Fee` scales exactly with the fee param (and with the discount). So the 2025 limitation no longer applies.

This PR **removes the Solana guard** so the integrator fee — reduced by the VULT discount — is sent on **every** route, identical to EVM behavior:
- Solana LiFi swaps now charge the affiliate fee (recovering revenue).
- VULT holders get their tier discount on Solana, at parity with EVM/native (addresses #5012's intent).
- The displayed fee now matches what is actually collected.

## Test plan

- [x] `:data:testDebugUnitTest` — new `LiFiChainApiImplRequestTest` (MockEngine) pins that `integrator`/`fee` are sent on a Solana-destination route and that `fee` reflects the VULT discount (50bps→0.005; Gold −20bps→0.003). Existing `LiFiChainApiIntegratorFeeTest` still green.
- [x] `:app:compileDebugKotlin` green; ktfmt clean.
- [x] Live `li.quest` quote API confirms the fee param is honored on EVM→Solana and scales with the discount.
- [ ] **Mainnet device verification (remaining):** run an EVM→SOL LiFi swap and confirm (a) the quote still signs/broadcasts with the fee present, and (b) the affiliate fee actually settles. Before/after screenshots to follow.

## Jupiter (Solana) half — out of scope, infrastructure-blocked

The other half of #5012 (apply the VULT discount to Jupiter/Solana swaps) cannot be done as a client code change today, and is being tracked/closed as infra-and-product work rather than left open:

- Jupiter currently charges **no** Vultisig fee on either Android or iOS — `JupiterApi` sends no `platformFeeBps`/`feeAccount`, and iOS' Jupiter quote endpoint has none either. With no baseline fee there is nothing to discount (the issue's "0 bps at Ultimate" presupposes a fee that doesn't exist).
- Introducing one requires Jupiter's platform-fee mechanism: a real **Vultisig-owned Solana fee-collection account** + a token account (ATA) **per fee mint**, `platformFeeBps` on the quote + `feeAccount` on the swap, and almost certainly a change to the `api.vultisig.com/jup` backend proxy.
- That's on-chain infrastructure + a product/business decision (whether to monetize Solana, which account collects), not something safe to fabricate in this client PR.

So this PR resolves the **LiFi non-EVM** portion of #5012; the **Jupiter** portion is deferred to dedicated infra/product work.

**Side-finding (separate ticket):** 1inch is in `GetDiscountBpsUseCase.supportedProviders` and is passed `bpsDiscount`, but `OneInchQuoteSource` never reads it — the 1inch discount may itself be a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated swap quote requests so LI.FI `integrator` and fee parameters are consistently included, ensuring Solana-based routes receive the same fee/discount behavior as other supported chains.
* **Tests**
  * Added coverage to verify outgoing quote URLs include the expected `integrator` and `fee` values, including correct discount application for Solana-destination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
