### PR TITLE
fix(tokens): require connectivity and retry on token-refresh failure

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.androidx.work.testing)
     testImplementation(kotlin("test"))
 
     androidTestImplementation(libs.junit)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DiscoverTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DiscoverTokenUseCase.kt
@@ -1,8 +1,11 @@
 package com.vultisig.wallet.data.usecases
 
 import android.content.Context
+import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.vultisig.wallet.data.workers.TokenRefreshWorker
@@ -18,20 +21,7 @@ internal class DiscoverTokenUseCaseImpl
 constructor(@ApplicationContext private val context: Context) : DiscoverTokenUseCase {
 
     override fun invoke(vaultId: String?, chainId: String?) {
-        val data =
-            Data.Builder()
-                .apply {
-                    vaultId?.takeIf(String::isNotBlank)?.let {
-                        putString(TokenRefreshWorker.ARG_VAULT_ID, it)
-                    }
-                    chainId?.takeIf(String::isNotBlank)?.let {
-                        putString(TokenRefreshWorker.ARG_CHAIN, it)
-                    }
-                }
-                .build()
-
-        val request =
-            OneTimeWorkRequestBuilder<TokenRefreshWorker>().setInputData(data).addTag(TAG).build()
+        val request = buildRefreshWorkRequest(vaultId, chainId)
 
         // Unique name is scoped to (vault, chain) so concurrent enqueues for different
         // scopes don't cancel each other (e.g. a full-vault scan on save vs. per-chain
@@ -47,4 +37,26 @@ constructor(@ApplicationContext private val context: Context) : DiscoverTokenUse
 
     private fun uniqueWorkName(vaultId: String?, chainId: String?): String =
         "$TAG:${vaultId.orEmpty()}:${chainId.orEmpty()}"
+}
+
+internal fun buildRefreshWorkRequest(vaultId: String?, chainId: String?): OneTimeWorkRequest {
+    val data =
+        Data.Builder()
+            .apply {
+                vaultId?.takeIf(String::isNotBlank)?.let {
+                    putString(TokenRefreshWorker.ARG_VAULT_ID, it)
+                }
+                chainId?.takeIf(String::isNotBlank)?.let {
+                    putString(TokenRefreshWorker.ARG_CHAIN, it)
+                }
+            }
+            .build()
+
+    val constraints = Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+
+    return OneTimeWorkRequestBuilder<TokenRefreshWorker>()
+        .setInputData(data)
+        .setConstraints(constraints)
+        .addTag(TAG)
+        .build()
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -38,6 +38,10 @@ constructor(
                 listOf(vaultRepository.get(inputVaultId) ?: return Result.failure())
             }
 
+        // Any transient failure below reschedules the whole run (with backoff) instead of
+        // dropping the affected chain permanently.
+        var hasRefreshFailure = false
+
         for (vault in vaults) {
             val allVaultChains = vault.coins.map { it.chain }.toSet()
             val chains =
@@ -54,7 +58,7 @@ constructor(
                 } catch (e: Exception) {
                     if (e is kotlinx.coroutines.CancellationException) throw e
                     Timber.e(e)
-                    return Result.failure()
+                    return Result.retry()
                 }
 
             for (chain in chains) {
@@ -75,13 +79,14 @@ constructor(
                 } catch (e: Exception) {
                     if (e is kotlinx.coroutines.CancellationException) throw e
                     Timber.e(e)
+                    hasRefreshFailure = true
                 }
 
                 if (chains.size > 1 && vaults.size > 1)
                     delay(1000) // should be removed when we use api without rate limit
             }
         }
-        return Result.success()
+        return if (hasRefreshFailure) Result.retry() else Result.success()
     }
 
     private suspend fun cleanupDeFiOnlyTokens(vault: Vault, chain: Chain) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -58,7 +58,7 @@ constructor(
                 } catch (e: Exception) {
                     if (e is kotlinx.coroutines.CancellationException) throw e
                     Timber.e(e)
-                    return Result.retry()
+                    return retryOrFail()
                 }
 
             for (chain in chains) {
@@ -86,8 +86,13 @@ constructor(
                     delay(1000) // should be removed when we use api without rate limit
             }
         }
-        return if (hasRefreshFailure) Result.retry() else Result.success()
+        return if (hasRefreshFailure) retryOrFail() else Result.success()
     }
