### PR TITLE
fix(swap): keep THORChain referral split at full VULT discount

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelper.kt
@@ -10,14 +10,6 @@ object ThorChainAffiliateHelper {
      * @param discountBps discount in basis points to subtract from the base affiliate fee
      */
     fun buildAffiliateParams(referralCode: String, discountBps: Int): Map<String, String> {
-        // Full discount: drop all affiliate fees and ignore the referral code.
-        if (discountBps >= 50) {
-            return mapOf(
-                "affiliate" to THORChainSwaps.AFFILIATE_FEE_ADDRESS,
-                "affiliate_bps" to "0",
-            )
-        }
-
         return if (referralCode.isNotEmpty()) {
             val affiliateFeeRateBp =
                 calculateBpsAfterDiscount(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelperTest.kt
@@ -68,7 +68,7 @@ class ThorChainAffiliateHelperTest {
     }
 
     @Test
-    fun `discount of 50 bps short-circuits to clean referral with zero affiliate fee`() {
+    fun `full discount without referral code zeroes the affiliate fee`() {
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "", discountBps = 50)
 
@@ -77,22 +77,21 @@ class ThorChainAffiliateHelperTest {
     }
 
     @Test
-    fun `discount of 50 bps short-circuits even when a referral code is provided`() {
+    fun `full discount keeps the referral split and still pays the referrer`() {
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "alice", discountBps = 50)
 
-        // Clean-referral branch ignores the code and emits the flat (non-nested) form.
-        assertEquals(THORChainSwaps.AFFILIATE_FEE_ADDRESS, params["affiliate"])
-        assertEquals("0", params["affiliate_bps"])
+        assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
+        assertEquals("${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/0", params["affiliate_bps"])
     }
 
     @Test
-    fun `discount above 50 bps continues to short-circuit`() {
+    fun `discount beyond the referred affiliate base still preserves the referrer share`() {
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "alice", discountBps = 100)
 
-        assertEquals(THORChainSwaps.AFFILIATE_FEE_ADDRESS, params["affiliate"])
-        assertEquals("0", params["affiliate_bps"])
+        assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
+        assertEquals("${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/0", params["affiliate_bps"])
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #5024

THORChain swap quotes build their `affiliate`/`affiliate_bps` query parameters in `ThorChainAffiliateHelper.buildAffiliateParams`. The helper short-circuited at `discountBps >= 50` and returned a single Vultisig affiliate with `affiliate_bps = "0"`, dropping the referral code even when one was present. So a referred user who holds enough VULT to reach the top tier (50 bps discount) stopped paying their referrer entirely — the referrer's fixed 10 bps cut disappeared from the on-chain memo, while the desktop and iOS apps keep paying it for the same swap.

The discount is meant to reduce only the Vultisig affiliate portion (it floors at 0), not the referrer's reward. Removing the early return lets the existing referral / no-referral branches run; both already subtract the discount through `maxOf(0, baseBps - discountBps)`, so at full discount a referred swap emits `affiliate = "<code>/va"` with `affiliate_bps = "10/0"` (referrer keeps 10 bps, Vultisig 0), and a swap with no referral still emits a single affiliate with `affiliate_bps = "0"`. This matches the desktop and iOS clients.

## Which feature is affected?
- [x] Swap - Please attach a tx link for the swap here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — this changes the affiliate query parameters sent to the THORChain quote endpoint; there is no UI surface. The swap form's referral-discount display is driven separately and is unchanged.

## Additional context

The MayaChain affiliate path is intentionally separate (no nested affiliates) and is untouched. The signing/keysign path is unaffected: the affiliate parameters only change what is sent to the quote endpoint; the local device and the VultiServer co-signer continue to sign the identical quote/memo returned by the node, so there is no divergence between regular and co-signed swaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed affiliate fee handling for full-discount scenarios so referral-based payouts are still applied when a referral code is present.
  * Updated zero-discount cases to keep the expected flat affiliate output when no referral code is provided.
  * Improved coverage for affiliate calculations to match the new behavior across both empty and populated referral inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->