### PR TITLE
fix(swap): default THORChain/Maya tolerance_bps to 0 so Auto swaps aren't rejected

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -204,7 +204,7 @@ constructor(
                     parameter("streaming_interval", MAYA_STREAMING_INTERVAL)
                     parameter("affiliate", THORChainSwaps.AFFILIATE_FEE_ADDRESS)
                     parameter("affiliate_bps", if (isAffiliate) affiliateFeeRate else "0")
-                    toleranceBps?.let { parameter("tolerance_bps", it) }
+                    toleranceBps?.takeIf { it > 0 }?.let { parameter("tolerance_bps", it) }
                     header(xClientID, xClientIDValue)
                 }
             val responseRawString = response.bodyAsText()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -235,7 +235,7 @@ constructor(
                 parameter("destination", request.address)
                 parameter("streaming_interval", request.interval)
                 request.streamingQuantity?.let { parameter("streaming_quantity", it) }
-                request.toleranceBps?.let { parameter("tolerance_bps", it) }
+                request.toleranceBps?.takeIf { it > 0 }?.let { parameter("tolerance_bps", it) }
                 if (affiliateParams.isNotEmpty()) {
                     affiliateParams.forEach { (key, value) ->
                         when (key) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/ThorChainSwapQuoteRequest.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/ThorChainSwapQuoteRequest.kt
@@ -10,9 +10,10 @@ data class ThorChainSwapQuoteRequest(
     val bpsDiscount: Int,
     val streamingQuantity: Int? = null,
     /**
-     * Minimum-output tolerance in basis points. When set, the node bakes a real `LIM` into the
-     * returned swap memo (`expected_amount_out × (1 − toleranceBps/10_000)`). When null/omitted the
-     * memo carries no limit, i.e. the swap accepts any output (unbounded slippage).
+     * Minimum-output tolerance in basis points. When positive, the node bakes a real `LIM` into the
+     * returned swap memo (`expected_amount_out × (1 − toleranceBps/10_000)`). When null or 0 the
+     * `tolerance_bps` param is omitted, so the memo carries no limit, i.e. the swap accepts any
+     * output (unbounded slippage). See [DEFAULT_THORCHAIN_TOLERANCE_BPS].
      */
     val toleranceBps: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -69,14 +69,15 @@ sealed class SwapQuoteResult {
 }
 
 /**
- * Minimum-output tolerance (basis points) sent on every THORChain/Maya quote request as
- * `tolerance_bps`. The node bakes a real `LIM` into the returned swap memo — `expected_amount_out ×
- * (1 − toleranceBps/10_000)` — protecting the user from adverse pool moves and front-running
- * between quote and execution. Without it the memo carries no limit (unbounded slippage). 100 bps
- * (1%) is a conservative default aligned with the streaming-upgrade threshold; there is no per-swap
- * user slippage control yet. Mirrors iOS `SwapService.defaultThorchainToleranceBps`.
+ * "Auto" slippage default for THORChain/Maya quotes. 0 → `tolerance_bps` is omitted, so the node
+ * sets no `LIM` and never rejects the quote. A nonzero default blocks legitimate swaps: the node
+ * gates `tolerance_bps` on the single-swap (full-size) emit rather than the streamed output, so any
+ * swap whose price impact exceeds it is refused (`emit asset X less than price limit Y`). Slippage
+ * stays mitigated by the rapid→streaming upgrade and the node's own auto-streaming. A user-set
+ * slippage overrides this and flows straight through. Mirrors iOS
+ * `SwapService.defaultThorchainToleranceBps` (vultisig-ios#4640).
  */
-internal const val DEFAULT_THORCHAIN_TOLERANCE_BPS = 100
+internal const val DEFAULT_THORCHAIN_TOLERANCE_BPS = 0
 
 /** Common contract for every per-provider quote source. */
 interface SwapQuoteSource {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryThorChainStreamingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryThorChainStreamingTest.kt
@@ -231,22 +231,25 @@ class SwapQuoteRepositoryThorChainStreamingTest {
     }
 
     @Test
-    fun `rapid request carries 1 percent tolerance_bps so the memo gets a real limit`() = runTest {
-        coEvery { thorChainApi.getSwapQuotes(match { it.interval == "0" }) } returns
-            THORChainSwapQuoteDeserialized.Result(
-                thorQuote(expectedAmountOut = "9950", feesTotal = "50")
-            )
+    fun `rapid request carries the Auto tolerance_bps default of 0 so the node sets no limit`() =
+        runTest {
+            coEvery { thorChainApi.getSwapQuotes(match { it.interval == "0" }) } returns
+                THORChainSwapQuoteDeserialized.Result(
+                    thorQuote(expectedAmountOut = "9950", feesTotal = "50")
+                )
 
-        fetchQuote()
+            fetchQuote()
 
-        coVerify(exactly = 1) {
-            thorChainApi.getSwapQuotes(match { it.interval == "0" && it.toleranceBps == 100 })
+            // Auto (no user slippage) → 0, which the API omits so the quote is never rejected.
+            coVerify(exactly = 1) {
+                thorChainApi.getSwapQuotes(match { it.interval == "0" && it.toleranceBps == 0 })
+            }
         }
-    }
 
     @Test
     fun `streaming fallback request also carries tolerance_bps`() = runTest {
-        // High slippage forces a streaming fetch; the .copy() must preserve toleranceBps.
+        // High slippage forces a streaming fetch; the .copy() must preserve toleranceBps (0 =
+        // Auto).
         val rapidData =
             thorQuote(expectedAmountOut = "6000", feesTotal = "4000", maxStreamingQuantity = 5)
         val streamingData = thorQuote(expectedAmountOut = "7500", feesTotal = "500")
@@ -259,7 +262,7 @@ class SwapQuoteRepositoryThorChainStreamingTest {
         fetchQuote()
 
         coVerify(exactly = 1) {
-            thorChainApi.getSwapQuotes(match { it.interval == "1" && it.toleranceBps == 100 })
+            thorChainApi.getSwapQuotes(match { it.interval == "1" && it.toleranceBps == 0 })
         }
     }
 


### PR DESCRIPTION
## Summary
- THORChain/Maya **Auto** swaps were rejected at quote time when price impact exceeded 1% (`emit asset X less than price limit Y`).
- Root cause: the node gates `tolerance_bps` against the **single-swap (full-size) emit**, not the streamed output — so a 1% default is unreachable for any non-trivial swap. The node only reports *streamed* slippage, so no protective-but-achievable default can be derived.
- Fix: `DEFAULT_THORCHAIN_TOLERANCE_BPS` `100 → 0`. When the value is 0 (or null) the `tolerance_bps` param is now **omitted** at the wire level (`takeIf { it > 0 }`), so the node sets no `LIM` and never rejects. A user-set slippage still flows straight through. Slippage stays mitigated by the rapid→streaming upgrade (`STREAMING_SLIPPAGE_THRESHOLD_BPS`) and the node's own auto-streaming (the memo streams regardless).

This ports **vultisig-ios#4640** to Android.

## Changes
| File | Change |
|------|--------|
| `data/.../repositories/swap/SwapQuoteSource.kt` | `DEFAULT_THORCHAIN_TOLERANCE_BPS` `100 → 0` + accurate comment |
| `data/.../api/ThorChainApi.kt` | omit `tolerance_bps` unless `> 0` |
| `data/.../api/MayaChainApi.kt` | omit `tolerance_bps` unless `> 0` |
| `data/.../api/models/quotes/ThorChainSwapQuoteRequest.kt` | updated KDoc (null **or 0** → omitted) |
| `data/.../repositories/SwapQuoteRepositoryThorChainStreamingTest.kt` | updated assertions (Auto default = 0) |

## Context
- The hardcoded `tolerance_bps` was the Android analogue of iOS's `defaultThorchainToleranceBps` (1%).
- iOS #4640 confirmed via a live quote probe that omitting `tolerance_bps` returns a valid quote + auto-streamed memo, while `tolerance_bps=100` is refused on a high-impact swap.

## Test plan
- [x] `:data:testDebugUnitTest` — `SwapQuoteRepositoryThorChainStreamingTest` passes
- [x] ktfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved swap quote request handling by adjusting default slippage tolerance behavior, reducing potential quote rejection issues and providing better compatibility with swap providers.
  * Enhanced tolerance parameter logic to omit limits when not explicitly set, allowing more flexible quote processing and better API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5023
