### PR TITLE
test: cover Kyber/LiFi quote sources, pin send validation messages

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/ChainValidationServiceTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/ChainValidationServiceTest.kt
@@ -12,7 +12,6 @@ import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
@@ -23,12 +22,18 @@ internal class ChainValidationServiceTest {
 
     @Test
     fun `validateSlippage - null returns required error`() {
-        assertTrue(service.validateSlippage(null) is UiText.StringResource)
+        assertEquals(
+            R.string.slippage_required_error,
+            (service.validateSlippage(null) as UiText.StringResource).resId,
+        )
     }
 
     @Test
     fun `validateSlippage - blank returns required error`() {
-        assertTrue(service.validateSlippage("  ") is UiText.StringResource)
+        assertEquals(
+            R.string.slippage_required_error,
+            (service.validateSlippage("  ") as UiText.StringResource).resId,
+        )
     }
 
     @Test
@@ -38,17 +43,26 @@ internal class ChainValidationServiceTest {
 
     @Test
     fun `validateSlippage - value above 100 returns invalid error`() {
-        assertTrue(service.validateSlippage("101") is UiText.StringResource)
+        assertEquals(
+            R.string.slippage_invalid_error,
+            (service.validateSlippage("101") as UiText.StringResource).resId,
+        )
     }
 
     @Test
     fun `validateSlippage - negative value returns invalid error`() {
-        assertTrue(service.validateSlippage("-1") is UiText.StringResource)
+        assertEquals(
+            R.string.slippage_invalid_error,
+            (service.validateSlippage("-1") as UiText.StringResource).resId,
+        )
     }
 
     @Test
     fun `validateSlippage - non-numeric returns format error`() {
-        assertTrue(service.validateSlippage("abc") is UiText.StringResource)
+        assertEquals(
+            R.string.slippage_format_error,
+            (service.validateSlippage("abc") as UiText.StringResource).resId,
+        )
     }
 
     @Test
@@ -271,6 +285,55 @@ internal class ChainValidationServiceTest {
                 assumeTrue(false, "WalletCore JNI not available: ${e.message}")
             } else throw e
         }
+    }
+
+    /**
+     * Below the dust threshold every BTC-like chain throws the same FormattedText. The threshold
+     * and the chain symbol are resolved through WalletCore, so the path is skipped when the native
+     * library is unavailable in a JVM run, mirroring the Bitcoin case above.
+     */
+    private fun assertBelowDustThrowsMinAmountMessage(chain: Chain) {
+        try {
+            service.validateBtcLikeAmount(
+                tokenAmountInt = BigInteger.valueOf(100L),
+                chain = chain,
+                plan = null,
+            )
+            fail("Expected InvalidTransactionDataException to be thrown")
+        } catch (e: InvalidTransactionDataException) {
+            assertEquals(
+                R.string.send_form_minimum_send_amount_is_requires_this,
+                (e.text as UiText.FormattedText).resId,
+            )
+        } catch (e: Throwable) {
+            if (
+                e is UnsatisfiedLinkError ||
+                    e is ExceptionInInitializerError ||
+                    e is NoClassDefFoundError
+            ) {
+                assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+            } else throw e
+        }
+    }
+
+    @Test
+    fun `validateBtcLikeAmount - amount below Dogecoin dust throws minimum send amount message`() {
+        assertBelowDustThrowsMinAmountMessage(Chain.Dogecoin)
+    }
+
+    @Test
+    fun `validateBtcLikeAmount - amount below Litecoin dust throws minimum send amount message`() {
+        assertBelowDustThrowsMinAmountMessage(Chain.Litecoin)
+    }
+
+    @Test
+    fun `validateBtcLikeAmount - amount below Dash dust throws minimum send amount message`() {
+        assertBelowDustThrowsMinAmountMessage(Chain.Dash)
+    }
+
+    @Test
+    fun `validateBtcLikeAmount - amount below Zcash dust throws minimum send amount message`() {
+        assertBelowDustThrowsMinAmountMessage(Chain.Zcash)
     }
 
     // selectUtxosIfNeeded tests (non-UTXO pass-through and null plan)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -1,11 +1,24 @@
 package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.api.JupiterApi
