### PR TITLE
Enlarge keygen/keysign QR card to fill screen width

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
@@ -461,17 +462,19 @@ private fun QrCodeContainer(
     val outerShape = RoundedCornerShape(24.75.dp)
     val innerShape = RoundedCornerShape(18.56.dp)
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier.fillMaxWidth()) {
         Box(
             modifier =
-                Modifier.clip(outerShape)
+                Modifier.fillMaxWidth()
+                    .clip(outerShape)
                     .background(brush = QrFrameGradient, shape = outerShape)
                     .clickable(onClick = onClick)
                     .padding(6.19.dp)
         ) {
             Box(
                 modifier =
-                    Modifier.background(
+                    Modifier.fillMaxWidth()
+                        .background(
                             color = Theme.v2.colors.backgrounds.surface1,
                             shape = innerShape,
                         )
@@ -512,7 +515,7 @@ private fun QrCodeContainer(
  */
 @Composable
 private fun QrCodeImage(qrCode: BitmapPainter?, modifier: Modifier = Modifier) {
-    Box(modifier = modifier.size(185.dp), contentAlignment = Alignment.Center) {
+    Box(modifier = modifier.fillMaxWidth().aspectRatio(1f), contentAlignment = Alignment.Center) {
         AnimatedVisibility(visible = qrCode != null, enter = fadeIn()) {
             if (qrCode != null) {
                 Image(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.screens.peer
 
+import android.graphics.Bitmap
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.RepeatMode
@@ -45,6 +46,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
@@ -67,6 +70,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import app.rive.Fit
 import app.rive.ViewModelSource
 import app.rive.rememberViewModelInstance
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.Utils
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
@@ -851,6 +857,32 @@ private fun Error(state: ErrorUiModel, onTryAgainClick: () -> Unit) {
     }
 }
 
+/**
+ * Builds a real QR painter so the static @Preview renders the framed card with actual content. In
+ * production the QR comes from a Hilt-provided generator backed by an Android context, which the
+ * preview renderer does not have — so the bitmap is encoded inline here with the same quiet-zone
+ * margin used by the app.
+ */
+@Composable
+private fun rememberPreviewQr(content: String): BitmapPainter =
+    remember(content) {
+        val matrix =
+            QRCodeWriter()
+                .encode(content, BarcodeFormat.QR_CODE, 0, 0, mapOf(EncodeHintType.MARGIN to 4))
+        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.ARGB_8888)
+        for (x in 0 until matrix.width) {
+            for (y in 0 until matrix.height) {
+                bitmap.setPixel(
+                    x,
+                    y,
+                    if (matrix.get(x, y)) android.graphics.Color.WHITE
+                    else android.graphics.Color.TRANSPARENT,
+                )
+            }
+        }
+        BitmapPainter(bitmap.asImageBitmap(), filterQuality = FilterQuality.None)
+    }
+
 @Preview
 @Composable
 private fun PeerDiscoveryScreenPreview() {
@@ -859,6 +891,20 @@ private fun PeerDiscoveryScreenPreview() {
             PeerDiscoveryUiModel(
                 localPartyId = "iPhone-A1B",
                 network = NetworkOption.Internet,
+                qr =
+                    rememberPreviewQr(
+                        // A production-sized keygen payload (session id, chain code, relay service,
+                        // encryption key, vault metadata) so the preview QR renders at realistic
+                        // density rather than a sparse low-version code.
+                        "https://vultisig.com?type=NewVault&tssType=Keygen&jsonData=" +
+                            "eyJzZXNzaW9uSWQiOiJDRkE5RTM3Qy0xN0I4LTRGMkEtOUQwMS0yQjNDNEQ1RTZG" +
+                            "N0EiLCJoZXhDaGFpbkNvZGUiOiI5ZjFhMmIzYzRkNWU2ZjdhOGI5YzBkMWUyZjNh" +
+                            "NGI1YzZkN2U4ZjlhMGIxYzJkM2U0ZjVhNmI3YzhkOWUwZjFhMmIzYyIsInNlcnZp" +
+                            "Y2VOYW1lIjoiVnVsdGlzaWctNEY3QSIsImVuY3J5cHRpb25LZXlIZXgiOiJhMWIy" +
+                            "YzNkNGU1ZjZhN2I4YzlkMGUxZjJhM2I0YzVkNmU3ZjhhOWIwYzFkMmUzZjRhNWI2" +
+                            "YzdkOGU5ZjBhMWIyYzNkNGU1ZjYiLCJ1c2VWdWx0aXNpZ1JlbGF5Ijp0cnVlLCJ2" +
+                            "YXVsdE5hbWUiOiJNYWluIFZhdWx0IiwibGlicmFyeVR5cGUiOiJES0xTIn0="
+                    ),
                 devices = listOf("MacBook-C2D", "iPhone-E3F"),
                 selectedDevices = listOf("MacBook-C2D", "iPhone-E3F"),
                 minimumDevices = 4,


### PR DESCRIPTION
## Summary

Follow-up to #5060 (merged). On the keygen/keysign Scan QR screen the QR was pinned to a fixed `185.dp`, leaving large empty margins inside the framed card. This enlarges the card and QR to the scaffold content width so the code consumes most of the screen width and scans more reliably from a second device — matching the iOS Pair screen.

- `QrCodeContainer` / `QrCodeImage` now stretch to `fillMaxWidth()` with a square `aspectRatio(1f)` instead of a fixed 185.dp footprint.
- The `@Preview` (`PeerDiscoveryScreenPreview`) previously passed `qr = null`, so the card rendered empty in Android Studio. It now encodes a QR inline (same quiet-zone margin) fed a production-sized keygen payload, so the preview shows a dense, representative code with the expand control — no emulator/Hilt context required.

## Before / After

| Before (fixed 185.dp) | After (full width) |
|--------|--------|
| ![before](https://i.imgur.com/RPptyN5.png) | ![after](https://i.imgur.com/E4U1Nzk.png) |

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Rendered the real keygen peer-discovery screen on an emulator (dense QR): card fills the content width, expand button stays on the top-right corner clear of the finder pattern
- [x] Android Studio `PeerDiscoveryScreenPreview` renders the QR after Build & Refresh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the peer discovery QR display so it scales more naturally across available space and stays centered during its fade-in animation.
  * Updated the preview to render a realistic QR code, making the screen preview closer to the actual app experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->