### PR TITLE
fix(swap): rKUJI destination fails with generic 'adjust the amount' error

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -62,6 +62,11 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("amount less than dust threshold") -> AmountBelowDustThreshold(error)
                     contains("amount less than min swap amount") -> SmallSwapAmount(error)
                     contains("pool does not exist") -> SwapRouteNotAvailable(error)
+                    // Thornode rejects an asset id it can't parse ("bad to asset: invalid
+                    // symbol: invalid request") — deterministic, so never "adjust the amount".
+                    contains("bad to asset") ||
+                        contains("bad from asset") ||
+                        contains("invalid symbol") -> SwapRouteNotAvailable(error)
                     contains("trading is halted") || contains("trading halted") ->
                         TradingHalted(error)
                     contains("timeout") -> TimeOut(error)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -39,6 +39,7 @@ constructor(private val poolEligibility: SwapPoolEligibilityRepository) : SwapPr
             "YFI",
         )
     private val thorBscTokens = setOf("BNB", "USDT", "USDC")
+    private val thorGaiaTokens = setOf("ATOM")
     private val thorAvaxTokens = setOf("AVAX", "USDC", "USDT", "SOL")
     private val thorBaseTokens = setOf("ETH", "CBBTC", "USDC", "VVV")
     private val mayaEthTokens = setOf("ETH", "USDC", "LLD")
@@ -118,7 +119,14 @@ constructor(private val poolEligibility: SwapPoolEligibilityRepository) : SwapPr
             Chain.ThorChain -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA)
             Chain.Bitcoin -> setOf(SwapProvider.THORCHAIN, SwapProvider.MAYA, SwapProvider.SWAPKIT)
 
-            Chain.GaiaChain -> setOf(SwapProvider.THORCHAIN)
+            // THORChain's only Cosmos Hub pool is native ATOM. IBC/factory tokens (e.g. rKUJI)
+            // would be sent as `GAIA.<TICKER>-ibc/...`, which Thornode rejects with "bad to asset"
+            // (#5113) — offer them no providers instead of a guaranteed-to-fail quote. A live
+            // Available pool can still add a route for a listed token.
+            Chain.GaiaChain ->
+                if (isThorEligible(Chain.GaiaChain, ticker, thorGaiaTokens))
+                    setOf(SwapProvider.THORCHAIN)
+                else emptySet()
 
             // SwapKit DOGE/BCH/LTC routes: DOGE/BCH are legacy P2PKH (SwapKitLegacyP2PKHSigner,
             // with

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/HandleSwapExceptionTest.kt
@@ -105,6 +105,27 @@ class HandleSwapExceptionTest {
     }
 
     @Test
