### PR TITLE
feat(qbtc): show 'UTXO still maturing' state instead of generic 'No claimable UTXOs'

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -97,6 +97,7 @@ import com.vultisig.wallet.ui.models.keysign.TransactionStatus
 import com.vultisig.wallet.ui.models.keysign.TransactionTypeUiModel
 import com.vultisig.wallet.ui.models.peer.NetworkOption
 import com.vultisig.wallet.ui.models.peer.PeerDiscoveryUiModel
+import com.vultisig.wallet.ui.models.qbtc.QbtcClaimMaturingUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUtxoUiModel
 import com.vultisig.wallet.ui.models.swap.SwapFormUiModel
@@ -246,6 +247,7 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_claim_done" -> QbtcClaimDonePreview()
                     "qbtc_claim_error" -> QbtcClaimErrorPreview()
                     "qbtc_claim_blocked" -> QbtcClaimBlockedPreview()
+                    "qbtc_claim_maturing" -> QbtcClaimMaturingPreview()
                     "keysign_signing_lunc" -> KeysignSigningLuncPreview()
                     "circle_usdc_widget" -> CircleUsdcWidgetPreview()
                     "btc_detail_claim" -> BtcDetailClaimPreview()
@@ -2051,6 +2053,41 @@ private fun QbtcClaimErrorPreview() {
 private fun QbtcClaimBlockedPreview() {
     QbtcClaimScreen(
         state = QbtcClaimUiState.Blocked(reason = QbtcClaimBlockedReason.NoUtxos),
+        isFastVault = true,
+        onBackClick = {},
+        onToggle = {},
+        onConfirm = {},
+        onStartSecureVault = {},
+        onRetry = {},
+    )
+}
+
+// The "all maturing" empty state for issue #4798 — no UTXO is claimable yet.
+@Composable
+private fun QbtcClaimMaturingPreview() {
+    QbtcClaimScreen(
+        state =
+            QbtcClaimUiState.Maturing(
+                utxos =
+                    listOf(
+                        QbtcClaimMaturingUtxoUiModel(
+                            key = "a3f1:0",
+                            shortId = "a3f1…8d2c:0",
+                            confirmationsCount = "112/144",
+                            remainingBlocks = 32,
+                            qbtcAmount = "0.75 QBTC",
+                            btcAmount = "0.75 BTC",
+                        ),
+                        QbtcClaimMaturingUtxoUiModel(
+                            key = "b7c4:2",
+                            shortId = "b7c4…1e9f:2",
+                            confirmationsCount = "58/144",
+                            remainingBlocks = 86,
+                            qbtcAmount = "0.25 QBTC",
+                            btcAmount = "0.25 BTC",
+                        ),
+                    )
+            ),
         isFastVault = true,
         onBackClick = {},
         onToggle = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -83,6 +83,17 @@ internal data class QbtcClaimUtxoUiModel(
 )
 
 @Immutable
+internal data class QbtcClaimMaturingUtxoUiModel(
+    val key: String,
+    val shortId: String,
+    /** e.g. "112/144" — the count is rendered in warning amber, the threshold after the slash. */
+    val confirmationsCount: String,
+    val remainingBlocks: Long,
+    val qbtcAmount: String,
+    val btcAmount: String,
+)
+
+@Immutable
 internal sealed interface QbtcClaimUiState {
     data object Loading : QbtcClaimUiState
 
@@ -96,6 +107,9 @@ internal sealed interface QbtcClaimUiState {
         val canConfirm: Boolean,
         val isAllSelected: Boolean,
     ) : QbtcClaimUiState
+
+    /** Nothing is claimable yet because every claimable UTXO is still maturing. */
+    data class Maturing(val utxos: List<QbtcClaimMaturingUtxoUiModel>) : QbtcClaimUiState
 
     /** Secure Vault: showing the pairing QR and waiting for the co-signing device(s) to join. */
     data class Pairing(
@@ -200,6 +214,10 @@ constructor(
                         claimable.take(QbtcClaimConfig.MAX_CLAIM_UTXOS).map { it.key() }
                     )
                     emitSelecting()
+                }
+                is QbtcClaimLoadResult.Maturing -> {
+                    uiState.value =
+                        QbtcClaimUiState.Maturing(result.utxos.map { it.toMaturingUiModel() })
                 }
             }
         }
@@ -441,6 +459,23 @@ constructor(
             qbtcAmount = QbtcClaimAmountFormatter.formatQbtc(amount),
             btcAmount = QbtcClaimAmountFormatter.formatBtc(amount),
         )
+
+    private fun ClaimableUtxo.toMaturingUiModel(): QbtcClaimMaturingUtxoUiModel {
+        // A maturing UTXO is `!isMature`: either short of the threshold or still unconfirmed
+        // (null → mempool / unknown tip), which we surface as 0 confirmations.
+        val confirmed = (confirmations ?: 0L).coerceAtLeast(0L)
+        // Maturity needs strictly more than the threshold, so the floor of 1 keeps the boundary
+        // case (exactly at the threshold) honest rather than implying "0 blocks left".
+        val remaining = (QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS - confirmed).coerceAtLeast(1L)
+        return QbtcClaimMaturingUtxoUiModel(
+            key = key(),
+            shortId = shortTxid(),
+            confirmationsCount = "$confirmed/${QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS}",
+            remainingBlocks = remaining,
+            qbtcAmount = QbtcClaimAmountFormatter.formatQbtc(amount),
+            btcAmount = QbtcClaimAmountFormatter.formatBtc(amount),
+        )
+    }
 
     private fun ClaimableUtxo.shortTxid(): String =
         if (txid.length <= 14) "$txid:$vout" else "${txid.take(4)}…${txid.takeLast(4)}:$vout"

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -65,6 +65,7 @@ import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.peer.NetworkOption
 import com.vultisig.wallet.ui.models.peer.PeerDiscoveryUiModel
+import com.vultisig.wallet.ui.models.qbtc.QbtcClaimMaturingUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimViewModel
@@ -123,19 +124,31 @@ internal fun QbtcClaimScreen(
                 onBackClick = onBackClick,
                 applyGradientBackground = false,
                 bottomBar = {
-                    if (state is QbtcClaimUiState.Selecting) {
-                        VsButton(
-                            label = ctaLabel(state),
-                            state =
-                                if (state.canConfirm) VsButtonState.Enabled
-                                else VsButtonState.Disabled,
-                            onClick = {
-                                if (isFastVault) passwordPrompt = true else onStartSecureVault()
-                            },
-                            modifier =
-                                Modifier.fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 24.dp),
-                        )
+                    when (state) {
+                        is QbtcClaimUiState.Selecting ->
+                            VsButton(
+                                label = ctaLabel(state),
+                                state =
+                                    if (state.canConfirm) VsButtonState.Enabled
+                                    else VsButtonState.Disabled,
+                                onClick = {
+                                    if (isFastVault) passwordPrompt = true else onStartSecureVault()
+                                },
+                                modifier =
+                                    Modifier.fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 24.dp),
+                            )
+                        // Maturing: nothing is claimable yet, so the CTA stays disabled.
+                        is QbtcClaimUiState.Maturing ->
+                            VsButton(
+                                label = stringResource(R.string.qbtc_claim_cta_all),
+                                state = VsButtonState.Disabled,
+                                onClick = {},
+                                modifier =
+                                    Modifier.fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 24.dp),
+                            )
+                        else -> Unit
                     }
                 },
             ) {
@@ -143,6 +156,7 @@ internal fun QbtcClaimScreen(
                     QbtcClaimUiState.Loading ->
                         CenteredProgress(stringResource(R.string.qbtc_claim_loading))
                     is QbtcClaimUiState.Selecting -> SelectingContent(state, onToggle)
+                    is QbtcClaimUiState.Maturing -> MaturingContent(state)
                     is QbtcClaimUiState.Signing ->
                         ClaimSigningProgress(
                             label = stringResource(R.string.qbtc_claim_proving),
@@ -343,6 +357,121 @@ private fun QbtcClaimUtxoRow(
                 color = Theme.v2.colors.text.tertiary,
             )
         }
+    }
+}
+
+@Composable
+private fun MaturingContent(state: QbtcClaimUiState.Maturing) {
+    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    // No mature UTXO means a 0 claimable total, matching the Figma "0 QBTC" hero.
+                    QbtcClaimHeroCard(totalEligibleSats = 0L)
+                    ClaimTabHeader()
+                }
+                MaturingInfoCard()
+                Text(
+                    text = stringResource(R.string.qbtc_claim_maturing_section),
+                    style = Theme.brockmann.supplementary.footnote,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+                // Pad the gap to the first card up to the 16dp the LazyColumn's 8dp can't reach.
+                UiSpacer(size = 8.dp)
+            }
+        }
+        items(state.utxos, key = { it.key }) { utxo -> MaturingUtxoRow(utxo) }
+    }
+}
+
+@Composable
+private fun MaturingInfoCard() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .background(Theme.v2.colors.backgrounds.surface1)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_hourglass),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = stringResource(R.string.qbtc_claim_maturing_title),
+            style = Theme.brockmann.headings.title3,
+            color = Theme.v2.colors.text.primary,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(R.string.qbtc_claim_maturing_detail),
+            style = Theme.brockmann.supplementary.footnote,
+            color = Theme.v2.colors.text.tertiary,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun MaturingUtxoRow(utxo: QbtcClaimMaturingUtxoUiModel) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(Theme.v2.colors.backgrounds.surface1)
+                .padding(16.dp),
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_clock_filled),
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp), modifier = Modifier.weight(1f)) {
+            Text(
+                text = utxo.shortId,
+                style = Theme.brockmann.button.semibold.medium,
+                color = Theme.v2.colors.text.primary,
+            )
+            Text(
+                text = maturingConfirmations(utxo.confirmationsCount),
+                style = Theme.brockmann.supplementary.caption,
+            )
+            Text(
+                text = stringResource(R.string.qbtc_claim_maturing_blocks, utxo.remainingBlocks),
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = utxo.qbtcAmount,
+                style = Theme.brockmann.button.semibold.medium,
+                color = Theme.v2.colors.text.primary,
+            )
+            Text(
+                text = utxo.btcAmount,
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
+    }
+}
+
+/** "112/144" in warning amber, then the localized "confirmations" label in tertiary. */
+@Composable
+private fun maturingConfirmations(count: String) = buildAnnotatedString {
+    withStyle(SpanStyle(color = Theme.v2.colors.alerts.warning)) { append(count) }
+    append(" ")
+    withStyle(SpanStyle(color = Theme.v2.colors.text.tertiary)) {
+        append(stringResource(R.string.qbtc_claim_maturing_confirmations_label))
     }
 }
 

