### PR TITLE
fix(qbtc): gate claim co-sign behind an explicit approval screen (#5019)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -207,11 +207,34 @@ sealed interface JoinKeysignState {
     data object Keysign : JoinKeysignState
 
     /**
+     * QBTC claim co-sign approval gate: shown after the pairing QR is scanned and before any
+     * signing starts, so the co-signer reviews the accounts being claimed against and explicitly
+     * approves. Confirming routes through [JoinKeysignViewModel.joinKeysign].
+     */
+    data class QbtcClaimConsent(val btcAddress: String, val qbtcAddress: String) : JoinKeysignState
+
+    /**
      * QBTC claim co-sign: [txHash] null while signing, set once the initiator pushes the result.
      */
     data class QbtcClaim(val txHash: String?, val totalSats: Long?) : JoinKeysignState
 
     data class Error(val errorType: JoinKeysignError) : JoinKeysignState
+}
+
+/**
+ * Builds the QBTC claim approval gate from a vault's [coins]. A vault missing the Bitcoin or QBTC
+ * account it needs to recompute the claim hash resolves to a
+ * [JoinKeysignError.MissingQbtcClaimAccount] error state — surfaced here, before signing, rather
+ * than mid-co-sign.
+ */
+internal fun buildQbtcClaimConsentState(coins: List<Coin>): JoinKeysignState {
+    val btc = coins.firstOrNull { it.chain == Chain.Bitcoin }
+    val qbtc = coins.firstOrNull { it.chain == Chain.Qbtc }
+    return if (btc == null || qbtc == null) {
+        JoinKeysignState.Error(JoinKeysignError.MissingQbtcClaimAccount)
+    } else {
+        JoinKeysignState.QbtcClaimConsent(btcAddress = btc.address, qbtcAddress = qbtc.address)
+    }
 }
 
 internal sealed class VerifyUiModel {
@@ -432,7 +455,7 @@ constructor(
                         }
                     }
                     if (_keysignPayload?.isQbtcClaim == true) {
-                        startQbtcClaimCosign()
+                        showQbtcClaimConsent()
                     } else {
                         _currentState.value = JoinKeysignState.JoinKeysign
                     }