+import com.vultisig.wallet.data.api.LiFiChainApi
 import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.models.KyberSwapRouteResponse
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.Fees
+import com.vultisig.wallet.data.api.models.quotes.KyberSwapErrorResponse
+import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteData
+import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapEstimateJson
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapFeeCostJson
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteError
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapTokenJson
+import com.vultisig.wallet.data.api.models.quotes.LiFiSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.QuoteSwapTotalDataJson
 import com.vultisig.wallet.data.api.models.quotes.QuoteSwapTransactionJson
@@ -14,12 +27,15 @@ import com.vultisig.wallet.data.api.models.quotes.SwapInfoJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteError
+import com.vultisig.wallet.data.api.swapAggregators.KyberApi
 import com.vultisig.wallet.data.api.swapAggregators.OneInchApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.swap.JupiterQuoteSource
+import com.vultisig.wallet.data.repositories.swap.KyberQuoteSource
+import com.vultisig.wallet.data.repositories.swap.LiFiQuoteSource
 import com.vultisig.wallet.data.repositories.swap.MayaQuoteSource
 import com.vultisig.wallet.data.repositories.swap.OneInchQuoteSource
 import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
@@ -38,10 +54,14 @@ class SwapQuoteRepositoryProvidersTest {
     private val oneInchApi: OneInchApi = mockk()
     private val mayaChainApi: MayaChainApi = mockk()
     private val jupiterApi: JupiterApi = mockk()
+    private val kyberApi: KyberApi = mockk()
+    private val liFiChainApi: LiFiChainApi = mockk()
 
     private val oneInchSource = OneInchQuoteSource(oneInchApi)
     private val mayaSource = MayaQuoteSource(mayaChainApi)
     private val jupiterSource = JupiterQuoteSource(jupiterApi)
+    private val kyberSource = KyberQuoteSource(kyberApi)
+    private val liFiSource = LiFiQuoteSource(liFiChainApi)
 
     private fun coin(
         chain: Chain,
@@ -369,6 +389,190 @@ class SwapQuoteRepositoryProvidersTest {
                     )
                 )
             }
