### PR TITLE
fix(solana): stop double-counting priority fee in send fee estimate

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
@@ -71,22 +71,21 @@ class SolanaFeeService @Inject constructor(private val solanaApi: SolanaApi) : F
 
         val serializedTx = SolanaHelper(vaultHexPubKey).getVersionedMessage(keySignPayload)
 
-        val baseFee = solanaApi.getFeeForMessage(serializedTx)
+        // serializedTx carries the ComputeBudget instructions, so getFeeForMessage already returns
+        // base signature fee + prioritization fee (price × limit / 1e6) — verified against mainnet
+        // RPC (a no-ComputeBudget message returns 5000, the same message with them returns 105000).
+        // Adding a separate priority term here would double-count it, so only rent-exemption is
+        // added on top.
+        val messageFee = solanaApi.getFeeForMessage(serializedTx)
         val rentExemptionFee = calculateRentExemptionForTokens(toAddress, coin)
 
         val solanaPriorityFee =
             (keySignPayload.blockChainSpecific as BlockChainSpecific.Solana).priorityFee
-        val priorityFee = solanaPriorityFee * SOLANA_PRIORITY_FEE_LIMIT.toBigInteger()
-        val priorityAmount =
-            priorityFee
-                .toBigDecimal()
-                .divide(BigDecimal.TEN.pow(6), RoundingMode.DOWN)
-                .toBigInteger()
 
         return GasFees(
             price = solanaPriorityFee,
             limit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
-            amount = baseFee + priorityAmount + rentExemptionFee,
+            amount = messageFee + rentExemptionFee,
         )
     }
 


### PR DESCRIPTION
## Summary
- `SolanaFeeService.calculateFees` was adding the prioritization fee **twice** to the displayed SOL network fee.
- `getFeeForMessage` already includes the prioritization fee, because the serialized message (`getVersionedMessage`) carries the ComputeBudget `SetComputeUnitPrice` / `SetComputeUnitLimit` instructions. The method then added a separate `priorityAmount` on top, so the estimate was `base + 2×priority + rent` instead of `base + priority + rent`.
- Fix: take the RPC message fee as the full base+priority and only add rent-exemption on top (`amount = messageFee + rentExemptionFee`).

## Verification (mainnet RPC, apiVersion 4.1.0)
Probed `getFeeForMessage` with a hand-built transfer message:

| message | `getFeeForMessage` |
|---|---|
| no ComputeBudget instructions | **5,000** (pure base, 1 signature) |
| with ComputeBudget (limit 100k, price 1,000,000 µLam/CU) | **105,000** (5,000 base + 100,000 priority) |

This confirms the RPC folds the priority fee into the message fee, so the old `+ priorityAmount` was a genuine double count.

## Notes
- Signing/broadcast are unaffected — this only changes the displayed estimate.
- Related area: the Solana priority-fee display work in #5114 / #5125.
- `calculateFees` builds its message via TrustWallet Core JNI, which isn't loaded in JVM unit tests (see `SolanaHelperTest`), so it isn't unit-testable here; the mainnet probe covered the behavior instead.
- **Not addressed here:** `calculateDefaultFees` (swap/estimate path) has a similar shape — its `DEFAULT_COIN_TRANSFER_BASE_FEE` constant (105,000 = base + floor-priority) also gets `priorityAmount` added on top. Left untouched pending a decision on the intended default margin.

## Test Plan
- [ ] Manual: send native SOL and an SPL token, confirm the displayed network fee matches the amount actually charged on-chain (explorer)
- [ ] Manual: verify under congestion the fee tracks base + single priority + rent
- [x] Lint passes (`./gradlew :data:lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

test tx link: https://orbmarkets.io/tx/3T3NC2xLTKr1BcN6qZ7AFYRg4X3HAEvAbjKknwgWJyVkwEiYTU1oeC2LadheN4QFYXaSJHdeSRUPy4cRokdCKRq9
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Solana transaction fee calculations so non-swap transactions use the full message fee plus rent exemption, avoiding double-counting of priority fees.
  * Improved fee reporting accuracy while keeping priority fee price and limit values unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->