### PR TITLE
feat(home): global TTL-based dismissal for promo banners (#5064)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -184,7 +184,7 @@ constructor(
     private fun collectBannerVisibility(vaultId: VaultId) {
         bannerJob?.cancel()
         bannerJob =
-            viewModelScope.launch {
+            viewModelScope.safeLaunch {
                 // Re-collected per vault so an expired TTL is re-evaluated on vault switch / home
                 // re-entry. The upgrade banner is migration-only (GG20); the others depend solely
                 // on

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -28,6 +28,8 @@ import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.PromoBanner
+import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TiersNFTRepository
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
@@ -35,7 +37,6 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
-import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import com.vultisig.wallet.data.usecases.IsGlobalBackupReminderRequiredUseCase
 import com.vultisig.wallet.data.usecases.NeverShowGlobalBackupReminderUseCase
@@ -84,7 +85,6 @@ internal data class VaultAccountsUiModel(
     val showNotificationIntroSheet: Boolean = false,
     val showNotificationVaultSheet: Boolean = false,
     val notificationIntroVaults: List<VaultIntroItem> = emptyList(),
-    val showMigration: Boolean = false,
     val isRefreshing: Boolean = false,
     val totalFiatValue: String? = null,
     val totalDeFiValue: String? = null,
@@ -92,7 +92,11 @@ internal data class VaultAccountsUiModel(
     val accounts: List<AccountUiModel> = emptyList(),
     val defiAccounts: List<AccountUiModel> = emptyList(),
     val searchTextFieldState: TextFieldState = TextFieldState(),
-    val isBannerVisible: Boolean = true,
+    // Per-banner visibility, each gated on a global, TTL-based dismissal (#5064). The upgrade
+    // banner
+    // additionally requires the vault to be GG20 (migration-eligible).
+    val showUpgradeBanner: Boolean = false,
+    val showFollowXBanner: Boolean = false,
     val showBuyVultBanner: Boolean = false,
     val cryptoConnectionType: CryptoConnectionType = CryptoConnectionType.Wallet,
     val scanQrUiModel: ScanQrUiModel = ScanQrUiModel(),
@@ -142,7 +146,7 @@ constructor(
     private val setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase,
     private val lastOpenedVaultRepository: LastOpenedVaultRepository,
     private val enableTokenUseCase: EnableTokenUseCase,
-    private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
+    private val promoBannerDismissalRepository: PromoBannerDismissalRepository,
     private val cryptoConnectionTypeRepository: CryptoConnectionTypeRepository,
     private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
     private val hasCircleAccount: HasCircleAccountUseCase,
@@ -161,18 +165,13 @@ constructor(
     private var loadVaultNameJob: Job? = null
     private var loadAccountsJob: Job? = null
     private var loadDeFiBalancesJob: Job? = null
-    private var buyVultBannerJob: Job? = null
+    private var bannerJob: Job? = null
 
     // Last merged snapshot per stream (wallet / DeFi), keyed in-memory so a chain that comes back
     // with a null balance mid-refetch can carry its previously-shown value forward (#4768). Reset
     // on vault switch so one vault's balances never leak into the next.
     private var lastWalletAddresses: List<Address> = emptyList()
     private var lastDeFiAddresses: List<Address> = emptyList()
-
-    // In-memory "dismissed for this visit" flag. When the vault holds less than the Silver-tier
-    // VULT amount, closing the Buy VULT banner only flips this (no persistence), so it returns the
-    // next time the home screen is entered or the vault is switched.
-    private val buyVultSessionDismissed = MutableStateFlow(false)
 
     private val _requestNotificationPermission = Channel<Unit>(Channel.BUFFERED)
     val requestNotificationPermission = _requestNotificationPermission.receiveAsFlow()
@@ -182,17 +181,37 @@ constructor(
         collectLastOpenedVault()
     }
 
-    private fun collectBuyVultBannerDismissed(vaultId: VaultId) {
-        buyVultBannerJob?.cancel()
-        buyVultBannerJob =
+    private fun collectBannerVisibility(vaultId: VaultId) {
+        bannerJob?.cancel()
+        bannerJob =
             viewModelScope.launch {
+                // Re-collected per vault so an expired TTL is re-evaluated on vault switch / home
+                // re-entry. The upgrade banner is migration-only (GG20); the others depend solely
+                // on
+                // their global dismissal window.
+                val isMigrationEligible =
+                    withContext(ioDispatcher) { vaultRepository.get(vaultId) }?.libType ==
+                        SigningLibType.GG20
                 combine(
-                        vaultDataStoreRepository.readBuyVultBannerDismissed(vaultId),
-                        buyVultSessionDismissed,
-                    ) { persisted, session ->
-                        !persisted && !session
+                        promoBannerDismissalRepository.isDismissed(PromoBanner.UpgradeVaultDkls),
+                        promoBannerDismissalRepository.isDismissed(PromoBanner.FollowXVultisig),
+                        promoBannerDismissalRepository.isDismissed(PromoBanner.BuyVultSwap),
+                    ) { upgradeDismissed, followXDismissed, buyVultDismissed ->
+                        Triple(
+                            isMigrationEligible && !upgradeDismissed,
+                            !followXDismissed,
+                            !buyVultDismissed,
+                        )
                     }
-                    .collect { show -> uiState.update { it.copy(showBuyVultBanner = show) } }
+                    .collect { (showUpgrade, showFollowX, showBuyVult) ->
+                        uiState.update {
+                            it.copy(
+                                showUpgradeBanner = showUpgrade,
+                                showFollowXBanner = showFollowX,
+                                showBuyVultBanner = showBuyVult,
+                            )
+                        }
+                    }
             }
     }
 
@@ -233,8 +252,6 @@ constructor(
 
         this.vaultId = vaultId
         if (vaultChanged) {
-            // Don't carry a per-visit Buy VULT dismissal across to the next vault.
-            buyVultSessionDismissed.value = false
             // Drop the previous vault's balances so the retain/partial-total logic can't surface
             // one vault's totals or rows under the next (#4768).
             lastWalletAddresses = emptyList()
@@ -248,7 +265,7 @@ constructor(
                 )
             }
         }
-        collectBuyVultBannerDismissed(vaultId)
+        collectBannerVisibility(vaultId)
         loadVaultNameAndShowBackup(vaultId)
         loadAccounts(vaultId)
         loadBalanceVisibility(vaultId)
@@ -364,16 +381,18 @@ constructor(
         }
     }
 
-    fun dismissBuyVultBanner() {
-        val vaultId = vaultId ?: return
-        // Always hide for the current visit; only persist once the vault reaches Silver tier,
-        // otherwise the banner returns on the next entry to the home screen / vault switch.
-        buyVultSessionDismissed.value = true
-        viewModelScope.safeLaunch {
-            if (getDiscountBpsUseCase.hasReachedSilverTier(vaultId)) {
-                vaultDataStoreRepository.setBuyVultBannerDismissed(vaultId, true)
-            }
-        }
+    fun dismissBuyVultBanner() = dismissPromoBanner(PromoBanner.BuyVultSwap)
+
+    fun dismissUpgradeBanner() = dismissPromoBanner(PromoBanner.UpgradeVaultDkls)
+
+    fun dismissFollowXBanner() = dismissPromoBanner(PromoBanner.FollowXVultisig)
+
+    // Global, TTL-based dismissal: the banner stays hidden across vaults until its TTL elapses,
+    // then
+    // becomes eligible again (#5064). Writing the timestamp re-emits the dismissal flow, so the
+    // banner hides reactively without a session flag.
+    private fun dismissPromoBanner(banner: PromoBanner) {
+        viewModelScope.safeLaunch { promoBannerDismissalRepository.dismiss(banner) }
     }
 
     fun receive() {
@@ -458,8 +477,6 @@ constructor(
                 }
                 val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
                 uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
-                val showMigration = vault.libType == SigningLibType.GG20
-                uiState.update { it.copy(showMigration = showMigration) }
             }
     }
 
@@ -710,10 +727,6 @@ constructor(
                 navigator.route(Route.VaultList(openType = Route.VaultList.OpenType.Home(it)))
             }
         }
-    }
-
-    fun tempRemoveBanner() {
-        uiState.update { it.copy(isBannerVisible = false) }
     }
 
     fun setCryptoConnectionType(type: CryptoConnectionType) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -262,6 +262,9 @@ constructor(
                     defiAccounts = emptyList(),
                     totalFiatValue = null,
                     totalDeFiValue = null,
+                    // Upgrade banner is vault-scoped (GG20-only); clear it eagerly so the previous
+                    // vault's CTA can't flash before collectBannerVisibility re-evaluates libType.
+                    showUpgradeBanner = false,
                 )
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -128,7 +128,8 @@ internal fun VaultAccountsScreen(viewModel: VaultAccountsViewModel = hiltViewMod
         onToggleVaultListClick = viewModel::openVaultList,
         onChooseChains = viewModel::openAddChainAccount,
         onMigrateClick = viewModel::migrate,
-        onDismissBanner = viewModel::tempRemoveBanner,
+        onUpgradeDismiss = viewModel::dismissUpgradeBanner,
+        onFollowXDismiss = viewModel::dismissFollowXBanner,
         onBuyVultClick = viewModel::buyVult,
         onBuyVultDismiss = viewModel::dismissBuyVultBanner,
         onCryptoConnectionTypeClick = viewModel::setCryptoConnectionType,
@@ -152,7 +153,8 @@ internal fun VaultAccountsScreen(
     onOpenHistoryClick: () -> Unit = {},
     onOpenSettingsClick: () -> Unit = {},
     onChooseChains: () -> Unit = {},
-    onDismissBanner: () -> Unit = {},
+    onUpgradeDismiss: () -> Unit = {},
+    onFollowXDismiss: () -> Unit = {},
     onBuyVultClick: () -> Unit = {},
     onBuyVultDismiss: () -> Unit = {},
     onCryptoConnectionTypeClick: (CryptoConnectionType) -> Unit = {},
@@ -279,7 +281,9 @@ internal fun VaultAccountsScreen(
                     item {
                         AnimatedVisibility(
                             visible =
-                                (state.isBannerVisible || state.showBuyVultBanner) &&
+                                (state.showUpgradeBanner ||
+                                    state.showFollowXBanner ||
+                                    state.showBuyVultBanner) &&
                                     state.cryptoConnectionType == CryptoConnectionType.Wallet,
                             enter = fadeIn() + expandVertically(),
                             exit = fadeOut() + shrinkVertically(),
@@ -287,14 +291,15 @@ internal fun VaultAccountsScreen(
                             Banners(
                                 modifier =
                                     Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp),
-                                hasMigration = state.showMigration,
-                                showSessionBanners = state.isBannerVisible,
+                                showUpgrade = state.showUpgradeBanner,
+                                showFollowX = state.showFollowXBanner,
                                 showBuyVult = state.showBuyVultBanner,
                                 onMigrateClick = onMigrateClick,
                                 onBuyVultClick = onBuyVultClick,
                                 onBuyVultDismiss = onBuyVultDismiss,
                                 context = context,
-                                onDismissBanner = onDismissBanner,
+                                onUpgradeDismiss = onUpgradeDismiss,
+                                onFollowXDismiss = onFollowXDismiss,
                             )
                         }
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/Banners.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/Banners.kt
@@ -11,21 +11,22 @@ import com.vultisig.wallet.ui.utils.VsAuxiliaryLinks
 @Composable
 internal fun Banners(
     modifier: Modifier,
-    hasMigration: Boolean,
-    showSessionBanners: Boolean,
+    showUpgrade: Boolean,
+    showFollowX: Boolean,
     showBuyVult: Boolean,
     onMigrateClick: () -> Unit,
     onBuyVultClick: () -> Unit,
     onBuyVultDismiss: () -> Unit,
     context: Context,
-    onDismissBanner: () -> Unit,
+    onUpgradeDismiss: () -> Unit,
+    onFollowXDismiss: () -> Unit,
 ) {
     HomepagePager(
         modifier = modifier,
         params =
             HomepagePagerParams(
-                hasMigration = hasMigration,
-                showSessionBanners = showSessionBanners,
+                showUpgrade = showUpgrade,
+                showFollowX = showFollowX,
                 showBuyVult = showBuyVult,
             ),
         onUpgradeClick = onMigrateClick,
@@ -34,6 +35,7 @@ internal fun Banners(
         },
         onBuyVultClick = onBuyVultClick,
         onBuyVultDismiss = onBuyVultDismiss,
-        onCloseClick = onDismissBanner,
+        onUpgradeDismiss = onUpgradeDismiss,
+        onFollowXDismiss = onFollowXDismiss,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/HomepagePager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/HomepagePager.kt
@@ -20,11 +20,12 @@ import com.vultisig.wallet.ui.screens.v2.home.pager.container.HomePagePagerConta
 internal fun HomepagePager(
     modifier: Modifier = Modifier,
     params: HomepagePagerParams,
-    onCloseClick: () -> Unit,
     onUpgradeClick: () -> Unit,
     onFollowXClick: () -> Unit,
     onBuyVultClick: () -> Unit,
     onBuyVultDismiss: () -> Unit,
+    onUpgradeDismiss: () -> Unit,
+    onFollowXDismiss: () -> Unit,
 ) {
     val state = rememberVsPagerState(key = params)
 
@@ -33,16 +34,16 @@ internal fun HomepagePager(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         VsPager(state = state) {
-            if (params.hasMigration && params.showSessionBanners)
+            if (params.showUpgrade)
                 item {
-                    HomePagePagerContainer(onCloseClick = onCloseClick) {
+                    HomePagePagerContainer(onCloseClick = onUpgradeDismiss) {
                         UpgradeBanner(onUpgradeClick = onUpgradeClick)
                     }
                 }
 
-            if (params.showSessionBanners)
+            if (params.showFollowX)
                 item {
-                    HomePagePagerContainer(onCloseClick = onCloseClick) {
+                    HomePagePagerContainer(onCloseClick = onFollowXDismiss) {
                         FollowXBanner(onFollowXClick = onFollowXClick)
                     }
                 }
@@ -72,18 +73,18 @@ internal fun HomepagePager(
 @Composable
 private fun HomepagePagerPreview() {
     HomepagePager(
-        params =
-            HomepagePagerParams(hasMigration = true, showSessionBanners = true, showBuyVult = true),
-        onCloseClick = {},
+        params = HomepagePagerParams(showUpgrade = true, showFollowX = true, showBuyVult = true),
         onUpgradeClick = {},
         onFollowXClick = {},
         onBuyVultClick = {},
         onBuyVultDismiss = {},
+        onUpgradeDismiss = {},
+        onFollowXDismiss = {},
     )
 }
 
 internal data class HomepagePagerParams(
-    val hasMigration: Boolean,
-    val showSessionBanners: Boolean,
+    val showUpgrade: Boolean,
+    val showFollowX: Boolean,
     val showBuyVult: Boolean,
 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.calculateAccountsPartialFiatValue
@@ -21,6 +22,8 @@ import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.PromoBanner
+import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TiersNFTRepository
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
@@ -28,7 +31,6 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
-import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import com.vultisig.wallet.data.usecases.IsGlobalBackupReminderRequiredUseCase
 import com.vultisig.wallet.data.usecases.NeverShowGlobalBackupReminderUseCase
@@ -89,7 +91,7 @@ internal class VaultAccountsViewModelTest {
     private lateinit var setNeverShowGlobalBackupReminder: NeverShowGlobalBackupReminderUseCase
     private lateinit var lastOpenedVaultRepository: LastOpenedVaultRepository
     private lateinit var enableTokenUseCase: EnableTokenUseCase
-    private lateinit var getDiscountBpsUseCase: GetDiscountBpsUseCase
+    private lateinit var promoBannerDismissalRepository: PromoBannerDismissalRepository
     private lateinit var cryptoConnectionTypeRepository: CryptoConnectionTypeRepository
     private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
     private lateinit var hasCircleAccount: HasCircleAccountUseCase
@@ -117,7 +119,7 @@ internal class VaultAccountsViewModelTest {
         setNeverShowGlobalBackupReminder = mockk(relaxed = true)
         lastOpenedVaultRepository = mockk(relaxed = true)
         enableTokenUseCase = mockk(relaxed = true)
-        getDiscountBpsUseCase = mockk(relaxed = true)
+        promoBannerDismissalRepository = mockk(relaxed = true)
         cryptoConnectionTypeRepository = mockk(relaxed = true)
         defaultDeFiChainsRepository = mockk(relaxed = true)
         hasCircleAccount = mockk(relaxed = true)
@@ -128,8 +130,7 @@ internal class VaultAccountsViewModelTest {
         every { cryptoConnectionTypeRepository.activeCryptoConnectionFlow } returns
             MutableStateFlow(CryptoConnectionType.Wallet)
         every { lastOpenedVaultRepository.lastOpenedVaultId } returns emptyFlow()
-        every { vaultDataStoreRepository.readBuyVultBannerDismissed(any()) } returns flowOf(true)
-        coEvery { getDiscountBpsUseCase.hasReachedSilverTier(any()) } returns false
+        every { promoBannerDismissalRepository.isDismissed(any()) } returns flowOf(false)
         // Function-type-interface mocks need explicit return-type stubs; relaxed mode auto-stubs
         // to a generic Object that fails the implicit cast at the VM call site.
         coEvery { isGlobalBackupReminderRequired() } returns false
@@ -159,7 +160,7 @@ internal class VaultAccountsViewModelTest {
             setNeverShowGlobalBackupReminder = setNeverShowGlobalBackupReminder,
             lastOpenedVaultRepository = lastOpenedVaultRepository,
             enableTokenUseCase = enableTokenUseCase,
-            getDiscountBpsUseCase = getDiscountBpsUseCase,
+            promoBannerDismissalRepository = promoBannerDismissalRepository,
             cryptoConnectionTypeRepository = cryptoConnectionTypeRepository,
             defaultDeFiChainsRepository = defaultDeFiChainsRepository,
             hasCircleAccount = hasCircleAccount,
@@ -179,13 +180,24 @@ internal class VaultAccountsViewModelTest {
             vm.uiState.value.showMonthlyBackupReminder.shouldBeFalse()
         }
 
-    /** Verifies tempRemoveBanner sets isBannerVisible to false. */
+    /** Verifies dismissing the Follow-X banner records a global dismissal for that banner. */
     @Test
-    fun `tempRemoveBanner sets isBannerVisible to false`() =
+    fun `dismissFollowXBanner records a global dismissal`() =
         runTest(testDispatcher) {
             val vm = createViewModel()
-            vm.tempRemoveBanner()
-            vm.uiState.value.isBannerVisible.shouldBeFalse()
+            vm.dismissFollowXBanner()
+            advanceUntilIdle()
+            coVerify { promoBannerDismissalRepository.dismiss(PromoBanner.FollowXVultisig) }
+        }
+
+    /** Verifies dismissing the upgrade banner records a global dismissal for that banner. */
+    @Test
+    fun `dismissUpgradeBanner records a global dismissal`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+            vm.dismissUpgradeBanner()
+            advanceUntilIdle()
+            coVerify { promoBannerDismissalRepository.dismiss(PromoBanner.UpgradeVaultDkls) }
         }
 
     /** Verifies onNotificationPermissionResult true sets showNotificationVaultSheet. */
@@ -388,72 +400,75 @@ internal class VaultAccountsViewModelTest {
             verify(atLeast = 1) { accountsRepository.loadAddressBalances("vault-1") }
         }
 
-    /**
-     * Verifies dismissBuyVultBanner persists the dismissed flag once the vault reaches Silver tier.
-     */
+    /** Verifies dismissBuyVultBanner records a global dismissal for the Buy VULT banner. */
     @Test
-    fun `dismissBuyVultBanner persists dismissed flag at Silver tier`() =
+    fun `dismissBuyVultBanner records a global dismissal`() =
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            coEvery { getDiscountBpsUseCase.hasReachedSilverTier("vault-1") } returns true
             val vm = createViewModel()
             advanceUntilIdle()
 
             vm.dismissBuyVultBanner()
             advanceUntilIdle()
 
-            coVerify { vaultDataStoreRepository.setBuyVultBannerDismissed("vault-1", true) }
+            coVerify { promoBannerDismissalRepository.dismiss(PromoBanner.BuyVultSwap) }
         }
 
-    /**
-     * Verifies that below Silver tier, dismiss hides the banner for the visit without persisting.
-     */
+    /** Verifies showBuyVultBanner is true while the banner is not within its dismissal TTL. */
     @Test
-    fun `dismissBuyVultBanner below Silver tier hides for visit without persisting`() =
+    fun `showBuyVultBanner is true when not dismissed`() =
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            coEvery { getDiscountBpsUseCase.hasReachedSilverTier("vault-1") } returns false
-            every { vaultDataStoreRepository.readBuyVultBannerDismissed("vault-1") } returns
-                flowOf(false)
-            val vm = createViewModel()
-            advanceUntilIdle()
-            vm.uiState.value.showBuyVultBanner.shouldBeTrue()
-
-            vm.dismissBuyVultBanner()
-            advanceUntilIdle()
-
-            vm.uiState.value.showBuyVultBanner.shouldBeFalse()
-            coVerify(exactly = 0) {
-                vaultDataStoreRepository.setBuyVultBannerDismissed(any(), any())
-            }
-        }
-
-    /** Verifies showBuyVultBanner reflects the persisted dismissed flag (dismissed=false). */
-    @Test
-    fun `showBuyVultBanner is true when dismissed flag is false`() =
-        runTest(testDispatcher) {
-            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
-            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { vaultDataStoreRepository.readBuyVultBannerDismissed("vault-1") } returns
+            every { promoBannerDismissalRepository.isDismissed(PromoBanner.BuyVultSwap) } returns
                 flowOf(false)
             val vm = createViewModel()
             advanceUntilIdle()
             vm.uiState.value.showBuyVultBanner.shouldBeTrue()
         }
 
-    /** Verifies showBuyVultBanner is false when the persisted dismissed flag is true. */
+    /** Verifies showBuyVultBanner is false while the banner is within its dismissal TTL. */
     @Test
-    fun `showBuyVultBanner is false when dismissed flag is true`() =
+    fun `showBuyVultBanner is false when dismissed within TTL`() =
         runTest(testDispatcher) {
             every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
             coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
-            every { vaultDataStoreRepository.readBuyVultBannerDismissed("vault-1") } returns
+            every { promoBannerDismissalRepository.isDismissed(PromoBanner.BuyVultSwap) } returns
                 flowOf(true)
             val vm = createViewModel()
             advanceUntilIdle()
             vm.uiState.value.showBuyVultBanner.shouldBeFalse()
+        }
+
+    /** Verifies the upgrade banner shows only for a GG20 (migration-eligible) vault. */
+    @Test
+    fun `showUpgradeBanner is true for a GG20 vault that is not dismissed`() =
+        runTest(testDispatcher) {
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns
+                Vault(id = "vault-1", name = "Test", libType = SigningLibType.GG20)
+            every {
+                promoBannerDismissalRepository.isDismissed(PromoBanner.UpgradeVaultDkls)
+            } returns flowOf(false)
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.showUpgradeBanner.shouldBeTrue()
+        }
+
+    /** Verifies the upgrade banner is hidden for a non-GG20 vault even when not dismissed. */
+    @Test
+    fun `showUpgradeBanner is false for a non-GG20 vault`() =
+        runTest(testDispatcher) {
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns
+                Vault(id = "vault-1", name = "Test", libType = SigningLibType.DKLS)
+            every {
+                promoBannerDismissalRepository.isDismissed(PromoBanner.UpgradeVaultDkls)
+            } returns flowOf(false)
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.showUpgradeBanner.shouldBeFalse()
         }
 
     /** Verifies buyVult navigates to Swap with VULT preselected when vault already has VULT. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
@@ -7,6 +7,7 @@ import androidx.datastore.core.DataMigration
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.vultisig.wallet.data.sources.AppDataStore
 import com.vultisig.wallet.data.sources.AppDataStoreImpl
@@ -45,7 +46,8 @@ internal interface MainDataModule {
         @Singleton
         fun provideDataStore(@ApplicationContext context: Context) =
             PreferenceDataStoreFactory.create(
-                migrations = listOf(removeLegacyBuyVultBannerKey()),
+                migrations =
+                    listOf(removeLegacyBuyVultBannerKey(), migrateLegacyPerVaultBuyVultDismissal()),
                 produceFile = { context.preferencesDataStoreFile("app_pref") },
             )
 
@@ -63,6 +65,39 @@ internal interface MainDataModule {
 
                 override suspend fun migrate(currentData: Preferences) =
                     currentData.toMutablePreferences().apply { remove(legacyKey) }.toPreferences()
+
+                override suspend fun cleanUp() = Unit
+            }
+        }
+
+        /**
+         * Migrates the per-vault Buy VULT dismissal (`buy_vult_banner_dismissed/<vaultId>`, a
+         * boolean with no expiry) onto the new global, TTL-based model (#5064). If the banner was
+         * dismissed in any vault, the global `banner_dismissed_at/buy_vult_swap` timestamp is
+         * seeded to "now" so the user's dismissal is honored across vaults for the banner's TTL
+         * instead of resetting. The old per-vault keys are then removed so they don't linger.
+         */
+        private fun migrateLegacyPerVaultBuyVultDismissal(): DataMigration<Preferences> {
+            val perVaultPrefix = "buy_vult_banner_dismissed/"
+            val globalDismissedAtKey = longPreferencesKey("banner_dismissed_at/buy_vult_swap")
+            return object : DataMigration<Preferences> {
+                override suspend fun shouldMigrate(currentData: Preferences) =
+                    currentData.asMap().keys.any { it.name.startsWith(perVaultPrefix) }
+
+                override suspend fun migrate(currentData: Preferences): Preferences {
+                    val perVaultKeys =
+                        currentData.asMap().keys.filter { it.name.startsWith(perVaultPrefix) }
+                    val wasDismissed = perVaultKeys.any { currentData[it] as? Boolean == true }
+                    return currentData
+                        .toMutablePreferences()
+                        .apply {
+                            if (wasDismissed && !currentData.contains(globalDismissedAtKey)) {
+                                this[globalDismissedAtKey] = System.currentTimeMillis()
+                            }
+                            perVaultKeys.forEach { remove(it) }
+                        }
+                        .toPreferences()
+                }
 
                 override suspend fun cleanUp() = Unit
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
@@ -1,0 +1,70 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.annotation.VisibleForTesting
+import androidx.datastore.preferences.core.longPreferencesKey
+import com.vultisig.wallet.data.sources.AppDataStore
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Promo banners that support global, time-bounded dismissal.
+ *
+ * Dismissal is keyed by the banner's CTA intent ([id]) — not by vault — so closing a banner in one
+ * vault keeps it hidden everywhere, and each banner carries its own [ttl]: once dismissed it stays
+ * hidden until the TTL elapses, then becomes eligible to show again (#5064).
+ *
+ * TTLs are product knobs and are centralized here rather than hard-coded into view logic, so they
+ * can be tuned per banner in one place.
+ */
+enum class PromoBanner(val id: String, val ttl: Duration) {
+    UpgradeVaultDkls(id = "upgrade_vault_dkls", ttl = 14.days),
+    BuyVultSwap(id = "buy_vult_swap", ttl = 7.days),
+    FollowXVultisig(id = "follow_x_vultisig", ttl = 30.days),
+}
+
+interface PromoBannerDismissalRepository {
+    /**
+     * Emits true while [banner] is still within its dismissal TTL window (i.e. should stay hidden).
+     */
+    fun isDismissed(banner: PromoBanner): Flow<Boolean>
+
+    /** Records that [banner] was dismissed now, starting its TTL window. */
+    suspend fun dismiss(banner: PromoBanner)
+}
+
+internal class PromoBannerDismissalRepositoryImpl
+@Inject
+constructor(private val appDataStore: AppDataStore) : PromoBannerDismissalRepository {
+
+    /** Minimal clock seam so tests can advance time without sleeping. */
+    fun interface Clock {
+        fun nowMillis(): Long
+    }
+
+    /**
+     * Overridable clock so tests can drive TTL expiry deterministically; production uses
+     * `System.currentTimeMillis`. Not [Inject]ed to keep Hilt wiring trivial.
+     */
+    @VisibleForTesting internal var clock: Clock = Clock { System.currentTimeMillis() }
+
+    override fun isDismissed(banner: PromoBanner): Flow<Boolean> =
+        appDataStore.readData(dismissedAtKey(banner)).map { dismissedAt ->
+            // No stored timestamp → never dismissed. Otherwise hidden only until the TTL elapses;
+            // an
+            // expired dismissal reads as "show again". The comparison is re-evaluated whenever the
+            // flow is re-collected (home re-entry / vault switch), so an expired TTL surfaces then.
+            dismissedAt != null && clock.nowMillis() - dismissedAt < banner.ttl.inWholeMilliseconds
+        }
+
+    override suspend fun dismiss(banner: PromoBanner) {
+        appDataStore.set(dismissedAtKey(banner), clock.nowMillis())
+    }
+
+    private companion object {
+        fun dismissedAtKey(banner: PromoBanner) =
+            longPreferencesKey(name = "banner_dismissed_at/${banner.id}")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.flow.map
  * can be tuned per banner in one place.
  */
 enum class PromoBanner(val id: String, val ttl: Duration) {
-    UpgradeVaultDkls(id = "upgrade_vault_dkls", ttl = 14.days),
+    UpgradeVaultDkls(id = "upgrade_vault_dkls", ttl = 15.days),
     BuyVultSwap(id = "buy_vult_swap", ttl = 7.days),
-    FollowXVultisig(id = "follow_x_vultisig", ttl = 30.days),
+    FollowXVultisig(id = "follow_x_vultisig", ttl = 15.days),
 }
 
 interface PromoBannerDismissalRepository {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -72,6 +72,12 @@ internal interface RepositoriesModule {
 
     @Binds
     @Singleton
+    fun bindPromoBannerDismissalRepository(
+        impl: PromoBannerDismissalRepositoryImpl
+    ): PromoBannerDismissalRepository
+
+    @Binds
+    @Singleton
     fun bindTransactionRepository(impl: TransactionRepositoryImpl): TransactionRepository
 
     @Binds

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultDataStoreRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultDataStoreRepository.kt
@@ -22,10 +22,6 @@ interface VaultDataStoreRepository {
     suspend fun setGlobalBackupReminderStatus(month: Int)
 
     suspend fun readGlobalBackupReminderStatus(): Flow<Int>
-
-    suspend fun setBuyVultBannerDismissed(vaultId: String, dismissed: Boolean)
-
-    fun readBuyVultBannerDismissed(vaultId: String): Flow<Boolean>
 }
 
 internal class VaultDataStoreRepositoryImpl
@@ -61,15 +57,6 @@ constructor(private val appDataStore: AppDataStore) : VaultDataStoreRepository {
         )
     }
 
-    override suspend fun setBuyVultBannerDismissed(vaultId: String, dismissed: Boolean) {
-        appDataStore.editData { preferences ->
-            preferences[onBuyVultBannerDismissedKey(vaultId)] = dismissed
-        }
-    }
-
-    override fun readBuyVultBannerDismissed(vaultId: String): Flow<Boolean> =
-        appDataStore.readData(onBuyVultBannerDismissedKey(vaultId), false)
-
     private companion object PreferencesKey {
         fun onVaultBackupStatusKey(vaultId: String) =
             booleanPreferencesKey(name = "vault_backup/$vaultId")
@@ -79,8 +66,5 @@ constructor(private val appDataStore: AppDataStore) : VaultDataStoreRepository {
 
         fun onGlobalBackupReminderStatusKey() =
             intPreferencesKey(name = "global_backup_reminder_status")
-
-        fun onBuyVultBannerDismissedKey(vaultId: String) =
-            booleanPreferencesKey(name = "buy_vult_banner_dismissed/$vaultId")
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
@@ -1,0 +1,90 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import com.vultisig.wallet.data.sources.AppDataStore
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the global, TTL-based dismissal model (#5064): a dismissal persists across reads, is keyed
+ * per banner (so banners are independent), and lapses once the banner's TTL elapses.
+ */
+internal class PromoBannerDismissalRepositoryTest {
+
+    /** In-memory [AppDataStore] so reads observe prior writes without Android DataStore. */
+    private val store = FakeAppDataStore()
+
+    private val repo = PromoBannerDismissalRepositoryImpl(store)
+
+    private var now = 1_000_000L
+
+    init {
+        repo.clock = PromoBannerDismissalRepositoryImpl.Clock { now }
+    }
+
+    @Test
+    fun `a banner is not dismissed before it is ever closed`() = runTest {
+        repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe false
+    }
+
+    @Test
+    fun `dismissing a banner hides it while within the TTL`() = runTest {
+        repo.dismiss(PromoBanner.BuyVultSwap)
+
+        repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
+
+        // One millisecond before the TTL elapses it is still hidden.
+        now += PromoBanner.BuyVultSwap.ttl.inWholeMilliseconds - 1
+        repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
+    }
+
+    @Test
+    fun `a dismissal lapses once the TTL elapses`() = runTest {
+        repo.dismiss(PromoBanner.FollowXVultisig)
+
+        now +=
+            PromoBanner.FollowXVultisig.ttl.inWholeMilliseconds + 1.milliseconds.inWholeMilliseconds
+
+        repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
+    }
+
+    @Test
+    fun `dismissals are independent per banner`() = runTest {
+        repo.dismiss(PromoBanner.BuyVultSwap)
+
+        repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
+        repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
+        repo.isDismissed(PromoBanner.UpgradeVaultDkls).first() shouldBe false
+    }
+
+    private class FakeAppDataStore : AppDataStore {
+        private val prefs = MutableStateFlow<Preferences>(emptyPreferences())
+
+        override suspend fun editData(
+            transform: suspend (MutablePreferences) -> Unit
+        ): Preferences {
+            val mutable = prefs.value.toMutablePreferences()
+            transform(mutable)
+            val updated = mutable.toPreferences()
+            prefs.value = updated
+            return updated
+        }
+
+        override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =
+            prefs.map { it[key] ?: defaultValue }
+
+        override suspend fun <T> set(key: Preferences.Key<T>, value: T) {
+            editData { it[key] = value }
+        }
+
+        override fun <T> readData(key: Preferences.Key<T>): Flow<T?> = prefs.map { it[key] }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5064.

Promo-banner dismissal was inconsistent and partly session-only / partly vault-scoped, so dismissing a CTA banner could resurface it just by switching vaults:

- **Upgrade / Follow X** — in-memory `isBannerVisible`, so dismissal lasted only for the current visit.
- **Buy VULT below Silver** — session-only.
- **Buy VULT at Silver** — persisted **per vault** (`buy_vult_banner_dismissed/<vaultId>`) with **no expiry**.

This replaces all three with one **global, TTL-based** model keyed by banner intent (not by vault).

## Changes

- **`PromoBannerDismissalRepository`** (new) — stores a per-banner `dismissedAt` timestamp and reports a banner as dismissed only while `now - dismissedAt < ttl`. Includes a `Clock` seam for deterministic tests.
- **`PromoBanner` enum** — centralizes banner ids + per-banner TTLs so they're tunable in one place rather than hard-coded into view logic.
- **`VaultAccountsViewModel`** — derives `showUpgradeBanner` / `showFollowXBanner` / `showBuyVultBanner` from the repo (upgrade additionally requires a GG20, migration-eligible vault). Dropped the session flag, `tempRemoveBanner()`, and the Silver-tier dependency that only gated persistence.
- **Pager / screen** — each banner's close button now dismisses **that** banner independently (previously one button hid Upgrade + Follow X together).
- **Migration** — `MainDataModule` seeds the global `buy_vult_swap` dismissal if any vault had the legacy per-vault key dismissed, then removes the stale keys. Removed the now-dead per-vault methods from `VaultDataStoreRepository`.

## Acceptance criteria

- ✅ Dismissing in one vault does not resurface the banner on a vault switch (global key)
- ✅ Each banner has its own TTL
- ✅ Expired dismissals are ignored → banner shows again
- ✅ Legacy `buy_vult_banner_dismissed/<vaultId>` data migrated safely
- ✅ Unit coverage for global dismissal, per-banner TTL, expiry, and the GG20 gate

## Note for reviewers

The issue states the TTL values are a **product decision**. The durations in `PromoBanner` (Upgrade 14d / Buy VULT 7d / Follow X 30d) are placeholder defaults — happy to adjust to whatever product prefers; they live in one enum.

## Test plan

- `PromoBannerDismissalRepositoryTest`: not-dismissed, within-TTL, TTL-lapse, per-banner independence.
- `VaultAccountsViewModelTest`: dismiss delegation, show/hide by TTL, GG20 gating of the upgrade banner.
- `:data` + `:app` compile (incl. Hilt); ktfmt applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promo banners now have independent, global visibility and dismissal for **Upgrade**, **Follow X**, and **Buy VULT**.
  * Dismissals are **TTL-based** and automatically reappear after the timeout.
* **Bug Fixes**
  * Banner visibility now updates correctly when switching vaults.
  * Upgrade banner eligibility is based on the selected vault’s type.
* **Chores**
  * Added data migration to move legacy Buy VULT dismissal state into the new TTL-based system.
* **Tests**
  * Updated and expanded unit tests for TTL dismissal and banner visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->