### PR TITLE
feat(swap): VULT-scaled Jupiter affiliate fee + Solana routing (#5053)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GetDiscountBpsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GetDiscountBpsUseCase.kt
@@ -139,6 +139,9 @@ constructor(
                 SwapProvider.LIFI,
                 SwapProvider.KYBER,
                 SwapProvider.SWAPKIT,
+                // Jupiter now charges a VULT-scaled affiliate fee too (#5053), so the holder's tier
+                // discount must reach it — without this the Jupiter candidate always pays full bps.
+                SwapProvider.JUPITER,
             )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -453,10 +453,19 @@ constructor(
         // the source balance here — that would mix decimals and could wrongly drive the usable
         // amount negative for a low-decimal source into a high-decimal destination.
         val reservedNetworkFee =
-            if (percentage >= 1f) {
-                quotePipeline.estimatedNetworkFeeTokenValue.value?.value?.takeIf {
-                    srcToken.isNativeToken && quotePipeline.gasFeeChain.value == srcToken.chain
-                } ?: BigInteger.ZERO
+            if (
+                percentage >= 1f &&
+                    srcToken.isNativeToken &&
+                    quotePipeline.gasFeeChain.value == srcToken.chain
+            ) {
+                val baseFee =
+                    quotePipeline.estimatedNetworkFeeTokenValue.value?.value ?: BigInteger.ZERO
+                // A Jupiter affiliate swap may create the destination-mint fee ATA on first use,
+                // whose ~0.002 SOL rent the payer (this wallet) funds but the network-fee estimate
+                // doesn't include. Reserve it on native-SOL MAX so the first such swap can't
+                // underfund and fail on submit; it leaves harmless dust when no ATA is created.
+                if (srcToken.chain == Chain.Solana) baseFee + SOLANA_FEE_ATA_RENT_RESERVE
+                else baseFee
             } else {
                 BigInteger.ZERO
             }
@@ -644,6 +653,11 @@ constructor(
 
         // Upper bound for slippage tolerance: 10_000 bps = 100%.
         private const val MAX_SLIPPAGE_BPS = 10_000
+
+        // Rent-exempt minimum for an SPL token account (~0.00203928 SOL, in lamports). Held back on
+        // native-SOL MAX swaps to cover a first-use Jupiter fee-ATA creation the fee estimate
+        // omits.
+        private val SOLANA_FEE_ATA_RENT_RESERVE = BigInteger.valueOf(2_039_280)
 
         // Grouped, up-to-8-decimal $VULT amount (e.g. "3,000", "6.65648001"); truncates rather than
         // rounds up so a displayed balance never overstates what the vault holds.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -464,7 +464,11 @@ constructor(
                 // whose ~0.002 SOL rent the payer (this wallet) funds but the network-fee estimate
                 // doesn't include. Reserve it on native-SOL MAX so the first such swap can't
                 // underfund and fail on submit; it leaves harmless dust when no ATA is created.
-                if (srcToken.chain == Chain.Solana) baseFee + SOLANA_FEE_ATA_RENT_RESERVE
+                // Jupiter only handles same-chain Solana, so a SOL→non-Solana MAX (routed via
+                // THORChain/LI.FI) never creates a fee ATA — don't reserve dust for it.
+                val dstChain = selectedDst.value?.account?.token?.chain
+                if (srcToken.chain == Chain.Solana && dstChain == Chain.Solana)
+                    baseFee + SOLANA_FEE_ATA_RENT_RESERVE
                 else baseFee
             } else {
                 BigInteger.ZERO

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -562,19 +562,24 @@ constructor(
         }
 
     /**
-     * Provider preference order for the banded selection. Lower index = preferred. THORChain is
-     * most preferred, then MayaChain, SwapKit, KyberSwap, 1inch, LI.FI; Jupiter (Solana-only,
-     * rarely competing in the same candidate set) ranks last.
+     * Provider preference order for the banded selection. Lower index = preferred. THORChain then
+     * MayaChain lead for cross-chain. Jupiter sits next, above SwapKit/Kyber/1inch/LI.FI: it is
+     * Solana-only and same-chain, so the only candidate set it ever appears in is an on-Solana
+     * SOL↔SPL / SPL↔SPL pair (against LI.FI and a SwapKit/NEAR cross-chain route), where the spec
+     * wants Jupiter — the native Solana DEX aggregator, no markup — preferred. Ranking it above
+     * those globally is safe because it never competes outside that set, and it never co-occurs
+     * with THORChain/Maya (those need a non-Solana or native-SOL leg Jupiter can't be eligible
+     * for).
      */
     private fun providerPriority(provider: SwapProvider): Int =
         when (provider) {
             SwapProvider.THORCHAIN -> 0
             SwapProvider.MAYA -> 1
-            SwapProvider.SWAPKIT -> 2
-            SwapProvider.KYBER -> 3
-            SwapProvider.ONEINCH -> 4
-            SwapProvider.LIFI -> 5
-            SwapProvider.JUPITER -> 6
+            SwapProvider.JUPITER -> 2
+            SwapProvider.SWAPKIT -> 3
+            SwapProvider.KYBER -> 4
+            SwapProvider.ONEINCH -> 5
+            SwapProvider.LIFI -> 6
         }
 
     /**
@@ -893,6 +898,14 @@ constructor(
                                     dstToken = dstToken,
                                     tokenValue = tokenValue,
                                     srcAddress = src.address.address,
+                                    // VULT-scaled affiliate fee (parity with Kyber/1inch/LiFi):
+                                    // 50 bps base, reduced by the holder's tier discount, never
+                                    // negative. Jupiter takes 0% itself, so this is the only fee.
+                                    affiliateBps =
+                                        maxOf(
+                                            0,
+                                            JUPITER_AFFILIATE_FEE_BPS - (vultBPSDiscount ?: 0),
+                                        ),
                                     slippageBps = slippageBps,
                                 ),
                             )
@@ -1272,6 +1285,10 @@ constructor(
         private const val KYBER_AFFILIATE_FEE_BPS = 50
         /** Base bps before tier discount; clamped to SwapKit's documented 0..1000 range. */
         private const val SWAPKIT_AFFILIATE_FEE_BPS = 50
+        /**
+         * Base bps before tier discount for Jupiter's `platformFeeBps` (parity with the others).
+         */
+        private const val JUPITER_AFFILIATE_FEE_BPS = 50
         private const val NATIVE_TOKEN_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         private const val QUOTE_FETCH_TIMEOUT_MS = 15_000L
         /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -591,6 +591,26 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `selectBestQuote prefers Jupiter over LI-FI and SwapKit for an on-Solana pair`() {
+        // SOL↔SPL / SPL↔SPL is the only candidate set Jupiter ever appears in: against LI.FI and a
+        // SwapKit/NEAR cross-chain route. The spec wants Jupiter (the native Solana DEX aggregator,
+        // no markup) preferred there (#5053). With equal net output all three are in band and none
+        // expose source gas, so provider priority decides — Jupiter must outrank BOTH LI.FI and
+        // SwapKit (whose higher cross-chain priority must not steal an on-Solana swap).
+        val best =
+            createManager()
+                .selectBestQuote(
+                    listOf(
+                        rankable(SwapProvider.SWAPKIT, "0.03"),
+                        rankable(SwapProvider.LIFI, "0.03"),
+                        rankable(SwapProvider.JUPITER, "0.03"),
+                    )
+                )
+
+        assertEquals(SwapProvider.JUPITER, best.candidate.provider)
+    }
+
+    @Test
     fun `selectBestQuote prefers the lower-gas route among in-band EVM aggregators`() {
         // KyberSwap has the marginally higher net AND higher priority, but burns more source gas;
         // 1inch is in band (floor 0.02985) with cheaper gas. The lower-gas quote wins, beating both

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
@@ -76,6 +76,10 @@ internal interface ApiModule {
 
     @Binds @Singleton fun bindJupiterApi(impl: JupiterApiImpl): JupiterApi
 
+    @Binds
+    @Singleton
+    fun bindJupiterFeeAtaService(impl: JupiterFeeAtaServiceImpl): JupiterFeeAtaService
+
     @Binds @Singleton fun bindTronApi(impl: TronApiImpl): TronApi
 
     @Binds @Singleton fun bindCardanoApi(impl: CardanoApiImpl): CardanoApi

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -75,8 +75,15 @@ constructor(
                 feeAtaService.resolveFeeAccount(toToken)
             else null
 
+        // When Jupiter floored the fee to 0 we resolve no `feeAccount`. Round-tripping the quote's
+        // `platformFee` back into `/swap` without a matching `feeAccount` makes Jupiter reject the
+        // fee-bearing swap, which would drop the now-preferred Jupiter route to a worse provider,
+        // so
+        // strip it. With no fee requested `platformFee` is already null, so this is a no-op there.
+        val quoteResponseForSwap = if (feeAccount == null) body.copy(platformFee = null) else body
+
         val quoteSwapRequestBody = buildJsonObject {
-            put("quoteResponse", json.encodeToJsonElement(body))
+            put("quoteResponse", json.encodeToJsonElement(quoteResponseForSwap))
             put("userPublicKey", fromAddress)
             put("dynamicComputeUnitLimit", true)
             if (feeAccount != null) put("feeAccount", feeAccount.feeAccount)
@@ -100,14 +107,24 @@ constructor(
         }
         val quoteSwapData = swapResponse.bodyOrThrow<QuoteSwapTransactionJson>()
 
-        // Jupiter never initializes the `feeAccount` ATA, so prepend an idempotent create for it.
-        // The user pays the ~0.002 SOL rent the first time per fee mint; it is a no-op thereafter.
-        // The co-signer signs this exact transaction from the keysign payload, so byte-parity
-        // holds. Note: the displayed Solana network-fee estimate does not yet include this one-time
-        // rent (the SDK adds `ataRentLamports`); that is a deferred fee-display refinement.
+        // Jupiter never initializes the `feeAccount` ATA, so prepend an idempotent create for it
+        // the
+        // first time per fee mint (the payer funds the ~0.002 SOL rent; it is skipped once the ATA
+        // exists, see `needsCreate`). The co-signer signs this exact transaction from the keysign
+        // payload, so byte-parity holds.
         val swapTxData =
-            if (feeAccount != null)
-                feeAtaService.prependCreateFeeAta(quoteSwapData.data, feeAccount, fromAddress)
+            if (feeAccount != null && feeAccount.needsCreate)
+                feeAtaService
+                    .prependCreateFeeAta(quoteSwapData.data, feeAccount, fromAddress)
+                    // Jupiter sized `SetComputeUnitLimit` from its `dynamicComputeUnitLimit`
+                    // simulation, which ran before this create-ATA existed, so the baked limit does
+                    // not budget for the ~30k CU a first-time ATA creation costs. Raise the limit
+                    // by
+                    // that headroom so the first swap per fee mint can't revert on an exceeded
+                    // compute budget.
+                    .let { withFeeAta ->
+                        bumpComputeUnitLimit(withFeeAta, CREATE_ATA_COMPUTE_UNITS)
+                    }
             else quoteSwapData.data
 
         val feePrice = (SolanaTransaction.getComputeUnitPrice(swapTxData) ?: "0").toBigInteger()
@@ -126,8 +143,23 @@ constructor(
         )
     }
 
+    /**
+     * Raise the transaction's `SetComputeUnitLimit` by [extraUnits]. Returns [txData] unchanged
+     * when it carries no limit instruction (nothing to rebase) or wallet-core cannot re-encode it.
+     */
+    private fun bumpComputeUnitLimit(txData: String, extraUnits: BigInteger): String {
+        val currentLimit =
+            SolanaTransaction.getComputeUnitLimit(txData)?.toBigIntegerOrNull() ?: return txData
+        return SolanaTransaction.setComputeUnitLimit(txData, (currentLimit + extraUnits).toString())
+            ?: txData
+    }
+
     internal companion object {
         val MIN_FEE_PRICE_SWAP = "150000".toBigInteger()
+
+        // CU headroom for one first-time SPL create-idempotent-ATA instruction (~25k observed),
+        // added on top of Jupiter's pre-prepend compute-limit estimate so the create can't overrun.
+        val CREATE_ATA_COMPUTE_UNITS = "30000".toBigInteger()
         val MAX_PRIORITY_FEE_LAMPORTS = 6000000
         val PRIORITY_LEVEL = "high"
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -145,13 +145,16 @@ constructor(
 
     /**
      * Raise the transaction's `SetComputeUnitLimit` by [extraUnits]. Returns [txData] unchanged
-     * when it carries no limit instruction (nothing to rebase) or wallet-core cannot re-encode it.
+     * when it carries no limit instruction (nothing to rebase). Fails closed if the limit exists
+     * but can't be re-encoded: returning the original would broadcast a tx whose budget doesn't
+     * cover the just-prepended ATA create, guaranteeing an on-chain revert — better to drop Jupiter
+     * and fall back to another provider.
      */
     private fun bumpComputeUnitLimit(txData: String, extraUnits: BigInteger): String {
         val currentLimit =
             SolanaTransaction.getComputeUnitLimit(txData)?.toBigIntegerOrNull() ?: return txData
         return SolanaTransaction.setComputeUnitLimit(txData, (currentLimit + extraUnits).toString())
-            ?: txData
+            ?: error("[Jupiter] Failed to re-encode SetComputeUnitLimit after prepending fee ATA")
     }
 
     internal companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
 import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -25,25 +26,38 @@ interface JupiterApi {
         toToken: String,
         fromAddress: String,
         slippageBps: Int?,
+        affiliateBps: Int?,
     ): QuoteSwapTotalDataJson
 }
 
 internal class JupiterApiImpl
 @Inject
-constructor(private val httpClient: HttpClient, private val json: Json) : JupiterApi {
+constructor(
+    private val httpClient: HttpClient,
+    private val json: Json,
+    private val feeAtaService: JupiterFeeAtaService,
+) : JupiterApi {
     override suspend fun getSwapQuote(
         fromAmount: String,
         fromToken: String,
         toToken: String,
         fromAddress: String,
         slippageBps: Int?,
+        affiliateBps: Int?,
     ): QuoteSwapTotalDataJson {
+        // Ask Jupiter to take the VULT-scaled affiliate fee (in the output mint) when a positive
+        // bps
+        // was requested. Whether we actually provision a fee account is decided below from the
+        // quote's real fee amount, not just the request.
+        val requestsPlatformFee = (affiliateBps ?: 0) > 0
+
         val quoteResponse =
             httpClient.get("$JUPITER_URL/swap/v1/quote") {
                 parameter("inputMint", fromToken)
                 parameter("outputMint", toToken)
                 parameter("amount", fromAmount)
                 parameter("slippageBps", slippageBps ?: DEFAULT_SLIPPAGE_BPS)
+                if (requestsPlatformFee) parameter("platformFeeBps", affiliateBps)
             }
         if (quoteResponse.status == HttpStatusCode.TooManyRequests) {
             throw SwapException.RateLimitExceeded("[Jupiter] Too many requests")
@@ -52,10 +66,20 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Jupite
         val outAmount = body.outAmount
         val routePlan = body.routePlan
 
+        // Gate the fee-account flow on the actually-quoted fee, not just the requested bps: Jupiter
+        // can floor `platformFee.amount` to 0 (tiny amounts / fee-ineligible route) even when a fee
+        // was asked for. Deriving a fee account and paying ATA rent for a zero fee would be wrong.
+        val quotedFeeAmount = body.platformFee?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        val feeAccount =
+            if (requestsPlatformFee && quotedFeeAmount > BigInteger.ZERO)
+                feeAtaService.resolveFeeAccount(toToken)
+            else null
+
         val quoteSwapRequestBody = buildJsonObject {
             put("quoteResponse", json.encodeToJsonElement(body))
             put("userPublicKey", fromAddress)
             put("dynamicComputeUnitLimit", true)
+            if (feeAccount != null) put("feeAccount", feeAccount.feeAccount)
             put(
                 "prioritizationFeeLamports",
                 buildJsonObject {
@@ -76,17 +100,23 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Jupite
         }
         val quoteSwapData = swapResponse.bodyOrThrow<QuoteSwapTransactionJson>()
 
-        val feePrice =
-            (SolanaTransaction.getComputeUnitPrice(quoteSwapData.data) ?: "0").toBigInteger()
+        // Jupiter never initializes the `feeAccount` ATA, so prepend an idempotent create for it.
+        // The user pays the ~0.002 SOL rent the first time per fee mint; it is a no-op thereafter.
+        // The co-signer signs this exact transaction from the keysign payload, so byte-parity
+        // holds. Note: the displayed Solana network-fee estimate does not yet include this one-time
+        // rent (the SDK adds `ataRentLamports`); that is a deferred fee-display refinement.
+        val swapTxData =
+            if (feeAccount != null)
+                feeAtaService.prependCreateFeeAta(quoteSwapData.data, feeAccount, fromAddress)
+            else quoteSwapData.data
+
+        val feePrice = (SolanaTransaction.getComputeUnitPrice(swapTxData) ?: "0").toBigInteger()
 
         val updatedSwapTx =
             if (feePrice < MIN_FEE_PRICE_SWAP) {
-                SolanaTransaction.setComputeUnitPrice(
-                    quoteSwapData.data,
-                    MIN_FEE_PRICE_SWAP.toString(),
-                )
+                SolanaTransaction.setComputeUnitPrice(swapTxData, MIN_FEE_PRICE_SWAP.toString())
             } else {
-                quoteSwapData.data
+                swapTxData
             }
 
         return QuoteSwapTotalDataJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
@@ -18,6 +18,14 @@ data class JupiterFeeAccount(
     val mint: String,
     val owner: String,
     val tokenProgramId: String,
+    /**
+     * False when the fee ATA already exists on-chain, letting the swap skip the create-ATA prepend.
+     * Skipping keeps the fee owner/ATA off the transaction's static keys on the steady-state path,
+     * so dense v0 routes (which insertInstruction can't fold into their address-lookup tables)
+     * don't grow toward the 1232-byte limit or risk AccountLoadedTwice on every swap — only on
+     * first use.
+     */
+    val needsCreate: Boolean,
 )
 
 /**
@@ -66,11 +74,16 @@ internal class JupiterFeeAtaServiceImpl @Inject constructor(private val solanaAp
         require(!feeAccount.isNullOrEmpty()) {
             "Failed to derive the Jupiter fee ATA for $outputMint"
         }
+        // Probe whether the fee ATA already exists so the caller can skip the create-ATA prepend on
+        // the common path. A transient probe failure resolves to null here, which conservatively
+        // keeps the (idempotent) create — never wrong, just the larger transaction.
+        val needsCreate = solanaApi.getAccountOwner(feeAccount) == null
         return JupiterFeeAccount(
             feeAccount = feeAccount,
             mint = outputMint,
             owner = JUPITER_FEE_OWNER_ADDRESS,
             tokenProgramId = tokenProgramId,
+            needsCreate = needsCreate,
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
@@ -1,0 +1,142 @@
+package com.vultisig.wallet.data.api
+
+import javax.inject.Inject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import wallet.core.jni.SolanaAddress
+import wallet.core.jni.SolanaTransaction
+
+/**
+ * Fee-mint metadata for a Jupiter affiliate fee: the Vultisig-owned Associated Token Account that
+ * Jupiter credits the fee to, plus the token program that owns the mint (so the create instruction
+ * and ATA derivation use the matching Token vs Token-2022 program).
+ */
+data class JupiterFeeAccount(
+    val feeAccount: String,
+    val mint: String,
+    val owner: String,
+    val tokenProgramId: String,
+)
+
+/**
+ * Resolves and provisions the Jupiter platform-fee account. Jupiter charges 0% itself; the only fee
+ * is the VULT-scaled affiliate fee we add, taken in the swap's output mint (the only mint allowed
+ * on an ExactIn swap besides the input) and credited to a Vultisig-owned ATA — we keep 100% of it
+ * (no Jupiter on-chain Referral Program). Jupiter's `/swap` auto-creates the *user's* output ATA
+ * but never the fee ATA, so we must prepend our own idempotent create. Behind an interface so the
+ * wallet-core JNI + RPC work can be faked in unit tests. Mirrors the SDK's `jupiterFeeAta.ts`.
+ */
+interface JupiterFeeAtaService {
+    /**
+     * Resolve the fee ATA + owning token program for [outputMint]. Throws on a missing/unsupported
+     * mint or RPC failure so the caller fails the Jupiter quote (falling back to another provider)
+     * rather than silently deriving the wrong ATA.
+     */
+    suspend fun resolveFeeAccount(outputMint: String): JupiterFeeAccount
+
+    /**
+     * Prepend an idempotent create-associated-token-account instruction for [fee] (payer =
+     * [feePayer], the swap's fee payer) to the base64 [txData], returning the updated transaction.
+     * The idempotent variant is a no-op (no rent) when the ATA already exists, so this is safe to
+     * run on every swap without an existence probe.
+     */
+    fun prependCreateFeeAta(txData: String, fee: JupiterFeeAccount, feePayer: String): String
+}
+
+internal class JupiterFeeAtaServiceImpl @Inject constructor(private val solanaApi: SolanaApi) :
+    JupiterFeeAtaService {
+
+    override suspend fun resolveFeeAccount(outputMint: String): JupiterFeeAccount {
+        val ownerProgram =
+            solanaApi.getAccountOwner(outputMint)
+                ?: error("Jupiter fee mint $outputMint not found; cannot resolve its token program")
+        val tokenProgramId =
+            when (ownerProgram) {
+                TOKEN_PROGRAM_ID -> TOKEN_PROGRAM_ID
+                TOKEN_2022_PROGRAM_ID -> TOKEN_2022_PROGRAM_ID
+                else ->
+                    error("Jupiter fee mint $outputMint owned by unsupported program $ownerProgram")
+            }
+        val owner = SolanaAddress(JUPITER_FEE_OWNER_ADDRESS)
+        val feeAccount =
+            if (tokenProgramId == TOKEN_2022_PROGRAM_ID) owner.token2022Address(outputMint)
+            else owner.defaultTokenAddress(outputMint)
+        require(!feeAccount.isNullOrEmpty()) {
+            "Failed to derive the Jupiter fee ATA for $outputMint"
+        }
+        return JupiterFeeAccount(
+            feeAccount = feeAccount,
+            mint = outputMint,
+            owner = JUPITER_FEE_OWNER_ADDRESS,
+            tokenProgramId = tokenProgramId,
+        )
+    }
+
+    override fun prependCreateFeeAta(
+        txData: String,
+        fee: JupiterFeeAccount,
+        feePayer: String,
+    ): String =
+        SolanaTransaction.insertInstruction(
+            txData,
+            FEE_ATA_INSTRUCTION_INDEX,
+            createIdempotentAtaInstructionJson(
+                feePayer = feePayer,
+                ata = fee.feeAccount,
+                owner = fee.owner,
+                mint = fee.mint,
+                tokenProgramId = fee.tokenProgramId,
+            ),
+        ) ?: error("Failed to insert the Jupiter fee-ATA create instruction")
+
+    companion object {
+        const val JUPITER_FEE_OWNER_ADDRESS = "8iqhrtBzMcYLR6c6FkzeoMHibedYDkHvLKnX2ArNie5z"
+        const val TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        const val TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+        // Prepend ahead of every program instruction; the create-ATA must run before Jupiter's swap
+        // transfers the fee into the account.
+        private const val FEE_ATA_INSTRUCTION_INDEX = 0
+    }
+}
+
+private const val ASSOCIATED_TOKEN_PROGRAM_ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+private const val SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
+
+// Base58 of the single instruction byte [1] — the SPL ATA program's CreateIdempotent discriminator.
+private const val CREATE_IDEMPOTENT_DATA_BASE58 = "2"
+
+/**
+ * Build the wallet-core `SolanaTransaction.insertInstruction` JSON for an idempotent
+ * create-associated-token-account instruction. Account order and signer/writable flags follow the
+ * SPL Associated Token Account program: payer (signer, writable), ata (writable), owner, mint,
+ * system program, token program; data is the single-byte CreateIdempotent discriminator.
+ */
+internal fun createIdempotentAtaInstructionJson(
+    feePayer: String,
+    ata: String,
+    owner: String,
+    mint: String,
+    tokenProgramId: String,
+): String {
+    fun meta(pubkey: String, isSigner: Boolean, isWritable: Boolean) = buildJsonObject {
+        put("pubkey", pubkey)
+        put("isSigner", isSigner)
+        put("isWritable", isWritable)
+    }
+    return buildJsonObject {
+            put("programId", ASSOCIATED_TOKEN_PROGRAM_ID)
+            putJsonArray("accounts") {
+                add(meta(feePayer, isSigner = true, isWritable = true))
+                add(meta(ata, isSigner = false, isWritable = true))
+                add(meta(owner, isSigner = false, isWritable = false))
+                add(meta(mint, isSigner = false, isWritable = false))
+                add(meta(SYSTEM_PROGRAM_ID, isSigner = false, isWritable = false))
+                add(meta(tokenProgramId, isSigner = false, isWritable = false))
+            }
+            put("data", CREATE_IDEMPOTENT_DATA_BASE58)
+        }
+        .toString()
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -400,8 +400,8 @@ constructor(
 
     override suspend fun getAccountOwner(account: String): String? =
         try {
-            httpClient
-                .postRpc<SolanaAccountInfoResponseJson>(
+            val response =
+                httpClient.postRpc<SolanaAccountInfoResponseJson>(
                     url = rpcEndpoint,
                     method = "getAccountInfo",
                     params =
@@ -410,9 +410,16 @@ constructor(
                             addJsonObject { put("encoding", "base64") }
                         },
                 )
-                .result
-                ?.value
-                ?.owner
+            // postRpc returns a 200 carrying a JSON-RPC `error` body without throwing, so a
+            // transient
+            // RPC failure would otherwise resolve to a null owner indistinguishable from a
+            // genuinely
+            // missing account — and silently drop the now-preferred Jupiter route. Log it so the
+            // failure is observable rather than masquerading as "mint not found".
+            response.error?.let {
+                Timber.tag("SolanaApiImp").w("getAccountOwner RPC error for %s: %s", account, it)
+            }
+            response.result?.value?.owner
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Timber.tag("SolanaApiImp").e(e, "getAccountOwner failed for %s", account)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.api.models.JupiterTokenResponseJson
 import com.vultisig.wallet.data.api.models.RecentBlockHashResponseJson
 import com.vultisig.wallet.data.api.models.RpcPayload
 import com.vultisig.wallet.data.api.models.SPLTokenRequestJson
+import com.vultisig.wallet.data.api.models.SolanaAccountInfoResponseJson
 import com.vultisig.wallet.data.api.models.SolanaBalanceJson
 import com.vultisig.wallet.data.api.models.SolanaFeeForMessageResponse
 import com.vultisig.wallet.data.api.models.SolanaFeeObjectRespJson
@@ -78,6 +79,13 @@ interface SolanaApi {
     ): Pair<String?, Boolean>
 
     suspend fun getFeeForMessage(message: String): BigInteger
+
+    /**
+     * The base58 program id that owns [account] on-chain (e.g. the SPL Token vs Token-2022 program
+     * that owns a mint), or null if the account is missing or the lookup fails. Used to derive the
+     * correct associated-token-account program for a fee mint.
+     */
+    suspend fun getAccountOwner(account: String): String?
 
     suspend fun checkStatus(txHash: String): SolanaRpcResponseJson<SolanaSignatureStatusesResult>?
 }
@@ -389,6 +397,27 @@ constructor(
             return Pair(null, false)
         }
     }
+
+    override suspend fun getAccountOwner(account: String): String? =
+        try {
+            httpClient
+                .postRpc<SolanaAccountInfoResponseJson>(
+                    url = rpcEndpoint,
+                    method = "getAccountInfo",
+                    params =
+                        buildJsonArray {
+                            add(account)
+                            addJsonObject { put("encoding", "base64") }
+                        },
+                )
+                .result
+                ?.value
+                ?.owner
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("SolanaApiImp").e(e, "getAccountOwner failed for %s", account)
+            null
+        }
 
     override suspend fun getFeeForMessage(message: String): BigInteger {
         val payload =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
@@ -71,3 +71,16 @@ data class SolanaRpcResponseJson<T>(
 )
 
 @Serializable data class SolanaSignatureStatus(val confirmationStatus: String? = null)
+
+@Serializable
+data class SolanaAccountInfoResponseJson(
+    @SerialName("result") val result: SolanaAccountInfoResultJson? = null,
+    @SerialName("error") val error: JsonObject? = null,
+)
+
+@Serializable
+data class SolanaAccountInfoResultJson(
+    @SerialName("value") val value: SolanaAccountInfoValueJson? = null
+)
+
+@Serializable data class SolanaAccountInfoValueJson(@SerialName("owner") val owner: String? = null)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
@@ -30,9 +30,21 @@ data class SwapRouteResponseJson(
     @SerialName("swapMode") val swapMode: String,
     @SerialName("slippageBps") val slippageBps: Int,
     @SerialName("priceImpactPct") val priceImpactPct: String,
+    // Present only when the quote was requested with `platformFeeBps`. Jupiter may floor `amount`
+    // to
+    // 0 even when a fee was requested (tiny amounts / fee-ineligible route), so the affiliate-fee
+    // flow keys off this amount rather than the requested bps. Round-tripped back into the `/swap`
+    // request's `quoteResponse` so Jupiter actually applies it.
+    @SerialName("platformFee") val platformFee: JupiterPlatformFeeJson? = null,
     @SerialName("routePlan") val routePlan: List<RoutePlanItemJson>,
     @SerialName("contextSlot") val contextSlot: Long,
     @SerialName("timeTaken") val timeTaken: Double,
+)
+
+@Serializable
+data class JupiterPlatformFeeJson(
+    @SerialName("amount") val amount: String? = null,
+    @SerialName("feeBps") val feeBps: Int? = null,
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/JupiterQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/JupiterQuoteSource.kt
@@ -22,6 +22,7 @@ internal class JupiterQuoteSource @Inject constructor(private val jupiterApi: Ju
                     fromAmount = request.tokenValue.value.toString(),
                     fromAddress = request.srcAddress,
                     slippageBps = request.slippageBps,
+                    affiliateBps = request.affiliateBps.takeIf { it > 0 },
                 )
             }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -119,6 +119,26 @@ class JupiterApiTest {
         }
     }
 
+    @Test
+    fun `a resolved fee prepends the create-ATA onto the swap transaction`() {
+        // Happy path: /swap returns a transaction, so the impl reaches prependCreateFeeAta with the
+        // resolved fee account. The fake records its inputs and raises a marker to stop before the
+        // native compute-budget step, pinning that the prepend runs on the swap tx with the swap's
+        // fee payer.
+        val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT, prependThrows = true)
+        val api = swapOkApi(service)
+
+        assertThrows(PrependInvoked::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
+            }
+        }
+
+        assertEquals(SWAP_TX, service.prependedTxData)
+        assertEquals(WALLET, service.prependedFeePayer)
+        assertEquals(FEE_ACCOUNT, service.prependedFee)
+    }
+
     /**
      * The quote GET returns 429 so [JupiterApi.getSwapQuote] short-circuits before the swap POST
      * and its WalletCore compute-budget step, keeping the slippage tests on the request they assert
@@ -170,6 +190,31 @@ class JupiterApiTest {
         return api to captured
     }
 
+    /**
+     * Both legs succeed: /quote returns a route with a non-zero platform fee and /swap returns a
+     * serialized transaction, so the impl resolves the fee account and reaches the fee-ATA prepend.
+     */
+    private fun swapOkApi(service: FakeFeeAtaService): JupiterApi =
+        jupiterApiImpl(
+            service = service,
+            engine =
+                MockEngine { request ->
+                    if (request.url.encodedPath.endsWith("/quote")) {
+                        respond(
+                            content = routeResponseJson("36341"),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    } else {
+                        respond(
+                            content = """{"swapTransaction":"$SWAP_TX"}""",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    }
+                },
+        )
+
     private fun jupiterApiImpl(service: JupiterFeeAtaService, engine: MockEngine): JupiterApi =
         JupiterApiImpl(
             HttpClient(engine) {
@@ -193,10 +238,26 @@ class JupiterApiTest {
         var swapBody: String? = null,
     )
 
-    /** Fake service: returns [feeAccount] from resolve, or throws when it is null. */
-    private class FakeFeeAtaService(private val feeAccount: JupiterFeeAccount?) :
-        JupiterFeeAtaService {
+    /**
+     * Fake service: [resolveFeeAccount] returns [feeAccount] or throws when it is null;
+     * [prependCreateFeeAta] records its arguments and, when [prependThrows], raises
+     * [PrependInvoked] so a happy-path test can assert the prepend was reached with the right
+     * inputs without crossing the native compute-budget step that runs right after it.
+     */
+    private class FakeFeeAtaService(
+        private val feeAccount: JupiterFeeAccount?,
+        private val prependThrows: Boolean = false,
+    ) : JupiterFeeAtaService {
         var resolveCalled = false
+            private set
+
+        var prependedTxData: String? = null
+            private set
+
+        var prependedFee: JupiterFeeAccount? = null
+            private set
+
+        var prependedFeePayer: String? = null
             private set
 
         override suspend fun resolveFeeAccount(outputMint: String): JupiterFeeAccount {
@@ -208,8 +269,16 @@ class JupiterApiTest {
             txData: String,
             fee: JupiterFeeAccount,
             feePayer: String,
-        ): String = txData
+        ): String {
+            prependedTxData = txData
+            prependedFee = fee
+            prependedFeePayer = feePayer
+            if (prependThrows) throw PrependInvoked
+            return txData
+        }
     }
+
+    private object PrependInvoked : RuntimeException("prepend invoked")
 
     private fun routeResponseJson(platformFeeAmount: String?): String {
         val platformFee =
@@ -239,6 +308,10 @@ class JupiterApiTest {
         const val INPUT_MINT = "So11111111111111111111111111111111111111112"
         const val OUTPUT_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
         const val WALLET = "Wallet"
+
+        // Opaque base64 stand-in for Jupiter's serialized swap tx; the fake short-circuits before
+        // any native decode, so its bytes only need to round-trip as a string.
+        const val SWAP_TX = "AQID"
 
         val FEE_ACCOUNT =
             JupiterFeeAccount(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -139,6 +139,34 @@ class JupiterApiTest {
         assertEquals(FEE_ACCOUNT, service.prependedFee)
     }
 
+    @Test
+    fun `an already-existing fee ATA skips the create-ATA prepend`() {
+        // needsCreate = false (the ATA is already on-chain) must short-circuit the prepend so the
+        // swap tx doesn't gain the fee owner/ATA as extra static keys on the steady-state path.
+        // prependThrows would raise PrependInvoked if reached; instead execution falls through to
+        // the
+        // native compute-budget step (absent in unit tests), so we only assert the prepend was
+        // skipped — the fake records its input before throwing, so a null input proves it ran
+        // never.
+        val service =
+            FakeFeeAtaService(
+                feeAccount = FEE_ACCOUNT.copy(needsCreate = false),
+                prependThrows = true,
+            )
+        val api = swapOkApi(service)
+
+        runCatching {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
+            }
+        }
+
+        assertNull(
+            service.prependedTxData,
+            "prepend must be skipped when the fee ATA already exists",
+        )
+    }
+
     /**
      * The quote GET returns 429 so [JupiterApi.getSwapQuote] short-circuits before the swap POST
      * and its WalletCore compute-budget step, keeping the slippage tests on the request they assert
@@ -319,6 +347,7 @@ class JupiterApiTest {
                 mint = OUTPUT_MINT,
                 owner = "8iqhrtBzMcYLR6c6FkzeoMHibedYDkHvLKnX2ArNie5z",
                 tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                needsCreate = true,
             )
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -4,10 +4,19 @@ import com.vultisig.wallet.data.api.errors.SwapException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.appendIfNameAbsent
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -17,10 +26,12 @@ class JupiterApiTest {
 
     @Test
     fun `quote request pins the default slippage when on Auto`() {
-        val (api, captured) = jupiterApi()
+        val (api, captured) = quoteOnlyApi()
 
         assertThrows(SwapException.RateLimitExceeded::class.java) {
-            runBlocking { api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null) }
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, null)
+            }
         }
 
         assertEquals("50", captured.slippageBps)
@@ -28,43 +39,213 @@ class JupiterApiTest {
 
     @Test
     fun `quote request forwards the user-set slippage override`() {
-        val (api, captured) = jupiterApi()
+        val (api, captured) = quoteOnlyApi()
 
         assertThrows(SwapException.RateLimitExceeded::class.java) {
-            runBlocking { api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, 250) }
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, 250, null)
+            }
         }
 
         assertEquals("250", captured.slippageBps)
     }
 
+    @Test
+    fun `positive affiliate bps with a quoted fee sends platformFeeBps and feeAccount`() {
+        val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
+        val (api, captured) = feeApi(service, quotedFeeAmount = "36341")
+
+        assertThrows(SwapException.RateLimitExceeded::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 45)
+            }
+        }
+
+        assertEquals("45", captured.platformFeeBps)
+        assertTrue(service.resolveCalled, "fee account must be resolved when a fee is quoted")
+        assertTrue(
+            captured.swapBody!!.contains("\"feeAccount\":\"${FEE_ACCOUNT.feeAccount}\""),
+            "swap body must carry the resolved fee account: ${captured.swapBody}",
+        )
+    }
+
+    @Test
+    fun `a null affiliate bps charges no fee`() {
+        val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
+        val (api, captured) = feeApi(service, quotedFeeAmount = null)
+
+        assertThrows(SwapException.RateLimitExceeded::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, null)
+            }
+        }
+
+        assertNull(captured.platformFeeBps)
+        assertFalse(service.resolveCalled)
+        assertFalse(captured.swapBody!!.contains("feeAccount"))
+    }
+
+    @Test
+    fun `a fee floored to zero by Jupiter sends platformFeeBps but no feeAccount`() {
+        // The quote asks for a fee (bps > 0) but Jupiter floors platformFee.amount to 0; we must
+        // not
+        // derive a fee account or prepend a create-ATA for a zero fee.
+        val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
+        val (api, captured) = feeApi(service, quotedFeeAmount = "0")
+
+        assertThrows(SwapException.RateLimitExceeded::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
+            }
+        }
+
+        assertEquals("50", captured.platformFeeBps)
+        assertFalse(service.resolveCalled, "no fee account for a zero-amount fee")
+        assertFalse(captured.swapBody!!.contains("feeAccount"))
+    }
+
+    @Test
+    fun `an unresolvable fee mint fails the quote`() {
+        // resolveFeeAccount throwing (missing/unsupported mint or RPC failure) must propagate so
+        // the
+        // Jupiter quote fails and the picker falls back to another provider.
+        val service = FakeFeeAtaService(feeAccount = null)
+        val (api, _) = feeApi(service, quotedFeeAmount = "36341")
+
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
+            }
+        }
+    }
+
     /**
      * The quote GET returns 429 so [JupiterApi.getSwapQuote] short-circuits before the swap POST
-     * and its WalletCore compute-budget step, keeping the test on the request it asserts and free
-     * of the native JNI.
+     * and its WalletCore compute-budget step, keeping the slippage tests on the request they assert
+     * and free of the native JNI.
      */
-    private fun jupiterApi(): Pair<JupiterApi, CapturedQuote> {
-        val captured = CapturedQuote()
+    private fun quoteOnlyApi(): Pair<JupiterApi, Captured> {
+        val captured = Captured()
         val api =
-            JupiterApiImpl(
-                HttpClient(
+            jupiterApiImpl(
+                service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT),
+                engine =
                     MockEngine { request ->
                         captured.slippageBps = request.url.parameters["slippageBps"]
                         respond(content = "", status = HttpStatusCode.TooManyRequests)
-                    }
-                ) {
-                    install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
-                },
-                Json { ignoreUnknownKeys = true },
+                    },
             )
         return api to captured
     }
 
-    private class CapturedQuote(var slippageBps: String? = null)
+    /**
+     * Lets the quote GET succeed (capturing `platformFeeBps`, returning a route with the given
+     * [quotedFeeAmount] platform fee) so the impl proceeds to build and POST the swap request; the
+     * swap POST then returns 429, capturing the swap body (with any `feeAccount`) and
+     * short-circuiting before the native compute-budget step and the fee-ATA prepend.
+     */
+    private fun feeApi(
+        service: FakeFeeAtaService,
+        quotedFeeAmount: String?,
+    ): Pair<JupiterApi, Captured> {
+        val captured = Captured()
+        val api =
+            jupiterApiImpl(
+                service = service,
+                engine =
+                    MockEngine { request ->
+                        if (request.url.encodedPath.endsWith("/quote")) {
+                            captured.platformFeeBps = request.url.parameters["platformFeeBps"]
+                            respond(
+                                content = routeResponseJson(quotedFeeAmount),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        } else {
+                            captured.swapBody = (request.body as? TextContent)?.text
+                            respond(content = "", status = HttpStatusCode.TooManyRequests)
+                        }
+                    },
+            )
+        return api to captured
+    }
+
+    private fun jupiterApiImpl(service: JupiterFeeAtaService, engine: MockEngine): JupiterApi =
+        JupiterApiImpl(
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+                // Mirror the production client's default JSON content type so the swap POST's
+                // JsonObject body serializes; without it ktor cannot pick a converter.
+                install(DefaultRequest) {
+                    headers.appendIfNameAbsent(
+                        HttpHeaders.ContentType,
+                        ContentType.Application.Json.toString(),
+                    )
+                }
+            },
+            Json { ignoreUnknownKeys = true },
+            service,
+        )
+
+    private class Captured(
+        var slippageBps: String? = null,
+        var platformFeeBps: String? = null,
+        var swapBody: String? = null,
+    )
+
+    /** Fake service: returns [feeAccount] from resolve, or throws when it is null. */
+    private class FakeFeeAtaService(private val feeAccount: JupiterFeeAccount?) :
+        JupiterFeeAtaService {
+        var resolveCalled = false
+            private set
+
+        override suspend fun resolveFeeAccount(outputMint: String): JupiterFeeAccount {
+            resolveCalled = true
+            return feeAccount ?: error("cannot resolve fee account for $outputMint")
+        }
+
+        override fun prependCreateFeeAta(
+            txData: String,
+            fee: JupiterFeeAccount,
+            feePayer: String,
+        ): String = txData
+    }
+
+    private fun routeResponseJson(platformFeeAmount: String?): String {
+        val platformFee =
+            if (platformFeeAmount == null) ""
+            else """"platformFee": { "amount": "$platformFeeAmount", "feeBps": 50 },"""
+        return """
+            {
+              "inputMint": "$INPUT_MINT",
+              "inAmount": "1000",
+              "outputMint": "$OUTPUT_MINT",
+              "outAmount": "1500000",
+              "otherAmountThreshold": "0",
+              "swapMode": "ExactIn",
+              "slippageBps": 50,
+              "priceImpactPct": "0",
+              $platformFee
+              "routePlan": [],
+              "contextSlot": 0,
+              "timeTaken": 0.0
+            }
+            """
+            .trimIndent()
+    }
 
     private companion object {
         const val QUOTE_AMOUNT = "1000"
         const val INPUT_MINT = "So11111111111111111111111111111111111111112"
         const val OUTPUT_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
         const val WALLET = "Wallet"
+
+        val FEE_ACCOUNT =
+            JupiterFeeAccount(
+                feeAccount = "tigMQDjwCNAzNndtiX93ZK1p71XaKTTRrQ8mfyp39LS",
+                mint = OUTPUT_MINT,
+                owner = "8iqhrtBzMcYLR6c6FkzeoMHibedYDkHvLKnX2ArNie5z",
+                tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            )
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaInstructionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaInstructionTest.kt
@@ -1,0 +1,69 @@
+package com.vultisig.wallet.data.api
+
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the wallet-core `insertInstruction` JSON for the idempotent create-fee-ATA instruction. A
+ * wrong account order, signer/writable flag, program id, or data byte would build a transaction
+ * that fails on-chain, so this guards the exact SPL Associated Token Account layout.
+ */
+class JupiterFeeAtaInstructionTest {
+
+    private val payer = "8iqhrtBzMcYLR6c6FkzeoMHibedYDkHvLKnX2ArNie5z"
+    private val ata = "tigMQDjwCNAzNndtiX93ZK1p71XaKTTRrQ8mfyp39LS"
+    private val owner = "FeeOwner111111111111111111111111111111111"
+    private val mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    private val tokenProgram = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+    private val associatedTokenProgram = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+    private val systemProgram = "11111111111111111111111111111111"
+
+    @Test
+    fun `builds the SPL create-idempotent ATA instruction with the canonical layout`() {
+        val element =
+            Json.parseToJsonElement(
+                    createIdempotentAtaInstructionJson(
+                        feePayer = payer,
+                        ata = ata,
+                        owner = owner,
+                        mint = mint,
+                        tokenProgramId = tokenProgram,
+                    )
+                )
+                .jsonObject
+
+        assertEquals(associatedTokenProgram, element["programId"]!!.jsonPrimitive.content)
+        // base58 of the single CreateIdempotent discriminator byte [1].
+        assertEquals("2", element["data"]!!.jsonPrimitive.content)
+
+        val accounts = element["accounts"]!!.jsonArray
+        assertEquals(6, accounts.size)
+
+        // payer: signer + writable (funds the rent)
+        accounts[0].jsonObject.let {
+            assertEquals(payer, it["pubkey"]!!.jsonPrimitive.content)
+            assertEquals(true, it["isSigner"]!!.jsonPrimitive.boolean)
+            assertEquals(true, it["isWritable"]!!.jsonPrimitive.boolean)
+        }
+        // associated token account: writable, not a signer
+        accounts[1].jsonObject.let {
+            assertEquals(ata, it["pubkey"]!!.jsonPrimitive.content)
+            assertEquals(false, it["isSigner"]!!.jsonPrimitive.boolean)
+            assertEquals(true, it["isWritable"]!!.jsonPrimitive.boolean)
+        }
+        // owner, mint, system program, token program: read-only, not signers
+        listOf(2 to owner, 3 to mint, 4 to systemProgram, 5 to tokenProgram).forEach { (i, key) ->
+            accounts[i].jsonObject.let {
+                assertEquals(key, it["pubkey"]!!.jsonPrimitive.content)
+                assertEquals(false, it["isSigner"]!!.jsonPrimitive.boolean)
+                assertEquals(false, it["isWritable"]!!.jsonPrimitive.boolean)
+            }
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -606,6 +606,29 @@ class SwapQuoteRepositoryProvidersTest {
         }
     }
 
+    @Test
+    fun `jupiter forwards a positive VULT-scaled affiliate bps to the api`() = runTest {
+        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
+            jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
+
+        val sol = coin(Chain.Solana, "SOL", contractAddress = "")
+        val usdc = coin(Chain.Solana, "USDC", contractAddress = USDC_MINT)
+        jupiterSource.fetch(
+            SwapQuoteRequest(
+                srcToken = sol,
+                dstToken = usdc,
+                tokenValue = TokenValue(value = BigInteger("1000"), token = sol),
+                srcAddress = "WALLET",
+                affiliateBps = 30,
+            )
+        )
+
+        // The source forwards the request's affiliate bps so the API can request the platform fee.
+        coVerify(exactly = 1) {
+            jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), affiliateBps = 30)
+        }
+    }
+
     companion object {
         const val SOL_MINT = "So11111111111111111111111111111111111111112"
         const val USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -325,7 +325,7 @@ class SwapQuoteRepositoryProvidersTest {
 
     @Test
     fun `jupiter happy path with matching feeMint returns swap fee from route`() = runTest {
-        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any()) } returns
+        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
             jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
 
         // Native SOL → empty contract address triggers SOL default mint mapping
@@ -350,7 +350,7 @@ class SwapQuoteRepositoryProvidersTest {
 
     @Test
     fun `jupiter no matching feeMint returns zero swap fee`() = runTest {
-        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any()) } returns
+        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
             jupiterQuoteResponse(feeMint = "differentMint", feeAmount = "9999")
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
@@ -374,7 +374,7 @@ class SwapQuoteRepositoryProvidersTest {
 
     @Test
     fun `jupiter api throws is wrapped in SwapException`() = runTest {
-        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any()) } throws
+        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } throws
             RuntimeException("rate limited")
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
@@ -579,7 +579,7 @@ class SwapQuoteRepositoryProvidersTest {
 
     @Test
     fun `jupiter forwards the request slippage to the api`() = runTest {
-        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any()) } returns
+        coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
             jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
@@ -595,7 +595,14 @@ class SwapQuoteRepositoryProvidersTest {
         )
 
         coVerify(exactly = 1) {
-            jupiterApi.getSwapQuote(any(), any(), any(), any(), slippageBps = 250)
+            jupiterApi.getSwapQuote(
+                any(),
+                any(),
+                any(),
+                any(),
+                slippageBps = 250,
+                affiliateBps = null,
+            )
         }
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -229,6 +229,58 @@ internal class SwapProviderTableTest {
         assertTrue(SwapProvider.ONEINCH in eligible, "ONEINCH missing same-chain: $eligible")
     }
 
+    @Test
+    fun `Jupiter is offered for on-Solana pairs and dropped for cross-chain Solana pairs`() {
+        // Jupiter is Solana-only and same-chain (#5053): it must be a candidate for SOL↔SPL and
+        // SPL↔SPL, but never for a cross-chain pair where it can't route. The cross-chain drop
+        // happens via the intersection — Jupiter is absent from every non-Solana chain's set.
+        val sol = coin(Chain.Solana, "SOL", isNative = true)
+        val splUsdc = coin(Chain.Solana, "USDC", isNative = false, contract = "EPjF")
+        val splBonk = coin(Chain.Solana, "BONK", isNative = false, contract = "DezX")
+        val btc = coin(Chain.Bitcoin, "BTC", isNative = true)
+        val eth = coin(Chain.Ethereum, "ETH", isNative = true)
+
+        assertTrue(
+            SwapProvider.JUPITER in table.eligibleProvidersFor(sol, splUsdc),
+            "Jupiter must be eligible for SOL↔SPL",
+        )
+        assertTrue(
+            SwapProvider.JUPITER in table.eligibleProvidersFor(splUsdc, splBonk),
+            "Jupiter must be eligible for SPL↔SPL",
+        )
+        assertFalse(
+            SwapProvider.JUPITER in table.eligibleProvidersFor(sol, btc),
+            "Jupiter must be dropped for native SOL → BTC",
+        )
+        assertFalse(
+            SwapProvider.JUPITER in table.eligibleProvidersFor(splUsdc, eth),
+            "Jupiter must be dropped for SPL → ETH",
+        )
+    }
+
+    @Test
+    fun `native SOL cross-chain keeps THORChain and drops Jupiter`() {
+        // Native SOL → BTC/ETH must route through THORChain (THORChain SOL support is wired), with
+        // Jupiter excluded as a cross-chain candidate (#5053).
+        val sol = coin(Chain.Solana, "SOL", isNative = true)
+
+        listOf(
+                coin(Chain.Bitcoin, "BTC", isNative = true),
+                coin(Chain.Ethereum, "ETH", isNative = true),
+            )
+            .forEach { dst ->
+                val eligible = table.eligibleProvidersFor(sol, dst)
+                assertTrue(
+                    SwapProvider.THORCHAIN in eligible,
+                    "THORChain must remain eligible for native SOL → ${dst.chain}: $eligible",
+                )
+                assertFalse(
+                    SwapProvider.JUPITER in eligible,
+                    "Jupiter must not be eligible for native SOL → ${dst.chain}: $eligible",
+                )
+            }
+    }
+
     /**
      * In-memory eligibility whose live `CHAIN.TICKER` sets stand in for fetched Available pools.
      */


### PR DESCRIPTION
## Summary
Brings the VULT-scaled affiliate fee to Android's Jupiter Solana swaps and aligns Solana routing with the cross-platform spec (SDK is the reference; iOS not yet implemented). Fixes #5053.

- **Affiliate fee** — the Jupiter quote sends `platformFeeBps = max(0, 50 − VULT tier discount)`; the swap credits the fee (taken in the output mint) to a Vultisig-owned ATA. Jupiter itself takes 0% and we use no on-chain Referral Program, so we keep 100%.
- **Fee-ATA provisioning** — Jupiter's `/swap` auto-creates the *user's* output ATA but never the fee ATA, so a `feeAccount` that doesn't exist makes the tx fail on submit. We prepend an idempotent `createAssociatedTokenAccount` via wallet-core `SolanaTransaction.insertInstruction` (resolving Token vs Token-2022 from the mint owner). The user pays the one-time ~0.002 SOL rent the first time per output mint; it is a no-op thereafter. The co-signer signs the same baked transaction, so MPC byte-parity holds.
- **Routing** — Jupiter is Solana-only and same-chain, so it is excluded from cross-chain pairs by construction; it is now preferred over LI.FI/SwapKit for on-Solana pairs.

## Routing
| Swap shape | Preference order |
|---|---|
| Native SOL ↔ other chain | THORChain → SwapKit → LI.FI |
| SOL ↔ SPL / SPL ↔ SPL (stays on Solana) | **Jupiter** → LI.FI |
| SPL ↔ other chain | THORChain (if supported) → SwapKit → LI.FI |

## On-chain proof (mainnet)
A real SOL → USDC swap executed via Jupiter with the fee collected:
https://solscan.io/tx/4xiCLYvoPWRU4V35UBGFKZWsa8mVxgppjugD2bD7s2vfBzskZ7sSwvJDugsqPgYvqqyzxXVtCpczmUDSYohChTVK

- transaction succeeded, routed through the Jupiter program
- the prepended create-idempotent-ATA executed: fee ATA `tigMQDjwCNAzNndtiX93ZK1p71XaKTTRrQ8mfyp39LS` (owner `8iqhrt…`) went from non-existent to created and credited the affiliate fee

## Test plan
- `JupiterApiTest` — quote carries `platformFeeBps`; swap carries `feeAccount`; **no** fee account when Jupiter floors the amount to 0; quote fails on an unresolvable mint
- `JupiterFeeAtaInstructionTest` — pins the SPL create-idempotent-ATA layout (account order/flags, programId, `data` byte), verified against `@solana/spl-token`
- `SwapProviderTableTest` — Jupiter eligible on-Solana, excluded cross-chain; THORChain kept for native SOL
- `SwapQuoteManagerTest` — Jupiter outranks SwapKit + LI.FI for an on-Solana pair
- All suites green offline; ktfmt clean

## Known limitation
The displayed Solana network-fee estimate does not yet include the one-time fee-ATA rent (~0.002 SOL, first swap per output mint); the SDK adds `ataRentLamports`. The user pays the correct amount on-chain — only the pre-swap estimate is slightly low. Deferred as a fee-display follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded swap quote routing to recognize Jupiter, including affiliate/platform fee handling and automatic fee-ATA setup when a non-zero platform fee is quoted.
  * Updated provider selection priority so Jupiter can be preferred for on-Solana routes.
* **Bug Fixes**
  * Avoid unnecessary fee-ATA actions when Jupiter floors the platform fee to zero.
  * Adjusted swap fee reservation to include the Solana fee-ATA rent-exempt minimum for native-SOL scenarios.
* **Tests**
  * Added/updated unit and API tests covering Jupiter fee handling, fee-ATA instruction generation, eligibility rules, and quote tie-breaking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->