--- a/app/src/main/res/drawable/ic_clock_filled.xml
+++ b/app/src/main/res/drawable/ic_clock_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#FFC25C"
+        android:pathData="M10,2C5.5889,2 2,5.5889 2,10C2,14.4111 5.5889,18 10,18C14.4111,18 18,14.4111 18,10C18,5.5889 14.4111,2 10,2ZM13.207,13.207C13.0117,13.4023 12.7558,13.5 12.5,13.5C12.2442,13.5 11.9883,13.4023 11.793,13.207L9.293,10.707C9.1055,10.5195 9,10.2651 9,10V6.5C9,5.9478 9.4473,5.5 10,5.5C10.5527,5.5 11,5.9478 11,6.5V9.5859L13.207,11.7929C13.5976,12.1835 13.5976,12.8163 13.207,13.207Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_hourglass.xml
+++ b/app/src/main/res/drawable/ic_hourglass.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:translateX="-159.5"
+        android:translateY="-20">
+        <path
+            android:fillColor="#FFAA1C"
+            android:strokeColor="#FFAA1C"
+            android:strokeWidth="1"
+            android:pathData="M177.57,24.1001L177.419,26.522C177.33,27.9426 176.706,29.2547 175.66,30.2202L174.13,31.6323L173.732,32.0005L174.13,32.3677L175.66,33.7798C176.706,34.7453 177.33,36.0574 177.419,37.478L177.57,39.8999H165.43L165.581,37.478C165.67,36.0573 166.295,34.7453 167.341,33.7798L168.87,32.3677L169.269,32.0005L168.87,31.6323L167.341,30.2202C166.36,29.3149 165.75,28.1052 165.604,26.7866L165.581,26.522L165.43,24.1001H177.57ZM172.039,34.6079C171.737,34.4819 171.403,34.4666 171.093,34.561L170.961,34.6079C169.41,35.2544 168.326,36.3354 167.785,37.8208C167.628,38.2497 167.691,38.728 167.953,39.1021V39.103C168.215,39.4781 168.645,39.6997 169.101,39.6997H173.9C174.356,39.6996 174.783,39.4775 175.045,39.103L175.047,39.104C175.31,38.73 175.372,38.251 175.216,37.8218C174.709,36.4288 173.724,35.3909 172.324,34.7339L172.039,34.6079Z" />
+        <path
+            android:strokeColor="#FFAA1C"
+            android:strokeWidth="2"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M178.7,23.6001H164.3" />
+        <path
+            android:strokeColor="#FFAA1C"
+            android:strokeWidth="2"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M178.7,40.3999H164.3" />
+    </group>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1334,6 +1334,11 @@
     <string name="qbtc_claim_eligible_header">Berechtigte UTXOs</string>
     <string name="qbtc_claim_utxo_block_format">Bestätigt · vor %1$d Blöcken</string>
     <string name="qbtc_claim_utxo_pending">Ausstehend</string>
