### PR TITLE
fix(keysign): reach a terminal state on a hashless broadcast

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -782,15 +782,18 @@ constructor(
     private suspend fun broadcastTransaction() {
         val payload = keysignPayload ?: return
 
-        when (
-            val result =
-                broadcastKeysign(
-                    vault = vault,
-                    payload = payload,
-                    signatures = signatures,
-                    isInitiatingDevice = isInitiatingDevice,
-                )
-        ) {
+        applyBroadcastResult(
+            broadcastKeysign(
+                vault = vault,
+                payload = payload,
+                signatures = signatures,
+                isInitiatingDevice = isInitiatingDevice,
+            )
+        )
+    }
+
+    internal suspend fun applyBroadcastResult(result: KeysignBroadcastResult) {
+        when (result) {
             is KeysignBroadcastResult.ApprovalNotConfirmed -> {
                 _state.update {
                     it.copy(
@@ -840,6 +843,17 @@ constructor(
                                     KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
                             )
                         }
+                    }
+                } else {
+                    // The broadcast succeeded but produced no hash. Land on the terminal
+                    // "broadcasted" state instead of leaving signingState at the last signing
+                    // state forever (infinite spinner → the user may force-retry and double-send).
+                    // Without a hash we cannot save history or poll status.
+                    _state.update {
+                        it.copy(
+                            signingState =
+                                KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.keysign
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
@@ -79,6 +80,11 @@ internal fun KeysignView(
     dappMetadata: DAppMetadata? = null,
     @DrawableRes coinLogoRes: Int? = null,
 ) {
+    // Block system back while signing/broadcasting is in progress. Popping the nav entry here
+    // cancels the ViewModel's coroutine scope mid-broadcast, before a terminal state lands, and a
+    // force-retry could double-send. Back is re-enabled once the flow reaches a finished/error
+    // state.
+    BackHandler(enabled = state.isInProgress) {}
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         if (state.isInProgress) {
             KeepScreenOn()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TssKeyType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.KeysignBroadcastResult
+import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class KeysignViewModelApplyBroadcastResultTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val vault = Vault(id = "v1", name = "Test Vault")
+
+    private lateinit var txStatusConfigurationProvider: TxStatusConfigurationProvider
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        txStatusConfigurationProvider = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // A hashless broadcast must still reach a terminal state; otherwise signingState stays at the
+    // last signing state forever (infinite spinner) and the user may force-retry → double-send.
+    @Test
+    fun `broadcasted with null txHash reaches the terminal broadcasted state`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+
+            vm.applyBroadcastResult(broadcasted(txHash = null))
+
+            vm.state.value.signingState shouldBe
+                KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+        }
+
+    // Guards the refactor: the non-polling success path still lands on the same terminal state.
+    @Test
+    fun `broadcasted with txHash on a non-status chain reaches the terminal broadcasted state`() =
+        runTest(testDispatcher) {
+            every { txStatusConfigurationProvider.supportTxStatus(any()) } returns false
+            val vm = createViewModel()
+
+            vm.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            vm.state.value.run {
+                signingState shouldBe KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+                txHash shouldBe "0xhash"
+            }
+        }
+
+    private fun broadcasted(txHash: String?) =
+        KeysignBroadcastResult.Broadcasted(
+            chain = Chain.Ethereum,
+            txHash = txHash,
+            txLink = if (txHash != null) "https://etherscan.io/tx/$txHash" else "",
+            swapProgressLink = null,
+            approveTxHash = "",
+            approveTxLink = "",
+        )
+
+    private fun createViewModel() =
+        KeysignViewModel(
+            vault = vault,
+            keysignCommittee = emptyList(),
+            serverUrl = "",
+            sessionId = "",
+            encryptionKeyHex = "",
+            messagesToSign = emptyList(),
+            keyType = TssKeyType.ECDSA,
+            keysignPayload = null,
+            customMessagePayload = null,
+            transactionTypeUiModel = null,
+            isInitiatingDevice = false,
+            transactionHistoryData = null,
+            thorChainApi = mockk(relaxed = true),
+            evmApiFactory = mockk(relaxed = true),
+            broadcastTx = mockk(relaxed = true),
+            explorerLinkRepository = mockk(relaxed = true),
+            navigator = mockk<Navigator<Destination>>(relaxed = true),
+            sessionApi = mockk(relaxed = true),
+            encryption = mockk(relaxed = true),
+            featureFlagApi = mockk(relaxed = true),
+            pullTssMessages = mockk(relaxed = true),
+            addressBookRepository = mockk(relaxed = true),
+            txStatusConfigurationProvider = txStatusConfigurationProvider,
+            txStatusPoller = mockk(relaxed = true),
+            vaultRepository = mockk(relaxed = true),
+            transactionHistoryRepository = mockk(relaxed = true),
+            balanceRepository = mockk(relaxed = true),
+            gasFeeToEstimatedFee = mockk(relaxed = true),
+            awaitApprovalConfirmation = mockk(relaxed = true),
+        )
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -44,34 +44,39 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
 
             val rpcResp = response.bodyOrThrow<RippleBroadcastResponseResponseJson>()
 
+            val engineResult = rpcResp.result.engineResult
             val resultMessage = rpcResp.result.engineResultMessage
+            val hash = rpcResp.result.txJson?.hash
 
-            if (rpcResp.result.engineResult != "tesSUCCESS") {
-                if (
-                    resultMessage?.contains("The transaction was applied", ignoreCase = true) ==
-                        true ||
-                        resultMessage.equals(
-                            "This sequence number has already passed.",
-                            ignoreCase = true,
-                        ) ||
-                        resultMessage.equals("The transaction is redundant.", ignoreCase = true)
-                ) {
-                    if (!rpcResp.result.txJson?.hash.isNullOrBlank()) {
-                        return rpcResp.result.txJson.hash
-                    }
+            // A benign duplicate-broadcast race: the peer's identical transaction was already
+            // applied/queued, so the transaction is (or will be) on-chain and we can recover its
+            // hash rather than treat it as a failure.
+            val alreadyApplied =
+                resultMessage?.contains("The transaction was applied", ignoreCase = true) == true ||
+                    resultMessage.equals(
+                        "This sequence number has already passed.",
+                        ignoreCase = true,
+                    ) ||
+                    resultMessage.equals("The transaction is redundant.", ignoreCase = true)
+
+            if (engineResult == "tesSUCCESS" || alreadyApplied) {
+                if (!hash.isNullOrBlank()) {
+                    return hash
                 }
-                return resultMessage ?: ""
-            } else {
-                val hash = rpcResp.result.txJson?.hash
-                return if (!hash.isNullOrBlank()) {
-                    hash
-                } else {
-                    resultMessage ?: ""
-                }
+                // Submitted but the node returned no hash. Don't invent one from the message; let
+                // the caller's on-chain recovery confirm using the locally computed hash instead.
+                error("XRP broadcast returned no transaction hash (engine_result=$engineResult)")
             }
+
+            // Any other engine result is a genuine rejection (e.g. temBAD_FEE, tecUNFUNDED). Throw
+            // the node's message instead of returning it as a fake txid, so the keysign surfaces
+            // the
+            // failure (matching iOS RippleService) rather than persisting the rejection text as a
+            // hash.
+            error(resultMessage ?: "XRP broadcast failed (engine_result=$engineResult)")
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e(e.message, "Error in Broadcast XRP Transaction")
+            Timber.e(e, "Error in Broadcast XRP Transaction")
             error(e.message ?: "Error in Broadcast XRP Transaction")
         }
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBodyReadTest.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Characterization tests for [RippleApiImp] methods that contain a raw `body<…>()` call:
@@ -52,28 +53,32 @@ class RippleApiBodyReadTest {
         assertEquals("RIPPLEHASH01", result)
     }
 
+    // A genuine rejection must throw, not return the engine result message as a fake txid — the
+    // keysign would otherwise persist the rejection text as a transaction hash and show success.
     @Test
-    fun `broadcastTransaction returns engine_result_message when engineResult is not tesSUCCESS and tx hash is blank`() =
-        runBlocking {
-            val body =
-                """
-                {
-                  "result": {
-                    "engine_result": "temBAD_FEE",
-                    "engine_result_message": "Fee must be positive.",
-                    "tx_json": {
-                      "hash": ""
-                    }
-                  }
+    fun `broadcastTransaction throws engine_result_message when engineResult is a genuine rejection`() {
+        val body =
+            """
+            {
+              "result": {
+                "engine_result": "temBAD_FEE",
+                "engine_result_message": "Fee must be positive.",
+                "tx_json": {
+                  "hash": ""
                 }
-                """
-                    .trimIndent()
-            val api = newApi(HttpStatusCode.OK, body)
+              }
+            }
+            """
+                .trimIndent()
+        val api = newApi(HttpStatusCode.OK, body)
 
-            val result = api.broadcastTransaction("signedtx")
+        val error =
+            assertThrows<IllegalStateException> {
+                runBlocking { api.broadcastTransaction("signedtx") }
+            }
 
-            assertEquals("Fee must be positive.", result)
-        }
+        assertEquals("Fee must be positive.", error.message)
+    }
 
     @Test
     fun `broadcastTransaction recovers hash from tx_json when result message matches already-applied wording`() =


### PR DESCRIPTION
## Summary

Fixes #5149.

In `KeysignViewModel`, the `is KeysignBroadcastResult.Broadcasted` branch only transitioned to a terminal state **inside** `if (txHash != null)` — there was no `else`.

`Broadcasted.txHash` is nullable, and a successful broadcast can legitimately yield `null` (e.g. `orKnownHash` returns `null` when both the RPC-returned hash and the local `tx.transactionHash` are blank). When that happened, `signingState` stayed at the last signing state (`KeysignECDSA`/`EdDSA`) forever — an infinite spinner with no success and no error. The user can't tell whether funds moved and may force-retry the whole keysign → **double-send risk**.

## Changes

- Add the missing `else` branch: a hashless-but-submitted broadcast now lands on the terminal `KeysignFinished(TransactionStatus.Broadcasted)` state, mirroring the existing non-polling success path. Because the use case only returns `Broadcasted` on a successful submit, a null hash means "submitted, hash unavailable" — a terminal success, not an error. Without a hash we can't save history or poll status, so those steps are skipped.
- Extract the result→state mapping into an `internal suspend fun applyBroadcastResult(result)` seam so it can be unit-tested without driving the full (static-`SigningHelper`-dependent) broadcast path.

## Test plan

- Added `KeysignViewModelApplyBroadcastResultTest`:
  - `Broadcasted(txHash = null)` → `signingState == KeysignFinished(Broadcasted)` (the bug).
  - `Broadcasted(txHash = "0x…")` on a non-status chain → `KeysignFinished(Broadcasted)` with `txHash` set (guards the refactor).
- `./gradlew :app:testDebugUnitTest --tests "…KeysignViewModelApplyBroadcastResultTest"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cases where broadcasts that return no transaction hash could leave the app in an unfinished signing flow; such broadcasts now correctly complete.
  * Prevented users from navigating back while signing/broadcasting is in progress to avoid interruption-related issues.
  * Improved broadcast handling to treat successful and benign duplicate outcomes correctly, and to surface meaningful errors on genuine rejections.
* **Tests**
  * Added tests for broadcast-result handling with and without a transaction hash.
  * Updated API tests to assert errors are thrown for genuine rejection cases with the expected message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->