### PR TITLE
feat(cardano): attach send memo on-chain as CIP-20 metadata (WalletCore 4.7.0)

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -560,6 +560,33 @@ class ChainHelpersTest {
         }
     }
 
+    @Test
+    fun cardanoMemoChangesSighash() {
+        val transactions: List<TransactionData> = loadTransactionData(CARDANO_JSON_FILE)
+        transactions.forEach { transaction ->
+            val internalPayload = transaction.keysignPayload.toInternalKeySignPayload()
+            val cardano = internalPayload.blockChainSpecific as BlockChainSpecific.Cardano
+
+            // WalletCore ignores forceFee for max-amount sends (output = total - fee), so the
+            // memo-driven aux hash can't be isolated from the fee there; assert only on ordinary
+            // sends, matching cardanoSignerForcesTransmittedByteFee.
+            if (cardano.sendMaxAmount) return@forEach
+
+            // Attaching a CIP-20 memo must flow through setAuxiliaryData into the pre-image hash:
+            // WalletCore commits blake2b-256(auxData) into body key 7, so the sighash MUST differ
+            // from the memo-less payload. Mirrors iOS's CardanoCip20SigningTests.
+            val noMemoHash = CardanoHelper.getPreSignedImageHash(internalPayload.copy(memo = null))
+            val memoHash =
+                CardanoHelper.getPreSignedImageHash(internalPayload.copy(memo = "hello world"))
+
+            assertTrue(
+                "Expected 64-char hex hash but got: ${memoHash[0]}",
+                memoHash[0].matches(Regex("[0-9a-f]{64}")),
+            )
+            assertNotEquals(noMemoHash, memoHash)
+        }
+    }
+
     private fun loadTransactionData(jsonFile: String): List<TransactionData> {
         val appContext: Context = InstrumentationRegistry.getInstrumentation().context
         val data =

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -550,6 +550,7 @@ class ChainHelpersTest {
                     sendMaxAmount = cardano.sendMaxAmount,
                     ttl = cardano.ttl.toLong(),
                     utxos = internalPayload.utxos,
+                    memo = internalPayload.memo,
                 )
 
             assertTrue(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeResolver.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeResolver.kt
@@ -87,8 +87,11 @@ constructor(
     ): BigInteger =
         if (
             blockChainSpecific is BlockChainSpecific.Ethereum ||
-                blockChainSpecific is BlockChainSpecific.THORChain
+                blockChainSpecific is BlockChainSpecific.THORChain ||
+                blockChainSpecific is BlockChainSpecific.Cardano
         ) {
+            // These subtypes read their fee straight from BlockChainSpecific in
+            // computeJoinKeysignNetworkFee, so the fee-service fallback is never used — skip it.
             BigInteger.ZERO
         } else {
             withContext(Dispatchers.IO) { feeServiceComposite.calculateFees(blockchainTransaction) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeUtils.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignFeeUtils.kt
@@ -34,6 +34,11 @@ internal fun computeJoinKeysignNetworkFee(
             )
         is BlockChainSpecific.THORChain ->
             TokenValue(value = blockChainSpecific.fee, token = nativeCoin)
+        // Cardano forces the initiator's transmitted byteFee into the signed body (memo-inclusive),
+        // so the joiner must surface that exact value — not UtxoFeeService's flat default, which
+        // would understate a memo send on the co-signing device's approval screen.
+        is BlockChainSpecific.Cardano ->
+            TokenValue(value = blockChainSpecific.byteFee.toBigInteger(), token = nativeCoin)
         else -> TokenValue(value = fallbackFeeAmount, token = nativeCoin)
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
@@ -326,6 +326,10 @@ internal class GasFeeOrchestrator(
             val tokenAmountFlow =
                 tokenAmountFieldState.textAsFlow().debounce(300).distinctUntilChanged()
 
+            // The memo is optional. textAsFlow() (snapshotFlow) emits the current text — an empty
+            // string when no memo is entered — immediately on collection, so this flow always has a
+            // value and never blocks the combine below; a missing memo simply yields cardanoMemo =
+            // null.
             val memoFlow = memoFieldState.textAsFlow().debounce(300).distinctUntilChanged()
 
             combine(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
@@ -326,12 +326,15 @@ internal class GasFeeOrchestrator(
             val tokenAmountFlow =
                 tokenAmountFieldState.textAsFlow().debounce(300).distinctUntilChanged()
 
+            val memoFlow = memoFieldState.textAsFlow().debounce(300).distinctUntilChanged()
+
             combine(
                     selectedToken.filterNotNull(),
                     gasFee.filterNotNull(),
                     dstAddressFlow,
                     tokenAmountFlow,
-                ) { token, gasFeeValue, dstAddress, tokenAmount ->
+                    memoFlow,
+                ) { token, gasFeeValue, dstAddress, tokenAmount, memo ->
                     val chain = token.chain
                     // Cardano forces the initiator's size-derived fee, so getSpecific needs the
                     // amount to plan it. For every other chain the amount is irrelevant here, so
@@ -346,10 +349,16 @@ internal class GasFeeOrchestrator(
                                 ?.toBigInteger()
                         } else null
 
-                    SpecificInput(token, gasFeeValue, dstAddress, cardanoAmount)
+                    // Only Cardano prices the memo into its byteFee here, so we drop the memo for
+                    // every other chain to keep them from refetching specifics on memo keystrokes.
+                    val cardanoMemo =
+                        if (chain == Chain.Cardano) memo.toString().takeIf { it.isNotEmpty() }
+                        else null
+
+                    SpecificInput(token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo)
                 }
                 .distinctUntilChanged()
-                .collect { (token, gasFeeValue, dstAddress, cardanoAmount) ->
+                .collect { (token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo) ->
                     val chain = token.chain
                     val srcAddress = token.address
                     advanceGasUiRepository.updateTokenStandard(token.chain.standard)
@@ -372,6 +381,7 @@ internal class GasFeeOrchestrator(
                                     isDeposit = false,
                                     dstAddress = validDstAddress,
                                     tokenAmountValue = cardanoAmount,
+                                    memo = cardanoMemo,
                                 )
                             }
                         specific.value = spec
@@ -420,6 +430,7 @@ private data class SpecificInput(
     val gasFee: TokenValue,
     val dstAddress: String,
     val cardanoAmount: BigInteger?,
+    val cardanoMemo: String?,
 )
 
 private data class PlanFeeInput(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -169,8 +169,12 @@ internal class DefaultSendStrategy(
                                     address = srcAddress,
                                     token = selectedToken,
                                     gasFee = gasFee,
-                                    memo =
-                                        memoFieldState.text.toString().takeIf { it.isNotEmpty() },
+                                    // Reuse the memo captured above rather than re-reading the
+                                    // field
+                                    // on Dispatchers.IO: a keystroke landing between the two reads
+                                    // could size the byteFee for a different memo than the one
+                                    // embedded in Transaction.memo and signed.
+                                    memo = memo,
                                     tokenAmountValue = tokenAmountInt,
                                     isSwap = false,
                                     isMaxAmountEnabled = isMaxAmount,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.crypto.CardanoCIP20
 import com.vultisig.wallet.data.crypto.CardanoUtils
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.Chain
@@ -40,6 +41,7 @@ object CardanoHelper {
         ttl: Long,
         utxos: List<UtxoInfo>,
         forceFee: Long,
+        memo: String?,
     ): Cardano.SigningInput.Builder {
         val input =
             Cardano.SigningInput.newBuilder()
@@ -51,8 +53,13 @@ object CardanoHelper {
                         .setChangeAddress(changeAddress)
                         .setForceFee(forceFee)
                 )
-                // TODO: Implement memo support when WalletCore adds Cardano metadata support
                 .setTtl(ttl)
+
+        // CIP-20 memo (label 674). When present, WalletCore commits
+        // blake2b-256(auxDataCbor) into the body at map key 7 and emits the aux
+        // CBOR as element [3] of the signed tx. The encoder is byte-parity pinned
+        // to the SDK golden vector so co-signers agree on the sighash.
+        cip20AuxData(memo)?.let { input.setAuxiliaryData(ByteString.copyFrom(it)) }
 
         // Add UTXOs to the input
         for (inputUtxo in utxos) {
@@ -95,7 +102,19 @@ object CardanoHelper {
             ttl = ttl.toLong(),
             utxos = keysignPayload.utxos,
             forceFee = byteFee,
+            memo = keysignPayload.memo,
         )
+    }
+
+    /**
+     * Canonical CIP-20 auxiliary-data CBOR (label 674) for the payload [memo], or `null` when there
+     * is no memo. Both the pre-sign input (`Cardano.SigningInput.auxiliary_data`) and the
+     * WalletCore-compiled signed envelope derive from these bytes, so the body's key-7 hash and the
+     * embedded aux stay consistent — and byte-identical to the iOS/Extension co-signers.
+     */
+    private fun cip20AuxData(memo: String?): ByteArray? {
+        if (memo.isNullOrEmpty()) return null
+        return CardanoCIP20.buildAuxData(memo).auxDataCbor
     }
 
     /**
@@ -133,6 +152,7 @@ object CardanoHelper {
         sendMaxAmount: Boolean,
         ttl: Long,
         utxos: List<UtxoInfo>,
+        memo: String?,
     ): Long {
         val signingInput =
             buildSigningInput(
@@ -143,6 +163,7 @@ object CardanoHelper {
                     ttl = ttl,
                     utxos = utxos,
                     forceFee = 0,
+                    memo = memo,
                 )
                 .build()
         return plan(signingInput).fee

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
@@ -56,9 +56,10 @@ object CardanoHelper {
                 .setTtl(ttl)
 
         // CIP-20 memo (label 674). When present, WalletCore commits
-        // blake2b-256(auxDataCbor) into the body at map key 7 and emits the aux
-        // CBOR as element [3] of the signed tx. The encoder is byte-parity pinned
-        // to the SDK golden vector so co-signers agree on the sighash.
+        // blake2b-256(auxDataCbor) into the body at map key 7 and embeds the aux
+        // CBOR as the transaction's auxiliary_data element. The encoder is
+        // byte-parity pinned to the SDK golden vector so co-signers agree on the
+        // sighash.
         cip20AuxData(memo)?.let { input.setAuxiliaryData(ByteString.copyFrom(it)) }
 
         // Add UTXOs to the input

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20.kt
@@ -13,8 +13,8 @@ import kotlin.experimental.and
  * Each `msg` text chunk is at most 64 UTF-8 bytes, split on Unicode codepoint boundaries (never
  * mid-codepoint). WalletCore 4.7.0 consumes these CBOR bytes via
  * `Cardano.SigningInput.auxiliary_data`: it commits `blake2b-256(auxDataCbor)` into the tx body at
- * map key 7 (auxiliary_data_hash) and embeds the bytes as element [3] of the signed transaction
- * array.
+ * map key 7 (auxiliary_data_hash) and embeds the bytes as the signed transaction's auxiliary_data
+ * element.
  *
  * Cardano signing is MPC/TSS: every co-signing device (iOS / Android / Extension) builds the input
  * independently and the Blake2b sighash must match byte-for-byte, so this encoding MUST be

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20.kt
@@ -1,0 +1,143 @@
+package com.vultisig.wallet.data.crypto
+
+import com.vultisig.wallet.data.common.Utils
+import kotlin.experimental.and
+
+/**
+ * Canonical CIP-20 transaction-metadata encoder for Cardano memos.
+ *
+ * A Cardano memo is CIP-20 metadata under the registered label 674:
+ *
+ *     { 674: { "msg": [ "<chunk1>", "<chunk2>", ... ] } }
+ *
+ * Each `msg` text chunk is at most 64 UTF-8 bytes, split on Unicode codepoint boundaries (never
+ * mid-codepoint). WalletCore 4.7.0 consumes these CBOR bytes via
+ * `Cardano.SigningInput.auxiliary_data`: it commits `blake2b-256(auxDataCbor)` into the tx body at
+ * map key 7 (auxiliary_data_hash) and embeds the bytes as element [3] of the signed transaction
+ * array.
+ *
+ * Cardano signing is MPC/TSS: every co-signing device (iOS / Android / Extension) builds the input
+ * independently and the Blake2b sighash must match byte-for-byte, so this encoding MUST be
+ * byte-identical across platforms. It mirrors the mainnet-verified iOS encoder `CardanoCIP20.swift`
+ * and the SDK encoder `vultisig-sdk/.../cardano/buildCip20AuxData.ts`.
+ */
+object CardanoCIP20 {
+
+    /** CIP-20 limits each metadata text chunk to 64 UTF-8 bytes. */
+    private const val MAX_CHUNK_BYTES = 64
+
+    /** The CIP-20 metadata label registered on cardano.org. */
+    private const val METADATA_LABEL = 674
+
+    /** Canonical CIP-20 auxiliary data plus its Blake2b-256 hash. */
+    data class AuxData(val auxDataCbor: ByteArray, val auxDataHash: ByteArray)
+
+    /**
+     * Split a memo into chunks of at most 64 UTF-8 bytes, respecting UTF-8 codepoint boundaries.
+     *
+     * A multi-byte codepoint straddling the 64-byte boundary is moved entirely to the next chunk
+     * rather than torn — a torn codepoint decodes to U+FFFD and corrupts the memo on-chain. UTF-8
+     * continuation bytes have the top bits `10xxxxxx`; we walk back off them until the cut lands on
+     * a leading byte. An empty memo yields a single empty-string chunk (matches the SDK, which
+     * always emits at least one `msg` element).
+     */
+    fun memoToChunks(memo: String): List<String> {
+        val bytes = memo.toByteArray(Charsets.UTF_8)
+        if (bytes.isEmpty()) return listOf("")
+
+        val chunks = mutableListOf<String>()
+        var start = 0
+        while (start < bytes.size) {
+            var end = minOf(start + MAX_CHUNK_BYTES, bytes.size)
+
+            // If we are not at the end and `end` lands on a continuation byte
+            // (0b10xxxxxx), back up until the byte at `end` starts a codepoint.
+            if (end < bytes.size) {
+                while (end > start && (bytes[end] and 0xC0.toByte()) == 0x80.toByte()) {
+                    end -= 1
+                }
+                // Defensive: a run of >64 continuation bytes is impossible for valid
+                // UTF-8 (max 4 bytes/codepoint); fall back to the raw cut so we
+                // always make forward progress.
+                if (end == start) {
+                    end = minOf(start + MAX_CHUNK_BYTES, bytes.size)
+                }
+            }
+
+            // Cuts always land on a codepoint boundary, so decoding a slice of the
+            // (always-valid) UTF-8 bytes never fails.
+            chunks.add(String(bytes, start, end - start, Charsets.UTF_8))
+            start = end
+        }
+        return chunks
+    }
+
+    /**
+     * Encode the CIP-20 auxiliary data for a memo.
+     *
+     * Returns the canonical CBOR bytes for `{ 674: { "msg": [chunks] } }` (to be set on
+     * `Cardano.SigningInput.auxiliary_data`) plus their `blake2b-256`, which WalletCore commits
+     * into the tx body at map key 7.
+     */
+    fun buildAuxData(memo: String): AuxData {
+        val chunks = memoToChunks(memo)
+        val msgArray = cborArray(chunks.map { cborText(it) })
+        val innerMap = cborMap(listOf(cborText("msg") to msgArray))
+        val auxDataCbor = cborMap(listOf(cborUint(METADATA_LABEL) to innerMap))
+        val auxDataHash = Utils.blake2bHash(auxDataCbor)
+        return AuxData(auxDataCbor, auxDataHash)
+    }
+
+    // Minimal canonical CBOR primitives (RFC 8949 §3.1)
+
+    /** CBOR text string (major type 3). */
+    private fun cborText(string: String): ByteArray {
+        val utf8 = string.toByteArray(Charsets.UTF_8)
+        return cborHead(majorType = 3, value = utf8.size) + utf8
+    }
+
+    /** CBOR unsigned integer (major type 0). */
+    private fun cborUint(value: Int): ByteArray = cborHead(majorType = 0, value = value)
+
+    /** CBOR array header (major type 4) followed by its items. */
+    private fun cborArray(items: List<ByteArray>): ByteArray {
+        var out = cborHead(majorType = 4, value = items.size)
+        for (item in items) out += item
+        return out
+    }
+
+    /** CBOR map header (major type 5) followed by its key/value pairs. */
+    private fun cborMap(entries: List<Pair<ByteArray, ByteArray>>): ByteArray {
+        var out = cborHead(majorType = 5, value = entries.size)
+        for ((key, value) in entries) {
+            out += key
+            out += value
+        }
+        return out
+    }
+
+    /** Encode the major-type + argument head in the smallest form (RFC 8949 §3.1). */
+    private fun cborHead(majorType: Int, value: Int): ByteArray {
+        val mt = (majorType shl 5)
+        val v = value.toLong() and 0xFFFFFFFFL
+        return when {
+            v < 24 -> byteArrayOf((mt or v.toInt()).toByte())
+            v < 0x100 -> byteArrayOf((mt or 24).toByte(), v.toByte())
+            v < 0x1_0000 ->
+                byteArrayOf(
+                    (mt or 25).toByte(),
+                    ((v shr 8) and 0xFF).toByte(),
+                    (v and 0xFF).toByte(),
+                )
+
+            else ->
+                byteArrayOf(
+                    (mt or 26).toByte(),
+                    ((v shr 24) and 0xFF).toByte(),
+                    ((v shr 16) and 0xFF).toByte(),
+                    ((v shr 8) and 0xFF).toByte(),
+                    (v and 0xFF).toByte(),
+                )
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -289,6 +289,7 @@ constructor(
                                     sendMaxAmount = isMaxAmountEnabled,
                                     ttl = ttl.toLong(),
                                     utxos = utxos,
+                                    memo = memo,
                                 )
                             } catch (e: CancellationException) {
                                 throw e

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20Test.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoCIP20Test.kt
@@ -1,0 +1,121 @@
+package com.vultisig.wallet.data.crypto
+
+import com.vultisig.wallet.data.common.Utils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Byte-parity fixtures shared with the iOS `CardanoCIP20Tests` and the SDK's
+ * `buildCip20AuxData.test.ts`. The CIP-20 CBOR bytes and blake2b-256 aux hash MUST be identical
+ * across iOS / Android / Extension or MPC co-signers disagree on the Cardano sighash. Any drift
+ * here or in another platform's encoder breaks one of these tests.
+ */
+class CardanoCIP20Test {
+
+    private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
+
+    private fun String.utf8Hex(): String = toByteArray(Charsets.UTF_8).hex()
+
+    // memoToChunks
+
+    @Test
+    fun `returns single chunk for short memo`() {
+        assertEquals(listOf("hello world"), CardanoCIP20.memoToChunks("hello world"))
+    }
+
+    @Test
+    fun `returns single empty chunk for empty input`() {
+        assertEquals(listOf(""), CardanoCIP20.memoToChunks(""))
+    }
+
+    @Test
+    fun `splits exactly on 64-byte boundary for ascii`() {
+        val chunks = CardanoCIP20.memoToChunks("a".repeat(65))
+        assertEquals(2, chunks.size)
+        assertEquals(64, chunks[0].toByteArray(Charsets.UTF_8).size)
+        assertEquals(1, chunks[1].toByteArray(Charsets.UTF_8).size)
+    }
+
+    @Test
+    fun `does not split a 64-byte memo`() {
+        val memo64 = "x".repeat(64)
+        assertEquals(listOf(memo64), CardanoCIP20.memoToChunks(memo64))
+    }
+
+    @Test
+    fun `does not tear a 4-byte codepoint straddling the boundary`() {
+        // 63 ASCII 'a' + U+1F600 (4 bytes) + 'b'. A naive byte-cut would tear the emoji.
+        val memo = "a".repeat(63) + "😀" + "b"
+        val chunks = CardanoCIP20.memoToChunks(memo)
+        assertEquals(memo, chunks.joinToString(""))
+        assertFalse(chunks.joinToString("").contains("�"))
+        assertTrue(chunks[0].toByteArray(Charsets.UTF_8).size <= 64)
+        assertTrue(chunks[1].contains("😀"))
+    }
+
+    @Test
+    fun `does not tear a 2-byte codepoint straddling the boundary`() {
+        val memo = "a".repeat(63) + "ñ" + "c"
+        val chunks = CardanoCIP20.memoToChunks(memo)
+        assertEquals(memo, chunks.joinToString(""))
+        assertFalse(chunks.joinToString("").contains("�"))
+    }
+
+    @Test
+    fun `does not tear a 3-byte codepoint straddling the boundary`() {
+        val memo = "a".repeat(62) + "日" + "d"
+        val chunks = CardanoCIP20.memoToChunks(memo)
+        assertEquals(memo, chunks.joinToString(""))
+        assertFalse(chunks.joinToString("").contains("�"))
+    }
+
+    @Test
+    fun `multi-byte memo round-trips through chunks`() {
+        val memo = "a".repeat(63) + "😀" + "b"
+        val chunks = CardanoCIP20.memoToChunks(memo)
+        assertEquals(memo, chunks.joinToString(""))
+        assertFalse(chunks.joinToString("").contains("�"))
+        for (chunk in chunks) {
+            assertTrue(chunk.toByteArray(Charsets.UTF_8).size <= 64)
+        }
+    }
+
+    // buildAuxData byte parity
+
+    @Test
+    fun `buildAuxData produces pinned cbor for hello world`() {
+        // a1 1902a2 a1 636d7367 81 6b <"hello world">
+        val expected = "a11902a2a1636d7367816b" + "hello world".utf8Hex()
+        assertEquals(expected, CardanoCIP20.buildAuxData("hello world").auxDataCbor.hex())
+    }
+
+    @Test
+    fun `buildAuxData encodes label 674 and msg key`() {
+        val hex = CardanoCIP20.buildAuxData("hello world").auxDataCbor.hex()
+        assertTrue(hex.startsWith("a11902a2a1636d7367"))
+    }
+
+    @Test
+    fun `buildAuxData chunks a 64-byte chunk head correctly`() {
+        // A 65-byte ASCII memo -> two text chunks: one 64-byte (head 78 40) and one 1-byte.
+        val hex = CardanoCIP20.buildAuxData("a".repeat(65)).auxDataCbor.hex()
+        assertTrue(hex.contains("82")) // array(2) header
+        assertTrue(hex.contains("7840" + "61".repeat(64))) // 64-byte text head + 64 'a'
+    }
+
+    @Test
+    fun `buildAuxData empty memo encodes single empty chunk`() {
+        // { 674: { "msg": [""] } } -> ... 81 60  (array(1), text(0))
+        assertEquals("a11902a2a1636d7367" + "8160", CardanoCIP20.buildAuxData("").auxDataCbor.hex())
+    }
+
+    @Test
+    fun `aux data hash is blake2b-256 of cbor`() {
+        val aux = CardanoCIP20.buildAuxData("vultisig-test")
+        assertEquals(32, aux.auxDataHash.size)
+        assertEquals(Utils.blake2bHash(aux.auxDataCbor).hex(), aux.auxDataHash.hex())
+        assertTrue(aux.auxDataHash.any { it.toInt() != 0 })
+    }
+}


### PR DESCRIPTION
## ⚠️ HIGH-tier Cardano signing path — needs on-device + cross-device review before merge

Attaches the Cardano send memo on-chain as **CIP-20 transaction metadata (label 674)** using WalletCore 4.7.0's native `Cardano.SigningInput.auxiliary_data`. Cardano signing is MPC/TSS, so this is **byte-parity-sensitive**: it needs on-device and cross-device (iOS ↔ Android ↔ Extension) co-signing byte-parity validation on mainnet before it leaves draft. Kept as a **draft** for that reason.

Closes #5124. Cross-platform reference: [vultisig-ios#4709](https://github.com/vultisig/vultisig-ios/pull/4709) (merged, mainnet-verified).

## Problem

The Cardano send memo was typed by the user but **silently dropped at signing time** — the old `CardanoHelper` carried a `// TODO: Implement memo support when WalletCore adds Cardano metadata support`. wallet-core `4.7.0` (already on `main` via #5154) exposes the native `Cardano.SigningInput.auxiliary_data` field, unblocking this.

## What changed

- **`CardanoCIP20`** (new) — canonical CIP-20 encoder: CBOR for `{ 674: { "msg": [chunks] } }`, each `msg` chunk ≤ **64 UTF-8 bytes** split on codepoint boundaries (never mid-codepoint), plus the `blake2b-256` aux hash. The encoding is **byte-parity pinned** to the iOS/SDK golden vector so MPC co-signers agree on the sighash.
- **`CardanoHelper`** — builds the aux CBOR from `keysignPayload.memo` and sets it on `Cardano.SigningInput.auxiliary_data`. WalletCore commits `blake2b-256(auxData)` into tx body **key 7** (`auxiliary_data_hash`) and embeds the aux bytes as signed-tx element **[3]** natively. Android compiles the signed tx via `compileWithSignatures`, so **no manual envelope patching is needed** (unlike iOS, which hand-builds the envelope because `compileWithSignatures` crashes there).
- **Fee** — the memo is threaded into `estimateFee` so the size-based dynamic fee **prices the aux bytes**. Without it a memo send underprices and the node rejects the broadcast with `FeeTooSmallUTxO`.

## No UI gating change (Android differs from iOS)

The Cardano memo input already renders on Android: the Send memo gate is `token.isNativeToken || COSMOS`, and native ADA is `isNativeToken = true`. iOS needed a `supportsMemo` change only because it used a separate gate that explicitly excluded Cardano.

## Byte parity (golden vector)

`{ 674: { "msg": ["hello world"] } }` encodes to `a11902a2a1636d7367816b68656c6c6f20776f726c64` — identical to the iOS `CardanoCIP20Tests` and SDK `buildCip20AuxData` fixtures.

## Test plan

- [x] `CardanoCIP20Test` — 13 tests: chunking (ASCII 64/65-byte boundaries, 2/3/4-byte codepoints never torn, empty memo → single empty chunk), pinned CBOR golden vectors, blake2b-256 aux hash. All green.
- [x] Existing `*Cardano*` suites still green (swap path passes `memo = null` → no aux, unchanged).
- [x] `ktfmtCheck` clean.
- [ ] **On-device mainnet send with a memo** → confirm CIP-20 label 674 metadata on cardanoscan.
- [ ] **Cross-device co-signing** (Android ↔ iOS ↔ Extension) → identical body/sighash, broadcast succeeds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

on chain tx link: 
https://cardanoscan.io/transaction/b555ee5c488bf18aa6471ecad6bb0756b7e0614f0a8a66f86bd068cb403c21eb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Optional Cardano memos are now encoded as CIP-20 auxiliary data and included in Cardano signing inputs.

* **Bug Fixes**
  * Memo content now consistently affects Cardano fee estimation and byte-fee reporting across send and join-fee flows.
  * Cardano-specific recalculations and submission now reliably use the memo value confirmed during validation.

* **Tests**
  * Added deterministic CIP-20 encoding/hash tests, including UTF-8 boundary-safe chunking.
  * Added coverage to ensure memo presence changes the Cardano sighash as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->