+    <string name="qbtc_claim_maturing_title">Ihr BTC reift noch</string>
+    <string name="qbtc_claim_maturing_detail">UTXOs benötigen 144 Bestätigungen, bevor sie als QBTC abgerufen werden können. Ihre Gelder sind sicher.</string>
+    <string name="qbtc_claim_maturing_section">Reifende UTXOs</string>
+    <string name="qbtc_claim_maturing_confirmations_label">Bestätigungen</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d Blöcke</string>
     <string name="qbtc_claim_cta_all">Alle abrufen</string>
     <string name="qbtc_claim_cta_partial">%1$d von %2$d abrufen</string>
     <string name="qbtc_claim_proving">Nachweis wird erstellt und gesendet…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1332,6 +1332,11 @@
     <string name="qbtc_claim_eligible_header">UTXOs elegibles</string>
     <string name="qbtc_claim_utxo_block_format">Confirmado · hace %1$d bloques</string>
     <string name="qbtc_claim_utxo_pending">Pendiente</string>
+    <string name="qbtc_claim_maturing_title">Tu BTC aún está madurando</string>
+    <string name="qbtc_claim_maturing_detail">Los UTXOs necesitan 144 confirmaciones antes de poder reclamarse como QBTC. Tus fondos están seguros.</string>
+    <string name="qbtc_claim_maturing_section">UTXOs en maduración</string>
+    <string name="qbtc_claim_maturing_confirmations_label">confirmaciones</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d bloques</string>
     <string name="qbtc_claim_cta_all">Reclamar todo</string>
     <string name="qbtc_claim_cta_partial">Reclamar %1$d de %2$d</string>
     <string name="qbtc_claim_proving">Generando prueba y transmitiendo…</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1342,6 +1342,11 @@
     <string name="qbtc_claim_eligible_header">Prihvatljivi UTXO-ovi</string>
     <string name="qbtc_claim_utxo_block_format">Potvrđeno · prije %1$d blokova</string>
     <string name="qbtc_claim_utxo_pending">Na čekanju</string>
