### PR TITLE
feat(price): compact subscript notation for tiny token prices (#5120)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapper.kt
@@ -3,7 +3,10 @@ package com.vultisig.wallet.ui.models.mappers
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import java.math.BigDecimal
+import java.math.MathContext
 import java.math.RoundingMode
+import java.text.AttributedCharacterIterator
+import java.text.CharacterIterator
 import java.text.NumberFormat
 import java.util.Currency
 import javax.inject.Inject
@@ -17,9 +20,11 @@ internal interface FiatValueToStringMapper {
      * extra precision (up to three extra fraction digits) using [RoundingMode.DOWN] so a sub-unit
      * fee like `$0.001234` displays as `$0.00123` instead of being truncated to `$0.00`.
      *
-     * When [asPrice] is true and the value is a sub-unit price, the result is rendered with enough
-     * fraction digits to reveal its first significant figures, so a tiny per-token price like
-     * LUNC's `$0.00006` displays as `$0.00006` instead of collapsing to `$0.00`.
+     * When [asPrice] is true and the value is a sub-unit price, the result is rendered with a few
+     * significant figures instead of collapsing to `$0.00`. Once there are four or more leading
+     * zeros after the decimal point, they are collapsed into compact subscript notation matching
+     * the desktop/extension contract, so `0.00000003` displays as `$0.0₇3` ("seven zeros then 3")
+     * while shallower prices like `0.0001234` keep their plain decimals as `$0.0001234`.
      *
      * All other values fall through to the currency's standard formatting. [asFee] takes precedence
      * over [asPrice] when both are set.
@@ -49,24 +54,79 @@ constructor(private val appCurrencyRepository: AppCurrencyRepository) : FiatValu
         if (value.value <= BigDecimal.ZERO || value.value >= subUnit) {
             return format.format(value.value)
         }
-        format.minimumFractionDigits = standardDigits
         if (asFee) {
+            format.minimumFractionDigits = standardDigits
             format.maximumFractionDigits = standardDigits + EXTRA_FEE_PRECISION_DIGITS
             format.roundingMode = RoundingMode.DOWN
-        } else {
-            // Number of zeros between the decimal point and the first significant digit, so we can
-            // extend precision just far enough to reveal the price's leading figures.
-            val leadingZeros = value.value.scale() - value.value.precision()
-            format.maximumFractionDigits =
-                (leadingZeros + PRICE_SIGNIFICANT_DIGITS).coerceAtMost(MAX_PRICE_FRACTION_DIGITS)
-            format.roundingMode = RoundingMode.HALF_UP
+            return format.format(value.value)
         }
-        return format.format(value.value)
+        return formatTinyPrice(value.value, format)
     }
+
+    /**
+     * Renders a positive sub-unit price without rounding it away to `$0.00`. Keeps
+     * [PRICE_SIGNIFICANT_DIGITS] significant figures and, once there are at least
+     * [SUBSCRIPT_NOTATION_THRESHOLD] leading zeros, collapses them into subscript notation (e.g.
+     * `0.00000003` -> `$0.0₇3`). Ports `formatTinyCurrencyAmount` from the shared TypeScript
+     * codebase so the presentation matches desktop and the browser extension.
+     */
+    private fun formatTinyPrice(value: BigDecimal, format: NumberFormat): String {
+        val significant =
+            value
+                .round(MathContext(PRICE_SIGNIFICANT_DIGITS, RoundingMode.HALF_UP))
+                .stripTrailingZeros()
+        // Zeros between the decimal point and the first significant digit. Computed after rounding
+        // so a carry (e.g. 0.0000999 -> 0.0001) shifts the count correctly.
+        val leadingZeros = significant.scale() - significant.precision()
+        val significantDigits = significant.unscaledValue().abs().toString()
+        val decimals =
+            if (leadingZeros >= SUBSCRIPT_NOTATION_THRESHOLD) {
+                "0${leadingZeros.toSubscript()}$significantDigits"
+            } else {
+                "0".repeat(leadingZeros) + significantDigits
+            }
+        val (prefix, suffix) = format.currencyAffixes()
+        return "${prefix}0.$decimals$suffix"
+    }
+
+    /**
+     * Formats zero with [this] to discover the characters that surround the number, so a custom
+     * numeric string can be substituted while preserving the currency symbol and its
+     * locale-specific placement (e.g. `$` prefix vs. ` €` suffix).
+     */
+    private fun NumberFormat.currencyAffixes(): Pair<String, String> {
+        val iterator = formatToCharacterIterator(BigDecimal.ZERO)
+        val prefix = StringBuilder()
+        val suffix = StringBuilder()
+        var seenNumber = false
+        var char = iterator.first()
+        while (char != CharacterIterator.DONE) {
+            val isNumberPart = iterator.attributes.keys.any { it in NUMBER_FIELDS }
+            when {
+                isNumberPart -> seenNumber = true
+                seenNumber -> suffix.append(char)
+                else -> prefix.append(char)
+            }
+            char = iterator.next()
+        }
+        return prefix.toString() to suffix.toString()
+    }
+
+    private fun Int.toSubscript(): String =
+        toString().map { SUBSCRIPT_DIGITS[it - '0'] }.joinToString("")
 
     private companion object {
         private const val EXTRA_FEE_PRECISION_DIGITS = 3
-        private const val PRICE_SIGNIFICANT_DIGITS = 2
-        private const val MAX_PRICE_FRACTION_DIGITS = 8
+        private const val PRICE_SIGNIFICANT_DIGITS = 4
+        private const val SUBSCRIPT_NOTATION_THRESHOLD = 4
+        private val SUBSCRIPT_DIGITS = charArrayOf('₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉')
+        private val NUMBER_FIELDS: Set<AttributedCharacterIterator.Attribute> =
+            setOf(
+                NumberFormat.Field.INTEGER,
+                NumberFormat.Field.FRACTION,
+                NumberFormat.Field.DECIMAL_SEPARATOR,
+                NumberFormat.Field.GROUPING_SEPARATOR,
+                NumberFormat.Field.SIGN,
+            )
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/FiatValueToStringMapperImplTest.kt
@@ -96,18 +96,48 @@ internal class FiatValueToStringMapperImplTest {
     @Test
     fun `asPrice reveals a sub-cent token price instead of collapsing to zero`() = runTest {
         // LUNC-like price: standard formatting shows $0.00, asPrice reveals the leading figures.
-        mapper(FiatValue(BigDecimal("0.00006"), "USD"), asPrice = true) shouldBe "$0.00006"
+        // Four leading zeros collapse into subscript notation.
+        mapper(FiatValue(BigDecimal("0.00006"), "USD"), asPrice = true) shouldBe "$0.0₄6"
     }
 
     @Test
-    fun `asPrice shows two significant figures of a long sub-cent price`() = runTest {
-        mapper(FiatValue(BigDecimal("0.00006123"), "USD"), asPrice = true) shouldBe "$0.000061"
+    fun `asPrice keeps up to four significant figures of a sub-cent price`() = runTest {
+        mapper(FiatValue(BigDecimal("0.00006123"), "USD"), asPrice = true) shouldBe "$0.0₄6123"
     }
 
     @Test
-    fun `asPrice caps precision at eight fraction digits for micro prices`() = runTest {
-        // Two significant figures would need 9 digits; capped to 8 → rounds to $0.00000012.
-        mapper(FiatValue(BigDecimal("0.000000123"), "USD"), asPrice = true) shouldBe "$0.00000012"
+    fun `asPrice rounds HALF_UP to four significant figures`() = runTest {
+        mapper(FiatValue(BigDecimal("0.000061237"), "USD"), asPrice = true) shouldBe "$0.0₄6124"
+    }
+
+    @Test
+    fun `asPrice renders a micro price with the leading-zero count as a subscript`() = runTest {
+        // 0.000000123 -> six leading zeros -> $0.0₆123.
+        mapper(FiatValue(BigDecimal("0.000000123"), "USD"), asPrice = true) shouldBe "$0.0₆123"
+    }
+
+    @Test
+    fun `asPrice uses subscript notation for extremely tiny prices`() = runTest {
+        // Parity with desktop: 0.00000003 -> seven leading zeros -> $0.0₇3.
+        mapper(FiatValue(BigDecimal("0.00000003"), "USD"), asPrice = true) shouldBe "$0.0₇3"
+    }
+
+    @Test
+    fun `asPrice collapses four leading zeros while keeping the significant digits`() = runTest {
+        mapper(FiatValue(BigDecimal("0.00001234"), "USD"), asPrice = true) shouldBe "$0.0₄1234"
+    }
+
+    @Test
+    fun `asPrice keeps plain decimals below the subscript threshold`() = runTest {
+        // Three leading zeros stay as plain decimals (no subscript).
+        mapper(FiatValue(BigDecimal("0.0001234"), "USD"), asPrice = true) shouldBe "$0.0001234"
+        mapper(FiatValue(BigDecimal("0.00456"), "USD"), asPrice = true) shouldBe "$0.00456"
+    }
+
+    @Test
+    fun `asPrice shifts the leading-zero count when rounding carries`() = runTest {
+        // 0.0000999999 rounds up to 0.0001, dropping from four to three leading zeros -> plain.
+        mapper(FiatValue(BigDecimal("0.0000999999"), "USD"), asPrice = true) shouldBe "$0.0001"
     }
 
     @Test


### PR DESCRIPTION
## Summary
Closes #5120.

Tiny per-token prices (e.g. LUNC) already avoided rendering as `$0.00`, but were shown as long plain decimals capped at 8 fraction digits, so extremely small prices lost precision and were hard to read. Desktop and the browser extension already render these using **compact subscript notation**, where a subscript digit encodes the number of leading zeros (`0.00000003` → `$0.0₇3`). This brings Android to parity.

The `asPrice` branch of `FiatValueToStringMapper` now ports the shared SDK `formatTinyCurrencyAmount` contract (vultisig/vultisig-sdk#918):

- Keep **4 significant figures**.
- Once there are **≥4 leading zeros** after the decimal point, collapse them into subscript notation.
- Round **HALF_UP**.
- Computed on `BigDecimal` (round to 4 sig figs via `MathContext`, then derive the leading-zero count from `scale()/precision()`), so a rounding carry (`0.0000999999` → `$0.0001`) shifts the count correctly.
- Android keeps its existing sub-unit (`0.01`) gate; the currency symbol and its locale placement are preserved via `formatToCharacterIterator`.

### Behavior

| Value | Before | After |
|---|---|---|
| `0.00000003` | `$0.00000003` (capped) | `$0.0₇3` |
| `0.00001234` | `$0.000012` | `$0.0₄1234` |
| `0.00006` | `$0.00006` | `$0.0₄6` |
| `0.0001234` | `$0.00012` | `$0.0001234` |
| `0.00456` | `$0.00456` | `$0.00456` |
| `≥ 0.01`, `0` | unchanged | unchanged |

> **Note on the issue's spec table:** it marked both `0.00001234` and `0.00006` differently, but both have exactly 4 leading zeros — impossible under a single threshold. Following the issue's directive to "match the TypeScript codebase", the SDK contract is authoritative, so `0.00006` → `$0.0₄6`.

## Test plan
- Updated + added unit tests in `FiatValueToStringMapperImplTest` covering subscript cases, the plain-decimal branch below the threshold, HALF_UP rounding, the rounding-carry shift, and unchanged fallbacks. `:app:testDebugUnitTest` green.
- Device-verified on the Assets screen (LUNC).

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/TNkwzAL.png) | ![after](https://i.imgur.com/shfFQsK.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for very small fiat prices, making tiny values display more clearly and consistently.
  * Preserved locale-specific currency placement while switching between compact subscript notation and regular decimal output.
  * Kept fee formatting behavior unchanged.

* **Tests**
  * Expanded coverage for tiny price rendering, rounding behavior, and the transition between subscript and plain decimal formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->