### PR TITLE
fix(settings): hide post-quantum keygen for legacy GG20 vaults

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/vault_settings/VaultSettingsViewModel.kt
@@ -297,7 +297,10 @@ constructor(
             hasFastSign = isVaultHasFastSignById(vaultId) && vault?.signers?.count() == 2
             val hasPassword = vaultPasswordRepository.getPassword(vaultId) != null
             val hasMldsaKey = vault != null && vault.hasValidMldsaKey()
-            val supportsDilithiumKeygen = vault != null && vault.libType != SigningLibType.KeyImport
+            // Only DKLS vaults can run the post-quantum (Dilithium/MLDSA) keygen: KeyImport vaults
+            // receive the key at import, and GG20 vaults must migrate to DKLS first — so the option
+            // stays hidden for them (an isEnabled=false item is filtered out of the list).
+            val supportsDilithiumKeygen = vault != null && vault.libType == SigningLibType.DKLS
 
             val newItems =
                 uiModel.value.settingGroups.map { group ->

--- a/app/src/test/java/com/vultisig/wallet/ui/models/settings/VaultSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/settings/VaultSettingsViewModelTest.kt
@@ -321,6 +321,36 @@ internal class VaultSettingsViewModelTest {
             customRpc.enabled.shouldBeFalse()
         }
 
+    /** The post-quantum keygen row shows for a DKLS vault without an MLDSA key yet. */
+    @Test
+    fun `dilithium keygen row is enabled for a DKLS vault`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(VAULT_ID) } returns
+                Vault(id = VAULT_ID, name = "Test", libType = SigningLibType.DKLS)
+            val vm = createViewModel()
+            val dilithium =
+                vm.uiModel.value.settingGroups
+                    .flatMap { it.items }
+                    .filterIsInstance<VaultSettingsItem.DilithiumKeygen>()
+                    .single()
+            dilithium.enabled.shouldBeTrue()
+        }
+
+    /** GG20 vaults must migrate to DKLS first, so the post-quantum keygen row is hidden. */
+    @Test
+    fun `dilithium keygen row is hidden for a GG20 vault`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(VAULT_ID) } returns
+                Vault(id = VAULT_ID, name = "Test", libType = SigningLibType.GG20)
+            val vm = createViewModel()
+            val dilithium =
+                vm.uiModel.value.settingGroups
+                    .flatMap { it.items }
+                    .filterIsInstance<VaultSettingsItem.DilithiumKeygen>()
+                    .single()
+            dilithium.enabled.shouldBeFalse()
+        }
+
     private companion object {
         const val VAULT_ID = "vault-1"
     }


### PR DESCRIPTION
## Summary

The **"enable post-quantum key"** (Dilithium/MLDSA keygen) option in **advanced vault settings** was shown for GG20 vaults. A GG20 vault can't run the DKLS-based post-quantum keygen — it must **migrate to DKLS first** — so offering the option there leads into a flow that can't complete.

The option was gated on `libType != SigningLibType.KeyImport`, which let GG20 through.

## Change

`VaultSettingsViewModel` now gates the row on `libType == SigningLibType.DKLS`:

- **KeyImport** vaults already receive the MLDSA key at import (excluded, as before).
- **GG20** vaults are now excluded — they should migrate first.
- **DKLS** vaults (without an MLDSA key yet) still see it.

The advanced-settings screen renders `group.items.filter(VaultSettingsItem::enabled)`, so an `isEnabled = false` item is filtered out of the list entirely — i.e. the row is **hidden** for GG20 vaults, not just greyed out.

> Note: the earlier `ChainTokensViewModel` claim-banner change was reverted — the existing eligibility logic there is already sufficient.

## Test plan

- [x] `VaultSettingsViewModelTest` — added `dilithium keygen row is enabled for a DKLS vault` and `dilithium keygen row is hidden for a GG20 vault`.
- [x] `./gradlew :app:testDebugUnitTest --tests VaultSettingsViewModelTest` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the availability of the Dilithium/MLDSA keygen option so it now appears only for supported vault types.
  * Vaults that are not eligible for this feature will no longer show it as enabled or visible.
* **Tests**
  * Added coverage for the keygen row visibility behavior to confirm it is shown for supported vaults and hidden for unsupported ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->