### PR TITLE
feat(ton): nominator-pool staking — data + transaction core (#5041)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/DepositMemo.kt
@@ -136,14 +136,6 @@ internal interface DepositMemo {
         }
     }
 
-    data object Stake : DepositMemo {
-        override fun toString(): String = "d"
-    }
-
-    data object Unstake : DepositMemo {
-        override fun toString(): String = "w"
-    }
-
     data class Custom(val memo: String) : DepositMemo {
         override fun toString(): String = memo
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/DepositStrategyFactory.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/DepositStrategyFactory.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models.deposit.submit
 
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -12,6 +13,7 @@ import com.vultisig.wallet.data.usecases.ValidateMayaTransactionHeightUseCase
 import com.vultisig.wallet.ui.models.deposit.DepositFieldValidator
 import com.vultisig.wallet.ui.models.deposit.DepositOption
 import javax.inject.Inject
+import wallet.core.jni.TONAddressConverter
 
 /**
  * Builds the [DepositSubmitStrategies] map for a `DepositFormViewModel`.
@@ -32,6 +34,7 @@ constructor(
     private val validateMayaTransactionHeight: ValidateMayaTransactionHeightUseCase,
     private val isAssetCharsValid: DepositMemoAssetsValidatorUseCase,
     private val fieldValidator: DepositFieldValidator,
+    private val tonStakingApi: TonStakingApi,
 ) {
 
     /**
@@ -122,7 +125,8 @@ constructor(
                         nodeAddressFieldState = fields.nodeAddressFieldState,
                         tokenAmountFieldState = fields.tokenAmountFieldState,
                         accountsRepository = accountsRepository,
-                        chainAccountAddressRepository = chainAccountAddressRepository,
+                        tonStakingApi = tonStakingApi,
+                        toBounceableAddress = ::toTonBounceableAddress,
                         blockChainSpecificRepository = context.blockChainSpecificRepository,
                         calculateGasFee = context.calculateGasFee,
                         getFeesFiatValue = context.getFeesFiatValue,
@@ -135,7 +139,8 @@ constructor(
                         nodeAddressFieldState = fields.nodeAddressFieldState,
                         tokenAmountFieldState = fields.tokenAmountFieldState,
                         accountsRepository = accountsRepository,
-                        chainAccountAddressRepository = chainAccountAddressRepository,
+                        tonStakingApi = tonStakingApi,
+                        toBounceableAddress = ::toTonBounceableAddress,
                         blockChainSpecificRepository = context.blockChainSpecificRepository,
                         calculateGasFee = context.calculateGasFee,
                         getFeesFiatValue = context.getFeesFiatValue,
@@ -266,3 +271,11 @@ constructor(
         return strategies
     }
 }
+
+/**
+ * Converts a TON pool address (raw `0:…` or user-friendly) to the bounceable `EQ…` form required
+ * for nominator-pool deposits/withdrawals — a non-bounceable message a pool rejects is absorbed
+ * (lost).
+ */
+private fun toTonBounceableAddress(address: String): String =
+    TONAddressConverter.toUserFriendly(address, /* bounceable= */ true, /* testnet= */ false)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
@@ -2,16 +2,16 @@ package com.vultisig.wallet.ui.models.deposit.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.blockchain.ton.TonNominatorPool
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.DepositMemo
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
@@ -20,7 +20,13 @@ import java.math.BigInteger
 import java.util.UUID
 import kotlinx.coroutines.flow.first
 
-/** Builds a Stake [DepositTransaction] for the TON chain. */
+/** Whether a TON nominator-pool transaction deposits into or withdraws from the pool. */
+internal enum class TonStakingAction {
+    DEPOSIT,
+    WITHDRAW,
+}
+
+/** Builds a Stake (deposit) [DepositTransaction] for a TON nominator pool. */
 internal class StakeStrategy(
     private val vaultIdProvider: () -> String?,
     private val chainProvider: () -> Chain?,
@@ -28,7 +34,8 @@ internal class StakeStrategy(
     private val nodeAddressFieldState: TextFieldState,
     private val tokenAmountFieldState: TextFieldState,
     private val accountsRepository: AccountsRepository,
-    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val tonStakingApi: TonStakingApi,
+    private val toBounceableAddress: (String) -> String,
     private val blockChainSpecificRepository: BlockChainSpecificRepository,
     private val calculateGasFee: suspend (Chain, Coin, String) -> TokenValue,
     private val getFeesFiatValue:
@@ -36,15 +43,16 @@ internal class StakeStrategy(
 ) : DepositSubmitStrategy {
 
     override suspend fun build(): DepositTransaction =
-        buildTonDepositTransaction(
-            memo = DepositMemo.Stake,
+        buildTonStakingTransaction(
+            action = TonStakingAction.DEPOSIT,
             vaultIdProvider = vaultIdProvider,
             chainProvider = chainProvider,
             stateProvider = stateProvider,
             nodeAddressFieldState = nodeAddressFieldState,
             tokenAmountFieldState = tokenAmountFieldState,
             accountsRepository = accountsRepository,
-            chainAccountAddressRepository = chainAccountAddressRepository,
+            tonStakingApi = tonStakingApi,
+            toBounceableAddress = toBounceableAddress,
             blockChainSpecificRepository = blockChainSpecificRepository,
             calculateGasFee = calculateGasFee,
             getFeesFiatValue = getFeesFiatValue,
@@ -52,21 +60,25 @@ internal class StakeStrategy(
 }
 
 /**
- * Builds a TON deposit [DepositTransaction] carrying [memo].
+ * Builds a TON nominator-pool [DepositTransaction] for [action] (deposit or withdraw).
  *
- * Shared by the Stake and Unstake strategies, which differ only by the memo they send.
- *
- * @param memo the deposit memo to attach (e.g. [DepositMemo.Stake] or [DepositMemo.Unstake]).
+ * Shared by the Stake and Unstake strategies. The destination pool's `implementation` (resolved
+ * from tonapi) drives the text comment — `whales` → `Deposit`/`Withdraw`, `tf` → `d`/`w` — and an
+ * unknown implementation blocks the action rather than guessing. The pool address is converted to
+ * the bounceable user-friendly `EQ…` form so a rejected message bounces back instead of being
+ * absorbed (lost). A deposit must clear `min_stake` + a ~1 TON commission; a withdraw carries only
+ * the fixed 0.2 TON signal fee (the pool returns the full staked balance).
  */
-internal suspend fun buildTonDepositTransaction(
-    memo: DepositMemo,
+internal suspend fun buildTonStakingTransaction(
+    action: TonStakingAction,
     vaultIdProvider: () -> String?,
     chainProvider: () -> Chain?,
     stateProvider: () -> DepositFormUiModel,
     nodeAddressFieldState: TextFieldState,
     tokenAmountFieldState: TextFieldState,
     accountsRepository: AccountsRepository,
-    chainAccountAddressRepository: ChainAccountAddressRepository,
+    tonStakingApi: TonStakingApi,
+    toBounceableAddress: (String) -> String,
     blockChainSpecificRepository: BlockChainSpecificRepository,
     calculateGasFee: suspend (Chain, Coin, String) -> TokenValue,
     getFeesFiatValue: suspend (BlockChainSpecificAndUtxo, TokenValue, Coin) -> EstimatedGasFee,
@@ -81,38 +93,65 @@ internal suspend fun buildTonDepositTransaction(
                 UiText.StringResource(R.string.send_error_no_address)
             )
 
-    val depositChain = stateProvider().depositChain
-
-    if (depositChain != Chain.Ton) {
+    if (stateProvider().depositChain != Chain.Ton) {
         throw InvalidTransactionDataException(UiText.StringResource(R.string.error_invalid_chain))
     }
 
-    val nodeAddress = nodeAddressFieldState.text.toString()
-
-    if (nodeAddress.isBlank() || !chainAccountAddressRepository.isValid(chain, nodeAddress)) {
+    val poolAddressInput = nodeAddressFieldState.text.toString().trim()
+    if (poolAddressInput.isBlank()) {
         throw InvalidTransactionDataException(UiText.StringResource(R.string.send_error_no_address))
     }
 
-    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+    // Resolve the pool: its implementation drives the comment word and gates the action; min_stake
+    // is needed to validate a deposit. A pool unknown to tonapi (or an unsupported implementation)
+    // is blocked rather than guessed.
+    val poolInfo =
+        tonStakingApi.getStakingPool(poolAddressInput)
+            ?: throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.ton_stake_error_unsupported_pool)
+            )
 
-    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
-        throw InvalidTransactionDataException(UiText.StringResource(R.string.send_error_no_amount))
-    }
+    val comment =
+        when (action) {
+            TonStakingAction.DEPOSIT -> TonNominatorPool.depositComment(poolInfo.implementation)
+            TonStakingAction.WITHDRAW -> TonNominatorPool.withdrawComment(poolInfo.implementation)
+        }
+            ?: throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.ton_stake_error_unsupported_pool)
+            )
+
+    // Pool addresses arrive raw `0:…`; convert to the bounceable `EQ…` form so a rejected deposit
+    // bounces back. An address that can't be converted is invalid.
+    val dstAddress =
+        runCatching { toBounceableAddress(poolAddressInput) }
+            .getOrElse {
+                throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.send_error_no_address)
+                )
+            }
+
     val address = accountsRepository.loadAddress(vaultId, chain).first()
-
     val selectedToken =
         address.accounts.firstOrNull { it.token.isNativeToken }?.token
             ?: throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_address)
             )
 
-    val tokenAmountInt =
-        tokenAmount.movePointRight(selectedToken.decimal)?.toBigInteger() ?: BigInteger.ONE
+    val amountNano =
+        when (action) {
+            TonStakingAction.DEPOSIT ->
+                resolveDepositAmount(tokenAmountFieldState, selectedToken, poolInfo.minStake)
+            // The withdraw message carries only the fixed signal fee; the entered amount is
+            // ignored.
+            TonStakingAction.WITHDRAW -> TonNominatorPool.WITHDRAW_FEE
+        }
 
     val srcAddress = selectedToken.address
 
     val gasFee = calculateGasFee(chain, selectedToken, srcAddress)
 
+    // Pass the bounceable destination so the spec resolves bounceable = true; without a dstAddress
+    // the flag defaults to false and a rejected deposit would be absorbed instead of bounced back.
     val specific =
         blockChainSpecificRepository.getSpecific(
             chain,
@@ -122,6 +161,7 @@ internal suspend fun buildTonDepositTransaction(
             isSwap = false,
             isMaxAmountEnabled = false,
             isDeposit = true,
+            dstAddress = dstAddress,
         )
 
     val gasFeeFiat = getFeesFiatValue(specific, gasFee, selectedToken)
@@ -131,11 +171,41 @@ internal suspend fun buildTonDepositTransaction(
         vaultId = vaultId,
         srcToken = selectedToken,
         srcAddress = srcAddress,
-        dstAddress = nodeAddress,
-        memo = memo.toString(),
-        srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+        dstAddress = dstAddress,
+        memo = comment,
+        srcTokenValue = TokenValue(value = amountNano, token = selectedToken),
         estimatedFees = gasFee,
         estimateFeesFiat = gasFeeFiat.formattedFiatValue,
         blockChainSpecific = specific.blockChainSpecific,
     )
+}
+
+/**
+ * Parses and validates the deposit amount entered for [token], enforcing the pool minimum
+ * (`min_stake` + ~1 TON commission). [minStakeNano] is the pool's `min_stake` in nanotons.
+ */
+private fun resolveDepositAmount(
+    tokenAmountFieldState: TextFieldState,
+    token: Coin,
+    minStakeNano: Long?,
+): BigInteger {
+    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+    if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
+        throw InvalidTransactionDataException(UiText.StringResource(R.string.send_error_no_amount))
+    }
+
+    val amountNano = tokenAmount.movePointRight(token.decimal).toBigInteger()
+
+    val minDeposit = TonNominatorPool.minimumDeposit(BigInteger.valueOf(minStakeNano ?: 0L))
+    if (amountNano < minDeposit) {
+        val minDepositTon = BigDecimal(minDeposit).movePointLeft(token.decimal).stripTrailingZeros()
+        throw InvalidTransactionDataException(
+            UiText.FormattedText(
+                R.string.ton_stake_error_min_amount,
+                listOf(minDepositTon.toPlainString()),
+            )
+        )
+    }
+
+    return amountNano
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
@@ -139,8 +139,16 @@ internal suspend fun buildTonStakingTransaction(
 
     val amountNano =
         when (action) {
-            TonStakingAction.DEPOSIT ->
-                resolveDepositAmount(tokenAmountFieldState, selectedToken, poolInfo.minStake)
+            TonStakingAction.DEPOSIT -> {
+                // A deposit needs a real minimum to enforce; a missing/zero min_stake means drifted
+                // pool metadata, so block rather than silently allow a near-zero deposit.
+                val minStakeNano =
+                    poolInfo.minStake?.takeIf { it > 0 }
+                        ?: throw InvalidTransactionDataException(
+                            UiText.StringResource(R.string.ton_stake_error_unsupported_pool)
+                        )
+                resolveDepositAmount(tokenAmountFieldState, selectedToken, minStakeNano)
+            }
             // The withdraw message carries only the fixed signal fee; the entered amount is
             // ignored.
             TonStakingAction.WITHDRAW -> TonNominatorPool.WITHDRAW_FEE
@@ -187,7 +195,7 @@ internal suspend fun buildTonStakingTransaction(
 private fun resolveDepositAmount(
     tokenAmountFieldState: TextFieldState,
     token: Coin,
-    minStakeNano: Long?,
+    minStakeNano: Long,
 ): BigInteger {
     val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
@@ -196,7 +204,7 @@ private fun resolveDepositAmount(
 
     val amountNano = tokenAmount.movePointRight(token.decimal).toBigInteger()
 
-    val minDeposit = TonNominatorPool.minimumDeposit(BigInteger.valueOf(minStakeNano ?: 0L))
+    val minDeposit = TonNominatorPool.minimumDeposit(BigInteger.valueOf(minStakeNano))
     if (amountNano < minDeposit) {
         val minDepositTon = BigDecimal(minDeposit).movePointLeft(token.decimal).stripTrailingZeros()
         throw InvalidTransactionDataException(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategy.kt
@@ -1,19 +1,18 @@
 package com.vultisig.wallet.ui.models.deposit.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.DepositMemo
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 
-/** Builds an Unstake [DepositTransaction] for the TON chain. */
+/** Builds an Unstake (withdraw) [DepositTransaction] for a TON nominator pool. */
 internal class UnstakeStrategy(
     private val vaultIdProvider: () -> String?,
     private val chainProvider: () -> Chain?,
@@ -21,7 +20,8 @@ internal class UnstakeStrategy(
     private val nodeAddressFieldState: TextFieldState,
     private val tokenAmountFieldState: TextFieldState,
     private val accountsRepository: AccountsRepository,
-    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val tonStakingApi: TonStakingApi,
+    private val toBounceableAddress: (String) -> String,
     private val blockChainSpecificRepository: BlockChainSpecificRepository,
     private val calculateGasFee: suspend (Chain, Coin, String) -> TokenValue,
     private val getFeesFiatValue:
@@ -29,15 +29,16 @@ internal class UnstakeStrategy(
 ) : DepositSubmitStrategy {
 
     override suspend fun build(): DepositTransaction =
-        buildTonDepositTransaction(
-            memo = DepositMemo.Unstake,
+        buildTonStakingTransaction(
+            action = TonStakingAction.WITHDRAW,
             vaultIdProvider = vaultIdProvider,
             chainProvider = chainProvider,
             stateProvider = stateProvider,
             nodeAddressFieldState = nodeAddressFieldState,
             tokenAmountFieldState = tokenAmountFieldState,
             accountsRepository = accountsRepository,
-            chainAccountAddressRepository = chainAccountAddressRepository,
+            tonStakingApi = tonStakingApi,
+            toBounceableAddress = toBounceableAddress,
             blockChainSpecificRepository = blockChainSpecificRepository,
             calculateGasFee = calculateGasFee,
             getFeesFiatValue = getFeesFiatValue,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
@@ -362,7 +362,8 @@ internal fun DepositFormScreen(
                                 depositChain == Chain.ThorChain) ||
                             (depositOption == DepositOption.Custom &&
                                 depositChain == Chain.MayaChain) ||
-                            depositOption == DepositOption.Unstake ||
+                            // TON unstake withdraws the full staked balance, so no amount is
+                            // entered.
                             depositOption == DepositOption.Stake ||
                             depositOption == DepositOption.AddCacaoPool
                     ) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -880,6 +880,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Stellen Sie sicher, dass Ihr Konto ausreichend Guthaben zur Deckung der Gebühren aufweist. Fällt Ihr Kontostand unter 1 XRP (Einzahlung), wird das Konto deaktiviert (eingezogen) und das verbleibende Guthaben geht verloren. Sie können die Adresse jederzeit mit einer neuen Einzahlung, die höher als die Mindesteinzahlung ist, reaktivieren. Dadurch werden die verlorenen Guthaben jedoch nicht wiederhergestellt.</string>
     <string name="error_invalid_chain">Die Blockchain ist ungültig</string>
+    <string name="ton_stake_error_unsupported_pool">Dieser Staking-Pool wird nicht unterstützt</string>
+    <string name="ton_stake_error_min_amount">Mindest-Stake für diesen Pool beträgt %1$s TON</string>
     <string name="vault_backup_verifying_pin">Code wird überprüft, bitte warten</string>
     <string name="select_vault_type_next">Weiter</string>
     <string name="select_vault_type_choose_setup">Wähle „Einrichtung“</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -878,6 +878,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Asegúrate de tener fondos suficientes para cubrir las comisiones. Si el saldo de una cuenta cae por debajo de 1 XRP (Depósito Existente), la cuenta se desactivará (se liquidará) y los fondos restantes se perderán. Puedes reactivar la dirección con un nuevo depósito superior al depósito existente en cualquier momento. Sin embargo, esto no recuperará los fondos perdidos.</string>
     <string name="error_invalid_chain">La cadena no es válida.</string>
+    <string name="ton_stake_error_unsupported_pool">Este pool de staking no es compatible</string>
+    <string name="ton_stake_error_min_amount">El stake mínimo para este pool es de %1$s TON</string>
     <string name="vault_backup_verifying_pin">Verificando código, por favor espere</string>
     <string name="select_vault_type_next">Siguiente</string>
     <string name="select_vault_type_choose_setup">Selecciona Configuración</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -883,6 +883,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Osigurajte dovoljno sredstava za pokrivanje naknada. Ako stanje na računu padne ispod 1 XRP (egzistencijalni depozit), račun će biti deaktiviran (potrošen) i sva preostala sredstva bit će izgubljena. Adresu možete ponovno aktivirati novim depozitom većim od egzistencijalnog depozita u bilo kojem trenutku. Međutim, to neće vratiti izgubljena sredstva.</string>
     <string name="error_invalid_chain">Lanac nije valjan</string>
+    <string name="ton_stake_error_unsupported_pool">Ovaj staking pool nije podržan</string>
+    <string name="ton_stake_error_min_amount">Minimalni ulog za ovaj pool je %1$s TON</string>
     <string name="vault_backup_verifying_pin">Provjera koda, molimo pričekajte</string>
     <string name="select_vault_type_next">Sljedeće</string>
     <string name="select_vault_type_choose_setup">Odaberite Postavljanje</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -878,6 +878,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Assicurati di lasciare fondi sufficienti per coprire le commissioni. Se il saldo di un conto scende al di sotto di 1 XRP (Deposito Esistenziale), il conto verrà disattivato (rimosso) e tutti i fondi rimanenti andranno persi. Puoi riattivare l\'indirizzo con un nuovo deposito superiore al deposito esistenziale in qualsiasi momento. Tuttavia, questo non recupererà i fondi persi.</string>
     <string name="error_invalid_chain">La catena non è valida</string>
+    <string name="ton_stake_error_unsupported_pool">Questo pool di staking non è supportato</string>
+    <string name="ton_stake_error_min_amount">Lo stake minimo per questo pool è %1$s TON</string>
     <string name="vault_backup_verifying_pin">Verifica del PIN in corso, attendere</string>
     <string name="select_vault_type_next">Avanti</string>
     <string name="select_vault_type_choose_setup">Scegli configurazione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -466,6 +466,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">수수료를 충당할 충분한 자금을 남겨두세요. 계정 잔액이 1 XRP(최소 예치금) 아래로 떨어지면 계정이 비활성화(수확)되고 남은 자금이 손실됩니다. 언제든지 최소 예치금보다 큰 새 입금으로 주소를 재활성화할 수 있습니다. 그러나 손실된 자금은 복구되지 않습니다.</string>
     <string name="error_invalid_chain">체인이 유효하지 않습니다</string>
+    <string name="ton_stake_error_unsupported_pool">이 스테이킹 풀은 지원되지 않습니다</string>
+    <string name="ton_stake_error_min_amount">이 풀의 최소 스테이킹 금액은 %1$s TON입니다</string>
     <string name="send_error_invalid_plan_fee">유효하지 않은 플랜 수수료</string>
     <string name="send_error_same_address">받는 주소는 보내는 주소와 달라야 합니다</string>
     <string name="select_vault_type_secure">보안</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -875,6 +875,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Zorg ervoor dat je voldoende saldo achterlaat om de kosten te dekken. Als het saldo onder de 1 XRP (Existentiële Storting) komt, wordt het account gedeactiveerd (opgenomen) en gaat het resterende saldo verloren. Je kunt het adres op elk moment reactiveren met een nieuwe storting die groter is dan de existentiële storting. Hiermee krijg je het verloren geld echter niet terug.</string>
     <string name="error_invalid_chain">Ketting is ongeldig</string>
+    <string name="ton_stake_error_unsupported_pool">Deze staking-pool wordt niet ondersteund</string>
+    <string name="ton_stake_error_min_amount">De minimale stake voor deze pool is %1$s TON</string>
     <string name="vault_backup_verifying_pin">Code verifiëren, even geduld a.u.b.</string>
     <string name="select_vault_type_next">Volgende</string>
     <string name="select_vault_type_choose_setup">Kies \'Instellen\'</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -877,6 +877,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Certifique-se de que deixa fundos suficientes para cobrir as taxas. Se o saldo de uma conta descer abaixo de 1 XRP (Depósito Existente), a conta será desativada (esgotada) e quaisquer fundos remanescentes serão perdidos. Pode reativar o endereço com um novo depósito maior do que o depósito existencial a qualquer momento. No entanto, isto não recuperará os fundos perdidos.</string>
     <string name="error_invalid_chain">A cadeia é inválida.</string>
+    <string name="ton_stake_error_unsupported_pool">Este pool de staking não é suportado</string>
+    <string name="ton_stake_error_min_amount">O stake mínimo para este pool é de %1$s TON</string>
     <string name="vault_backup_verifying_pin">Verificando código, aguarde</string>
     <string name="select_vault_type_next">Próximo</string>
     <string name="select_vault_type_choose_setup">Selecione Configurar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -883,6 +883,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Убедитесь, что у вас достаточно средств для покрытия комиссий. Если баланс счёта опустится ниже 1 XRP (экзистенциальный депозит), счёт будет деактивирован (списан), а все оставшиеся средства будут потеряны. Вы можете в любое время повторно активировать адрес, внеся новый депозит, превышающий экзистенциальный депозит. Однако это не вернёт потерянные средства.</string>
     <string name="error_invalid_chain">Сеть недействительна</string>
+    <string name="ton_stake_error_unsupported_pool">Этот стейкинг-пул не поддерживается</string>
+    <string name="ton_stake_error_min_amount">Минимальная сумма стейкинга для этого пула — %1$s TON</string>
     <string name="vault_backup_verifying_pin">Подтверждение кода, пожалуйста, подождите.</string>
     <string name="select_vault_type_next">Далее</string>
     <string name="select_vault_type_choose_setup">Выберите конфигурацию</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1209,6 +1209,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">请确保账户中留有足够的资金以支付手续费。如果账户余额低于 1 XRP（存量保证金），账户将被停用（清算），剩余资金也将丢失。您可以随时通过存入高于存量保证金的金额来重新激活账户。但是，这无法找回已丢失的资金。</string>
     <string name="error_invalid_chain">链无效</string>
+    <string name="ton_stake_error_unsupported_pool">不支持此质押池</string>
+    <string name="ton_stake_error_min_amount">此质押池的最低质押金额为 %1$s TON</string>
     <string name="vault_backup_verifying_pin">正在验证代码，请稍候</string>
     <string name="select_vault_type_next">下一步</string>
     <string name="select_vault_type_choose_setup">选择“设置”</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,6 +477,8 @@
     </plurals>
     <string name="send_form_ripple_reaping_warning">Ensure you leave enough funds to cover the fees. If an account balance falls below 1 XRP (Existential Deposit), the account will be deactivated (reaped) and any remaining funds will be lost. You can reactivate the address with a new deposit larger than the existential deposit at any time. However, this will not recover the lost funds.</string>
     <string name="error_invalid_chain">Chain is invalid</string>
+    <string name="ton_stake_error_unsupported_pool">This staking pool isn\'t supported</string>
+    <string name="ton_stake_error_min_amount">Minimum stake for this pool is %1$s TON</string>
     <string name="send_error_invalid_plan_fee">Invalid Plan Fee</string>
     <string name="send_error_same_address">The to address must be different from the from address</string>
     <string name="select_vault_type_secure">Secure</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -91,6 +92,7 @@ internal class DepositFormViewModelTest {
     private val requestResultRepository: RequestResultRepository = mockk(relaxed = true)
     private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk(relaxed = true)
     private val transactionRepository: DepositTransactionRepository = mockk(relaxed = true)
+    private val tonStakingApi: TonStakingApi = mockk(relaxed = true)
     private val blockChainSpecificRepository: BlockChainSpecificRepository = mockk(relaxed = true)
     private val thorChainApi: ThorChainApi = mockk(relaxed = true)
     private val mayaChainApi: MayaChainApi = mockk(relaxed = true)
@@ -315,6 +317,7 @@ internal class DepositFormViewModelTest {
             validateMayaTransactionHeight = validateMayaTransactionHeight,
             isAssetCharsValid = isAssetCharsValid,
             fieldValidator = fieldValidator,
+            tonStakingApi = tonStakingApi,
         )
 
     @BeforeEach

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
@@ -4,6 +4,8 @@ package com.vultisig.wallet.ui.models.deposit.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingPoolInfoJson
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
@@ -14,7 +16,6 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import io.mockk.coEvery
@@ -33,65 +34,122 @@ internal class StakeStrategyTest {
     private val tokenAmount = TextFieldState()
 
     private val accountsRepo: AccountsRepository = mockk()
-    private val chainRepo: ChainAccountAddressRepository = mockk()
     private val specificRepo: BlockChainSpecificRepository = mockk()
+    private val tonStakingApi: TonStakingApi = mockk()
 
     @Test
-    fun `Ton stake memo is d and uses native token scaled by decimals`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
+    fun `whales deposit uses Deposit comment, bounceable dest and scaled amount`() = runTest {
+        givenPool(implementation = "whales", minStake = 0)
         givenAccounts()
         givenSpecific()
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("1")
 
-        val tx = build().build()
+        val tx = stake().build()
 
-        assertEquals("d", tx.memo)
+        assertEquals("Deposit", tx.memo)
         assertEquals(tonCoin(), tx.srcToken)
-        assertEquals("tonNode", tx.dstAddress)
+        assertEquals("EQ_0:pool", tx.dstAddress)
         assertEquals(BigInteger.valueOf(1_000_000_000), tx.srcTokenValue.value)
     }
 
     @Test
-    fun `stake throws when deposit chain is not Ton`() = runTest {
-        coEvery { chainRepo.isValid(any(), any()) } returns true
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
+    fun `tf deposit uses d comment`() = runTest {
+        givenPool(implementation = "tf", minStake = 0)
+        givenAccounts()
+        givenSpecific()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("1")
 
+        assertEquals("d", stake().build().memo)
+    }
+
+    @Test
+    fun `whales withdraw uses Withdraw comment and fixed 0_2 TON fee`() = runTest {
+        givenPool(implementation = "whales", minStake = 50_000_000_000)
+        givenAccounts()
+        givenSpecific()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        // Entered amount is ignored for withdraw.
+        tokenAmount.setTextAndPlaceCursorAtEnd("999")
+
+        val tx = unstake().build()
+
+        assertEquals("Withdraw", tx.memo)
+        assertEquals(BigInteger.valueOf(200_000_000), tx.srcTokenValue.value)
+    }
+
+    @Test
+    fun `deposit blocked for unsupported pool implementation`() = runTest {
+        givenPool(implementation = "liquidTF", minStake = 0)
+        givenAccounts()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        tokenAmount.setTextAndPlaceCursorAtEnd("100")
+
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+    }
+
+    @Test
+    fun `deposit blocked when pool is unknown to tonapi`() = runTest {
+        coEvery { tonStakingApi.getStakingPool(any()) } returns null
+        givenAccounts()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        tokenAmount.setTextAndPlaceCursorAtEnd("100")
+
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+    }
+
+    @Test
+    fun `deposit below pool minimum is rejected`() = runTest {
+        givenPool(implementation = "whales", minStake = 50_000_000_000)
+        givenAccounts()
+        givenSpecific()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        // 50 TON < min_stake (50) + 1 TON commission.
+        tokenAmount.setTextAndPlaceCursorAtEnd("50")
+
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+    }
+
+    @Test
+    fun `stake throws when deposit chain is not Ton`() = runTest {
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        tokenAmount.setTextAndPlaceCursorAtEnd("100")
+
         assertFailsWith<InvalidTransactionDataException> {
-            build(depositChain = Chain.ThorChain).build()
+            stake(depositChain = Chain.ThorChain).build()
         }
     }
 
     @Test
     fun `stake throws when node address is blank`() = runTest {
-        coEvery { chainRepo.isValid(any(), any()) } returns false
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
+        tokenAmount.setTextAndPlaceCursorAtEnd("100")
 
-        assertFailsWith<InvalidTransactionDataException> { build().build() }
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
     }
 
     @Test
     fun `stake throws when token amount is missing or zero`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
+        givenPool(implementation = "whales", minStake = 0)
+        givenAccounts()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("0")
 
-        assertFailsWith<InvalidTransactionDataException> { build().build() }
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
     }
 
     @Test
     fun `stake throws when no native token account exists`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
+        givenPool(implementation = "whales", minStake = 0)
         coEvery { accountsRepo.loadAddress("vault-1", Chain.Ton) } returns
-            flowOf(Address(chain = Chain.Ton, address = "tonNode", accounts = emptyList()))
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
+            flowOf(Address(chain = Chain.Ton, address = "0:pool", accounts = emptyList()))
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("1")
 
-        assertFailsWith<InvalidTransactionDataException> { build().build() }
+        assertFailsWith<InvalidTransactionDataException> { stake().build() }
     }
 
-    private fun build(depositChain: Chain = Chain.Ton) =
+    private fun stake(depositChain: Chain = Chain.Ton) =
         StakeStrategy(
             vaultIdProvider = { "vault-1" },
             chainProvider = { Chain.Ton },
@@ -99,11 +157,32 @@ internal class StakeStrategyTest {
             nodeAddressFieldState = nodeAddress,
             tokenAmountFieldState = tokenAmount,
             accountsRepository = accountsRepo,
-            chainAccountAddressRepository = chainRepo,
+            tonStakingApi = tonStakingApi,
+            toBounceableAddress = { "EQ_$it" },
             blockChainSpecificRepository = specificRepo,
             calculateGasFee = { _, token, _ -> TokenValue(BigInteger.ONE, token) },
             getFeesFiatValue = { _, _, _ -> estimatedFee() },
         )
+
+    private fun unstake(depositChain: Chain = Chain.Ton) =
+        UnstakeStrategy(
+            vaultIdProvider = { "vault-1" },
+            chainProvider = { Chain.Ton },
+            stateProvider = { DepositFormUiModel(depositChain = depositChain) },
+            nodeAddressFieldState = nodeAddress,
+            tokenAmountFieldState = tokenAmount,
+            accountsRepository = accountsRepo,
+            tonStakingApi = tonStakingApi,
+            toBounceableAddress = { "EQ_$it" },
+            blockChainSpecificRepository = specificRepo,
+            calculateGasFee = { _, token, _ -> TokenValue(BigInteger.ONE, token) },
+            getFeesFiatValue = { _, _, _ -> estimatedFee() },
+        )
+
+    private fun givenPool(implementation: String, minStake: Long) {
+        coEvery { tonStakingApi.getStakingPool(any()) } returns
+            TonStakingPoolInfoJson(implementation = implementation, minStake = minStake)
+    }
 
     private fun givenAccounts() {
         coEvery { accountsRepo.loadAddress("vault-1", Chain.Ton) } returns
@@ -134,13 +213,14 @@ internal class StakeStrategyTest {
                 isSwap = any(),
                 isMaxAmountEnabled = any(),
                 isDeposit = any(),
+                dstAddress = any(),
             )
         } returns
             BlockChainSpecificAndUtxo(
                 BlockChainSpecific.Ton(
                     sequenceNumber = 0UL,
                     expireAt = 0UL,
-                    bounceable = false,
+                    bounceable = true,
                     sendMaxAmount = false,
                 )
             )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.ui.models.deposit.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
 import com.vultisig.wallet.data.api.chains.ton.TonStakingPoolInfoJson
 import com.vultisig.wallet.data.models.Account
@@ -18,6 +19,7 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigInteger
@@ -86,7 +88,11 @@ internal class StakeStrategyTest {
         nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("100")
 
-        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        assertEquals(
+            R.string.ton_stake_error_unsupported_pool,
+            (ex.text as UiText.StringResource).resId,
+        )
     }
 
     @Test
@@ -96,7 +102,11 @@ internal class StakeStrategyTest {
         nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("100")
 
-        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        assertEquals(
+            R.string.ton_stake_error_unsupported_pool,
+            (ex.text as UiText.StringResource).resId,
+        )
     }
 
     @Test
@@ -108,7 +118,8 @@ internal class StakeStrategyTest {
         // 50 TON < min_stake (50) + 1 TON commission.
         tokenAmount.setTextAndPlaceCursorAtEnd("50")
 
-        assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        assertEquals(R.string.ton_stake_error_min_amount, (ex.text as UiText.FormattedText).resId)
     }
 
     @Test
@@ -213,7 +224,9 @@ internal class StakeStrategyTest {
                 isSwap = any(),
                 isMaxAmountEnabled = any(),
                 isDeposit = any(),
-                dstAddress = any(),
+                // Pin the bounceable EQ destination so the test fails if the strategy stops
+                // forwarding it into the spec.
+                dstAddress = "EQ_0:pool",
             )
         } returns
             BlockChainSpecificAndUtxo(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
@@ -41,29 +41,44 @@ internal class StakeStrategyTest {
 
     @Test
     fun `whales deposit uses Deposit comment, bounceable dest and scaled amount`() = runTest {
-        givenPool(implementation = "whales", minStake = 0)
+        // min_stake 1 TON + 1 TON commission => 2 TON minimum; deposit exactly 2 TON.
+        givenPool(implementation = "whales", minStake = 1_000_000_000)
         givenAccounts()
         givenSpecific()
         nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
+        tokenAmount.setTextAndPlaceCursorAtEnd("2")
 
         val tx = stake().build()
 
         assertEquals("Deposit", tx.memo)
         assertEquals(tonCoin(), tx.srcToken)
         assertEquals("EQ_0:pool", tx.dstAddress)
-        assertEquals(BigInteger.valueOf(1_000_000_000), tx.srcTokenValue.value)
+        assertEquals(BigInteger.valueOf(2_000_000_000), tx.srcTokenValue.value)
     }
 
     @Test
     fun `tf deposit uses d comment`() = runTest {
-        givenPool(implementation = "tf", minStake = 0)
+        givenPool(implementation = "tf", minStake = 1_000_000_000)
         givenAccounts()
         givenSpecific()
         nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
+        tokenAmount.setTextAndPlaceCursorAtEnd("2")
 
         assertEquals("d", stake().build().memo)
+    }
+
+    @Test
+    fun `deposit blocked when pool reports no usable minimum stake`() = runTest {
+        givenPool(implementation = "whales", minStake = 0)
+        givenAccounts()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        tokenAmount.setTextAndPlaceCursorAtEnd("100")
+
+        val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
+        assertEquals(
+            R.string.ton_stake_error_unsupported_pool,
+            (ex.text as UiText.StringResource).resId,
+        )
     }
 
     @Test
@@ -141,7 +156,7 @@ internal class StakeStrategyTest {
 
     @Test
     fun `stake throws when token amount is missing or zero`() = runTest {
-        givenPool(implementation = "whales", minStake = 0)
+        givenPool(implementation = "whales", minStake = 1_000_000_000)
         givenAccounts()
         nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
         tokenAmount.setTextAndPlaceCursorAtEnd("0")

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategyTest.kt
@@ -136,7 +136,9 @@ internal class UnstakeStrategyTest {
                 isSwap = any(),
                 isMaxAmountEnabled = any(),
                 isDeposit = any(),
-                dstAddress = any(),
+                // Pin the bounceable EQ destination so the test fails if the strategy stops
+                // forwarding it into the spec.
+                dstAddress = "EQ_0:pool",
             )
         } returns
             BlockChainSpecificAndUtxo(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnstakeStrategyTest.kt
@@ -4,6 +4,8 @@ package com.vultisig.wallet.ui.models.deposit.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingPoolInfoJson
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
@@ -14,7 +16,6 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import io.mockk.coEvery
@@ -33,30 +34,38 @@ internal class UnstakeStrategyTest {
     private val tokenAmount = TextFieldState()
 
     private val accountsRepo: AccountsRepository = mockk()
-    private val chainRepo: ChainAccountAddressRepository = mockk()
     private val specificRepo: BlockChainSpecificRepository = mockk()
+    private val tonStakingApi: TonStakingApi = mockk()
 
     @Test
-    fun `Ton unstake memo is w and uses native token scaled by decimals`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
+    fun `tf withdraw uses w comment, bounceable dest and fixed 0_2 TON fee`() = runTest {
+        givenPool(implementation = "tf")
         givenAccounts()
         givenSpecific()
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+        // Entered amount is ignored for withdraw.
         tokenAmount.setTextAndPlaceCursorAtEnd("1")
 
         val tx = build().build()
 
         assertEquals("w", tx.memo)
         assertEquals(tonCoin(), tx.srcToken)
-        assertEquals("tonNode", tx.dstAddress)
-        assertEquals(BigInteger.valueOf(1_000_000_000), tx.srcTokenValue.value)
+        assertEquals("EQ_0:pool", tx.dstAddress)
+        assertEquals(BigInteger.valueOf(200_000_000), tx.srcTokenValue.value)
+    }
+
+    @Test
+    fun `withdraw blocked for unsupported pool implementation`() = runTest {
+        givenPool(implementation = "liquidTF")
+        givenAccounts()
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+
+        assertFailsWith<InvalidTransactionDataException> { build().build() }
     }
 
     @Test
     fun `unstake throws when deposit chain is not Ton`() = runTest {
-        coEvery { chainRepo.isValid(any(), any()) } returns true
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
 
         assertFailsWith<InvalidTransactionDataException> {
             build(depositChain = Chain.ThorChain).build()
@@ -65,28 +74,15 @@ internal class UnstakeStrategyTest {
 
     @Test
     fun `unstake throws when node address is blank`() = runTest {
-        coEvery { chainRepo.isValid(any(), any()) } returns false
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
-
-        assertFailsWith<InvalidTransactionDataException> { build().build() }
-    }
-
-    @Test
-    fun `unstake throws when token amount is missing or zero`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
-        tokenAmount.setTextAndPlaceCursorAtEnd("0")
-
         assertFailsWith<InvalidTransactionDataException> { build().build() }
     }
 
     @Test
     fun `unstake throws when no native token account exists`() = runTest {
-        coEvery { chainRepo.isValid(Chain.Ton, "tonNode") } returns true
+        givenPool(implementation = "whales")
         coEvery { accountsRepo.loadAddress("vault-1", Chain.Ton) } returns
-            flowOf(Address(chain = Chain.Ton, address = "tonNode", accounts = emptyList()))
-        nodeAddress.setTextAndPlaceCursorAtEnd("tonNode")
-        tokenAmount.setTextAndPlaceCursorAtEnd("1")
+            flowOf(Address(chain = Chain.Ton, address = "0:pool", accounts = emptyList()))
+        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
 
         assertFailsWith<InvalidTransactionDataException> { build().build() }
     }
@@ -99,11 +95,17 @@ internal class UnstakeStrategyTest {
             nodeAddressFieldState = nodeAddress,
             tokenAmountFieldState = tokenAmount,
             accountsRepository = accountsRepo,
-            chainAccountAddressRepository = chainRepo,
+            tonStakingApi = tonStakingApi,
+            toBounceableAddress = { "EQ_$it" },
             blockChainSpecificRepository = specificRepo,
             calculateGasFee = { _, token, _ -> TokenValue(BigInteger.ONE, token) },
             getFeesFiatValue = { _, _, _ -> estimatedFee() },
         )
+
+    private fun givenPool(implementation: String) {
+        coEvery { tonStakingApi.getStakingPool(any()) } returns
+            TonStakingPoolInfoJson(implementation = implementation)
+    }
 
     private fun givenAccounts() {
         coEvery { accountsRepo.loadAddress("vault-1", Chain.Ton) } returns
@@ -134,13 +136,14 @@ internal class UnstakeStrategyTest {
                 isSwap = any(),
                 isMaxAmountEnabled = any(),
                 isDeposit = any(),
+                dstAddress = any(),
             )
         } returns
             BlockChainSpecificAndUtxo(
                 BlockChainSpecific.Ton(
                     sequenceNumber = 0UL,
                     expireAt = 0UL,
-                    bounceable = false,
+                    bounceable = true,
                     sendMaxAmount = false,
                 )
             )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
@@ -4,6 +4,8 @@ import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.SuiApiImpl
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.TonApiImpl
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApiImpl
 import com.vultisig.wallet.data.api.swapAggregators.KyberApi
 import com.vultisig.wallet.data.api.swapAggregators.KyberApiImpl
 import com.vultisig.wallet.data.api.swapAggregators.OneInchApi
@@ -63,6 +65,8 @@ internal interface ApiModule {
     @Binds @Singleton fun bindSuiApi(impl: SuiApiImpl): SuiApi
 
     @Binds @Singleton fun bindTonApi(impl: TonApiImpl): TonApi
+
+    @Binds @Singleton fun bindTonStakingApi(impl: TonStakingApiImpl): TonStakingApi
 
     @Binds @Singleton fun bindRippleApi(impl: RippleApiImp): RippleApi
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
@@ -1,0 +1,124 @@
+package com.vultisig.wallet.data.api.chains.ton
+
+import com.vultisig.wallet.data.utils.bodyOrThrow
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import javax.inject.Inject
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Client for tonapi.io nominator-pool staking endpoints.
+ *
+ * These endpoints are served exclusively by `tonapi.io` (the Vultisig proxy `/ton/v3/wallet`
+ * `pools` field does not populate), so they are hit directly rather than through [TonApi]'s
+ * `api.vultisig.com` host.
+ */
+interface TonStakingApi {
+
+    /**
+     * List of known staking pools, backing the pool picker. `include_unverified=false` is sent so
+     * only verified pools are returned; callers re-filter defensively to nominator implementations.
+     */
+    suspend fun getStakingPools(): List<TonStakingPoolEntryJson>
+
+    /**
+     * Computed pool info (name, APY, min stake, implementation, cycle end) for a single pool. Used
+     * to decorate a held position. Returns `null` when the pool is unknown or the response drifts.
+     */
+    suspend fun getStakingPool(poolAddress: String): TonStakingPoolInfoJson?
+
+    /**
+     * Nominator-pool positions for an account. Authoritative source for staked positions; empty
+     * participation returns an empty list.
+     */
+    suspend fun getNominatorPools(address: String): List<TonAccountStakingInfoJson>
+}
+
+internal class TonStakingApiImpl @Inject constructor(private val http: HttpClient) : TonStakingApi {
+
+    override suspend fun getStakingPools(): List<TonStakingPoolEntryJson> =
+        http
+            .get("$BASE_URL/v2/staking/pools") { parameter("include_unverified", false) }
+            .bodyOrThrow<TonStakingPoolsResponseJson>()
+            .pools
+
+    override suspend fun getStakingPool(poolAddress: String): TonStakingPoolInfoJson? =
+        runCatching {
+                http
+                    .get("$BASE_URL/v2/staking/pool/$poolAddress")
+                    .bodyOrThrow<TonStakingPoolResponseJson>()
+                    .pool
+            }
+            .getOrNull()
+
+    override suspend fun getNominatorPools(address: String): List<TonAccountStakingInfoJson> =
+        http
+            .get("$BASE_URL/v2/staking/nominator/$address/pools")
+            .bodyOrThrow<TonAccountStakingResponseJson>()
+            .pools
+
+    private companion object {
+        const val BASE_URL = "https://tonapi.io"
+    }
+}
+
+@Serializable
+data class TonStakingPoolsResponseJson(
+    @SerialName("pools") val pools: List<TonStakingPoolEntryJson> = emptyList()
+)
+
+/**
+ * A single pool from the list endpoint. `apy` is a percentage (e.g. `13.27` = 13.27%) and
+ * `minStake` is in nanotons. Picker-critical fields are required; the rest are optional so a shape
+ * drift degrades rather than dropping the whole list.
+ */
+@Serializable
+data class TonStakingPoolEntryJson(
+    @SerialName("address") val address: String,
+    @SerialName("name") val name: String,
+    @SerialName("apy") val apy: Double,
+    @SerialName("min_stake") val minStake: Long,
+    @SerialName("verified") val verified: Boolean = false,
+    @SerialName("current_nominators") val currentNominators: Int? = null,
+    @SerialName("max_nominators") val maxNominators: Int? = null,
+    @SerialName("implementation") val implementation: String? = null,
+)
+
+@Serializable
+data class TonStakingPoolResponseJson(@SerialName("pool") val pool: TonStakingPoolInfoJson? = null)
+
+/**
+ * Computed info for a single pool. `apy` is a percentage; `cycleEnd` is a Unix timestamp (seconds)
+ * marking when the current validation cycle ends — i.e. when a pending withdrawal becomes
+ * claimable. All fields are optional so a partial response degrades gracefully.
+ */
+@Serializable
+data class TonStakingPoolInfoJson(
+    @SerialName("address") val address: String? = null,
+    @SerialName("name") val name: String? = null,
+    @SerialName("apy") val apy: Double? = null,
+    @SerialName("min_stake") val minStake: Long? = null,
+    @SerialName("implementation") val implementation: String? = null,
+    @SerialName("cycle_end") val cycleEnd: Long? = null,
+)
+
+@Serializable
+data class TonAccountStakingResponseJson(
+    @SerialName("pools") val pools: List<TonAccountStakingInfoJson> = emptyList()
+)
+
+/**
+ * A single nominator-pool position for an account. All amounts are nanotons. `amount` is the active
+ * stake; `pendingDeposit` is a just-placed stake awaiting the next cycle (must surface so a fresh
+ * stake is visible immediately); `pendingWithdraw`/`readyWithdraw` indicate a withdrawal in flight.
+ */
+@Serializable
+data class TonAccountStakingInfoJson(
+    @SerialName("pool") val pool: String,
+    @SerialName("amount") val amount: Long = 0,
+    @SerialName("pending_deposit") val pendingDeposit: Long = 0,
+    @SerialName("pending_withdraw") val pendingWithdraw: Long = 0,
+    @SerialName("ready_withdraw") val readyWithdraw: Long = 0,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
@@ -1,9 +1,11 @@
 package com.vultisig.wallet.data.api.chains.ton
 
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.http.HttpStatusCode
 import javax.inject.Inject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -25,7 +27,9 @@ interface TonStakingApi {
 
     /**
      * Computed pool info (name, APY, min stake, implementation, cycle end) for a single pool. Used
-     * to decorate a held position. Returns `null` when the pool is unknown or the response drifts.
+     * to decorate a held position and to gate a deposit/withdraw. Returns `null` only when the pool
+     * is genuinely unknown (HTTP 404); transient/network failures propagate so a caller can tell an
+     * outage apart from an unsupported pool.
      */
     suspend fun getStakingPool(poolAddress: String): TonStakingPoolInfoJson?
 
@@ -45,13 +49,17 @@ internal class TonStakingApiImpl @Inject constructor(private val http: HttpClien
             .pools
 
     override suspend fun getStakingPool(poolAddress: String): TonStakingPoolInfoJson? =
-        runCatching {
-                http
-                    .get("$BASE_URL/v2/staking/pool/$poolAddress")
-                    .bodyOrThrow<TonStakingPoolResponseJson>()
-                    .pool
-            }
-            .getOrNull()
+        try {
+            http
+                .get("$BASE_URL/v2/staking/pool/$poolAddress")
+                .bodyOrThrow<TonStakingPoolResponseJson>()
+                .pool
+        } catch (e: NetworkException) {
+            // A 404 means the pool isn't known to tonapi — surface that as null; let every other
+            // failure (timeout, 5xx, transport) propagate so callers don't mistake an outage for an
+            // unsupported pool.
+            if (e.httpStatusCode == HttpStatusCode.NotFound.value) null else throw e
+        }
 
     override suspend fun getNominatorPools(address: String): List<TonAccountStakingInfoJson> =
         http

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonStakingApi.kt
@@ -20,8 +20,9 @@ import kotlinx.serialization.Serializable
 interface TonStakingApi {
 
     /**
-     * List of known staking pools, backing the pool picker. `include_unverified=false` is sent so
-     * only verified pools are returned; callers re-filter defensively to nominator implementations.
+     * List of verified staking pools, backing the pool picker. `include_unverified=false` is sent,
+     * but tonapi does not honor it, so results are filtered on the decoded `verified` flag
+     * client-side; callers may re-filter defensively to nominator implementations.
      */
     suspend fun getStakingPools(): List<TonStakingPoolEntryJson>
 
@@ -47,6 +48,9 @@ internal class TonStakingApiImpl @Inject constructor(private val http: HttpClien
             .get("$BASE_URL/v2/staking/pools") { parameter("include_unverified", false) }
             .bodyOrThrow<TonStakingPoolsResponseJson>()
             .pools
+            // `include_unverified=false` does not actually restrict tonapi's response, so filter on
+            // the decoded `verified` flag client-side (mirrors vultisig-ios).
+            .filter { it.verified }
 
     override suspend fun getStakingPool(poolAddress: String): TonStakingPoolInfoJson? =
         try {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/BlockchainServicesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/BlockchainServicesModule.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.blockchain
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingService
 import com.vultisig.wallet.data.blockchain.ethereum.CircleDeFiBalanceService
@@ -13,6 +14,7 @@ import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionServi
 import com.vultisig.wallet.data.blockchain.thorchain.RujiStakingService
 import com.vultisig.wallet.data.blockchain.thorchain.TCYStakingService
 import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
 import com.vultisig.wallet.data.repositories.ActiveBondedNodeRepository
 import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
@@ -117,6 +119,17 @@ internal interface BlockchainServicesModule {
         ): TronDeFiBalanceService =
             TronDeFiBalanceService(
                 tronApi = tronApi,
+                stakingDetailsRepository = stakingDetailsRepository,
+            )
+
+        @Provides
+        @Singleton
+        fun provideTonDeFiBalanceService(
+            tonStakingApi: TonStakingApi,
+            stakingDetailsRepository: StakingDetailsRepository,
+        ): TonDeFiBalanceService =
+            TonDeFiBalanceService(
+                tonStakingApi = tonStakingApi,
                 stakingDetailsRepository = stakingDetailsRepository,
             )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.genera
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import com.vultisig.wallet.data.utils.NetworkException
 import java.io.IOException
 import java.math.BigInteger
 import timber.log.Timber
@@ -34,8 +35,7 @@ class TonDeFiBalanceService(
                     ?: return persistAndEmpty(vaultId)
 
             val staked = primary.stakedTotal()
-            // APY decoration is best-effort: a missing pool info must not drop the position.
-            val apr = tonStakingApi.getStakingPool(primary.pool)?.apy
+            val apr = fetchPoolApr(primary.pool)
 
             persistStakedBalance(vaultId, staked, apr)
 
@@ -44,11 +44,28 @@ class TonDeFiBalanceService(
             } else {
                 listOf(tonDeFiBalance(staked))
             }
+        } catch (e: NetworkException) {
+            Timber.w(e, "TonDeFiBalanceService: Network error fetching nominator-pool balance")
+            // Keep the last-known stake rather than erasing it; the empty result would otherwise be
+            // cached by BalanceRepository and hide the position until the next invalidation.
+            getCacheDeFiBalance(address, vaultId)
         } catch (e: IOException) {
             Timber.w(e, "TonDeFiBalanceService: Network error fetching nominator-pool balance")
-            emptyList()
+            getCacheDeFiBalance(address, vaultId)
         }
     }
+
+    /** Best-effort pool APY; a decoration failure must not drop an otherwise-valid position. */
+    private suspend fun fetchPoolApr(poolAddress: String): Double? =
+        try {
+            tonStakingApi.getStakingPool(poolAddress)?.apy
+        } catch (e: NetworkException) {
+            Timber.w(e, "TonDeFiBalanceService: Failed to decorate TON staking APY")
+            null
+        } catch (e: IOException) {
+            Timber.w(e, "TonDeFiBalanceService: Failed to decorate TON staking APY")
+            null
+        }
 
     override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
         val cached = stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Ton.TON.id)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
@@ -55,10 +55,14 @@ class TonDeFiBalanceService(
         }
     }
 
-    /** Best-effort pool APY; a decoration failure must not drop an otherwise-valid position. */
+    /**
+     * Best-effort pool APY; a decoration failure must not drop an otherwise-valid position. tonapi
+     * returns `apy` as a percentage (e.g. `13.27` = 13.27%), but `StakingDetails.apr` is stored as
+     * a fraction (the DeFi screen's `formatPercentage` multiplies by 100), so scale it down here.
+     */
     private suspend fun fetchPoolApr(poolAddress: String): Double? =
         try {
-            tonStakingApi.getStakingPool(poolAddress)?.apy
+            tonStakingApi.getStakingPool(poolAddress)?.apy?.let { it / 100 }
         } catch (e: NetworkException) {
             Timber.w(e, "TonDeFiBalanceService: Failed to decorate TON staking APY")
             null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceService.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.data.blockchain.ton
+
+import com.vultisig.wallet.data.api.chains.ton.TonAccountStakingInfoJson
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.blockchain.DeFiService
+import com.vultisig.wallet.data.blockchain.model.DeFiBalance
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import java.io.IOException
+import java.math.BigInteger
+import timber.log.Timber
+
+/**
+ * Reads native TON nominator-pool staking positions for the DeFi/Earn tab.
+ *
+ * The visible staked balance is the **primary** pool's active stake plus any `pending_deposit` — a
+ * freshly placed stake sits in pending until the next validation cycle, so it must still surface
+ * immediately. When an account holds positions in several pools, only the largest is treated as the
+ * primary (mirrors vultisig-ios `TonStakeInteractor`). The position is decorated with the pool's
+ * APY fetched from `/v2/staking/pool/{address}`.
+ */
+class TonDeFiBalanceService(
+    private val tonStakingApi: TonStakingApi,
+    private val stakingDetailsRepository: StakingDetailsRepository,
+) : DeFiService {
+
+    override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
+        return try {
+            val primary =
+                tonStakingApi.getNominatorPools(address).maxByOrNull { it.stakedTotal() }
+                    ?: return persistAndEmpty(vaultId)
+
+            val staked = primary.stakedTotal()
+            // APY decoration is best-effort: a missing pool info must not drop the position.
+            val apr = tonStakingApi.getStakingPool(primary.pool)?.apy
+
+            persistStakedBalance(vaultId, staked, apr)
+
+            if (staked == BigInteger.ZERO) {
+                emptyList()
+            } else {
+                listOf(tonDeFiBalance(staked))
+            }
+        } catch (e: IOException) {
+            Timber.w(e, "TonDeFiBalanceService: Network error fetching nominator-pool balance")
+            emptyList()
+        }
+    }
+
+    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
+        val cached = stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Ton.TON.id)
+        val staked = cached?.stakeAmount ?: return emptyList()
+        if (staked == BigInteger.ZERO) return emptyList()
+        return listOf(tonDeFiBalance(staked))
+    }
+
+    private fun tonDeFiBalance(staked: BigInteger): DeFiBalance =
+        DeFiBalance(
+            chain = Chain.Ton,
+            balances = listOf(DeFiBalance.Balance(coin = Coins.Ton.TON, amount = staked)),
+        )
+
+    private suspend fun persistAndEmpty(vaultId: String): List<DeFiBalance> {
+        persistStakedBalance(vaultId, BigInteger.ZERO, apr = null)
+        return emptyList()
+    }
+
+    private suspend fun persistStakedBalance(vaultId: String, staked: BigInteger, apr: Double?) {
+        try {
+            val details =
+                StakingDetails(
+                    id = Coins.Ton.TON.generateId(),
+                    coin = Coins.Ton.TON,
+                    stakeAmount = staked,
+                    apr = apr,
+                    estimatedRewards = null,
+                    nextPayoutDate = null,
+                    rewards = null,
+                    rewardsCoin = null,
+                )
+            val existing =
+                stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Ton.TON.id)
+            when {
+                existing == null -> stakingDetailsRepository.saveStakingDetails(vaultId, details)
+                existing.stakeAmount != staked || existing.apr != apr ->
+                    stakingDetailsRepository.updateStakingDetails(vaultId, details)
+            }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "TonDeFiBalanceService: Failed to persist staked TON balance")
+        }
+    }
+
+    private fun TonAccountStakingInfoJson.stakedTotal(): BigInteger =
+        BigInteger.valueOf(amount) + BigInteger.valueOf(pendingDeposit)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPool.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPool.kt
@@ -1,0 +1,63 @@
+package com.vultisig.wallet.data.blockchain.ton
+
+import java.math.BigInteger
+
+/**
+ * Mechanics for native TON nominator-pool staking, verified against live on-chain data.
+ *
+ * Deposits and withdrawals are plain TON transfers carrying a **text comment**, but the comment
+ * word differs per pool implementation. These must be exact — a wrong comment is rejected on-chain
+ * (e.g. the stale tonwhales README `"Stake"` fails with exit code 72), and a deposit sent without
+ * the bounce flag that the pool rejects is absorbed (lost) rather than returned.
+ */
+object TonNominatorPool {
+
+    /** tonwhales/ton-nominators implementation. Accessible (min ~50 TON). */
+    const val IMPLEMENTATION_WHALES = "whales"
+
+    /** Standard ton-blockchain/nominator-pool implementation (needs ~300k TON, rarely usable). */
+    const val IMPLEMENTATION_TF = "tf"
+
+    /** Tonstakers liquid staking — a different jetton/op-code mechanism; not a nominator pool. */
+    const val IMPLEMENTATION_LIQUID_TF = "liquidTF"
+
+    /**
+     * Processing commission a deposit must clear on top of the pool's `min_stake`; depositing
+     * exactly the minimum is rejected. ~1 TON.
+     */
+    val DEPOSIT_COMMISSION: BigInteger = BigInteger.valueOf(1_000_000_000L)
+
+    /**
+     * Amount carried by a withdraw message. The pool returns the full staked balance; this is only
+     * the withdraw signal fee (0.2 TON). Sending more (e.g. 1 TON) fails on-chain.
+     */
+    val WITHDRAW_FEE: BigInteger = BigInteger.valueOf(200_000_000L)
+
+    /** Pools backed by a genuine nominator implementation that this app can stake into. */
+    fun isNominatorImplementation(implementation: String?): Boolean =
+        implementation == IMPLEMENTATION_WHALES || implementation == IMPLEMENTATION_TF
+
+    /**
+     * Deposit comment for [implementation], or `null` for an unknown/unsupported implementation —
+     * in which case the action must be blocked rather than guessing a comment.
+     */
+    fun depositComment(implementation: String?): String? =
+        when (implementation) {
+            IMPLEMENTATION_WHALES -> "Deposit"
+            IMPLEMENTATION_TF -> "d"
+            else -> null
+        }
+
+    /**
+     * Withdraw comment for [implementation], or `null` for an unknown/unsupported implementation.
+     */
+    fun withdrawComment(implementation: String?): String? =
+        when (implementation) {
+            IMPLEMENTATION_WHALES -> "Withdraw"
+            IMPLEMENTATION_TF -> "w"
+            else -> null
+        }
+
+    /** Minimum deposit (in nanotons) for a pool whose `min_stake` is [minStakeNano]. */
+    fun minimumDeposit(minStakeNano: BigInteger): BigInteger = minStakeNano + DEPOSIT_COMMISSION
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.data.blockchain.ethereum.CircleDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.maya.MayaDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.model.DeFiBalance
 import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
 import com.vultisig.wallet.data.db.dao.TokenValueDao
 import com.vultisig.wallet.data.db.models.TokenValueEntity
@@ -144,6 +145,7 @@ constructor(
     private val circleDeFiBalanceService: CircleDeFiBalanceService,
     private val mayaDeFiBalanceService: MayaDeFiBalanceService,
     private val tronDeFiBalanceService: TronDeFiBalanceService,
+    private val tonDeFiBalanceService: TonDeFiBalanceService,
     private val cosmosStakingDeFiBalanceService: CosmosStakingDeFiBalanceService,
 ) : BalanceRepository {
 
@@ -181,6 +183,7 @@ constructor(
             Ethereum -> address
             MayaChain,
             Chain.Tron,
+            Chain.Ton,
             Chain.Terra,
             Chain.TerraClassic,
             Chain.Qbtc -> "${chain.id}:$vaultId:$address"
@@ -228,6 +231,7 @@ constructor(
                 Ethereum -> circleDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 MayaChain -> mayaDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Tron -> tronDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
+                Chain.Ton -> tonDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Terra,
                 Chain.TerraClassic,
                 Chain.Qbtc ->
@@ -401,6 +405,7 @@ constructor(
             Ethereum -> circleDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             MayaChain -> mayaDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             Chain.Tron -> tronDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
+            Chain.Ton -> tonDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             // Each staking chain has its own LCD (Terra / TerraClassic even share an address), so
             // the chain is passed explicitly.
             Chain.Terra,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceServiceTest.kt
@@ -1,0 +1,91 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.blockchain.ton
+
+import com.vultisig.wallet.data.api.chains.ton.TonAccountStakingInfoJson
+import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
+import com.vultisig.wallet.data.api.chains.ton.TonStakingPoolInfoJson
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import com.vultisig.wallet.data.utils.NetworkException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class TonDeFiBalanceServiceTest {
+
+    private val api: TonStakingApi = mockk(relaxed = true)
+    private val repo: StakingDetailsRepository = mockk(relaxed = true)
+    private val service = TonDeFiBalanceService(api, repo)
+
+    private val address = "EQself"
+    private val vaultId = "vault-1"
+
+    @Test
+    fun `staked balance is the largest pool's amount plus pending deposit`() = runTest {
+        coEvery { api.getNominatorPools(address) } returns
+            listOf(
+                position(pool = "0:small", amount = 10, pendingDeposit = 0),
+                position(pool = "0:big", amount = 50_000_000_000, pendingDeposit = 800_000_000),
+            )
+        coEvery { api.getStakingPool("0:big") } returns TonStakingPoolInfoJson(apy = 5.0)
+        coEvery { repo.getStakingDetailsByCoindId(vaultId, Coins.Ton.TON.id) } returns null
+
+        val result = service.getRemoteDeFiBalance(address, vaultId)
+
+        val balance = result.single().balances.single()
+        assertEquals(Coins.Ton.TON, balance.coin)
+        assertEquals(BigInteger.valueOf(50_800_000_000), balance.amount)
+        coVerify { repo.saveStakingDetails(vaultId, match { it.stakeAmount == balance.amount }) }
+    }
+
+    @Test
+    fun `APY lookup failure still surfaces the staked position`() = runTest {
+        coEvery { api.getNominatorPools(address) } returns
+            listOf(position(pool = "0:big", amount = 50_000_000_000, pendingDeposit = 0))
+        coEvery { api.getStakingPool(any()) } throws NetworkException(500, "boom")
+
+        val result = service.getRemoteDeFiBalance(address, vaultId)
+
+        assertEquals(BigInteger.valueOf(50_000_000_000), result.single().balances.single().amount)
+    }
+
+    @Test
+    fun `network failure falls back to the cached stake instead of erasing it`() = runTest {
+        coEvery { api.getNominatorPools(address) } throws NetworkException(503, "down")
+        coEvery { repo.getStakingDetailsByCoindId(vaultId, Coins.Ton.TON.id) } returns
+            stakingDetails(BigInteger.valueOf(42_000_000_000))
+
+        val result = service.getRemoteDeFiBalance(address, vaultId)
+
+        assertEquals(BigInteger.valueOf(42_000_000_000), result.single().balances.single().amount)
+    }
+
+    @Test
+    fun `no positions yields an empty balance`() = runTest {
+        coEvery { api.getNominatorPools(address) } returns emptyList()
+
+        assertEquals(emptyList(), service.getRemoteDeFiBalance(address, vaultId))
+    }
+
+    private fun position(pool: String, amount: Long, pendingDeposit: Long) =
+        TonAccountStakingInfoJson(pool = pool, amount = amount, pendingDeposit = pendingDeposit)
+
+    private fun stakingDetails(amount: BigInteger) =
+        StakingDetails(
+            id = "ton",
+            coin = Coins.Ton.TON,
+            stakeAmount = amount,
+            apr = null,
+            estimatedRewards = null,
+            nextPayoutDate = null,
+            rewards = null,
+            rewardsCoin = null,
+        )
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonDeFiBalanceServiceTest.kt
@@ -42,7 +42,14 @@ internal class TonDeFiBalanceServiceTest {
         val balance = result.single().balances.single()
         assertEquals(Coins.Ton.TON, balance.coin)
         assertEquals(BigInteger.valueOf(50_800_000_000), balance.amount)
-        coVerify { repo.saveStakingDetails(vaultId, match { it.stakeAmount == balance.amount }) }
+        // tonapi `apy` is a percentage (5.0 = 5%); it must persist as a fraction (0.05) since the
+        // DeFi screen's formatPercentage multiplies by 100.
+        coVerify {
+            repo.saveStakingDetails(
+                vaultId,
+                match { it.stakeAmount == balance.amount && it.apr == 0.05 },
+            )
+        }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPoolTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPoolTest.kt
@@ -1,0 +1,50 @@
+package com.vultisig.wallet.data.blockchain.ton
+
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class TonNominatorPoolTest {
+
+    @Test
+    fun `whales comments are capitalized Deposit and Withdraw`() {
+        assertEquals("Deposit", TonNominatorPool.depositComment("whales"))
+        assertEquals("Withdraw", TonNominatorPool.withdrawComment("whales"))
+    }
+
+    @Test
+    fun `tf comments are short d and w`() {
+        assertEquals("d", TonNominatorPool.depositComment("tf"))
+        assertEquals("w", TonNominatorPool.withdrawComment("tf"))
+    }
+
+    @Test
+    fun `unknown and liquidTF implementations have no comment`() {
+        assertNull(TonNominatorPool.depositComment("liquidTF"))
+        assertNull(TonNominatorPool.withdrawComment("liquidTF"))
+        assertNull(TonNominatorPool.depositComment(null))
+        assertNull(TonNominatorPool.depositComment("something-else"))
+    }
+
+    @Test
+    fun `only whales and tf are nominator implementations`() {
+        assertTrue(TonNominatorPool.isNominatorImplementation("whales"))
+        assertTrue(TonNominatorPool.isNominatorImplementation("tf"))
+        assertFalse(TonNominatorPool.isNominatorImplementation("liquidTF"))
+        assertFalse(TonNominatorPool.isNominatorImplementation(null))
+    }
+
+    @Test
+    fun `minimum deposit adds the one TON commission to min stake`() {
+        val minStake = BigInteger.valueOf(50_000_000_000L) // 50 TON
+        assertEquals(BigInteger.valueOf(51_000_000_000L), TonNominatorPool.minimumDeposit(minStake))
+    }
+
+    @Test
+    fun `withdraw fee is fixed at 0_2 TON`() {
+        assertEquals(BigInteger.valueOf(200_000_000L), TonNominatorPool.WITHDRAW_FEE)
+    }
+}


### PR DESCRIPTION
## Summary

First PR toward native **TON nominator-pool staking** on the DeFi/Earn tab (iOS parity — vultisig-ios #4654, issue #5041). This PR lands the **data layer** and the **fund-safe transaction-building core**. The pool picker, DeFi-tab positions screen, and chain gating land in a **follow-up** PR (which carries the before/after UI screenshots).

Scope was split this way deliberately: the transaction mechanics are fund-safety critical and verified on-chain, so they ship first with full unit coverage; the visual pieces ship next.

## What's included

### Data layer
- `TonStakingApi` against `tonapi.io` — `/v2/staking/pools`, `/v2/staking/pool/{addr}`, `/v2/staking/nominator/{acct}/pools` + DTOs (these endpoints are served only by tonapi.io, not the Vultisig proxy).
- `TonDeFiBalanceService` — reads the **primary** pool's `amount + pending_deposit`, decorates with APY, persists via `StakingDetailsRepository`. Wired into DI and `BalanceRepository` (dispatch + cache key). It is **dormant** until the gating lands in the follow-up.

### Transaction core (mechanics verified on-chain)
- **Per-implementation comment:** `whales` → `Deposit`/`Withdraw`, `tf` → `d`/`w`. An unknown implementation **blocks** the action rather than guessing a comment.
- **Bounceable send:** the pool address is converted to the user-friendly bounceable `EQ…` form and passed as `dstAddress`, so the block-chain spec resolves `bounceable = true`. Previously `dstAddress` was never passed for stake/unstake, so the flag defaulted to `false` — a deposit a pool rejects would be **absorbed (lost)** instead of bounced back.
- **Amounts:** a deposit must clear `min_stake + ~1 TON` commission (depositing exactly the minimum is rejected); a withdraw carries the fixed **0.2 TON** signal fee (the pool returns the full staked balance).
- Removed the stale hardcoded `"d"/"w"` `DepositMemo` entries.

## Tests
- `TonNominatorPoolTest` (comment resolution per implementation, min-deposit math, fixed withdraw fee).
- Rewritten `StakeStrategyTest` / `UnstakeStrategyTest` — comment, bounceable destination, amount rules, and blocking of unsupported/unknown pools.
- Updated `DepositFormViewModelTest` for the new factory dependency.
- New error strings translated across all 10 locales.

## Follow-up (next PR)
- Pool picker on the stake flow (filtered to `whales`/`tf`, excludes `liquidTF`).
- TON DeFi-tab positions screen + chain gating (`isDeFiSupported` / `hasDeFiPositionsScreen` / `PositionTon` route), pending-withdrawal lock with unlock time, staked TON in the DeFi total.
- Before/after screenshots.

## Test plan
- [x] `:data:testDebugUnitTest` (TON staking tests) green
- [x] `:app:testDebugUnitTest` (Stake/Unstake/DepositForm tests) green
- [x] ktfmt clean on `:data` and `:app`
- [ ] Manual: stake into a Whales pool and unstake (covered by the follow-up UI PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TON staking support, including staking pool lookup, deposit/withdraw handling, and TON DeFi balance visibility.
  * Added support for supported pool types and minimum stake checks with clearer error messages.

* **Bug Fixes**
  * Improved TON transaction address handling and memo selection for staking actions.
  * Withdrawals now use the correct fixed fee and reject unsupported pools instead of proceeding with invalid data.

* **Documentation**
  * Expanded localized error text for TON staking across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->