### PR TITLE
fix(swap): align route-not-available error tooltip under the flip button (#5062)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -187,7 +189,12 @@ internal fun SwapScreen(
             var bottomCenter by remember { mutableStateOf(Offset.Zero) }
             val space = 8.dp
 
+            // The flip button reports its bottom-center in its own parent's space, but the error
+            // hint is offset in the outer Box's space. Adding the input block's top-left translates
+            // the anchor into that outer space so the hint sits directly under the red error circle
+            // instead of floating too high and overlapping the From/To rows (#5062).
             var flipButtonBottomCenter by remember { mutableStateOf(Offset.Zero) }
+            var inputBlockTopLeft by remember { mutableStateOf(Offset.Zero) }
 
             val error = state.error ?: state.formError
 
@@ -211,7 +218,12 @@ internal fun SwapScreen(
                             modifier = Modifier.padding(vertical = 48.dp),
                         )
                     } else {
-                        Box {
+                        Box(
+                            modifier =
+                                Modifier.onGloballyPositioned {
+                                    inputBlockTopLeft = it.boundsInParent().topLeft
+                                }
+                        ) {
                             Column(verticalArrangement = Arrangement.spacedBy(space)) {
                                 Box {
                                     SrcTokenInput(
@@ -324,8 +336,12 @@ internal fun SwapScreen(
                             title = stringResource(R.string.dialog_default_error_title),
                             offset =
                                 IntOffset(
-                                    x = flipButtonBottomCenter.x.toInt() - errorWidthBoxPx.div(2),
-                                    y = flipButtonBottomCenter.y.toInt() + spacePx,
+                                    x =
+                                        (inputBlockTopLeft.x + flipButtonBottomCenter.x).toInt() -
+                                            errorWidthBoxPx.div(2),
+                                    y =
+                                        (inputBlockTopLeft.y + flipButtonBottomCenter.y).toInt() +
+                                            spacePx,
                                 ),
                             isVisible = true,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -189,10 +189,6 @@ internal fun SwapScreen(
             var bottomCenter by remember { mutableStateOf(Offset.Zero) }
             val space = 8.dp
 
-            // The flip button reports its bottom-center in its own parent's space, but the error
-            // hint is offset in the outer Box's space. Adding the input block's top-left translates
-            // the anchor into that outer space so the hint sits directly under the red error circle
-            // instead of floating too high and overlapping the From/To rows (#5062).
             var flipButtonBottomCenter by remember { mutableStateOf(Offset.Zero) }
             var inputBlockTopLeft by remember { mutableStateOf(Offset.Zero) }
 


### PR DESCRIPTION
## Summary

Fixes #5062.

On the Swap screen, the **"Swap route not available"** error tooltip rendered misaligned — floating over the From/To rows, hiding the red error circle and the "To" amount.

**Root cause:** the error `HintBox` is offset using the flip button's bottom-center. The flip button reports that position via `boundsInParent()` — relative to **its own parent** (the source-input `Box`) — while the hint is positioned in the **outer `Box`** coordinate space. The missing vertical offset of the content above the input block (the Market/Limit tabs + spacing) pushed the tooltip too high, so it covered the red circle and overlapped the rows.

**Fix:** track the input block's top-left in the outer `Box` space and add it to the flip-button anchor, translating it into the correct space. The tooltip now sits directly under the red error circle, with its caret aligned to it, and no longer overlaps the swap inputs.

## Changes
- `SwapScreen.kt` — translate the error-hint anchor from the flip button's parent space into the outer `Box` space.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/CP0GoLZ.png) | ![after](https://i.imgur.com/1hNzD3T.png) |

Real Android renders captured via `PreviewActivity` + ADB screencap on the emulator.

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] ktfmt clean (`ktfmtCheckMain`)
- [x] Device-verified: tooltip sits under the red circle, caret aligned, both From/To amounts fully visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the placement of swap error hints so they appear correctly aligned under the relevant error indicator in Market mode.
  * Fixed hint positioning when the swap input area is laid out differently, making error messages easier to read and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->