### PR TITLE
fix(keysign): on-chain broadcast rejections shown as network errors, not device timeout

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -25,15 +25,20 @@ internal data class SigningError(
  * use the red critical variant.
  */
 @Composable
-internal fun resolveSigningError(rawMessage: String): SigningError =
-    when {
-        rawMessage.contains("Blockhash not found") ->
+internal fun resolveSigningError(rawMessage: String): SigningError {
+    // Normalize away spaces/underscores/case so a single check matches both the RPC's human wording
+    // ("Blockhash not found", "insufficient lamports") and Solana's camelCase enum forms
+    // ("BlockhashNotFound", "BlockHeightExceeded") that error.data.err carries.
+    val normalized = rawMessage.lowercase().replace(" ", "").replace("_", "")
+    return when {
+        // Blockhash expiry — both RPC wordings map to the same "sign again" copy.
+        normalized.contains("blockhashnotfound") || normalized.contains("blockheightexceeded") ->
             SigningError(
                 title = stringResource(R.string.signing_error_transaction_failed_title),
                 description = stringResource(R.string.signing_error_transaction_timeout),
                 errorState = ErrorState.CRITICAL,
             )
-        rawMessage.contains("insufficient funds") ->
+        normalized.contains("insufficientfunds") || normalized.contains("insufficientlamports") ->
             SigningError(
                 title = stringResource(R.string.error_insufficient_funds_title),
                 description = stringResource(R.string.signing_error_insufficient_funds),
@@ -87,6 +92,15 @@ internal fun resolveSigningError(rawMessage: String): SigningError =
                 )
             }
         }
+        // On-chain rejection at broadcast: the app runs no client-side simulation, so a
+        // "simulation failed" can only come from the node's preflight. This is a network rejection,
+        // NOT a device/connection timeout — surface it as such, with the on-chain reason.
+        normalized.contains("simulationfailed") ->
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description = onChainRejectionDescription(rawMessage),
+                errorState = ErrorState.CRITICAL,
+            )
         else ->
             SigningError(
                 title = stringResource(R.string.signing_error_transaction_failed_title),
@@ -94,6 +108,30 @@ internal fun resolveSigningError(rawMessage: String): SigningError =
                 errorState = ErrorState.CRITICAL,
             )
     }
