### PR TITLE
test(solana): guard send fee estimate against priority double-count

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
@@ -11,14 +11,12 @@ import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
-import com.vultisig.wallet.data.utils.toUnit
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import wallet.core.jni.CoinType
 
 /**
  * Implementation of [FeeService] for Solana blockchain transactions.
@@ -52,7 +50,23 @@ import wallet.core.jni.CoinType
  *
  * @property solanaApi API interface for interacting with Solana blockchain RPC endpoints.
  */
-class SolanaFeeService @Inject constructor(private val solanaApi: SolanaApi) : FeeService {
+class SolanaFeeService
+internal constructor(
+    private val solanaApi: SolanaApi,
+    // Serializes a versioned Solana message for [getFeeForMessage]. Backed by WalletCore JNI in
+    // production; overridable so the fee-composition arithmetic can be unit-tested without the
+    // native library.
+    private val serializeVersionedMessage:
+        (vaultHexPubKey: String, payload: KeysignPayload) -> String,
+) : FeeService {
+
+    @Inject
+    constructor(
+        solanaApi: SolanaApi
+    ) : this(
+        solanaApi,
+        { vaultHexPubKey, payload -> SolanaHelper(vaultHexPubKey).getVersionedMessage(payload) },
+    )
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
         // Jupiter builds its own versioned tx at signing time. Serializing a fake SPL/SOL transfer
@@ -69,7 +83,7 @@ class SolanaFeeService @Inject constructor(private val solanaApi: SolanaApi) : F
 
         val keySignPayload = buildKeySignPayload(coin, toAddress, amount)
 
-        val serializedTx = SolanaHelper(vaultHexPubKey).getVersionedMessage(keySignPayload)
+        val serializedTx = serializeVersionedMessage(vaultHexPubKey, keySignPayload)
 
         // serializedTx carries the ComputeBudget instructions, so getFeeForMessage already returns
         // base signature fee + prioritization fee (price × limit / 1e6) — verified against mainnet
@@ -181,6 +195,10 @@ class SolanaFeeService @Inject constructor(private val solanaApi: SolanaApi) : F
     }
 
     private companion object {
-        val DEFAULT_COIN_TRANSFER_BASE_FEE = CoinType.SOLANA.toUnit("0.000105".toBigDecimal())
+        // 0.000105 SOL expressed in lamports (SOL has 9 decimals). Computed without CoinType so the
+        // service can be constructed and its fee arithmetic exercised in JVM unit tests, which have
+        // no WalletCore native library loaded.
+        val DEFAULT_COIN_TRANSFER_BASE_FEE: BigInteger =
+            "0.000105".toBigDecimal().movePointRight(9).toBigInteger()
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeServiceTest.kt
@@ -1,0 +1,175 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.blockchain.solana
+
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.blockchain.model.GasFees
+import com.vultisig.wallet.data.blockchain.model.Swap
+import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for #5115 / PR #5156 — the Solana send fee estimate double-counted the priority
+ * fee (~2× the real on-chain fee).
+ *
+ * `getFeeForMessage` already folds the ComputeBudget priority fee into the returned message fee
+ * (base signature fee + price × limit / 1e6). The fix stopped adding a separate priority term on
+ * top, so the displayed send fee is `messageFee + rentExemption`, not `messageFee + priority + …`.
+ *
+ * These tests stub the versioned-message serializer (a WalletCore JNI call not available in JVM
+ * unit tests) via the service's test seam so the fee-composition arithmetic can be locked without
+ * the native library.
+ */
+class SolanaFeeServiceTest {
+
+    private val solanaApi: SolanaApi = mockk()
+    private val service =
+        SolanaFeeService(solanaApi, serializeVersionedMessage = { _, _ -> "serialized-msg" })
+
+    private val messageFee = BigInteger.valueOf(105_000L) // 5000 base + 100000 folded-in priority
+    private val rentExemption = BigInteger.valueOf(2_039_280L)
+    private val dynamicPriorityFee = BigInteger.valueOf(1_234L)
+
+    @BeforeEach
+    fun setUp() {
+        coEvery { solanaApi.getRecentBlockHash() } returns "blockhash"
+        coEvery { solanaApi.getFeeForMessage(any()) } returns messageFee
+        coEvery { solanaApi.getMedianPriorityFee(any()) } returns dynamicPriorityFee
+    }
+
+    @Test
+    fun `native SOL send fee is message fee only, priority not double-counted`() = runTest {
+        val fee = service.calculateFees(nativeTransfer()) as GasFees
+
+        // The whole point of #5156: amount equals the RPC message fee (which already contains the
+        // priority fee) with no extra priority term added on top. A double-count would exceed this.
+        assertEquals(messageFee, fee.amount)
+        assertEquals(dynamicPriorityFee, fee.price)
+        assertEquals(SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(), fee.limit)
+
+        // Native transfers never touch a token account, so no rent-exemption RPC is made.
+        coVerify(exactly = 0) { solanaApi.getMinimumBalanceForRentExemption() }
+    }
+
+    @Test
+    fun `SPL send with no recipient token account adds rent exemption once on top of message fee`() =
+        runTest {
+            coEvery { solanaApi.getTokenAssociatedAccountByOwner(SENDER, MINT) } returns
+                Pair("senderAta", false)
+            // Recipient has no associated token account -> sender pays rent exemption to create it.
+            coEvery { solanaApi.getTokenAssociatedAccountByOwner(RECIPIENT, MINT) } returns
+                Pair("", false)
+            coEvery { solanaApi.getMinimumBalanceForRentExemption() } returns rentExemption
+
+            val fee = service.calculateFees(tokenTransfer()) as GasFees
+
+            // Priority counted once (inside messageFee) + rent counted once. No priority
+            // double-count.
+            assertEquals(messageFee + rentExemption, fee.amount)
+            assertEquals(dynamicPriorityFee, fee.price)
+            assertEquals(SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(), fee.limit)
+        }
+
+    @Test
+    fun `SPL send with existing recipient token account charges no rent exemption`() = runTest {
+        coEvery { solanaApi.getTokenAssociatedAccountByOwner(SENDER, MINT) } returns
+            Pair("senderAta", false)
+        // Recipient already has an associated token account -> no rent to pay.
+        coEvery { solanaApi.getTokenAssociatedAccountByOwner(RECIPIENT, MINT) } returns
+            Pair("recipientAta", false)
+
+        val fee = service.calculateFees(tokenTransfer()) as GasFees
+
+        assertEquals(messageFee, fee.amount)
+        coVerify(exactly = 0) { solanaApi.getMinimumBalanceForRentExemption() }
+    }
+
+    @Test
+    fun `swap default fee converts micro-lamports-per-CU to lamports and adds base once`() =
+        runTest {
+            // price is in micro-lamports per compute unit; the estimate must scale by the CU limit
+            // and divide by 1e6 to reach lamports (the per-CU-price vs total-lamports distinction
+            // from #5101/#5114), then add the flat base fee exactly once.
+            val pricePerCu = BigInteger.valueOf(1_000_000L)
+            coEvery { solanaApi.getMedianPriorityFee(any()) } returns pricePerCu
+
+            val fee = service.calculateFees(swap()) as GasFees
+
+            // priorityAmount = 1_000_000 * 100_000 / 1_000_000 = 100_000 lamports
+            // amount = base(105_000) + 100_000 = 205_000
+            assertEquals(BigInteger.valueOf(205_000L), fee.amount)
+            assertEquals(pricePerCu, fee.price)
+            assertEquals(SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(), fee.limit)
+        }
+
+    private fun nativeTransfer() =
+        Transfer(
+            coin = solCoin(),
+            vault = VaultData(vaultHexPublicKey = VAULT_PUBKEY, vaultHexChainCode = "chain"),
+            amount = BigInteger.valueOf(1_000_000L),
+            to = RECIPIENT,
+        )
+
+    private fun tokenTransfer() =
+        Transfer(
+            coin = usdcCoin(),
+            vault = VaultData(vaultHexPublicKey = VAULT_PUBKEY, vaultHexChainCode = "chain"),
+            amount = BigInteger.valueOf(1_000_000L),
+            to = RECIPIENT,
+        )
+
+    private fun swap() =
+        Swap(
+            coin = solCoin(),
+            vault = VaultData(vaultHexPublicKey = VAULT_PUBKEY, vaultHexChainCode = "chain"),
+            amount = BigInteger.valueOf(1_000_000L),
+            to = RECIPIENT,
+            callData = "",
+            approvalData = null,
+        )
+
+    private fun solCoin() =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "",
+            address = SENDER,
+            decimal = 9,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun usdcCoin() =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "USDC",
+            logo = "",
+            address = SENDER,
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = MINT,
+            isNativeToken = false,
+        )
+
+    private companion object {
+        const val VAULT_PUBKEY = "vaultpub"
+        const val SENDER = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+        const val RECIPIENT = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR"
+        const val MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    }
+}


### PR DESCRIPTION
Closes #5174.

## Context
PR #5156 fixed #5115 — the Solana **send** fee estimate double-counted the priority fee (~2× the real on-chain fee) — but shipped in v1.0.112 with no test coverage. This adds the regression guard.

`getFeeForMessage` already folds the ComputeBudget priority fee into the returned message fee (base signature fee + `price × limit / 1e6`). The fix stopped adding a separate priority term, so the displayed send fee is `messageFee + rentExemption`.

## Why it wasn't testable before
- Constructing `SolanaFeeService` triggered a WalletCore **JNI** call at class load (`CoinType.SOLANA.toUnit(...)` in the companion), which throws `UnsatisfiedLinkError` in JVM unit tests.
- The exact-fee path serializes the message via `SolanaHelper.getVersionedMessage()`, also JNI-backed.

## Changes
Two behavior-preserving, testability-only production tweaks in `SolanaFeeService`:
1. Compute `DEFAULT_COIN_TRANSFER_BASE_FEE` (0.000105 SOL = 105,000 lamports, SOL has 9 decimals) without `CoinType`, so the service constructs off-device. Value is identical.
2. Extract the versioned-message serializer into a constructor seam. The `@Inject` constructor keeps using the real `SolanaHelper`; an `internal` constructor lets the test stub it.

## Tests (`SolanaFeeServiceTest`, 4 cases)
- Native SOL send → `amount == messageFee` (priority **not** double-counted); no rent RPC.
- SPL send, recipient has **no** token account → `amount == messageFee + rentExemption` (each counted once).
- SPL send, recipient **has** a token account → no rent charged.
- Swap default path → locks the micro-lamports-per-CU → lamports conversion (`price × limit ÷ 1e6 + base`), the per-CU-price vs total-lamports distinction from #5101/#5114.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest --tests "*SolanaFeeServiceTest"` — all 4 pass.
- [x] Mutation check: re-introducing the `+ priorityFee` double-count fails 3 tests; reverting makes them pass.
- [x] ktfmt applied.