### PR TITLE
fix(ripple): populate the canonical transaction hash on signed XRP txs

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.tss.getSignature
 import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
 import com.vultisig.wallet.data.utils.Numeric
+import java.security.MessageDigest
 import timber.log.Timber
 import wallet.core.jni.CoinType
 import wallet.core.jni.DataVector
@@ -150,9 +151,26 @@ object RippleHelper {
             error(errorMessage)
         }
 
+        val signedTransaction = output.encoded.toByteArray()
         return SignedTransactionResult(
-            rawTransaction = output.encoded.toByteArray().toHexString(),
-            transactionHash = "",
+            rawTransaction = signedTransaction.toHexString(),
+            transactionHash = calculateTransactionHash(signedTransaction),
         )
     }
+
+    /**
+     * Derives the canonical XRPL transaction ID: the first 32 bytes (SHA-512Half) of the SHA-512
+     * digest of the signed transaction blob prefixed with the transaction hash prefix 0x54584E00.
+     * WalletCore's [Ripple.SigningOutput] does not expose the hash, so it must be computed here to
+     * match the value the node returns and the explorer indexes - an empty hash breaks status
+     * polling, explorer deep-links, and duplicate-broadcast recovery.
+     */
+    fun calculateTransactionHash(signedTransaction: ByteArray): String {
+        val digest =
+            MessageDigest.getInstance("SHA-512").digest(TRANSACTION_HASH_PREFIX + signedTransaction)
+        return digest.copyOfRange(0, 32).toHexString(HexFormat.UpperCase)
+    }
+
+    // 0x54584E00 is the ASCII "TXN" mnemonic plus a zero byte: XRPL's transaction-ID hash prefix.
+    private val TRANSACTION_HASH_PREFIX = byteArrayOf(0x54, 0x58, 0x4E, 0x00)
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
@@ -1,0 +1,26 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalStdlibApi::class)
+class RippleHelperTest {
+
+    /**
+     * Canonical XRPL transaction ID derivation, checked against a real validated transaction
+     * (ledger tx `005899AE…C974`). The blob is the binary form returned by the node's `tx` command,
+     * and the expected hash is the id the node and explorers index it under. This locks in that we
+     * hash SHA-512Half over the `TXN `-prefixed blob and uppercase the result.
+     */
+    @Test
+    fun `calculateTransactionHash matches the canonical XRPL transaction id`() {
+        val signedBlob =
+            "1200072200000000240F81187C20190F81186B201B064808B764D5484DDC1BC9340000000000000000000000000045555200000000002ADB0B3959D60A6E6991F729E1918B716392523065400000008841978068400000000000000A73210253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C574473045022100A92E57F5E483E3DBBE6D88F75EB8A0193C97C853095868140CE83EFBDCB356C002206E7857B5EC8F0482D884E6D38C4548820C53B1EA81A4562D3DDB41253C287502811472A3DE6B0973062D5F2FE77383EF02F0C17901AB"
+                .hexToByteArray()
+
+        assertEquals(
+            "005899AE70C8A8E0148C331956CF37D216596BB757764EA11F3B19392609C974",
+            RippleHelper.calculateTransactionHash(signedBlob),
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
@@ -10,7 +10,8 @@ class RippleHelperTest {
      * Canonical XRPL transaction ID derivation, checked against a real validated transaction
      * (ledger tx `005899AE…C974`). The blob is the binary form returned by the node's `tx` command,
      * and the expected hash is the id the node and explorers index it under. This locks in that we
-     * hash SHA-512Half over the `TXN `-prefixed blob and uppercase the result.
+     * hash SHA-512Half over the `0x54584E00` (`TXN` + zero byte) prefixed blob and uppercase the
+     * result.
      */
     @Test
     fun `calculateTransactionHash matches the canonical XRPL transaction id`() {


### PR DESCRIPTION
## Summary
- `RippleHelper.getSignedTransaction` returned `transactionHash = ""`, unlike every other chain helper.
- The empty hash left XRP sends untrackable (status polling, explorer deep-links) **and** silently disabled the duplicate-broadcast recovery path in `BroadcastTxUseCase`, which only recovers when `tx.transactionHash` is non-blank.
- WalletCore's `Ripple.SigningOutput` exposes only `encoded`/`error`/`errorMessage` — no hash. So the fix derives the canonical XRPL transaction ID locally: **SHA-512Half (first 32 bytes of SHA-512) of the signed blob prefixed with `0x54584E00` (`TXN\0`), uppercased**.
- Additive change — it does not alter the signed bytes.

## Issue
Closes #5150

## Test Plan
- [x] New unit test `RippleHelperTest` verifies the derivation against a **real validated ledger transaction** (blob + node-assigned hash fetched from the XRPL cluster) — passes
- [x] Lint passes (`./gradlew :data:lint`)
- [ ] Manual: send XRP, confirm the tx hash appears and the explorer deep-link + status polling resolve
- [ ] Manual: verify duplicate-broadcast recovery no longer silently fails for XRP

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

on chain tx link: https://xrpscan.com/tx/055F94F6B8883A733C2AA59AA0D4E7571AA2C6B64BB808A2DBAD8D9C1456D48D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Ripple transactions now produce the correct canonical transaction hash (no longer returning an empty value).
  * Signed Ripple transaction data is now properly retained and used to derive the transaction identifier for tracking.

* **Tests**
  * Added JUnit coverage to confirm the derived Ripple transaction hash matches the expected canonical XRPL transaction ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->