### PR TITLE
Redesign keysign waiting-to-connect screen to new Figma design

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeygenScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -137,10 +139,16 @@ private fun KeygenScreen(state: KeygenUiModel, onTryAgainClick: () -> Unit) {
                             vmi.setNumber("progessPercentage", animatedValue)
                         }
 
+                        val statusDescription =
+                            stringResource(R.string.keygen_connecting_with_server)
+
                         RiveAnimation(
                             file = riveFile,
                             viewModelInstance = vmi,
-                            modifier = Modifier.fillMaxSize(),
+                            modifier =
+                                Modifier.fillMaxSize().semantics {
+                                    contentDescription = statusDescription
+                                },
                             fit = Fit.Cover(),
                         )
                     } else {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -74,6 +74,11 @@ internal fun JoinKeysignView() {
     val isKeysignFinished = keysignState is KeysignState.KeysignFinished
     val isKeysignInProgress = state == Keysign && keysignState.isInProgress
     val isSignMessageDone = isKeysignFinished && verifyUiModel is VerifyUiModel.SignMessage
+    val isConnecting =
+        state == DiscoveringSessionID ||
+            state == WaitingForKeysignStart ||
+            state == DiscoverService ||
+            state is QbtcClaim
 
     if (state == JoinKeysign) {
         // Each Verify*Screen owns its scaffold + toolbar, so the join path renders
@@ -161,27 +166,19 @@ internal fun JoinKeysignView() {
         title = title,
         onBack = viewModel::navigateToHome,
         isError = state is Error,
-        fullScreen = isKeysignInProgress,
+        fullScreen = isKeysignInProgress || isConnecting,
         applyDefaultPaddings = !isKeysignFinished,
     ) {
         when (state) {
             DiscoveringSessionID,
             WaitingForKeysignStart -> {
-                val text =
-                    when (state) {
-                        DiscoveringSessionID ->
-                            stringResource(R.string.join_keysign_discovering_session_id)
-                        WaitingForKeysignStart ->
-                            stringResource(R.string.join_keysign_waiting_keysign_start)
-                        else -> ""
-                    }
-                KeysignLoadingScreen(text = text)
+                KeysignLoadingScreen()
             }
 
             DiscoverService -> {
                 val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
                 viewModel.discoveryMediator(nsdManager)
-                KeysignLoadingScreen(text = stringResource(R.string.join_keysign_discovery_service))
+                KeysignLoadingScreen()
             }
 
             JoinKeysign -> Unit // handled above, before the JoinKeysignScreen wrapper
@@ -198,7 +195,7 @@ internal fun JoinKeysignView() {
             is QbtcClaim -> {
                 // The done state (txHash != null) is rendered before the JoinKeysignScreen wrapper;
                 // here the claim is still proving/broadcasting.
-                KeysignLoadingScreen(text = stringResource(R.string.qbtc_claim_proving))
+                KeysignLoadingScreen()
             }
 
             Keysign -> {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import app.rive.Fit
 import app.rive.ViewModelSource
 import app.rive.rememberViewModelInstance
@@ -41,7 +44,14 @@ internal fun KeysignLoadingScreen(modifier: Modifier = Modifier) {
         showRive = true
     }
 
-    Box(modifier = modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+    val statusDescription = stringResource(R.string.keygen_connecting_with_server)
+
+    Box(
+        modifier =
+            modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary).semantics {
+                contentDescription = statusDescription
+            }
+    ) {
         if (showRive && riveFile != null) {
             val vmi =
                 rememberViewModelInstance(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignLoadingScreen.kt
@@ -1,49 +1,61 @@
 package com.vultisig.wallet.ui.screens.keysign
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import app.rive.Fit
+import app.rive.ViewModelSource
+import app.rive.rememberViewModelInstance
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.KeepScreenOn
-import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
+import com.vultisig.wallet.ui.components.rive.rememberRiveResourceFile
 import com.vultisig.wallet.ui.theme.Theme
+import kotlinx.coroutines.delay
 
+/**
+ * Full-bleed "waiting to connect" screen shown to a keysign joiner while it discovers the session /
+ * waits for the initiator. It plays the shared [R.raw.riv_keysign] animation in its default
+ * "Connecting" state (the "Connected" boolean is only flipped later, on the signing-progress
+ * screen), mirroring the keygen connecting screen so the same Rive design carries across both
+ * flows.
+ */
 @Composable
-internal fun KeysignLoadingScreen(text: String, modifier: Modifier = Modifier) {
+internal fun KeysignLoadingScreen(modifier: Modifier = Modifier) {
     KeepScreenOn()
 
-    Column(
-        modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        RiveAnimation(animation = R.raw.riv_connecting_with_server, modifier = Modifier.size(24.dp))
+    val riveFile = rememberRiveResourceFile(resId = R.raw.riv_keysign).value
 
-        UiSpacer(size = 16.dp)
+    // Reveal the Rive only after it has had a moment to inflate, so the transition from the
+    // preceding screen renders the solid app background rather than an empty/blank frame.
+    var showRive by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        delay(RIVE_REVEAL_DELAY_MS)
+        showRive = true
+    }
 
-        Text(
-            text = text,
-            color = Theme.v2.colors.text.primary,
-            style = Theme.brockmann.headings.title2,
-            textAlign = TextAlign.Center,
-        )
+    Box(modifier = modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+        if (showRive && riveFile != null) {
+            val vmi =
+                rememberViewModelInstance(
+                    file = riveFile,
+                    source = ViewModelSource.Named("ViewModel").defaultInstance(),
+                )
+            RiveAnimation(
+                file = riveFile,
+                viewModelInstance = vmi,
+                modifier = Modifier.fillMaxSize(),
+                fit = Fit.Cover(),
+            )
+        }
     }
 }
 
-@Preview
-@Composable
-private fun KeysignLoadingScreenPreview() {
-    KeysignLoadingScreen(text = stringResource(R.string.join_keysign_discovering_session_id))
-}
+private const val RIVE_REVEAL_DELAY_MS = 300L

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -149,7 +149,6 @@
     <string name="app_name">Vultisig</string>
     <string name="tokens">Tokens</string>
     <string name="vault_list_vaults_list">Tresore</string>
-    <string name="join_keysign_waiting_keysign_start">Warte auf den Start von Keysign.</string>
     <string name="tx_done_address_copied">%1$s in die Zwischenablage kopiert</string>
     <string name="token_logo">Token-Logo</string>
     <string name="vault_edit_this_name_already_exist">dieser Name existiert bereits</string>
@@ -182,8 +181,6 @@
     <string name="swap_price_impact_good">Gut</string>
     <string name="swap_price_impact_average">Mittel</string>
     <string name="swap_price_impact_high">Hoch</string>
-    <string name="join_keysign_discovering_session_id">Sitzungs-ID ermitteln</string>
-    <string name="join_keysign_discovery_service">Service entdecken</string>
     <string name="vault_settings_delete_subtitle">Löschen Sie Ihren Tresor dauerhaft.</string>
     <string name="currency_unit_setting_screen_title">Währung</string>
     <string name="share_qr_utils_choose_an_app">Wählen Sie eine App</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -76,8 +76,6 @@
     <string name="vault_settings_security_screen_title_content">Puedes desactivar la seguridad en cadena en tiempo real proporcionada por Blockaid.</string>
     <string name="vault_settings_security_screen_title">Seguridad</string>
     <string name="join_keysign_missing_required_vault">No tienes la bóveda necesaria para Keysign</string>
-    <string name="join_keysign_discovery_service">Descubriendo el servicio</string>
-    <string name="join_keysign_waiting_keysign_start">Esperando que se inicie Keysign.</string>
     <string name="naming_vault_screen_invalid_name">Nombre inválido</string>
     <string name="rename_vault_invalid_name">Nombre inválido</string>
     <string name="vault_name_too_long_error">El nombre de la bóveda es demasiado largo</string>
@@ -124,7 +122,6 @@
     <string name="verify_transaction_consent_address">Estoy enviando a la dirección correcta</string>
     <string name="verify_transaction_consent_amount">La cantidad es correcta</string>
     <string name="verify_transaction_error_not_enough_consent">Por favor, revise todos los consentimientos</string>
-    <string name="join_keysign_discovering_session_id">Descubriendo el ID de sesión</string>
     <string name="transaction_done_title">Hecho</string>
     <string name="transaction_done_overview">Resumen</string>
     <string name="transaction_done_complete">Completo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -149,7 +149,6 @@
     <string name="swap_form_vault">Trezor</string>
     <string name="swap_form_min_pay">min. isplata</string>
     <string name="vault_list_vaults_list">Sefovi</string>
-    <string name="join_keysign_waiting_keysign_start">Čeka se da se Keysign pokrene.</string>
     <string name="tx_done_address_copied">%1$s kopirano u međuspremnik</string>
     <string name="token_logo">Logo tokena</string>
     <string name="vault_edit_this_name_already_exist">ovo ime već postoji</string>
@@ -182,8 +181,6 @@
     <string name="swap_price_impact_good">Dobro</string>
     <string name="swap_price_impact_average">Srednje</string>
     <string name="swap_price_impact_high">Visoko</string>
-    <string name="join_keysign_discovering_session_id">Otkrivanje ID-a sesije</string>
-    <string name="join_keysign_discovery_service">Usluga otkrivanja</string>
     <string name="vault_settings_delete_subtitle">Trajno izbrišite svoj trezor.</string>
     <string name="currency_unit_setting_screen_title">Valuta</string>
     <string name="share_qr_utils_choose_an_app">Odaberite aplikaciju</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -149,7 +149,6 @@
     <string name="faq_settings_q1">Che cos\'è Vultisig?</string>
     <string name="vault_list_vaults_list">Cassaforti</string>
     <string name="swap_screen_invalid_vault">La transazione probabilmente fallirà, la cassaforte non è stata caricata.</string>
-    <string name="join_keysign_waiting_keysign_start">In attesa dell\'avvio di Keysign.</string>
     <string name="tx_done_address_copied">%1$s copiato negli appunti</string>
     <string name="token_logo">Logo del gettone</string>
     <string name="vault_edit_this_name_already_exist">questo nome esiste già</string>
@@ -182,8 +181,6 @@
     <string name="swap_price_impact_good">Buono</string>
     <string name="swap_price_impact_average">Medio</string>
     <string name="swap_price_impact_high">Alto</string>
-    <string name="join_keysign_discovering_session_id">Individuazione dell\'ID sessione</string>
-    <string name="join_keysign_discovery_service">Scoprire il servizio</string>
     <string name="vault_settings_delete_subtitle">Elimina definitivamente il tuo vault.</string>
     <string name="currency_unit_setting_screen_title">Valuta</string>
     <string name="share_qr_utils_choose_an_app">Scegli un\'app</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -155,8 +155,6 @@
     <string name="vault_tier_ultimate_description_part2">Vultisig 수수료 완전 면제</string>
     <string name="vault_tier_ultimate_description_part3">를 받을 수 있습니다.</string>
     <string name="join_keysign_missing_required_vault">서명에 필요한 볼트가 없습니다</string>
-    <string name="join_keysign_discovery_service">서비스 검색 중</string>
-    <string name="join_keysign_waiting_keysign_start">서명 시작 대기 중.</string>
     <string name="send_screen_title">보내기</string>
     <string name="send_from_address">보내는 주소</string>
     <string name="send_to_address">받는 주소</string>
@@ -199,7 +197,6 @@
     <string name="verify_transaction_consent_amount">금액이 정확합니다</string>
     <string name="verify_transaction_error_not_enough_consent">모든 동의 항목을 확인해 주세요</string>
     <string name="camera_permission_open_settings">설정 열기</string>
-    <string name="join_keysign_discovering_session_id">세션 ID 검색 중</string>
     <string name="transaction_done_title">완료</string>
     <string name="transaction_done_overview">개요</string>
     <string name="transaction_done_complete">완료됨</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -78,8 +78,6 @@
     <string name="vault_settings_security_screen_title_bottomsheet">On-chain beveiliging uitgeschakeld</string>
     <string name="vault_settings_security_screen_content_bottomsheet">Het uitschakelen van on-chain beveiliging betekent dat Blockaid transacties niet kan verifiëren. Je bent dan minder beschermd.</string>
     <string name="vault_settings_security_screen_title">Beveiliging</string>
-    <string name="join_keysign_discovery_service">Service ontdekken</string>
-    <string name="join_keysign_waiting_keysign_start">Wachten op het starten van Keysign.</string>
     <string name="send_screen_title">Sturen</string>
     <string name="bond_screen_title">Bonden</string>
     <string name="transaction_type_button_send">Sturen</string>
@@ -124,7 +122,6 @@
     <string name="verify_transaction_consent_amount">Het bedrag is correct</string>
     <string name="verify_transaction_error_not_enough_consent">Controleer alle toestemmingen</string>
     <string name="camera_permission_open_settings">Instellingen openen</string>
-    <string name="join_keysign_discovering_session_id">Sessienummer ontdekken</string>
     <string name="transaction_done_title">Gedaan</string>
     <string name="transaction_done_overview">Overzicht</string>
     <string name="transaction_done_complete">Voltooid</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -147,7 +147,6 @@
     <string name="verify_swap_sign_button">Assinar transação</string>
     <string name="swap_screen_invalid_vault">A transação provavelmente falhará, o cofre não pôde ser carregado.</string>
     <string name="swap_error_no_amount">A quantidade deve ser um número positivo.</string>
-    <string name="join_keysign_waiting_keysign_start">Aguardando o início do Keysign.</string>
     <string name="tx_done_address_copied">%1$s copiado para a área de transferência</string>
     <string name="token_logo">Logotipo do token</string>
     <string name="vault_edit_this_name_already_exist">esse nome já existe</string>
@@ -182,8 +181,6 @@
     <string name="swap_price_impact_good">Bom</string>
     <string name="swap_price_impact_average">Médio</string>
     <string name="swap_price_impact_high">Alto</string>
-    <string name="join_keysign_discovering_session_id">Descobrindo o ID da sessão</string>
-    <string name="join_keysign_discovery_service">Descobrindo o Serviço</string>
     <string name="vault_settings_delete_subtitle">Exclua seu cofre permanentemente.</string>
     <string name="currency_unit_setting_screen_title">Moeda</string>
     <string name="share_qr_utils_choose_an_app">Escolha um aplicativo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -78,8 +78,6 @@
     <string name="vault_tier_ultimate_description_part2">полное освобождение от комиссий Vultisig</string>
     <string name="vault_tier_ultimate_description_part3"> при всех обменах.</string>
     <string name="join_keysign_missing_required_vault">У вас нет необходимого хранилища для Keysign</string>
-    <string name="join_keysign_discovery_service">Обнаружение службы</string>
-    <string name="join_keysign_waiting_keysign_start">Ожидание начала ключевой подписи.</string>
     <string name="send_screen_title">Отправить</string>
     <string name="bond_screen_title">Привязать</string>
     <string name="transaction_type_button_send">Отправить</string>
@@ -124,7 +122,6 @@
     <string name="verify_transaction_consent_amount">Сумма верна</string>
     <string name="verify_transaction_error_not_enough_consent">Пожалуйста, проверьте все согласия</string>
     <string name="camera_permission_open_settings">Открыть настройки</string>
-    <string name="join_keysign_discovering_session_id">Обнаружение ID сессии</string>
     <string name="transaction_done_title">Готово</string>
     <string name="transaction_done_overview">Обзор</string>
     <string name="transaction_done_complete">Завершено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -153,8 +153,6 @@
     <string name="vault_tier_ultimate_description_part3">在所有交换中。</string>
     <!-- Keysign & Join -->
     <string name="join_keysign_missing_required_vault">您没有密钥签名所需的保险库</string>
-    <string name="join_keysign_discovery_service">发现服务中</string>
-    <string name="join_keysign_waiting_keysign_start">等待密钥签名开始。</string>
 
     <!-- Send Screen -->
     <string name="send_screen_title">发送</string>
@@ -227,7 +225,6 @@
 
     <!-- Camera & QR -->
     <string name="camera_permission_open_settings">打开设置</string>
-    <string name="join_keysign_discovering_session_id">发现会话 ID</string>
 
     <!-- Transaction Done -->
     <string name="transaction_done_title">完成</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,8 +155,6 @@
     <string name="vault_tier_ultimate_description_part2">a complete Vultisig fee waiver</string>
     <string name="vault_tier_ultimate_description_part3"> on all swaps.</string>
     <string name="join_keysign_missing_required_vault">You do not have the required vault for Keysign</string>
-    <string name="join_keysign_discovery_service">Discovering Service</string>
-    <string name="join_keysign_waiting_keysign_start">Waiting for Keysign to start.</string>
     <string name="send_screen_title">Send</string>
     <string name="send_from_address">From</string>
     <string name="send_to_address">Send to</string>
@@ -200,7 +198,6 @@
     <string name="verify_transaction_consent_amount">The amount is correct</string>
     <string name="verify_transaction_error_not_enough_consent">Please check all consents</string>
     <string name="camera_permission_open_settings">Open Settings</string>
-    <string name="join_keysign_discovering_session_id">Discovering Session ID</string>
     <string name="transaction_done_title">Done</string>
     <string name="transaction_done_overview">Overview</string>
     <string name="transaction_done_complete">Complete</string>


### PR DESCRIPTION
## Summary
Reimplements the keysign "waiting to connect" state to match the new Figma frame ([Keygen - Connecting - Rive](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=66720-110569)). The old screen showed a small 24dp spinner + centered per-state text ("Discovering Session ID", …).

The shared `KeysignLoadingScreen` is now the full-bleed connecting animation — the same treatment already shipped for the keygen flow (`PeerDiscoveryScreen.connectingToServer` / `KeygenScreen`), reusing the `riv_keysign` Rive file which contains the whole `Connecting → Connected → progress → Success` lifecycle.

Fixes #5135.

## Changes
- **`KeysignLoadingScreen`**: plays `riv_keysign` full-screen (`fillMaxSize` + `Fit.Cover`) in its default "Connecting" state, on a solid background, with a 300ms reveal to avoid a blank transition frame. The "Connecting…" copy is baked into the Rive, so the per-state `text` parameter is removed.
- **`JoinKeysignView`**: routes all joiner loading states (`DiscoveringSessionID`, `WaitingForKeysignStart`, `DiscoverService`, and the QBTC claim proving state) through the shared screen and renders them edge-to-edge (`fullScreen`) without the "Sign Transaction" toolbar. Hardware back still works via the wrapper's `BackHandler`.
- Removed the three now-orphaned strings (`join_keysign_discovering_session_id`, `join_keysign_waiting_keysign_start`, `join_keysign_discovery_service`) from all 10 locale files.

## Notes
- Follows the keygen precedent of keeping the connecting animation and the signing-progress animation on **separate screens/ViewModels** (each owning its own Rive instance) rather than merging the two ViewModels.
- The `Connected=true` flip on the signing-progress screen (`Keysign.kt`) is intentionally out of scope for this PR.

## Test plan
- [x] `:app:ktfmtFormat` clean
- [x] `:app:compileDebugKotlin` green
- [ ] On-device visual check of the joiner waiting state (needs a real keysign session; the full-bleed `riv_keysign` renders only on device, not in Compose previews)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the joining/connection flow by using a consistent full-screen loading animation during session discovery and connecting states.
  * Streamlined intermediate Keysign loading screens to remove state-specific text variations, resulting in a smoother, more polished experience.
* **Accessibility**
  * Enhanced the Keygen connecting UI by adding a semantic content description for assistive technologies.
* **Localization**
  * Updated Keysign-related translations by removing discovery/waiting messages (and reflecting the new missing-vault messaging where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->