### PR TITLE
test(swap): pin SwapKit EVM network fee to the oracle bond (#5121)

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
@@ -2,12 +2,17 @@
 
 package com.vultisig.wallet.ui.models.mappers
 
+import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
+import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
@@ -96,6 +101,88 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
         uiModel.totalFee shouldBe "1.42"
     }
 
+    /**
+     * Proof for #5121: on a SwapKit EVM route the near-zero `fees[].inbound` placeholder surfaces
+     * only in the "Estimated Fees" (providerFee) row — NOT the Network Fee — and the total is the
+     * oracle gas bond, not an under-reported value. This pins WHERE the `0.0000…13 ETH` the
+     * reporter saw actually renders: the swap-fee row, mis-read as the Network Fee. The Network Fee
+     * row is fed by `gasFees`/`gasFeeFiatValue` (the oracle bond), and Total = swap-fee($0.00) +
+     * gas.
+     */
+    @Test
+    fun `swapkit evm places the inbound placeholder in the swap-fee row, not the network fee (#5121)`() =
+        runTest {
+            every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+            every { mapTokenValueToDecimalUiString(any()) } returns "0"
+            coEvery { fiatValueToStringMapper(any(), any()) } answers
+                {
+                    firstArg<FiatValue>().value.toPlainString()
+                }
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+            // SwapKit maps the fee onto the source-chain native coin.
+            coEvery { tokenRepository.getNativeToken(eth.chain.id) } returns eth
+            // The inbound placeholder (130 wei ETH) converts to ~$0.00 — the near-zero value.
+            coEvery { convertTokenValueToFiat(eth, inboundPlaceholder, AppCurrency.USD) } returns
+                usd("0.00")
+
+            val uiModel = mapper().invoke(swapKitEvmTransaction())
+
+            // The near-zero placeholder shows in the "Estimated Fees" / Swap Fee row…
+            uiModel.providerFee.fiatValue shouldBe "0.00"
+            // …while the Network Fee row is the oracle gas bond ($3.50 here), never the
+            // placeholder…
+            uiModel.networkFee.fiatValue shouldBe "3.50"
+            // …and the Total is that gas bond, i.e. NOT under-reported (0.00 swap fee + 3.50 gas).
+            uiModel.totalFee shouldBe "3.50"
+        }
+
+    private fun swapKitEvmTransaction(): RegularSwapTransaction =
+        RegularSwapTransaction(
+            id = "tx-swapkit",
+            vaultId = "vault-1",
+            srcToken = eth,
+            srcTokenValue = srcValue,
+            dstToken = usdt,
+            dstAddress = "0xRouter",
+            expectedDstTokenValue = dstValue,
+            blockChainSpecific = mockk<BlockChainSpecificAndUtxo>(relaxed = true),
+            // The SwapKit inbound native-gas placeholder rides estimatedFees; swapFee stays null.
+            estimatedFees = inboundPlaceholder,
+            swapFee = null,
+            outboundFee = null,
+            // Network Fee = the oracle bond the tx is signed with.
+            gasFees = TokenValue(BigInteger.valueOf(2_000_000_000_000_000L), eth),
+            memo = null,
+            payload =
+                SwapPayload.EVM(
+                    EVMSwapPayloadJson(
+                        fromCoin = eth,
+                        toCoin = usdt,
+                        fromAmount = srcValue.value,
+                        toAmountDecimal = BigDecimal.ONE,
+                        quote =
+                            EVMSwapQuoteJson(
+                                dstAmount = "400",
+                                tx =
+                                    OneInchSwapTxJson(
+                                        from = "0xsrc",
+                                        to = "0xRouter",
+                                        gas = 100_000L,
+                                        data = "0xdata",
+                                        value = "0",
+                                        gasPrice = "76833041",
+                                        swapFee = "130",
+                                        swapFeeTokenContract = "",
+                                    ),
+                            ),
+                        provider = SwapProvider.SWAPKIT.getSwapProviderId(),
+                        subProvider = "FLASHNET",
+                    )
+                ),
+            isApprovalRequired = false,
+            gasFeeFiatValue = usd("3.50"),
+        )
+
     private fun transaction(
         swapFee: TokenValue? = affiliateFee,
         outboundFee: TokenValue? = SwapTransactionToUiModelMapperFeeBreakdownTest.outboundFee,
@@ -167,5 +254,8 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
         val totalFees = TokenValue(value = BigInteger.valueOf(30), token = usdt)
         val affiliateFee = TokenValue(value = BigInteger.valueOf(40), token = usdt)
         val outboundFee = TokenValue(value = BigInteger.valueOf(50), token = usdt)
+
+        // SwapKit's FLASHNET-style near-zero inbound placeholder: 130 wei of native ETH (#5121).
+        val inboundPlaceholder = TokenValue(value = BigInteger.valueOf(130), token = eth)
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapGasCalculatorTest.kt
@@ -654,6 +654,64 @@ internal class SwapGasCalculatorTest {
         assertEquals(BigInteger.valueOf(4_000_000), capturedParams.captured.gasFee.value)
     }
 
+    /**
+     * Proof for #5121 ("SwapKit EVM verify-screen Network Fee is understated"): the displayed
+     * network fee is re-based off the ORACLE gas price, never SwapKit's `fees[].inbound`
+     * placeholder or its stale quote-time `gasPrice`. Fed the exact FLASHNET/NEAR fixture from the
+     * issue — `tx.gas = 0x186a0` (100k), `tx.gasPrice = 0x4946111` (~0.077 gwei), inbound
+     * placeholder 130 wei — against a realistic 20 gwei oracle. The re-based fee is `20 gwei × 100k
+     * = 0.002 ETH`, which is neither the 130-wei placeholder nor SwapKit's `gasPrice × gas` seed
+     * (~7.68e12 wei).
+     *
+     * Structural point the assertion encodes: `rebaseEvmSwapNetworkFee` takes only (srcToken,
+     * baselineGasFee, routeGas) — the inbound placeholder is not even an input, so it cannot leak
+     * into the Network Fee by construction. (`baselineGasFee` is the oracle `maxFeePerGas × 600k`
+     * produced by `calculateGasFee`.)
+     */
+    @Test
+    fun `rebaseEvmSwapNetworkFee ignores the SwapKit inbound placeholder and returns the oracle bond (#5121)`() =
+        runTest {
+            val ethCoin = nativeCoinFor(Chain.Ethereum)
+            coEvery { tokenRepository.getNativeToken(Chain.Ethereum.id) } returns ethCoin
+
+            // Oracle maxFeePerGas = 20 gwei; baseline = 20 gwei × 600k (the flat swap bond).
+            val oracleMaxFeePerGasWei = BigInteger.valueOf(20_000_000_000L)
+            val baselineGasFee =
+                TokenValue(
+                    oracleMaxFeePerGasWei * BigInteger.valueOf(600_000L), // 1.2e16 wei
+                    ethCoin,
+                )
+            // Exact issue fixture (hex → decimal).
+            val routeGas = 0x186a0L // 100_000
+            val swapKitQuoteGasPriceWei = BigInteger.valueOf(0x4946111L) // ~0.077 gwei
+            val inboundPlaceholderWei = BigInteger.valueOf(130L) // FLASHNET near-zero placeholder
+
+            val expectedOracleBond =
+                oracleMaxFeePerGasWei * BigInteger.valueOf(routeGas) // 20 gwei × 100k = 2e15 wei
+            val capturedParams = slot<GasFeeParams>()
+            coEvery { gasFeeToEstimatedFee(capture(capturedParams)) } returns
+                estimatedFee(ethCoin, expectedOracleBond)
+
+            val result =
+                calculator.rebaseEvmSwapNetworkFee(
+                    srcToken = ethCoin,
+                    baselineGasFee = baselineGasFee,
+                    routeGas = routeGas,
+                )
+
+            requireNotNull(result)
+            // Network Fee = oracle bond (0.002 ETH), the fee the signed tx actually commits to.
+            assertEquals(expectedOracleBond, result.gasFee.value)
+            assertEquals(expectedOracleBond, capturedParams.captured.gasFee.value)
+            // …and provably NOT the SwapKit inbound placeholder…
+            assertTrue(result.gasFee.value != inboundPlaceholderWei)
+            // …nor SwapKit's stale quote-time `gasPrice × gas` seed (the value iOS #4707
+            // mis-showed).
+            assertTrue(
+                result.gasFee.value != swapKitQuoteGasPriceWei * BigInteger.valueOf(routeGas)
+            )
+        }
+
     // ── evmSwapDisplayGasLimit: the shared floor used by both initiator and joiner (#5056) ──
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
@@ -23,6 +23,7 @@ import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -74,6 +75,53 @@ internal class SwapQuotePipelineNetworkFeeTest {
         assertEquals(BigInteger.valueOf(2_861_460), set.tokenValue.value)
     }
 
+    /**
+     * Proof for #5121: a SwapKit EVM route (wrapped as [SwapQuote.OneInch] by
+     * `SwapQuoteManager.fetchSwapKitQuote`) takes the SAME oracle-rebase branch as 1inch/Kyber/LiFi
+     * — the branch keys on `quote is SwapQuote.OneInch && chain.standard == EVM`, independent of
+     * the provider. The Network Fee is the re-based oracle bond, NOT the near-zero `fees[].inbound`
+     * placeholder the quote carries (here 130 wei). `resolveNetworkFee` never reads `quote.fees`,
+     * so the placeholder cannot reach the displayed Network Fee nor the balance/gas-sufficiency
+     * check (which validates against `effectiveNetworkFeeTokenValue`).
+     */
+    @Test
+    fun `swapkit evm route uses the oracle bond for network fee, not the inbound placeholder (#5121)`() =
+        runTest {
+            val ethCoin = coin(Chain.Ethereum)
+            val src = sendSrc(ethCoin)
+            val inboundPlaceholder = TokenValue(BigInteger.valueOf(130), ethCoin) // FLASHNET seed
+            val oracleBond = TokenValue(BigInteger.valueOf(2_000_000_000_000_000L), ethCoin) // .002
+            coEvery {
+                swapGasCalculator.rebaseEvmSwapNetworkFee(ethCoin, any(), routeGas = 100_000L)
+            } returns gasResult(ethCoin, oracleBond.value)
+
+            val outcome =
+                pipeline.resolveNetworkFee(
+                    result =
+                        success(
+                            swapKitEvmQuote(
+                                ethCoin,
+                                routeGas = 0x186a0L, // 100_000
+                                gasPriceWei = "76833041", // 0x4946111 ≈ 0.077 gwei
+                                inboundFee = inboundPlaceholder,
+                            )
+                        ),
+                    src = src,
+                    vaultId = "vault",
+                    gasFee = TokenValue(BigInteger.valueOf(6_000_000), ethCoin),
+                    gasFeeChain = Chain.Ethereum,
+                    networkFeeTokenValue = TokenValue(BigInteger.valueOf(6_000_000), ethCoin),
+                )
+
+            val set = assertIs<NetworkFeeUpdate.Set>(outcome.networkFee)
+            assertEquals(oracleBond.value, set.tokenValue.value)
+            assertTrue(set.tokenValue.value != inboundPlaceholder.value)
+            // The SwapKit route was routed through the oracle rebase exactly like a 1inch quote.
+            coVerify(exactly = 1) {
+                swapGasCalculator.rebaseEvmSwapNetworkFee(ethCoin, any(), routeGas = 100_000L)
+            }
+        }
+
     @Test
     fun `leaves the network fee untouched for a Solana aggregator quote`() = runTest {
         val solCoin = coin(Chain.Solana)
@@ -108,6 +156,40 @@ internal class SwapQuotePipelineNetworkFeeTest {
         assertEquals(NetworkFeeUpdate.Clear, outcome.networkFee)
         coVerify(exactly = 0) { swapGasCalculator.rebaseEvmSwapNetworkFee(any(), any(), any()) }
     }
+
+    // A SwapKit EVM route as SwapQuoteManager.fetchSwapKitQuote materialises it: SwapQuote.OneInch
+    // with provider "SwapKit", a sub-provider label, the near-zero inbound placeholder on `fees`,
+    // and SwapKit's stale sub-gwei `gasPrice` on the tx. Used to prove the placeholder never
+    // reaches
+    // the Network Fee (#5121).
+    private fun swapKitEvmQuote(
+        srcToken: Coin,
+        routeGas: Long,
+        gasPriceWei: String,
+        inboundFee: TokenValue,
+    ) =
+        SwapQuote.OneInch(
+            expectedDstValue = TokenValue(BigInteger.valueOf(400), srcToken),
+            fees = inboundFee,
+            expiredAt = Clock.System.now(),
+            data =
+                EVMSwapQuoteJson(
+                    dstAmount = "400",
+                    tx =
+                        OneInchSwapTxJson(
+                            from = "0xsrc",
+                            to = "0xrouter",
+                            gas = routeGas,
+                            data = "0xdata",
+                            value = "0",
+                            gasPrice = gasPriceWei,
+                            swapFee = inboundFee.value.toString(),
+                            swapFeeTokenContract = "",
+                        ),
+                ),
+            provider = "SwapKit",
+            subProvider = "FLASHNET",
+        )
 
     private fun oneInchQuote(dstToken: Coin, routeGas: Long) =
         SwapQuote.OneInch(


### PR DESCRIPTION
## Summary

#5121 reports that the SwapKit EVM verify-screen **Network Fee** is understated — allegedly taken from SwapKit's near-zero `fees[].inbound` placeholder rather than the oracle-priced broadcast gas, with the same understated value feeding the gas-sufficiency check (the actionable "insufficient funds for gas at broadcast" risk).

Tracing the Android code, **this does not reproduce**. A SwapKit EVM route is wrapped as `SwapQuote.OneInch` (`SwapQuoteManager.fetchSwapKitQuote`) and its Network Fee is the oracle bond from `SwapGasCalculator.rebaseEvmSwapNetworkFee` — `oracle maxFeePerGas × routeGasLimit`, the same number the tx is signed with in `OneInchSwap`. This was already true at `ae7decbd6` (PR #5076), the exact commit the issue was verified against. The `inbound` placeholder only feeds the separate **"Estimated Fees"** row, where its ~$0 value is harmless to the Total.

This PR is **tests only** — it adds regression coverage that reproduces the issue's exact FLASHNET fixture and pins the correct behavior, so the invariant can't silently regress. It's the Android mirror of the iOS parity test in vultisig-ios#4723 (which closes the iOS sibling #4707 — a real bug there because iOS *excluded* SwapKit EVM from the oracle path; Android does not).

## Tests added

Fixture from the issue: `tx.gas=0x186a0` (100k), `tx.gasPrice=0x4946111` (≈0.077 gwei), inbound placeholder `130 wei`.

- **`SwapGasCalculatorTest`** — the rebased Network Fee is the oracle bond (`20 gwei × 100k = 0.002 ETH`), asserted `!=` the 130-wei placeholder and `!=` SwapKit's stale `gasPrice × gas` seed. `rebaseEvmSwapNetworkFee` doesn't even take the placeholder as an input.
- **`SwapQuotePipelineNetworkFeeTest`** — a `provider="SwapKit"` EVM quote takes the *same* oracle-rebase branch as 1inch (the branch keys on `OneInch && chain==EVM`, never reads `quote.fees`), so the placeholder reaches neither the displayed Network Fee nor the balance/gas-sufficiency check.
- **`SwapTransactionToUiModelMapperFeeBreakdownTest`** — the placeholder renders only in the "Estimated Fees" (swap-fee) row (~$0.00); Network Fee and Total are the oracle bond → Total is **not** under-reported. This pinpoints where the reporter's `0.0000…13 ETH` actually came from.

## Test plan

```bash
./gradlew :app:testDebugUnitTest \
  --tests "*SwapGasCalculatorTest" \
  --tests "*SwapQuotePipelineNetworkFeeTest" \
  --tests "*SwapTransactionToUiModelMapperFeeBreakdownTest"
```

`BUILD SUCCESSFUL` — `SwapGasCalculatorTest` 50/0/0, `SwapQuotePipelineNetworkFeeTest` 4/0/0, `SwapTransactionToUiModelMapperFeeBreakdownTest` 3/0/0.

## Recommendation

Close #5121 as already-addressed by #5076 / not-reproducible on Android; these tests stand as the proof and guard against regression. No production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for swap fee and network fee calculations in EVM swap scenarios.
  * Verified that near-zero placeholder fees are ignored and the correct oracle-based fee is shown instead.
  * Added checks to ensure the total and fee breakdown match the expected swap route values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->