+    <string name="qbtc_claim_maturing_title">Vaš BTC još uvijek sazrijeva</string>
+    <string name="qbtc_claim_maturing_detail">UTXO-ovi trebaju 144 potvrde prije nego što se mogu preuzeti kao QBTC. Vaša su sredstva sigurna.</string>
+    <string name="qbtc_claim_maturing_section">UTXO-ovi koji sazrijevaju</string>
+    <string name="qbtc_claim_maturing_confirmations_label">potvrde</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d blokova</string>
     <string name="qbtc_claim_cta_all">Preuzmi sve</string>
     <string name="qbtc_claim_cta_partial">Preuzmi %1$d od %2$d</string>
     <string name="qbtc_claim_proving">Generiranje dokaza i emitiranje…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1335,6 +1335,11 @@
     <string name="qbtc_claim_eligible_header">UTXO idonei</string>
     <string name="qbtc_claim_utxo_block_format">Confermato · %1$d blocchi fa</string>
     <string name="qbtc_claim_utxo_pending">In sospeso</string>
+    <string name="qbtc_claim_maturing_title">Il tuo BTC sta ancora maturando</string>
+    <string name="qbtc_claim_maturing_detail">Gli UTXO necessitano di 144 conferme prima di poter essere prelevati come QBTC. I tuoi fondi sono al sicuro.</string>
+    <string name="qbtc_claim_maturing_section">UTXO in maturazione</string>
+    <string name="qbtc_claim_maturing_confirmations_label">conferme</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d blocchi</string>
     <string name="qbtc_claim_cta_all">Preleva tutto</string>
     <string name="qbtc_claim_cta_partial">Preleva %1$d di %2$d</string>
     <string name="qbtc_claim_proving">Generazione della prova e trasmissione…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1351,6 +1351,11 @@
     <string name="qbtc_claim_eligible_header">청구 가능한 UTXO</string>
     <string name="qbtc_claim_utxo_block_format">확인됨 · %1$d블록 전</string>
     <string name="qbtc_claim_utxo_pending">대기 중</string>
+    <string name="qbtc_claim_maturing_title">BTC가 아직 성숙 중입니다</string>
+    <string name="qbtc_claim_maturing_detail">UTXO는 QBTC로 청구되기 전에 144번의 확인이 필요합니다. 자금은 안전합니다.</string>
+    <string name="qbtc_claim_maturing_section">성숙 중인 UTXO</string>
+    <string name="qbtc_claim_maturing_confirmations_label">확인</string>
+    <string name="qbtc_claim_maturing_blocks">약 %1$d블록</string>
     <string name="qbtc_claim_cta_all">모두 청구</string>
     <string name="qbtc_claim_cta_partial">%2$d개 중 %1$d개 청구</string>
     <string name="qbtc_claim_proving">증명 생성 및 브로드캐스트 중…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1326,6 +1326,11 @@
     <string name="qbtc_claim_eligible_header">Geschikte UTXO\'s</string>
     <string name="qbtc_claim_utxo_block_format">Bevestigd · %1$d blokken geleden</string>
     <string name="qbtc_claim_utxo_pending">In behandeling</string>