+    fun `thorchain bad to asset full message maps to SwapRouteNotAvailable`() {
+        // Thornode 400 for a destination asset it can't parse, e.g. GAIA.rKUJI-ibc/... (#5113).
+        val result =
+            SwapException.handleSwapException("bad to asset: invalid symbol: invalid request")
+        assertInstanceOf(SwapException.SwapRouteNotAvailable::class.java, result)
+    }
+
+    @Test
+    fun `thorchain bad from asset maps to SwapRouteNotAvailable`() {
+        val result =
+            SwapException.handleSwapException("bad from asset: invalid symbol: invalid request")
+        assertInstanceOf(SwapException.SwapRouteNotAvailable::class.java, result)
+    }
+
+    @Test
+    fun `invalid symbol maps to SwapRouteNotAvailable`() {
+        val result = SwapException.handleSwapException("Invalid Symbol")
+        assertInstanceOf(SwapException.SwapRouteNotAvailable::class.java, result)
+    }
+
+    @Test
     fun `amount less than min swap maps to SmallSwapAmount`() {
         val result = SwapException.handleSwapException("amount less than min swap amount: 10000")
         assertInstanceOf(SwapException.SmallSwapAmount::class.java, result)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTableTest.kt
@@ -198,6 +198,37 @@ internal class SwapProviderTableTest {
     }
 
     @Test
+    fun `GaiaChain offers THORChain for native ATOM but nothing for IBC tokens`() {
+        // THORChain's only Cosmos Hub pool is GAIA.ATOM. An IBC token like rKUJI would be quoted
+        // as `GAIA.rKUJI-ibc/...`, which Thornode rejects with "bad to asset" — it must get an
+        // empty provider set so the pair reads "Swap route not available" up front (#5113).
+        assertEquals(
+            setOf(SwapProvider.THORCHAIN),
+            table.providersFor(coin(Chain.GaiaChain, "ATOM", isNative = true)),
+            "Native ATOM must keep its THORChain route",
+        )
+        assertEquals(
+            emptySet<SwapProvider>(),
+            table.providersFor(
+                coin(Chain.GaiaChain, "rKUJI", isNative = false, contract = "ibc/50A69DC508AC")
+            ),
+            "A Cosmos IBC token has no THORChain pool and must get no providers",
+        )
+    }
+
+    @Test
+    fun `live THORChain pool adds a GaiaChain token route the static fallback omits`() {
+        val liveTable = SwapProviderTableImpl(FakeEligibility(thor = setOf("GAIA.RKUJI")))
+        assertEquals(
+            setOf(SwapProvider.THORCHAIN),
+            liveTable.providersFor(
+                coin(Chain.GaiaChain, "rKUJI", isNative = false, contract = "ibc/50A69DC508AC")
+            ),
+            "An Available GAIA pool must re-enable the THORChain route",
+        )
+    }
+
+    @Test
     fun `live Maya pool adds MAYA for ETH USDT that the static fallback omits`() {
         // USDT is not in the static mayaEthTokens fallback, so with no live pools the Ethereum
         // branch never offers MAYA for it.


### PR DESCRIPTION
## Summary

Fixes #5113 — requesting a THORChain quote into a Cosmos Hub IBC token (e.g. ATOM → rKUJI) always failed with a deterministic Thornode 400 (`bad to asset: invalid symbol: invalid request`), surfaced as the misleading *"Swap quote failed. Please try again or adjust the amount."*

Both sub-problems from the issue are addressed:

- **Don't offer the unroutable pair**: the provider table offered THORCHAIN for every `GaiaChain` coin, but THORChain's only Cosmos Hub pool is native ATOM. The GaiaChain branch is now gated on THORChain eligibility (static `ATOM` fallback + live `Available` pools, same pattern as the BSC/Avalanche/Base branches). Selecting rKUJI as a destination now resolves to an empty provider set and shows **"Swap route not available"** immediately — no doomed network call.
- **Honest error for unsupported routes**: Thornode's `bad to asset` / `bad from asset` / `invalid symbol` messages now map to `SwapRouteNotAvailable` instead of falling through to `UnkownSwapError`, so any path that still reaches the node reports the route as unsupported instead of suggesting an amount change.

If THORChain ever lists a Cosmos IBC pool, the live pool eligibility cache re-enables the route automatically — no static table change needed.

## Test plan

- New unit tests pin the behavior:
  - `SwapProviderTableTest`: native ATOM keeps THORCHAIN; a GaiaChain IBC token gets no providers; a live `GAIA.RKUJI` Available pool re-enables the route.
  - `HandleSwapExceptionTest`: the exact Thornode message (`bad to asset: invalid symbol: invalid request`), the `bad from asset` variant, and bare `invalid symbol` all map to `SwapRouteNotAvailable`.
- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — all green.
- Manual: Swap ATOM → rKUJI now shows "Swap route not available" instead of the retry/amount toast; ATOM → BTC/ETH quoting unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated swap error handling to recognize additional “invalid asset symbol” conditions from swap failures and surface them as route-unavailable.
  * Improved Gaia/THORChain swap routing by introducing a native fallback token list and requiring eligibility before enabling THORChain for specific Gaia assets.
* **Tests**
  * Added unit tests for “invalid symbol” swap error mapping.
  * Added Gaia/THORChain routing tests to verify provider availability for native ATOM vs. specific IBC tokens based on eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->