### PR TITLE
perf(balances): decouple price refresh from balance fetch (#5077)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -324,7 +324,7 @@ constructor(
                             tokenPriceRepository.refresh(updatedCoins)
                         } catch (e: Exception) {
                             if (e is kotlinx.coroutines.CancellationException) throw e
-                            Timber.e(e, "Price refresh failed for ${chain.id}")
+                            Timber.e(e, "Price refresh failed for %s", chain.id)
                         }
                     }
 
@@ -558,8 +558,12 @@ constructor(
         // cache, so once prices land we recompute fiat from the cache without a second network
         // call.
         val loadPrices = async {
-            runCatching { tokenPriceRepository.refresh(coins) }
-                .onFailure { Timber.e(it, "Failed to refresh token prices for chain: $chain") }
+            try {
+                tokenPriceRepository.refresh(coins)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Timber.e(e, "Failed to refresh token prices for chain: %s", chain)
+            }
         }
 
         val accountToUpdate =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -109,8 +109,12 @@ constructor(
                             async {
                                 try {
                                     val address = account.address
-                                    loadPrices.await()
 
+                                    // Don't gate balances on the price refresh: prices come from an
+                                    // in-memory StateFlow that resolves instantly (cached/zero), so
+                                    // awaiting the refresh here only delayed balances for chains
+                                    // that need no pricing. Fiat is recomputed below once prices
+                                    // land. (Desktop decouples these the same way.)
                                     val newAccounts =
                                         if (account.chain.standard == TokenStandard.EVM) {
                                             // One Multicall3 round-trip per (chain, address) for
@@ -174,6 +178,21 @@ constructor(
                         }
                         .awaitAll()
 
+                    // Balances are already streamed; now wait for the price refresh and recompute
+                    // fiat from the freshly persisted prices. On a warm start the StateFlow already
+                    // held prices, so the per-chain emissions were already correct and this is a
+                    // no-op confirmation; only a cold start (empty StateFlow) updates fiat here.
+                    try {
+                        loadPrices.await()
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        Timber.e(
+                            e,
+                            "Price refresh failed; emitting balances with last-known prices",
+                        )
+                    }
+                    addresses.recomputeFiatFromFreshPrices()
+
                     // Terminal emission: every chain has resolved (or failed). Carries the final
                     // snapshot and flags completion so the UI can stop the refresh spinner.
                     send(AddressBalancesUpdate(addresses.toList(), isComplete = true))
@@ -229,6 +248,29 @@ constructor(
         }
     }
 
+    /**
+     * Recomputes each account's fiat value and unit price from the now-refreshed prices, reusing
+     * the Room-backed [BalanceRepository.getCachedTokenBalanceAndPrice] read (the freshly fetched
+     * balance was already persisted there, and so is the fresh price) so no extra network calls are
+     * made. Accounts with no cached balance (e.g. a brand-new coin whose network fetch failed) are
+     * left untouched so a streamed value is never overwritten with null.
+     */
+    private suspend fun MutableList<Address>.recomputeFiatFromFreshPrices() {
+        forEachIndexed { index, account ->
+            val newAccounts =
+                account.accounts.map { acc ->
+                    val balance =
+                        balanceRepository.getCachedTokenBalanceAndPrice(account.address, acc.token)
+                    if (balance.tokenBalance.tokenValue != null) {
+                        acc.applyBalance(balance.tokenBalance, balance.price)
+                    } else {
+                        acc
+                    }
+                }
+            this[index] = account.copy(accounts = newAccounts)
+        }
+    }
+
     private suspend fun getSPLCoins(solanaCoins: List<Coin>, vault: Vault): List<Coin> {
         if (solanaCoins.any { !it.isNativeToken }) return emptyList()
         val solanaAddress = solanaCoins.firstOrNull()?.address
@@ -267,13 +309,26 @@ constructor(
 
                 emitCachedAddress(account)
 
-                val loadPrices = supervisorScope {
-                    async { tokenPriceRepository.refresh(updatedCoins) }
+                coroutineScope {
+                    // Fetch the network balance in parallel with the price refresh instead of
+                    // gating it behind the refresh; emitRefreshAddress already shows the balance
+                    // using whatever price the StateFlow currently holds.
+                    val loadPrices = async { tokenPriceRepository.refresh(updatedCoins) }
+
+                    emitRefreshAddress(account)
+
+                    try {
+                        loadPrices.await()
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        Timber.e(e, "Price refresh failed for ${chain.id}")
+                    }
+
+                    // Re-emit from the cache so fiat reflects the freshly persisted balance and
+                    // price (no extra network call). On a warm start this just confirms the values
+                    // emitRefreshAddress already produced.
+                    emitCachedAddress(account)
                 }
-
-                loadPrices.await()
-
-                emitRefreshAddress(account)
             }
             .map { it.distinctByChainAndContractAddress() }
 
@@ -490,8 +545,14 @@ constructor(
             chainAndTokensToAddressMapper.map(ChainAndTokens(chain, coins))
                 ?: error("Failed to map address for chain: $chain with coins: $coins")
 
-        runCatching { tokenPriceRepository.refresh(coins) }
-            .onFailure { Timber.e(it, "Failed to refresh token prices for chain: $chain") }
+        // Refresh prices and fetch the balance concurrently (wall-clock max of the two, not the
+        // sum) instead of awaiting prices first. The balance fetch persists the value to the Room
+        // cache, so once prices land we recompute fiat from the cache without a second network
+        // call.
+        val loadPrices = async {
+            runCatching { tokenPriceRepository.refresh(coins) }
+                .onFailure { Timber.e(it, "Failed to refresh token prices for chain: $chain") }
+        }
 
         val accountToUpdate =
             finalAccount.accounts.firstOrNull { it.token.id == updatedToken.id }
@@ -500,7 +561,15 @@ constructor(
         val balance =
             balanceRepository.getTokenBalanceAndPrice(finalAccount.address, updatedToken).first()
 
-        accountToUpdate.applyBalance(balance.tokenBalance, balance.price)
+        loadPrices.await()
+
+        val refreshed =
+            balanceRepository.getCachedTokenBalanceAndPrice(finalAccount.address, updatedToken)
+        if (refreshed.tokenBalance.tokenValue != null) {
+            accountToUpdate.applyBalance(refreshed.tokenBalance, refreshed.price)
+        } else {
+            accountToUpdate.applyBalance(balance.tokenBalance, balance.price)
+        }
     }
 
     private fun Account.applyBalance(balance: TokenBalance): Account =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -182,16 +182,20 @@ constructor(
                     // fiat from the freshly persisted prices. On a warm start the StateFlow already
                     // held prices, so the per-chain emissions were already correct and this is a
                     // no-op confirmation; only a cold start (empty StateFlow) updates fiat here.
+                    // Guard both the price await and the cache recompute: a failure in either must
+                    // not skip the terminal emission below, or the UI's refresh spinner would hang
+                    // (it only stops on isComplete). On failure we keep the already-streamed
+                    // balances with their last-known fiat.
                     try {
                         loadPrices.await()
+                        addresses.recomputeFiatFromFreshPrices()
                     } catch (e: Exception) {
                         if (e is kotlinx.coroutines.CancellationException) throw e
                         Timber.e(
                             e,
-                            "Price refresh failed; emitting balances with last-known prices",
+                            "Price refresh/fiat recompute failed; emitting last-known balances",
                         )
                     }
-                    addresses.recomputeFiatFromFreshPrices()
 
                     // Terminal emission: every chain has resolved (or failed). Carries the final
                     // snapshot and flags completion so the UI can stop the refresh spinner.
@@ -312,17 +316,21 @@ constructor(
                 coroutineScope {
                     // Fetch the network balance in parallel with the price refresh instead of
                     // gating it behind the refresh; emitRefreshAddress already shows the balance
-                    // using whatever price the StateFlow currently holds.
-                    val loadPrices = async { tokenPriceRepository.refresh(updatedCoins) }
+                    // using whatever price the StateFlow currently holds. The refresh is caught
+                    // inside the async: an uncaught failure here would cancel this coroutineScope
+                    // and propagate out (catching await() alone is not enough), failing the flow.
+                    val loadPrices = async {
+                        try {
+                            tokenPriceRepository.refresh(updatedCoins)
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
+                            Timber.e(e, "Price refresh failed for ${chain.id}")
+                        }
+                    }
 
                     emitRefreshAddress(account)
 
-                    try {
-                        loadPrices.await()
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        Timber.e(e, "Price refresh failed for ${chain.id}")
-                    }
+                    loadPrices.await()
 
                     // Re-emit from the cache so fiat reflects the freshly persisted balance and
                     // price (no extra network call). On a warm start this just confirms the values

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -72,7 +72,16 @@ constructor(
 
     @ExperimentalCoroutinesApi
     override fun getPrice(token: Coin, appCurrency: AppCurrency): Flow<BigDecimal> =
-        tokenIdToPrice.map { it[token.id]?.get(appCurrency.ticker.lowercase()) ?: BigDecimal.ZERO }
+        tokenIdToPrice.map { prices ->
+            // Fall back to the last-known persisted price when the in-memory map has no entry yet.
+            // The map is empty on every cold start, so without this fallback a balance fetch that
+            // decoupled from the price refresh would price fresh balances at $0 until the refresh
+            // lands, flashing the cached fiat to zero. The cached price holds the last-known fiat
+            // until the refresh updates the StateFlow.
+            prices[token.id]?.get(appCurrency.ticker.lowercase())
+                ?: getCachedPrice(token.id, appCurrency)
+                ?: BigDecimal.ZERO
+        }
 
     override suspend fun refresh(tokens: List<Coin>) {
         val currency = appCurrencyRepository.currency.first().ticker.lowercase()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -316,6 +316,56 @@ internal class AccountsRepositoryImplTest {
             job.cancel()
         }
 
+    @Test
+    fun `loadAddressBalances still completes when the fiat recompute fails`() = runTest {
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(sol)
+        coJustRun { tokenPriceRepository.refresh(any()) }
+        coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+            listOf(wrapped(amount = CACHED, coin = sol))
+        every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            flowOf(balance(amount = NETWORK, coin = sol))
+        // The terminal recompute reads the cache; simulate a DB/cache read failure there.
+        coEvery { balanceRepository.getCachedTokenBalanceAndPrice(SOL_ADDRESS, sol) } throws
+            IllegalStateException("cache read failed")
+
+        val emissions = mutableListOf<AddressBalancesUpdate>()
+        val job = launch { repository.loadAddressBalances(VAULT_ID).collect(emissions::add) }
+        advanceUntilIdle()
+
+        // Completion must still fire — otherwise the pull-to-refresh spinner hangs — and it carries
+        // the already-streamed balance with its last-known fiat.
+        val terminal = emissions.last()
+        assertTrue(terminal.isComplete, "load must complete even when the fiat recompute fails")
+        assertEquals(NETWORK, terminal.addresses.solValue())
+        job.cancel()
+    }
+
+    @Test
+    fun `loadAddress surfaces balances even when the price refresh throws`() = runTest {
+        val eth = Coins.Ethereum.ETH.copy(address = ETH_ADDRESS)
+        val vault = Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(eth))
+        coEvery { vaultRepository.get(VAULT_ID) } returns vault
+        // A failing refresh must not tear down the flow (catching await() alone would not, since
+        // the async failure cancels the enclosing coroutineScope).
+        coEvery { tokenPriceRepository.refresh(any()) } throws RuntimeException("coingecko 429")
+        every { balanceRepository.getTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
+            flowOf(balance(amount = ETH_NETWORK, coin = eth))
+        coEvery { balanceRepository.getCachedTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
+            balance(amount = ETH_NETWORK, coin = eth)
+
+        val emissions = mutableListOf<Address>()
+        // Collecting would throw without the fix; the assertion is that it completes normally.
+        repository.loadAddress(VAULT_ID, Chain.Ethereum).collect(emissions::add)
+
+        val finalEth = emissions.lastOrNull()?.accounts?.firstOrNull { it.token.id == eth.id }
+        assertEquals(
+            ETH_NETWORK,
+            finalEth?.tokenValue?.value?.toLong(),
+            "balance should surface even though the price refresh failed",
+        )
+    }
+
     private fun stubVault(vararg coins: Coin) {
         val vault = Vault(id = VAULT_ID, name = "Test Vault", coins = coins.toList())
         every { vaultRepository.getAsFlow(VAULT_ID) } returns flowOf(vault)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -62,7 +62,12 @@ internal class AccountsRepositoryImplTest {
         // about the recomputed terminal values override it per coin.
         coEvery { balanceRepository.getCachedTokenBalanceAndPrice(any(), any()) } coAnswers
             {
-                balanceWithFiat(amount = 0L, fiat = 0L, coin = secondArg<Coin>())
+                balanceWithFiat(
+                    amount = 0L,
+                    fiat = 0L,
+                    coin = secondArg<Coin>(),
+                    price = BigDecimal.ZERO,
+                )
             }
     }
 
@@ -313,6 +318,10 @@ internal class AccountsRepositoryImplTest {
                 terminal.addresses.solFiat(),
                 "fiat should populate once prices land, without a second balance fetch",
             )
+            verify(exactly = 1) { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) }
+            coVerify(exactly = 1) {
+                balanceRepository.getCachedTokenBalanceAndPrice(SOL_ADDRESS, sol)
+            }
             job.cancel()
         }
 
@@ -384,14 +393,19 @@ internal class AccountsRepositoryImplTest {
             price = FiatValue(BigDecimal.ONE, USD),
         )
 
-    private fun balanceWithFiat(amount: Long, fiat: Long, coin: Coin) =
+    private fun balanceWithFiat(
+        amount: Long,
+        fiat: Long,
+        coin: Coin,
+        price: BigDecimal = BigDecimal.ONE,
+    ) =
         TokenBalanceAndPrice(
             tokenBalance =
                 TokenBalance(
                     tokenValue = TokenValue(BigInteger.valueOf(amount), coin.ticker, coin.decimal),
                     fiatValue = FiatValue(BigDecimal.valueOf(fiat), USD),
                 ),
-            price = FiatValue(BigDecimal.ONE, USD),
+            price = FiatValue(price, USD),
         )
 
     private fun gatedBalance(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -56,6 +56,14 @@ internal class AccountsRepositoryImplTest {
                 chainAndTokensToAddressMapper = ChainAndTokensToAddressMapperImpl(),
                 splTokenRepository = splTokenRepository,
             )
+
+        // After every chain resolves, loadAddressBalances recomputes fiat from the Room cache once
+        // the price refresh lands. Default this read to a zero-priced snapshot; tests that care
+        // about the recomputed terminal values override it per coin.
+        coEvery { balanceRepository.getCachedTokenBalanceAndPrice(any(), any()) } coAnswers
+            {
+                balanceWithFiat(amount = 0L, fiat = 0L, coin = secondArg<Coin>())
+            }
     }
 
     @Test
@@ -156,6 +164,13 @@ internal class AccountsRepositoryImplTest {
         every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
             gatedBalance(solanaGate, amount = SOL_NETWORK, coin = sol)
 
+        // The terminal emission recomputes fiat from the cache; mirror the network balances there
+        // so the persisted values carry through completion.
+        coEvery { balanceRepository.getCachedTokenBalanceAndPrice(ETH_ADDRESS, eth) } returns
+            balance(amount = ETH_NETWORK, coin = eth)
+        coEvery { balanceRepository.getCachedTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+            balance(amount = SOL_NETWORK, coin = sol)
+
         val emissions = mutableListOf<AddressBalancesUpdate>()
         val job = launch { repository.loadAddressBalances(VAULT_ID).collect(emissions::add) }
 
@@ -248,6 +263,59 @@ internal class AccountsRepositoryImplTest {
         job.cancel()
     }
 
+    @Test
+    fun `balances stream before the price refresh completes and fiat updates once prices land`() =
+        runTest {
+            val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+            stubVault(sol)
+
+            // The price refresh is slow/gated — it must not hold up the crypto amount.
+            val priceGate = CompletableDeferred<Unit>()
+            coEvery { tokenPriceRepository.refresh(any()) } coAnswers { priceGate.await() }
+
+            coEvery { balanceRepository.getCachedTokenBalances(any(), any()) } returns
+                listOf(wrapped(amount = CACHED, coin = sol))
+            // Network balance resolves immediately; on a cold start its fiat is $0 because the
+            // price
+            // StateFlow is still empty.
+            every { balanceRepository.getTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+                flowOf(balanceWithFiat(amount = NETWORK, fiat = 0L, coin = sol))
+            // Once prices land, the Room cache yields the same balance, now priced.
+            coEvery { balanceRepository.getCachedTokenBalanceAndPrice(SOL_ADDRESS, sol) } returns
+                balanceWithFiat(amount = NETWORK, fiat = NETWORK, coin = sol)
+
+            val emissions = mutableListOf<AddressBalancesUpdate>()
+            val job = launch { repository.loadAddressBalances(VAULT_ID).collect(emissions::add) }
+
+            advanceUntilIdle()
+
+            // The crypto amount is already streamed even though the price refresh is still blocked
+            // —
+            // this is the decoupling the issue asks for. Before the fix the balance waited on
+            // loadPrices.await().
+            val streamed = emissions.last()
+            assertEquals(NETWORK, streamed.addresses.solValue())
+            assertEquals(0L, streamed.addresses.solFiat(), "fiat is not priced yet on cold start")
+            assertTrue(
+                emissions.none { it.isComplete },
+                "load must not complete while the price refresh is pending",
+            )
+
+            priceGate.complete(Unit)
+            advanceUntilIdle()
+
+            // Once prices resolve, the terminal emission recomputes fiat from the cache.
+            val terminal = emissions.last()
+            assertTrue(terminal.isComplete)
+            assertEquals(NETWORK, terminal.addresses.solValue())
+            assertEquals(
+                NETWORK,
+                terminal.addresses.solFiat(),
+                "fiat should populate once prices land, without a second balance fetch",
+            )
+            job.cancel()
+        }
+
     private fun stubVault(vararg coins: Coin) {
         val vault = Vault(id = VAULT_ID, name = "Test Vault", coins = coins.toList())
         every { vaultRepository.getAsFlow(VAULT_ID) } returns flowOf(vault)
@@ -263,6 +331,16 @@ internal class AccountsRepositoryImplTest {
     private fun balance(amount: Long, coin: Coin) =
         TokenBalanceAndPrice(
             tokenBalance = tokenBalance(amount, coin),
+            price = FiatValue(BigDecimal.ONE, USD),
+        )
+
+    private fun balanceWithFiat(amount: Long, fiat: Long, coin: Coin) =
+        TokenBalanceAndPrice(
+            tokenBalance =
+                TokenBalance(
+                    tokenValue = TokenValue(BigInteger.valueOf(amount), coin.ticker, coin.decimal),
+                    fiatValue = FiatValue(BigDecimal.valueOf(fiat), USD),
+                ),
             price = FiatValue(BigDecimal.ONE, USD),
         )
 
@@ -285,6 +363,14 @@ internal class AccountsRepositoryImplTest {
         firstOrNull { it.chain == chain }?.accounts?.firstOrNull()?.tokenValue?.value?.toLong()
 
     private fun List<Address>.solValue(): Long? = value(Chain.Solana)
+
+    private fun List<Address>.solFiat(): Long? =
+        firstOrNull { it.chain == Chain.Solana }
+            ?.accounts
+            ?.firstOrNull()
+            ?.fiatValue
+            ?.value
+            ?.toLong()
 
     private companion object {
         const val VAULT_ID = "vault-1"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -91,6 +91,30 @@ internal class TokenPriceRepositoryImplTest {
     }
 
     @Test
+    fun `getPrice falls back to the persisted price before any refresh`() = runTest {
+        // Cold start: the in-memory map is empty, but Room holds a last-known price. getPrice must
+        // serve it instead of $0 so decoupled balance fetches don't flash cached fiat to zero.
+        coEvery { tokenPriceDao.getTokenPrice(ezEth.id, "usd") } returns "3500.0"
+
+        val price = repository.getPrice(ezEth, AppCurrency.USD).first()
+
+        assertEquals(BigDecimal("3500.0"), price)
+    }
+
+    @Test
+    fun `getPrice prefers the refreshed in-memory price over the persisted price`() = runTest {
+        // Room holds a stale price, but a refresh populated the in-memory map with a newer one.
+        coEvery { tokenPriceDao.getTokenPrice(ezEth.id, "usd") } returns "3000.0"
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns
+            mapOf("ezETH" to mapOf("usd" to BigDecimal("3400.0")))
+
+        repository.refresh(listOf(ezEth))
+        val price = repository.getPrice(ezEth, AppCurrency.USD).first()
+
+        assertEquals(BigDecimal("3400.0"), price)
+    }
+
+    @Test
     fun `does not call contract-address lookup when priceProviderID returns a price`() = runTest {
         coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns
             mapOf("ezETH" to mapOf("usd" to BigDecimal("3400.0")))


### PR DESCRIPTION
## Summary

Fixes #5077.

Each per-address coroutine in `AccountsRepository` awaited the **full price refresh before fetching balances**, so a slow price feed (measured batch RTT ≈ 540 ms, plus trailing THOR/Maya pool calls) delayed balances even for chains that need no pricing — and a failed refresh blocked *every* balance fetch. Prices are served from an in-memory `MutableStateFlow` (`tokenIdToPrice`) that resolves instantly, and `getTokenBalanceAndPrice` zips it with a single-shot balance flow, so `.first()` just snapshots whatever price is present at collection time. The `loadPrices.await()` gate was a **sequencing artifact**, not a real data dependency (desktop already decouples these).

## Changes

- **`loadAddressBalances`** — removed the per-chain `loadPrices.await()` gate so balances fetch immediately in parallel with the refresh and stream as each chain resolves. After every chain resolves, fiat is recomputed from the freshly persisted prices via a new `recomputeFiatFromFreshPrices()` helper that reuses the Room-cache read (`getCachedTokenBalanceAndPrice`) — **no extra network calls**. The terminal `isComplete=true` emission is preserved, and a price-refresh failure is caught so it can't block completion.
- **`loadAddress`** — replaced the `supervisorScope`-joined refresh (which serialized refresh → balance) with a `coroutineScope`/`async` so the balance fetch runs concurrently with the refresh, then re-emits from cache once prices land.
- **`loadAccount`** — the refresh now runs as `async` concurrently with the balance fetch (wall-clock `max` instead of sum), then recomputes fiat from cache.

## Correctness / risks

- `$0`-fiat flicker only on a first-ever cold start (empty in-memory price StateFlow). Rates persist in Room + StateFlow, so warm starts never flicker — the recompute is a no-op confirmation there.
- No change to call count / load; independent of the Multicall and TTL work.
- A failed price refresh no longer blocks balance display.

## Acceptance criteria

- [x] Crypto amounts render without waiting for the price refresh.
- [x] A slow/stubbed price endpoint no longer delays balance amounts for price-independent chains.
- [x] Fiat populates/updates once prices land (no permanent `$0` on warm start).
- [x] Cached-snapshot-first cold-start behavior + `isComplete` terminal emission unchanged.

## Test plan

- `AccountsRepositoryImplTest` updated for the cache-recompute path.
- New test **`balances stream before the price refresh completes and fiat updates once prices land`**: gates the price refresh, asserts the crypto amount surfaces with `$0` fiat while prices are still pending, then asserts fiat populates on the terminal emission once prices resolve (no second balance fetch).
- `./gradlew :data:testDebugUnitTest --tests "*AccountsRepositoryImplTest"` green; ktfmt applied.

_Part of a cross-app balance-fetching initiative (also filed for vultisig-ios)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Balance streaming now prioritizes immediate crypto amount updates while token price refresh happens independently, without delaying partial results.
  * When loading completes, fiat values are recalculated from the latest persisted cached balance/price, improving accuracy across address and account views.
  * Token price lookup now falls back to persisted (cached) prices when in-memory data is empty.
  * Token price refresh errors are logged and handled gracefully so completion still completes.

* **Tests**
  * Updated/added repository tests to verify streaming vs. refresh timing, correct fiat recomputation from cache, cold-start price fallback, and resilience to refresh/cache failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->