### PR TITLE
fix(solana): fall back to default compute-unit limit on a zero override

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -64,6 +64,12 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         }
         val toAddress = AnyAddress(keysignPayload.toAddress, coinType)
 
+        val effectivePriorityLimit =
+            solanaSpecific.priorityLimit
+                .takeIf { it > BigInteger.ZERO }
+                ?.min(BigInteger.valueOf(Int.MAX_VALUE.toLong()))
+                ?.toInt() ?: SOLANA_PRIORITY_FEE_LIMIT
+
         val input =
             Solana.SigningInput.newBuilder()
                 .setV0Msg(true)
@@ -82,13 +88,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
                         .build()
                 )
                 .setPriorityFeeLimit(
-                    Solana.PriorityFeeLimit.newBuilder()
-                        .setLimit(
-                            solanaSpecific.priorityLimit
-                                .min(BigInteger.valueOf(Int.MAX_VALUE.toLong()))
-                                .toInt()
-                        )
-                        .build()
+                    Solana.PriorityFeeLimit.newBuilder().setLimit(effectivePriorityLimit).build()
                 )
 
         if (keysignPayload.coin.isNativeToken) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -7,8 +7,10 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import wallet.core.jni.proto.Solana
 
 class SolanaHelperTest {
 
@@ -55,5 +57,78 @@ class SolanaHelperTest {
         val error =
             assertThrows<IllegalStateException> { SolanaHelper("").getPreSignedImageHash(payload) }
         assertEquals(SOLANA_MISSING_TOKEN_ACCOUNT_PREFIX + usdc.ticker, error.message)
+    }
+
+    /**
+     * A zero compute-limit override (e.g. a joining device reconstructing a payload with a missing
+     * value) must fall back to the app's default limit rather than encoding a zero compute budget.
+     * Uses [SolanaHelper.getSwapPreSignedInputData] since it is the only public entry point that
+     * returns the raw signing-input bytes without invoking a WalletCore signing/hashing call.
+     */
+    @Test
+    fun `zero priorityLimit falls back to the default compute-unit limit`() {
+        try {
+            val inputData =
+                SolanaHelper("").getSwapPreSignedInputData(solanaSwapPayload(BigInteger.ZERO))
+            val signingInput = Solana.SigningInput.parseFrom(inputData)
+            assertEquals(SOLANA_PRIORITY_FEE_LIMIT, signingInput.priorityFeeLimit.limit)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `positive priorityLimit is passed through unchanged`() {
+        try {
+            val inputData =
+                SolanaHelper("")
+                    .getSwapPreSignedInputData(solanaSwapPayload(BigInteger.valueOf(42_000L)))
+            val signingInput = Solana.SigningInput.parseFrom(inputData)
+            assertEquals(42_000, signingInput.priorityFeeLimit.limit)
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    private fun solanaSwapPayload(priorityLimit: BigInteger): KeysignPayload =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Solana,
+                    ticker = "SOL",
+                    logo = "",
+                    address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                    decimal = 9,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
+            toAmount = BigInteger.valueOf(1_000_000L),
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "",
+                    priorityFee = BigInteger.ZERO,
+                    priorityLimit = priorityLimit,
+                    fromAddressPubKey = null,
+                    toAddressPubKey = null,
+                    programId = false,
+                ),
+            memo = "SWAP:THOR.RUNE:thor1abc:0",
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+        )
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
     }
 }


### PR DESCRIPTION
## Summary
`SolanaHelper.getPreSignedInputData` set the Solana compute-unit limit straight from `BlockChainSpecific.Solana.priorityLimit` with no positive-value check. A zero value (e.g. a joining device reconstructing the payload from a peer's proto whose `compute_limit` came through as `"0"`) encoded a zero compute budget instead of falling back to the app's default (`SOLANA_PRIORITY_FEE_LIMIT` = 100000). Guarded the value with the same `takeIf { it > BigInteger.ZERO } ?: default` idiom already used elsewhere in this codebase for peer-supplied numeric overrides.

Closes #5178

## Testing
- `./gradlew :data:testDebugUnitTest` (full `data` module: 1870 passed, 0 failed, 39 skipped — pre-existing + these two gracefully skip locally since WalletCore's native lib is Android-only and unavailable to the host JVM, same as the rest of this file's JNI-dependent tests)
- `./gradlew :data:lintDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solana swap transactions now handle priority fee limits more reliably by using a default value when none is provided and preventing overly large values from being used.
* **Tests**
  * Added coverage for Solana swap payloads to verify both default fallback behavior and preserving valid custom priority limits.
  * Improved test handling when native libraries are unavailable, allowing unsupported environments to skip cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->