+}
+
+/**
+ * Builds the description for an on-chain broadcast rejection, appending the node-supplied reason
+ * (the text after "simulation failed", e.g. `AccountLoadedTwice`) when present. Reuses the same
+ * "rejected by the network" copy as the Cosmos broadcast path.
+ */
+@Composable
+private fun onChainRejectionDescription(rawMessage: String): String {
+    val detail =
+        rawMessage
+            .substringAfter("simulation failed", "")
+            .trimStart(':', ' ')
+            .let { raw ->
+                if (raw.length > BROADCAST_DETAIL_MAX_LENGTH) {
+                    raw.take(BROADCAST_DETAIL_MAX_LENGTH).trimEnd() + "…"
+                } else raw
+            }
+    return if (detail.isBlank()) {
+        stringResource(R.string.signing_error_broadcast_rejected)
+    } else {
+        stringResource(R.string.signing_error_broadcast_rejected_s, detail)
+    }
+}
 
 @Composable
 internal fun KeysignErrorScreen(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -117,9 +117,12 @@ internal fun resolveSigningError(rawMessage: String): SigningError {
  */
 @Composable
 private fun onChainRejectionDescription(rawMessage: String): String {
+    // Match the marker the same way the branch does (case + spaces/underscores insensitive) so the
+    // on-chain reason after it isn't lost for wordings like "SimulationFailed: AccountLoadedTwice".
     val detail =
-        rawMessage
-            .substringAfter("simulation failed", "")
+        SIMULATION_FAILED_MARKER.find(rawMessage)
+            ?.let { rawMessage.substring(it.range.last + 1) }
+            .orEmpty()
             .trimStart(':', ' ')
             .let { raw ->
                 if (raw.length > BROADCAST_DETAIL_MAX_LENGTH) {
@@ -159,6 +162,9 @@ internal fun KeysignErrorScreen(
  * truncated with an ellipsis before being interpolated into the user-facing label.
  */
 private const val BROADCAST_DETAIL_MAX_LENGTH = 120
+
+/** Matches the RPC "simulation failed" marker regardless of case and space/underscore wording. */
+private val SIMULATION_FAILED_MARKER = Regex("(?i)simulation[ _]?failed")
 
 @Preview(showBackground = true, name = "KeysignErrorScreen Preview")
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -38,7 +38,19 @@ internal fun resolveSigningError(rawMessage: String): SigningError {
                 description = stringResource(R.string.signing_error_transaction_timeout),
                 errorState = ErrorState.CRITICAL,
             )
-        normalized.contains("insufficientfunds") || normalized.contains("insufficientlamports") ->
+        // On-chain rejection at broadcast: the app runs no client-side simulation, so a
+        // "simulation failed" can only come from the node's preflight. Checked BEFORE the
+        // insufficient-funds branch so an on-chain reason that merely contains "insufficient funds"
+        // (e.g. "InsufficientFundsForRent") is reported as a network rejection with its reason,
+        // rather than the fund-the-wallet warning.
+        normalized.contains("simulationfailed") ->
+            SigningError(
+                title = stringResource(R.string.signing_error_transaction_failed_title),
+                description = onChainRejectionDescription(rawMessage),
+                errorState = ErrorState.CRITICAL,
+            )
+        // Pre-broadcast insufficient funds (e.g. EVM gas) — actionable "fund the wallet" copy.
+        normalized.contains("insufficientfunds") ->
             SigningError(
                 title = stringResource(R.string.error_insufficient_funds_title),
                 description = stringResource(R.string.signing_error_insufficient_funds),
@@ -92,15 +104,6 @@ internal fun resolveSigningError(rawMessage: String): SigningError {
                 )
             }
         }
-        // On-chain rejection at broadcast: the app runs no client-side simulation, so a
-        // "simulation failed" can only come from the node's preflight. This is a network rejection,
-        // NOT a device/connection timeout — surface it as such, with the on-chain reason.
-        normalized.contains("simulationfailed") ->
-            SigningError(
-                title = stringResource(R.string.signing_error_transaction_failed_title),
-                description = onChainRejectionDescription(rawMessage),
-                errorState = ErrorState.CRITICAL,
-            )
         else ->
             SigningError(
                 title = stringResource(R.string.signing_error_transaction_failed_title),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -42,13 +42,13 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import timber.log.Timber
@@ -222,7 +222,7 @@ constructor(
                 // failed". Append the reason so the failure surfaced to the user names the real cause
                 // instead of a bare, generic message.
                 val reason =
-                    error["data"]?.jsonObject?.get("err")?.let { err ->
+                    (error["data"] as? JsonObject)?.get("err")?.let { err ->
                         (err as? JsonPrimitive)?.contentOrNull ?: err.toString()
                     }
                 val detailedMessage =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -222,8 +222,14 @@ constructor(
                 // failed". Append the reason so the failure surfaced to the user names the real cause
                 // instead of a bare, generic message.
                 val reason =
-                    (error["data"] as? JsonObject)?.get("err")?.let { err ->
-                        (err as? JsonPrimitive)?.contentOrNull ?: err.toString()
+                    when (val err = (error["data"] as? JsonObject)?.get("err")) {
+                        // Bare string enum, e.g. "AccountLoadedTwice", "BlockhashNotFound".
+                        is JsonPrimitive -> err.contentOrNull
+                        // Structured error, e.g. {"InstructionError":[1,{"Custom":6001}]}. Use the
+                        // variant name (the single top-level key) rather than embedding raw JSON in
+                        // the user-facing rejection text.
+                        is JsonObject -> err.keys.firstOrNull()
+                        else -> null
                     }
                 val detailedMessage =
                     if (!reason.isNullOrBlank()) "$message: $reason" else message

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -48,6 +48,7 @@ import kotlinx.serialization.json.addJsonArray
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import timber.log.Timber
@@ -216,6 +217,16 @@ constructor(
                     result.error ?: return result.result ?: error("broadcastTransaction error")
 
                 val message = error["message"]?.jsonPrimitive?.contentOrNull ?: error.toString()
+                // Solana puts the actual on-chain reason in error.data.err (e.g. "AccountLoadedTwice",
+                // "BlockhashNotFound"); error.message only carries the generic "Transaction simulation
+                // failed". Append the reason so the failure surfaced to the user names the real cause
+                // instead of a bare, generic message.
+                val reason =
+                    error["data"]?.jsonObject?.get("err")?.let { err ->
+                        (err as? JsonPrimitive)?.contentOrNull ?: err.toString()
+                    }
+                val detailedMessage =
+                    if (!reason.isNullOrBlank()) "$message: $reason" else message
                 Timber.tag("SolanaApiImp")
                     .d("Error broadcasting transaction: %s", responseRawString)
 
@@ -238,8 +249,9 @@ constructor(
                     // True expiry (or exhausted resends): the same tx can no longer land, so
                     // surface it as expired. Re-signing with a fresh blockhash is a deferred
                     // follow-up (needs a cross-device KeysignMessage proto change).
-                    SolanaBroadcastAction.EXPIRED -> throw SolanaBlockhashExpiredException(message)
-                    SolanaBroadcastAction.FATAL -> error(message)
+                    SolanaBroadcastAction.EXPIRED ->
+                        throw SolanaBlockhashExpiredException(detailedMessage)
+                    SolanaBroadcastAction.FATAL -> error(detailedMessage)
                 }
             }
             error("broadcastTransaction failed after $BROADCAST_MAX_ATTEMPTS attempts")

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -150,6 +150,28 @@ class SolanaApiBodyReadTest {
         assertInstanceOf(IllegalStateException::class.java, error)
     }
 
+    @Test
+    fun `broadcastTransaction appends the on-chain reason from error data err`() = runTest {
+        val body =
+            """
+            {
+              "error": {
+                "code": -32002,
+                "message": "Transaction simulation failed",
+                "data": { "err": "AccountLoadedTwice", "logs": [] }
+              },
+              "result": null
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        val error = runCatching { api.broadcastTransaction("tx") }.exceptionOrNull()
+
+        assertInstanceOf(IllegalStateException::class.java, error)
+        assertEquals(true, error?.message?.contains("AccountLoadedTwice"))
+    }
+
     // ── getSPLTokensInfo2 ───────────────────────────────────────────────────────
     // Uses .body<List<SplTokenInfo>>() for each token in parallel; respondingWith returns the same
     // body for every request.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -173,6 +173,30 @@ class SolanaApiBodyReadTest {
     }
 
     @Test
+    fun `broadcastTransaction uses the variant name for a structured err, not raw JSON`() = runTest {
+        val body =
+            """
+            {
+              "error": {
+                "code": -32002,
+                "message": "Transaction simulation failed",
+                "data": { "err": { "InstructionError": [1, { "Custom": 6001 }] }, "logs": [] }
+              },
+              "result": null
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        val error = runCatching { api.broadcastTransaction("tx") }.exceptionOrNull()
+
+        assertInstanceOf(IllegalStateException::class.java, error)
+        assertEquals(true, error?.message?.contains("InstructionError"))
+        // The raw JSON payload must not leak into the surfaced message.
+        assertEquals(false, error?.message?.contains("Custom"))
+    }
+
+    @Test
     fun `broadcastTransaction does not crash when error data is a primitive`() = runTest {
         // A non-object `data` must not throw while building the error (jsonObject would); the
         // original RPC message should still surface.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaApiBodyReadTest.kt
@@ -172,6 +172,26 @@ class SolanaApiBodyReadTest {
         assertEquals(true, error?.message?.contains("AccountLoadedTwice"))
     }
 
+    @Test
+    fun `broadcastTransaction does not crash when error data is a primitive`() = runTest {
+        // A non-object `data` must not throw while building the error (jsonObject would); the
+        // original RPC message should still surface.
+        val body =
+            """
+            {
+              "error": { "code": -32002, "message": "Transaction simulation failed", "data": "oops" },
+              "result": null
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        val error = runCatching { api.broadcastTransaction("tx") }.exceptionOrNull()
+
+        assertInstanceOf(IllegalStateException::class.java, error)
+        assertEquals(true, error?.message?.contains("Transaction simulation failed"))
+    }
+
     // ── getSPLTokensInfo2 ───────────────────────────────────────────────────────
     // Uses .body<List<SplTokenInfo>>() for each token in parallel; respondingWith returns the same
     // body for every request.


### PR DESCRIPTION
Closes #5099

## Problem

A Solana send/swap with a Fast Vault that fails **at broadcast** was shown on the keysign error screen as:

- Title: **Transaction failed**
- Body: **"One of your devices didn't respond in time. Check your connection and try again."**
- "Show exact error": **`Transaction simulation failed`** (bare, no reason)

That copy blames pairing/connectivity/MPC. But the MPC ceremony succeeded — the signature was produced and locally verified — and the failure happened later, when the Solana RPC `sendTransaction` preflight rejected the tx on-chain. The app runs **no** client-side simulation, so `Transaction simulation failed` can only come from the node's preflight.

Real example (Jupiter swap, `err = AccountLoadedTwice`): the on-chain reason was discarded and the screen said "device didn't respond".

## Fix

**1. Surface the on-chain reason (`SolanaApi.broadcastTransaction`).** Solana puts the real cause in `error.data.err` (`AccountLoadedTwice`, `BlockhashNotFound`, …) while `error.message` is only the generic `Transaction simulation failed`. The reason was parsed into the model but dropped. Now it's appended to the surfaced message.

**2. Classify broadcast rejections as on-chain (`resolveSigningError`).** Any `simulation failed` now routes to an **on-chain rejection** branch — `Transaction rejected by the network: <reason>` (reusing the existing Cosmos-broadcast strings, no new copy) — instead of the device-timeout `else`. Matching is normalized (lowercase, strip spaces/underscores) so it catches both the RPC wording and Solana's camelCase enums. Also:
- Blockhash expiry is unified: both `Blockhash not found` and `block height exceeded` map to the "sign again" copy (previously inconsistent).
- `insufficient funds` **and** `insufficient lamports` map to the insufficient-funds copy (the lamports wording previously missed the branch).

Raw text stays under "Show exact error". **"Try again"** already routes back to the Verify screen, which re-signs with a fresh blockhash (`KeysignFlowViewModel.tryAgain() → back()`), so the re-sign UX is correct for MPC.

## Cross-platform

Matches iOS, which surfaces the raw RPC reason rather than a friendly device-timeout. (iOS also reclassifies an already-on-chain tx as success — Android's `BroadcastTxUseCase.recoverIfAlreadyBroadcast` already covers the landed-tx case via status polling; a fuller reclassification can be a follow-up.) Windows shares the mislabel — worth a mirror issue.

## Before / After

Same failure (Fast Vault Jupiter swap, on-chain `AccountLoadedTwice` at broadcast), real device renders.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/xffFLSG.png) | ![after](https://i.imgur.com/szTeGww.png) |

Before: *"One of your devices didn't respond in time…"* (implies pairing/connectivity). After: *"Transaction rejected by the network: AccountLoadedTwice"* (the actual on-chain cause).

## Test plan

- [x] `:data:compileDebugKotlin` + `:app:compileDebugKotlin` pass
- [x] `SolanaApiBodyReadTest` passes, incl. a new case asserting the broadcast exception message contains the on-chain reason (`AccountLoadedTwice`)
- [ ] CI: ktfmt + build (local pre-commit ktfmt worker segfaults — environment issue)
- [x] Manual (on-device, Fast Vault Jupiter swap): broadcast rejected with `AccountLoadedTwice`. Logcat: `Error broadcasting transaction: Transaction simulation failed: AccountLoadedTwice` (reason now appended); the error screen reads **"Transaction rejected by the network: AccountLoadedTwice"** — not "device didn't respond".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction error handling by matching failure messages more reliably across casing and formatting.
  * Enhanced “signing error” descriptions, including clearer guidance for common failures and better support for simulation-related rejection details.
  * Broadcast and send transaction failures now surface more specific on-chain reasons when available, with safe fallbacks to generic messaging.
* **Tests**
  * Expanded coverage for extracting on-chain error reasons across string, structured, and non-object payload formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->