### PR TITLE
feat(terra): support adding custom CW20 tokens on Terra / Terra Classic

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -17,6 +17,8 @@ import com.vultisig.wallet.data.api.models.cosmos.CosmosIbcDenomTraceJson
 import com.vultisig.wallet.data.api.models.cosmos.CosmosSimulateResponse
 import com.vultisig.wallet.data.api.models.cosmos.CosmosTHORChainAccountResponse
 import com.vultisig.wallet.data.api.models.cosmos.CosmosTxStatusJson
+import com.vultisig.wallet.data.api.models.cosmos.Cw20TokenInfoJson
+import com.vultisig.wallet.data.api.models.cosmos.Cw20TokenInfoResponseJson
 import com.vultisig.wallet.data.api.models.cosmos.THORChainAccountValue
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.CustomRpcSupportedChains
@@ -61,6 +63,13 @@ interface CosmosApi {
     suspend fun simulate(txBytes: String): Long?
 
     suspend fun getWasmTokenBalance(address: String, contractAddress: String): CosmosBalance
+
+    /**
+     * CW20 `{"token_info":{}}` smart-query metadata for [contractAddress], or `null` when the
+     * address is not a CW20 contract (wallet address, non-CW20 contract, unknown address) or the
+     * request fails. Used by the custom-token flow on Terra / Terra Classic.
+     */
+    suspend fun getCw20TokenInfo(contractAddress: String): Cw20TokenInfoJson?
 
     suspend fun getIbcDenomTraces(contractAddress: String): CosmosIbcDenomTraceDenomTraceJson
 
@@ -218,6 +227,21 @@ internal class CosmosApiImp(
                     ?.jsonPrimitive
                     ?.content ?: "0",
         )
+    }
+
+    override suspend fun getCw20TokenInfo(contractAddress: String): Cw20TokenInfoJson? {
+        val payload = "{\"token_info\":{}}".encodeBase64()
+        return try {
+            httpClient
+                .get("$rpcEndpoint/cosmwasm/wasm/v1/contract/$contractAddress/smart/$payload")
+                .bodyOrThrow<Cw20TokenInfoResponseJson>()
+                .data
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.d(e, "CW20 token_info lookup failed for %s", contractAddress)
+            null
+        }
     }
 
     override suspend fun getIbcDenomTraces(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -31,6 +31,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -210,17 +211,26 @@ internal class CosmosApiImp(
         }
     }
 
