### PR TITLE
chore: bump version to 1.0.112

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 35
-        versionCode = 111
-        versionName = "1.0.111"
+        versionCode = 112
+        versionName = "1.0.112"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -143,7 +143,8 @@ private fun MainActivityContent(
     val statusBarHeightPx = WindowInsets.statusBars.getTop(density)
 
     // On-screen height the banner overlay occupies below the status bar, captured from its measured
-    // layout. Used to reserve matching space in the content column so the banner pushes content down
+    // layout. Used to reserve matching space in the content column so the banner pushes content
+    // down
     // instead of floating over it (#5134).
     var bannerHeightPx by remember { mutableIntStateOf(0) }
     val bannerHeightDp = with(density) { bannerHeightPx.toDp() }


### PR DESCRIPTION
## Summary
- Bump `versionCode` 111 → 112 and `versionName` 1.0.111 → 1.0.112
- Minor incidental ktfmt comment rewrap in `MainActivityContent.kt` (auto-applied by the pre-commit hook)

## Test Plan
- [ ] Debug build succeeds (`./gradlew assembleDebug`)
- [ ] Version shows as 1.0.112 in-app

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **1.0.112** for the next release.
* **Style**
  * Adjusted a nearby comment formatting in the main screen layout code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->