### PR TITLE
feat: Show MLDSA key in vault details screen

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -71,8 +72,10 @@ import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.ChainTokenUiModel
 import com.vultisig.wallet.ui.models.ChainTokensUiModel
+import com.vultisig.wallet.ui.models.DeviceMeta
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
+import com.vultisig.wallet.ui.models.VaultDetailUiModel
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
@@ -104,6 +107,7 @@ import com.vultisig.wallet.ui.models.swap.VultTierGateUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
 import com.vultisig.wallet.ui.screens.TransactionDoneView
+import com.vultisig.wallet.ui.screens.VaultDetailScreen
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsContent
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingPositionSkeleton
@@ -265,6 +269,8 @@ class PreviewActivity : ComponentActivity() {
                     "sign_message_before" -> VerifySignMessageCtaPreview(newButtons = false)
                     "sign_message_after" -> VerifySignMessageCtaPreview(newButtons = true)
                     "review_vault_devices" -> ReviewVaultDevicesPreview()
+                    "vault_detail_no_mldsa" -> VaultDetailPreview(withMldsa = false)
+                    "vault_detail_mldsa" -> VaultDetailPreview(withMldsa = true)
                     "error_screen_after" -> ErrorScreenAfterPreview()
                     else -> SwapConfirmPreview()
                 }
@@ -441,6 +447,41 @@ private fun ReviewVaultDevicesPreview() {
                 devices = listOf("iPhone", "Extension", "MacBook"),
             ),
         onEvent = {},