+
+    // WorkManager has no built-in attempt cap, so bound it here to stop rescheduling permanent
+    // failures.
+    private fun retryOrFail(): Result =
+        if (runAttemptCount < MAX_REFRESH_ATTEMPTS) Result.retry() else Result.failure()
 
     private suspend fun cleanupDeFiOnlyTokens(vault: Vault, chain: Chain) {
         if (chain != Chain.ThorChain) return
@@ -120,5 +125,6 @@ constructor(
     companion object {
         const val ARG_VAULT_ID = "vault_id"
         const val ARG_CHAIN = "chain_id"
+        const val MAX_REFRESH_ATTEMPTS = 3
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/DiscoverTokenUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/DiscoverTokenUseCaseTest.kt
@@ -1,0 +1,15 @@
+package com.vultisig.wallet.data.usecases
+
+import androidx.work.NetworkType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class DiscoverTokenUseCaseTest {
+
+    @Test
+    fun `refresh work request requires network connectivity`() {
+        val request = buildRefreshWorkRequest(vaultId = "vault-1", chainId = "chain-1")
+
+        assertEquals(NetworkType.CONNECTED, request.workSpec.constraints.requiredNetworkType)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -34,9 +34,13 @@ internal class TokenRefreshWorkerTest {
         context = mockk(relaxed = true)
     }
 
-    private fun buildWorker(inputData: Data = Data.EMPTY): TokenRefreshWorker =
+    private fun buildWorker(
+        inputData: Data = Data.EMPTY,
+        runAttemptCount: Int = 0,
+    ): TokenRefreshWorker =
         TestListenableWorkerBuilder<TokenRefreshWorker>(context)
             .setInputData(inputData)
+            .setRunAttemptCount(runAttemptCount)
             .setWorkerFactory(
                 object : WorkerFactory() {
                     override fun createWorker(
@@ -92,6 +96,19 @@ internal class TokenRefreshWorkerTest {
         coEvery { vaultRepository.get("missing-vault") } returns null
 
         val result = buildWorker(inputData).doWork()
+
+        assertEquals(ListenableWorker.Result.failure(), result)
+    }
+
+    @Test
+    fun `doWork fails once a chain refresh call keeps throwing past the max attempts`() = runTest {
+        val vault = vault(id = "vault-3", coins = listOf(coin(Chain.Ethereum)))
+        coEvery { vaultRepository.getAll() } returns listOf(vault)
+        coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+        every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(emptyList())
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } throws IOException("offline")
+
+        val result = buildWorker(runAttemptCount = TokenRefreshWorker.MAX_REFRESH_ATTEMPTS).doWork()
 
         assertEquals(ListenableWorker.Result.failure(), result)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -1,0 +1,98 @@
+package com.vultisig.wallet.data.workers
+
+import android.content.Context
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TokenRefreshWorkerTest {
+
+    private lateinit var tokenRepository: TokenRepository
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setUp() {
+        tokenRepository = mockk()
+        vaultRepository = mockk()
+        context = mockk(relaxed = true)
+    }
+
+    private fun buildWorker(inputData: Data = Data.EMPTY): TokenRefreshWorker =
+        TestListenableWorkerBuilder<TokenRefreshWorker>(context)
+            .setInputData(inputData)
+            .setWorkerFactory(
+                object : WorkerFactory() {
+                    override fun createWorker(
+                        appContext: Context,
+                        workerClassName: String,
+                        workerParameters: WorkerParameters,
+                    ): ListenableWorker =
+                        TokenRefreshWorker(
+                            appContext,
+                            workerParameters,
+                            tokenRepository,
+                            vaultRepository,
+                        )
+                }
+            )
+            .build()
+
+    private fun vault(id: String, coins: List<Coin>) = Vault(id = id, name = id, coins = coins)
+
+    private fun coin(chain: Chain) =
+        Coin.EMPTY.copy(chain = chain, ticker = chain.id, contractAddress = "")
+
+    @Test
+    fun `doWork retries when a chain refresh call throws`() = runTest {
+        val vault = vault(id = "vault-1", coins = listOf(coin(Chain.Ethereum)))
+        coEvery { vaultRepository.getAll() } returns listOf(vault)
+        coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+        every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(emptyList())
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } throws IOException("offline")
+
+        val result = buildWorker().doWork()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+    }
+
+    @Test
+    fun `doWork succeeds when every chain refreshes without error`() = runTest {
+        val vault = vault(id = "vault-2", coins = listOf(coin(Chain.Ethereum)))
+        coEvery { vaultRepository.getAll() } returns listOf(vault)
+        coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+        every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(emptyList())
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } returns emptyList()
+
+        val result = buildWorker().doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `doWork fails without retry when the requested vault does not exist`() = runTest {
+        val inputData =
+            Data.Builder().putString(TokenRefreshWorker.ARG_VAULT_ID, "missing-vault").build()
+        coEvery { vaultRepository.get("missing-vault") } returns null
+
+        val result = buildWorker(inputData).doWork()
+
+        assertEquals(ListenableWorker.Result.failure(), result)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -15,6 +15,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -87,6 +88,19 @@ internal class TokenRefreshWorkerTest {
         val result = buildWorker().doWork()
 
         assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `doWork retries when reading enabled tokens fails`() = runTest {
+        val vault = vault(id = "vault-4", coins = listOf(coin(Chain.Ethereum)))
+        coEvery { vaultRepository.getAll() } returns listOf(vault)
+        coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+        every { vaultRepository.getEnabledTokens(vault.id) } returns
+            flow { throw IOException("offline") }
+
+        val result = buildWorker().doWork()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidx-browser = { module = "androidx.browser:browser", version.ref = "browser
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-work = { group = "androidx.work", name = "work-runtime", version.ref = "work" }
 androidx-work-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt" }


### PR DESCRIPTION
## Summary
Token discovery work (`TokenRefreshWorker`) had no network constraint and never retried, so a run that started offline or hit a transient failure either failed permanently or silently swallowed the error and reported success. The work request now requires `NetworkType.CONNECTED`, and `doWork()` returns `Result.retry()` when reading enabled tokens or refreshing a chain fails, instead of a hard failure or a silently-ignored exception. A missing/unknown vault ID still returns `Result.failure()` since that's a permanent condition, not a transient one.

## Testing
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.usecases.DiscoverTokenUseCaseTest" --tests "com.vultisig.wallet.data.workers.TokenRefreshWorkerTest"`
- `./gradlew :data:testDebugUnitTest` (full data module suite, no regressions)
- `./gradlew :data:lintDebug`
- `./gradlew :data:ktfmtFormat`

Closes #5194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token refresh jobs now require an active network connection before running.
  * Refresh processing now automatically retries when transient (non-cancellation) errors occur, up to a configured maximum attempt limit.
* **Tests**
  * Added unit tests validating connected-network constraints and the retry/success/failure outcomes for token refresh work.
  * Added the AndroidX Work testing dependency to support these new test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->