### PR TITLE
fix(swap): show affiliate-only Swap Fee on the overview, add Outbound Fee row (#5061)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
@@ -27,6 +28,7 @@ import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
+import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
@@ -330,6 +332,7 @@ constructor(
                             ),
                         )
                         .expectNative(SwapProvider.THORCHAIN)
+                val rawFees = (quote as? SwapQuote.ThorChain)?.data?.fees
                 val swapTransactionUiModel =
                     buildSwapUiModel(
                         srcToken = srcToken,
@@ -342,6 +345,8 @@ constructor(
                         providerFeeToken = dstToken,
                         currency = currency,
                         externalRecipient = externalRecipient,
+                        swapFee = rawFees?.let { dstToken.convertToTokenValue(it.affiliate) },
+                        outboundFee = rawFees?.let { dstToken.convertToTokenValue(it.outbound) },
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -389,6 +394,7 @@ constructor(
                             ),
                         )
                         .expectNative(SwapProvider.MAYA)
+                val rawFees = (quote as? SwapQuote.MayaChain)?.data?.fees
                 val swapTransactionUiModel =
                     buildSwapUiModel(
                         srcToken = srcToken,
@@ -401,6 +407,8 @@ constructor(
                         providerFeeToken = dstToken,
                         currency = currency,
                         externalRecipient = externalRecipient,
+                        swapFee = rawFees?.let { dstToken.convertToTokenValue(it.affiliate) },
+                        outboundFee = rawFees?.let { dstToken.convertToTokenValue(it.outbound) },
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -485,8 +493,28 @@ constructor(
         currency: AppCurrency,
         providerLabel: String = provider,
         externalRecipient: String? = null,
+        swapFee: TokenValue? = null,
+        outboundFee: TokenValue? = null,
     ): SwapTransactionUiModel {
         val estimatedFee = convertTokenValueToFiat(providerFeeToken, providerFee, currency)
+
+        // Affiliate / outbound breakdown for THORChain / MayaChain so the co-signer's verify screen
+        // shows the same affiliate-only "Swap Fee" + separate "Outbound Fee" as the initiator,
+        // rather than folding the outbound fee into "Swap Fee" (#5061). Null for providers without
+        // a
+        // breakdown, which keep showing the single estimated-fees total.
+        val swapFeeFiat = swapFee?.let { convertTokenValueToFiat(providerFeeToken, it, currency) }
+        val outboundFeeFiat =
+            outboundFee?.let { convertTokenValueToFiat(providerFeeToken, it, currency) }
+        val displaySwapFee = swapFeeFiat ?: estimatedFee
+        // Total mirrors the swap form: gas + affiliate + outbound (liquidity already in dst
+        // amount).
+        val feesFiatForTotal =
+            if (swapFeeFiat != null) {
+                outboundFeeFiat?.let { swapFeeFiat + it } ?: swapFeeFiat
+            } else {
+                estimatedFee
+            }
         return SwapTransactionUiModel(
             src =
                 ValuedToken(
@@ -516,15 +544,16 @@ constructor(
             providerFee =
                 ValuedToken(
                     token = providerFeeToken,
-                    value = providerFee.value.toString(),
-                    fiatValue = fiatValueToStringMapper(estimatedFee, asFee = true),
+                    value = (swapFee ?: providerFee).value.toString(),
+                    fiatValue = fiatValueToStringMapper(displaySwapFee, asFee = true),
                 ),
+            outboundFee = outboundFeeFiat?.let { fiatValueToStringMapper(it, asFee = true) },
             networkFeeFormatted =
                 mapTokenValueToDecimalUiString(estimatedNetworkGasFee.tokenValue) +
                     " ${estimatedNetworkGasFee.tokenValue.unit}",
             totalFee =
                 fiatValueToStringMapper(
-                    estimatedFee + estimatedNetworkGasFee.fiatValue,
+                    feesFiatForTotal + estimatedNetworkGasFee.fiatValue,
                     asFee = true,
                 ),
             provider = provider,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -498,11 +498,7 @@ constructor(
     ): SwapTransactionUiModel {
         val estimatedFee = convertTokenValueToFiat(providerFeeToken, providerFee, currency)
 
-        // Affiliate / outbound breakdown for THORChain / MayaChain so the co-signer's verify screen
-        // shows the same affiliate-only "Swap Fee" + separate "Outbound Fee" as the initiator,
-        // rather than folding the outbound fee into "Swap Fee" (#5061). Null for providers without
-        // a
-        // breakdown, which keep showing the single estimated-fees total.
+        // Affiliate-only "Swap Fee" + separate "Outbound Fee" breakdown for the co-signer (#5061).
         val swapFeeFiat = swapFee?.let { convertTokenValueToFiat(providerFeeToken, it, currency) }
         val outboundFeeFiat =
             outboundFee?.let { convertTokenValueToFiat(providerFeeToken, it, currency) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -64,6 +64,25 @@ constructor(
 
         val quotesFeesFiat = convertTokenValueToFiat(tokenValue, from.estimatedFees, currency)
 
+        // THORChain / MayaChain quotes carry a fee breakdown (affiliate + outbound + liquidity).
+        // When present, show the affiliate-only "Swap Fee" and a separate "Outbound Fee" row — the
+        // same decomposition the swap form does — instead of rendering the opaque total under the
+        // "Swap Fee" label (#5061). Aggregators report no breakdown, so both stay null and the
+        // single estimated-fees total is shown as before.
+        val swapFeeFiat = from.swapFee?.let { convertTokenValueToFiat(from.dstToken, it, currency) }
+        val outboundFeeFiat =
+            from.outboundFee?.let { convertTokenValueToFiat(from.dstToken, it, currency) }
+
+        // Headline total mirrors the swap form: gas + affiliate + outbound, dropping the liquidity
+        // (asset) component already reflected in the destination amount. Falls back to the opaque
+        // total when there is no breakdown.
+        val feesFiatForTotal =
+            if (swapFeeFiat != null) {
+                outboundFeeFiat?.let { swapFeeFiat + it } ?: swapFeeFiat
+            } else {
+                quotesFeesFiat
+            }
+
         // SwapTransaction carries no destination fiat, so it is recomputed here for the verify and
         // keysign screens. Apply the same value-preserving clamp the swap form uses (#4878) so an
         // illiquid token's inflated market mark can't reappear on the screens the user signs from.
@@ -110,9 +129,10 @@ constructor(
             providerFee =
                 ValuedToken(
                     token = tokenValue,
-                    value = from.estimatedFees.value.toString(),
-                    fiatValue = fiatValueToStringMapper(quotesFeesFiat, asFee = true),
+                    value = (from.swapFee ?: from.estimatedFees).value.toString(),
+                    fiatValue = fiatValueToStringMapper(swapFeeFiat ?: quotesFeesFiat, asFee = true),
                 ),
+            outboundFee = outboundFeeFiat?.let { fiatValueToStringMapper(it, asFee = true) },
             networkFee =
                 ValuedToken(
                     token = from.srcToken,
@@ -121,7 +141,8 @@ constructor(
                 ),
             networkFeeFormatted =
                 mapTokenValueToDecimalUiString(from.gasFees) + " ${from.gasFees.unit}",
-            totalFee = fiatValueToStringMapper(quotesFeesFiat + from.gasFeeFiatValue, asFee = true),
+            totalFee =
+                fiatValueToStringMapper(feesFiatForTotal + from.gasFeeFiatValue, asFee = true),
             provider = provider.getSwapProviderId(),
             providerLabel = providerLabel,
             swapId = swapId,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.repositories.AllowanceRepository
+import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import java.math.RoundingMode
 import java.util.UUID
 import javax.inject.Inject
@@ -89,6 +90,8 @@ constructor(
                     expectedDstTokenValue = dstTokenValue,
                     blockChainSpecific = specificAndUtxo,
                     estimatedFees = quote.fees,
+                    swapFee = dstToken.convertToTokenValue(quote.data.fees.affiliate),
+                    outboundFee = dstToken.convertToTokenValue(quote.data.fees.outbound),
                     gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
                     isApprovalRequired = isApprovalRequired,
                     memo = quote.data.memo,
@@ -164,6 +167,8 @@ constructor(
                     expectedDstTokenValue = dstTokenValue,
                     blockChainSpecific = specificAndUtxo,
                     estimatedFees = quote.fees,
+                    swapFee = dstToken.convertToTokenValue(quote.data.fees.affiliate),
+                    outboundFee = dstToken.convertToTokenValue(quote.data.fees.outbound),
                     gasFees = estimatedNetworkFeeTokenValue ?: gasFee,
                     memo = quote.data.memo,
                     isApprovalRequired = isApprovalRequired,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -44,6 +44,10 @@ internal data class SwapTransactionUiModel(
     val dst: ValuedToken = ValuedToken.Empty,
     val networkFee: ValuedToken = ValuedToken.Empty,
     val providerFee: ValuedToken = ValuedToken.Empty,
+    // Outbound-fee portion of the fee breakdown, already formatted as fiat. Non-null only for
+    // THORChain / MayaChain swaps; rendered as its own row so the overview reconciles to the swap
+    // form's breakdown instead of folding the outbound fee into "Swap Fee" (#5061).
+    val outboundFee: String? = null,
     val totalFee: String = "",
     val networkFeeFormatted: String = "",
     val providerFeeFormatted: String = "",

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -292,6 +292,16 @@ private fun VerifySwapScreen(
                         subtitle = tx.providerFee.fiatValue,
                     )
 
+                    // Shown only for THORChain / MayaChain, which report an outbound fee distinct
+                    // from the affiliate swap fee. Mirrors the swap form's breakdown so the rows
+                    // reconcile to the total (#5061).
+                    tx.outboundFee?.let { outboundFee ->
+                        VerifyCardDetails(
+                            title = stringResource(R.string.swap_form_outbound_fee_title),
+                            subtitle = outboundFee,
+                        )
+                    }
+
                     VerifyCardDivider(size = 10.dp)
 
                     VerifyCardDetails(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
@@ -1,0 +1,171 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * THORChain / MayaChain swaps carry a fee breakdown (affiliate + outbound + liquidity). The verify
+ * / overview screen must show the affiliate-only "Swap Fee" and a separate "Outbound Fee" — the
+ * same decomposition the swap form does — rather than folding the outbound fee into the "Swap Fee"
+ * label (#5061).
+ */
+internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
+
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper =
+        mockk(relaxed = true)
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk()
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk()
+    private val appCurrencyRepository: AppCurrencyRepository = mockk()
+    private val tokenRepository: TokenRepository = mockk()
+
+    private fun mapper() =
+        SwapTransactionToUiModelMapperImpl(
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            appCurrencyRepository = appCurrencyRepository,
+            tokenRepository = tokenRepository,
+        )
+
+    @Test
+    fun `splits affiliate and outbound into Swap Fee and Outbound Fee rows`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        // Source / destination valuation (destination below source → no clamp interference).
+        coEvery { convertTokenValueToFiat(eth, srcValue, AppCurrency.USD) } returns usd("100")
+        coEvery { convertTokenValueToFiat(usdt, dstValue, AppCurrency.USD) } returns usd("99")
+        // Fee breakdown: affiliate $0.00, outbound $1.18, opaque total $1.40 (incl. liquidity).
+        coEvery { convertTokenValueToFiat(usdt, totalFees, AppCurrency.USD) } returns usd("1.40")
+        coEvery { convertTokenValueToFiat(usdt, affiliateFee, AppCurrency.USD) } returns usd("0.00")
+        coEvery { convertTokenValueToFiat(usdt, outboundFee, AppCurrency.USD) } returns usd("1.18")
+
+        val uiModel = mapper().invoke(transaction())
+
+        // "Swap Fee" shows the affiliate portion, not the inflated total.
+        uiModel.providerFee.fiatValue shouldBe "0.00"
+        // Outbound fee surfaces as its own row.
+        uiModel.outboundFee shouldBe "1.18"
+        // Total reconciles to gas + affiliate + outbound (liquidity dropped), not gas + total.
+        uiModel.totalFee shouldBe "1.20"
+    }
+
+    @Test
+    fun `keeps the opaque total when there is no fee breakdown`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        coEvery { convertTokenValueToFiat(eth, srcValue, AppCurrency.USD) } returns usd("100")
+        coEvery { convertTokenValueToFiat(usdt, dstValue, AppCurrency.USD) } returns usd("99")
+        coEvery { convertTokenValueToFiat(usdt, totalFees, AppCurrency.USD) } returns usd("1.40")
+
+        val uiModel = mapper().invoke(transaction(swapFee = null, outboundFee = null))
+
+        uiModel.providerFee.fiatValue shouldBe "1.40"
+        uiModel.outboundFee shouldBe null
+        uiModel.totalFee shouldBe "1.42"
+    }
+
+    private fun transaction(
+        swapFee: TokenValue? = affiliateFee,
+        outboundFee: TokenValue? = SwapTransactionToUiModelMapperFeeBreakdownTest.outboundFee,
+    ): RegularSwapTransaction =
+        RegularSwapTransaction(
+            id = "tx-1",
+            vaultId = "vault-1",
+            srcToken = eth,
+            srcTokenValue = srcValue,
+            dstToken = usdt,
+            dstAddress = "0xDest",
+            expectedDstTokenValue = dstValue,
+            blockChainSpecific = mockk<BlockChainSpecificAndUtxo>(relaxed = true),
+            estimatedFees = totalFees,
+            swapFee = swapFee,
+            outboundFee = outboundFee,
+            gasFees = srcValue,
+            memo = null,
+            payload =
+                SwapPayload.ThorChain(
+                    THORChainSwapPayload(
+                        fromAddress = "0xOwner",
+                        fromCoin = eth,
+                        toCoin = usdt,
+                        vaultAddress = "0xVault",
+                        routerAddress = null,
+                        fromAmount = BigInteger.TEN,
+                        toAmountDecimal = BigDecimal.ONE,
+                        toAmountLimit = "0",
+                        streamingInterval = "1",
+                        streamingQuantity = "0",
+                        expirationTime = 0uL,
+                        isAffiliate = true,
+                    )
+                ),
+            isApprovalRequired = false,
+            gasFeeFiatValue = usd("0.02"),
+        )
+
+    private companion object {
+        fun usd(value: String) = FiatValue(BigDecimal(value), "USD")
+
+        val eth =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "ETH",
+                logo = "eth",
+                address = "0xOwner",
+                decimal = 18,
+                hexPublicKey = "hex",
+                priceProviderID = "ethereum",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+        val usdt =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "USDT",
+                logo = "usdt",
+                address = "0xOwner",
+                decimal = 6,
+                hexPublicKey = "hex",
+                priceProviderID = "tether",
+                contractAddress = "0xUsdt",
+                isNativeToken = false,
+            )
+        val srcValue = TokenValue(value = BigInteger.valueOf(10), token = eth)
+        val dstValue = TokenValue(value = BigInteger.valueOf(20), token = usdt)
+        val totalFees = TokenValue(value = BigInteger.valueOf(30), token = usdt)
+        val affiliateFee = TokenValue(value = BigInteger.valueOf(40), token = usdt)
+        val outboundFee = TokenValue(value = BigInteger.valueOf(50), token = usdt)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import com.vultisig.wallet.data.chains.helpers.EvmHelper
@@ -66,6 +67,8 @@ internal class SwapTransactionBuilderTest {
         val dstToken = coin(Chain.Ethereum, "ETH", "0xdst", 18, isNative = true)
         val data =
             mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { fees } returns
+                    Fees(affiliate = "0", asset = "0", outbound = "0", total = "0")
                 every { router } returns null
                 every { inboundAddress } returns "thor-inbound"
                 every { memo } returns "=:ETH.ETH:0xdst"
@@ -119,6 +122,8 @@ internal class SwapTransactionBuilderTest {
         val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
         val data =
             mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { fees } returns
+                    Fees(affiliate = "0", asset = "0", outbound = "0", total = "0")
                 every { router } returns null
                 every { inboundAddress } returns "maya-inbound"
                 every { memo } returns "=:BTC.BTC:bc1qdst"
@@ -167,6 +172,8 @@ internal class SwapTransactionBuilderTest {
         val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
         val data =
             mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { fees } returns
+                    Fees(affiliate = "0", asset = "0", outbound = "0", total = "0")
                 every { router } returns "0xrouter"
                 every { inboundAddress } returns "thor-inbound"
                 every { memo } returns "=:BTC.BTC:bc1qdst"
@@ -219,6 +226,8 @@ internal class SwapTransactionBuilderTest {
         val dstToken = coin(Chain.Bitcoin, "BTC", "bc1qdst", 8, isNative = true)
         val data =
             mockk<THORChainSwapQuote>(relaxed = true).apply {
+                every { fees } returns
+                    Fees(affiliate = "0", asset = "0", outbound = "0", total = "0")
                 every { router } returns "0xrouter"
                 every { inboundAddress } returns "maya-inbound"
                 every { memo } returns "=:BTC.BTC:bc1qdst"
@@ -601,6 +610,8 @@ internal class SwapTransactionBuilderTest {
             val dstToken = coin(Chain.Ethereum, "ETH", "0xdst", 18, isNative = true)
             val data =
                 mockk<THORChainSwapQuote>(relaxed = true).apply {
+                    every { fees } returns
+                        Fees(affiliate = "0", asset = "0", outbound = "0", total = "0")
                     every { router } returns null
                     every { inboundAddress } returns "thor-inbound"
                     every { memo } returns "=:ETH.ETH:0xExternal"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapTransaction.kt
@@ -21,6 +21,19 @@ sealed interface SwapTransaction {
     val expectedDstTokenValue: TokenValue
     val blockChainSpecific: BlockChainSpecificAndUtxo
     val estimatedFees: TokenValue
+    /**
+     * Affiliate (swap) fee portion of [estimatedFees], denominated in [dstToken]. Non-null only for
+     * providers that report a fee breakdown (THORChain / MayaChain); null for aggregators whose
+     * [estimatedFees] is a single opaque total. Lets the verify/overview screen show the same
+     * affiliate-only "Swap Fee" the swap form shows instead of the full total (#5061).
+     */
+    val swapFee: TokenValue?
+    /**
+     * Outbound fee portion of [estimatedFees], denominated in [dstToken]. Non-null alongside
+     * [swapFee] for THORChain / MayaChain; rendered as its own "Outbound Fee" row so the verify
+     * screen reconciles to the same breakdown the swap form shows (#5061).
+     */
+    val outboundFee: TokenValue?
     val gasFees: TokenValue
     val memo: String?
     val payload: SwapPayload
@@ -38,6 +51,8 @@ sealed interface SwapTransaction {
         override val expectedDstTokenValue: TokenValue,
         override val blockChainSpecific: BlockChainSpecificAndUtxo,
         override val estimatedFees: TokenValue,
+        override val swapFee: TokenValue? = null,
+        override val outboundFee: TokenValue? = null,
         override val gasFees: TokenValue,
         override val memo: String?,
         override val payload: SwapPayload,


### PR DESCRIPTION
## Summary

Fixes #5061.

On the **Swap overview** (confirmation) screen, the row labeled **Swap Fee** displayed the value of the **Outbound Fee**, not the actual swap fee. The row was rendered from `tx.providerFee.fiatValue`, which is derived from the quote's **total** estimated fees (affiliate + liquidity + outbound) rather than the affiliate-only portion.

The main Swap screen already decomposes the total into separate Swap Fee / Outbound Fee rows (`SwapQuoteManager` → `SwapFeeBreakdown`); the overview did not. The same bug existed on the **co-signer** path (`JoinSwapUiModelBuilder`), which renders the same `VerifySwapScreen`.

## Changes

- **`SwapTransaction`** — added optional `swapFee` (affiliate) and `outboundFee` token values, populated only for THORChain/MayaChain quotes (null for aggregators → behavior unchanged).
- **`SwapTransactionBuilder`** — fills them from `quote.data.fees.affiliate` / `.outbound` via the existing `Coin.convertToTokenValue` helper.
- **`SwapTransactionToUiModelMapper`** (initiator) and **`JoinSwapUiModelBuilder`** (co-signer) — render the affiliate-only Swap Fee, expose the new `outboundFee` fiat string, and compute the total as `gas + affiliate + outbound`, dropping the liquidity component already reflected in the destination amount (matching the swap form's reconciliation).
- **`VerifySwapScreen`** — added an **Outbound Fee** row (reusing the existing `swap_form_outbound_fee_title` string and `VerifyCardDetails`), shown only for THOR/Maya, so the rows reconcile to the total.

### Example (issue's MayaChain CACAO → Ethereum USDT)

| Row | Before | After |
|---|---|---|
| Swap Fee | $1.18 (outbound) | **$0.00** (affiliate) |
| Outbound Fee | — | **$1.18** |
| Total | $1.21 | **$1.20** (gas + affiliate + outbound) |

Now matches the Swap screen breakdown.

## Test plan

- New `SwapTransactionToUiModelMapperFeeBreakdownTest`: affiliate/outbound split + fallback when no breakdown.
- Updated `SwapTransactionBuilderTest` mocks to stub `fees`.
- `:data` + `:app` compile clean; swap/keysign/mapper unit tests green; ktfmt applied.

No new UI strings (reused the swap form's `swap_form_outbound_fee_title`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap verification now shows a separate **outbound fee** row when available (THORChain/MayaChain).
  * Swap fee display is clearer by splitting **swap fee** (provider fee) and **outbound fee**.
* **Bug Fixes**
  * Fee totals now reconcile with the displayed breakdown when fee components are provided.
  * When breakdown data isn’t available, fee display behavior remains unchanged.
* **Tests**
  * Added automated coverage to validate fee breakdown handling and UI mapping for swaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->