### PR TITLE
fix(vault-details): cap MLDSA key row height with ellipsis

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -43,6 +44,9 @@ import com.vultisig.wallet.ui.models.DeviceMeta
 import com.vultisig.wallet.ui.models.VaultDetailUiModel
 import com.vultisig.wallet.ui.models.VaultDetailViewModel
 import com.vultisig.wallet.ui.theme.Theme
+
+/** Caps the height of the long MLDSA public key row before it ellipsizes. */
+private const val MLDSA_KEY_MAX_LINES = 4
 
 @Composable
 internal fun VaultDetailScreen(
@@ -125,6 +129,10 @@ internal fun VaultDetailScreen(
                         KeyItem(
                             type = stringResource(R.string.vault_detail_screen_mldsa_key),
                             value = state.pubKeyMLDSA,
+                            // The MLDSA public key is far longer than the ECDSA/EdDSA keys; cap its
+                            // height and ellipsize so it doesn't blow up the row. The full value is
+                            // still copyable via the copy icon.
+                            maxValueLines = MLDSA_KEY_MAX_LINES,
                             onCopyCompleted = { snackBarState.show(mldsaKeyCopiedMessage) },
                         )
                     }
@@ -242,7 +250,12 @@ internal fun Modifier.itemModifier(): Modifier =
         .padding(vertical = 24.dp, horizontal = 20.dp)
 
 @Composable
-private fun KeyItem(type: String, value: String, onCopyCompleted: (String) -> Unit = {}) {
+private fun KeyItem(
+    type: String,
+    value: String,
+    maxValueLines: Int = Int.MAX_VALUE,
+    onCopyCompleted: (String) -> Unit = {},
+) {
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -259,6 +272,8 @@ private fun KeyItem(type: String, value: String, onCopyCompleted: (String) -> Un
                 text = value,
                 style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.text.tertiary,
+                maxLines = maxValueLines,
+                overflow = TextOverflow.Ellipsis,
             )
         }
         UiSpacer(16.dp)


### PR DESCRIPTION
## Summary
- The MLDSA public key shown in the vault Details screen "Keys" section is far longer than the ECDSA/EdDSA keys, so its row expanded arbitrarily and pushed the rest of the screen down.
- Added a `maxValueLines` parameter to the shared `KeyItem` composable and applied `maxLines` + `TextOverflow.Ellipsis` to the value text.
- The MLDSA row now caps at 4 lines (`MLDSA_KEY_MAX_LINES`) and ellipsizes; ECDSA/EdDSA rows keep the previous unbounded rendering.
- The full key remains copyable via the existing copy icon — only the on-screen preview is truncated.

## Test Plan
- [ ] Open a vault that holds a post-quantum MLDSA key → vault Details: MLDSA row is capped at 4 lines with a trailing `…`
- [ ] ECDSA/EdDSA rows render unchanged
- [ ] Copy icon on the MLDSA row still copies the full key
- [x] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long public key values now wrap more gracefully in the vault details view, preventing the layout from expanding unnecessarily.
  * The key text now truncates with an ellipsis when needed, while still allowing the full value to be copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->