### PR TITLE
fix(swap): clamp quote countdown ring progress to 0f..1f after expiry

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
@@ -43,7 +43,7 @@ internal fun QuoteTimer(expiredAt: Instant, modifier: Modifier = Modifier) {
             val now = Clock.System.now()
             val left = expiredAt - now
             timeLeft = formatDurationAsMinutesSeconds(left)
-            progress = (left / expiredAfter).toFloat()
+            progress = quoteTimerProgress(left, expiredAfter)
         }
     }
 
@@ -85,3 +85,11 @@ private fun formatDurationAsMinutesSeconds(duration: Duration): String {
     val seconds = totalSeconds % 60
     return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
 }
+
+/**
+ * Fraction of the quote's lifetime still remaining, clamped to the 0f..1f range
+ * [CircularProgressIndicator] requires. [remaining] goes negative once the quote expires before it
+ * is replaced, so the raw ratio is coerced rather than passed straight to the indicator.
+ */
+internal fun quoteTimerProgress(remaining: Duration, lifetime: Duration): Float =
+    (remaining / lifetime).toFloat().coerceIn(0f, 1f)

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimerProgressTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimerProgressTest.kt
@@ -1,0 +1,36 @@
+package com.vultisig.wallet.ui.screens.swap.components
+
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Test
+
+internal class QuoteTimerProgressTest {
+
+    private val lifetime = 1.minutes
+
+    @Test
+    fun `remaining equal to lifetime is full progress`() {
+        assertEquals(1f, quoteTimerProgress(remaining = lifetime, lifetime = lifetime))
+    }
+
+    @Test
+    fun `half the lifetime remaining is half progress`() {
+        assertEquals(0.5f, quoteTimerProgress(remaining = 30.seconds, lifetime = lifetime))
+    }
+
+    @Test
+    fun `no time remaining is zero progress`() {
+        assertEquals(0f, quoteTimerProgress(remaining = 0.seconds, lifetime = lifetime))
+    }
+
+    @Test
+    fun `negative remaining after expiry is clamped to zero`() {
+        assertEquals(0f, quoteTimerProgress(remaining = (-5).seconds, lifetime = lifetime))
+    }
+
+    @Test
+    fun `remaining beyond lifetime is clamped to one`() {
+        assertEquals(1f, quoteTimerProgress(remaining = 90.seconds, lifetime = lifetime))
+    }
+}


### PR DESCRIPTION
## Description

Fixes #5028

The swap quote countdown ring feeds `CircularProgressIndicator` the fraction `remainingTime / quoteLifetime`. Once a quote reaches 0:00 before a fresh quote replaces it, `remainingTime` is negative, so the ring is driven with a negative progress — outside the indicator's documented `0f..1f` range, while the countdown text right next to it is already floored at zero.

This clamps the fraction to `0f..1f` in a small pure helper (`quoteTimerProgress`) so the ring's value matches the floored text and stays inside the indicator's contract. The helper is unit-tested at the boundaries.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

> UI-only change to the swap quote countdown ring; no on-chain transaction is involved.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

No visible before/after delta to show. The current Material3 (`material3` 1.4.0) determinate `CircularProgressIndicator` renders a negative progress the same as `0` (empty ring), so the expired-quote ring already looks correct on screen — I verified this by rendering the expired state both with and without the clamp and getting identical output. The fix removes the out-of-contract value the indicator is fed, which the text is already guarded against and which the framework's masking of out-of-range input is not guaranteed to keep doing.

## Additional context

- The countdown text already floors remaining time at zero (`inWholeSeconds.coerceAtLeast(0)`); this brings the ring's progress in line with it.
- Parity: the Windows app clamps the remaining-time value at the source (`Math.max(prev - 1, 0)`), and iOS resets its timer rather than letting it go negative — Android now stays within range too.
- No signing, keysign, payload, or co-sign path is touched; this only affects the value passed to a progress indicator on the swap form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quote timer progress handling so the circular indicator stays within a valid range, including after a quote expires.
  * Prevented negative or overfilled progress values from being shown in the swap timer.

* **Tests**
  * Added coverage for quote timer progress across full, partial, zero, expired, and over-limit timing cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->