### PR TITLE
fix(solana): retry transient BlockhashNotFound and fix tx-status verification

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -207,7 +207,11 @@ constructor(
                 Timber.tag("SolanaApiImp")
                     .d("Error broadcasting transaction: %s", responseRawString)
 
-                when (solanaBroadcastAction(message, attempt, BROADCAST_MAX_ATTEMPTS)) {
+                // Solana reports the specific failure (e.g. "BlockhashNotFound") in error.data.err,
+                // while error.message only carries the generic "Transaction simulation failed".
+                // Classify against the whole error object so a transient blockhash-not-found is
+                // retried (RESEND) instead of being misread as a fatal error.
+                when (solanaBroadcastAction(error.toString(), attempt, BROADCAST_MAX_ATTEMPTS)) {
                     // Propagation lag: the RPC node hasn't observed our confirmed blockhash yet.
                     // Resending the same signed tx after a short backoff typically clears it.
                     SolanaBroadcastAction.RESEND -> {
@@ -479,11 +483,13 @@ internal fun solanaBroadcastAction(
     attempt: Int,
     maxAttempts: Int,
 ): SolanaBroadcastAction {
-    val lowered = errorMessage.lowercase()
+    // Normalize away spaces/underscores so we match both the human-readable RPC message
+    // ("Blockhash not found") and Solana's camelCase TransactionError enum ("BlockhashNotFound").
+    val normalized = errorMessage.lowercase().replace(" ", "").replace("_", "")
     return when {
-        lowered.contains("blockhash not found") && attempt < maxAttempts ->
+        normalized.contains("blockhashnotfound") && attempt < maxAttempts ->
             SolanaBroadcastAction.RESEND
-        lowered.contains("blockhash not found") || lowered.contains("block height exceeded") ->
+        normalized.contains("blockhashnotfound") || normalized.contains("blockheightexceeded") ->
             SolanaBroadcastAction.EXPIRED
         else -> SolanaBroadcastAction.FATAL
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -8,9 +8,9 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.tss.getSignature
 import com.vultisig.wallet.data.utils.Numeric
-import io.ktor.util.encodeBase64
 import java.math.BigInteger
 import wallet.core.jni.AnyAddress
+import wallet.core.jni.Base58
 import wallet.core.jni.Base64
 import wallet.core.jni.CoinType
 import wallet.core.jni.DataVector
@@ -39,6 +39,34 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
 
     companion object {
         val DefaultFeeInLamports: BigInteger = 1000000.toBigInteger()
+
+        /**
+         * The Solana transaction id is the base58 of the first 64-byte signature in the wire
+         * transaction — NOT a substring of the base58-encoded transaction. WalletCore emits
+         * `output.encoded` as base58 (the signing input never sets `txEncoding`, so the proto
+         * default applies), so decode it, skip the shortvec signature count, and base58-encode
+         * the first signature. Mirrors vultisig-ios `getHashFromRawTransaction`.
+         */
+        internal fun solanaTransactionHash(encoded: String): String {
+            val txData =
+                Base58.decodeNoCheck(encoded)
+                    ?: error("Failed to decode signed Solana transaction")
+            // compact-u16 (shortvec) decode: 7 bits per byte, high bit = continuation.
+            var offset = 0
+            var numSigs = 0
+            var shift = 0
+            while (offset < txData.size) {
+                val byte = txData[offset].toInt() and 0xFF
+                numSigs = numSigs or ((byte and 0x7F) shl shift)
+                offset++
+                if (byte and 0x80 == 0) break
+                shift += 7
+                require(shift <= 14) { "Invalid shortvec for signature count" }
+            }
+            require(numSigs >= 1) { "Transaction declares no signatures" }
+            require(offset + 64 <= txData.size) { "Transaction too short to extract signature" }
+            return Base58.encodeNoCheck(txData.copyOfRange(offset, offset + 64))
+        }
     }
 
     private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
@@ -186,7 +214,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val output = Solana.SigningOutput.parseFrom(compiledWithSignature).checkError()
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = output.encoded.take(64).encodeBase64(),
+            transactionHash = solanaTransactionHash(output.encoded),
         )
     }
 
@@ -232,7 +260,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val output = Solana.SigningOutput.parseFrom(compileWithSignature).checkError()
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = output.encoded.take(64).encodeBase64(),
+            transactionHash = solanaTransactionHash(output.encoded),
         )
     }
 
@@ -348,7 +376,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
 
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = output.encoded.take(64).encodeBase64(),
+            transactionHash = solanaTransactionHash(output.encoded),
         )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -10,7 +10,6 @@ import com.vultisig.wallet.data.tss.getSignature
 import com.vultisig.wallet.data.utils.Numeric
 import java.math.BigInteger
 import wallet.core.jni.AnyAddress
-import wallet.core.jni.Base58
 import wallet.core.jni.Base64
 import wallet.core.jni.CoinType
 import wallet.core.jni.DataVector
@@ -41,32 +40,14 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val DefaultFeeInLamports: BigInteger = 1000000.toBigInteger()
 
         /**
-         * The Solana transaction id is the base58 of the first 64-byte signature in the wire
-         * transaction — NOT a substring of the base58-encoded transaction. WalletCore emits
-         * `output.encoded` as base58 (the signing input never sets `txEncoding`, so the proto
-         * default applies), so decode it, skip the shortvec signature count, and base58-encode
-         * the first signature. Mirrors vultisig-ios `getHashFromRawTransaction`.
+         * The Solana transaction id is the first signature in the signed transaction. WalletCore
+         * populates [Solana.SigningOutput.getSignaturesList] (base58) on the
+         * `compileWithSignatures` path, so read it directly instead of re-deriving it from the
+         * encoded transaction.
          */
-        internal fun solanaTransactionHash(encoded: String): String {
-            val txData =
-                Base58.decodeNoCheck(encoded)
-                    ?: error("Failed to decode signed Solana transaction")
-            // compact-u16 (shortvec) decode: 7 bits per byte, high bit = continuation.
-            var offset = 0
-            var numSigs = 0
-            var shift = 0
-            while (offset < txData.size) {
-                val byte = txData[offset].toInt() and 0xFF
-                numSigs = numSigs or ((byte and 0x7F) shl shift)
-                offset++
-                if (byte and 0x80 == 0) break
-                shift += 7
-                require(shift <= 14) { "Invalid shortvec for signature count" }
-            }
-            require(numSigs >= 1) { "Transaction declares no signatures" }
-            require(offset + 64 <= txData.size) { "Transaction too short to extract signature" }
-            return Base58.encodeNoCheck(txData.copyOfRange(offset, offset + 64))
-        }
+        internal fun Solana.SigningOutput.transactionHash(): String =
+            signaturesList.firstOrNull()?.signature
+                ?: error("Signed Solana transaction has no signature")
     }
 
     private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
