### PR TITLE
fix(zcash): re-plan memo txs to the ZIP-317 conventional fee

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -35,6 +35,12 @@ class UtxoHelper(
     val vaultHexChainCode: String,
 ) {
     companion object {
+        /**
+         * Max non-ZIP-317 re-plans before giving up raising the Zcash fee. Matches the SDK's cap so
+         * every co-signing device fails identically instead of diverging on the plan.
+         */
+        private const val MAX_ZCASH_FEE_BUMPS = 5
+
         fun getHelper(vault: Vault, coinType: CoinType): UtxoHelper {
             when (coinType) {
                 CoinType.BITCOIN,
@@ -53,6 +59,89 @@ class UtxoHelper(
                 else -> throw Exception("Unsupported chain")
             }
         }
+    }
+
+    /**
+     * Plan the transaction, guarding Zcash plans against WalletCore's underpaying ZIP-317 mode.
+     * Every other coin plans directly. For Zcash the [signingInput] builder is mutated (zip0317
+     * toggled off, byteFee bumped) so the serialized input the digests commit to matches the plan.
+     */
+    private fun planTransaction(
+        signingInput: Bitcoin.SigningInput.Builder
+    ): Bitcoin.TransactionPlan =
+        if (coinType == CoinType.ZCASH) {
+            planZcashConventionalFee(signingInput)
+        } else {
+            AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
+        }
+
+    /**
+     * Produce a Zcash plan whose fee meets the ZIP-317 conventional fee.
+     *
+     * WalletCore's `zip_0317` planner sizes an OP_RETURN output as a flat ~34 bytes and ignores
+     * `byteFee`, so memo transactions (MayaChain-routed swaps carry the swap instruction in an
+     * OP_RETURN; sends with memo too) plan one logical action short — e.g. 15,000 zats where the
+     * network requires 20,000 — with no way to raise the fee in that mode. When the `zip_0317` plan
+     * underpays the byte-accurate conventional fee, re-plan with `zip_0317` off — where WalletCore
+     * honours `byteFee` — and bump `byteFee` until the fee clears. Plain (no-memo) sends already
+     * meet the fee and keep the `zip_0317` plan.
+     *
+     * An empty plan (no selected UTXOs) is returned untouched: coin selection produced nothing
+     * (insufficient funds), and that flow owns the outcome.
+     *
+     * Byte-parity port of the SDK's `planZcashConventionalFee` (and iOS `UTXOChainsHelper`) — every
+     * co-signing device must derive the same plan or the MPC preimage digests diverge and keysign
+     * fails. Keep in lockstep with the SDK.
+     */
+    private fun planZcashConventionalFee(
+        signingInput: Bitcoin.SigningInput.Builder
+    ): Bitcoin.TransactionPlan {
+        val memoSize = signingInput.outputOpReturn.size()
+
+        fun conventionalFee(plan: Bitcoin.TransactionPlan): Long =
+            ZcashConventionalFee.conventionalFee(
+                inputCount = plan.utxosCount,
+                outputSizes =
+                    ZcashConventionalFee.transparentOutputSizes(
+                        change = plan.change,
+                        memoSize = memoSize,
+                    ),
+            )
+
+        // An empty plan has no shape to charge for; leave the fee flow to the caller.
+        fun meetsConventionalFee(plan: Bitcoin.TransactionPlan): Boolean =
+            plan.utxosCount == 0 || plan.fee >= conventionalFee(plan)
+
+        val zipPlan =
+            AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
+        if (meetsConventionalFee(zipPlan)) {
+            return zipPlan
+        }
+
+        signingInput.setZip0317(false)
+        var byteFee = 1L
+        var plan = zipPlan
+        repeat(MAX_ZCASH_FEE_BUMPS) {
+            signingInput.setByteFee(byteFee)
+            plan = AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
+            if (meetsConventionalFee(plan)) {
+                return plan
+            }
+
+            // byteFee mode scales fee linearly with vsize; derive the byteFee that clears the
+            // conventional fee for this plan's (byteFee-independent) vsize.
+            val plannerVsize = if (plan.fee > 0L) plan.fee / byteFee else 1L
+            byteFee =
+                maxOf(
+                    ZcashConventionalFee.ceilDiv(conventionalFee(plan), plannerVsize),
+                    byteFee + 1,
+                )
+        }
+
+        error(
+            "Failed to meet the Zcash minimum network fee (ZIP-317): planned ${plan.fee} zats, " +
+                "required ${conventionalFee(plan)}"
+        )
     }
 
     fun getPreSignedImageHash(keysignPayload: KeysignPayload): List<String> {
@@ -145,8 +234,7 @@ class UtxoHelper(
             signingInput.addUtxo(utxoItem.build())
         }
 
-        val plan: Bitcoin.TransactionPlan =
-            AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
+        val plan = planTransaction(signingInput)
         signingInput.setPlan(plan)
         return signingInput.build().toByteArray()
     }
@@ -216,8 +304,7 @@ class UtxoHelper(
 
     private fun getBitcoinPreSigningInputData(keysignPayload: KeysignPayload): ByteArray {
         val signingInput = getBitcoinSigningInput(keysignPayload)
-        val initialPlan: Bitcoin.TransactionPlan =
-            AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
+        val initialPlan = planTransaction(signingInput)
 
         val plan =
             if (coinType == CoinType.ZCASH) {
@@ -332,9 +419,7 @@ class UtxoHelper(
             return getBitcoinTransactionPlanFromSignBitcoin(it)
         }
         val signingInput = getBitcoinSigningInput(keysignPayload)
-        val plan: Bitcoin.TransactionPlan =
-            AnySigner.plan(signingInput.build(), coinType, Bitcoin.TransactionPlan.parser())
-        return plan
+        return planTransaction(signingInput)
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConventionalFee.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConventionalFee.kt
@@ -1,0 +1,87 @@
+package com.vultisig.wallet.data.chains.helpers
+
+/**
+ * ZIP-317 conventional fee for a transparent-only Zcash transaction. Nodes relay zero "unpaid
+ * actions" by default, so any tx paying less is rejected at broadcast with "tx unpaid action limit
+ * exceeded".
+ *
+ * Byte-parity port of the SDK's canonical implementation
+ * (`packages/core/chain/chains/utxo/fee/zip317.ts`): every co-signing device must derive the same
+ * fee from the same transaction shape, or the MPC preimage digests diverge and keysign fails. Keep
+ * the math in lockstep with the SDK (and the iOS `ZcashConventionalFee`) when touching this file.
+ *
+ * https://zips.z.cash/zip-0317
+ */
+internal object ZcashConventionalFee {
+    private const val MARGINAL_FEE: Long = 5_000L
+    private const val GRACE_ACTIONS: Long = 2L
+    /** Serialized size of a signed transparent P2PKH input (ZIP-317 section 3.1). */
+    private const val P2PKH_INPUT_SIZE: Long = 148L
+    private const val INPUT_ACTION_SIZE: Long = 150L
+    private const val OUTPUT_ACTION_SIZE: Long = 34L
+    /** Serialized tx_out size of a P2PKH output: 8 value + 1 scriptLen + 25 script. */
+    private const val P2PKH_OUTPUT_SIZE: Long = 34L
+
+    /** Ceiling division: smallest n such that n * divisor >= value. */
+    fun ceilDiv(value: Long, divisor: Long): Long = (value + divisor - 1) / divisor
+
+    /**
+     * Minimum fee the Zcash network relays for a transparent tx of the given shape: 5,000 zats per
+     * logical action with a two-action grace window, where logical actions = max(ceil(tx_in bytes /
+     * 150), ceil(tx_out bytes / 34)).
+     */
+    fun conventionalFee(inputCount: Int, outputSizes: List<Long>): Long {
+        val inputActions = ceilDiv(inputCount.toLong() * P2PKH_INPUT_SIZE, INPUT_ACTION_SIZE)
+        val outputActions = ceilDiv(outputSizes.sum(), OUTPUT_ACTION_SIZE)
+        val logicalActions = maxOf(inputActions, outputActions)
+        return MARGINAL_FEE * maxOf(GRACE_ACTIONS, logicalActions)
+    }
+
+    /**
+     * Serialized tx_out size of an OP_RETURN output carrying [memoSize] bytes: 8 value + scriptLen
+     * CompactSize + script (OP_RETURN + push opcode(s) + data). WalletCore's planner sizes this
+     * output as a flat ~34 bytes regardless of memo length, so longer memos make its plan
+     * undercount ZIP-317 actions. Models the push opcode (direct / PUSHDATA1 / PUSHDATA2 /
+     * PUSHDATA4) and the script-length CompactSize so long memos are not undercharged.
+     */
+    fun opReturnOutputSize(memoSize: Int): Long {
+        val dataSize = memoSize.toLong()
+
+        // OP_RETURN (1 byte) + push opcode bytes for `dataSize`.
+        val pushOverhead: Long =
+            when {
+                dataSize <= 75L -> 2L
+                dataSize <= 0xffL -> 3L
+                dataSize <= 0xffffL -> 4L
+                else -> 6L
+            }
+        val scriptSize = pushOverhead + dataSize
+
+        // CompactSize encoding of the script length prefix.
+        val scriptLengthSize: Long =
+            when {
+                scriptSize < 0xfdL -> 1L
+                scriptSize <= 0xffffL -> 3L
+                scriptSize <= 0xffff_ffffL -> 5L
+                else -> 9L
+            }
+
+        return 8L + scriptLengthSize + scriptSize
+    }
+
+    /**
+     * Serialized tx_out sizes for a transparent Zcash send: recipient P2PKH, optional change P2PKH
+     * (only when change is positive), and an optional OP_RETURN memo (only when [memoSize] is
+     * positive). Feed into [conventionalFee] to size the conventional fee by real bytes.
+     */
+    fun transparentOutputSizes(change: Long, memoSize: Int): List<Long> {
+        val sizes = mutableListOf(P2PKH_OUTPUT_SIZE)
+        if (change > 0L) {
+            sizes.add(P2PKH_OUTPUT_SIZE)
+        }
+        if (memoSize > 0) {
+            sizes.add(opReturnOutputSize(memoSize))
+        }
+        return sizes
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConventionalFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashConventionalFeeTest.kt
@@ -1,0 +1,134 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Golden vectors mirrored from the SDK's `zip317.test.ts`
+ * (`packages/core/chain/chains/utxo/fee/zip317.test.ts`) and the iOS `ZcashConventionalFeeTests` —
+ * the three implementations must stay byte-identical for MPC co-signing.
+ */
+class ZcashConventionalFeeTest {
+
+    private val p2pkhOutput = 34L
+
+    // conventionalFee
+
+    @Test
+    fun `returns the ten-thousand-zat floor for a simple one-in two-out send`() {
+        assertEquals(
+            10_000L,
+            ZcashConventionalFee.conventionalFee(
+                inputCount = 1,
+                outputSizes = listOf(p2pkhOutput, p2pkhOutput),
+            ),
+        )
+    }
+
+    @Test
+    fun `scales with input count beyond the grace window`() {
+        assertEquals(
+            20_000L,
+            ZcashConventionalFee.conventionalFee(
+                inputCount = 4,
+                outputSizes = listOf(p2pkhOutput, p2pkhOutput),
+            ),
+        )
+    }
+
+    @Test
+    fun `charges input actions from serialized bytes not raw count`() {
+        // 75 P2PKH inputs: ceil(75 * 148 / 150) = 74 actions, not 75.
+        assertEquals(
+            370_000L,
+            ZcashConventionalFee.conventionalFee(
+                inputCount = 75,
+                outputSizes = listOf(p2pkhOutput, p2pkhOutput),
+            ),
+        )
+    }
+
+    @Test
+    fun `counts large OP_RETURN outputs as multiple actions`() {
+        // 80-byte memo output: 92 bytes serialized -> with two p2pkh outputs,
+        // ceil(160 / 34) = 5 actions -> 25,000 zats.
+        assertEquals(
+            25_000L,
+            ZcashConventionalFee.conventionalFee(
+                inputCount = 1,
+                outputSizes = listOf(p2pkhOutput, p2pkhOutput, 92L),
+            ),
+        )
+    }
+
+    // opReturnOutputSize
+
+    @Test
+    fun `sizes a short memo with a single-byte push`() {
+        // 9 fixed bytes + 2 push overhead + data length.
+        assertEquals(51L, ZcashConventionalFee.opReturnOutputSize(40))
+    }
+
+    @Test
+    fun `adds a byte of push overhead once the memo exceeds 75 bytes`() {
+        assertEquals(86L, ZcashConventionalFee.opReturnOutputSize(75))
+        assertEquals(88L, ZcashConventionalFee.opReturnOutputSize(76))
+    }
+
+    @Test
+    fun `handles CompactSize and PUSHDATA boundaries for long memos`() {
+        // 250-byte memo: script length 253 crosses the CompactSize 1->3 byte threshold.
+        assertEquals(261L, ZcashConventionalFee.opReturnOutputSize(249))
+        assertEquals(264L, ZcashConventionalFee.opReturnOutputSize(250))
+        // 256-byte memo: push opcode crosses PUSHDATA1 -> PUSHDATA2.
+        assertEquals(269L, ZcashConventionalFee.opReturnOutputSize(255))
+        assertEquals(271L, ZcashConventionalFee.opReturnOutputSize(256))
+    }
+
+    @Test
+    fun `handles upper CompactSize and PUSHDATA boundaries`() {
+        // Script length 65535 -> 65536 crosses the CompactSize 3 -> 5 byte threshold
+        // (memo 65531 -> script 65535; memo 65532 -> script 65536).
+        assertEquals(65_546L, ZcashConventionalFee.opReturnOutputSize(65_531))
+        assertEquals(65_549L, ZcashConventionalFee.opReturnOutputSize(65_532))
+        // Memo 65535 -> 65536 crosses the PUSHDATA2 -> PUSHDATA4 threshold (push overhead 4 -> 6).
+        assertEquals(65_552L, ZcashConventionalFee.opReturnOutputSize(65_535))
+        assertEquals(65_555L, ZcashConventionalFee.opReturnOutputSize(65_536))
+    }
+
+    // transparentOutputSizes
+
+    @Test
+    fun `returns recipient only when there is no change and no memo`() {
+        assertEquals(
+            listOf(34L),
+            ZcashConventionalFee.transparentOutputSizes(change = 0L, memoSize = 0),
+        )
+    }
+
+    @Test
+    fun `adds a change output only when change is positive`() {
+        assertEquals(
+            listOf(34L, 34L),
+            ZcashConventionalFee.transparentOutputSizes(change = 1L, memoSize = 0),
+        )
+    }
+
+    @Test
+    fun `appends the OP_RETURN size for a memo send`() {
+        assertEquals(
+            listOf(34L, 34L, 51L),
+            ZcashConventionalFee.transparentOutputSizes(change = 1L, memoSize = 40),
+        )
+    }
+
+    // ceilDiv
+
+    @Test
+    fun `ceilDiv rounds up to the smallest clearing multiple`() {
+        assertEquals(0L, ZcashConventionalFee.ceilDiv(0L, 34L))
+        assertEquals(1L, ZcashConventionalFee.ceilDiv(34L, 34L))
+        assertEquals(2L, ZcashConventionalFee.ceilDiv(35L, 34L))
+        assertEquals(77L, ZcashConventionalFee.ceilDiv(20_000L, 260L))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashZip317PlanTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ZcashZip317PlanTest.kt
@@ -1,0 +1,186 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.UtxoInfo
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import wallet.core.jni.CoinType
+import wallet.core.jni.proto.Common.SigningError
+
+/**
+ * Real-WalletCore regression for the Zcash ZIP-317 conventional-fee guard in [UtxoHelper].
+ * WalletCore's `zip_0317` planner flat-sizes OP_RETURN and ignores `byteFee`, so memo txs plan one
+ * logical action short; the helper re-plans with `zip_0317` off until the fee clears the
+ * conventional fee.
+ *
+ * Golden vectors mirror the iOS `ZcashZip317PlanTests` (extracted from a live SDK resolver run
+ * against wallet-core 4.7.0 — the version this module pins, `gradle/libs.versions.toml`). The
+ * planned fee/amount/change must be byte-identical across platforms or MPC co-signing devices
+ * derive different preimage digests and keysign fails. Skipped gracefully when the WalletCore
+ * native library is unavailable in the JVM test host.
+ */
+class ZcashZip317PlanTest {
+
+    private val zcashAddress = "t1PoLLLwEcVhqMBhk53tANtSepnPXAQJkPM"
+    private val branchIdHex = "30f33754"
+
+    @Test
+    fun `plain send keeps the zip_0317 plan at the floor`() {
+        planTest(amount = 5_000_000L, balance = 8_300_000L, memo = null) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(10_000L, plan.fee)
+            assertEquals(5_000_000L, plan.amount)
+            assertEquals(3_290_000L, plan.change)
+        }
+    }
+
+    @Test
+    fun `memo send re-plans to meet the conventional fee`() {
+        // zip_0317 plans 15,000 where ZIP-317 requires 20,000; the guard re-plans to 20,020.
+        planTest(amount = 5_000_000L, balance = 8_300_000L, memo = "m".repeat(40)) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(20_020L, plan.fee)
+            assertEquals(5_000_000L, plan.amount)
+            assertEquals(3_279_980L, plan.change)
+        }
+    }
+
+    @Test
+    fun `send-max memo send re-plans to meet the conventional fee`() {
+        planTest(
+            amount = 2_200_000L,
+            balance = 2_200_000L,
+            memo = "m".repeat(40),
+            sendMax = true,
+        ) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(15_142L, plan.fee)
+            assertEquals(2_184_858L, plan.amount)
+            assertEquals(0L, plan.change)
+        }
+    }
+
+    @Test
+    fun `long memo spanning extra actions clears the conventional fee`() {
+        planTest(amount = 5_000_000L, balance = 8_300_000L, memo = "m".repeat(200)) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(45_240L, plan.fee)
+            assertEquals(3_254_760L, plan.change)
+        }
+    }
+
+    @Test
+    fun `Maya-swap-shaped memo re-plans to meet the conventional fee`() {
+        // Maya-native ZEC swaps ride the plain send path with the swap instruction as the memo;
+        // this is the live shape the issue reports.
+        val memo =
+            "=:ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48:" +
+                "0x92009f858E52D5C48CBaBFE0EE9AB05EF5eEC865:1494322902:vi:35"
+        planTest(amount = 5_000_000L, balance = 8_300_000L, memo = memo) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(30_160L, plan.fee)
+            assertEquals(3_269_840L, plan.change)
+        }
+    }
+
+    @Test
+    fun `non-ascii memo is charged by utf8 byte length`() {
+        // TextEncoder().encode(memo) and Kotlin's UTF-8 encoding of outputOpReturn must agree on
+        // the byte length that sizes the OP_RETURN — 17 characters but 34 UTF-8 bytes.
+        val memo = "меморандум-🚀-мемо"
+        assertEquals(34, memo.toByteArray(Charsets.UTF_8).size)
+        planTest(amount = 5_000_000L, balance = 8_300_000L, memo = memo) { plan ->
+            assertEquals(SigningError.OK, plan.error)
+            assertEquals(20_020L, plan.fee)
+            assertEquals(3_279_980L, plan.change)
+        }
+    }
+
+    @Test
+    fun `insufficient funds plan passes through untouched`() {
+        // Balance can't cover amount + fee + dust, so WalletCore selects no UTXOs. The
+        // conventional-fee guard must not hijack this with a ZIP-317 error — the send flow owns the
+        // insufficient-funds outcome.
+        planTest(amount = 90_000L, balance = 100_000L, memo = "m".repeat(40)) { plan ->
+            assertTrue(
+                plan.utxosList.isEmpty(),
+                "Expected no selected UTXOs, got ${plan.utxosCount}",
+            )
+            assertEquals(0L, plan.fee)
+        }
+    }
+
+    private fun planTest(
+        amount: Long,
+        balance: Long,
+        memo: String?,
+        sendMax: Boolean = false,
+        assertions: (wallet.core.jni.proto.Bitcoin.TransactionPlan) -> Unit,
+    ) {
+        val helper = UtxoHelper(CoinType.ZCASH, "", "")
+        try {
+            val plan =
+                helper.getBitcoinTransactionPlan(
+                    makePayload(amount = amount, balance = balance, memo = memo, sendMax = sendMax)
+                )
+            assertions(plan)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private fun makePayload(
+        amount: Long,
+        balance: Long,
+        memo: String?,
+        sendMax: Boolean,
+    ): KeysignPayload =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Zcash,
+                    ticker = "ZEC",
+                    logo = "",
+                    address = zcashAddress,
+                    decimal = 8,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = zcashAddress,
+            toAmount = BigInteger.valueOf(amount),
+            blockChainSpecific =
+                BlockChainSpecific.UTXO(
+                    byteFee = BigInteger.valueOf(100L),
+                    sendMaxAmount = sendMax,
+                    zcashBranchId = branchIdHex,
+                ),
+            utxos = listOf(UtxoInfo(hash = "00".repeat(32), amount = balance, index = 0u)),
+            memo = memo,
+            swapPayload = null,
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+        )
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else {
+            throw e
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5155

## Problem

WalletCore's `zip_0317` planner sizes an OP_RETURN output at a flat ~34 bytes and ignores `byteFee`, so ZEC **memo** transactions plan exactly one logical action short (e.g. 15,000 zats planned where ZIP-317 requires 20,000). This breaks two flows:

1. **Extension-initiated ZEC swap, Android co-signs → keysign fails every time.** The extension's SDK signer plans the higher conventional fee; Android planned WalletCore's underpaying `zip_0317` fee. Different fee → different change output → different preimage digests → MPC keysign can't converge.
2. **Mobile-only signing → tx signs but the network rejects it at broadcast** (fee below the ZIP-317 conventional minimum).

Maya-native ZEC swaps ride the plain send path with the swap instruction carried in the OP_RETURN memo, so they hit exactly this path. SwapKit ZEC swaps are unaffected (frozen PSBT plan); NEAR-route swaps are plain transfers with no memo.

## Fix

Ports the SDK's `planZcashConventionalFee` (and the merged iOS sibling #4728) into `UtxoHelper`:

1. Plan with `zip_0317 = true` as today.
2. Compute the byte-accurate ZIP-317 conventional fee for the planned tx (recipient + change + OP_RETURN, with PUSHDATA/CompactSize thresholds) via the new `ZcashConventionalFee`.
3. If the plan's fee is below it, re-plan with `zip_0317 = false` (where WalletCore honours `byteFee`) and bump `byteFee` until the fee clears (capped at 5 bumps).
4. Plain (no-memo) sends already meet the fee and keep the `zip_0317` plan unchanged.

All three planning call sites (`getSigningInputData`, `getBitcoinPreSigningInputData`, `getBitcoinTransactionPlan`) route through the new `planTransaction` guard so the fee preview and the signed tx agree.

## Cross-platform parity

The re-plan is a **byte-parity** port — every co-signing device must derive the same plan or the digests diverge and the keysign failure just moves. `ZcashConventionalFee` mirrors the SDK's `zip317.ts` line-for-line, and the plan-level golden vectors mirror iOS against the same **wallet-core 4.7.0** pin this module already uses.

## Tests

- `ZcashConventionalFeeTest` — pure-math golden vectors mirrored from the SDK's `zip317.test.ts` / iOS `ZcashConventionalFeeTests` (12 tests, run on the JVM host, all green).
- `ZcashZip317PlanTest` — real-WalletCore regression: plain send stays at the floor, memo/send-max/long-memo/Maya-swap-shaped/non-ASCII memos re-plan to the exact iOS golden fee & change, and the insufficient-funds plan passes through untouched. Skipped gracefully when the WalletCore native lib is absent in the JVM host (runs on CI/device).

## Follow-up

A ZEC-memo signing vector should be added to the cross-platform signing-vector net (vultisig/commondata#94) to pin this across platforms — tracked separately since `commondata/` is a submodule.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.chains.helpers.*"` green
- [x] `./gradlew :data:ktfmtCheck` clean
- [ ] On device: ZEC → USDC Maya swap, extension-initiated + Android co-sign, converges and broadcasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zcash transactions now better match the expected network fee rules, including memo/OP_RETURN cases and larger outputs.
  * Transaction planning is more reliable for Bitcoin-family sends, with improved fee and change calculations in edge cases.
* **Tests**
  * Added regression coverage for Zcash fee calculation and planning across common, memo-heavy, and insufficient-funds scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->