+    <string name="qbtc_claim_maturing_title">Uw BTC is nog aan het rijpen</string>
+    <string name="qbtc_claim_maturing_detail">UTXO\'s hebben 144 bevestigingen nodig voordat ze als QBTC kunnen worden geclaimd. Uw geld is veilig.</string>
+    <string name="qbtc_claim_maturing_section">Rijpende UTXO\'s</string>
+    <string name="qbtc_claim_maturing_confirmations_label">bevestigingen</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d blokken</string>
     <string name="qbtc_claim_cta_all">Alles claimen</string>
     <string name="qbtc_claim_cta_partial">%1$d van %2$d claimen</string>
     <string name="qbtc_claim_proving">Bewijs genereren en uitzenden…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1330,6 +1330,11 @@
     <string name="qbtc_claim_eligible_header">UTXOs elegíveis</string>
     <string name="qbtc_claim_utxo_block_format">Confirmado · há %1$d blocos</string>
     <string name="qbtc_claim_utxo_pending">Pendente</string>
+    <string name="qbtc_claim_maturing_title">O seu BTC ainda está a amadurecer</string>
+    <string name="qbtc_claim_maturing_detail">Os UTXOs precisam de 144 confirmações antes de poderem ser resgatados como QBTC. Os seus fundos estão seguros.</string>
+    <string name="qbtc_claim_maturing_section">UTXOs em maturação</string>
+    <string name="qbtc_claim_maturing_confirmations_label">confirmações</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d blocos</string>
     <string name="qbtc_claim_cta_all">Resgatar tudo</string>
     <string name="qbtc_claim_cta_partial">Resgatar %1$d de %2$d</string>
     <string name="qbtc_claim_proving">A gerar prova e a transmitir…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1344,6 +1344,11 @@
     <string name="qbtc_claim_eligible_header">Подходящие UTXO</string>
     <string name="qbtc_claim_utxo_block_format">Подтверждено · %1$d блоков назад</string>
     <string name="qbtc_claim_utxo_pending">Ожидание</string>
+    <string name="qbtc_claim_maturing_title">Ваш BTC ещё созревает</string>
+    <string name="qbtc_claim_maturing_detail">UTXO требуется 144 подтверждения, прежде чем их можно будет получить в виде QBTC. Ваши средства в безопасности.</string>
+    <string name="qbtc_claim_maturing_section">Созревающие UTXO</string>
+    <string name="qbtc_claim_maturing_confirmations_label">подтверждений</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d блоков</string>
     <string name="qbtc_claim_cta_all">Получить всё</string>
     <string name="qbtc_claim_cta_partial">Получить %1$d из %2$d</string>
     <string name="qbtc_claim_proving">Генерация доказательства и отправка…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1657,6 +1657,11 @@
     <string name="qbtc_claim_eligible_header">符合条件的 UTXO</string>
     <string name="qbtc_claim_utxo_block_format">已确认 · %1$d 个区块前</string>
     <string name="qbtc_claim_utxo_pending">待处理</string>
+    <string name="qbtc_claim_maturing_title">您的 BTC 仍在成熟中</string>
+    <string name="qbtc_claim_maturing_detail">UTXO 需要 144 个确认才能提取为 QBTC。您的资金是安全的。</string>
+    <string name="qbtc_claim_maturing_section">成熟中的 UTXO</string>
+    <string name="qbtc_claim_maturing_confirmations_label">确认</string>
+    <string name="qbtc_claim_maturing_blocks">约 %1$d 个区块</string>
     <string name="qbtc_claim_cta_all">全部提取</string>
     <string name="qbtc_claim_cta_partial">提取 %2$d 个中的 %1$d 个</string>
     <string name="qbtc_claim_proving">正在生成证明并广播…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1386,6 +1386,11 @@
     <string name="qbtc_claim_eligible_header">Eligible UTXOs</string>
     <string name="qbtc_claim_utxo_block_format">Confirmed · %1$d blocks ago</string>
     <string name="qbtc_claim_utxo_pending">Pending</string>
+    <string name="qbtc_claim_maturing_title">Your BTC is still maturing</string>
+    <string name="qbtc_claim_maturing_detail">UTXOs need 144 confirmations before they can be claimed as QBTC. Your funds are safe.</string>
+    <string name="qbtc_claim_maturing_section">Maturing UTXOs</string>
+    <string name="qbtc_claim_maturing_confirmations_label">confirmations</string>
+    <string name="qbtc_claim_maturing_blocks">~%1$d blocks</string>
     <string name="qbtc_claim_cta_all">Claim All</string>
     <string name="qbtc_claim_cta_partial">Claim %1$d of %2$d</string>
     <string name="qbtc_claim_proving">Generating proof and broadcasting…</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
@@ -174,6 +174,39 @@ internal class QbtcClaimViewModelTest {
         }
 
     @Test