@@ -214,7 +195,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val output = Solana.SigningOutput.parseFrom(compiledWithSignature).checkError()
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = solanaTransactionHash(output.encoded),
+            transactionHash = output.transactionHash(),
         )
     }
 
@@ -260,7 +241,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val output = Solana.SigningOutput.parseFrom(compileWithSignature).checkError()
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = solanaTransactionHash(output.encoded),
+            transactionHash = output.transactionHash(),
         )
     }
 
@@ -376,7 +357,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
 
         return SignedTransactionResult(
             rawTransaction = output.encoded,
-            transactionHash = solanaTransactionHash(output.encoded),
+            transactionHash = output.transactionHash(),
         )
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaBroadcastActionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaBroadcastActionTest.kt
@@ -62,4 +62,20 @@ internal class SolanaBroadcastActionTest {
             solanaBroadcastAction("BLOCK HEIGHT EXCEEDED", attempt = 1, maxAttempts = maxAttempts),
         )
     }
+
+    // The real sendTransaction error body carries the failure as the camelCase TransactionError
+    // enum nested in data.err, not as the spaced human-readable phrase.
+    @Test
+    fun `camelCase BlockhashNotFound from the raw error object resends`() {
+        val rawError =
+            """{"code":-32002,"message":"Transaction simulation failed","data":{"err":"BlockhashNotFound","logs":[]}}"""
+        assertEquals(
+            SolanaBroadcastAction.RESEND,
+            solanaBroadcastAction(rawError, attempt = 1, maxAttempts = maxAttempts),
+        )
+        assertEquals(
+            SolanaBroadcastAction.EXPIRED,
+            solanaBroadcastAction(rawError, attempt = 3, maxAttempts = maxAttempts),
+        )
+    }
 }


### PR DESCRIPTION
## Problem

Sending SOL from a Fast Vault could fail immediately with `Transaction simulation failed` / `BlockhashNotFound`, even though the recent blockhash was fetched only seconds before broadcast and was still valid.

### Successful Fast Vault SOL send after the fix:
https://orb.helius.dev/tx/5wqiKo8QXyroqyr5ESQvVWfgZddTE8AhojJQpKfVDdKwFcC1GkvXnYxCsko9BN7rb2u8Ezg3J9VGQhT1VE3nWj6c

### Successful Secure Vault SOL send after the fix:
https://orb.helius.dev/tx/5VEatWkYsiSJnJoAXcHfLE7rGU716uj5CTVCnQ25cYiYQLRHRpFAe8kqpQc9gMVFK76EqCNJbWze6qKtpGrrZj6H