@@ -937,6 +960,16 @@ constructor(
     }
 
     /**
+     * Shows the QBTC claim approval gate. The claim hash is recomputed locally from this vault's
+     * own Bitcoin + QBTC accounts during the co-sign (never trusted from the QR), so the gate
+     * surfaces those two accounts for review before any signing starts. A vault missing either
+     * account fails here — before signing — instead of mid-co-sign.
+     */
+    private fun showQbtcClaimConsent() {
+        _currentState.value = buildQbtcClaimConsentState(_currentVault.coins)
+    }
+
+    /**
      * Drives the QBTC claim co-sign: flips into [JoinKeysignState.QbtcClaim], delegates the suspend
      * co-sign work to [qbtcClaimCosign], then surfaces the broadcast result. A missing Bitcoin/QBTC
      * account maps to [JoinKeysignError.MissingQbtcClaimAccount]; any other failure to
@@ -970,6 +1003,12 @@ constructor(
     }
 
     fun joinKeysign() {
+        // A QBTC claim has no relay keysign session to join — confirming the approval gate kicks
+        // off the local co-sign instead. startQbtcClaimCosign() owns its own join guard.
+        if (_keysignPayload?.isQbtcClaim == true) {
+            startQbtcClaimCosign()
+            return
+        }
         if (!isJoiningKeysign.compareAndSet(false, true)) return
         viewModelScope.safeLaunch {
             withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -3,17 +3,37 @@ package com.vultisig.wallet.ui.screens.keysign
 import android.content.Context
 import android.net.nsd.NsdManager
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.errors.ErrorState
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
@@ -26,6 +46,7 @@ import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.Error
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.JoinKeysign
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.Keysign
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.QbtcClaim
+import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.QbtcClaimConsent
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignState.WaitingForKeysignStart
 import com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignState
@@ -34,6 +55,7 @@ import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.sign.VerifySignMessageScreen
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
+import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
 @Composable
@@ -147,6 +169,15 @@ internal fun JoinKeysignView() {
 
             JoinKeysign -> Unit // handled above, before the JoinKeysignScreen wrapper
 
+            is QbtcClaimConsent -> {
+                val consent = state as QbtcClaimConsent
+                QbtcClaimConsentContent(
+                    btcAddress = consent.btcAddress,
+                    qbtcAddress = consent.qbtcAddress,
+                    onApprove = viewModel::joinKeysign,
+                )
+            }
+
             is QbtcClaim -> {
                 val claim = state as QbtcClaim
                 KeysignLoadingScreen(
@@ -234,6 +265,79 @@ internal fun JoinKeysignView() {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun QbtcClaimConsentContent(
+    btcAddress: String,
+    qbtcAddress: String,
+    onApprove: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = stringResource(R.string.qbtc_claim_cosign_description),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.secondary,
+        )
+
+        UiSpacer(size = 24.dp)
+
+        val shape = RoundedCornerShape(16.dp)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .clip(shape)
+                    .background(Theme.v2.colors.backgrounds.surface1)
+                    .border(1.dp, Theme.v2.colors.border.light, shape)
+                    .padding(16.dp),
+        ) {
+            QbtcClaimAccountRow(
+                logo = painterResource(R.drawable.bitcoin),
+                label = stringResource(R.string.qbtc_claim_cosign_btc_account),
+                address = btcAddress,
+            )
+            QbtcClaimAccountRow(
+                logo = painterResource(R.drawable.qbtc),
+                label = stringResource(R.string.qbtc_claim_cosign_qbtc_account),
+                address = qbtcAddress,
+            )
+        }
+
+        UiSpacer(weight = 1f)
+
+        VsButton(
+            label = stringResource(R.string.qbtc_claim_cosign_approve),
+            onClick = onApprove,
+            modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+        )
+    }
+}
+
+@Composable
+private fun QbtcClaimAccountRow(logo: Painter, label: String, address: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Image(
+                painter = logo,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp).clip(RoundedCornerShape(50)),
+            )
+            Text(
+                text = label,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
+        Text(
+            text = address,
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.primary,
+        )
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1325,6 +1325,10 @@
     <string name="qbtc_claim_banner_subtitle">Dasselbe Bitcoin. Quantensicher.</string>
     <string name="qbtc_claim_banner_title">Rufen Sie Ihr QBTC ab</string>
     <string name="qbtc_claim_banner_cta">Jetzt abrufen</string>
+    <string name="qbtc_claim_cosign_description">Ein anderes Gerät hat einen QBTC-Abruf gestartet. Mit dem Genehmigen signieren Sie ihn mit Ihrem Bitcoin-Schlüssel mit. Überprüfen Sie die folgenden Konten, bevor Sie fortfahren.</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin-Konto</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC-Konto</string>
+    <string name="qbtc_claim_cosign_approve">Genehmigen &amp; mitsignieren</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Einfordern</string>
     <string name="cosmos_staking_action_delegate">Staken</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1323,6 +1323,10 @@
     <string name="qbtc_claim_banner_subtitle">El mismo Bitcoin. A prueba de cuántica.</string>
     <string name="qbtc_claim_banner_title">Reclama tu QBTC</string>
     <string name="qbtc_claim_banner_cta">Reclamar ahora</string>
+    <string name="qbtc_claim_cosign_description">Otro dispositivo inició un reclamo de QBTC. Al aprobar, lo cofirmarás con tu clave de Bitcoin. Revisa las cuentas a continuación antes de continuar.</string>
+    <string name="qbtc_claim_cosign_btc_account">Cuenta de Bitcoin</string>
+    <string name="qbtc_claim_cosign_qbtc_account">Cuenta de QBTC</string>
+    <string name="qbtc_claim_cosign_approve">Aprobar y cofirmar</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Reclamar</string>
     <string name="cosmos_staking_action_delegate">Apostar</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1333,6 +1333,10 @@
     <string name="qbtc_claim_banner_subtitle">Isti Bitcoin. Kvantno-siguran.</string>
     <string name="qbtc_claim_banner_title">Preuzmite svoj QBTC</string>
     <string name="qbtc_claim_banner_cta">Preuzmi sada</string>
+    <string name="qbtc_claim_cosign_description">Drugi uređaj je pokrenuo preuzimanje QBTC-a. Odobravanjem ćete ga supotpisati svojim Bitcoin ključem. Pregledajte račune u nastavku prije nego što nastavite.</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin račun</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC račun</string>
+    <string name="qbtc_claim_cosign_approve">Odobri i supotpiši</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Preuzmi</string>
     <string name="cosmos_staking_action_delegate">Ulog</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1326,6 +1326,10 @@
     <string name="qbtc_claim_banner_subtitle">Lo stesso Bitcoin. A prova di quantistica.</string>
     <string name="qbtc_claim_banner_title">Preleva il tuo QBTC</string>
     <string name="qbtc_claim_banner_cta">Preleva ora</string>
+    <string name="qbtc_claim_cosign_description">Un altro dispositivo ha avviato un prelievo di QBTC. Approvando lo cofirmerai con la tua chiave Bitcoin. Controlla gli account qui sotto prima di continuare.</string>
+    <string name="qbtc_claim_cosign_btc_account">Account Bitcoin</string>
+    <string name="qbtc_claim_cosign_qbtc_account">Account QBTC</string>
+    <string name="qbtc_claim_cosign_approve">Approva e cofirma</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Riscatta</string>
     <string name="cosmos_staking_action_delegate">Stake</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1342,6 +1342,10 @@
     <string name="qbtc_claim_banner_subtitle">같은 Bitcoin. 양자 내성.</string>
     <string name="qbtc_claim_banner_title">QBTC를 청구하세요</string>
     <string name="qbtc_claim_banner_cta">지금 청구</string>
+    <string name="qbtc_claim_cosign_description">다른 기기에서 QBTC 청구를 시작했습니다. 승인하면 Bitcoin 키로 공동 서명합니다. 계속하기 전에 아래 계정을 확인하세요.</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin 계정</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC 계정</string>
+    <string name="qbtc_claim_cosign_approve">승인 및 공동 서명</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">청구</string>
     <string name="cosmos_staking_action_delegate">스테이킹</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1317,6 +1317,10 @@
     <string name="qbtc_claim_banner_subtitle">Dezelfde Bitcoin. Kwantumveilig.</string>
     <string name="qbtc_claim_banner_title">Claim uw QBTC</string>
     <string name="qbtc_claim_banner_cta">Nu claimen</string>
+    <string name="qbtc_claim_cosign_description">Een ander apparaat is een QBTC-claim gestart. Door goed te keuren ondertekent u deze mede met uw Bitcoin-sleutel. Controleer de onderstaande accounts voordat u doorgaat.</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin-account</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC-account</string>
+    <string name="qbtc_claim_cosign_approve">Goedkeuren en mede-ondertekenen</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Claimen</string>
     <string name="cosmos_staking_action_delegate">Staken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1321,6 +1321,10 @@
     <string name="qbtc_claim_banner_subtitle">O mesmo Bitcoin. Resistente à computação quântica.</string>
     <string name="qbtc_claim_banner_title">Resgate o seu QBTC</string>
     <string name="qbtc_claim_banner_cta">Resgatar agora</string>
+    <string name="qbtc_claim_cosign_description">Outro dispositivo iniciou um resgate de QBTC. Ao aprovar, irá coassiná-lo com a sua chave Bitcoin. Reveja as contas abaixo antes de continuar.</string>
+    <string name="qbtc_claim_cosign_btc_account">Conta Bitcoin</string>
+    <string name="qbtc_claim_cosign_qbtc_account">Conta QBTC</string>
+    <string name="qbtc_claim_cosign_approve">Aprovar e coassinar</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Reivindicar</string>
     <string name="cosmos_staking_action_delegate">Stake</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1335,6 +1335,10 @@
     <string name="qbtc_claim_banner_subtitle">Тот же Bitcoin. Квантово-устойчивый.</string>
     <string name="qbtc_claim_banner_title">Получите свой QBTC</string>
     <string name="qbtc_claim_banner_cta">Получить сейчас</string>
+    <string name="qbtc_claim_cosign_description">Другое устройство начало получение QBTC. При одобрении вы вместе подпишете его своим ключом Bitcoin. Проверьте счета ниже, прежде чем продолжить.</string>
+    <string name="qbtc_claim_cosign_btc_account">Счёт Bitcoin</string>
+    <string name="qbtc_claim_cosign_qbtc_account">Счёт QBTC</string>
+    <string name="qbtc_claim_cosign_approve">Одобрить и подписать</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Получить</string>
     <string name="cosmos_staking_action_delegate">Стейк</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1648,6 +1648,10 @@
     <string name="qbtc_claim_banner_subtitle">同样的 Bitcoin。抗量子。</string>
     <string name="qbtc_claim_banner_title">提取您的 QBTC</string>
     <string name="qbtc_claim_banner_cta">立即提取</string>
+    <string name="qbtc_claim_cosign_description">另一台设备发起了 QBTC 提取。批准后将使用您的 Bitcoin 密钥共同签署。请在继续前查看以下账户。</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin 账户</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC 账户</string>
+    <string name="qbtc_claim_cosign_approve">批准并共同签署</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">领取</string>
     <string name="cosmos_staking_action_delegate">质押</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1376,6 +1376,10 @@
     <string name="qbtc_claim_banner_subtitle">Same Bitcoin. Quantum-safe.</string>
     <string name="qbtc_claim_banner_title">Claim your QBTC</string>
     <string name="qbtc_claim_banner_cta">Claim Now</string>
+    <string name="qbtc_claim_cosign_description">Another device started a QBTC claim. Approving will co-sign it with your Bitcoin key. Review the accounts below before you continue.</string>
+    <string name="qbtc_claim_cosign_btc_account">Bitcoin account</string>
+    <string name="qbtc_claim_cosign_qbtc_account">QBTC account</string>
+    <string name="qbtc_claim_cosign_approve">Approve &amp; co-sign</string>
     <!-- Cosmos staking (LUNA / LUNC) — issue #4499 -->
     <string name="cosmos_staking_action_claim">Claim</string>
     <string name="cosmos_staking_action_delegate">Stake</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimConsentStateTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimConsentStateTest.kt
@@ -1,0 +1,74 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+internal class QbtcClaimConsentStateTest {
+
+    private fun coin(chain: Chain, address: String) =
+        Coin(
+            chain = chain,
+            ticker = chain.raw,
+            logo = "",
+            address = address,
+            decimal = 8,
+            hexPublicKey = "hex",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    /** Both accounts present → the consent gate exposes their addresses for review. */
+    @Test
+    fun `builds consent state with btc and qbtc addresses`() {
+        val state =
+            buildQbtcClaimConsentState(
+                listOf(coin(Chain.Bitcoin, "btcAddr"), coin(Chain.Qbtc, "qbtcAddr"))
+            )
+
+        val consent = state.shouldBeInstanceOf<JoinKeysignState.QbtcClaimConsent>()
+        consent.btcAddress shouldBe "btcAddr"
+        consent.qbtcAddress shouldBe "qbtcAddr"
+    }
+
+    /** A QBTC claim never auto-signs — the gate is a consent state, not the signing state. */
+    @Test
+    fun `consent state is not the signing state`() {
+        val state =
+            buildQbtcClaimConsentState(
+                listOf(coin(Chain.Bitcoin, "btcAddr"), coin(Chain.Qbtc, "qbtcAddr"))
+            )
+
+        (state is JoinKeysignState.QbtcClaim) shouldBe false
+    }
+
+    /** Missing the Bitcoin account fails before signing rather than mid-co-sign. */
+    @Test
+    fun `missing bitcoin account yields missing-account error`() {
+        val state = buildQbtcClaimConsentState(listOf(coin(Chain.Qbtc, "qbtcAddr")))
+
+        val error = state.shouldBeInstanceOf<JoinKeysignState.Error>()
+        error.errorType shouldBe JoinKeysignError.MissingQbtcClaimAccount
+    }
+
+    /** Missing the QBTC account fails before signing rather than mid-co-sign. */
+    @Test
+    fun `missing qbtc account yields missing-account error`() {
+        val state = buildQbtcClaimConsentState(listOf(coin(Chain.Bitcoin, "btcAddr")))
+
+        val error = state.shouldBeInstanceOf<JoinKeysignState.Error>()
+        error.errorType shouldBe JoinKeysignError.MissingQbtcClaimAccount
+    }
+
+    /** An empty vault also fails closed. */
+    @Test
+    fun `empty coins yields missing-account error`() {
+        val state = buildQbtcClaimConsentState(emptyList())
+
+        state.shouldBeInstanceOf<JoinKeysignState.Error>().errorType shouldBe
+            JoinKeysignError.MissingQbtcClaimAccount
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5019.

A device joining a **secure-vault QBTC claim** as the co-signer began the MPC co-sign **as soon as the pairing QR was scanned** — signing with the user's Bitcoin key with no review or consent. Every other keysign on the join path shows an approval screen first.

This adds the missing approval gate.

### Root cause
`JoinKeysignViewModel.setScanResult` called `startQbtcClaimCosign()` immediately when `isQbtcClaim`, bypassing the normal `JoinKeysignState.JoinKeysign` consent path:

```kotlin
if (_keysignPayload?.isQbtcClaim == true) {
    startQbtcClaimCosign()                                // jumped straight to signing
} else {
    _currentState.value = JoinKeysignState.JoinKeysign    // normal path: show approval first
}
```

### Fix
- `setScanResult` now shows a new `JoinKeysignState.QbtcClaimConsent` approval gate instead of signing.
- The co-sign starts **only after the user confirms**, routed through `joinKeysign()` (which now branches QBTC claims to `startQbtcClaimCosign()`; that function keeps its own `isJoiningKeysign` guard).
- The gate surfaces the **Bitcoin** and **QBTC** accounts the claim hash is recomputed from locally (the only data available pre-sign; the claim amount is only known post-broadcast).
- A vault missing the Bitcoin or QBTC account now fails **before** signing (`MissingQbtcClaimAccount`) rather than mid-co-sign.

The signing/protocol itself is unchanged — this only adds the consent gate, per the issue's "Must NOT do".

## Changes
- `JoinKeysignViewModel.kt` — new `QbtcClaimConsent` state, testable `buildQbtcClaimConsentState(coins)` helper, `setScanResult` + `joinKeysign()` routing.
- `JoinKeysignView.kt` — `QbtcClaimConsentContent` approval screen (account rows + "Approve & co-sign" button; Back declines without signing).
- 4 new `qbtc_claim_cosign_*` strings across all 10 locales.
- `QbtcClaimConsentStateTest.kt` — 5 unit tests (consent state built, not the signing state, fail-closed on missing BTC / missing QBTC / empty vault).

## Test plan
- [x] `buildQbtcClaimConsentState` unit tests (5)
- [ ] `./gradlew :app:testDebugUnitTest --tests "*QbtcClaimConsentStateTest*"`
- [ ] Manual (two secure-vault devices): device A starts a QBTC claim → shows pairing QR; device B scans → **approval screen appears**, signing starts only after Approve; Back declines without signing.

## Screenshot

The new approval gate the joining device shows **before** any signing starts (rendered via `PreviewActivity`). Before this fix, this screen did not exist — the device went straight from QR scan to the signing/proving loader.

| After (this PR) |
|--------|
| <img src="https://i.imgur.com/lxpAzN4.png" width="320" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced QBTC claim approval gateway that displays Bitcoin and QBTC account addresses, enabling users to review transaction details and approve before proceeding with co-signing operations.

* **Localization**
  * Extended application language support to include German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese for improved global accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
