### PR TITLE
fix(defi): prune disabled chains from persisted DeFi selection

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainSelectionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainSelectionViewModel.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.hasPreGeneratedKey
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -53,6 +54,7 @@ constructor(
     private val tokenRepository: TokenRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val discoverTokenUseCase: DiscoverTokenUseCase,
+    private val defaultDeFiChainsRepository: DefaultDeFiChainsRepository,
     private val navigator: Navigator<Destination>,
     private val requestResultRepository: RequestResultRepository,
     private val snackbarFlow: SnackbarFlow,
@@ -129,6 +131,13 @@ constructor(
                     }
             }
             toDisableAccounts.forEach { disableAccount(it.coin) }
+
+            // Keep the persisted DeFi chain selection in sync: a chain removed from the vault
+            // must not silently resurrect in the DeFi Portfolio when it is later re-enabled.
+            defaultDeFiChainsRepository.removeChains(
+                vaultId,
+                toDisableAccounts.map { it.coin.chain }.toSet(),
+            )
 
             if (failedChains.isNotEmpty()) {
                 val shown = failedChains.take(MAX_FAILED_CHAINS_SHOWN).joinToString(", ")

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ChainSelectionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ChainSelectionViewModelTest.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -48,6 +49,7 @@ internal class ChainSelectionViewModelTest {
     private lateinit var tokenRepository: TokenRepository
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var discoverTokenUseCase: DiscoverTokenUseCase
+    private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
     private lateinit var navigator: Navigator<Destination>
     private lateinit var requestResultRepository: RequestResultRepository
     private lateinit var snackbarFlow: SnackbarFlow
@@ -63,6 +65,7 @@ internal class ChainSelectionViewModelTest {
         chainAccountAddressRepository = mockk(relaxed = true)
         discoverTokenUseCase = mockk()
         every { discoverTokenUseCase(any(), any()) } just Runs
+        defaultDeFiChainsRepository = mockk(relaxed = true)
         navigator = mockk(relaxed = true)
         requestResultRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
@@ -192,6 +195,43 @@ internal class ChainSelectionViewModelTest {
             verify { discoverTokenUseCase(VAULT_ID, Chain.Bitcoin.raw) }
         }
 
+    @Test
+    fun `prunes disabled chains from the persisted DeFi chain selection`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+            vm.uiState.update {
+                it.copy(
+                    chains =
+                        listOf(
+                            ChainUiModel(isEnabled = false, coin = nativeCoin(Chain.ThorChain)),
+                            ChainUiModel(isEnabled = true, coin = nativeCoin(Chain.Ethereum)),
+                        )
+                )
+            }
+
+            vm.onCommitChanges()
+            advanceUntilIdle()
+
+            coVerify { defaultDeFiChainsRepository.removeChains(VAULT_ID, setOf(Chain.ThorChain)) }
+        }
+
+    @Test
+    fun `does not prune any DeFi chains when nothing is disabled`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+            vm.uiState.update {
+                it.copy(
+                    chains =
+                        listOf(ChainUiModel(isEnabled = true, coin = nativeCoin(Chain.Ethereum)))
+                )
+            }
+
+            vm.onCommitChanges()
+            advanceUntilIdle()
+
+            coVerify { defaultDeFiChainsRepository.removeChains(VAULT_ID, emptySet()) }
+        }
+
     private fun createViewModel() =
         ChainSelectionViewModel(
             savedStateHandle = mockk(relaxed = true),
@@ -199,6 +239,7 @@ internal class ChainSelectionViewModelTest {
             tokenRepository = tokenRepository,
             chainAccountAddressRepository = chainAccountAddressRepository,
             discoverTokenUseCase = discoverTokenUseCase,
+            defaultDeFiChainsRepository = defaultDeFiChainsRepository,
             navigator = navigator,
             requestResultRepository = requestResultRepository,
             snackbarFlow = snackbarFlow,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefaultDeFiChainsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefaultDeFiChainsRepository.kt
@@ -7,9 +7,12 @@ import com.vultisig.wallet.data.sources.AppDataStore
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 
 interface DefaultDeFiChainsRepository {
     suspend fun setDefaultChains(vaultId: String, chains: Set<Chain>)
+
+    suspend fun removeChains(vaultId: String, chains: Set<Chain>)
 
     fun getDefaultChains(vaultId: String): Flow<Set<Chain>>
 }
@@ -26,6 +29,14 @@ constructor(private val dataStore: AppDataStore) : DefaultDeFiChainsRepository {
             preferences[chainsKey] = chains.map { it.raw }.toSet()
             preferences[hasBeenSetKey] = true
         }
+    }
+
+    override suspend fun removeChains(vaultId: String, chains: Set<Chain>) {
+        if (chains.isEmpty()) return
+        val current = getDefaultChains(vaultId).first()
+        val updated = current - chains
+        if (updated == current) return
+        setDefaultChains(vaultId, updated)
     }
 
     override fun getDefaultChains(vaultId: String): Flow<Set<Chain>> {


### PR DESCRIPTION
## Summary

Fixes #5093.

Disabling a chain in **Wallet → Select chains** removed it from the vault but left it a member of the persisted DeFi chain set (`defi_chains_<vaultId>`). Because the DeFi Portfolio / *Select DeFi chains* screens derive their *available* chains from the vault's coins, the stale membership stayed dormant while the chain was gone — and silently resurrected (re-appearing as **enabled** in the DeFi Portfolio) when the chain was later re-enabled.

This keeps the two stores in sync: when chains are disabled in the Wallet selector commit path, they are also pruned from the persisted DeFi set. Re-enabling a chain now comes back in a neutral (unselected) state; the user must explicitly opt it back into DeFi via *Select DeFi chains*.

## Changes

- `DefaultDeFiChainsRepository`: new `removeChains(vaultId, chains)` that prunes chains from the effective set and persists **only when something actually changes** — so disabling an unrelated / non-DeFi chain never needlessly materializes defaults or flips the `hasBeenSet` flag.
- `ChainSelectionViewModel.onCommitChanges()`: after disabling accounts, prune the disabled chains from the DeFi set.

## Edge cases handled

- Never-customized vault (default DeFi set `{ThorChain, Ethereum}`): disabling ThorChain persists `{Ethereum}`, so it won't reappear on re-enable.
- Disabling a chain not in the DeFi set (or a non-DeFi chain): no-op, defaults stay un-materialized.

## Test plan

- Added `ChainSelectionViewModelTest` cases: prunes disabled chains on commit; passes an empty set when nothing is disabled.
- `ChainSelectionViewModelTest` + `DeFiChainSelectionViewModelTest` green.
- ktfmt applied.

## Related

- #5085 / #5090 (immediate refresh of the DeFi list after editing DeFi chains)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When vault chain selections are reduced, matching DeFi chain selections are now removed too.
  * Empty updates are handled safely without changing saved selections.
  * Added coverage for both removal and no-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->