Traced from a real keysign logcat:
- `getLatestBlockhash` → `AYjiWrtZohyNQycDYnDM2F5LKxJLhN5Jx2hvcSWAuEAe` (slot 429823911)
- The signed message carries that exact blockhash (`8dda7c…` = its hex), and `sendTransaction` runs **~6s later** — far inside Solana's ~60–90s validity window.
- Yet the node returns `{"err":"BlockhashNotFound"}`.

The `api.vultisig.com/solana/` proxy load-balances across backend nodes, so `sendTransaction` can hit a node that hasn't yet observed the blockhash served by `getLatestBlockhash`. That's a **transient lag** the broadcast path is already designed to retry (`RESEND` with backoff) — but two bugs prevented it, and a third broke the recovery fallback.

## Root causes & fixes

**1. Broadcast misclassified the transient error as fatal.**
`broadcastTransaction` extracted `error.message` (`"Transaction simulation failed"`) and passed *that* to the classifier, but Solana puts the real failure in `error.data.err` (`"BlockhashNotFound"`). The classifier also only matched the spaced human phrase `"blockhash not found"`, never Solana's camelCase enum `"BlockhashNotFound"`. Result: a retryable lag was classified `FATAL` and thrown on attempt 1 with no resend.
→ Classify against the whole error object, and normalize spacing/underscores so both the human message and the enum match. Transient `BlockhashNotFound` now `RESEND`s with backoff as intended.

**2. The "already on-chain?" recovery used a bogus tx hash.**
The Solana `transactionHash` was computed as `output.encoded.take(64).encodeBase64()` — a substring of the base58 transaction re-encoded as base64, which is **not a valid signature**. `getSignatureStatuses` rejected it (`Invalid param`), and because the error body has no `result`, deserialization then threw `MissingFieldException` on every verify attempt.
→ Read the real Solana transaction id from WalletCore: `output.signaturesList.first().signature`. Verified on-device that `signaturesList` is populated on the `compileWithSignatures` (TSS) path and its first signature equals the value derived by parsing the wire transaction. This also corrects the hash used for explorer links and transaction history.

## Why this surfaced recently, and mostly on Fast Vaults

Neither bug branches on vault type (the Solana broadcast/blockhash path has no vault-type logic, and vultiserver is a pure TSS co-signer with no Solana broadcast). The pattern is a **timing × commitment** effect:

**Recently** — #4875 (Jun 11) switched the blockhash fetch from `finalized` → `confirmed`.
- `finalized` is ~32 slots / ~13s old *when fetched*, so by broadcast time it has propagated to essentially every backend node behind the proxy → `BlockhashNotFound` was rare. The earlier failed broadcasts were a different class (genuine expiry, fees, etc.).
- `confirmed` tracks the tip (~0.5s old). The `api.vultisig.com/solana` proxy load-balances `sendTransaction` across backend nodes, so it often lands on one that hasn't yet ingested that fresh blockhash → transient `BlockhashNotFound`. This is a new error class `finalized` used to mask, and #4875's new retry/recovery path was buggy (bugs 1 & 2 above), so it became fatal instead of self-healing.

**Mostly Fast Vaults** — the danger window for a `confirmed` blockhash is right after fetch, while it is freshest and least-propagated; the longer between fetch and broadcast, the more nodes have it.
- Fast Vault: the server co-signer returns in well under a second, so the app broadcasts while the blockhash is still "young" → lands in the unpropagated window.
- Secure Vault: keysign needs a second human device to scan the QR and approve (tens of seconds), so by broadcast time the blockhash has aged enough to propagate everywhere → dodges the window.

It is probabilistic, not literally Fast-Vault-exclusive, but the timing skew is why reports cluster there.

## Notes / scope

- Re-signing with a fresh blockhash on genuine expiry remains a separate, deferred follow-up (needs a cross-device `KeysignMessage` proto change) — already noted in the existing code comments. This PR addresses the transient-lag path, which is what the captured failure actually was.

## Test plan

- [x] `:data:compileDebugKotlin` passes
- [x] `SolanaBroadcastActionTest` passes (6/6), including a new case feeding the real `{"err":"BlockhashNotFound"}` error body
- [ ] CI: ktfmt + build (local pre-commit ktfmt worker segfaults — environment issue; formatting mirrors existing patterns in the same files)
- [x] Manual: SOL sent from a Fast Vault now broadcasts successfully (retries through node lag) and resolves on-chain

### Proof (on-chain)



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana broadcast retry/expiration handling to recognize more Solana error payload formats.
  * Updated Solana signed-transaction hash detection to use the actual signature instead of deriving it from encoded output.

* **Tests**
  * Added coverage for Solana RPC error responses that use compact/camelCase forms to ensure retry behavior remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->