### PR TITLE
fix(swap): set real byte fee on THORChain UTXO swap pre-signing input

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -72,13 +72,14 @@ class UtxoHelper(
         require(thorChainSwapPayload.data.vaultAddress.isNotEmpty()) {
             "Vault address is required for THORChain swap"
         }
+        val utxo = keysignPayload.blockChainSpecific as BlockChainSpecific.UTXO
         val input =
             Bitcoin.SigningInput.newBuilder()
                 .setHashType(BitcoinScript.hashTypeForCoin(coinType))
                 .setAmount(thorChainSwapPayload.data.fromAmount.toLong())
                 .setToAddress(thorChainSwapPayload.data.vaultAddress)
                 .setChangeAddress(keysignPayload.coin.address)
-                .setByteFee(1L)
+                .setByteFee(utxo.byteFee.toLong())
                 .setCoinType(coinType.value())
                 .setUseMaxAmount(false)
                 .setOutputOpReturn( // output index is the latest by default

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelperTest.kt
@@ -235,26 +235,26 @@ class UtxoHelperTest {
         verifySwapOpReturn(memo)
     }
 
+    @Test
+    fun `getSwapPreSigningInputData - applies the payload byte fee, not a placeholder`() {
+        val helper = UtxoHelper(CoinType.BITCOIN, "", "")
+        val payload =
+            utxoPayload(
+                byteFee = BigInteger.valueOf(7L),
+                memo = "SWAP:BTC.BTC:$btcAddress:0:t:0:30",
+                swapPayload = thorChainSwapPayload(),
+            )
+        try {
+            val input = helper.getSwapPreSigningInputData(payload)
+            assertEquals(7L, input.byteFee)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
     private fun verifySwapOpReturn(memo: String) {
         val helper = UtxoHelper(CoinType.BITCOIN, "", "")
-        val swapPayload =
-            SwapPayload.ThorChain(
-                THORChainSwapPayload(
-                    fromAddress = btcAddress,
-                    fromCoin = btcCoin,
-                    toCoin = btcCoin,
-                    vaultAddress = btcAddress,
-                    routerAddress = null,
-                    fromAmount = BigInteger.valueOf(10_000L),
-                    toAmountDecimal = BigDecimal.ZERO,
-                    toAmountLimit = "0",
-                    streamingInterval = "0",
-                    streamingQuantity = "0",
-                    expirationTime = 0uL,
-                    isAffiliate = false,
-                )
-            )
-        val payload = utxoPayload(memo = memo, swapPayload = swapPayload)
+        val payload = utxoPayload(memo = memo, swapPayload = thorChainSwapPayload())
         try {
             val input = helper.getSwapPreSigningInputData(payload)
             assertEquals(ByteString.copyFromUtf8(memo), input.outputOpReturn)
@@ -262,6 +262,24 @@ class UtxoHelperTest {
             skipIfJniUnavailable(e)
         }
     }
+
+    private fun thorChainSwapPayload(): SwapPayload.ThorChain =
+        SwapPayload.ThorChain(
+            THORChainSwapPayload(
+                fromAddress = btcAddress,
+                fromCoin = btcCoin,
+                toCoin = btcCoin,
+                vaultAddress = btcAddress,
+                routerAddress = null,
+                fromAmount = BigInteger.valueOf(10_000L),
+                toAmountDecimal = BigDecimal.ZERO,
+                toAmountLimit = "0",
+                streamingInterval = "0",
+                streamingQuantity = "0",
+                expirationTime = 0uL,
+                isAffiliate = false,
+            )
+        )
 
     // BIP-143 sighash tests — exercise the new from-scratch PSBT signing path against the
     // canonical test vectors from https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki


### PR DESCRIPTION
## Description

`UtxoHelper.getSwapPreSigningInputData` built the THORChain swap signing input with a hardcoded `byteFee` of 1 sat/vByte. Its only caller, `THORChainSwaps.getPreSignedInputData`, immediately re-runs the builder through `getSigningInputData`, which re-applies the real per-byte fee from the keysign payload — so the hardcoded `1` was never used. The literal was a latent hazard: any future caller that built the swap input without that second pass would sign a THORChain swap at 1 sat/vByte, which the network rejects.

This sets the byte fee from the payload's UTXO `byteFee` directly — the same value the regular send path uses in `getBitcoinSigningInput`. Because `getSigningInputData` already applies that exact fee, the signed transaction is byte-for-byte identical to before; this only removes the misleading literal and makes the builder correct on its own.

Fixes #5032

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — signing-path logic, no UI surface.

## Additional context

No behavioural change: the per-byte fee that reaches the wire is unchanged (`getSigningInputData` already overwrote the placeholder with `keysignPayload`'s UTXO `byteFee`), so the produced transaction — and therefore every co-signer's pre-image hashes and the final broadcast — is byte-for-byte identical to `main`. This is why no swap tx link is attached: there is no observable on-chain difference to demonstrate.

Co-sign is unaffected: the initiator, peer devices, and VultiServer all rebuild the signing input from the shared keysign payload, and the byte fee is taken from that same payload in both the old and new code.

The added unit test asserts the swap pre-signing input carries the payload's `byteFee` (7) rather than a placeholder. It is JNI-gated like the sibling `UtxoHelper` swap/plan tests (it needs Trust Wallet Core native), so it runs where that library is present and is skipped otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swap signing now uses the network fee value provided in the transaction payload, instead of a fixed placeholder amount.
  * Added test coverage to confirm swap signing respects the provided fee value.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->