### PR TITLE
QBTC claim: work without Bitcoin chain enabled; fix co-signer stuck on spinner

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -166,13 +166,11 @@ constructor(
         }
     }
 
-    // Instant in-memory eligibility (MLDSA key + BTC address); the claim screen does the real
-    // check.
+    // Instant in-memory eligibility (MLDSA key); the claim screen does the real check, including
+    // BTC availability — so the entry point shows even when the Bitcoin chain isn't enabled.
     private fun checkQbtcClaimEligibility(chain: Chain) {
         val vault = currentVault
-        val btcAddress = vault?.coins?.firstOrNull { it.chain == Chain.Bitcoin }?.address
-        val isEligible =
-            vault != null && vault.pubKeyMLDSA.isNotEmpty() && !btcAddress.isNullOrEmpty()
+        val isEligible = vault != null && vault.pubKeyMLDSA.isNotEmpty()
         uiState.update {
             it.copy(
                 showQbtcClaimBanner = isEligible && chain == Chain.Bitcoin,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -222,20 +222,16 @@ sealed interface JoinKeysignState {
 }
 
 /**
- * Builds the QBTC claim approval gate from a vault's [coins]. A vault missing the Bitcoin or QBTC
- * account it needs to recompute the claim hash resolves to a
- * [JoinKeysignError.MissingQbtcClaimAccount] error state — surfaced here, before signing, rather
- * than mid-co-sign.
+ * Builds the QBTC claim approval gate from the resolved [coins], surfacing the two accounts the
+ * claim hash is recomputed from for review before any signing starts. The accounts are resolved
+ * (and derived when not enabled) by [ResolveQbtcClaimCoinsUseCase]; a vault that can't produce them
+ * fails earlier with [JoinKeysignError.MissingQbtcClaimAccount].
  */
-internal fun buildQbtcClaimConsentState(coins: List<Coin>): JoinKeysignState {
-    val btc = coins.firstOrNull { it.chain == Chain.Bitcoin }
-    val qbtc = coins.firstOrNull { it.chain == Chain.Qbtc }
-    return if (btc == null || qbtc == null) {
-        JoinKeysignState.Error(JoinKeysignError.MissingQbtcClaimAccount)
-    } else {
-        JoinKeysignState.QbtcClaimConsent(btcAddress = btc.address, qbtcAddress = qbtc.address)
-    }
-}
+internal fun buildQbtcClaimConsentState(coins: QbtcClaimCoins): JoinKeysignState =
+    JoinKeysignState.QbtcClaimConsent(
+        btcAddress = coins.btc.address,
+        qbtcAddress = coins.qbtc.address,
+    )
 
 internal sealed class VerifyUiModel {
 
@@ -274,6 +270,7 @@ constructor(
     private val blockaidSimulationService: BlockaidSimulationService,
     private val buildHeroContent: BuildHeroContentUseCase,
     private val qbtcClaimCosign: QbtcClaimCosignUseCase,
+    private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
     private val joinSwapUiModelBuilder: JoinSwapUiModelBuilder,
     private val joinDepositUiModelBuilder: JoinDepositUiModelBuilder,
     private val joinSendUiModelBuilder: JoinSendUiModelBuilder,
@@ -965,8 +962,13 @@ constructor(
      * surfaces those two accounts for review before any signing starts. A vault missing either
      * account fails here — before signing — instead of mid-co-sign.
      */
-    private fun showQbtcClaimConsent() {
-        _currentState.value = buildQbtcClaimConsentState(_currentVault.coins)
+    private suspend fun showQbtcClaimConsent() {
+        _currentState.value =
+            try {
+                buildQbtcClaimConsentState(resolveQbtcClaimCoins(_currentVault))
+            } catch (_: MissingQbtcClaimAccountException) {
+                JoinKeysignState.Error(JoinKeysignError.MissingQbtcClaimAccount)
+            }
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -35,6 +35,7 @@ import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.proto.v1.KeysignMessageProto
 import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.securityscanner.BLOCKAID_PROVIDER
 import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
@@ -215,8 +216,14 @@ sealed interface JoinKeysignState {
 
     /**
      * QBTC claim co-sign: [txHash] null while signing, set once the initiator pushes the result.
+     * [explorerUrl] is the QBTC explorer link for [txHash], populated alongside it so the peer's
+     * done screen can link out the same way the initiator's does.
      */
-    data class QbtcClaim(val txHash: String?, val totalSats: Long?) : JoinKeysignState
+    data class QbtcClaim(
+        val txHash: String?,
+        val totalSats: Long?,
+        val explorerUrl: String? = null,
+    ) : JoinKeysignState
 
     data class Error(val errorType: JoinKeysignError) : JoinKeysignState
 }
@@ -271,6 +278,7 @@ constructor(
     private val buildHeroContent: BuildHeroContentUseCase,
     private val qbtcClaimCosign: QbtcClaimCosignUseCase,
     private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
+    private val explorerLinkRepository: ExplorerLinkRepository,
     private val joinSwapUiModelBuilder: JoinSwapUiModelBuilder,
     private val joinDepositUiModelBuilder: JoinDepositUiModelBuilder,
     private val joinSendUiModelBuilder: JoinSendUiModelBuilder,
@@ -1000,7 +1008,14 @@ constructor(
                     encryptionKeyHex = _encryptionKeyHex,
                 )
             _currentState.value =
-                JoinKeysignState.QbtcClaim(txHash = result.txHash, totalSats = result.totalSats)
+                JoinKeysignState.QbtcClaim(
+                    txHash = result.txHash,
+                    totalSats = result.totalSats,
+                    explorerUrl =
+                        result.txHash?.let {
+                            explorerLinkRepository.getTransactionLink(Chain.Qbtc, it)
+                        },
+                )
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimCosignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimCosignUseCase.kt
@@ -28,6 +28,7 @@ internal class QbtcClaimCosignUseCase
 @Inject
 constructor(
     private val computeQbtcClaimMessageHash: ComputeQbtcClaimMessageHashUseCase,
+    private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
     private val qbtcClaimPeerRoundRunner: QbtcClaimPeerRoundRunner,
     private val qbtcClaimResultPoller: QbtcClaimResultPoller,
 ) {
@@ -43,12 +44,7 @@ constructor(
         sessionId: String,
         encryptionKeyHex: String,
     ): QbtcClaimCosignResult {
-        val btc =
-            vault.coins.firstOrNull { it.chain == Chain.Bitcoin }
-                ?: throw MissingQbtcClaimAccountException(Chain.Bitcoin)
-        val qbtc =
-            vault.coins.firstOrNull { it.chain == Chain.Qbtc }
-                ?: throw MissingQbtcClaimAccountException(Chain.Qbtc)
+        val (btc, qbtc) = resolveQbtcClaimCoins(vault)
         val messageHashHex =
             computeQbtcClaimMessageHash(btc.address, btc.hexPublicKey, qbtc.address)
         val session =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimCosignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimCosignUseCase.kt
@@ -7,9 +7,9 @@ import com.vultisig.wallet.data.qbtc.QbtcClaimPeerRoundRunner
 import com.vultisig.wallet.data.qbtc.QbtcClaimResultPoller
 import javax.inject.Inject
 
-/** Thrown when a QBTC claim co-sign cannot find the [chain] account it needs in this vault. */
-internal class MissingQbtcClaimAccountException(chain: Chain) :
-    Exception("Missing ${chain.raw} account for QBTC claim co-sign")
+/** Thrown when a QBTC claim co-sign cannot find or derive the [chain] account it needs. */
+internal class MissingQbtcClaimAccountException(chain: Chain, cause: Throwable? = null) :
+    Exception("Missing ${chain.raw} account for QBTC claim co-sign", cause)
 
 /** The broadcast result of a QBTC claim co-sign, or nulls while the initiator hasn't pushed it. */
 internal data class QbtcClaimCosignResult(val txHash: String?, val totalSats: Long?)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCase.kt
@@ -1,0 +1,45 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import javax.inject.Inject
+
+/** The Bitcoin and QBTC accounts a QBTC claim is derived from. */
+internal data class QbtcClaimCoins(val btc: Coin, val qbtc: Coin)
+
+/**
+ * Resolves the Bitcoin and QBTC accounts a QBTC claim needs. Neither chain has to be enabled in the
+ * vault: an already-enabled coin is used as-is, otherwise the account is derived in-memory from the
+ * native-token template and the vault's own keys. This keeps both the initiator and the co-signer
+ * able to recompute the claim hash regardless of which chains the user has added.
+ *
+ * @throws MissingQbtcClaimAccountException when an account can't be derived (the vault lacks the
+ *   key material for that chain).
+ */
+internal class ResolveQbtcClaimCoinsUseCase
+@Inject
+constructor(
+    private val tokenRepository: TokenRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+) {
+    suspend operator fun invoke(vault: Vault): QbtcClaimCoins =
+        QbtcClaimCoins(btc = resolve(vault, Chain.Bitcoin), qbtc = resolve(vault, Chain.Qbtc))
+
+    private suspend fun resolve(vault: Vault, chain: Chain): Coin {
+        vault.coins
+            .firstOrNull { it.chain == chain }
+            ?.let {
+                return it
+            }
+        return runCatching {
+                val nativeToken = tokenRepository.getNativeToken(chain.id)
+                val (address, derivedPublicKey) =
+                    chainAccountAddressRepository.getAddress(nativeToken, vault)
+                nativeToken.copy(address = address, hexPublicKey = derivedPublicKey)
+            }
+            .getOrElse { throw MissingQbtcClaimAccountException(chain) }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCase.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 
 /** The Bitcoin and QBTC accounts a QBTC claim is derived from. */
 internal data class QbtcClaimCoins(val btc: Coin, val qbtc: Coin)
@@ -34,12 +35,17 @@ constructor(
             ?.let {
                 return it
             }
-        return runCatching {
-                val nativeToken = tokenRepository.getNativeToken(chain.id)
-                val (address, derivedPublicKey) =
-                    chainAccountAddressRepository.getAddress(nativeToken, vault)
-                nativeToken.copy(address = address, hexPublicKey = derivedPublicKey)
+        // Repository/template errors propagate as themselves — only a failure to derive the address
+        // (the vault lacks the key material for this chain) is the genuine "missing account" case.
+        val nativeToken = tokenRepository.getNativeToken(chain.id)
+        val (address, derivedPublicKey) =
+            try {
+                chainAccountAddressRepository.getAddress(nativeToken, vault)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw MissingQbtcClaimAccountException(chain, e)
             }
-            .getOrElse { throw MissingQbtcClaimAccountException(chain) }
+        return nativeToken.copy(address = address, hexPublicKey = derivedPublicKey)
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -158,7 +158,8 @@ constructor(
             // The claim needs a Bitcoin and a QBTC coin, but neither chain has to be enabled in the
             // vault — they're derived on the fly when missing so the claim works regardless of
             // which
-            // chains the user has added, matching the other platforms.
+            // chains the user has added (as Windows does; iOS currently blocks when the coin is
+            // absent — see https://github.com/vultisig/vultisig-ios/issues/4679).
             val coins =
                 if (loadedVault == null) null
                 else

--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -47,6 +47,8 @@ import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.GenerateServiceName
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.models.keysign.MissingQbtcClaimAccountException
+import com.vultisig.wallet.ui.models.keysign.ResolveQbtcClaimCoinsUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -118,6 +120,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
     private val vaultRepository: VaultRepository,
+    private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
     private val loadClaimableUtxos: LoadClaimableQbtcUtxosUseCase,
     private val proofService: QbtcProofService,
     private val fastVaultRoundRunner: QbtcClaimFastVaultRoundRunner,
@@ -152,9 +155,19 @@ constructor(
         uiState.value = QbtcClaimUiState.Loading
         viewModelScope.safeLaunch {
             val loadedVault = vaultRepository.get(vaultId)
-            val btc = loadedVault?.coins?.firstOrNull { it.chain == Chain.Bitcoin }
-            val qbtc = loadedVault?.coins?.firstOrNull { it.chain == Chain.Qbtc }
-            if (loadedVault == null || btc == null || qbtc == null) {
+            // The claim needs a Bitcoin and a QBTC coin, but neither chain has to be enabled in the
+            // vault — they're derived on the fly when missing so the claim works regardless of
+            // which
+            // chains the user has added, matching the other platforms.
+            val coins =
+                if (loadedVault == null) null
+                else
+                    try {
+                        resolveQbtcClaimCoins(loadedVault)
+                    } catch (_: MissingQbtcClaimAccountException) {
+                        null
+                    }
+            if (loadedVault == null || coins == null) {
                 uiState.value =
                     QbtcClaimUiState.Blocked(
                         QbtcClaimBlockedReason.UtxoFetchFailed("Missing Bitcoin or QBTC account")
@@ -162,10 +175,10 @@ constructor(
                 return@safeLaunch
             }
             vault = loadedVault
-            btcCoin = btc
-            qbtcCoin = qbtc
+            btcCoin = coins.btc
+            qbtcCoin = coins.qbtc
 
-            when (val result = loadClaimableUtxos(btc.address)) {
+            when (val result = loadClaimableUtxos(coins.btc.address)) {
                 is QbtcClaimLoadResult.Blocked -> {
                     uiState.value = QbtcClaimUiState.Blocked(result.reason)
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -167,7 +167,14 @@ constructor(
                     } catch (_: MissingQbtcClaimAccountException) {
                         null
                     }
-            if (loadedVault == null || coins == null) {
+            if (loadedVault == null) {
+                uiState.value =
+                    QbtcClaimUiState.Blocked(
+                        QbtcClaimBlockedReason.UtxoFetchFailed("Vault not found")
+                    )
+                return@safeLaunch
+            }
+            if (coins == null) {
                 uiState.value =
                     QbtcClaimUiState.Blocked(
                         QbtcClaimBlockedReason.UtxoFetchFailed("Missing Bitcoin or QBTC account")

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -52,6 +52,7 @@ import com.vultisig.wallet.ui.models.keysign.JoinKeysignViewModel
 import com.vultisig.wallet.ui.models.keysign.KeysignState
 import com.vultisig.wallet.ui.models.keysign.VerifyUiModel
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
+import com.vultisig.wallet.ui.screens.qbtc.QbtcClaimDoneContent
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.sign.VerifySignMessageScreen
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
@@ -180,11 +181,16 @@ internal fun JoinKeysignView() {
 
             is QbtcClaim -> {
                 val claim = state as QbtcClaim
-                KeysignLoadingScreen(
-                    text =
-                        if (claim.txHash == null) stringResource(R.string.qbtc_claim_proving)
-                        else stringResource(R.string.qbtc_claim_success_title)
-                )
+                if (claim.txHash == null) {
+                    KeysignLoadingScreen(text = stringResource(R.string.qbtc_claim_proving))
+                } else {
+                    QbtcClaimDoneContent(
+                        txHash = claim.txHash,
+                        explorerUrl = claim.explorerUrl.orEmpty(),
+                        totalSats = claim.totalSats ?: 0L,
+                        onComplete = viewModel::complete,
+                    )
+                }
             }
 
             Keysign -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -133,6 +133,22 @@ internal fun JoinKeysignView() {
         return
     }
 
+    val currentState = state
+    if (currentState is QbtcClaim && currentState.txHash != null) {
+        // QbtcClaimDoneContent owns its TxDoneScaffold + toolbar, so render it directly instead of
+        // nesting it inside JoinKeysignScreen — avoids the double scaffold/toolbar this file
+        // already
+        // works around for the other full-screen flows.
+        BackHandler(onBack = viewModel::complete)
+        QbtcClaimDoneContent(
+            txHash = currentState.txHash,
+            explorerUrl = currentState.explorerUrl.orEmpty(),
+            totalSats = currentState.totalSats ?: 0L,
+            onComplete = viewModel::complete,
+        )
+        return
+    }
+
     val title =
         stringResource(
             when {
@@ -180,17 +196,9 @@ internal fun JoinKeysignView() {
             }
 
             is QbtcClaim -> {
-                val claim = state as QbtcClaim
-                if (claim.txHash == null) {
-                    KeysignLoadingScreen(text = stringResource(R.string.qbtc_claim_proving))
-                } else {
-                    QbtcClaimDoneContent(
-                        txHash = claim.txHash,
-                        explorerUrl = claim.explorerUrl.orEmpty(),
-                        totalSats = claim.totalSats ?: 0L,
-                        onComplete = viewModel::complete,
-                    )
-                }
+                // The done state (txHash != null) is rendered before the JoinKeysignScreen wrapper;
+                // here the claim is still proving/broadcasting.
+                KeysignLoadingScreen(text = stringResource(R.string.qbtc_claim_proving))
             }
 
             Keysign -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimDoneContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimDoneContent.kt
@@ -1,0 +1,87 @@
+package com.vultisig.wallet.ui.screens.qbtc
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimAmountFormatter
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.models.keysign.TransactionStatus
+import com.vultisig.wallet.ui.screens.transaction.TransactionStatusRow
+import com.vultisig.wallet.ui.screens.transaction.TxDoneScaffold
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * The shared QBTC claim "done" screen. Rendered both by the initiator ([QbtcClaimScreen]) and the
+ * co-signing peer (the join-keysign flow) so both devices land on the same success screen with the
+ * on-chain tx hash once the claim broadcasts.
+ */
+@Composable
+internal fun QbtcClaimDoneContent(
+    txHash: String,
+    explorerUrl: String,
+    totalSats: Long,
+    onComplete: () -> Unit,
+) {
+    var detailsVisible by remember { mutableStateOf(false) }
+    TxDoneScaffold(
+        transactionHash = txHash,
+        transactionLink = explorerUrl,
+        transactionStatus = TransactionStatus.Confirmed,
+        isTransactionDetailVisible = detailsVisible,
+        onTransactionDetailVisibleChange = { detailsVisible = it },
+        onBack = onComplete,
+        successTitle = stringResource(R.string.qbtc_claim_successful),
+        tokenContent = { ClaimedAmountCard(totalSats) },
+        detailContent = { TransactionStatusRow(TransactionStatus.Confirmed) },
+        bottomBarContent = {
+            VsButton(
+                label = stringResource(R.string.transaction_done_complete),
+                onClick = onComplete,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
+            )
+        },
+    )
+}
+
+@Composable
+private fun ClaimedAmountCard(totalSats: Long) {
+    val shape = RoundedCornerShape(24.dp)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .background(color = Theme.v2.colors.backgrounds.secondary, shape = shape)
+                .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = shape)
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+    ) {
+        Image(
+            painter = painterResource(R.drawable.qbtc),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(
+            text = QbtcClaimAmountFormatter.formatQbtc(totalSats),
+            style = Theme.satoshi.price.title1,
+            color = Theme.v2.colors.text.primary,
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -63,7 +63,6 @@ import com.vultisig.wallet.ui.components.loader.VsSigningProgressIndicator
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
-import com.vultisig.wallet.ui.models.keysign.TransactionStatus
 import com.vultisig.wallet.ui.models.peer.NetworkOption
 import com.vultisig.wallet.ui.models.peer.PeerDiscoveryUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
@@ -71,8 +70,6 @@ import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimViewModel
 import com.vultisig.wallet.ui.screens.peer.PeerDiscoveryScreen
 import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
-import com.vultisig.wallet.ui.screens.transaction.TransactionStatusRow
-import com.vultisig.wallet.ui.screens.transaction.TxDoneScaffold
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
@@ -351,50 +348,12 @@ private fun QbtcClaimUtxoRow(
 
 @Composable
 private fun ClaimDoneScreen(state: QbtcClaimUiState.Done, onComplete: () -> Unit) {
-    var detailsVisible by remember { mutableStateOf(false) }
-    TxDoneScaffold(
-        transactionHash = state.txHash,
-        transactionLink = state.explorerUrl,
-        transactionStatus = TransactionStatus.Confirmed,
-        isTransactionDetailVisible = detailsVisible,
-        onTransactionDetailVisibleChange = { detailsVisible = it },
-        onBack = onComplete,
-        successTitle = stringResource(R.string.qbtc_claim_successful),
-        tokenContent = { ClaimedAmountCard(state.totalSats) },
-        detailContent = { TransactionStatusRow(TransactionStatus.Confirmed) },
-        bottomBarContent = {
-            VsButton(
-                label = stringResource(R.string.transaction_done_complete),
-                onClick = onComplete,
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
-            )
-        },
+    QbtcClaimDoneContent(
+        txHash = state.txHash,
+        explorerUrl = state.explorerUrl,
+        totalSats = state.totalSats,
+        onComplete = onComplete,
     )
-}
-
-@Composable
-private fun ClaimedAmountCard(totalSats: Long) {
-    val shape = RoundedCornerShape(24.dp)
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier =
-            Modifier.fillMaxWidth()
-                .background(color = Theme.v2.colors.backgrounds.secondary, shape = shape)
-                .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = shape)
-                .padding(horizontal = 16.dp, vertical = 24.dp),
-    ) {
-        Image(
-            painter = painterResource(R.drawable.qbtc),
-            contentDescription = null,
-            modifier = Modifier.size(48.dp),
-        )
-        Text(
-            text = QbtcClaimAmountFormatter.formatQbtc(totalSats),
-            style = Theme.satoshi.price.title1,
-            color = Theme.v2.colors.text.primary,
-        )
-    }
 }
 
 @Composable

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1337,7 +1337,6 @@
     <string name="qbtc_claim_cta_all">Alle abrufen</string>
     <string name="qbtc_claim_cta_partial">%1$d von %2$d abrufen</string>
     <string name="qbtc_claim_proving">Nachweis wird erstellt und gesendet…</string>
-    <string name="qbtc_claim_success_title">QBTC abgerufen</string>
     <string name="qbtc_claim_successful">QBTC erfolgreich abgerufen</string>
     <string name="qbtc_claim_password_title">Tresorpasswort eingeben</string>
     <string name="qbtc_claim_failed">Abruf fehlgeschlagen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1335,7 +1335,6 @@
     <string name="qbtc_claim_cta_all">Reclamar todo</string>
     <string name="qbtc_claim_cta_partial">Reclamar %1$d de %2$d</string>
     <string name="qbtc_claim_proving">Generando prueba y transmitiendo…</string>
-    <string name="qbtc_claim_success_title">QBTC reclamado</string>
     <string name="qbtc_claim_successful">QBTC reclamado correctamente</string>
     <string name="qbtc_claim_password_title">Introduce la contraseña de la bóveda</string>
     <string name="qbtc_claim_failed">Reclamación fallida</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1345,7 +1345,6 @@
     <string name="qbtc_claim_cta_all">Preuzmi sve</string>
     <string name="qbtc_claim_cta_partial">Preuzmi %1$d od %2$d</string>
     <string name="qbtc_claim_proving">Generiranje dokaza i emitiranje…</string>
-    <string name="qbtc_claim_success_title">QBTC preuzet</string>
     <string name="qbtc_claim_successful">QBTC uspješno preuzet</string>
     <string name="qbtc_claim_password_title">Unesite lozinku trezora</string>
     <string name="qbtc_claim_failed">Preuzimanje nije uspjelo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1338,7 +1338,6 @@
     <string name="qbtc_claim_cta_all">Preleva tutto</string>
     <string name="qbtc_claim_cta_partial">Preleva %1$d di %2$d</string>
     <string name="qbtc_claim_proving">Generazione della prova e trasmissione…</string>
-    <string name="qbtc_claim_success_title">QBTC prelevato</string>
     <string name="qbtc_claim_successful">QBTC prelevato con successo</string>
     <string name="qbtc_claim_password_title">Inserisci la password della cassaforte</string>
     <string name="qbtc_claim_failed">Prelievo non riuscito</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1354,7 +1354,6 @@
     <string name="qbtc_claim_cta_all">모두 청구</string>
     <string name="qbtc_claim_cta_partial">%2$d개 중 %1$d개 청구</string>
     <string name="qbtc_claim_proving">증명 생성 및 브로드캐스트 중…</string>
-    <string name="qbtc_claim_success_title">QBTC 청구 완료</string>
     <string name="qbtc_claim_successful">QBTC 청구 성공</string>
     <string name="qbtc_claim_password_title">볼트 비밀번호 입력</string>
     <string name="qbtc_claim_failed">청구 실패</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1329,7 +1329,6 @@
     <string name="qbtc_claim_cta_all">Alles claimen</string>
     <string name="qbtc_claim_cta_partial">%1$d van %2$d claimen</string>
     <string name="qbtc_claim_proving">Bewijs genereren en uitzenden…</string>
-    <string name="qbtc_claim_success_title">QBTC geclaimd</string>
     <string name="qbtc_claim_successful">QBTC succesvol geclaimd</string>
     <string name="qbtc_claim_password_title">Voer kluiswachtwoord in</string>
     <string name="qbtc_claim_failed">Claimen mislukt</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1333,7 +1333,6 @@
     <string name="qbtc_claim_cta_all">Resgatar tudo</string>
     <string name="qbtc_claim_cta_partial">Resgatar %1$d de %2$d</string>
     <string name="qbtc_claim_proving">A gerar prova e a transmitir…</string>
-    <string name="qbtc_claim_success_title">QBTC resgatado</string>
     <string name="qbtc_claim_successful">QBTC resgatado com sucesso</string>
     <string name="qbtc_claim_password_title">Introduza a palavra-passe do cofre</string>
     <string name="qbtc_claim_failed">Resgate falhou</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1347,7 +1347,6 @@
     <string name="qbtc_claim_cta_all">Получить всё</string>
     <string name="qbtc_claim_cta_partial">Получить %1$d из %2$d</string>
     <string name="qbtc_claim_proving">Генерация доказательства и отправка…</string>
-    <string name="qbtc_claim_success_title">QBTC получен</string>
     <string name="qbtc_claim_successful">QBTC успешно получен</string>
     <string name="qbtc_claim_password_title">Введите пароль хранилища</string>
     <string name="qbtc_claim_failed">Получение не удалось</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1660,7 +1660,6 @@
     <string name="qbtc_claim_cta_all">全部提取</string>
     <string name="qbtc_claim_cta_partial">提取 %2$d 个中的 %1$d 个</string>
     <string name="qbtc_claim_proving">正在生成证明并广播…</string>
-    <string name="qbtc_claim_success_title">QBTC 已提取</string>
     <string name="qbtc_claim_successful">QBTC 提取成功</string>
     <string name="qbtc_claim_password_title">输入保险库密码</string>
     <string name="qbtc_claim_failed">提取失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1389,7 +1389,6 @@
     <string name="qbtc_claim_cta_all">Claim All</string>
     <string name="qbtc_claim_cta_partial">Claim %1$d of %2$d</string>
     <string name="qbtc_claim_proving">Generating proof and broadcasting…</string>
-    <string name="qbtc_claim_success_title">QBTC claimed</string>
     <string name="qbtc_claim_successful">QBTC Claim Successful</string>
     <string name="qbtc_claim_password_title">Enter vault password</string>
     <string name="qbtc_claim_failed">Claim failed</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimConsentStateTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/QbtcClaimConsentStateTest.kt
@@ -21,12 +21,15 @@ internal class QbtcClaimConsentStateTest {
             isNativeToken = true,
         )
 
-    /** Both accounts present → the consent gate exposes their addresses for review. */
+    /** The consent gate exposes the resolved accounts' addresses for review. */
     @Test
     fun `builds consent state with btc and qbtc addresses`() {
         val state =
             buildQbtcClaimConsentState(
-                listOf(coin(Chain.Bitcoin, "btcAddr"), coin(Chain.Qbtc, "qbtcAddr"))
+                QbtcClaimCoins(
+                    btc = coin(Chain.Bitcoin, "btcAddr"),
+                    qbtc = coin(Chain.Qbtc, "qbtcAddr"),
+                )
             )
 
         val consent = state.shouldBeInstanceOf<JoinKeysignState.QbtcClaimConsent>()
@@ -39,36 +42,12 @@ internal class QbtcClaimConsentStateTest {
     fun `consent state is not the signing state`() {
         val state =
             buildQbtcClaimConsentState(
-                listOf(coin(Chain.Bitcoin, "btcAddr"), coin(Chain.Qbtc, "qbtcAddr"))
+                QbtcClaimCoins(
+                    btc = coin(Chain.Bitcoin, "btcAddr"),
+                    qbtc = coin(Chain.Qbtc, "qbtcAddr"),
+                )
             )
 
         (state is JoinKeysignState.QbtcClaim) shouldBe false
-    }
-
-    /** Missing the Bitcoin account fails before signing rather than mid-co-sign. */
-    @Test
-    fun `missing bitcoin account yields missing-account error`() {
-        val state = buildQbtcClaimConsentState(listOf(coin(Chain.Qbtc, "qbtcAddr")))
-
-        val error = state.shouldBeInstanceOf<JoinKeysignState.Error>()
-        error.errorType shouldBe JoinKeysignError.MissingQbtcClaimAccount
-    }
-
-    /** Missing the QBTC account fails before signing rather than mid-co-sign. */
-    @Test
-    fun `missing qbtc account yields missing-account error`() {
-        val state = buildQbtcClaimConsentState(listOf(coin(Chain.Bitcoin, "btcAddr")))
-
-        val error = state.shouldBeInstanceOf<JoinKeysignState.Error>()
-        error.errorType shouldBe JoinKeysignError.MissingQbtcClaimAccount
-    }
-
-    /** An empty vault also fails closed. */
-    @Test
-    fun `empty coins yields missing-account error`() {
-        val state = buildQbtcClaimConsentState(emptyList())
-
-        state.shouldBeInstanceOf<JoinKeysignState.Error>().errorType shouldBe
-            JoinKeysignError.MissingQbtcClaimAccount
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCaseTest.kt
@@ -1,0 +1,88 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class ResolveQbtcClaimCoinsUseCaseTest {
+
+    private val tokenRepository = mockk<TokenRepository>()
+    private val chainAccountAddressRepository = mockk<ChainAccountAddressRepository>()
+
+    private val useCase =
+        ResolveQbtcClaimCoinsUseCase(tokenRepository, chainAccountAddressRepository)
+
+    private fun coin(chain: Chain, address: String, pubKey: String = "pub") =
+        Coin(
+            chain = chain,
+            ticker = chain.raw,
+            logo = "",
+            address = address,
+            decimal = 8,
+            hexPublicKey = pubKey,
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    /** Already-enabled accounts are returned as-is, without deriving anything. */
+    @Test
+    fun `returns enabled coins as-is`() = runTest {
+        val vault =
+            Vault(
+                id = "v",
+                name = "v",
+                coins = listOf(coin(Chain.Bitcoin, "btcAddr"), coin(Chain.Qbtc, "qbtcAddr")),
+            )
+
+        val result = useCase(vault)
+
+        result.btc.address shouldBe "btcAddr"
+        result.qbtc.address shouldBe "qbtcAddr"
+    }
+
+    /** A missing account is derived in-memory from the native template and the vault's keys. */
+    @Test
+    fun `derives missing accounts`() = runTest {
+        val vault = Vault(id = "v", name = "v", coins = emptyList())
+
+        coEvery { tokenRepository.getNativeToken(Chain.Bitcoin.id) } returns
+            coin(Chain.Bitcoin, address = "", pubKey = "")
+        coEvery { tokenRepository.getNativeToken(Chain.Qbtc.id) } returns
+            coin(Chain.Qbtc, address = "", pubKey = "")
+        coEvery {
+            chainAccountAddressRepository.getAddress(coin(Chain.Bitcoin, "", ""), vault)
+        } returns ("derivedBtc" to "btcPub")
+        coEvery {
+            chainAccountAddressRepository.getAddress(coin(Chain.Qbtc, "", ""), vault)
+        } returns ("derivedQbtc" to "qbtcPub")
+
+        val result = useCase(vault)
+
+        result.btc.address shouldBe "derivedBtc"
+        result.btc.hexPublicKey shouldBe "btcPub"
+        result.qbtc.address shouldBe "derivedQbtc"
+        result.qbtc.hexPublicKey shouldBe "qbtcPub"
+    }
+
+    /** Derivation failure surfaces as MissingQbtcClaimAccountException. */
+    @Test
+    fun `throws when derivation fails`() = runTest {
+        val vault = Vault(id = "v", name = "v", coins = emptyList())
+
+        coEvery { tokenRepository.getNativeToken(Chain.Bitcoin.id) } returns
+            coin(Chain.Bitcoin, address = "", pubKey = "")
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), vault) } throws
+            IllegalStateException("no key material")
+
+        shouldThrow<MissingQbtcClaimAccountException> { useCase(vault) }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveQbtcClaimCoinsUseCaseTest.kt
@@ -85,4 +85,15 @@ internal class ResolveQbtcClaimCoinsUseCaseTest {
 
         shouldThrow<MissingQbtcClaimAccountException> { useCase(vault) }
     }
+
+    /** A repository/template failure propagates as itself, not as a missing-account error. */
+    @Test
+    fun `propagates template fetch failures`() = runTest {
+        val vault = Vault(id = "v", name = "v", coins = emptyList())
+
+        coEvery { tokenRepository.getNativeToken(Chain.Bitcoin.id) } throws
+            IllegalStateException("token repo down")
+
+        shouldThrow<IllegalStateException> { useCase(vault) }
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
@@ -25,6 +25,9 @@ import com.vultisig.wallet.data.usecases.Encryption
 import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.GenerateServiceName
 import com.vultisig.wallet.data.usecases.tss.DiscoverParticipantsUseCase
+import com.vultisig.wallet.ui.models.keysign.MissingQbtcClaimAccountException
+import com.vultisig.wallet.ui.models.keysign.QbtcClaimCoins
+import com.vultisig.wallet.ui.models.keysign.ResolveQbtcClaimCoinsUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -56,6 +59,7 @@ internal class QbtcClaimViewModelTest {
 
     private lateinit var navigator: Navigator<Destination>
     private lateinit var vaultRepository: VaultRepository
+    private lateinit var resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase
     private lateinit var loadClaimableUtxos: LoadClaimableQbtcUtxosUseCase
     private lateinit var proofService: QbtcProofService
     private lateinit var roundRunner: QbtcClaimFastVaultRoundRunner
@@ -78,6 +82,7 @@ internal class QbtcClaimViewModelTest {
             Route.QbtcClaim(vaultId = VAULT_ID)
         navigator = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
+        resolveQbtcClaimCoins = mockk()
         loadClaimableUtxos = mockk(relaxed = true)
         proofService = mockk(relaxed = true)
         roundRunner = mockk(relaxed = true)
@@ -92,6 +97,8 @@ internal class QbtcClaimViewModelTest {
         protoBuf = mockk(relaxed = true)
         json = mockk(relaxed = true)
         coEvery { vaultRepository.get(VAULT_ID) } returns fastVault()
+        coEvery { resolveQbtcClaimCoins(any()) } returns
+            QbtcClaimCoins(btc = btcCoin(), qbtc = qbtcCoin())
         every { explorerLinkRepository.getTransactionLink(Chain.Qbtc, any()) } returns ""
     }
 
@@ -106,6 +113,7 @@ internal class QbtcClaimViewModelTest {
             savedStateHandle = SavedStateHandle(),
             navigator = navigator,
             vaultRepository = vaultRepository,
+            resolveQbtcClaimCoins = resolveQbtcClaimCoins,
             loadClaimableUtxos = loadClaimableUtxos,
             proofService = proofService,
             fastVaultRoundRunner = roundRunner,
@@ -166,10 +174,12 @@ internal class QbtcClaimViewModelTest {
         }
 
     @Test
-    fun `load blocks when the vault has no QBTC account`() =
+    fun `load blocks when the claim accounts cannot be resolved`() =
         runTest(testDispatcher) {
-            coEvery { vaultRepository.get(VAULT_ID) } returns
-                fastVault().copy(coins = listOf(btcCoin()))
+            // Neither chain is enabled and derivation can't produce the account → resolver throws.
+            coEvery { vaultRepository.get(VAULT_ID) } returns fastVault().copy(coins = emptyList())
+            coEvery { resolveQbtcClaimCoins(any()) } throws
+                MissingQbtcClaimAccountException(Chain.Qbtc)
 
             val vm = viewModel()
             advanceUntilIdle()


### PR DESCRIPTION
## Summary

Makes the QBTC claim flow work regardless of which chains a vault has enabled, and fixes the co-signer (joined device) getting stuck on a spinner after a successful claim.

Previously the **Claim QBTC** entry point required the vault's Bitcoin chain to be enabled, unlike the other platforms — so on a vault without Bitcoin enabled the button either didn't show or the claim screen failed with *"Missing Bitcoin or QBTC account"*. Separately, the co-signing device finished the claim successfully but its terminal screen kept rendering a perpetual loading spinner titled "QBTC claimed" with no tx hash, explorer link, or way out.

## Changes

**Show the claim regardless of enabled chains; derive accounts on the fly**
- Dropped the BTC-address gate on the Claim QBTC button (`ChainTokensViewModel`) — eligibility is now just an MLDSA-capable vault on the QBTC chain screen.
- New `ResolveQbtcClaimCoinsUseCase`: returns the vault's enabled Bitcoin/QBTC coin, or derives it in-memory from the native-token template + the vault's keys when the chain isn't enabled (same pattern as `ChainSelectionViewModel.enableAccount`). The claim hash is still recomputed locally from the vault's own keys, never trusted from the QR.
- Wired into the initiator (`QbtcClaimViewModel`), the peer co-sign (`QbtcClaimCosignUseCase`), and the peer consent gate (`JoinKeysignViewModel`).

**Real done screen on the co-signer**
- The peer's QBTC-claim success state was drawn with `KeysignLoadingScreen` (perpetual spinner). Extracted the initiator's done UI into a shared `QbtcClaimDoneContent` composable and render it on the peer once the tx hash arrives, with the claimed amount, explorer link, and a Done → home button — matching iOS, which lands the peer on the same done screen as the initiator.
- Carry `explorerUrl` on `JoinKeysignState.QbtcClaim`, built from the tx hash via `ExplorerLinkRepository`.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.keysign.*" --tests "com.vultisig.wallet.ui.models.qbtc.*"`
- New `ResolveQbtcClaimCoinsUseCaseTest` (enabled-as-is / derives-when-missing / throws-on-failure); updated `QbtcClaimConsentStateTest` and `QbtcClaimViewModelTest`.
- Manual: Secure Vault QBTC claim across an iOS initiator + Android co-signer with Bitcoin **not** enabled on the peer — claim completes and the peer lands on the done screen with the tx hash; verified the cross-platform result-push protocol (JSON shape + AES-GCM key derivation + base64 framing) matches iOS and the DKLS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated QBTC claim “done” screen with claimed amount and completion action (used for both initiator and co-signing).
  * QBTC claim co-signing now includes a transaction explorer link when available.
* **Bug Fixes**
  * Improved QBTC claim eligibility/loading by resolving required Bitcoin/QBTC claim accounts as needed, so the flow can proceed more reliably.
  * Updated blocked messaging when vault/claim accounts can’t be resolved.
* **Tests**
  * Updated and expanded tests for QBTC coin resolution, consent state, and view model loading.
* **Chores**
  * Refreshed QBTC success localization copy across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->