### PR TITLE
fix(chains): clear nav bar inset on Select chains grid bottom (#5084)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -70,8 +70,10 @@ import com.vultisig.wallet.ui.components.v2.fastselection.components.ChainSelect
 import com.vultisig.wallet.ui.components.v2.fastselection.components.SelectPopup
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.models.AccountUiModel
+import com.vultisig.wallet.ui.models.ChainSelectionUiModel
 import com.vultisig.wallet.ui.models.ChainTokenUiModel
 import com.vultisig.wallet.ui.models.ChainTokensUiModel
+import com.vultisig.wallet.ui.models.ChainUiModel
 import com.vultisig.wallet.ui.models.DeviceMeta
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
@@ -106,6 +108,7 @@ import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.swap.VultTierGateUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
+import com.vultisig.wallet.ui.screens.ChainSelectionScreen
 import com.vultisig.wallet.ui.screens.TransactionDoneView
 import com.vultisig.wallet.ui.screens.VaultDetailScreen
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsContent
@@ -272,6 +275,7 @@ class PreviewActivity : ComponentActivity() {
                     "vault_detail_no_mldsa" -> VaultDetailPreview(withMldsa = false)
                     "vault_detail_mldsa" -> VaultDetailPreview(withMldsa = true)
                     "error_screen_after" -> ErrorScreenAfterPreview()
+                    "chain_selection" -> ChainSelectionClipPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -284,6 +288,30 @@ class PreviewActivity : ComponentActivity() {
 // "Show exact error" disclosure that opens the raw-trace sheet. Rendered as the "Transaction
 // failed"
 // critical case with a real stack trace so the disclosure row is visible.
+/**
+ * "Select chains" bottom sheet (#5084) rendered with the full chain list so the grid overflows and
+ * scrolls. Used to verify the last row's label (alphabetically Zcash) is no longer clipped behind
+ * the system navigation bar. Scroll to the bottom before capturing.
+ */
+@Composable
+private fun ChainSelectionClipPreview() {
+    val chains = remember {
+        Coins.coins.values
+            .mapNotNull { it.firstOrNull() }
+            .sortedBy { it.chain.raw }
+            .map { ChainUiModel(isEnabled = it.chain == Chain.Bitcoin, coin = it) }
+    }
+    ChainSelectionScreen(
+        title = "Select chains",
+        state = ChainSelectionUiModel(chains = chains),
+        searchTextFieldState = remember { TextFieldState() },
+        onEnableAccount = {},
+        onDisableAccount = {},
+        onCommitChanges = {},
+        onBackClick = {},
+    )
+}
+
 @Composable
 private fun ErrorScreenAfterPreview() {
     ErrorView(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenSelectionList.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -143,11 +146,13 @@ internal fun <T> TokenSelectionList(
                 notFoundContent()
             } else
                 Box(modifier = Modifier.weight(1f)) {
+                    val navigationBarPadding =
+                        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(minSize = 74.dp),
                         verticalArrangement = Arrangement.spacedBy(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        contentPadding = PaddingValues(bottom = 60.dp),
+                        contentPadding = PaddingValues(bottom = 60.dp + navigationBarPadding),
                     ) {
                         groups.forEachIndexed { groupIndex, (title, items, mapper, plusUiModel) ->
                             title?.let {


### PR DESCRIPTION
## Summary
Fixes #5084 — on the **Select chains** bottom sheet, the last row's chain label (alphabetically *Zcash*) is clipped/dimmed at the bottom of the sheet.

The grid (`TokenSelectionList`) reserved a hardcoded `60.dp` bottom content padding (originally added in #3911 for the same "chain names hidden" class of bug). On devices where the bottom sheet renders **under** the system navigation bar, that fixed 60dp isn't enough to lift the last row clear of a tall nav bar plus the `BottomFadeEffect`, so the final label gets clipped.

## Change
- Make the grid's bottom content padding **nav-bar-inset aware** so it scales with the actual device instead of a fixed value:
  ```kotlin
  contentPadding = PaddingValues(bottom = 60.dp + navigationBarPadding)
  ```
  This benefits every grid built on `TokenSelectionList` (chain selection, DeFi chain selection, token management).
- Adds a `chain_selection` `PreviewActivity` entry that renders the full chain list, for reproduction.

## Reproduction note
The clip does **not** reproduce on a stock Pixel AVD — Material's `ModalBottomSheet` insets its content above the nav bar there. The bug manifests on devices/OEMs where the sheet renders edge-to-edge under the nav bar. The before/after below were captured on **Small_Phone (360×640dp, 3-button nav)** reproducing that under-nav-bar condition; the last row sits tight against the nav bar before, and clears it after.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/LmwdGmL.png) | ![after](https://i.imgur.com/tVNi03N.png) |

## Test plan
- [x] `./gradlew :app:assembleDebug` green
- [x] ktfmt clean
- [x] Last-row label clears the nav bar on the affected configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the token selection grid so items no longer sit too close to the bottom navigation area on devices with gesture or system navigation bars.
* **Chores**
  * Expanded the app’s preview coverage with an additional chain-selection preview screen for easier visual checks during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->