### PR TITLE
fix(swap): clamp 1inch referrer fee at zero

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/swapAggregators/OneInchApi.kt
@@ -123,10 +123,6 @@ constructor(
         bpsDiscount: Int,
         slippageBps: Int?,
     ) {
-        val bpsDiscountTransformed = round(bpsDiscount.toDouble()) / 100.0
-        val referrerFeeUpdated =
-            round((ONEINCH_REFERRER_FEE - bpsDiscountTransformed) * 100) / 100.0
-
         // bps → percent (100 bps = 1%); Auto (null) keeps 1inch's historical 0.5% default.
         val slippagePercent = slippageBps?.let { it.toDouble() / 100.0 } ?: ONEINCH_DEFAULT_SLIPPAGE
 
@@ -138,7 +134,7 @@ constructor(
         parameter("disableEstimate", true)
         parameter("includeGas", true)
         parameter("referrer", ONEINCH_REFERRER_ADDRESS)
-        parameter("fee", if (isAffiliate) referrerFeeUpdated else "0")
+        parameter("fee", if (isAffiliate) discountedReferrerFee(bpsDiscount) else "0")
     }
 
     override suspend fun getTokens(chain: Chain): OneInchTokensJson =
@@ -174,5 +170,16 @@ constructor(
         private const val ONEINCH_NULL_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         /** 1inch's historical default slippage (percent) used when the user leaves it on Auto. */
         private const val ONEINCH_DEFAULT_SLIPPAGE = 0.5
+
+        /**
+         * The affiliate fee percent sent to 1inch, reduced by the VULT [bpsDiscount] and clamped at
+         * zero so a discount larger than [ONEINCH_REFERRER_FEE] never produces a negative fee
+         * (which 1inch rejects). Mirrors iOS' `bps(for:)` and the zero-clamp every other provider
+         * applies.
+         */
+        internal fun discountedReferrerFee(bpsDiscount: Int): Double {
+            val discountPercent = round(bpsDiscount.toDouble()) / 100.0
+            return round(maxOf(ONEINCH_REFERRER_FEE - discountPercent, 0.0) * 100) / 100.0
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/OneInchReferrerFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/OneInchReferrerFeeTest.kt
@@ -1,0 +1,34 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.swapAggregators.OneInchApiImpl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the affiliate fee 1inch is sent for a swap: the base 0.5% reduced by the VULT discount
+ * and clamped at zero. The clamp guards against a discount larger than the base fee producing a
+ * negative `fee` parameter, which 1inch rejects.
+ */
+class OneInchReferrerFeeTest {
+
+    @Test
+    fun `referrer fee is the base 0_5 percent when there is no discount`() {
+        assertEquals(0.5, OneInchApiImpl.discountedReferrerFee(bpsDiscount = 0))
+    }
+
+    @Test
+    fun `referrer fee is reduced by the VULT discount`() {
+        assertEquals(0.25, OneInchApiImpl.discountedReferrerFee(bpsDiscount = 25))
+    }
+
+    @Test
+    fun `referrer fee bottoms out at zero when the discount equals the base fee`() {
+        assertEquals(0.0, OneInchApiImpl.discountedReferrerFee(bpsDiscount = 50))
+    }
+
+    @Test
+    fun `referrer fee is clamped at zero when the discount exceeds the base fee`() {
+        assertEquals(0.0, OneInchApiImpl.discountedReferrerFee(bpsDiscount = 60))
+        assertEquals(0.0, OneInchApiImpl.discountedReferrerFee(bpsDiscount = 100))
+    }
+}


### PR DESCRIPTION
## Description

The affiliate fee 1inch is sent for a swap was computed as the base `0.5%` referrer fee minus the user's VULT discount, with no lower bound:

```kotlin
round((ONEINCH_REFERRER_FEE - bpsDiscountTransformed) * 100) / 100.0
```

The highest VULT tier already discounts the full 50 bps, which exactly equals the 0.5% base fee, so today the value bottoms out at `0.0`. But there is no clamp, so any future tier increase — or any path passing a discount above the base fee — would send a negative `fee` to 1inch, which rejects it and breaks the swap for top-tier holders. Every other provider already clamps this (LI.FI, Kyber, SwapKit, THORChain/Maya), and iOS clamps it in `OneInchService.bps(for:)` (`max(0, referredFee - formattedDiscount)`); only the Android 1inch path didn't.

This clamps the discounted referrer fee at zero and pulls the small calculation into a testable helper so the clamp is covered by a unit test. The value on the wire is unchanged for every discount the app can produce today (0 → `0.5`, 50 → `0.0`); the only behavioral change is that a discount above the base fee now yields `0.0` instead of a negative number.

Fixes #5026

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

> No swap tx link: the defect is latent (the largest discount the app can reach today lands the fee on exactly `0.0`, so the request 1inch receives is byte-identical before and after this change). The fix is a safety clamp against future discount-tier changes, verified by unit test.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — data-layer change with no UI surface.

## Additional context

Co-signer impact: none. The `fee` parameter feeds the 1inch quote/swap request that produces the EVM calldata the VultiServer co-signer later signs, but the value sent is identical for every discount the app can currently produce (max discount 50 bps = base 0.5% → `0.0`), so the signed payload is unchanged. The clamp only diverges from the old behavior for a discount greater than the base fee, which is unreachable today.

`./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.OneInchReferrerFeeTest"` passes (4/4).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote fee calculation so affiliate fees now reflect the configured discount correctly.
  * Prevented fees from dropping below zero when discounts meet or exceed the base fee.

* **Tests**
  * Added coverage for fee calculation scenarios, including no discount, partial discount, and full discount cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->