### PR TITLE
fix(qbtc): block claim co-sign when the vault password is empty

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -241,7 +241,7 @@ constructor(
         val claim = readyClaim() ?: return
         // The password sheet already disables Confirm while the field is blank, so this is a
         // defense-in-depth guard against ever reaching the co-sign call with an empty password.
-        if (fastVaultPassword.isEmpty()) {
+        if (fastVaultPassword.isBlank()) {
             passwordError = UiText.StringResource(R.string.password_should_not_be_empty)
             emitSelecting()
             return

--- a/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.ClaimableUtxo
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.LoadClaimableQbtcUtxosUseCase
@@ -53,6 +54,7 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
+import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.ktor.util.encodeBase64
 import java.math.BigInteger
@@ -106,6 +108,7 @@ internal sealed interface QbtcClaimUiState {
         val totalEligibleSats: Long,
         val canConfirm: Boolean,
         val isAllSelected: Boolean,
+        val passwordError: UiText? = null,
     ) : QbtcClaimUiState
 
     /** Nothing is claimable yet because every claimable UTXO is still maturing. */
@@ -160,6 +163,7 @@ constructor(
     private var claimable: List<ClaimableUtxo> = emptyList()
     private val selectedKeys = linkedSetOf<String>()
     private var claimJob: Job? = null
+    private var passwordError: UiText? = null
 
     init {
         load()
@@ -167,6 +171,7 @@ constructor(
 
     fun load() {
         uiState.value = QbtcClaimUiState.Loading
+        passwordError = null
         viewModelScope.safeLaunch {
             val loadedVault = vaultRepository.get(vaultId)
             // The claim needs a Bitcoin and a QBTC coin, but neither chain has to be enabled in the
@@ -234,6 +239,14 @@ constructor(
     /** Fast Vault: sign with the server co-signer using the entered vault password. */
     fun confirm(fastVaultPassword: String) {
         val claim = readyClaim() ?: return
+        // The password sheet already disables Confirm while the field is blank, so this is a
+        // defense-in-depth guard against ever reaching the co-sign call with an empty password.
+        if (fastVaultPassword.isEmpty()) {
+            passwordError = UiText.StringResource(R.string.password_should_not_be_empty)
+            emitSelecting()
+            return
+        }
+        passwordError = null
         claimJob =
             viewModelScope.safeLaunch {
                 runOrchestrator(
@@ -446,6 +459,7 @@ constructor(
                 totalEligibleSats = totalEligible,
                 canConfirm = canConfirm(),
                 isAllSelected = selectedKeys.size == cap,
+                passwordError = passwordError,
             )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -58,6 +58,7 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.errors.ErrorView
 import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.components.inputs.VsTextInputField
+import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldInnerState
 import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldType
 import com.vultisig.wallet.ui.components.loader.VsSigningProgressIndicator
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
@@ -72,6 +73,8 @@ import com.vultisig.wallet.ui.models.qbtc.QbtcClaimViewModel
 import com.vultisig.wallet.ui.screens.peer.PeerDiscoveryScreen
 import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.asString
 
 @Composable
 internal fun QbtcClaimScreen(viewModel: QbtcClaimViewModel = hiltViewModel()) {
@@ -106,6 +109,7 @@ internal fun QbtcClaimScreen(
                 passwordPrompt = false
                 onConfirm(it)
             },
+            passwordError = (state as? QbtcClaimUiState.Selecting)?.passwordError,
         )
     }
 
@@ -613,12 +617,17 @@ private fun ClaimPairingScreen(state: QbtcClaimUiState.Pairing, onBackClick: () 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun FastVaultPasswordSheet(onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+private fun FastVaultPasswordSheet(
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+    passwordError: UiText?,
+) {
     val passwordFieldState = remember { TextFieldState() }
     var isPasswordVisible by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
 
-    val submit = { onConfirm(passwordFieldState.text.toString()) }
+    val canSubmit = passwordFieldState.text.isNotEmpty()
+    val submit = { if (canSubmit) onConfirm(passwordFieldState.text.toString()) }
 
     V2BottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
@@ -657,6 +666,10 @@ private fun FastVaultPasswordSheet(onDismiss: () -> Unit, onConfirm: (String) ->
                 focusRequester = focusRequester,
                 imeAction = ImeAction.Go,
                 onKeyboardAction = { submit() },
+                innerState =
+                    if (passwordError != null) VsTextInputFieldInnerState.Error
+                    else VsTextInputFieldInnerState.Default,
+                footNote = passwordError?.asString(),
                 invisibleIcon = R.drawable.eye_closed,
             )
 
@@ -664,6 +677,7 @@ private fun FastVaultPasswordSheet(onDismiss: () -> Unit, onConfirm: (String) ->
 
             VsButton(
                 label = stringResource(R.string.qbtc_claim_title),
+                state = if (canSubmit) VsButtonState.Enabled else VsButtonState.Disabled,
                 onClick = submit,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -626,7 +626,7 @@ private fun FastVaultPasswordSheet(
     var isPasswordVisible by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
 
-    val canSubmit = passwordFieldState.text.isNotEmpty()
+    val canSubmit = passwordFieldState.text.isNotBlank()
     val submit = { if (canSubmit) onConfirm(passwordFieldState.text.toString()) }
 
     V2BottomSheet(onDismissRequest = onDismiss) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.ui.models.qbtc
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.ClaimProofResponse
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.ClaimableUtxo
@@ -31,6 +32,7 @@ import com.vultisig.wallet.ui.models.keysign.ResolveQbtcClaimCoinsUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -305,6 +307,25 @@ internal class QbtcClaimViewModelTest {
 
             coVerify(exactly = 0) { roundRunner.run(any()) }
             assertTrue(vm.uiState.value is QbtcClaimUiState.Selecting)
+        }
+
+    @Test
+    fun `confirm sets a validation error and never calls the orchestrator when the password is empty`() =
+        runTest(testDispatcher) {
+            coEvery { loadClaimableUtxos(BTC_ADDRESS) } returns
+                QbtcClaimLoadResult.Available(utxos(2))
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.confirm(fastVaultPassword = "")
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { roundRunner.run(any()) }
+            val state = vm.uiState.value as QbtcClaimUiState.Selecting
+            assertEquals(
+                UiText.StringResource(R.string.password_should_not_be_empty),
+                state.passwordError,
+            )
         }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
@@ -329,6 +329,25 @@ internal class QbtcClaimViewModelTest {
         }
 
     @Test
+    fun `confirm sets a validation error and never calls the orchestrator when the password is whitespace only`() =
+        runTest(testDispatcher) {
+            coEvery { loadClaimableUtxos(BTC_ADDRESS) } returns
+                QbtcClaimLoadResult.Available(utxos(2))
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.confirm(fastVaultPassword = "   ")
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { roundRunner.run(any()) }
+            val state = vm.uiState.value as QbtcClaimUiState.Selecting
+            assertEquals(
+                UiText.StringResource(R.string.password_should_not_be_empty),
+                state.passwordError,
+            )
+        }
+
+    @Test
     fun `retry reloads after a block`() =
         runTest(testDispatcher) {
             coEvery { loadClaimableUtxos(BTC_ADDRESS) } returns


### PR DESCRIPTION
## Summary
Fixes #5179. The QBTC Fast Vault claim password sheet had no validation at all: the Confirm button had no disabled state, and the keyboard "Go" action called straight into `QbtcClaimViewModel.confirm()` regardless of whether the field was blank, so an empty password could reach the server co-sign call.

- `FastVaultPasswordSheet` now disables Confirm while the password field is blank and guards the shared submit path so the IME action can't bypass it either.
- `QbtcClaimViewModel.confirm()` adds a defense-in-depth check: an empty password sets a `passwordError` on the `Selecting` state (reusing the existing `password_should_not_be_empty` string) and returns without ever launching the round runner.

## Screenshots

| After (blank password, Confirm disabled) |
|---|
| ![after](https://i.imgur.com/DTEFLXK.png) |

A matching "before" capture (button not yet disabled) couldn't be produced — the local emulator hit repeated ANRs from unrelated host load while trying to interact with the sheet, reproducing identically on the unmodified pre-fix build, so it's an environment issue rather than a regression from this change.

## Testing
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.qbtc.QbtcClaimViewModelTest"` — 12/12 passing, including the new empty-password test
- `./gradlew :app:ktfmtCheck`
- `./gradlew :app:lintDebug`
- `./gradlew :app:assembleDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added Fast Vault password validation in the QBTC claim flow.
  * Empty or whitespace-only passwords now display an error message/footnote and stop the claim from proceeding.
  * The password input and submit CTA now reflect validation (submit enabled only when the password is non-empty).

* **Tests**
  * Added unit tests covering empty and whitespace-only password validation, ensuring the claim action is not triggered when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->