### PR TITLE
Join-transaction banner: swipe-up dismiss + stop covering home content

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -2,27 +2,33 @@ package com.vultisig.wallet.app.activity.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.semantics
@@ -136,6 +142,12 @@ private fun MainActivityContent(
     val density = LocalDensity.current
     val statusBarHeightPx = WindowInsets.statusBars.getTop(density)
 
+    // On-screen height the banner overlay occupies below the status bar, captured from its measured
+    // layout. Used to reserve matching space in the content column so the banner pushes content down
+    // instead of floating over it (#5134).
+    var bannerHeightPx by remember { mutableIntStateOf(0) }
+    val bannerHeightDp = with(density) { bannerHeightPx.toDp() }
+
     Box(
         modifier =
             Modifier.semantics {
@@ -150,6 +162,16 @@ private fun MainActivityContent(
         // reveal the screen's gradient instead of the solid outer Box background.
         Column(modifier = Modifier.fillMaxSize()) {
             OfflineBanner(isOffline)
+            // Reserve the banner's height so content sits below it while it is shown. This
+            // AnimatedVisibility mirrors the overlay's enter/exit so the reserved space grows and
+            // collapses in step with the banner sliding in and out.
+            AnimatedVisibility(
+                visible = foregroundNotification != null,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Spacer(modifier = Modifier.height(bannerHeightDp))
+            }
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) { navContent() }
         }
 
@@ -160,12 +182,14 @@ private fun MainActivityContent(
                 enter = slideInVertically { -it },
                 exit = slideOutVertically { -it },
                 modifier =
-                    Modifier.fillMaxWidth().layout { measurable, constraints ->
-                        val placeable = measurable.measure(constraints)
-                        layout(placeable.width, placeable.height - statusBarHeightPx) {
-                            placeable.placeRelative(0, -statusBarHeightPx)
-                        }
-                    },
+                    Modifier.fillMaxWidth()
+                        .onSizeChanged { bannerHeightPx = it.height }
+                        .layout { measurable, constraints ->
+                            val placeable = measurable.measure(constraints)
+                            layout(placeable.width, placeable.height - statusBarHeightPx) {
+                                placeable.placeRelative(0, -statusBarHeightPx)
+                            }
+                        },
             ) {
                 lastNotification?.let { notification ->
                     ForegroundNotificationBanner(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
@@ -3,7 +3,7 @@ package com.vultisig.wallet.ui.components.banners
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -92,10 +92,13 @@ internal fun ForegroundNotificationBanner(
     val shape = RoundedCornerShape(bottomStart = 40.dp, bottomEnd = 40.dp)
     val imagePainter = painterResource(R.drawable.foreground_layer)
 
-    // Horizontal swipe-to-dismiss: lets the user flick away a stale or unwanted signing
-    // request (e.g. an old notification) without acting on it. Dragging past ~35% of the
-    // banner width settles it off-screen and reports the dismissal; a shorter drag springs back.
+    // Swipe-to-dismiss on two axes: lets the user flick away a stale or unwanted signing request
+    // (e.g. an old notification) without acting on it. A horizontal flick past ~35% of the banner
+    // width, or an upward drag past ~25% of its height, settles it off-screen and reports the
+    // dismissal; a shorter drag springs back. Downward drag is clamped to 0 (the banner sits at the
+    // top edge, so pushing it further into the content is meaningless).
     val offsetX = remember { Animatable(0f) }
+    val offsetY = remember { Animatable(0f) }
     val scope = rememberCoroutineScope()
 
     // Re-center only when a live request (re)enters. A new or re-broadcast push produces a fresh
@@ -103,40 +106,64 @@ internal fun ForegroundNotificationBanner(
     // do NOT reset on dismissal: after a successful swipe the banner must stay off-screen while the
     // parent's vertical exit transition plays out, otherwise the snap-back rides that exit and the
     // banner visibly re-centers then slides up (#5001).
-    LaunchedEffect(qrCodeData, isActive) { if (isActive) offsetX.snapTo(0f) }
+    LaunchedEffect(qrCodeData, isActive) {
+        if (isActive) {
+            offsetX.snapTo(0f)
+            offsetY.snapTo(0f)
+        }
+    }
 
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
                 .pointerInput(Unit) {
-                    val dismissThreshold = size.width * 0.35f
-                    detectHorizontalDragGestures(
-                        onHorizontalDrag = { change, dragAmount ->
+                    val horizontalThreshold = size.width * 0.35f
+                    val verticalThreshold = size.height * 0.25f
+                    detectDragGestures(
+                        onDrag = { change, dragAmount ->
                             change.consume()
-                            scope.launch { offsetX.snapTo(offsetX.value + dragAmount) }
+                            scope.launch {
+                                offsetX.snapTo(offsetX.value + dragAmount.x)
+                                // Only allow upward travel; a downward drag can't push the banner
+                                // deeper into the content below it.
+                                offsetY.snapTo((offsetY.value + dragAmount.y).coerceAtMost(0f))
+                            }
                         },
                         onDragEnd = {
                             scope.launch {
-                                if (abs(offsetX.value) >= dismissThreshold) {
-                                    val target =
-                                        if (offsetX.value > 0) size.width.toFloat()
-                                        else -size.width.toFloat()
-                                    offsetX.animateTo(target)
-                                    // Leave the banner off-screen and clear the request; the
-                                    // retained offset keeps it hidden through the parent's vertical
-                                    // exit transition. The LaunchedEffect above re-centers it only
-                                    // when a fresh request next (re)enters.
-                                    onDismiss()
-                                } else {
-                                    offsetX.animateTo(0f)
+                                when {
+                                    -offsetY.value >= verticalThreshold -> {
+                                        offsetY.animateTo(-size.height.toFloat())
+                                        // Leave the banner off-screen and clear the request; the
+                                        // retained offset keeps it hidden through the parent's
+                                        // vertical exit transition. The LaunchedEffect above
+                                        // re-centers it only when a fresh request next (re)enters.
+                                        onDismiss()
+                                    }
+                                    abs(offsetX.value) >= horizontalThreshold -> {
+                                        val target =
+                                            if (offsetX.value > 0) size.width.toFloat()
+                                            else -size.width.toFloat()
+                                        offsetX.animateTo(target)
+                                        onDismiss()
+                                    }
+                                    else -> {
+                                        offsetX.animateTo(0f)
+                                        offsetY.animateTo(0f)
+                                    }
                                 }
                             }
                         },
                         // A drag interrupted by a second pointer or an arena steal runs neither
                         // onDragEnd branch; without this the banner freezes at its partial offset.
-                        onDragCancel = { scope.launch { offsetX.animateTo(0f) } },
+                        onDragCancel = {
+                            scope.launch {
+                                offsetX.animateTo(0f)
+                                offsetY.animateTo(0f)
+                            }
+                        },
                     )
                 }
                 .clip(shape)


### PR DESCRIPTION
Fixes #5134

The "Join transaction" foreground-notification banner (shown while a keysign/swap session is live) behaved like a stuck, blocking popup. Two fixes:

## Changes

**1. Swipe-up now dismisses the banner** (`ForegroundNotificationBanner.kt`)
- Dismissal was wired to horizontal drag only (`detectHorizontalDragGestures`), so the natural "swipe up to dismiss a top banner" gesture did nothing.
- Switched to `detectDragGestures` and added an upward-flick dismissal: dragging up past ~25% of the banner height animates it off-screen and reports the dismissal, mirroring the existing horizontal logic. The retained off-screen offset keeps it hidden through the parent's vertical exit transition, so the #5001 double-animation fix stays intact.
- Downward travel is clamped to `0` — the banner is top-anchored, so pushing it down into content is meaningless.

**2. Banner no longer covers home content** (`MainActivityContent.kt`)
- The banner floated as an overlay on top of `navContent` and obscured the top of the balance card.
- Its measured height is now reserved in the content `Column` via a mirrored `AnimatedVisibility` spacer, so content is pushed down while the banner is shown and returns up when it's dismissed.
- The overlay itself is unchanged, preserving its status-bar bleed and rounded-corner gradient reveal.

## Test plan
- [ ] Start/join a swap keysign session so the "Join transaction" banner appears on home.
- [ ] Swipe the banner **up** → it dismisses.
- [ ] Swipe the banner **sideways** → still dismisses (unchanged).
- [ ] Short drag in either direction → springs back.
- [ ] While the banner is shown, the balance card sits fully below it (not covered); when dismissed, content returns to its normal position.