+    /**
+     * Issues a CosmWasm smart query — a base64-encoded JSON [queryJson] against
+     * `.../contract/{contractAddress}/smart/{payload}`. Shared by the CW20 balance and token_info
+     * lookups so the query-path construction stays in one place.
+     */
+    private suspend fun smartQuery(contractAddress: String, queryJson: String): HttpResponse {
+        val payload = queryJson.encodeBase64()
+        return httpClient.get(
+            "$rpcEndpoint/cosmwasm/wasm/v1/contract/$contractAddress/smart/$payload"
+        )
+    }
+
     override suspend fun getWasmTokenBalance(
         address: String,
         contractAddress: String,
     ): CosmosBalance {
-        val payload = "{\"balance\":{\"address\":\"$address\"}}".encodeBase64()
-
         return CosmosBalance(
             denom = contractAddress,
             amount =
-                httpClient
-                    .get("$rpcEndpoint/cosmwasm/wasm/v1/contract/$contractAddress/smart/$payload")
+                smartQuery(contractAddress, "{\"balance\":{\"address\":\"$address\"}}")
                     .bodyOrThrow<JsonObject>()["data"]
                     ?.jsonObject
                     ?.get("balance")
@@ -230,10 +240,8 @@ internal class CosmosApiImp(
     }
 
     override suspend fun getCw20TokenInfo(contractAddress: String): Cw20TokenInfoJson? {
-        val payload = "{\"token_info\":{}}".encodeBase64()
         return try {
-            httpClient
-                .get("$rpcEndpoint/cosmwasm/wasm/v1/contract/$contractAddress/smart/$payload")
+            smartQuery(contractAddress, "{\"token_info\":{}}")
                 .bodyOrThrow<Cw20TokenInfoResponseJson>()
                 .data
         } catch (e: CancellationException) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/Cw20TokenInfoJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/Cw20TokenInfoJson.kt
@@ -1,0 +1,19 @@
+package com.vultisig.wallet.data.api.models.cosmos
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Cw20TokenInfoResponseJson(@SerialName("data") val data: Cw20TokenInfoJson? = null)
+
+/**
+ * CW20 `{"token_info":{}}` smart-query reply. Fields are optional because the query is issued
+ * against arbitrary user-pasted contract addresses — a non-CW20 contract may answer with an
+ * unrelated shape.
+ */
+@Serializable
+data class Cw20TokenInfoJson(
+    @SerialName("name") val name: String? = null,
+    @SerialName("symbol") val symbol: String? = null,
+    @SerialName("decimals") val decimals: Int? = null,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -154,6 +154,10 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindSearchTerraTokenUseCase(impl: SearchTerraTokenUseCaseImpl): SearchTerraTokenUseCase
+
+    @Binds
+    @Singleton
     fun bindCreateVaultBackupFileNameUseCase(
         impl: CreateVaultBackupFileNameUseCaseImpl
     ): CreateVaultBackupFileNameUseCase

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCase.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import java.math.BigDecimal
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Resolves a user-pasted CW20 contract address into a [Coin] for the custom-token flow on Terra and
+ * Terra Classic.
+ *
+ * CW20 tokens are CosmWasm contracts, not bank denoms, so their metadata comes from the
+ * `{"token_info":{}}` smart query on the chain's LCD rather than `denoms_metadata`. A curated
+ * [Coins] catalog entry (matched by contract address) is preferred so known tokens keep their real
+ * logo and price provider id; unknown tokens get an empty logo and no price id — the same behavior
+ * as custom tokens on every other chain.
+ */
+internal interface SearchTerraTokenUseCase : suspend (Chain, String) -> CoinAndPrice?
+
+internal class SearchTerraTokenUseCaseImpl
+@Inject
+constructor(private val cosmosApiFactory: CosmosApiFactory) : SearchTerraTokenUseCase {
+
+    override suspend operator fun invoke(chain: Chain, contractAddress: String): CoinAndPrice? {
+        val tokenInfo =
+            try {
+                cosmosApiFactory.createCosmosApi(chain).getCw20TokenInfo(contractAddress)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            } ?: return null
+
+        val symbol = tokenInfo.symbol?.trim().orEmpty()
+        val decimals = tokenInfo.decimals
+        if (symbol.isEmpty() || decimals == null || decimals < 0) return null
+
+        val coin =
+            Coins.coins[chain]?.firstOrNull { it.contractAddress == contractAddress }
+                ?: Coin(
+                    chain = chain,
+                    ticker = symbol,
+                    logo = "",
+                    address = "",
+                    hexPublicKey = "",
+                    decimal = decimals,
+                    priceProviderID = "",
+                    contractAddress = contractAddress,
+                    isNativeToken = false,
+                )
+        return CoinAndPrice(coin, BigDecimal.ZERO)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -24,6 +24,7 @@ constructor(
     private val searchEvmToken: SearchEvmTokenUseCase,
     private val searchSolToken: SearchSolTokenUseCase,
     private val searchKujiToken: SearchKujiraTokenUseCase,
+    private val searchTerraToken: SearchTerraTokenUseCase,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
 ) : SearchTokenUseCase {
 
@@ -42,6 +43,7 @@ constructor(
             chain.standard == EVM -> searchEvmToken(chainId, address)
             chain.standard == SOL -> searchSolToken(address)
             chain == Chain.Kujira -> searchKujiToken(address)
+            chain == Chain.Terra || chain == Chain.TerraClassic -> searchTerraToken(chain, address)
             else -> null
         }
 
@@ -51,17 +53,38 @@ constructor(
     }
 
     private fun String.isValidAddressOn(chain: Chain): Boolean =
-        isNotEmpty() && chainAccountAddressRepository.isValid(chain, canonicalizedFor(chain))
+        when (chain) {
+            Chain.Terra,
+            Chain.TerraClassic -> isCw20ContractAddressShape()
+            else ->
+                isNotEmpty() &&
+                    chainAccountAddressRepository.isValid(chain, canonicalizedFor(chain))
+        }
 
     private fun String.canonicalizedFor(chain: Chain): String =
         if (chain == Chain.Kujira && startsWith(KUJIRA_FACTORY_PREFIX)) {
             substringAfter('/').substringBefore('/')
         } else this
 
+    /**
+     * Bech32 *shape* check for a Terra CW20 contract address, mirroring the SDK's
+     * `isCosmosWasmTokenId` — WalletCore address validation isn't specified for 32-byte contract
+     * payloads, so it can't be used here. Contract addresses can be 20-byte (Terra Classic
+     * pre-migration contracts, indistinguishable from wallet addresses) or 32-byte; only the LCD
+     * query itself can tell a contract from a wallet address. `ibc/…` and `factory/…` bank denoms
+     * are rejected.
+     */
+    private fun String.isCw20ContractAddressShape(): Boolean {
+        if (!startsWith(TERRA_CONTRACT_PREFIX)) return false
+        val payload = removePrefix(TERRA_CONTRACT_PREFIX)
+        return payload.length in 20..80 && payload.all { it in 'a'..'z' || it in '0'..'9' }
+    }
+
     private fun Coin.hasSaneMetadata(): Boolean = ticker.isNotBlank() && decimal in 0..MAX_DECIMALS
 
     private companion object {
         const val KUJIRA_FACTORY_PREFIX = "factory/"
+        const val TERRA_CONTRACT_PREFIX = "terra1"
         const val MAX_DECIMALS = 30
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiBodyReadTest.kt
@@ -75,6 +75,49 @@ class CosmosApiBodyReadTest {
         assertEquals("42000000", result.amount)
     }
 
+    // ── getCw20TokenInfo ────────────────────────────────────────────────────────
+    // Uses bodyOrThrow<Cw20TokenInfoResponseJson>().data; null on any failure.
+
+    @Test
+    fun `getCw20TokenInfo extracts token_info metadata and ignores extra fields`() = runTest {
+        val body =
+            """
+            {
+              "data": {
+                "name": "Astroport",
+                "symbol": "ASTRO",
+                "decimals": 6,
+                "total_supply": "1000000000000"
+              }
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        val result = api.getCw20TokenInfo("terra1contractXYZ")
+
+        assertEquals("Astroport", result?.name)
+        assertEquals("ASTRO", result?.symbol)
+        assertEquals(6, result?.decimals)
+    }
+
+    @Test
+    fun `getCw20TokenInfo returns null when the LCD rejects the smart query`() = runTest {
+        val api =
+            CosmosApiImp(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        HttpStatusCode.BadRequest,
+                        """{"code":3,"message":"Error parsing into type ..."}""",
+                    ),
+                rpcEndpoint = "https://example.test",
+                json = json,
+                cosmosThorChainResponseSerializer = CosmosThorChainResponseSerializerImpl(json),
+            )
+
+        assertEquals(null, api.getCw20TokenInfo("terra1walletaddress"))
+    }
+
     // ── getIbcDenomTraces ───────────────────────────────────────────────────────
     // Uses .body<CosmosIbcDenomTraceJson>().denomTrace!!
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCaseImplTest.kt
@@ -1,0 +1,113 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.models.cosmos.Cw20TokenInfoJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class SearchTerraTokenUseCaseImplTest {
+
+    private val cosmosApi: CosmosApi = mockk()
+    private val cosmosApiFactory: CosmosApiFactory = mockk {
+        every { createCosmosApi(any()) } returns cosmosApi
+    }
+
+    private val useCase = SearchTerraTokenUseCaseImpl(cosmosApiFactory)
+
+    @Test
+    fun `resolves an unknown CW20 contract to a coin with token_info metadata`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(name = "Some Token", symbol = "STK", decimals = 8))
+
+        val result = useCase(Chain.Terra, CONTRACT)
+
+        val coin = result?.coin
+        assertEquals(Chain.Terra, coin?.chain)
+        assertEquals("STK", coin?.ticker)
+        assertEquals(8, coin?.decimal)
+        assertEquals(CONTRACT, coin?.contractAddress)
+        assertEquals("", coin?.logo)
+        assertEquals("", coin?.priceProviderID)
+        assertEquals(false, coin?.isNativeToken)
+        assertEquals(BigDecimal.ZERO, result?.price)
+    }
+
+    @Test
+    fun `prefers the curated catalog entry so known tokens keep logo and price id`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(name = "Astroport", symbol = "ASTRO", decimals = 6))
+
+        val result = useCase(Chain.Terra, Coins.Terra.ASTRO.contractAddress)
+
+        assertEquals(Coins.Terra.ASTRO, result?.coin)
+    }
+
+    @Test
+    fun `resolves on Terra Classic via the Terra Classic api`() = runTest {
+        every { cosmosApiFactory.createCosmosApi(Chain.TerraClassic) } returns cosmosApi
+        givenTokenInfo(Cw20TokenInfoJson(name = "Classic Token", symbol = "CLS", decimals = 6))
+
+        val result = useCase(Chain.TerraClassic, CONTRACT)
+
+        assertEquals(Chain.TerraClassic, result?.coin?.chain)
+        assertEquals("CLS", result?.coin?.ticker)
+    }
+
+    @Test
+    fun `trims whitespace around the symbol`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(symbol = "  STK  ", decimals = 6))
+
+        assertEquals("STK", useCase(Chain.Terra, CONTRACT)?.coin?.ticker)
+    }
+
+    @Test
+    fun `null token_info returns null`() = runTest {
+        givenTokenInfo(null)
+
+        assertNull(useCase(Chain.Terra, CONTRACT))
+    }
+
+    @Test
+    fun `blank symbol returns null`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(name = "No Symbol", symbol = "   ", decimals = 6))
+
+        assertNull(useCase(Chain.Terra, CONTRACT))
+    }
+
+    @Test
+    fun `missing decimals returns null`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(name = "No Decimals", symbol = "STK", decimals = null))
+
+        assertNull(useCase(Chain.Terra, CONTRACT))
+    }
+
+    @Test
+    fun `negative decimals returns null`() = runTest {
+        givenTokenInfo(Cw20TokenInfoJson(symbol = "STK", decimals = -1))
+
+        assertNull(useCase(Chain.Terra, CONTRACT))
+    }
+
+    @Test
+    fun `api failure returns null instead of throwing`() = runTest {
+        coEvery { cosmosApi.getCw20TokenInfo(CONTRACT) } throws RuntimeException("boom")
+
+        assertNull(useCase(Chain.Terra, CONTRACT))
+    }
+
+    private fun givenTokenInfo(info: Cw20TokenInfoJson?) {
+        coEvery { cosmosApi.getCw20TokenInfo(any()) } returns info
+    }
+
+    private companion object {
+        /** Not in the [Coins] catalog, so tests exercise the unknown-token path. */
+        const val CONTRACT = "terra1unknown0token0contract0address0qqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
@@ -23,6 +23,7 @@ internal class SearchTokenUseCaseImplTest {
     private val searchEvmToken: SearchEvmTokenUseCase = mockk()
     private val searchSolToken: SearchSolTokenUseCase = mockk()
     private val searchKujiToken: SearchKujiraTokenUseCase = mockk()
+    private val searchTerraToken: SearchTerraTokenUseCase = mockk()
     private val appCurrencyRepository: AppCurrencyRepository = mockk {
         every { currency } returns flowOf(AppCurrency.USD)
     }
@@ -33,6 +34,7 @@ internal class SearchTokenUseCaseImplTest {
             searchEvmToken = searchEvmToken,
             searchSolToken = searchSolToken,
             searchKujiToken = searchKujiToken,
+            searchTerraToken = searchTerraToken,
             chainAccountAddressRepository = addressRepository,
         )
 
@@ -160,6 +162,70 @@ internal class SearchTokenUseCaseImplTest {
     }
 
     @Test
+    fun `valid Terra contract address delegated to Terra searcher without WalletCore`() = runTest {
+        coEvery { searchTerraToken(Chain.Terra, TERRA_CONTRACT) } returns
+            CoinAndPrice(terraCoin(contract = TERRA_CONTRACT), BigDecimal.ZERO)
+
+        val result = useCase(Chain.Terra.id, "  $TERRA_CONTRACT  ")
+
+        assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
+        coVerify(exactly = 1) { searchTerraToken(Chain.Terra, TERRA_CONTRACT) }
+        verify(exactly = 0) { addressRepository.isValid(any(), any()) }
+    }
+
+    @Test
+    fun `Terra Classic wallet-shaped contract address delegated to Terra searcher`() = runTest {
+        val address = "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+        coEvery { searchTerraToken(Chain.TerraClassic, address) } returns
+            CoinAndPrice(terraCoin(chain = Chain.TerraClassic, contract = address), BigDecimal.ZERO)
+
+        val result = useCase(Chain.TerraClassic.id, address)
+
+        assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
+        coVerify(exactly = 1) { searchTerraToken(Chain.TerraClassic, address) }
+    }
+
+    @Test
+    fun `Terra ibc denom rejected without hitting the searcher`() = runTest {
+        assertNull(
+            useCase(
+                Chain.Terra.id,
+                "ibc/8D8A7F7253615E5F76CB6252A1E1BD921D5EDB7BBAAF8913FB1C77FF125D9995",
+            )
+        )
+
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
+    }
+
+    @Test
+    fun `Terra factory denom rejected without hitting the searcher`() = runTest {
+        assertNull(useCase(Chain.Terra.id, "factory/terra1creator/utoken"))
+
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
+    }
+
+    @Test
+    fun `Terra address with uppercase characters rejected`() = runTest {
+        assertNull(useCase(Chain.Terra.id, "terra1NSUQSK6KH58ULCZATWEV87TTQ2Z6R3PUSULG9R24M"))
+
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
+    }
+
+    @Test
+    fun `Terra prefix with too-short payload rejected`() = runTest {
+        assertNull(useCase(Chain.Terra.id, "terra1short"))
+
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
+    }
+
+    @Test
+    fun `EVM-shaped address rejected on Terra`() = runTest {
+        assertNull(useCase(Chain.Terra.id, EVM_ADDRESS))
+
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
+    }
+
+    @Test
     fun `blank ticker in response returns null`() = runTest {
         givenEvmResponse(evmCoin(ticker = "   "))
 
@@ -225,6 +291,7 @@ internal class SearchTokenUseCaseImplTest {
         coVerify(exactly = 0) { searchEvmToken(any(), any()) }
         coVerify(exactly = 0) { searchSolToken(any()) }
         coVerify(exactly = 0) { searchKujiToken(any()) }
+        coVerify(exactly = 0) { searchTerraToken(any(), any()) }
     }
 
     private fun stubValid(chain: Chain, address: String, valid: Boolean) {
@@ -279,7 +346,22 @@ internal class SearchTokenUseCaseImplTest {
             isNativeToken = false,
         )
 
+    private fun terraCoin(chain: Chain = Chain.Terra, contract: String): Coin =
+        Coin(
+            chain = chain,
+            ticker = "STK",
+            logo = "",
+            address = "",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contract,
+            isNativeToken = false,
+        )
+
     private companion object {
         const val EVM_ADDRESS = "0x1234567890123456789012345678901234567890"
+        const val TERRA_CONTRACT =
+            "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     }
 }


### PR DESCRIPTION
## Summary

Let users dynamically add a custom CW20 token on Terra (LUNA) and Terra Classic (LUNC) by pasting the contract address — parity with the extension and iOS (vultisig-ios#4733). `SearchTokenUseCase` previously dispatched only EVM / SOL / Kujira, so a `terra1…` contract always surfaced as Token Not Found.

- **`CosmosApi.getCw20TokenInfo`** — new `{"token_info":{}}` wasm smart query against the chain's LCD (the same lookup the SDK/extension perform in `getCw20MetaFromLCD`). Returns `null` when the LCD rejects the query (wallet address, non-CW20 contract, unknown address) or the request fails, so those cases surface as the existing not-found UX.
- **`SearchTerraTokenUseCase`** (new, sibling of `SearchKujiraTokenUseCase`) — resolves symbol/decimals from `token_info`, preferring curated `Coins` catalog entries matched by contract address so known tokens keep their real logo and price provider id; unknown tokens get an empty logo and no price id, matching custom tokens on every other chain.
- **`SearchTokenUseCase`** — Terra/TerraClassic dispatch + bech32 *shape* validation mirroring the SDK's `isCosmosWasmTokenId` (`terra1` + 20–80 lowercase alphanumerics). WalletCore address validation isn't specified for 32-byte contract payloads, so it can't gate the lookup; Terra Classic pre-migration contracts are 20-byte and shape-identical to wallet addresses, so only the LCD query can disambiguate. `ibc/…` and `factory/…` bank denoms are rejected without a network call.

Balance, send, and signing paths are untouched — they already support CW20 end-to-end for catalog tokens (wasm balance query keyed off `contractAddress.startsWith("terra")`, `MsgExecuteContract {transfer}` send).

## Test plan

- [x] `SearchTerraTokenUseCaseImplTest` — metadata resolution, curated-catalog preference, Terra Classic routing, symbol trimming, null/blank-symbol/missing-decimals/negative-decimals/API-failure → null
- [x] `SearchTokenUseCaseImplTest` — Terra dispatch bypasses WalletCore validation, Terra Classic wallet-shaped contract dispatched, `ibc/`/`factory/`/uppercase/too-short/EVM-shaped inputs rejected without hitting the searcher
- [x] `CosmosApiBodyReadTest` — `token_info` response decode (extra `total_supply` field ignored), LCD rejection → null
- [x] Full `:data` unit suite green; `:app` compiles (Hilt graph valid)
- [x] Live LCD verified for both chains: Terra ASTRO and Terra Classic ASTROC contracts return `{"data":{"name":…,"symbol":…,"decimals":6}}`; a wallet address returns HTTP 500 → not-found UX
- [ ] On-device: paste an uncatalogued CW20 contract on Terra → token resolves and can be added; balance shows via the existing wasm query

Closes #5159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cosmos-backed lookup for CW20 `token_info`, enabling token name, symbol, and decimals to be fetched from Terra/Terra Classic contract addresses.
  * Extended token search to resolve Terra and Terra Classic CW20 tokens by contract address, returning a coin entry when metadata is valid.
* **Bug Fixes**
  * Improved resilience to failed or malformed token queries by returning no result (instead of failing).
  * Strengthened Terra CW20 contract address validation to reject invalid inputs more reliably.
* **Tests**
  * Added coverage for successful/failed CW20 info queries and Terra token search scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->