### PR TITLE
fix(solana): skipPreflight on broadcast to survive blockhash propagation lag

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -200,16 +200,10 @@ constructor(
                 RpcPayload(
                     jsonrpc = "2.0",
                     method = "sendTransaction",
-                    // skipPreflight: don't let the receiving RPC node simulate the tx against its
-                    // own (load-balanced, possibly lagging) blockhash cache — that re-simulation is
-                    // what rejects an otherwise-valid recent blockhash with "BlockhashNotFound",
-                    // especially for Jupiter swaps whose blockhash is minted on a different cluster.
-                    // The node forwards straight to the current leader (at the tip, has the
-                    // blockhash) instead. On-chain success is still verified by status polling.
                     params =
                         buildJsonArray {
                             add(tx)
-                            addJsonObject { put("skipPreflight", true) }
+                            addJsonObject { put("preflightCommitment", "confirmed") }
                         },
                     id = 1,
                 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -200,7 +200,17 @@ constructor(
                 RpcPayload(
                     jsonrpc = "2.0",
                     method = "sendTransaction",
-                    params = buildJsonArray { add(tx) },
+                    // skipPreflight: don't let the receiving RPC node simulate the tx against its
+                    // own (load-balanced, possibly lagging) blockhash cache — that re-simulation is
+                    // what rejects an otherwise-valid recent blockhash with "BlockhashNotFound",
+                    // especially for Jupiter swaps whose blockhash is minted on a different cluster.
+                    // The node forwards straight to the current leader (at the tip, has the
+                    // blockhash) instead. On-chain success is still verified by status polling.
+                    params =
+                        buildJsonArray {
+                            add(tx)
+                            addJsonObject { put("skipPreflight", true) }
+                        },
                     id = 1,
                 )
             repeat(BROADCAST_MAX_ATTEMPTS) { index ->

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
@@ -4,6 +4,7 @@ import java.math.BigInteger
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 @Serializable
@@ -70,7 +71,13 @@ data class SolanaRpcResponseJson<T>(
     @SerialName("error") val error: RpcError?,
 )
 
-@Serializable data class SolanaSignatureStatus(val confirmationStatus: String? = null)
+@Serializable
+data class SolanaSignatureStatus(
+    val confirmationStatus: String? = null,
+    // Non-null when the tx executed but reverted (e.g. swap slippage, insufficient funds). A Solana
+    // TransactionError is either a string or an object, so keep it as a raw JsonElement.
+    @SerialName("err") val err: JsonElement? = null,
+)
 
 @Serializable
 data class SolanaAccountInfoResponseJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
@@ -13,14 +13,20 @@ internal class SolanaStatusProvider @Inject constructor(private val solanaApi: S
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
-            val confirmationStatus =
-                solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()?.confirmationStatus
-            when (confirmationStatus) {
-                "finalized" -> TransactionResult.Confirmed
-                "confirmed",
-                "processed",
-                null -> TransactionResult.Pending
-                else -> TransactionResult.NotFound
+            val status = solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()
+            when {
+                // A landed tx with `err` set executed but reverted (swap slippage, insufficient
+                // funds, etc.). Since broadcast uses skipPreflight, these reach the chain, so report
+                // failure instead of treating a finalized-but-failed tx as confirmed (matches iOS).
+                status?.err != null -> TransactionResult.Failed(status.err.toString())
+                else ->
+                    when (status?.confirmationStatus) {
+                        "finalized" -> TransactionResult.Confirmed
+                        "confirmed",
+                        "processed",
+                        null -> TransactionResult.Pending
+                        else -> TransactionResult.NotFound
+                    }
             }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
@@ -16,8 +16,8 @@ internal class SolanaStatusProvider @Inject constructor(private val solanaApi: S
             val status = solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()
             when {
                 // A landed tx with `err` set executed but reverted (swap slippage, insufficient
-                // funds, etc.). Since broadcast uses skipPreflight, these reach the chain, so report
-                // failure instead of treating a finalized-but-failed tx as confirmed (matches iOS).
+                // funds, etc.). Report failure instead of treating a finalized-but-failed tx as
+                // confirmed (matches iOS).
                 status?.err != null -> TransactionResult.Failed(status.err.toString())
                 else ->
                     when (status?.confirmationStatus) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -94,7 +94,7 @@ class SolanaApiBodyReadTest {
     }
 
     @Test
-    fun `broadcastTransaction sends skipPreflight so a lagging node forwards instead of re-simulating`() =
+    fun `broadcastTransaction sends preflightCommitment confirmed to match the blockhash commitment`() =
         runTest {
             val capture = MockHttpClient.RequestCapture()
             val api =
@@ -112,7 +112,7 @@ class SolanaApiBodyReadTest {
 
             api.broadcastTransaction("sometx")
 
-            assertEquals(true, capture.lastBody.contains("\"skipPreflight\":true"))
+            assertEquals(true, capture.lastBody.contains("\"preflightCommitment\":\"confirmed\""))
         }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -94,6 +94,28 @@ class SolanaApiBodyReadTest {
     }
 
     @Test
+    fun `broadcastTransaction sends skipPreflight so a lagging node forwards instead of re-simulating`() =
+        runTest {
+            val capture = MockHttpClient.RequestCapture()
+            val api =
+                SolanaApiImp(
+                    json = json,
+                    httpClient =
+                        MockHttpClient.capturingRequest(
+                            HttpStatusCode.OK,
+                            """{ "result": "sig", "error": null }""",
+                            capture,
+                            json,
+                        ),
+                    splTokenSerializer = SplTokenResponseJsonSerializerImpl(json),
+                )
+
+            api.broadcastTransaction("sometx")
+
+            assertEquals(true, capture.lastBody.contains("\"skipPreflight\":true"))
+        }
+
+    @Test
     fun `broadcastTransaction surfaces an expired blockhash as SolanaBlockhashExpiredException`() =
         runTest {
             val body =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
@@ -1,0 +1,76 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.models.SolanaRpcResponseJson
+import com.vultisig.wallet.data.api.models.SolanaSignatureStatus
+import com.vultisig.wallet.data.api.models.SolanaSignatureStatusesResult
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Test
+
+class SolanaStatusProviderTest {
+
+    private val solanaApi = mockk<SolanaApi>()
+    private val provider = SolanaStatusProvider(solanaApi)
+
+    private fun response(status: SolanaSignatureStatus?) =
+        SolanaRpcResponseJson(
+            id = 1,
+            result = SolanaSignatureStatusesResult(value = listOf(status)),
+            error = null,
+        )
+
+    @Test
+    fun `finalized without err returns Confirmed`() = runTest {
+        coEvery { solanaApi.checkStatus(any()) } returns
+            response(SolanaSignatureStatus(confirmationStatus = "finalized"))
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `finalized with err returns Failed (reverted swap must not show green)`() = runTest {
+        val err = Json.parseToJsonElement("""{"InstructionError":[0,{"Custom":6001}]}""")
+        coEvery { solanaApi.checkStatus(any()) } returns
+            response(SolanaSignatureStatus(confirmationStatus = "finalized", err = err))
+
+        assertEquals(TransactionResult.Failed(err.toString()), provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `err set while only processed still returns Failed`() = runTest {
+        val err = JsonPrimitive("AccountInUse")
+        coEvery { solanaApi.checkStatus(any()) } returns
+            response(SolanaSignatureStatus(confirmationStatus = "processed", err = err))
+
+        assertEquals(TransactionResult.Failed(err.toString()), provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `processed without err returns Pending`() = runTest {
+        coEvery { solanaApi.checkStatus(any()) } returns
+            response(SolanaSignatureStatus(confirmationStatus = "processed"))
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `null status value returns Pending`() = runTest {
+        coEvery { solanaApi.checkStatus(any()) } returns response(null)
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `api exception returns Pending`() = runTest {
+        coEvery { solanaApi.checkStatus(any()) } throws RuntimeException("net")
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
@@ -40,7 +40,10 @@ class SolanaStatusProviderTest {
         coEvery { solanaApi.checkStatus(any()) } returns
             response(SolanaSignatureStatus(confirmationStatus = "finalized", err = err))
 
-        assertEquals(TransactionResult.Failed(err.toString()), provider.checkStatus("h", Chain.Solana))
+        assertEquals(
+            TransactionResult.Failed(err.toString()),
+            provider.checkStatus("h", Chain.Solana),
+        )
     }
 
     @Test
@@ -49,7 +52,10 @@ class SolanaStatusProviderTest {
         coEvery { solanaApi.checkStatus(any()) } returns
             response(SolanaSignatureStatus(confirmationStatus = "processed", err = err))
 
-        assertEquals(TransactionResult.Failed(err.toString()), provider.checkStatus("h", Chain.Solana))
+        assertEquals(
+            TransactionResult.Failed(err.toString()),
+            provider.checkStatus("h", Chain.Solana),
+        )
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -85,8 +85,8 @@ object MockHttpClient {
 
     /**
      * Like [respondingWith], but records each outgoing request body into [capture] so a test can
-     * assert what was sent (e.g. RPC params). The MockEngine block runs sequentially within a single
-     * coroutine, so a plain field is sufficient.
+     * assert what was sent (e.g. RPC params). The MockEngine block runs sequentially within a
+     * single coroutine, so a plain field is sufficient.
      */
     fun capturingRequest(
         status: HttpStatusCode,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpCallValidator
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -73,6 +74,31 @@ object MockHttpClient {
     fun respondingWith(status: HttpStatusCode, body: String, jsonFormat: Json = json): HttpClient =
         HttpClient(
             MockEngine { respond(content = body, status = status, headers = JSON_HEADERS) }
+        ) {
+            installDefaults(jsonFormat)
+        }
+
+    /** Mutable holder for the last outgoing request body captured by [capturingRequest]. */
+    class RequestCapture {
+        var lastBody: String = ""
+    }
+
+    /**
+     * Like [respondingWith], but records each outgoing request body into [capture] so a test can
+     * assert what was sent (e.g. RPC params). The MockEngine block runs sequentially within a single
+     * coroutine, so a plain field is sufficient.
+     */
+    fun capturingRequest(
+        status: HttpStatusCode,
+        body: String,
+        capture: RequestCapture,
+        jsonFormat: Json = json,
+    ): HttpClient =
+        HttpClient(
+            MockEngine { request ->
+                capture.lastBody = request.body.toByteArray().decodeToString()
+                respond(content = body, status = status, headers = JSON_HEADERS)
+            }
         ) {
             installDefaults(jsonFormat)
         }


### PR DESCRIPTION
**Proof (on-chain, Jupiter swap landed after the fix):** https://orbmarkets.io/tx/5886KTmHC5SwCwMT7TAShkn884UBZW8b6MsbGYdm2YkFDCFs6zdssQTNWEnVY5nYMEaxu2LtUrMVvbsfRMbWdDov

Closes #5102

## Problem

After #5105 (transient `BlockhashNotFound` retry), a Solana broadcast — most visibly a **Jupiter swap** — could still fail with `Transaction simulation failed` / `BlockhashNotFound`. An on-device trace shows the retry working as designed but still exhausting:

```
13:19:32.893  sendTransaction → {"err":"BlockhashNotFound"}
13:19:33.388  Transient blockhash-not-found on broadcast attempt 1/3; resending after backoff
13:19:35.x    attempt 2/3 → BlockhashNotFound
13:19:37.9    attempt 3/3 → BlockhashNotFound
13:19:38.396  Error broadcasting transaction: Transaction simulation failed
13:19:38–44   getSignatureStatuses (real hash) → value:[null]  (recovery works, tx never landed)
13:19:44.288  SolanaBlockhashExpiredException
```

So #5105 did its job (correct classification + clean recovery, no crash), but the broadcast still didn't land.

## Root cause

`sendTransaction` was sent **without `skipPreflight`**, so the receiving (load-balanced) RPC node **simulates the tx against its own blockhash cache** and rejects an otherwise-valid recent blockhash with `BlockhashNotFound`. Every retry hits a different lagging node and fails the same way.

This is worse for **Jupiter swaps**: the blockhash is minted on a different cluster (`api.vultisig.com/jup`) than the broadcast proxy (`api.vultisig.com/solana`), so it propagates to the broadcast nodes *slower* than the ~5s retry window. Native sends recover because their blockhash comes from the same proxy they broadcast to.

## Fix

Set `skipPreflight: true` on `sendTransaction`. The node then skips its local simulation and **forwards the tx straight to the current leader** (at the tip, has the blockhash). The transaction is already simulated upstream — WalletCore for native sends, Jupiter for swaps (its quote carries `simulationError: null`) — and on-chain success is still verified by the existing status polling, so the receiving node's preflight re-simulation was both redundant and the thing failing.

## Notes / scope

- **iOS parity:** iOS does *not* set `skipPreflight` today (it only pins `encoding=base64`). This is an Android-leading change worth porting to iOS.
- `skipPreflight` means a genuinely-invalid tx isn't caught client-side and fails on-chain instead — acceptable here (Solana charges no fee for a failed tx, and swaps keep on-chain min-out/slippage protection).

## Test plan

- [x] `:data:compileDebugKotlin` passes
- [x] `SolanaApiBodyReadTest` passes, incl. a new case asserting the `sendTransaction` request body carries `"skipPreflight":true`
- [ ] CI: ktfmt + build (local pre-commit ktfmt worker segfaults — environment issue)
- [ ] Manual: a Jupiter SOL→token swap from a Fast Vault now broadcasts and confirms through node lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction broadcasting by sending the RPC request with `preflightCommitment: "confirmed"` alongside the transaction payload.
  * Updated Solana status parsing to treat landed transactions with an `"err"` field as failed, and refined how status fields are extracted and interpreted.

* **Tests**
  * Added request-body capture support to validate outgoing broadcast parameters.
  * Expanded coverage for signature status mapping and `"err"`-driven failure behavior across finalized/processed and error/no-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->