### PR TITLE
fix(solana): priority fee conflates total lamports with per-CU price

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -398,10 +398,22 @@ constructor(
                     val fromAddressPubKeyResult = fromAddressPubKey.await()
                     val toAddressPubKeyResult = toAddressPubKey.await()
                     Timber.d("solana blockhash: $recentBlockHashResult")
+                    // priorityFee is a per-compute-unit PRICE (microlamports/CU), not the total fee
+                    // amount. gasFee.value holds the total (base + priority + rent); assigning it
+                    // here made SolanaHelper multiply the whole fee by the 100k CU limit, mispricing
+                    // the tx. Read the dynamic median price the same way the fee display does
+                    // (getRecentPrioritizationFees) so the signed tx is prioritized correctly and the
+                    // charged fee matches the estimate. iOS/Windows keep these two fields separate.
+                    val priorityAccounts = buildList {
+                        add(token.address)
+                        fromAddressPubKeyResult?.first?.let { add(it) }
+                        toAddressPubKeyResult?.first?.let { add(it) }
+                    }
+                    val priorityFeePrice = solanaApi.getMedianPriorityFee(priorityAccounts)
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Solana(
                             recentBlockHash = recentBlockHashResult,
-                            priorityFee = gasFee.value,
+                            priorityFee = priorityFeePrice,
                             fromAddressPubKey = fromAddressPubKeyResult?.first,
                             toAddressPubKey = toAddressPubKeyResult?.first,
                             programId = fromAddressPubKeyResult?.second == true,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -29,6 +29,7 @@ import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.CardanoHelper
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -398,18 +399,21 @@ constructor(
                     val fromAddressPubKeyResult = fromAddressPubKey.await()
                     val toAddressPubKeyResult = toAddressPubKey.await()
                     Timber.d("solana blockhash: $recentBlockHashResult")
-                    // priorityFee is a per-compute-unit PRICE (microlamports/CU), not the total fee
-                    // amount. gasFee.value holds the total (base + priority + rent); assigning it
-                    // here made SolanaHelper multiply the whole fee by the 100k CU limit, mispricing
-                    // the tx. Read the dynamic median price the same way the fee display does
-                    // (getRecentPrioritizationFees) so the signed tx is prioritized correctly and the
-                    // charged fee matches the estimate. iOS/Windows keep these two fields separate.
-                    val priorityAccounts = buildList {
-                        add(token.address)
-                        fromAddressPubKeyResult?.first?.let { add(it) }
-                        toAddressPubKeyResult?.first?.let { add(it) }
-                    }
-                    val priorityFeePrice = solanaApi.getMedianPriorityFee(priorityAccounts)
+                    // priorityFee is a per-compute-unit price (microlamports/CU); priorityLimit is
+                    // the CU limit. SolanaHelper charges price * limit / 1e6 as the priority fee.
+                    // Swaps sign the aggregator's prebuilt tx, which carries its own compute budget,
+                    // so these fields are ignored for swaps — skip the RPC and use the fallback.
+                    val priorityFeePrice =
+                        if (isSwap) {
+                            SOLANA_PRIORITY_FEE_PRICE.toBigInteger()
+                        } else {
+                            val priorityAccounts = buildList {
+                                add(token.address)
+                                fromAddressPubKeyResult?.first?.let { add(it) }
+                                toAddressPubKeyResult?.first?.let { add(it) }
+                            }
+                            solanaApi.getMedianPriorityFee(priorityAccounts)
+                        }
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Solana(
                             recentBlockHash = recentBlockHashResult,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -27,12 +27,14 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.utils.increaseByPercent
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigInteger
 import kotlin.test.assertEquals
@@ -132,6 +134,39 @@ internal class BlockChainSpecificRepositoryImplTest {
             assertEquals(
                 SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
                 specific.priorityLimit,
+            )
+        }
+
+    @Test
+    fun `Solana swap skips the priority-fee RPC (aggregator tx carries its own compute budget)`() =
+        runTest {
+            val coin = solanaCoin()
+            val solanaApi =
+                mockk<SolanaApi> {
+                    coEvery { getRecentBlockHash() } returns "SolanaBlockHash1111"
+                    coEvery { getTokenAssociatedAccountByOwner(any(), any()) } returns (null to false)
+                }
+
+            val result =
+                repository(solanaApi = solanaApi)
+                    .getSpecific(
+                        chain = Chain.Solana,
+                        address = SOURCE_ADDRESS,
+                        token = coin,
+                        gasFee = TokenValue(BigInteger("105000"), coin),
+                        isSwap = true,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                        dstAddress = "SolRecipient1111",
+                    )
+
+            val specific = result.blockChainSpecific
+            assertTrue(specific is BlockChainSpecific.Solana)
+            // No median fetched — swap signers ignore priorityFee; it falls back to the floor price.
+            coVerify(exactly = 0) { solanaApi.getMedianPriorityFee(any()) }
+            assertEquals(
+                SOLANA_PRIORITY_FEE_PRICE.toBigInteger(),
+                (specific as BlockChainSpecific.Solana).priorityFee,
             )
         }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
@@ -98,6 +99,41 @@ internal class BlockChainSpecificRepositoryImplTest {
         assertTrue(specific is BlockChainSpecific.UTXO)
         assertEquals("30f33754", (specific as BlockChainSpecific.UTXO).zcashBranchId)
     }
+
+    @Test
+    fun `Solana specific carries the per-CU median price as priorityFee, not the total gas fee`() =
+        runTest {
+            val coin = solanaCoin()
+            val solanaApi =
+                mockk<SolanaApi> {
+                    coEvery { getRecentBlockHash() } returns "SolanaBlockHash1111"
+                    coEvery { getTokenAssociatedAccountByOwner(any(), any()) } returns (null to false)
+                    coEvery { getMedianPriorityFee(any()) } returns BigInteger("50000")
+                }
+
+            val result =
+                repository(solanaApi = solanaApi)
+                    .getSpecific(
+                        chain = Chain.Solana,
+                        address = SOURCE_ADDRESS,
+                        token = coin,
+                        // Total fee (base + priority + rent) in lamports — must NOT leak into
+                        // priorityFee, which is a per-compute-unit price.
+                        gasFee = TokenValue(BigInteger("105000"), coin),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                        dstAddress = "SolRecipient1111",
+                    )
+
+            val specific = result.blockChainSpecific
+            assertTrue(specific is BlockChainSpecific.Solana)
+            assertEquals(BigInteger("50000"), (specific as BlockChainSpecific.Solana).priorityFee)
+            assertEquals(
+                SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
+                specific.priorityLimit,
+            )
+        }
 
     @Test
     fun `ERC20 estimation uses destination address in returned dto`() = runTest {
@@ -449,6 +485,19 @@ internal class BlockChainSpecificRepositoryImplTest {
             isNativeToken = true,
         )
 
+    private fun solanaCoin() =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "",
+            address = SOURCE_ADDRESS,
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
     private fun repository(
         evmApi: EvmApi = mockk<EvmApi>(relaxed = true),
         evmFeeService: FeeService = NoOpFeeService,
@@ -456,6 +505,7 @@ internal class BlockChainSpecificRepositoryImplTest {
         suiFeeService: FeeService = NoOpFeeService,
         blockChairApi: BlockChairApi = mockk<BlockChairApi>(relaxed = true),
         zcashApi: ZcashApi = mockk<ZcashApi>(relaxed = true),
+        solanaApi: SolanaApi = mockk<SolanaApi>(relaxed = true),
     ): BlockChainSpecificRepositoryImpl {
         val evmApiFactory =
             object : EvmApiFactory {
@@ -466,7 +516,7 @@ internal class BlockChainSpecificRepositoryImplTest {
             thorChainApi = mockk<ThorChainApi>(relaxed = true),
             mayaChainApi = mockk<MayaChainApi>(relaxed = true),
             evmApiFactory = evmApiFactory,
-            solanaApi = mockk<SolanaApi>(relaxed = true),
+            solanaApi = solanaApi,
             cosmosApiFactory = mockk<CosmosApiFactory>(relaxed = true),
             blockChairApi = blockChairApi,
             dashApi = mockk<DashApi>(relaxed = true),


### PR DESCRIPTION
**Proof (on-chain, Fast Vault SOL send after the fix):** https://orb.helius.dev/tx/3GuQC3eYetR7AK6LF6fxV2WFpjWgjcuiQF7ytxzt3mRFpXHszxyg8saW5Yhw8QmddfT3KUm2qG1dXcZuoMrCyJ7y

Closes #5101

## Problem

The Solana send path stored the **total fee** (lamports) into the field used as the **per-compute-unit price** (microlamports/CU). `BlockChainSpecificRepository` assigned `gasFee.value` (base + priority + rent) to `BlockChainSpecific.Solana.priorityFee`, which `SolanaHelper` feeds into `setPriorityFeePrice(...)` and multiplies by the 100k CU limit. The `maxOf(price, 1_000_000)` floor masked it at low fees, but it diverges as the dynamic median rises.

**Net effect:** under congestion the broadcast tx is **under-prioritized** — it lingers unconfirmed and is more likely to hit blockhash expiry — and the displayed network fee doesn't equal the fee actually paid.

## Fix

In the `TokenStandard.SOL` branch of `getSpecific`, read the dynamic median price via `solanaApi.getMedianPriorityFee(...)` (`getRecentPrioritizationFees`) — the same source the fee **display** uses (`SolanaFeeService`) — and pass it as `priorityFee`, keeping `priorityLimit` as the CU limit. So the signed tx is prioritized correctly and `display fee == base + (price × limit / 1e6)`.

## Cross-platform parity

Verified against the local iOS repo: `BlockChainService.swift` builds `.Solana(priorityFee: dynamicPriorityFee, priorityLimit: SolanaHelper.priorityFeeLimit, …)` where `dynamicPriorityFee = max(fetchRecentPrioritizationFees(), defaultFee)` — identical to this change. Windows keeps the two fields separate too. **The bug was Android-only.**

## Test plan

- [x] `:data:compileDebugKotlin` passes
- [x] `BlockChainSpecificRepositoryImplTest` passes, incl. a new case asserting the SOL `priorityFee` is the per-CU median (`50000`) and **not** the total `gasFee` (`105000`)
- [ ] CI: ktfmt + build (local pre-commit ktfmt worker segfaults — environment issue)
- [ ] Manual: send SOL under congestion — priority fee in the signed tx matches the median price × limit, and the charged fee equals the displayed estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)