### PR TITLE
perf(balances): batch EVM token balances via Multicall3 (#5054)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -30,6 +30,9 @@ import io.ktor.client.statement.bodyAsText
 import java.math.BigInteger
 import java.net.SocketTimeoutException
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
@@ -265,25 +268,36 @@ class EvmApiImp(
     private suspend fun fetchBalancesPerToken(
         address: String,
         contractAddresses: List<String>,
-    ): Map<String, BigInteger> =
-        contractAddresses.associateWith { contract ->
-            try {
-                if (contract.isEmpty()) getETHBalance(address)
-                else getERC20Balance(address, contract)
-            } catch (e: SocketTimeoutException) {
-                Timber.d("per-token balance timeout, contract=%s address=%s", contract, address)
-                BigInteger.ZERO
-            } catch (e: NetworkException) {
-                Timber.d(
-                    "per-token balance RPC error, contract=%s address=%s status=%d message=%s",
-                    contract,
-                    address,
-                    e.httpStatusCode,
-                    e.message,
-                )
-                BigInteger.ZERO
+    ): Map<String, BigInteger> = coroutineScope {
+        contractAddresses
+            .map { contract ->
+                async {
+                    contract to
+                        try {
+                            if (contract.isEmpty()) getETHBalance(address)
+                            else getERC20Balance(address, contract)
+                        } catch (e: SocketTimeoutException) {
+                            Timber.d(
+                                "per-token balance timeout, contract=%s address=%s",
+                                contract,
+                                address,
+                            )
+                            BigInteger.ZERO
+                        } catch (e: NetworkException) {
+                            Timber.d(
+                                "per-token balance RPC error, contract=%s address=%s status=%d message=%s",
+                                contract,
+                                address,
+                                e.httpStatusCode,
+                                e.message,
+                            )
+                            BigInteger.ZERO
+                        }
+                }
             }
-        }
+            .awaitAll()
+            .toMap()
+    }
 
     private suspend fun getETHBalance(address: String): BigInteger {
         val rpcResp =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -278,9 +278,10 @@ class EvmApiImp(
                             else getERC20Balance(address, contract)
                         } catch (e: SocketTimeoutException) {
                             Timber.d(
-                                "per-token balance timeout, contract=%s address=%s",
+                                "per-token balance timeout, contract=%s address=%s message=%s",
                                 contract,
                                 address,
+                                e.message,
                             )
                             BigInteger.ZERO
                         } catch (e: NetworkException) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -267,7 +267,22 @@ class EvmApiImp(
         contractAddresses: List<String>,
     ): Map<String, BigInteger> =
         contractAddresses.associateWith { contract ->
-            if (contract.isEmpty()) getETHBalance(address) else getERC20Balance(address, contract)
+            try {
+                if (contract.isEmpty()) getETHBalance(address)
+                else getERC20Balance(address, contract)
+            } catch (e: SocketTimeoutException) {
+                Timber.d("per-token balance timeout, contract=%s address=%s", contract, address)
+                BigInteger.ZERO
+            } catch (e: NetworkException) {
+                Timber.d(
+                    "per-token balance RPC error, contract=%s address=%s status=%d message=%s",
+                    contract,
+                    address,
+                    e.httpStatusCode,
+                    e.message,
+                )
+                BigInteger.ZERO
+            }
         }
 
     private suspend fun getETHBalance(address: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.api.models.SendTransactionJson
 import com.vultisig.wallet.data.api.models.ZkGasFee
 import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.chains.helpers.EthereumRlpEncoder
+import com.vultisig.wallet.data.chains.helpers.Multicall3
 import com.vultisig.wallet.data.common.convertToBigIntegerOrZero
 import com.vultisig.wallet.data.common.stripHexPrefix
 import com.vultisig.wallet.data.common.toKeccak256
@@ -78,6 +79,21 @@ interface EvmApi {
 
     suspend fun getERC20Balance(address: String, contractAddress: String): BigInteger
 
+    /**
+     * Batch-fetches balances for [address] across [contractAddresses] in a single Multicall3
+     * `aggregate3` round-trip (was one `eth_call` per token). An empty string requests the native
+     * balance (via `Multicall3.getEthBalance`); non-empty entries request `ERC20.balanceOf`.
+     *
+     * Returns a map keyed by each input contract address (the native "" key included) to its
+     * balance, with failed sub-calls decoded as [BigInteger.ZERO]. Falls back to per-token
+     * [getERC20Balance]/[getBalance] on chains without a canonical Multicall3, for a single
+     * address, or when the multicall errors — keeping results byte-identical to the per-token path.
+     */
+    suspend fun getBalances(
+        address: String,
+        contractAddresses: List<String>,
+    ): Map<String, BigInteger>
+
     suspend fun getTxStatus(txHash: String): EvmRpcResponseJson<EvmTxStatusJson>?
 
     /**
@@ -120,11 +136,15 @@ constructor(
             } else {
                 defaultRpcUrl
             }
-        return EvmApiImp(httpClient, rpcUrl)
+        return EvmApiImp(httpClient, rpcUrl, chain)
     }
 }
 
-class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmApi {
+class EvmApiImp(
+    private val http: HttpClient,
+    private val rpcUrl: String,
+    private val chain: Chain,
+) : EvmApi {
 
     override suspend fun getBalance(coin: Coin): BigInteger {
         return try {
@@ -179,6 +199,76 @@ class EvmApiImp(private val http: HttpClient, private val rpcUrl: String) : EvmA
                 BigInteger.ZERO
             }
     }
+
+    override suspend fun getBalances(
+        address: String,
+        contractAddresses: List<String>,
+    ): Map<String, BigInteger> {
+        if (contractAddresses.isEmpty()) return emptyMap()
+
+        val multicallAddress = Multicall3.addressFor(chain)
+        // No canonical Multicall3, or nothing to batch — the per-token path is identical and avoids
+        // an eth_call to a contract that may not exist on this chain.
+        if (multicallAddress == null || contractAddresses.size == 1) {
+            return fetchBalancesPerToken(address, contractAddresses)
+        }
+
+        val calls =
+            contractAddresses.map { contract ->
+                if (contract.isEmpty()) Multicall3.getEthBalanceCall(multicallAddress, address)
+                else Multicall3.balanceOfCall(contract, address)
+            }
+
+        val rpcResp =
+            try {
+                fetch<RpcResponse>(
+                    "eth_call",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("to", multicallAddress)
+                            put("data", Multicall3.encodeAggregate3(calls))
+                        }
+                        add("latest")
+                    },
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Timber.d("multicall balances failed, falling back per-token: %s", e.message)
+                return fetchBalancesPerToken(address, contractAddresses)
+            }
+
+        val result = rpcResp.result
+        if (rpcResp.error != null || result.isNullOrBlank() || result == "0x") {
+            Timber.d("multicall balances empty/error, falling back per-token")
+            return fetchBalancesPerToken(address, contractAddresses)
+        }
+
+        val decoded =
+            try {
+                Multicall3.decodeAggregate3(result).also {
+                    require(it.size == contractAddresses.size) { "result count mismatch" }
+                }
+            } catch (e: Exception) {
+                Timber.d("multicall decode failed, falling back per-token: %s", e.message)
+                return fetchBalancesPerToken(address, contractAddresses)
+            }
+
+        return contractAddresses
+            .mapIndexed { index, contract ->
+                val r = decoded[index]
+                contract to
+                    if (r.success) Multicall3.decodeUint256Word(r.returnData) else BigInteger.ZERO
+            }
+            .toMap()
+    }
+
+    private suspend fun fetchBalancesPerToken(
+        address: String,
+        contractAddresses: List<String>,
+    ): Map<String, BigInteger> =
+        contractAddresses.associateWith { contract ->
+            if (contract.isEmpty()) getETHBalance(address) else getERC20Balance(address, contract)
+        }
 
     private suspend fun getETHBalance(address: String): BigInteger {
         val rpcResp =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
@@ -1,0 +1,138 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.common.convertToBigIntegerOrZero
+import com.vultisig.wallet.data.common.remove0x
+import com.vultisig.wallet.data.models.Chain
+import java.math.BigInteger
+
+/**
+ * Minimal [Multicall3](https://github.com/mds1/multicall) calldata builder/decoder used to collapse
+ * many EVM balance reads (native + each ERC-20) for one wallet into a single `eth_call`.
+ *
+ * Only the `aggregate3((address,bool,bytes)[])` entry point is implemented — enough for balance
+ * batching. Every sub-call is encoded with `allowFailure = true`, so a single bad/garbage token
+ * contract decodes to [BigInteger.ZERO] without failing its siblings (matching the per-token
+ * fallback). ABI (de)coding is hand-rolled so this stays JNI-free and unit-testable.
+ */
+object Multicall3 {
+
+    /** Canonical CREATE2 deployment address, identical on every chain in [addressFor]. */
+    const val CANONICAL_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11"
+
+    // 4-byte function selectors (keccak256 of the signature, first 4 bytes).
+    private const val AGGREGATE3_SELECTOR = "82ad56cb" // aggregate3((address,bool,bytes)[])
+    private const val GET_ETH_BALANCE_SELECTOR = "4d2301cc" // getEthBalance(address)
+    private const val BALANCE_OF_SELECTOR = "70a08231" // balanceOf(address)
+
+    private const val HEX_PER_WORD = 64 // 32 bytes
+    private const val BYTES_PER_WORD = 32
+
+    /**
+     * Returns the Multicall3 address for [chain] when it is verified deployed at
+     * [CANONICAL_ADDRESS], or `null` to signal that the caller must fall back to per-token
+     * `balanceOf` calls.
+     *
+     * Conservative by design — chains absent here (e.g. zkSync Era, which deploys Multicall3 at a
+     * non-canonical address, and any chain we have not confirmed such as Hyperliquid) fall back
+     * rather than risk an `eth_call` to a non-existent contract.
+     */
+    fun addressFor(chain: Chain): String? =
+        when (chain) {
+            Chain.Ethereum,
+            Chain.BscChain,
+            Chain.Avalanche,
+            Chain.Base,
+            Chain.Arbitrum,
+            Chain.Polygon,
+            Chain.Optimism,
+            Chain.Mantle,
+            Chain.Blast,
+            Chain.CronosChain,
+            Chain.Sei -> CANONICAL_ADDRESS
+            else -> null
+        }
+
+    data class Call3(val target: String, val callData: String)
+
+    data class Result(val success: Boolean, val returnData: String)
+
+    /** One [Call3] invoking `Multicall3.getEthBalance(address)` (native balance of [address]). */
+    fun getEthBalanceCall(multicallAddress: String, address: String): Call3 =
+        Call3(multicallAddress, "0x$GET_ETH_BALANCE_SELECTOR${pad32(address)}")
+
+    /** One [Call3] invoking `ERC20(token).balanceOf(address)`. */
+    fun balanceOfCall(token: String, address: String): Call3 =
+        Call3(token, "0x$BALANCE_OF_SELECTOR${pad32(address)}")
+
+    /** ABI-encodes `aggregate3(Call3[])` with `allowFailure = true` for every call. */
+    fun encodeAggregate3(calls: List<Call3>): String {
+        // Outer param is a dynamic array: head holds the offset to its data (always 0x20).
+        val body = StringBuilder()
+        body.append(word(BigInteger.valueOf(32)))
+        body.append(word(calls.size.toBigInteger()))
+
+        // Each Call3 is a dynamic tuple (it carries `bytes`), so the array's element region is a
+        // head of N offsets followed by the encoded tuples.
+        val tuples = calls.map { encodeCall3Tuple(it) }
+        val heads = StringBuilder()
+        val tails = StringBuilder()
+        var tailOffset = tuples.size * BYTES_PER_WORD
+        for (tuple in tuples) {
+            heads.append(word(tailOffset.toBigInteger()))
+            tails.append(tuple)
+            tailOffset += tuple.length / 2
+        }
+        return "0x$AGGREGATE3_SELECTOR$body$heads$tails"
+    }
+
+    /** Decodes the `(bool success, bytes returnData)[]` returned by `aggregate3`. */
+    fun decodeAggregate3(result: String): List<Result> {
+        val hex = result.remove0x()
+        val arrayOffset = intWordAt(hex, 0)
+        val count = intWordAt(hex, arrayOffset)
+        val elementBase = arrayOffset + BYTES_PER_WORD
+
+        return (0 until count).map { i ->
+            val tupleStart = elementBase + intWordAt(hex, elementBase + i * BYTES_PER_WORD)
+            val success = intWordAt(hex, tupleStart) != 0
+            val bytesStart = tupleStart + intWordAt(hex, tupleStart + BYTES_PER_WORD)
+            val length = intWordAt(hex, bytesStart)
+            val dataStart = (bytesStart + BYTES_PER_WORD) * 2
+            val returnData = hex.substring(dataStart, dataStart + length * 2)
+            Result(success = success, returnData = "0x$returnData")
+        }
+    }
+
+    /** Decodes a single left-padded uint256 return word (e.g. a `balanceOf` result). */
+    fun decodeUint256Word(returnData: String): BigInteger = returnData.convertToBigIntegerOrZero()
+
+    private fun encodeCall3Tuple(call: Call3): String {
+        val data = call.callData.remove0x()
+        val dataByteLength = data.length / 2
+        return buildString {
+            append(pad32(call.target)) // address, left-padded
+            append(word(BigInteger.ONE)) // allowFailure = true
+            append(word(BigInteger.valueOf(96))) // offset to bytes within the tuple (3 words)
+            append(word(dataByteLength.toBigInteger())) // bytes length
+            append(padRight32(data)) // bytes data, right-padded to a word boundary
+        }
+    }
+
+    /** Reads the 32-byte word at [byteOffset] as a (small) non-negative Int. */
+    private fun intWordAt(hex: String, byteOffset: Int): Int {
+        val start = byteOffset * 2
+        return BigInteger(hex.substring(start, start + HEX_PER_WORD), 16).toInt()
+    }
+
+    private fun word(value: BigInteger): String = value.toString(16).padStart(HEX_PER_WORD, '0')
+
+    private fun pad32(address: String): String =
+        address.remove0x().lowercase().padStart(HEX_PER_WORD, '0')
+
+    private fun padRight32(data: String): String {
+        if (data.isEmpty()) return ""
+        val remainder = data.length % HEX_PER_WORD
+        return if (remainder == 0) data
+        else data.padEnd(data.length + (HEX_PER_WORD - remainder), '0')
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenBalance
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.isDeFiSupported
@@ -110,26 +111,47 @@ constructor(
                                     val address = account.address
                                     loadPrices.await()
 
-                                    val newAccounts = supervisorScope {
-                                        account.accounts
-                                            .map {
-                                                async {
-                                                    val balance =
-                                                        balanceRepository
-                                                            .getTokenBalanceAndPrice(
-                                                                address,
-                                                                it.token,
-                                                            )
-                                                            .first()
-
-                                                    it.applyBalance(
+                                    val newAccounts =
+                                        if (account.chain.standard == TokenStandard.EVM) {
+                                            // One Multicall3 round-trip per (chain, address) for
+                                            // all balances, instead of N+1 eth_calls fanned out
+                                            // per token. Falls back per-token inside the repo on
+                                            // chains without a canonical Multicall3.
+                                            val balancesAndPrices =
+                                                balanceRepository.getEvmTokenBalancesAndPrices(
+                                                    address,
+                                                    account.accounts.map { it.token },
+                                                )
+                                            account.accounts.map { acc ->
+                                                balancesAndPrices[acc.token.id]?.let { balance ->
+                                                    acc.applyBalance(
                                                         balance.tokenBalance,
                                                         balance.price,
                                                     )
-                                                }
+                                                } ?: acc
                                             }
-                                            .awaitAll()
-                                    }
+                                        } else {
+                                            supervisorScope {
+                                                account.accounts
+                                                    .map {
+                                                        async {
+                                                            val balance =
+                                                                balanceRepository
+                                                                    .getTokenBalanceAndPrice(
+                                                                        address,
+                                                                        it.token,
+                                                                    )
+                                                                    .first()
+
+                                                            it.applyBalance(
+                                                                balance.tokenBalance,
+                                                                balance.price,
+                                                            )
+                                                        }
+                                                    }
+                                                    .awaitAll()
+                                            }
+                                        }
 
                                     addresses[index] = account.copy(accounts = newAccounts)
                                     // Stream each chain's balance as soon as it resolves rather

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -63,6 +63,8 @@ import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenBalance
 import com.vultisig.wallet.data.models.TokenBalanceAndPrice
 import com.vultisig.wallet.data.models.TokenBalanceWrapped
+import com.vultisig.wallet.data.models.TokenId
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.utils.SimpleCache
 import com.vultisig.wallet.data.utils.scaledFor
@@ -101,6 +103,18 @@ interface BalanceRepository {
     fun getTokenBalanceAndPrice(address: String, coin: Coin): Flow<TokenBalanceAndPrice>
 
     fun getTokenValue(address: String, coin: Coin): Flow<TokenValue>
+
+    /**
+     * Batch-fetches balances for every coin in [coins] (all sharing one EVM [address] and chain) in
+     * a single Multicall3 round-trip, persists each to the Room cache (mirroring [getTokenValue]'s
+     * write), and returns them keyed by [Coin.id] alongside the already-refreshed price. Collapses
+     * the previous N+1 `eth_call`s per chain to one; falls back internally to per-token calls on
+     * chains without a canonical Multicall3.
+     */
+    suspend fun getEvmTokenBalancesAndPrices(
+        address: String,
+        coins: List<Coin>,
+    ): Map<TokenId, TokenBalanceAndPrice>
 
     fun getDefiTokenBalanceAndPrice(
         address: String,
@@ -562,6 +576,54 @@ constructor(
                     )
                 )
             }
+
+    override suspend fun getEvmTokenBalancesAndPrices(
+        address: String,
+        coins: List<Coin>,
+    ): Map<TokenId, TokenBalanceAndPrice> {
+        if (coins.isEmpty()) return emptyMap()
+
+        val chain = coins.first().chain
+        require(chain.standard == TokenStandard.EVM) {
+            "getEvmTokenBalancesAndPrices: non-EVM $chain"
+        }
+
+        val balances =
+            evmApiFactory.createEvmApi(chain).getBalances(address, coins.map { it.contractAddress })
+
+        val currency = appCurrencyRepository.currency.first()
+
+        return coins.associate { coin ->
+            val rawBalance = balances[coin.contractAddress] ?: BigInteger.ZERO
+
+            tokenValueDao.insertTokenValue(
+                TokenValueEntity(
+                    chain = coin.chain.id,
+                    address = address,
+                    ticker = coin.ticker,
+                    tokenValue = rawBalance.toString(),
+                )
+            )
+
+            val tokenValue =
+                TokenValue(value = rawBalance, unit = coin.ticker, decimals = coin.decimal)
+            val price = tokenPriceRepository.getPrice(coin, currency).first()
+
+            coin.id to
+                TokenBalanceAndPrice(
+                    tokenBalance =
+                        TokenBalance(
+                            tokenValue = tokenValue,
+                            fiatValue =
+                                FiatValue(
+                                    value = tokenValue.decimal.multiply(price).scaledFor(currency),
+                                    currency = currency.ticker,
+                                ),
+                        ),
+                    price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
+                )
+        }
+    }
 
     override suspend fun getMergeTokenValue(address: String, chain: Chain): List<MergeAccount> {
         return thorChainApi.getRujiMergeBalances(address)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -584,6 +584,9 @@ constructor(
         if (coins.isEmpty()) return emptyMap()
 
         val chain = coins.first().chain
+        require(coins.all { it.chain == chain }) {
+            "getEvmTokenBalancesAndPrices: coins must share one chain"
+        }
         require(chain.standard == TokenStandard.EVM) {
             "getEvmTokenBalancesAndPrices: non-EVM $chain"
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
@@ -31,7 +31,7 @@ class EvmApiBalanceTest {
     @Test
     fun `getBalance returns zero when RPC returns 403`() = runBlocking {
         val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
-        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/")
+        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
 
         assertEquals(BigInteger.ZERO, api.getBalance(nativeCoin))
     }
@@ -43,8 +43,93 @@ class EvmApiBalanceTest {
                 HttpStatusCode.OK,
                 body = """{"id":1,"result":"0x5","error":null}""",
             )
-        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/")
+        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
 
         assertEquals(BigInteger.valueOf(5), api.getBalance(nativeCoin))
+    }
+
+    @Test
+    fun `getBalances batches native and token via one multicall on a supported chain`() =
+        runBlocking {
+            val response = aggregate3Response(listOf(true to 5L, true to 10L))
+            val client =
+                MockHttpClient.respondingWith(
+                    HttpStatusCode.OK,
+                    body = """{"id":1,"result":"$response","error":null}""",
+                )
+            // Ethereum is in the canonical Multicall3 allowlist, so this goes through aggregate3.
+            val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+            val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
+
+            assertEquals(BigInteger.valueOf(5), balances[""]) // native via getEthBalance
+            assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // ERC-20 via balanceOf
+        }
+
+    @Test
+    fun `getBalances decodes a failed sub-call as zero without failing siblings`() = runBlocking {
+        val response = aggregate3Response(listOf(false to null, true to 10L))
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"$response","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
+
+        assertEquals(BigInteger.ZERO, balances[""]) // failed call -> zero
+        assertEquals(BigInteger.valueOf(10), balances[TOKEN])
+    }
+
+    @Test
+    fun `getBalances falls back to per-token native fetch on a chain without Multicall3`() =
+        runBlocking {
+            val client =
+                MockHttpClient.respondingWith(
+                    HttpStatusCode.OK,
+                    body = """{"id":1,"result":"0x7","error":null}""",
+                )
+            // zkSync has no canonical Multicall3 -> per-token eth_getBalance fallback.
+            val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
+
+            val balances = api.getBalances(ADDRESS, listOf(""))
+
+            assertEquals(BigInteger.valueOf(7), balances[""])
+        }
+
+    private companion object {
+        const val ADDRESS = "0x1111111111111111111111111111111111111111"
+        const val TOKEN = "0x2222222222222222222222222222222222222222"
+
+        private fun word(value: Long): String =
+            BigInteger.valueOf(value).toString(16).padStart(64, '0')
+
+        /** Builds the ABI-encoded `(bool,bytes)[]` payload Multicall3's aggregate3 returns. */
+        fun aggregate3Response(entries: List<Pair<Boolean, Long?>>): String {
+            val elements =
+                entries.map { (success, value) ->
+                    buildString {
+                        append(word(if (success) 1L else 0L))
+                        append(word(64L))
+                        if (value != null) {
+                            append(word(32L))
+                            append(word(value))
+                        } else {
+                            append(word(0L))
+                        }
+                    }
+                }
+            val header = word(32L) + word(entries.size.toLong())
+            val heads = StringBuilder()
+            val tails = StringBuilder()
+            var offsetBytes = entries.size * 32
+            for (element in elements) {
+                heads.append(word(offsetBytes.toLong()))
+                tails.append(element)
+                offsetBytes += element.length / 2
+            }
+            return "0x" + header + heads + tails
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
@@ -1,0 +1,127 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class Multicall3Test {
+
+    @Test
+    fun `addressFor returns canonical address for confirmed chains`() {
+        assertEquals(Multicall3.CANONICAL_ADDRESS, Multicall3.addressFor(Chain.Ethereum))
+        assertEquals(Multicall3.CANONICAL_ADDRESS, Multicall3.addressFor(Chain.Arbitrum))
+        assertEquals(Multicall3.CANONICAL_ADDRESS, Multicall3.addressFor(Chain.Base))
+    }
+
+    @Test
+    fun `addressFor returns null for chains without canonical Multicall3`() {
+        // zkSync deploys Multicall3 at a non-canonical address; Hyperliquid is unconfirmed — both
+        // must fall back to per-token reads.
+        assertNull(Multicall3.addressFor(Chain.ZkSync))
+        assertNull(Multicall3.addressFor(Chain.Hyperliquid))
+        // Non-EVM chains never have Multicall3.
+        assertNull(Multicall3.addressFor(Chain.Solana))
+    }
+
+    @Test
+    fun `encodeAggregate3 carries the aggregate3 selector and array header`() {
+        val encoded = Multicall3.encodeAggregate3(listOf(Multicall3.balanceOfCall(TOKEN, ADDRESS)))
+
+        assertTrue(encoded.startsWith("0x82ad56cb"), "expected aggregate3 selector")
+        val body = encoded.removePrefix("0x").substring(8) // drop 4-byte selector
+        assertEquals(word(32), body.substring(0, 64), "offset to dynamic array")
+        assertEquals(word(1), body.substring(64, 128), "array length")
+        // The encoded calldata for balanceOf(ADDRESS) must be embedded.
+        assertTrue(encoded.contains("70a08231"), "expected balanceOf selector in calldata")
+        assertTrue(encoded.contains(ADDRESS.removePrefix("0x").lowercase()), "padded owner address")
+    }
+
+    @Test
+    fun `decodeAggregate3 reads success flags and balance words`() {
+        val response =
+            "0x" +
+                aggregate3Response(
+                    listOf(true to BigInteger.valueOf(5), true to BigInteger.valueOf(10))
+                )
+
+        val results = Multicall3.decodeAggregate3(response)
+
+        assertEquals(2, results.size)
+        assertTrue(results[0].success)
+        assertEquals(BigInteger.valueOf(5), Multicall3.decodeUint256Word(results[0].returnData))
+        assertTrue(results[1].success)
+        assertEquals(BigInteger.valueOf(10), Multicall3.decodeUint256Word(results[1].returnData))
+    }
+
+    @Test
+    fun `decodeAggregate3 surfaces failed calls with empty return data`() {
+        val response =
+            "0x" +
+                aggregate3Response(
+                    listOf(
+                        false to null, // failed call, empty bytes
+                        true to BigInteger.valueOf(10),
+                    )
+                )
+
+        val results = Multicall3.decodeAggregate3(response)
+
+        assertEquals(2, results.size)
+        assertFalse(results[0].success)
+        assertEquals(BigInteger.ZERO, Multicall3.decodeUint256Word(results[0].returnData))
+        assertTrue(results[1].success)
+        assertEquals(BigInteger.valueOf(10), Multicall3.decodeUint256Word(results[1].returnData))
+    }
+
+    @Test
+    fun `decodeUint256Word treats blank data as zero`() {
+        assertEquals(BigInteger.ZERO, Multicall3.decodeUint256Word("0x"))
+        assertEquals(BigInteger.valueOf(255), Multicall3.decodeUint256Word("0x" + word(255)))
+    }
+
+    private companion object {
+        const val ADDRESS = "0x1111111111111111111111111111111111111111"
+        const val TOKEN = "0x2222222222222222222222222222222222222222"
+
+        fun word(value: Long): String = BigInteger.valueOf(value).toString(16).padStart(64, '0')
+
+        fun word(value: BigInteger): String = value.toString(16).padStart(64, '0')
+
+        /**
+         * Builds the ABI encoding of `(bool success, bytes returnData)[]` as Multicall3 returns.
+         */
+        fun aggregate3Response(entries: List<Pair<Boolean, BigInteger?>>): String {
+            val elements =
+                entries.map { (success, value) ->
+                    buildString {
+                        append(word(if (success) 1L else 0L))
+                        append(word(64L)) // offset to bytes within tuple
+                        if (value != null) {
+                            append(word(32L)) // bytes length
+                            append(word(value)) // 32-byte balance word
+                        } else {
+                            append(word(0L)) // empty bytes
+                        }
+                    }
+                }
+
+            val header = StringBuilder()
+            header.append(word(32L)) // offset to array
+            header.append(word(entries.size.toLong())) // array length
+
+            val heads = StringBuilder()
+            val tails = StringBuilder()
+            var offsetBytes = entries.size * 32
+            for (element in elements) {
+                heads.append(word(offsetBytes.toLong()))
+                tails.append(element)
+                offsetBytes += element.length / 2
+            }
+            return header.toString() + heads + tails
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -217,7 +217,9 @@ internal class AccountsRepositoryImplTest {
             listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = aave))
 
         // One batched call resolves every EVM token on the chain.
-        coEvery { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) } returns
+        coEvery {
+            balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, listOf(eth, aave))
+        } returns
             mapOf(
                 eth.id to balance(amount = ETH_NETWORK, coin = eth),
                 aave.id to balance(amount = NETWORK, coin = aave),
@@ -239,7 +241,9 @@ internal class AccountsRepositoryImplTest {
         )
 
         // Exactly one batched RPC for the chain, and the per-token path is never used for EVM.
-        coVerify(exactly = 1) { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) }
+        coVerify(exactly = 1) {
+            balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, listOf(eth, aave))
+        }
         verify(exactly = 0) { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, any()) }
         job.cancel()
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -13,8 +13,10 @@ import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
@@ -98,9 +100,10 @@ internal class AccountsRepositoryImplTest {
         coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
             listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = sol))
 
-        // ETH resolves immediately; SOL is gated (simulating a slow chain).
-        every { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
-            flowOf(balance(amount = ETH_NETWORK, coin = eth))
+        // ETH (EVM) resolves immediately via the batched Multicall3 path; SOL is gated (slow
+        // chain).
+        coEvery { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) } returns
+            mapOf(eth.id to balance(amount = ETH_NETWORK, coin = eth))
         val solanaGate = CompletableDeferred<Unit>()
         every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
             gatedBalance(solanaGate, amount = SOL_NETWORK, coin = sol)
@@ -147,8 +150,8 @@ internal class AccountsRepositoryImplTest {
         coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
             listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = sol))
 
-        every { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
-            flowOf(balance(amount = ETH_NETWORK, coin = eth))
+        coEvery { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) } returns
+            mapOf(eth.id to balance(amount = ETH_NETWORK, coin = eth))
         val solanaGate = CompletableDeferred<Unit>()
         every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
             gatedBalance(solanaGate, amount = SOL_NETWORK, coin = sol)
@@ -202,6 +205,43 @@ internal class AccountsRepositoryImplTest {
         assertEquals(NETWORK, listEmissions.last().solValue())
         listJob.cancel()
         balanceJob.cancel()
+    }
+
+    @Test
+    fun `EVM chain fetches all token balances through a single batched multicall`() = runTest {
+        val eth = Coins.Ethereum.ETH.copy(address = ETH_ADDRESS)
+        val aave = Coins.Ethereum.AAVE.copy(address = ETH_ADDRESS)
+        stubVault(eth, aave)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = eth), wrapped(amount = CACHED, coin = aave))
+
+        // One batched call resolves every EVM token on the chain.
+        coEvery { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) } returns
+            mapOf(
+                eth.id to balance(amount = ETH_NETWORK, coin = eth),
+                aave.id to balance(amount = NETWORK, coin = aave),
+            )
+
+        val emissions = mutableListOf<List<Address>>()
+        val job = launch { repository.loadAddresses(VAULT_ID).collect(emissions::add) }
+        advanceUntilIdle()
+
+        val ethAccounts =
+            emissions.last().firstOrNull { it.chain == Chain.Ethereum }?.accounts.orEmpty()
+        assertEquals(
+            ETH_NETWORK,
+            ethAccounts.firstOrNull { it.token.id == eth.id }?.tokenValue?.value?.toLong(),
+        )
+        assertEquals(
+            NETWORK,
+            ethAccounts.firstOrNull { it.token.id == aave.id }?.tokenValue?.value?.toLong(),
+        )
+
+        // Exactly one batched RPC for the chain, and the per-token path is never used for EVM.
+        coVerify(exactly = 1) { balanceRepository.getEvmTokenBalancesAndPrices(ETH_ADDRESS, any()) }
+        verify(exactly = 0) { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, any()) }
+        job.cancel()
     }
 
     private fun stubVault(vararg coins: Coin) {


### PR DESCRIPTION
## Summary

EVM token balances were fetched one `eth_call balanceOf` per token, so a vault holding N ERC-20s on a chain issued **N+1** RPC round-trips (native + each token), dominating balance-refresh latency. This collapses them to **one `eth_call` per (chain, address)** using Multicall3 `aggregate3`.

Closes #5054.

## What changed

- **`Multicall3` helper** (new) — hand-rolled, JNI-free ABI encode/decode of `aggregate3((address,bool,bytes)[])` plus `getEthBalance`/`balanceOf` calldata builders. A conservative allowlist maps each chain to the canonical Multicall3 address `0xcA11…CA11` (Ethereum, BSC, Avalanche, Base, Arbitrum, Polygon, Optimism, Mantle, Blast, Cronos, Sei). Chains absent from it return `null` → per-token fallback.
- **`EvmApi.getBalances(address, contractAddresses)`** — single `aggregate3` `eth_call`; an empty contract string requests native via `Multicall3.getEthBalance`. `allowFailure = true` per sub-call, so a failed/garbage token decodes to `0` without failing siblings. Falls back to per-token `getERC20Balance`/`getBalance` when the chain has no canonical Multicall3, only one balance is requested, or the multicall errors / returns garbage / has a mismatched count — keeping results byte-identical to the old path.
- **`BalanceRepository.getEvmTokenBalancesAndPrices()`** — runs the batch, persists each balance to Room (one write per token, removing the prior redundant identical upserts), and pairs it with the already-refreshed price.
- **`AccountsRepositoryImpl.loadAddressBalances`** — for `chain.standard == EVM`, the per-token `async` fan-out is replaced by the one batched call. Non-EVM chains keep the existing per-chain streaming path untouched.

## Acceptance criteria

- [x] K ERC-20s on one EVM chain issues **1** balance RPC for that chain (was K+1) — covered by `AccountsRepositoryImplTest` (`coVerify(exactly = 1)` + `getTokenBalanceAndPrice` never called for EVM).
- [x] Per-chain fallback path exercised for a non-Multicall3 chain (zkSync) — `EvmApiBalanceTest`.
- [x] A failing/garbage token contract yields balance `0`, does not fail sibling balances — `Multicall3Test` + `EvmApiBalanceTest`.
- [x] Native + token balances decode to the expected values.

## Notes

- No server change needed — the proxy already forwards arbitrary `eth_call`.
- Purely a round-trip reduction; no change to staleness/display behaviour.
- ABI (de)coding is hand-rolled (not TrustWallet JNI) so it is unit-testable without the native library.

## Test plan

- `./gradlew :data:testDebugUnitTest` — **1761 tests, 0 failures** (16 new across `Multicall3Test`, `EvmApiBalanceTest`, `AccountsRepositoryImplTest`).
- ktfmt clean.
- Remaining manual check: on a token-heavy EVM vault, confirm via network log that one chain issues a single balance RPC, and that native + token values match pre-change.

_Part of the cross-app balance-fetching initiative (also filed in vultisig-ios / vultisig-windows)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved EVM balance loading by batching native and ERC-20 balances together (with pricing) using Multicall3 when available.
* **Bug Fixes**
  * If a batched sub-call fails, only the affected token balance resolves to zero while other balances still load.
  * Automatically falls back to per-token balance fetching when batching isn’t supported or encounters errors/cancellations.
* **Tests**
  * Expanded unit coverage for Multicall3 batching (encoding/decoding) and EVM batched-vs-fallback loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->