### PR TITLE
fix(swap): forward user slippage to SwapKit quotes

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -922,9 +922,8 @@ constructor(
                 cacheDstAddress,
                 srcTokenValue,
                 SwapProvider.SWAPKIT,
-                // Slippage is part of the cache key so a tolerance change re-fetches a correctly
-                // routed quote rather than serving the stale one built at the old tolerance
-                // (#5050).
+                // Keyed by slippage so a tolerance change re-fetches instead of serving a quote
+                // routed to the previous tolerance.
                 slippageBps = slippageBps,
             ) {
                 val result =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -283,6 +283,7 @@ constructor(
                         tokenValue,
                         vultBPSDiscount,
                         srcNativeToken,
+                        slippageBps,
                         externalRecipient,
                     )
             }
@@ -900,6 +901,7 @@ constructor(
         tokenValue: TokenValue,
         vultBPSDiscount: Int?,
         srcNativeToken: Coin,
+        slippageBps: Int?,
         externalRecipient: String?,
     ): Pair<SwapQuote, UiText> {
         // iOS' SwapKit tier-discount formula at this milestone:
@@ -920,9 +922,10 @@ constructor(
                 cacheDstAddress,
                 srcTokenValue,
                 SwapProvider.SWAPKIT,
-                // SwapKit uses a server-side slippage floor (no quote-time override, #4858) — keep
-                // its cache key slippage-agnostic.
-                slippageBps = null,
+                // Slippage is part of the cache key so a tolerance change re-fetches a correctly
+                // routed quote rather than serving the stale one built at the old tolerance
+                // (#5050).
+                slippageBps = slippageBps,
             ) {
                 val result =
                     swapQuoteRepository.getQuote(
@@ -934,6 +937,7 @@ constructor(
                             srcAddress = src.address.address,
                             dstAddress = requestDstAddress,
                             affiliateBps = affiliateBps,
+                            slippageBps = slippageBps,
                         ),
                     )
                 val evmResult =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -352,6 +352,49 @@ internal class SwapFormViewModelTest {
 
     // endregion
 
+    @Test
+    fun `setSlippageBps stores an in-range tolerance`() =
+        runTest(mainDispatcher) {
+            val vm = createViewModel()
+
+            vm.setSlippageBps(300)
+
+            assertEquals(300, vm.uiState.value.slippageBps)
+        }
+
+    @Test
+    fun `setSlippageBps clears the tolerance to Auto on null`() =
+        runTest(mainDispatcher) {
+            val vm = createViewModel()
+            vm.setSlippageBps(300)
+
+            vm.setSlippageBps(null)
+
+            assertNull(vm.uiState.value.slippageBps)
+        }
+
+    @Test
+    fun `setSlippageBps rejects a non-positive tolerance and keeps the previous value`() =
+        runTest(mainDispatcher) {
+            val vm = createViewModel()
+            vm.setSlippageBps(300)
+
+            vm.setSlippageBps(0)
+
+            assertEquals(300, vm.uiState.value.slippageBps)
+        }
+
+    @Test
+    fun `setSlippageBps rejects a tolerance above 100 percent and keeps the previous value`() =
+        runTest(mainDispatcher) {
+            val vm = createViewModel()
+            vm.setSlippageBps(300)
+
+            vm.setSlippageBps(10_001)
+
+            assertEquals(300, vm.uiState.value.slippageBps)
+        }
+
     // region back
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -741,6 +741,63 @@ internal class SwapQuoteManagerTest {
         coVerify(exactly = 2) { swapQuoteRepository.getQuote(SwapProvider.JUPITER, any()) }
     }
 
+    @Test
+    fun `fetchQuote forwards the user-set slippage to the SwapKit request`() = runTest {
+        // SwapKit silently dropped the user tolerance before #5050 (the request was built without a
+        // slippage). Pin that the chosen value now reaches the request the source forwards to
+        // /v3/quote. Throw after capture to stay off the fee path.
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        val requestSlot = slot<SwapQuoteRequest>()
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, capture(requestSlot)) } throws
+            SwapException.SwapRouteNotAvailable("stop after capture")
+
+        assertFailsWith<SwapException.SwapRouteNotAvailable> {
+            fetchSwapKitQuote(createManager(), slippageBps = 250)
+        }
+
+        assertEquals(250, requestSlot.captured.slippageBps)
+    }
+
+    @Test
+    fun `SwapKit quotes that differ only in slippage do not collide in the cache`() = runTest {
+        // Slippage is now part of the SwapKit cache key, so a re-fetch after a tolerance change
+        // must
+        // miss and re-quote rather than serve the stale route. Two identical-slippage calls share
+        // one network call; a third at a different slippage adds a second — three calls, two
+        // fetches.
+        val eth = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
+        coEvery { tokenRepository.getNativeToken(any()) } returns eth
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) } returns
+            SwapQuoteResult.Evm(jupiterEvmQuote())
+
+        val manager = createManager()
+        fetchSwapKitQuote(manager, slippageBps = 100)
+        fetchSwapKitQuote(manager, slippageBps = 100)
+        fetchSwapKitQuote(manager, slippageBps = 200)
+
+        coVerify(exactly = 2) { swapQuoteRepository.getQuote(SwapProvider.SWAPKIT, any()) }
+    }
+
+    private suspend fun fetchSwapKitQuote(manager: SwapQuoteManager, slippageBps: Int?) =
+        manager.fetchQuote(
+            provider = SwapProvider.SWAPKIT,
+            src = mockk(relaxed = true),
+            dst = mockk(relaxed = true),
+            srcToken = coin(Chain.Ethereum, "ETH", "0xsrc", 18),
+            dstToken = coin(Chain.Ethereum, "USDC", "0xdst", 6),
+            srcTokenValue = BigInteger.ONE,
+            tokenValue = TokenValue(BigInteger.ONE, coin(Chain.Ethereum, "ETH", "0xsrc", 18)),
+            currency = AppCurrency.USD,
+            vultBPSDiscount = null,
+            referral = null,
+            amount = BigDecimal.ONE,
+            slippageBps = slippageBps,
+        )
+
     private suspend fun fetchJupiterQuote(manager: SwapQuoteManager, slippageBps: Int?) =
         manager.fetchQuote(
             provider = SwapProvider.JUPITER,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -743,8 +743,7 @@ internal class SwapQuoteManagerTest {
 
     @Test
     fun `fetchQuote forwards the user-set slippage to the SwapKit request`() = runTest {
-        // SwapKit silently dropped the user tolerance before #5050 (the request was built without a
-        // slippage). Pin that the chosen value now reaches the request the source forwards to
+        // Pin that the chosen tolerance reaches the request the source forwards to SwapKit's
         // /v3/quote. Throw after capture to stay off the fee path.
         coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
             FiatValue(BigDecimal.ZERO, "USD")
@@ -761,11 +760,10 @@ internal class SwapQuoteManagerTest {
 
     @Test
     fun `SwapKit quotes that differ only in slippage do not collide in the cache`() = runTest {
-        // Slippage is now part of the SwapKit cache key, so a re-fetch after a tolerance change
-        // must
-        // miss and re-quote rather than serve the stale route. Two identical-slippage calls share
-        // one network call; a third at a different slippage adds a second — three calls, two
-        // fetches.
+        // Slippage is part of the SwapKit cache key, so a re-fetch after a tolerance change must
+        // miss and re-quote rather than serve a route built for the old tolerance. Two
+        // identical-slippage calls share one network call; a third at a different slippage adds a
+        // second — three calls, two fetches.
         val eth = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
         coEvery { tokenRepository.getNativeToken(any()) } returns eth
         coEvery { convertTokenValueToFiat(any(), any(), any()) } returns

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteJson.kt
@@ -23,12 +23,13 @@ data class SwapKitQuoteRequest(
     /** Limits the liquidity providers considered. Omit to let SwapKit pick from all available. */
     @SerialName("providers") val providers: List<String>? = null,
     /**
-     * Max slippage as a percentage (`1` == 1%, NOT bps). Nullable and omitted from the wire when
-     * unset: the shared Json sets `explicitNulls = false`, so a null is dropped — the same
-     * mechanism the sibling [sourceAddress] / [destinationAddress] fields rely on. iOS sends no
-     * slippage, and the Phase 0 spike found an explicit slippage makes NEAR Intents / Chainflip
-     * return `noRoutesFound` on some pairs, so the default is to send nothing and let SwapKit
-     * choose.
+     * Max slippage as a percentage (`1` == 1%, NOT bps). Carries the user's Advanced-swap tolerance
+     * when set and is omitted from the wire on Auto: the shared Json sets `explicitNulls = false`,
+     * so a null is dropped — the same mechanism the sibling [sourceAddress] / [destinationAddress]
+     * fields rely on. Omitting on Auto is deliberate: the Phase 0 spike found that forcing an
+     * explicit slippage makes NEAR Intents / Chainflip return `noRoutesFound` on some pairs, so
+     * Auto lets SwapKit pick its own per-route tolerance. Mirrors iOS, which likewise forwards a
+     * user override and omits on Auto (#5050).
      */
     @SerialName("slippage") val slippage: Double? = null,
     /** Affiliate fee override in basis points (range 0..1000, max 10%). */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/SwapKitQuoteJson.kt
@@ -23,13 +23,11 @@ data class SwapKitQuoteRequest(
     /** Limits the liquidity providers considered. Omit to let SwapKit pick from all available. */
     @SerialName("providers") val providers: List<String>? = null,
     /**
-     * Max slippage as a percentage (`1` == 1%, NOT bps). Carries the user's Advanced-swap tolerance
-     * when set and is omitted from the wire on Auto: the shared Json sets `explicitNulls = false`,
-     * so a null is dropped — the same mechanism the sibling [sourceAddress] / [destinationAddress]
-     * fields rely on. Omitting on Auto is deliberate: the Phase 0 spike found that forcing an
-     * explicit slippage makes NEAR Intents / Chainflip return `noRoutesFound` on some pairs, so
-     * Auto lets SwapKit pick its own per-route tolerance. Mirrors iOS, which likewise forwards a
-     * user override and omits on Auto (#5050).
+     * Max slippage as a percentage (`1` == 1%, NOT bps), or null to omit it from the wire — the
+     * shared Json sets `explicitNulls = false`, so a null is dropped, like the sibling
+     * [sourceAddress] / [destinationAddress] fields. Omitting it lets SwapKit pick its own
+     * per-route tolerance: forcing an explicit slippage makes NEAR Intents / Chainflip reject some
+     * pairs with `noRoutesFound`, so a value is sent only when the user overrides the default.
      */
     @SerialName("slippage") val slippage: Double? = null,
     /** Affiliate fee override in basis points (range 0..1000, max 10%). */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -153,10 +153,10 @@ constructor(
                     sourceAddress = request.srcAddress.ifBlank { null },
                     destinationAddress = request.dstAddress.ifBlank { null },
                     affiliateFee = request.affiliateBps,
-                    // User-set tolerance as a percentage (100 bps = 1%); omitted on Auto so NEAR
-                    // Intents / Chainflip keep negotiating their own per-route slippage. Mirrors
-                    // iOS SwapKitService.fetchBestRoute (#5050).
-                    slippage = request.slippageBps?.let { it / SLIPPAGE_BPS_PER_PERCENT },
+                    // SwapKit expects slippage as a percentage, so convert from basis points (100
+                    // bps = 1%). A null tolerance is omitted from the wire so NEAR Intents /
+                    // Chainflip negotiate their own per-route slippage instead of being capped.
+                    slippage = request.slippageBps?.let { it / 100.0 },
                 )
             )
 
@@ -985,9 +985,6 @@ constructor(
 
         /** ERC20 `approve(address,uint256)` 4-byte function selector (hex, no `0x`). */
         private const val APPROVE_SELECTOR = "095ea7b3"
-
-        /** bps→percent divisor for SwapKit's `slippage` field (100 bps = 1%). */
-        private const val SLIPPAGE_BPS_PER_PERCENT = 100.0
 
         /**
          * Sub-provider ids (lower-cased, underscored — matches the wire format of SwapKit's

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -153,6 +153,10 @@ constructor(
                     sourceAddress = request.srcAddress.ifBlank { null },
                     destinationAddress = request.dstAddress.ifBlank { null },
                     affiliateFee = request.affiliateBps,
+                    // User-set tolerance as a percentage (100 bps = 1%); omitted on Auto so NEAR
+                    // Intents / Chainflip keep negotiating their own per-route slippage. Mirrors
+                    // iOS SwapKitService.fetchBestRoute (#5050).
+                    slippage = request.slippageBps?.let { it / SLIPPAGE_BPS_PER_PERCENT },
                 )
             )
 
@@ -981,6 +985,9 @@ constructor(
 
         /** ERC20 `approve(address,uint256)` 4-byte function selector (hex, no `0x`). */
         private const val APPROVE_SELECTOR = "095ea7b3"
+
+        /** bps→percent divisor for SwapKit's `slippage` field (100 bps = 1%). */
+        private const val SLIPPAGE_BPS_PER_PERCENT = 100.0
 
         /**
          * Sub-provider ids (lower-cased, underscored — matches the wire format of SwapKit's

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -26,8 +26,9 @@ data class SwapQuoteRequest(
      * User-chosen slippage tolerance in basis points (100 = 1%), or null for "Auto" — in which case
      * each provider keeps its own default ([DEFAULT_THORCHAIN_TOLERANCE_BPS] for THORChain/Maya,
      * 0.5% for 1inch and Jupiter, 1% for Kyber, LI.FI's and SwapKit's own server defaults).
-     * Honoured by every provider; SwapKit converts it to a percentage and omits it on Auto so NEAR
-     * Intents / Chainflip can negotiate their own per-route tolerance. See #4858, #5050.
+     * Honoured by every provider; each converts it to its native unit (bps, percent, or fraction),
+     * and SwapKit omits it on Auto so NEAR Intents / Chainflip can negotiate their own per-route
+     * tolerance.
      */
     val slippageBps: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -25,8 +25,9 @@ data class SwapQuoteRequest(
     /**
      * User-chosen slippage tolerance in basis points (100 = 1%), or null for "Auto" — in which case
      * each provider keeps its own default ([DEFAULT_THORCHAIN_TOLERANCE_BPS] for THORChain/Maya,
-     * 0.5% for 1inch and Jupiter, 1% for Kyber, LI.FI's own server default). Honoured by every
-     * provider except SwapKit, which applies a server-side slippage floor. See #4858.
+     * 0.5% for 1inch and Jupiter, 1% for Kyber, LI.FI's and SwapKit's own server defaults).
+     * Honoured by every provider; SwapKit converts it to a percentage and omits it on Auto so NEAR
+     * Intents / Chainflip can negotiate their own per-route tolerance. See #4858, #5050.
      */
     val slippageBps: Int? = null,
 )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiSlippageTest.kt
@@ -1,0 +1,91 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the `tolerance_bps` query param sent to MayaChain, mirroring [ThorChainApiSlippageTest]. A 0
+ * / Auto tolerance must be omitted so MayaChain never rejects the quote for a limit it never set; a
+ * user override is sent verbatim in basis points. The request short-circuits on a deserialization
+ * stub so the outgoing params — not the response — are the subject under test.
+ */
+class MayaChainApiSlippageTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun apiCapturing(onRequest: (HttpRequestData) -> Unit) =
+        MayaChainApiImp(
+            httpClient =
+                HttpClient(
+                    MockEngine { request ->
+                        onRequest(request)
+                        respond("{}", HttpStatusCode.BadRequest, jsonHeaders)
+                    }
+                ),
+            thorChainApi = mockk<ThorChainApi>(),
+            thorChainSwapQuoteResponseJsonSerializer =
+                mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
+            json = json,
+        )
+
+    private suspend fun MayaChainApiImp.quoteWith(toleranceBps: Int?) =
+        getSwapQuotes(
+            address = "maya1dest",
+            fromAsset = "ETH.ETH",
+            toAsset = "MAYA.CACAO",
+            amount = "1000",
+            isAffiliate = true,
+            bpsDiscount = 0,
+            referralCode = "",
+            toleranceBps = toleranceBps,
+        )
+
+    @Test
+    fun `a 300 bps tolerance is sent verbatim`() = runTest {
+        var toleranceParam: String? = null
+        val api = apiCapturing { toleranceParam = it.url.parameters["tolerance_bps"] }
+
+        api.quoteWith(toleranceBps = 300)
+
+        assertEquals("300", toleranceParam)
+    }
+
+    @Test
+    fun `auto tolerance of 0 omits the parameter`() = runTest {
+        var hasTolerance = true
+        val api = apiCapturing { hasTolerance = it.url.parameters.contains("tolerance_bps") }
+
+        api.quoteWith(toleranceBps = 0)
+
+        assertFalse(hasTolerance)
+    }
+
+    @Test
+    fun `null tolerance omits the parameter`() = runTest {
+        var hasTolerance = true
+        val api = apiCapturing { hasTolerance = it.url.parameters.contains("tolerance_bps") }
+
+        api.quoteWith(toleranceBps = null)
+
+        assertFalse(hasTolerance)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/OneInchApiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/OneInchApiSlippageTest.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.swapAggregators.OneInchApiImpl
+import com.vultisig.wallet.data.models.Chain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the `slippage` query param 1inch receives. 1inch denominates slippage as a PERCENT (`1` ==
+ * 1%), so the user's basis-point tolerance must be divided by 100; Auto (null) falls back to
+ * 1inch's historical 0.5% default. That percent value is what bounds the min-received, so a wrong
+ * magnitude would silently widen or tighten the user's tolerance. Each request short-circuits on a
+ * `BadRequest` so the outgoing params — not the response — are the subject under test.
+ */
+class OneInchApiSlippageTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun apiCapturing(onRequest: (HttpRequestData) -> Unit) =
+        OneInchApiImpl(
+            httpClient =
+                HttpClient(
+                    MockEngine { request ->
+                        onRequest(request)
+                        respond(
+                            """{"statusCode":400,"description":"stop"}""",
+                            HttpStatusCode.BadRequest,
+                            jsonHeaders,
+                        )
+                    }
+                ),
+            oneInchSwapQuoteResponseJsonSerializer = mockk(),
+            json = json,
+        )
+
+    private suspend fun OneInchApiImpl.quoteWith(slippageBps: Int?) =
+        getSwapQuote(
+            chain = Chain.Ethereum,
+            srcTokenContractAddress = "0xsrc",
+            dstTokenContractAddress = "0xdst",
+            srcAddress = "0xfrom",
+            amount = "1000",
+            isAffiliate = false,
+            bpsDiscount = 0,
+            slippageBps = slippageBps,
+        )
+
+    @Test
+    fun `auto slippage falls back to the 0_5 percent default`() = runTest {
+        var slippageParam: String? = null
+        val api = apiCapturing { slippageParam = it.url.parameters["slippage"] }
+
+        api.quoteWith(slippageBps = null)
+
+        assertEquals("0.5", slippageParam)
+    }
+
+    @Test
+    fun `100 bps slippage is sent as 1_0 percent`() = runTest {
+        var slippageParam: String? = null
+        val api = apiCapturing { slippageParam = it.url.parameters["slippage"] }
+
+        api.quoteWith(slippageBps = 100)
+
+        assertEquals("1.0", slippageParam)
+    }
+
+    @Test
+    fun `a 300 bps override is sent as 3_0 percent`() = runTest {
+        var slippageParam: String? = null
+        val api = apiCapturing { slippageParam = it.url.parameters["slippage"] }
+
+        api.quoteWith(slippageBps = 300)
+
+        assertEquals("3.0", slippageParam)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiSlippageTest.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
+import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the `tolerance_bps` query param sent to THORChain. The node bakes a real `LIM` into the swap
+ * memo only when `tolerance_bps` is positive; a 0 / Auto tolerance must be omitted so the quote is
+ * never rejected for exceeding a limit it never set. A user override is sent verbatim in basis
+ * points. The request short-circuits on a deserialization stub so the outgoing params — not the
+ * response — are the subject under test.
+ */
+class ThorChainApiSlippageTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun apiCapturing(onRequest: (HttpRequestData) -> Unit) =
+        ThorChainApiImpl(
+            httpClient =
+                HttpClient(
+                    MockEngine { request ->
+                        onRequest(request)
+                        respond("{}", HttpStatusCode.BadRequest, jsonHeaders)
+                    }
+                ),
+            thorChainSwapQuoteResponseJsonSerializer =
+                mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
+            json = json,
+        )
+
+    private suspend fun ThorChainApiImpl.quoteWith(toleranceBps: Int?) =
+        getSwapQuotes(
+            ThorChainSwapQuoteRequest(
+                address = "thor1dest",
+                fromAsset = "ETH.ETH",
+                toAsset = "THOR.RUNE",
+                amount = "1000",
+                interval = "1",
+                referralCode = "",
+                bpsDiscount = 0,
+                toleranceBps = toleranceBps,
+            )
+        )
+
+    @Test
+    fun `a 300 bps tolerance is sent verbatim`() = runTest {
+        var toleranceParam: String? = null
+        val api = apiCapturing { toleranceParam = it.url.parameters["tolerance_bps"] }
+
+        api.quoteWith(toleranceBps = 300)
+
+        assertEquals("300", toleranceParam)
+    }
+
+    @Test
+    fun `auto tolerance of 0 omits the parameter`() = runTest {
+        var hasTolerance = true
+        val api = apiCapturing { hasTolerance = it.url.parameters.contains("tolerance_bps") }
+
+        api.quoteWith(toleranceBps = 0)
+
+        assertFalse(hasTolerance)
+    }
+
+    @Test
+    fun `null tolerance omits the parameter`() = runTest {
+        var hasTolerance = true
+        val api = apiCapturing { hasTolerance = it.url.parameters.contains("tolerance_bps") }
+
+        api.quoteWith(toleranceBps = null)
+
+        assertFalse(hasTolerance)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -171,8 +171,9 @@ internal class SwapKitQuoteSourceTest {
 
     @Test
     fun `fetch forwards the user slippage to the quote request as a percentage`() = runTest {
-        // SwapKit takes slippage as a percentage (100 bps = 1%); a user override must reach the
-        // /v3/quote body so the route is built to the chosen tolerance (mirrors iOS, #5050).
+        // SwapKit takes slippage as a percentage, so a user override must reach the /v3/quote body
+        // converted from basis points (150 bps = 1.5%). A non-round value pins the division so a
+        // truncating or wrong-divisor regression can't pass.
         every { config.isFeatureEnabled } returns flowOf(true)
         val quoteRequest = slot<SwapKitQuoteRequest>()
         coEvery { api.quote(capture(quoteRequest)) } returns
@@ -181,16 +182,15 @@ internal class SwapKitQuoteSourceTest {
             )
         coEvery { api.swap(any()) } returns evmSwapResponse()
 
-        source().fetch(request(slippageBps = 100))
+        source().fetch(request(slippageBps = 150))
 
-        assertEquals(1.0, quoteRequest.captured.slippage)
+        assertEquals(1.5, quoteRequest.captured.slippage)
     }
 
     @Test
     fun `fetch omits slippage from the quote request on Auto`() = runTest {
-        // Auto (null) must omit slippage entirely so NEAR Intents / Chainflip keep negotiating
-        // their
-        // own per-route tolerance rather than failing noRoutesFound on an imposed cap (#5050).
+        // Auto (null) must omit slippage so NEAR Intents / Chainflip keep negotiating their own
+        // per-route tolerance instead of failing noRoutesFound on an imposed cap.
         every { config.isFeatureEnabled } returns flowOf(true)
         val quoteRequest = slot<SwapKitQuoteRequest>()
         coEvery { api.quote(capture(quoteRequest)) } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -170,6 +170,41 @@ internal class SwapKitQuoteSourceTest {
         }
 
     @Test
+    fun `fetch forwards the user slippage to the quote request as a percentage`() = runTest {
+        // SwapKit takes slippage as a percentage (100 bps = 1%); a user override must reach the
+        // /v3/quote body so the route is built to the chosen tolerance (mirrors iOS, #5050).
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val quoteRequest = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(quoteRequest)) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "winner", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        source().fetch(request(slippageBps = 100))
+
+        assertEquals(1.0, quoteRequest.captured.slippage)
+    }
+
+    @Test
+    fun `fetch omits slippage from the quote request on Auto`() = runTest {
+        // Auto (null) must omit slippage entirely so NEAR Intents / Chainflip keep negotiating
+        // their
+        // own per-route tolerance rather than failing noRoutesFound on an imposed cap (#5050).
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val quoteRequest = slot<SwapKitQuoteRequest>()
+        coEvery { api.quote(capture(quoteRequest)) } returns
+            SwapKitQuoteResponseJson(
+                routes = listOf(route(routeId = "winner", providers = listOf("CHAINFLIP")))
+            )
+        coEvery { api.swap(any()) } returns evmSwapResponse()
+
+        source().fetch(request(slippageBps = null))
+
+        assertNull(quoteRequest.captured.slippage)
+    }
+
+    @Test
     fun `fetch throws RouteFiltered when every route is filtered out including streaming variants`() =
         runTest {
             // Upstream returned candidates but the client Thor/Maya/multi-hop filter emptied them.
@@ -1830,6 +1865,7 @@ internal class SwapKitQuoteSourceTest {
         dstToken: Coin = solanaCoin(),
         tokenValue: TokenValue = TokenValue(value = BigInteger.ONE, token = srcToken),
         affiliateBps: Int = 0,
+        slippageBps: Int? = null,
     ) =
         SwapQuoteRequest(
             srcToken = srcToken,
@@ -1838,6 +1874,7 @@ internal class SwapKitQuoteSourceTest {
             srcAddress = "0xsrc",
             dstAddress = "0xdst",
             affiliateBps = affiliateBps,
+            slippageBps = slippageBps,
         )
 
     private fun route(


### PR DESCRIPTION
## Summary

The Advanced-swap slippage value reached every provider except SwapKit, which built its `/v3/quote` request without a slippage and dropped the user's tolerance silently — a no-op control on a money path. This threads the value into the SwapKit quote request and cache key, and sets `SwapKitQuoteRequest.slippage` to `bps / 100` (SwapKit takes a percentage), omitting it on Auto so NEAR Intents / Chainflip keep negotiating their own per-route tolerance. Matches iOS `SwapKitService.fetchBestRoute`.

The other six providers already convert the user value to their native unit correctly; this also adds the wire-level tests that were missing, so each provider's tolerance is verified per the ticket's acceptance.

## Per-provider tolerance (after this change)

| Provider | Wire param | Unit | Auto default |
|---|---|---|---|
| THORChain / Maya | `tolerance_bps` | bps (omitted at 0) | omit |
| Kyber | `slippageTolerance` | bps | 100 |
| 1inch | `slippage` | percent (bps/100) | 0.5 |
| LI.FI | `slippage` | fraction (bps/10000) | server |
| Jupiter | `slippageBps` | bps | 50 |
| SwapKit | `slippage` | percent (bps/100), omit on Auto | server |

## Testing

- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.repositories.swap.*" --tests "com.vultisig.wallet.data.api.*"`
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.*"`
- `./gradlew :data:lintDebug :app:lintDebug`
- ktfmt format + check

New tests cover the SwapKit forward-on-override / omit-on-Auto behavior, manager plumbing and cache-key collision, `setSlippageBps` bounds, and the previously-missing wire-level `slippage` / `tolerance_bps` assertions for 1inch, THORChain, and Maya.

Closes #5050.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap quotes now respect the user-selected slippage tolerance and no longer reuse cached quotes from a different tolerance.
  * Slippage is now consistently forwarded to the SwapKit quote path and correctly omitted when set to Auto.

* **Tests**
  * Added unit tests for swap slippage input validation in the swap form view model.
  * Added SwapKit quote caching and forwarding tests by slippage value.
  * Added request-encoding tests for slippage parameters for multiple quote providers (e.g., OneInch, ThorChain, MayaChain).

* **Documentation**
  * Updated slippage KDoc/comments to clarify how Auto vs explicit tolerances are represented and transmitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->