### PR TITLE
fix(backup): wait for the vault list before writing an all-vaults backup

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -302,7 +302,7 @@ constructor(
                 when (backupType) {
                     BackupType.AllVaults -> {
                         awaitVaults().forEach { vault ->
-                            launch { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+                            vaultDataStoreRepository.setBackupStatus(vault.id, true)
                         }
                     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -37,6 +37,8 @@ import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -90,7 +92,7 @@ constructor(
     private val backupType = args?.backupType
 
     private val vault = MutableStateFlow<Vault?>(null)
-    private var vaults = listOf<Vault>()
+    private val vaults = MutableStateFlow<List<Vault>?>(null)
     private val isVaultLoaded = MutableStateFlow(false)
 
     val state =
@@ -119,7 +121,7 @@ constructor(
             }
         } else {
             viewModelScope.launch {
-                vaults = vaultRepository.getAll()
+                vaults.value = vaultRepository.getAll()
                 val loadedVault = vaultRepository.get(vaultId)
                 if (loadedVault == null) {
                     showError()
@@ -185,9 +187,11 @@ constructor(
     }
 
     private suspend fun requestToCreateVaultsZipFile() {
-        val fileName = createZipVaultsBackupFileName(vaults)
+        val fileName = createZipVaultsBackupFileName(awaitVaults())
         createDocumentRequestFlow.emit(fileName)
     }
+
+    private suspend fun awaitVaults(): List<Vault> = vaults.filterNotNull().first()
 
     fun showMoreInfo() {
         isMoreInfoVisible = true
@@ -277,9 +281,10 @@ constructor(
     }
 
     private suspend fun backupAllVaults(password: String, uri: Uri): Boolean {
+        val vaultsToBackup = awaitVaults()
         val content =
             withContext(Dispatchers.Default) {
-                vaults.map { vault ->
+                vaultsToBackup.map { vault ->
                     val vaultBackupData =
                         createVaultBackup(mapVaultToProto(vault), password)
                             ?: return@withContext null
@@ -296,7 +301,7 @@ constructor(
             if (backupSuccess) {
                 when (backupType) {
                     BackupType.AllVaults -> {
-                        vaults.forEach { vault ->
+                        awaitVaults().forEach { vault ->
                             launch { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
                         }
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
@@ -79,7 +79,7 @@ constructor(
     private val backupType = args.backupType
 
     private val vault = MutableStateFlow<Vault?>(null)
-    private var vaults = listOf<Vault>()
+    private val vaults = MutableStateFlow<List<Vault>?>(null)
 
     val state =
         MutableStateFlow(
@@ -97,9 +97,11 @@ constructor(
     init {
         viewModelScope.launch {
             vault.value = vaultRepository.get(vaultId) ?: error("Vault with id $vaultId not found")
-            vaults = vaultRepository.getAll()
+            vaults.value = vaultRepository.getAll()
         }
     }
+
+    private suspend fun awaitVaults(): List<Vault> = vaults.filterNotNull().first()
 
     fun dismissError() {
         state.update { it.copy(error = null) }
@@ -164,9 +166,10 @@ constructor(
     }
 
     private suspend fun backupAllVaults(uri: Uri): Boolean {
+        val vaultsToBackup = awaitVaults()
         val content =
             withContext(Dispatchers.Default) {
-                vaults.map { vault ->
+                vaultsToBackup.map { vault ->
                     val vaultBackupData =
                         createVaultBackup(mapVaultToProto(vault), null) ?: return@withContext null
                     val fileName = createVaultBackupFileName(vault)
@@ -223,7 +226,9 @@ constructor(
     private suspend fun updateBackupStatus() {
         when (backupType) {
             BackupType.AllVaults -> {
-                vaults.forEach { vault -> vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+                awaitVaults().forEach { vault ->
+                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
+                }
             }
 
             is BackupType.CurrentVault -> {
@@ -236,7 +241,7 @@ constructor(
         viewModelScope.launch {
             when (backupType) {
                 BackupType.AllVaults -> {
-                    createDocumentRequestFlow.emit(createZipVaultsBackupFileName(vaults))
+                    createDocumentRequestFlow.emit(createZipVaultsBackupFileName(awaitVaults()))
                 }
 
                 is BackupType.CurrentVault -> {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
@@ -1,0 +1,173 @@
+package com.vultisig.wallet.ui.models
+
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.mappers.MapVaultToProto
+import com.vultisig.wallet.data.mappers.MapVaultToProtoImpl
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
+import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
+import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
+import com.vultisig.wallet.ui.navigation.BackupType
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class BackupPasswordViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var mapVaultToProto: MapVaultToProto
+    private lateinit var createVaultBackupFileName: CreateVaultBackupFileNameUseCase
+    private lateinit var createZipVaultsBackupFileName: CreateZipVaultBackupFileNameUseCase
+    private lateinit var createVaultBackup: CreateVaultBackupUseCase
+    private lateinit var isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
+    private lateinit var snackbarFlow: SnackbarFlow
+    private lateinit var saveBackupToUri: SaveBackupToUriUseCase
+    private lateinit var deleteBackupDocument: DeleteBackupDocumentUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+
+        vaultRepository = mockk()
+        mapVaultToProto = MapVaultToProtoImpl()
+        createVaultBackupFileName = mockk(relaxed = true)
+        createZipVaultsBackupFileName = mockk(relaxed = true)
+        createVaultBackup = mockk()
+        isFileExtensionValid = mockk()
+        navigator = mockk(relaxed = true)
+        vaultDataStoreRepository = mockk(relaxed = true)
+        snackbarFlow = mockk(relaxed = true)
+        saveBackupToUri = mockk()
+        deleteBackupDocument = mockk(relaxed = true)
+
+        coEvery { isFileExtensionValid(any(), any()) } returns true
+        coEvery { saveBackupToUri(any(), any<List<AppZipEntry>>()) } returns true
+        every { createVaultBackup(any(), any()) } returns "encoded-vault-backup"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    private fun testVault(id: String) =
+        Vault(id = id, name = "Vault $id", libType = SigningLibType.DKLS)
+
+    private fun createViewModel(vaultId: String = "vault-1"): BackupPasswordViewModel {
+        every { any<SavedStateHandle>().toRoute<Route.BackupPassword>(typeMap = any()) } returns
+            Route.BackupPassword(vaultId = vaultId, backupType = BackupType.AllVaults)
+
+        return BackupPasswordViewModel(
+            savedStateHandle = SavedStateHandle(),
+            vaultRepository = vaultRepository,
+            mapVaultToProto = mapVaultToProto,
+            createVaultBackupFileName = createVaultBackupFileName,
+            createZipVaultsBackupFileName = createZipVaultsBackupFileName,
+            createVaultBackup = createVaultBackup,
+            isFileExtensionValid = isFileExtensionValid,
+            navigator = navigator,
+            vaultDataStoreRepository = vaultDataStoreRepository,
+            snackbarFlow = snackbarFlow,
+            saveBackupToUri = saveBackupToUri,
+            deleteBackupDocument = deleteBackupDocument,
+        )
+    }
+
+    @Test
+    fun `backing up all vaults waits for the vault list to finish loading instead of writing an empty zip`() =
+        runTest(testDispatcher) {
+            // Regression test for issue #5173: vaults used to be a plain var populated by a
+            // background coroutine, so a backup requested before that coroutine finished wrote
+            // a zero-entry ZIP and still reported success.
+            val vaults = listOf(testVault("a"), testVault("b"), testVault("c"))
+            val vaultsLoaded = CompletableDeferred<Unit>()
+            coEvery { vaultRepository.get("vault-1") } returns vaults.first()
+            coEvery { vaultRepository.getAll() } coAnswers
+                {
+                    vaultsLoaded.await()
+                    vaults
+                }
+
+            val vm = createViewModel()
+            val uri = mockk<Uri>()
+
+            // User already picked a save location before the vault list finished loading.
+            vm.saveContentToUriResult(uri, "application/zip")
+
+            // Must not write anything until the vault list is actually available.
+            coVerify(exactly = 0) { saveBackupToUri(any(), any<List<AppZipEntry>>()) }
+
+            vaultsLoaded.complete(Unit)
+
+            val contentSlot = slot<List<AppZipEntry>>()
+            coVerify { saveBackupToUri(uri, capture(contentSlot)) }
+            assertEquals(vaults.size, contentSlot.captured.size)
+            vaults.forEach { vault ->
+                coVerify { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+            }
+        }
+
+    @Test
+    fun `requesting the zip file name waits for the vault list before opening the document picker`() =
+        runTest(testDispatcher) {
+            val vaults = listOf(testVault("a"), testVault("b"))
+            val vaultsLoaded = CompletableDeferred<Unit>()
+            coEvery { vaultRepository.get("vault-1") } returns vaults.first()
+            coEvery { vaultRepository.getAll() } coAnswers
+                {
+                    vaultsLoaded.await()
+                    vaults
+                }
+            every { createZipVaultsBackupFileName(any()) } returns "vaults_backup.zip"
+
+            val vm = createViewModel()
+            var requestedFileName: String? = null
+            val collectJob = launch {
+                vm.createDocumentRequestFlow.collect { requestedFileName = it }
+            }
+
+            vm.backupEncryptedVault()
+            assertNull(requestedFileName, "must not request a document before vaults are loaded")
+
+            vaultsLoaded.complete(Unit)
+            assertEquals("vaults_backup.zip", requestedFileName)
+            collectJob.cancel()
+        }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
@@ -21,6 +21,8 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -28,8 +30,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -136,11 +136,15 @@ internal class BackupPasswordViewModelTest {
 
             vaultsLoaded.complete(Unit)
 
+            // backupAllVaults hops onto the real Dispatchers.Default, so the write below
+            // completes asynchronously — poll instead of asserting immediately.
             val contentSlot = slot<List<AppZipEntry>>()
-            coVerify { saveBackupToUri(uri, capture(contentSlot)) }
-            assertEquals(vaults.size, contentSlot.captured.size)
+            coVerify(timeout = 5_000) { saveBackupToUri(uri, capture(contentSlot)) }
+            contentSlot.captured.size shouldBe vaults.size
             vaults.forEach { vault ->
-                coVerify { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+                coVerify(timeout = 5_000) {
+                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
+                }
             }
         }
 
@@ -164,10 +168,10 @@ internal class BackupPasswordViewModelTest {
             }
 
             vm.backupEncryptedVault()
-            assertNull(requestedFileName, "must not request a document before vaults are loaded")
+            requestedFileName.shouldBeNull()
 
             vaultsLoaded.complete(Unit)
-            assertEquals("vaults_backup.zip", requestedFileName)
+            requestedFileName shouldBe "vaults_backup.zip"
             collectJob.cancel()
         }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.vultisig.wallet.ui.screens.backup
+
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.mappers.MapVaultToProto
+import com.vultisig.wallet.data.mappers.MapVaultToProtoImpl
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
+import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.CreateZipVaultBackupFileNameUseCase
+import com.vultisig.wallet.data.usecases.backup.DeleteBackupDocumentUseCase
+import com.vultisig.wallet.data.usecases.backup.IsVaultBackupFileExtensionValidUseCase
+import com.vultisig.wallet.data.usecases.backup.SaveBackupToUriUseCase
+import com.vultisig.wallet.ui.navigation.BackupType
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class BackupPasswordRequestViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var snackbarFlow: SnackbarFlow
+    private lateinit var createVaultBackupFileName: CreateVaultBackupFileNameUseCase
+    private lateinit var createZipVaultsBackupFileName: CreateZipVaultBackupFileNameUseCase
+    private lateinit var createVaultBackup: CreateVaultBackupUseCase
+    private lateinit var isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
+    private lateinit var mapVaultToProto: MapVaultToProto
+    private lateinit var saveBackupToUri: SaveBackupToUriUseCase
+    private lateinit var deleteBackupDocument: DeleteBackupDocumentUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+
+        navigator = mockk(relaxed = true)
+        snackbarFlow = mockk(relaxed = true)
+        createVaultBackupFileName = mockk(relaxed = true)
+        createZipVaultsBackupFileName = mockk(relaxed = true)
+        createVaultBackup = mockk()
+        isFileExtensionValid = mockk()
+        vaultRepository = mockk()
+        vaultDataStoreRepository = mockk(relaxed = true)
+        mapVaultToProto = MapVaultToProtoImpl()
+        saveBackupToUri = mockk()
+        deleteBackupDocument = mockk(relaxed = true)
+
+        coEvery { isFileExtensionValid(any(), any()) } returns true
+        coEvery { saveBackupToUri(any(), any<List<AppZipEntry>>()) } returns true
+        every { createVaultBackup(any(), any()) } returns "encoded-vault-backup"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    private fun testVault(id: String) =
+        Vault(id = id, name = "Vault $id", libType = SigningLibType.DKLS)
+
+    private fun createViewModel(vaultId: String = "vault-1"): BackupPasswordRequestViewModel {
+        every {
+            any<SavedStateHandle>().toRoute<Route.BackupPasswordRequest>(typeMap = any())
+        } returns Route.BackupPasswordRequest(vaultId = vaultId, backupType = BackupType.AllVaults)
+
+        return BackupPasswordRequestViewModel(
+            savedStateHandle = SavedStateHandle(),
+            navigator = navigator,
+            snackbarFlow = snackbarFlow,
+            createVaultBackupFileName = createVaultBackupFileName,
+            createZipVaultsBackupFileName = createZipVaultsBackupFileName,
+            createVaultBackup = createVaultBackup,
+            isFileExtensionValid = isFileExtensionValid,
+            vaultRepository = vaultRepository,
+            vaultDataStoreRepository = vaultDataStoreRepository,
+            mapVaultToProto = mapVaultToProto,
+            saveBackupToUri = saveBackupToUri,
+            deleteBackupDocument = deleteBackupDocument,
+        )
+    }
+
+    @Test
+    fun `backing up all vaults waits for the vault list to finish loading instead of writing an empty zip`() =
+        runTest(testDispatcher) {
+            // Regression test for issue #5173, mirrored for the VultiServer-password variant of
+            // the same "backup all vaults" flow.
+            val vaults = listOf(testVault("a"), testVault("b"), testVault("c"))
+            val vaultsLoaded = CompletableDeferred<Unit>()
+            coEvery { vaultRepository.get("vault-1") } returns vaults.first()
+            coEvery { vaultRepository.getAll() } coAnswers
+                {
+                    vaultsLoaded.await()
+                    vaults
+                }
+
+            val vm = createViewModel()
+            val uri = mockk<Uri>()
+
+            // User already picked a save location before the vault list finished loading.
+            vm.saveVaultIntoUri(uri, "application/zip")
+
+            coVerify(exactly = 0) { saveBackupToUri(any(), any<List<AppZipEntry>>()) }
+
+            vaultsLoaded.complete(Unit)
+
+            val contentSlot = slot<List<AppZipEntry>>()
+            coVerify { saveBackupToUri(uri, capture(contentSlot)) }
+            assertEquals(vaults.size, contentSlot.captured.size)
+            vaults.forEach { vault ->
+                coVerify { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+            }
+        }
+
+    @Test
+    fun `backupWithoutPassword waits for the vault list before opening the document picker`() =
+        runTest(testDispatcher) {
+            val vaults = listOf(testVault("a"), testVault("b"))
+            val vaultsLoaded = CompletableDeferred<Unit>()
+            coEvery { vaultRepository.get("vault-1") } returns vaults.first()
+            coEvery { vaultRepository.getAll() } coAnswers
+                {
+                    vaultsLoaded.await()
+                    vaults
+                }
+            every { createZipVaultsBackupFileName(any()) } returns "vaults_backup.zip"
+
+            val vm = createViewModel()
+            var requestedFileName: String? = null
+            val collectJob = launch {
+                vm.createDocumentRequestFlow.collect { requestedFileName = it }
+            }
+
+            vm.backupWithoutPassword()
+            assertNull(requestedFileName, "must not request a document before vaults are loaded")
+
+            vaultsLoaded.complete(Unit)
+            assertEquals("vaults_backup.zip", requestedFileName)
+            collectJob.cancel()
+        }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
@@ -21,6 +21,8 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -28,8 +30,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -135,11 +135,15 @@ internal class BackupPasswordRequestViewModelTest {
 
             vaultsLoaded.complete(Unit)
 
+            // backupAllVaults hops onto the real Dispatchers.Default, so the write below
+            // completes asynchronously — poll instead of asserting immediately.
             val contentSlot = slot<List<AppZipEntry>>()
-            coVerify { saveBackupToUri(uri, capture(contentSlot)) }
-            assertEquals(vaults.size, contentSlot.captured.size)
+            coVerify(timeout = 5_000) { saveBackupToUri(uri, capture(contentSlot)) }
+            contentSlot.captured.size shouldBe vaults.size
             vaults.forEach { vault ->
-                coVerify { vaultDataStoreRepository.setBackupStatus(vault.id, true) }
+                coVerify(timeout = 5_000) {
+                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
+                }
             }
         }
 
@@ -163,10 +167,10 @@ internal class BackupPasswordRequestViewModelTest {
             }
 
             vm.backupWithoutPassword()
-            assertNull(requestedFileName, "must not request a document before vaults are loaded")
+            requestedFileName.shouldBeNull()
 
             vaultsLoaded.complete(Unit)
-            assertEquals("vaults_backup.zip", requestedFileName)
+            requestedFileName shouldBe "vaults_backup.zip"
             collectJob.cancel()
         }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/FileHelper.kt
@@ -51,6 +51,10 @@ suspend fun Context.saveContentToUri(uri: Uri, content: String) = doFileOperatio
 
 suspend fun Context.saveContentToUri(uri: Uri, contentList: List<AppZipEntry>): Boolean =
     doFileOperation {
+        if (contentList.isEmpty()) {
+            Timber.w("Refusing to write a ZIP backup with no entries")
+            return@doFileOperation false
+        }
         try {
             contentResolver.openOutputStream(uri).use { outputStream ->
                 ZipOutputStream(outputStream).use { zipOutputStream ->

--- a/data/src/test/kotlin/com/vultisig/wallet/data/common/FileHelperSaveZipContentTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/common/FileHelperSaveZipContentTest.kt
@@ -1,0 +1,63 @@
+package com.vultisig.wallet.data.common
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipInputStream
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [Context.saveContentToUri] (the `List<AppZipEntry>` / ZIP overload) — verifies the fix
+ * for issue #5173, where a zero-entry list produced a broken ZIP that was still reported as a
+ * successful backup.
+ */
+internal class FileHelperSaveZipContentTest {
+
+    private val uri: Uri = mockk()
+    private val context: Context = mockk()
+    private val contentResolver: ContentResolver = mockk()
+
+    init {
+        every { context.contentResolver } returns contentResolver
+    }
+
+    @Test
+    fun `returns false and never opens an output stream for an empty entry list`() = runTest {
+        val result = context.saveContentToUri(uri, emptyList())
+
+        assertFalse(result)
+        verify(exactly = 0) { contentResolver.openOutputStream(any()) }
+    }
+
+    @Test
+    fun `writes every entry into the zip and returns true`() = runTest {
+        val output = ByteArrayOutputStream()
+        every { contentResolver.openOutputStream(uri) } returns output
+        val entries =
+            listOf(
+                AppZipEntry("vault-a.vult", "content-a"),
+                AppZipEntry("vault-b.vult", "content-b"),
+            )
+
+        val result = context.saveContentToUri(uri, entries)
+
+        assertTrue(result)
+        val readBack = mutableMapOf<String, String>()
+        ZipInputStream(output.toByteArray().inputStream()).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                readBack[entry.name] = zip.readBytes().toString(Charsets.UTF_8)
+                entry = zip.nextEntry
+            }
+        }
+        assertEquals(mapOf("vault-a.vult" to "content-a", "vault-b.vult" to "content-b"), readBack)
+    }
+}


### PR DESCRIPTION
## Summary

`BackupPasswordViewModel` and `BackupPasswordRequestViewModel` load the vault list asynchronously in `init`, but `backupAllVaults`/`backupWithoutPassword` read it from a plain `var` with no guard. A backup requested before that coroutine finished (fast tap, or a process death/recreation while the system file picker was open) wrote a zero-entry ZIP and still reported success to the user. Both ViewModels now await the vault list the same way they already await the single-vault case.

`FileHelper.saveContentToUri` also refuses to write a zero-entry ZIP as a backstop, since a broken backup silently reported as success is a data-loss risk independent of what produced the empty list.

Closes #5173

## Testing

- `./gradlew :app:testDebugUnitTest :data:testDebugUnitTest` — full suite green (3349 tests, 0 failures)
- New regression tests fail against the pre-fix code and pass after the fix (confirmed by temporarily reverting the production change and re-running)
- `./gradlew :app:ktfmtCheck :data:ktfmtCheck`
- `./gradlew :app:lintDebug :data:lintDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “all vaults” backup reliability by ensuring vault data finishes loading before generating ZIP content and updating per-vault backup status.
  * Deferred the backup filename/document-picker request until vault loading completes.
  * Prevented creating ZIP backups when there are no backup entries available.

* **Tests**
  * Added/expanded coroutine regression tests to verify correct sequencing for asynchronous vault loading, ZIP creation, filename emission, and backup-status updates.
  * Added unit coverage for blocking empty ZIP writes and validating written ZIP contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->