+        }
+    }
+
+    // ---------- Kyber ----------
+
+    private fun kyberRoute() =
+        KyberSwapRouteResponse(
+            code = 0,
+            message = "OK",
+            data =
+                KyberSwapRouteResponse.RouteData(
+                    routeSummary =
+                        KyberSwapRouteResponse.RouteSummary(
+                            tokenIn = "0xEth",
+                            amountIn = "1000000",
+                            amountInUsd = "1.0",
+                            tokenOut = "0xUsdc",
+                            amountOut = "990000",
+                            amountOutUsd = "0.99",
+                            gas = "150000",
+                            gasPrice = "5",
+                            gasUsd = "0.5",
+                            route = emptyList(),
+                            routeID = "route-1",
+                            checksum = "checksum-1",
+                            timestamp = 1,
+                        ),
+                    routerAddress = "0xRouter",
+                ),
+            requestId = "req-1",
+        )
+
+    private fun kyberTx() =
+        KyberSwapQuoteJson(
+            code = 0,
+            message = "OK",
+            data =
+                KyberSwapQuoteData(
+                    amountIn = "1000000",
+                    amountInUsd = "1.0",
+                    amountOut = "990000",
+                    amountOutUsd = "0.99",
+                    gas = "210000",
+                    gasUsd = "0.5",
+                    data = "0xkyberdata",
+                    routerAddress = "0xRouter",
+                    transactionValue = "0",
+                ),
+            requestId = "req-1",
+        )
+
+    private fun kyberRequest() =
+        SwapQuoteRequest(
+            srcToken = coin(Chain.Ethereum, "ETH"),
+            dstToken = coin(Chain.Ethereum, "USDC", contractAddress = "0xUsdc"),
+            tokenValue =
+                TokenValue(value = BigInteger("1000000"), token = coin(Chain.Ethereum, "ETH")),
+            isAffiliate = true,
+        )
+
+    @Test
+    fun `kyber happy path returns mapped evm quote`() = runTest {
+        coEvery { kyberApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any()) } returns
+            KyberSwapQuoteDeserialized.Result(kyberRoute())
+        coEvery { kyberApi.getKyberSwapQuote(any(), any(), any(), any(), any(), any()) } returns
+            kyberTx()
+
+        val result = (kyberSource.fetch(kyberRequest()) as SwapQuoteResult.Evm).data
+
+        assertEquals("990000", result.dstAmount)
+        assertEquals("0xRouter", result.tx.to)
+        assertEquals("0xkyberdata", result.tx.data)
+        assertEquals("5", result.tx.gasPrice)
+        // Ethereum doubles the response gas (multiplier 20/10): 210000 → 420000.
+        assertEquals(420000L, result.tx.gas)
+        // No extraFee on the route → swapFee stays "0"; tokenOut becomes the fee token contract.
+        assertEquals("0", result.tx.swapFee)
+        assertEquals("0xUsdc", result.tx.swapFeeTokenContract)
+    }
+
+    @Test
+    fun `kyber deserialization error throws mapped SwapException`() = runTest {
+        coEvery { kyberApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any()) } returns
+            KyberSwapQuoteDeserialized.Error(KyberSwapErrorResponse("insufficient funds for swap"))
+
+        assertThrows<SwapException.InsufficientFunds> {
+            runBlocking { kyberSource.fetch(kyberRequest()) }
+        }
+    }
+
+    @Test
+    fun `kyber api failure is wrapped in mapped SwapException`() = runTest {
+        coEvery { kyberApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any()) } throws
+            RuntimeException("too many requests")
+
+        assertThrows<SwapException.RateLimitExceeded> {
+            runBlocking { kyberSource.fetch(kyberRequest()) }
+        }
+    }
+
+    // ---------- LiFi ----------
+
+    private fun liFiQuote(message: String? = null) =
+        LiFiSwapQuoteJson(
+            estimate =
+                LiFiSwapEstimateJson(
+                    toAmount = "2500000",
+                    feeCosts =
+                        listOf(
+                            LiFiSwapFeeCostJson(
+                                amount = "1250",
+                                included = false,
+                                name = "LIFI Fixed Fee",
+                                token = LiFiSwapTokenJson(address = "0xFeeToken"),
+                            )
+                        ),
+                ),
+            transactionRequest =
+                // LiFi returns the numeric tx fields as hex strings (decoded via
+                // convertToBigIntegerOrZero): 0x5208 = 21000, 0x3b9aca00 = 1e9 wei.
+                LiFiSwapTxJson(
+                    from = "0xWallet",
+                    to = "0xLifiRouter",
+                    gasLimit = "0x5208",
+                    data = "0xlifidata",
+                    value = "0x0",
+                    gasPrice = "0x3b9aca00",
+                ),
+            message = message,
+        )
+
+    private fun liFiRequest() =
+        SwapQuoteRequest(
+            srcToken = coin(Chain.Ethereum, "ETH"),
+            dstToken = coin(Chain.Ethereum, "USDC", contractAddress = "0xUsdc"),
+            tokenValue =
+                TokenValue(value = BigInteger("1000000"), token = coin(Chain.Ethereum, "ETH")),
+            srcAddress = "0xWallet",
+            dstAddress = "0xDest",
+        )
+
+    @Test
+    fun `lifi happy path returns mapped evm quote with fee`() = runTest {
+        coEvery {
+            liFiChainApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns LiFiSwapQuoteDeserialized.Result(liFiQuote())
+
+        val result = (liFiSource.fetch(liFiRequest()) as SwapQuoteResult.Evm).data
+
+        assertEquals("2500000", result.dstAmount)
+        assertEquals("0xWallet", result.tx.from)
+        assertEquals("0xLifiRouter", result.tx.to)
+        assertEquals("0xlifidata", result.tx.data)
+        // Hex tx fields are decoded to decimal: 0x5208 → 21000, 0x3b9aca00 → 1e9.
+        assertEquals(21000L, result.tx.gas)
+        assertEquals("0", result.tx.value)
+        assertEquals("1000000000", result.tx.gasPrice)
+        // The "LIFI Fixed Fee" cost surfaces as the swap fee in the destination token.
+        assertEquals("1250", result.tx.swapFee)
+        assertEquals("0xFeeToken", result.tx.swapFeeTokenContract)
+    }
+
+    @Test
+    fun `lifi deserialization error throws mapped SwapException`() = runTest {
+        coEvery {
+            liFiChainApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns
+            LiFiSwapQuoteDeserialized.Error(
+                LiFiSwapQuoteError("no available quotes for the requested route")
+            )
+
+        assertThrows<SwapException.SwapRouteNotAvailable> {
+            runBlocking { liFiSource.fetch(liFiRequest()) }
+        }
+    }
+
+    @Test
+    fun `lifi inner message error throws mapped SwapException`() = runTest {
+        coEvery {
+            liFiChainApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns LiFiSwapQuoteDeserialized.Result(liFiQuote(message = "price impact too high"))
+
+        assertThrows<SwapException.HighPriceImpact> {
+            runBlocking { liFiSource.fetch(liFiRequest()) }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the remaining test-coverage gaps from the `[Test]` series for swap quote sources (#4189) and send validation (#4185). Test-only — no production code changes.

## What changed

**Swap quote sources (#4189)** — `SwapQuoteRepositoryProvidersTest`
- `KyberQuoteSource` and `LiFiQuoteSource` were the only two `QuoteSource` implementations with no `fetch()` coverage anywhere. Added happy-path and error-path tests for both, mocking the underlying `*Api` and asserting the mapped `EVMSwapQuoteJson` and the specific `SwapException` subtype, matching the existing 1inch/Maya/Jupiter pattern.
- The LiFi happy-path test pins that `transactionRequest` numeric fields are hex-decoded (`0x5208` → `21000`, `0x3b9aca00` → `1e9`); the Kyber test pins the per-chain gas multiplier (Ethereum doubles the response gas).

**Send validation (#4185)** — `ChainValidationServiceTest`
- The five `validateSlippage` tests only checked the `UiText` type, so a wrong string would still pass. They now assert the resource id (`slippage_required_error` / `slippage_invalid_error` / `slippage_format_error`).
- Added below-dust cases for Dogecoin, Litecoin, Dash and Zcash, reusing the existing Bitcoin test's WalletCore JNI skip so they extend the per-chain dust coverage.

## Already covered on main (no change needed)

While scoping the series I confirmed two of the linked tickets are already satisfied on `main`, so this PR leaves them untouched:
- **#4194** — `SessionApiTest` already pins `withRelayRetry` (3 attempts, exponential backoff, 4xx/cancellation passthrough) and `getSetupMessage` (10 attempts), and `HttpClientConfiguratorTest` pins the retry policy incl. POST non-retry (added by #4936). `MockHttpClient` already has `respondingWithSequence`/`throwing`.
- **#4191** — `KeyImportRepositoryImplTest` already covers the BTC/ETH/Solana-Phantom/Cosmos/Tron derivation paths plus `clear`/`toString`-no-leak; `VaultRepositoryImplTest` already covers every repository method incl. the unknown-chain corruption skip and `SigningLibType` round-trip. (In-memory Room isn't possible in `:data` — `AppDatabase` lives in `:app` — so the mockk-backed test is the feasible form.)

The `SwapFormViewModel` provider/allowance cases from #4189 are not added: `SwapFormViewModel` holds no allowance logic (allowance lives in the keysign flow), and provider fee/flip/price-impact behavior is already exercised by the existing THORChain/Maya/flip/`HighPriceImpact` tests, so per-provider VM variants would only re-run the same path through a mock.

## Testing

```
./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.repositories.SwapQuoteRepositoryProvidersTest"
  -> 16 passed (6 new Kyber/LiFi)
./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.send.ChainValidationServiceTest"
  -> 29 tests, 0 failures, 5 ignored (the JNI-gated dust tests skip when WalletCore isn't loaded, same as the existing Bitcoin case)
./gradlew :data:ktfmtCheck :app:ktfmtCheck
  -> BUILD SUCCESSFUL
```

Refs #4189, #4185, #4194, #4191.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slippage validation so missing, whitespace, out-of-range, and non-numeric inputs map to the correct error message.
  * Refined dust-threshold/minimum-send checks for low-value transfers to ensure the expected minimum-send error text is shown.
  * Expanded swap quote coverage for Kyber and LiFi, with more accurate handling of failure modes (e.g., insufficient funds, rate limiting, and high price impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->