### PR TITLE
Scope tx-status notification manager as a singleton

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/services/TransactionStatusServiceManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/TransactionStatusServiceManager.kt
@@ -9,11 +9,18 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+/**
+ * Bound to the running foreground [TransactionStatusService], so it must be a singleton: every
+ * injection site (the poller that starts it and the screen that completes it) needs to observe and
+ * cancel the same bound service, not a fresh, never-bound instance.
+ */
+@Singleton
 class TransactionStatusServiceManager
 @Inject
 constructor(@param:ApplicationContext private val context: Context) {

--- a/app/src/test/java/com/vultisig/wallet/data/services/TransactionStatusServiceManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/TransactionStatusServiceManagerTest.kt
@@ -1,0 +1,19 @@
+package com.vultisig.wallet.data.services
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import javax.inject.Singleton
+import org.junit.jupiter.api.Test
+
+internal class TransactionStatusServiceManagerTest {
+
+    // Regression guard: KeysignTxStatusPoller (which binds the running foreground service) and
+    // KeysignFlowViewModel.complete() (which cancels its notification) each inject this class
+    // separately. Without @Singleton, Hilt hands each site its own never-bound instance, so
+    // completion silently no-ops instead of reaching the service that's actually running.
+    @Test
+    fun `is scoped as a singleton so every injection site shares the bound instance`() {
+        val scope = TransactionStatusServiceManager::class.java.getAnnotation(Singleton::class.java)
+
+        scope.shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
Fixes #5193

`KeysignTxStatusPoller` (which binds the running foreground service) and `KeysignFlowViewModel.complete()` (which cancels its notification) each injected their own `TransactionStatusServiceManager`. With no scope, Hilt handed each site a separate instance, so `complete()` cancelled a manager that was never bound to the running service and the notification stayed visible after the transaction settled. Scoped the manager `@Singleton` so both sides share the same bound instance, matching how `PushNotificationManager` and other cross-ViewModel shared-state classes are already scoped in this codebase.

## Testing
- `./gradlew :app:testDebugUnitTest` (new `TransactionStatusServiceManagerTest` plus full suite)
- `./gradlew :app:assembleDebug`
- `./gradlew :app:lintDebug`
- `./gradlew :app:ktfmtCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the transaction status manager is treated as a single shared instance, improving consistency across the app.

* **Tests**
  * Added a regression test to verify the transaction status manager remains correctly configured as a singleton.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->