+    fun `load maps a maturing result to the maturing state with confirmation and block counts`() =
+        runTest(testDispatcher) {
+            coEvery { loadClaimableUtxos(BTC_ADDRESS) } returns
+                QbtcClaimLoadResult.Maturing(
+                    listOf(
+                        ClaimableUtxo(
+                            txid = "ab".repeat(32),
+                            vout = 0,
+                            amount = 75_000_000,
+                            confirmations = 112,
+                        ),
+                        // Unconfirmed (mempool) UTXO → shown as 0 confirmations.
+                        ClaimableUtxo(
+                            txid = "cd".repeat(32),
+                            vout = 2,
+                            amount = 25_000_000,
+                            confirmations = null,
+                        ),
+                    )
+                )
+
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            val state = vm.uiState.value as QbtcClaimUiState.Maturing
+            assertEquals(2, state.utxos.size)
+            assertEquals("112/144", state.utxos[0].confirmationsCount)
+            assertEquals(32L, state.utxos[0].remainingBlocks)
+            assertEquals("0/144", state.utxos[1].confirmationsCount)
+            assertEquals(144L, state.utxos[1].remainingBlocks)
+        }
+
+    @Test
     fun `load blocks when the claim accounts cannot be resolved`() =
         runTest(testDispatcher) {
             // Neither chain is enabled and derivation can't produce the account → resolver throws.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
@@ -18,6 +18,13 @@ sealed interface QbtcClaimBlockedReason {
 sealed interface QbtcClaimLoadResult {
     data class Available(val utxos: List<ClaimableUtxo>) : QbtcClaimLoadResult
 
+    /**
+     * No UTXO is claimable yet, but one or more are still maturing (claimable on-chain, just short
+     * of [QbtcClaimConfig.MIN_CLAIM_CONFIRMATIONS]). Surfaced so the UI can explain the wait
+     * instead of implying nothing is claimable.
+     */
+    data class Maturing(val utxos: List<ClaimableUtxo>) : QbtcClaimLoadResult
+
     data class Blocked(val reason: QbtcClaimBlockedReason) : QbtcClaimLoadResult
 }
 
@@ -64,10 +71,10 @@ constructor(
             return QbtcClaimLoadResult.Blocked(QbtcClaimBlockedReason.KillSwitchClosed)
         }
 
-        val filtered =
+        val claimable =
             try {
                 val candidates = utxosService.fetchClaimableCandidates(btcAddress)
-                chainService.filterClaimable(candidates).filter { it.isMature }
+                chainService.filterClaimable(candidates)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -77,10 +84,11 @@ constructor(
                 )
             }
 
-        return if (filtered.isEmpty()) {
-            QbtcClaimLoadResult.Blocked(QbtcClaimBlockedReason.NoUtxos)
-        } else {
-            QbtcClaimLoadResult.Available(filtered)
+        val (mature, maturing) = claimable.partition { it.isMature }
+        return when {
+            mature.isNotEmpty() -> QbtcClaimLoadResult.Available(mature)
+            maturing.isNotEmpty() -> QbtcClaimLoadResult.Maturing(maturing)
+            else -> QbtcClaimLoadResult.Blocked(QbtcClaimBlockedReason.NoUtxos)
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCase.kt
@@ -71,10 +71,18 @@ constructor(
             return QbtcClaimLoadResult.Blocked(QbtcClaimBlockedReason.KillSwitchClosed)
         }
 
-        val claimable =
+        val (claimableMature, maturing) =
             try {
                 val candidates = utxosService.fetchClaimableCandidates(btcAddress)
-                chainService.filterClaimable(candidates)
+                // Partition on BTC confirmations BEFORE the chain cross-check, mirroring iOS
+                // which gates confirmations before querying the chain. The QBTC chain only
+                // indexes a UTXO once it crosses the confirmation threshold, so a still-maturing
+                // UTXO comes back as 404/NotIndexed; filterClaimable would drop it and it would
+                // never reach the Maturing branch — the screen would fall back to the generic
+                // "nothing to claim". Only the mature set is worth cross-checking for
+                // already-claimed / not-indexed; maturing ones surface straight from Blockchair.
+                val (matureCandidates, maturingCandidates) = candidates.partition { it.isMature }
+                chainService.filterClaimable(matureCandidates) to maturingCandidates
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -84,9 +92,8 @@ constructor(
                 )
             }
 
-        val (mature, maturing) = claimable.partition { it.isMature }
         return when {
-            mature.isNotEmpty() -> QbtcClaimLoadResult.Available(mature)
+            claimableMature.isNotEmpty() -> QbtcClaimLoadResult.Available(claimableMature)
             maturing.isNotEmpty() -> QbtcClaimLoadResult.Maturing(maturing)
             else -> QbtcClaimLoadResult.Blocked(QbtcClaimBlockedReason.NoUtxos)
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
@@ -156,14 +156,42 @@ class LoadClaimableQbtcUtxosUseCaseTest {
             assertEquals(listOf(mature), (result as QbtcClaimLoadResult.Available).utxos)
         }
 
+    @Test
+    fun `maturing utxos survive even when the chain has not indexed them yet`() = runTest {
+        // The chain 404s every UTXO it hasn't indexed — which is exactly what happens for a
+        // still-maturing (sub-threshold) UTXO. The maturing set must NOT be routed through the
+        // cross-check, or it would be dropped and the screen would fall back to NoUtxos.
+        val maturing = utxoWith(50)
+        val result =
+            useCase(FakeChainService(dropsAll = true), FakeUtxosService(listOf(maturing)))
+                .invoke(p2wpkh)
+        assertEquals(listOf(maturing), (result as QbtcClaimLoadResult.Maturing).utxos)
+    }
+
+    @Test
+    fun `only the mature set is cross-checked against the chain`() = runTest {
+        val mature =
+            ClaimableUtxo(txid = "cc".repeat(32), vout = 0, amount = 50_000, confirmations = 200)
+        val maturing =
+            ClaimableUtxo(txid = "dd".repeat(32), vout = 0, amount = 60_000, confirmations = 50)
+        val chain = FakeChainService()
+        val result = useCase(chain, FakeUtxosService(listOf(maturing, mature))).invoke(p2wpkh)
+
+        assertEquals(listOf(mature), (result as QbtcClaimLoadResult.Available).utxos)
+        // The maturing UTXO must never reach filterClaimable.
+        assertEquals(listOf(mature), chain.filteredArgument)
+    }
+
     private fun useCase(chain: FakeChainService, utxos: FakeUtxosService) =
         LoadClaimableQbtcUtxosUseCaseImpl(chain, utxos)
 
     private class FakeChainService(
         private val disabled: Boolean = false,
         private val disabledError: Throwable? = null,
+        private val dropsAll: Boolean = false,
     ) : QbtcClaimChainService {
         var disabledCalls = 0
+        var filteredArgument: List<ClaimableUtxo>? = null
 
         override suspend fun isClaimWithProofDisabled(): Boolean {
             disabledCalls++
@@ -171,9 +199,13 @@ class LoadClaimableQbtcUtxosUseCaseTest {
             return disabled
         }
 
-        // Identity filter — the use-case test exercises pipeline branching, not the cross-check.
-        override suspend fun filterClaimable(utxos: List<ClaimableUtxo>): List<ClaimableUtxo> =
-            utxos
+        // Records what it was asked to cross-check. Identity filter by default — the use-case test
+        // exercises pipeline branching, not the cross-check — or drops everything to emulate the
+        // chain 404ing UTXOs it has not indexed.
+        override suspend fun filterClaimable(utxos: List<ClaimableUtxo>): List<ClaimableUtxo> {
+            filteredArgument = utxos
+            return if (dropsAll) emptyList() else utxos
+        }
     }
 
     private class FakeUtxosService(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/qbtc/claim/LoadClaimableQbtcUtxosUseCaseTest.kt
@@ -80,21 +80,19 @@ class LoadClaimableQbtcUtxosUseCaseTest {
     }
 
     @Test
-    fun `utxo with 143 confirmations is excluded as immature`() = runTest {
-        val result =
-            useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(143)))).invoke(p2wpkh)
-        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
+    fun `utxo with 143 confirmations surfaces as maturing`() = runTest {
+        val immature = utxoWith(143)
+        val result = useCase(FakeChainService(), FakeUtxosService(listOf(immature))).invoke(p2wpkh)
+        assertEquals(listOf(immature), (result as QbtcClaimLoadResult.Maturing).utxos)
     }
 
     @Test
-    fun `utxo with exactly 144 confirmations is excluded since chain requires strictly more`() =
+    fun `utxo with exactly 144 confirmations surfaces as maturing since chain requires strictly more`() =
         runTest {
+            val immature = utxoWith(144)
             val result =
-                useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(144)))).invoke(p2wpkh)
-            assertEquals(
-                QbtcClaimBlockedReason.NoUtxos,
-                (result as QbtcClaimLoadResult.Blocked).reason,
-            )
+                useCase(FakeChainService(), FakeUtxosService(listOf(immature))).invoke(p2wpkh)
+            assertEquals(listOf(immature), (result as QbtcClaimLoadResult.Maturing).utxos)
         }
 
     @Test
@@ -105,10 +103,10 @@ class LoadClaimableQbtcUtxosUseCaseTest {
     }
 
     @Test
-    fun `utxo with null confirmations is excluded as immature`() = runTest {
-        val result =
-            useCase(FakeChainService(), FakeUtxosService(listOf(utxoWith(null)))).invoke(p2wpkh)
-        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
+    fun `utxo with null confirmations surfaces as maturing`() = runTest {
+        val immature = utxoWith(null)
+        val result = useCase(FakeChainService(), FakeUtxosService(listOf(immature))).invoke(p2wpkh)
+        assertEquals(listOf(immature), (result as QbtcClaimLoadResult.Maturing).utxos)
     }
 
     @Test
@@ -126,7 +124,7 @@ class LoadClaimableQbtcUtxosUseCaseTest {
     }
 
     @Test
-    fun `all immature utxos block as no utxos`() = runTest {
+    fun `all immature utxos surface as maturing`() = runTest {
         val immature =
             listOf(
                 ClaimableUtxo(txid = "11".repeat(32), vout = 0, amount = 1, confirmations = 0),
@@ -135,8 +133,28 @@ class LoadClaimableQbtcUtxosUseCaseTest {
                 ClaimableUtxo(txid = "44".repeat(32), vout = 0, amount = 1, confirmations = null),
             )
         val result = useCase(FakeChainService(), FakeUtxosService(immature)).invoke(p2wpkh)
-        assertEquals(QbtcClaimBlockedReason.NoUtxos, (result as QbtcClaimLoadResult.Blocked).reason)
+        assertEquals(immature, (result as QbtcClaimLoadResult.Maturing).utxos)
     }
+
+    @Test
+    fun `mature utxos take priority and maturing ones are hidden from the available set`() =
+        runTest {
+            val mature =
+                ClaimableUtxo(
+                    txid = "cc".repeat(32),
+                    vout = 0,
+                    amount = 50_000,
+                    confirmations = 200,
+                )
+            val immature =
+                ClaimableUtxo(txid = "dd".repeat(32), vout = 0, amount = 60_000, confirmations = 10)
+            val result =
+                useCase(FakeChainService(), FakeUtxosService(listOf(immature, mature)))
+                    .invoke(p2wpkh)
+            // As long as something is claimable now, the screen shows the selectable set, not
+            // maturing.
+            assertEquals(listOf(mature), (result as QbtcClaimLoadResult.Available).utxos)
+        }
 
     private fun useCase(chain: FakeChainService, utxos: FakeUtxosService) =
         LoadClaimableQbtcUtxosUseCaseImpl(chain, utxos)


### PR DESCRIPTION
## Summary

Closes #4798 (follow-up to #4797).

After #4797, QBTC UTXOs with ≤144 confirmations are filtered out of the claim flow. A wallet whose only UTXOs are still maturing therefore landed on the generic **"Nothing to claim"** screen — implying the funds aren't claimable at all, when in fact they become claimable shortly.

This adds a dedicated **"still maturing"** state that explains the wait and shows how far each UTXO is from maturity.

## What changed

- **Data** — `LoadClaimableQbtcUtxosUseCase` no longer discards immature UTXOs. It partitions the claimable set into mature vs maturing and returns a new `QbtcClaimLoadResult.Maturing` when nothing is claimable yet but funds are still maturing (only falling back to `Blocked(NoUtxos)` when there's truly nothing).
- **ViewModel** — new `QbtcClaimUiState.Maturing` + `QbtcClaimMaturingUtxoUiModel`, exposing the `conf/144` count and `~N blocks` remaining (`(144 − confirmations).coerceAtLeast(1)`; a null/mempool confirmation count shows as 0).
- **UI** — hourglass info card, "Maturing UTXOs" list (per-UTXO count in warning amber, remaining blocks, amounts) and a disabled "Claim All" button, matching the Figma design. Adds `ic_hourglass` and `ic_clock_filled` vector icons exported from Figma.
- **Strings** — 5 new keys across all 10 locales.

## Design

Figma: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=78433-177381

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/dGiEJz9.png) | ![after](https://i.imgur.com/73n8BZz.png) |

## Test plan

- `:data` — `LoadClaimableQbtcUtxosUseCaseTest`: immature (143/144/null) and all-immature sets now surface as `Maturing`; mature-present sets stay `Available`; truly-empty stays `NoUtxos`.
- `:app` — `QbtcClaimViewModelTest`: maturing result maps to the `Maturing` state with correct `conf/144` and remaining-block counts (incl. mempool → 0).
- Both unit suites green; `assembleDebug` builds; rendered on device (see After).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a QBTC claim “maturing” state that lists UTXOs waiting on confirmations, including remaining blocks and confirmation progress.
  * Updated the claim screen to show a maturing information section and hide/disable CTAs accordingly.
  * Extended the preview/demo to render the new maturing screen state.
* **Bug Fixes**
  * Updated eligibility logic and tests so sub-threshold UTXOs surface as “maturing” rather than being treated as unavailable.
* **Documentation**
  * Added localized UI strings for the new maturing state across supported languages, plus new icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->