+    )
+}
+
+/**
+ * Vault details screen for a 2-of-2 vault. [withMldsa] = false renders the Keys section as it looks
+ * today (only ECDSA and EdDSA rows); true adds the post-quantum "MLDSA key" row that shows for
+ * vaults holding an MLDSA public key (#5038).
+ */
+@Composable
+private fun VaultDetailPreview(withMldsa: Boolean) {
+    VaultDetailScreen(
+        state =
+            VaultDetailUiModel(
+                name = "Main Vault",
+                vaultPart = "1",
+                vaultSize = "2",
+                pubKeyECDSA = "0274d5e2f5c5b2c3a1b8e9d0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1",
+                pubKeyEDDSA = "9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a39281706f5e4d3c2b1a0",
+                pubKeyMLDSA =
+                    if (withMldsa)
+                        "a3f1c0b29d8e76543210fedcba9876540123456789abcdef" +
+                            "fedcba98765432100123456789abcdefa3f1c0b29d8e7654" +
+                            "3210fedcba9876540123456789abcdef"
+                    else "",
+                libType = "DKLS",
+                deviceList =
+                    listOf(
+                        DeviceMeta(name = "iPhone", isThisDevice = true),
+                        DeviceMeta(name = "MacBook", isThisDevice = false),
+                    ),
+            ),
+        snackBarState = rememberVsSnackbarState(),
+        graphicsLayer = rememberGraphicsLayer(),
+        onShareClick = {},
+        onBackClick = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultDetailViewModel.kt
@@ -28,6 +28,7 @@ internal data class VaultDetailUiModel(
     val vaultSize: String = "",
     val pubKeyECDSA: String = "",
     val pubKeyEDDSA: String = "",
+    val pubKeyMLDSA: String = "",
     val deviceList: List<DeviceMeta> = emptyList(),
     val libType: String? = "",
 )
@@ -63,6 +64,7 @@ constructor(
                         vaultSize = vault.signers.size.toString(),
                         pubKeyECDSA = vault.pubKeyECDSA,
                         pubKeyEDDSA = vault.pubKeyEDDSA,
+                        pubKeyMLDSA = vault.pubKeyMLDSA,
                         deviceList =
                             vault.signers.map {
                                 DeviceMeta(name = it, isThisDevice = it == vault.localPartyID)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
@@ -63,7 +63,7 @@ internal fun VaultDetailScreen(
 }
 
 @Composable
-private fun VaultDetailScreen(
+internal fun VaultDetailScreen(
     state: VaultDetailUiModel,
     snackBarState: VSSnackbarState,
     onBackClick: () -> Unit,
@@ -72,6 +72,7 @@ private fun VaultDetailScreen(
 ) {
     val ecdsaKeyCopiedMessage = stringResource(R.string.vault_detail_screen_ecdsa_key_copied)
     val eddsaKeyCopiedMessage = stringResource(R.string.vault_detail_screen_eddsa_key_copied)
+    val mldsaKeyCopiedMessage = stringResource(R.string.vault_detail_screen_mldsa_key_copied)
 
     Box(modifier = Modifier.fillMaxSize()) {
         V2Scaffold(
@@ -120,6 +121,13 @@ private fun VaultDetailScreen(
                         value = state.pubKeyEDDSA,
                         onCopyCompleted = { snackBarState.show(eddsaKeyCopiedMessage) },
                     )
+                    if (state.pubKeyMLDSA.isNotBlank()) {
+                        KeyItem(
+                            type = stringResource(R.string.vault_detail_screen_mldsa_key),
+                            value = state.pubKeyMLDSA,
+                            onCopyCompleted = { snackBarState.show(mldsaKeyCopiedMessage) },
+                        )
+                    }
                 }
 
                 UiSpacer(24.dp)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -114,6 +114,8 @@
     <string name="vault_detail_screen_vault_name">Tresorname</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA-Schlüssel kopiert</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA-Schlüssel kopiert</string>
+    <string name="vault_detail_screen_mldsa_key">MLDSA-Schlüssel</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA-Schlüssel kopiert</string>
     <string name="welcome_screen_skip">Überspringen</string>
     <string name="keysign_screen_preparing_vault">TRESOR VORBEREITEN…</string>
     <string name="vault_settings_delete_vault_caution1">Mir ist bewusst, dass der Tresor dauerhaft gelöscht wird</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -141,6 +141,8 @@
     <string name="vault_detail_screen_vault_name">Nombre de la Bóveda</string>
     <string name="vault_detail_screen_ecdsa_key_copied">Clave ECDSA Copiada</string>
     <string name="vault_detail_screen_eddsa_key_copied">Clave EdDSA Copiada</string>
+    <string name="vault_detail_screen_mldsa_key">Clave MLDSA</string>
+    <string name="vault_detail_screen_mldsa_key_copied">Clave MLDSA Copiada</string>
     <string name="welcome_screen_skip">Saltar</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO BÓVEDA..</string>
     <string name="vault_settings_delete_vault_caution1">Soy consciente de que la bóveda será eliminada permanentemente</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -112,6 +112,8 @@
     <string name="vault_detail_screen_vault_name">Ime sefa</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA ključ kopiran</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA ključ kopiran</string>
+    <string name="vault_detail_screen_mldsa_key">Ključ MLDSA-e</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA ključ kopiran</string>
     <string name="welcome_screen_skip">Preskoči</string>
     <string name="keysign_screen_preparing_vault">PRIPREMA SEFA…</string>
     <string name="vault_settings_delete_vault_caution1">Ovaj sef će biti trajno uklonjen</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -112,6 +112,8 @@
     <string name="vault_detail_screen_vault_name">Nome Cassaforte</string>
     <string name="vault_detail_screen_ecdsa_key_copied">Chiave ECDSA Copiata</string>
     <string name="vault_detail_screen_eddsa_key_copied">Chiave EdDSA Copiata</string>
+    <string name="vault_detail_screen_mldsa_key">Chiave MLDSA</string>
+    <string name="vault_detail_screen_mldsa_key_copied">Chiave MLDSA Copiata</string>
     <string name="welcome_screen_skip">Salta</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO LA CASSAFORTE…</string>
     <string name="vault_settings_delete_vault_caution1">Sono consapevole che il caveau sarà eliminato permanentemente</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -216,6 +216,8 @@
     <string name="vault_detail_screen_vault_name">볼트 이름</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA 키 복사됨</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA 키 복사됨</string>
+    <string name="vault_detail_screen_mldsa_key">MLDSA 키</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA 키 복사됨</string>
     <string name="welcome_screen_skip">건너뛰기</string>
     <string name="keysign_screen_preparing_vault">볼트 준비 중…</string>
     <string name="vault_settings_delete_vault_caution1">볼트가 영구적으로 삭제된다는 것을 알고 있습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -141,6 +141,8 @@
     <string name="vault_detail_screen_vault_name">Kluisnaam</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA-sleutel gekopieerd</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA-sleutel gekopieerd</string>
+    <string name="vault_detail_screen_mldsa_key">MLDSA-sleutel</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA-sleutel gekopieerd</string>
     <string name="welcome_screen_skip">Overslaan</string>
     <string name="keysign_screen_preparing_vault">Kluis voorbereiden…</string>
     <string name="vault_settings_delete_vault_caution1">Ik ben me ervan bewust dat de kluis permanent zal worden verwijderd</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -117,6 +117,8 @@
     <string name="vault_detail_screen_vault_name">Nome do Cofre</string>
     <string name="vault_detail_screen_ecdsa_key_copied">Chave ECDSA Copiada</string>
     <string name="vault_detail_screen_eddsa_key_copied">Chave EdDSA Copiada</string>
+    <string name="vault_detail_screen_mldsa_key">Chave MLDSA</string>
+    <string name="vault_detail_screen_mldsa_key_copied">Chave MLDSA Copiada</string>
     <string name="welcome_screen_skip">Pular</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO COFRE…</string>
     <string name="vault_settings_delete_vault_caution1">Estou ciente de que o cofre será excluído permanentemente</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -141,6 +141,8 @@
     <string name="vault_detail_screen_vault_name">Имя хранилища</string>
     <string name="vault_detail_screen_ecdsa_key_copied">Ключ ECDSA скопирован</string>
     <string name="vault_detail_screen_eddsa_key_copied">Ключ EdDSA скопирован</string>
+    <string name="vault_detail_screen_mldsa_key">Ключ MLDSA</string>
+    <string name="vault_detail_screen_mldsa_key_copied">Ключ MLDSA скопирован</string>
     <string name="welcome_screen_skip">Пропустить</string>
     <string name="keysign_screen_preparing_vault">Подготовка хранилища…</string>
     <string name="vault_settings_delete_vault_caution1">Я понимаю, что хранилище будет удалено навсегда</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -258,6 +258,8 @@
     <string name="vault_detail_screen_vault_name">保险库名称</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA 密钥已复制</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA 密钥已复制</string>
+    <string name="vault_detail_screen_mldsa_key">MLDSA 密钥</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA 密钥已复制</string>
 
     <!-- Welcome Screen -->
     <string name="welcome_screen_skip">跳过</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,8 @@
     <string name="vault_detail_screen_vault_name">Vault Name</string>
     <string name="vault_detail_screen_ecdsa_key_copied">ECDSA Key Copied</string>
     <string name="vault_detail_screen_eddsa_key_copied">EdDSA Key Copied</string>
+    <string name="vault_detail_screen_mldsa_key">MLDSA key</string>
+    <string name="vault_detail_screen_mldsa_key_copied">MLDSA Key Copied</string>
     <string name="welcome_screen_skip">Skip</string>
     <string name="keysign_screen_preparing_vault">Preparing vault…</string>
     <string name="vault_settings_delete_vault_caution1">I am aware that the vault will be deleted permanently</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/VaultDetailViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/VaultDetailViewModelTest.kt
@@ -1,0 +1,110 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.usecases.ShareBitmapUseCase
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class VaultDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var shareBitmap: ShareBitmapUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        every { any<SavedStateHandle>().toRoute<Route.Details>() } returns
+            Route.Details(vaultId = VAULT_ID)
+        vaultRepository = mockk(relaxed = true)
+        shareBitmap = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `exposes the MLDSA public key when the vault has one`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault(pubKeyMLDSA = MLDSA_KEY)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiModel.value.pubKeyMLDSA shouldBe MLDSA_KEY
+        }
+
+    @Test
+    fun `exposes an empty MLDSA public key when the vault has none`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault(pubKeyMLDSA = "")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiModel.value.pubKeyMLDSA shouldBe ""
+        }
+
+    @Test
+    fun `keeps exposing the ECDSA and EdDSA keys`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault(pubKeyMLDSA = MLDSA_KEY)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiModel.value.pubKeyECDSA shouldBe ECDSA_KEY
+            vm.uiModel.value.pubKeyEDDSA shouldBe EDDSA_KEY
+        }
+
+    private fun createViewModel() =
+        VaultDetailViewModel(
+            savedStateHandle = mockk(relaxed = true),
+            vaultRepository = vaultRepository,
+            shareBitmap = shareBitmap,
+        )
+
+    private fun vault(pubKeyMLDSA: String) =
+        Vault(
+            id = VAULT_ID,
+            name = "Test Vault",
+            pubKeyECDSA = ECDSA_KEY,
+            pubKeyEDDSA = EDDSA_KEY,
+            pubKeyMLDSA = pubKeyMLDSA,
+            signers = listOf("iPhone", "Server-1"),
+            localPartyID = "iPhone",
+        )
+
+    private companion object {
+        private const val VAULT_ID = "test-vault-id"
+        private const val ECDSA_KEY = "ecdsa-public-key"
+        private const val EDDSA_KEY = "eddsa-public-key"
+        private const val MLDSA_KEY = "mldsa-public-key"
+    }
+}


### PR DESCRIPTION
## Summary
The vault Details screen only listed the ECDSA and EdDSA public keys. Vaults that hold a post-quantum MLDSA key had no way to view or copy it. This adds a copyable **MLDSA key** row to the Keys section, shown only when the vault has an MLDSA public key, reusing the existing key-row/copy component and matching the Windows/extension layout.

ECDSA/EdDSA rows and all other sections are unchanged, and vaults without an MLDSA key show no MLDSA row.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/0nuiTGB.png) | ![after](https://i.imgur.com/SY9uq1P.png) |

## Testing
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.VaultDetailViewModelTest"` — new test covers the MLDSA key being exposed when present, empty when absent, and ECDSA/EdDSA staying intact
- `./gradlew :app:ktfmtCheck`
- `./gradlew :app:lintDebug`
- Screenshots captured from `PreviewActivity` on an emulator

Closes #5038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault details can now display an MLDSA key when available.
  * Users can copy the MLDSA key and see a confirmation message.
  * Vault detail previews now cover both vault states: with and without an MLDSA key.

* **Localization**
  * Added MLDSA labels and copy-confirmation text in multiple languages, including English, German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese.

* **Bug Fixes**
  * Improved vault detail data handling so the MLDSA key is shown correctly when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->