### PR TITLE
fix(solana): honor Jupiter swap simulationError instead of signing a doomed tx

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -110,8 +110,8 @@ constructor(
         // Jupiter pre-simulates the swap tx and reports a non-null `simulationError` when it will
         // fail on-chain (slippage / min-out / liquidity at execution). Don't build or offer a tx
         // Jupiter already knows is doomed — drop the Jupiter route so the picker re-quotes or falls
-        // back to another provider. This matters especially with client-side `skipPreflight`, where
-        // a sim-failing tx would still land on-chain and burn the fee.
+        // back to another provider, instead of taking the user through the full keysign only for
+        // the broadcast to be rejected at preflight.
         quoteSwapData.simulationError?.let { simError ->
             throw SwapException.SwapRouteNotAvailable(
                 "[Jupiter] swap simulation failed: ${simError.error ?: simError.errorCode ?: "unknown"}"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -107,6 +107,17 @@ constructor(
         }
         val quoteSwapData = swapResponse.bodyOrThrow<QuoteSwapTransactionJson>()
 
+        // Jupiter pre-simulates the swap tx and reports a non-null `simulationError` when it will
+        // fail on-chain (slippage / min-out / liquidity at execution). Don't build or offer a tx
+        // Jupiter already knows is doomed — drop the Jupiter route so the picker re-quotes or falls
+        // back to another provider. This matters especially with client-side `skipPreflight`, where
+        // a sim-failing tx would still land on-chain and burn the fee.
+        quoteSwapData.simulationError?.let { simError ->
+            throw SwapException.SwapRouteNotAvailable(
+                "[Jupiter] swap simulation failed: ${simError.error ?: simError.errorCode ?: "unknown"}"
+            )
+        }
+
         // Jupiter never initializes the `feeAccount` ATA, so prepend an idempotent create for it
         // the
         // first time per fee mint (the payer funds the ~0.002 SOL rent; it is skipped once the ATA

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
@@ -18,7 +18,19 @@ data class QuoteSwapTotalDataJson(
     @SerialName("routePlan") val routePlan: List<RoutePlanItemJson>,
 )
 
-@Serializable data class QuoteSwapTransactionJson(@SerialName("swapTransaction") val data: String)
+@Serializable
+data class QuoteSwapTransactionJson(
+    @SerialName("swapTransaction") val data: String,
+    // Non-null when Jupiter's own pre-simulation of the swap tx failed (e.g. slippage / min-out /
+    // liquidity at execution). Present in the `/swap` response; the swap must not be signed when set.
+    @SerialName("simulationError") val simulationError: JupiterSimulationErrorJson? = null,
+)
+
+@Serializable
+data class JupiterSimulationErrorJson(
+    @SerialName("errorCode") val errorCode: String? = null,
+    @SerialName("error") val error: String? = null,
+)
 
 @Serializable
 data class SwapRouteResponseJson(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -167,6 +167,40 @@ class JupiterApiTest {
         )
     }
 
+    @Test
+    fun `a swap simulationError drops the Jupiter route`() {
+        // Jupiter's /swap response carries a non-null simulationError (the built tx would fail
+        // on-chain). getSwapQuote must throw so the doomed route is never offered/signed — and it
+        // must throw before the native compute-budget step, so no JNI is reached.
+        val api =
+            jupiterApiImpl(
+                service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT),
+                engine =
+                    MockEngine { request ->
+                        if (request.url.encodedPath.endsWith("/quote")) {
+                            respond(
+                                content = routeResponseJson(null),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        } else {
+                            respond(
+                                content =
+                                    """{"swapTransaction":"$SWAP_TX","simulationError":{"errorCode":"TRANSACTION_ERROR","error":"Error processing Instruction 2: custom program error: 0x1789"}}""",
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        }
+                    },
+            )
+
+        assertThrows(SwapException.SwapRouteNotAvailable::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, null)
+            }
+        }
+    }
+
     /**
      * The quote GET returns 429 so [JupiterApi.getSwapQuote] short-circuits before the swap POST
      * and its WalletCore compute-budget step, keeping the slippage tests on the request they assert


### PR DESCRIPTION
Closes #5118

## Problem

Jupiter's `/jup/swap/v1/swap` response **pre-simulates the built transaction** and returns a non-null `simulationError` when it will fail on-chain (slippage / min-out / liquidity at execution). The app dropped that field, so it proceeded to keysign + broadcast a transaction Jupiter already flagged as doomed.

Captured (PYTH → SOL, Meteora → Raydium CLMM → Manifest):
```json
{ "swapTransaction": "…",
  "simulationError": { "errorCode": "TRANSACTION_ERROR",
                       "error": "Error processing Instruction 2: custom program error: 0x1789" } }
```

## Fix

- Add `simulationError` to `QuoteSwapTransactionJson` (the `/swap` response DTO).
- In `JupiterApiImpl.getSwapQuote`, when `simulationError` is non-null, throw `SwapException.SwapRouteNotAvailable` **before** building the tx. `swapApiCall` passes typed `SwapException`s through unchanged, so this drops just the Jupiter route — the picker re-quotes or falls back to another provider, and the user sees "route not available" (`R.string.swap_route_not_available`) instead of being asked to sign a doomed tx.

The throw fires right after parsing the `/swap` body, before the WalletCore compute-budget step, so no native JNI is involved on the failing path.

## Why it matters now

With client-side `skipPreflight` on the Solana broadcast (#5110), a sim-failing tx is no longer rejected at preflight — it lands on-chain as a **failed tx that still pays the fee**. Honoring `simulationError` before signing prevents paying for a known-failing swap. Independent of #5117 (structural `AccountLoadedTwice`).

## Test plan

- [x] `:data:compileDebugKotlin` passes
- [x] `JupiterApiTest` passes, incl. a new case asserting a `/swap` `simulationError` throws `SwapRouteNotAvailable` before the native compute-budget step
- [ ] CI: ktfmt + build (local pre-commit ktfmt worker segfaults — environment issue)
- [ ] Manual: a Jupiter route whose `/swap` returns `simulationError` is dropped from the picker (no sign prompt), and a healthy route still swaps

## Cross-platform

Verify iOS/Windows honor Jupiter's `simulationError` before signing; mirror if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap handling by detecting simulation errors in Jupiter swap responses.
  - If a swap response includes a simulation error, the app now stops and marks the route as unavailable instead of proceeding.
  - Added automated test coverage to ensure routes with simulation errors are correctly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->