### PR TITLE
fix(tokens): show sub-cent token prices instead of $0.00

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -297,7 +297,10 @@ constructor(
                                     chainLogo = chain.logo,
                                     monotoneChainLogo = chain.monoToneLogo,
                                     mergeBalance = mergeBalances.findMergeBalance(token).toString(),
-                                    price = account.price?.let { fiatValueToStringMapper(it) },
+                                    price =
+                                        account.price?.let {
+                                            fiatValueToStringMapper(it, asPrice = true)
+                                        },
                                     network = token.chain.raw,
                                 )
                             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/CustomTokenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/CustomTokenViewModel.kt
@@ -59,7 +59,7 @@ constructor(
             if (searchedToken == null) {
                 showError()
             } else {
-                val price = fiatValueToStringMapper(searchedToken.fiatValue)
+                val price = fiatValueToStringMapper(searchedToken.fiatValue, asPrice = true)
                 Timber.d("token url: ${searchedToken.coin.logo}")
                 uiModel.update {
                     it.copy(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -136,7 +136,10 @@ constructor(
                                         tokenLogo = getCoinLogo(token.logo),
                                         chainLogo = chain.logo,
                                         mergeBalance = mergedBalance,
-                                        price = account.price?.let { fiatValueToStringMapper(it) },
+                                        price =
+                                            account.price?.let {
+                                                fiatValueToStringMapper(it, asPrice = true)
+                                            },
                                         network = token.chain.raw,
                                     )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapper.kt
@@ -15,23 +15,33 @@ internal interface FiatValueToStringMapper {
      * When [asFee] is true and the value lies between zero and one standard sub-unit of the
      * currency (e.g. less than `0.01` for USD, less than `1` for JPY), the result is rendered with
      * extra precision (up to three extra fraction digits) using [RoundingMode.DOWN] so a sub-unit
-     * fee like `$0.001234` displays as `$0.00123` instead of being truncated to `$0.00`. All other
-     * values fall through to the currency's standard formatting.
+     * fee like `$0.001234` displays as `$0.00123` instead of being truncated to `$0.00`.
+     *
+     * When [asPrice] is true and the value is a sub-unit price, the result is rendered with enough
+     * fraction digits to reveal its first significant figures, so a tiny per-token price like
+     * LUNC's `$0.00006` displays as `$0.00006` instead of collapsing to `$0.00`.
+     *
+     * All other values fall through to the currency's standard formatting. [asFee] takes precedence
+     * over [asPrice] when both are set.
      */
-    suspend operator fun invoke(value: FiatValue, asFee: Boolean = false): String
+    suspend operator fun invoke(
+        value: FiatValue,
+        asFee: Boolean = false,
+        asPrice: Boolean = false,
+    ): String
 }
 
 internal class FiatValueToStringMapperImpl
 @Inject
 constructor(private val appCurrencyRepository: AppCurrencyRepository) : FiatValueToStringMapper {
 
-    override suspend fun invoke(value: FiatValue, asFee: Boolean): String {
+    override suspend fun invoke(value: FiatValue, asFee: Boolean, asPrice: Boolean): String {
         val currency = Currency.getInstance(value.currency)
         val format =
             (appCurrencyRepository.getCurrencyFormat().clone() as NumberFormat).apply {
                 this.currency = currency
             }
-        if (!asFee) {
+        if (!asFee && !asPrice) {
             return format.format(value.value)
         }
         val standardDigits = currency.defaultFractionDigits.coerceAtLeast(0)
@@ -40,12 +50,23 @@ constructor(private val appCurrencyRepository: AppCurrencyRepository) : FiatValu
             return format.format(value.value)
         }
         format.minimumFractionDigits = standardDigits
-        format.maximumFractionDigits = standardDigits + EXTRA_FEE_PRECISION_DIGITS
-        format.roundingMode = RoundingMode.DOWN
+        if (asFee) {
+            format.maximumFractionDigits = standardDigits + EXTRA_FEE_PRECISION_DIGITS
+            format.roundingMode = RoundingMode.DOWN
+        } else {
+            // Number of zeros between the decimal point and the first significant digit, so we can
+            // extend precision just far enough to reveal the price's leading figures.
+            val leadingZeros = value.value.scale() - value.value.precision()
+            format.maximumFractionDigits =
+                (leadingZeros + PRICE_SIGNIFICANT_DIGITS).coerceAtMost(MAX_PRICE_FRACTION_DIGITS)
+            format.roundingMode = RoundingMode.HALF_UP
+        }
         return format.format(value.value)
     }
 
     private companion object {
         private const val EXTRA_FEE_PRECISION_DIGITS = 3
+        private const val PRICE_SIGNIFICANT_DIGITS = 2
+        private const val MAX_PRICE_FRACTION_DIGITS = 8
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
@@ -92,4 +92,40 @@ internal class FiatValueToStringMapperImplTest {
         // Sub-cent value with standard formatting truncates to USD's 2 digits.
         mapper(FiatValue(BigDecimal("0.0015"), "USD")) shouldBe "$0.00"
     }
+
+    @Test
+    fun `asPrice reveals a sub-cent token price instead of collapsing to zero`() = runTest {
+        // LUNC-like price: standard formatting shows $0.00, asPrice reveals the leading figures.
+        mapper(FiatValue(BigDecimal("0.00006"), "USD"), asPrice = true) shouldBe "$0.00006"
+    }
+
+    @Test
+    fun `asPrice shows two significant figures of a long sub-cent price`() = runTest {
+        mapper(FiatValue(BigDecimal("0.00006123"), "USD"), asPrice = true) shouldBe "$0.000061"
+    }
+
+    @Test
+    fun `asPrice caps precision at eight fraction digits for micro prices`() = runTest {
+        // Two significant figures would need 9 digits; capped to 8 → rounds to $0.00000012.
+        mapper(FiatValue(BigDecimal("0.000000123"), "USD"), asPrice = true) shouldBe "$0.00000012"
+    }
+
+    @Test
+    fun `asPrice falls back to standard formatting at or above one cent`() = runTest {
+        val value = FiatValue(BigDecimal("1.50"), "USD")
+        mapper(value, asPrice = true) shouldBe mapper(value)
+        mapper(value, asPrice = true) shouldBe "$1.50"
+    }
+
+    @Test
+    fun `asPrice falls back to standard formatting for zero`() = runTest {
+        val value = FiatValue(BigDecimal.ZERO, "USD")
+        mapper(value, asPrice = true) shouldBe mapper(value)
+    }
+
+    @Test
+    fun `asFee takes precedence over asPrice`() = runTest {
+        val value = FiatValue(BigDecimal("0.0001256"), "USD")
+        mapper(value, asFee = true, asPrice = true) shouldBe mapper(value, asFee = true)
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
@@ -111,7 +111,15 @@ internal class FiatValueToStringMapperImplTest {
     }
 
     @Test
-    fun `asPrice falls back to standard formatting at or above one cent`() = runTest {
+    fun `asPrice falls back to standard formatting at exactly one cent`() = runTest {
+        // The subUnit guard is exclusive, so 0.01 is the first value that must use standard format.
+        val value = FiatValue(BigDecimal("0.01"), "USD")
+        mapper(value, asPrice = true) shouldBe mapper(value)
+        mapper(value, asPrice = true) shouldBe "$0.01"
+    }
+
+    @Test
+    fun `asPrice falls back to standard formatting above one cent`() = runTest {
         val value = FiatValue(BigDecimal("1.50"), "USD")
         mapper(value, asPrice = true) shouldBe mapper(value)
         mapper(value, asPrice = true) shouldBe "$1.50"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -228,7 +228,9 @@ constructor(
 
         return TokenBalanceAndPrice(
             tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
-            price = FiatValue(priceValue.scaledFor(currency), currency.ticker),
+            // Keep the full-precision unit price; display formatting (incl. sub-cent prices like
+            // LUNC) is handled by FiatValueToStringMapper. Scaling here would collapse it to $0.00.
+            price = FiatValue(priceValue, currency.ticker),
         )
     }
 
@@ -280,7 +282,7 @@ constructor(
                 tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
                 price =
                     if (price != null) {
-                        FiatValue(price.scaledFor(currency), currency.ticker)
+                        FiatValue(price, currency.ticker)
                     } else {
                         null
                     },
@@ -341,7 +343,7 @@ constructor(
                                     currency = currency.ticker,
                                 ),
                         ),
-                    price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
+                    price = FiatValue(value = price, currency = currency.ticker),
                 )
             }
         }
@@ -379,7 +381,7 @@ constructor(
         emit(
             TokenBalanceAndPrice(
                 tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
-                price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
+                price = FiatValue(value = price, currency = currency.ticker),
             )
         )
     }
@@ -628,7 +630,7 @@ constructor(
                                     currency = currency.ticker,
                                 ),
                         ),
-                    price = FiatValue(value = price.scaledFor(currency), currency = currency.ticker),
+                    price = FiatValue(value = price, currency = currency.ticker),
                 )
         }
     }


### PR DESCRIPTION
## Summary

Per-token prices below one currency sub-unit (e.g. **LUNC ~$0.00006**, **USTC ~$0.0054**) were displayed as `$0.00`, hiding the real price from users. Closes #5088.

### Root cause
The unit price was rounded away **before it ever reached the UI**:
1. In `BalanceRepository`, the price `FiatValue` was built with `price.scaledFor(currency)` — `setScale(2, RoundingMode.DOWN)` for USD — so `$0.000059` became `0.00` at the data source.
2. The display mapper then formatted to the currency's standard 2 fraction digits anyway.

### Fix
- **`BalanceRepository`** — stop pre-scaling the **unit price** at all 5 construction sites; it now carries full precision. The **holdings** value (`fiatValue`) keeps `scaledFor` — a tiny holding correctly still shows `$0.00`.
- **`FiatValueToStringMapper`** — new opt-in `asPrice` mode that extends precision just far enough to reveal a sub-cent price's leading significant figures (2 sig figs, capped at 8 fraction digits).
- Apply `asPrice = true` at the per-token price display sites (`ChainTokensViewModel`, `TokenDetailViewModel`, `CustomTokenViewModel`).

Prices ≥ one sub-unit are unaffected; balances are unaffected.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/E0dNZnD.png) | ![after](https://i.imgur.com/kNuydcP.png) |

LUNC `$0.00` → `$0.000059`, USTC `$0.00` → `$0.0054`. Tokens with no/zero price (UUSDC, KRT) correctly remain `$0.00`.

## Test plan
- [x] `:data:compileDebugKotlin` + `:app:compileDebugKotlin`
- [x] New `FiatValueToStringMapperImplTest` cases: LUNC-style sub-cent reveal, 2-sig-fig, 8-digit cap, fallback ≥ 1¢, zero, `asFee` precedence
- [x] `AccountsRepositoryImplTest`, `ChainTokensViewModelTest` green
- [x] ktfmt clean
- [x] Device-verified on Terra Classic vault (see Before/After)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token price formatting across token lists, token details, and custom token search, showing meaningful fractional pricing for very small values.

* **Bug Fixes**
  * Fixed incorrect rendering of sub-cent token prices by preserving full-precision values until display formatting is applied.
  * Updated formatting logic to handle price vs. fee modes correctly, including correct precision and rounding behavior.

* **Tests**
  * Expanded mapper test coverage for `asPrice` formatting (including edge cases and precedence with fee formatting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->