### PR TITLE
fix(backup): validate PIN length and clean up failed vault exports

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -134,12 +134,18 @@ constructor(
         }
 
         viewModelScope.launch {
-            passwordDelegate.validatePasswords().collect { passwordState ->
+            passwordDelegate.validatePasswords(MIN_BACKUP_PASSWORD_LENGTH).collect { passwordState
+                ->
                 val errorMessage =
-                    if (passwordState is PasswordState.Mismatch) {
-                        UiText.StringResource(R.string.fast_vault_password_screen_error)
-                    } else {
-                        null
+                    when (passwordState) {
+                        is PasswordState.Mismatch ->
+                            UiText.StringResource(R.string.fast_vault_password_screen_error)
+                        is PasswordState.TooShort ->
+                            UiText.FormattedText(
+                                R.string.backup_password_screen_error_too_short,
+                                listOf(passwordState.minLength),
+                            )
+                        else -> null
                     }
 
                 state.update { state ->
@@ -245,6 +251,9 @@ constructor(
 
                         null -> false
                     }
+                if (!isSuccess) {
+                    deleteBackupDocument(uri)
+                }
                 completeBackupVault(isSuccess)
             } else {
                 deleteBackupDocument(uri)
@@ -356,12 +365,20 @@ constructor(
                     navigator.route(Route.Home(vaultId), NavigationOptions(clearBackStack = true))
                 }
             } else {
-                showError()
+                state.update {
+                    it.copy(
+                        error = UiText.StringResource(R.string.vault_settings_error_backup_failed)
+                    )
+                }
             }
         }
     }
 
     private suspend fun showError() {
         snackbarFlow.showMessage(UiText.StringResource(R.string.vault_settings_error_backup_file))
+    }
+
+    companion object {
+        private const val MIN_BACKUP_PASSWORD_LENGTH = 4
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/PasswordViewModelDelegate.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/PasswordViewModelDelegate.kt
@@ -11,6 +11,8 @@ sealed interface PasswordState {
     data object Mismatch : PasswordState
 
     data object Empty : PasswordState
+
+    data class TooShort(val minLength: Int) : PasswordState
 }
 
 class PasswordViewModelDelegate {
@@ -18,14 +20,15 @@ class PasswordViewModelDelegate {
     val passwordTextFieldState = TextFieldState()
     val confirmPasswordTextFieldState = TextFieldState()
 
-    fun validatePasswords(): Flow<PasswordState> =
+    fun validatePasswords(minLength: Int = 1): Flow<PasswordState> =
         combine(passwordTextFieldState.textAsFlow(), confirmPasswordTextFieldState.textAsFlow()) {
             password,
             confirmPassword ->
             when {
                 password.isEmpty() || confirmPassword.isEmpty() -> PasswordState.Empty
-                password.toString() == confirmPassword.toString() -> PasswordState.Valid
-                else -> PasswordState.Mismatch
+                password.toString() != confirmPassword.toString() -> PasswordState.Mismatch
+                password.length < minLength -> PasswordState.TooShort(minLength)
+                else -> PasswordState.Valid
             }
         }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -191,6 +191,7 @@
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
+    <string name="vault_settings_error_backup_failed">Backup fehlgeschlagen. Es wurde keine Datei gespeichert. Bitte versuchen Sie es erneut.</string>
     <string name="vault_settings_delete_vault_name">Tresorname:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">ECDSA Schlüssel:</string>
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA Schlüssel:</string>
@@ -204,6 +205,7 @@
     <string name="import_file_screen_password_error">Falsches Passwort, bitte versuchen Sie es erneut.</string>
     <string name="add_vault_save">Speichern</string>
     <string name="backup_password_screen_enter_password">Passwort eingeben</string>
+    <string name="backup_password_screen_error_too_short">Das Passwort muss mindestens %1$d Zeichen lang sein</string>
     <string name="import_file_screen_enter_password_sub">Dieses Passwort wurde beim Export der Tresorfreigabe festgelegt.</string>
     <string name="import_file_screen_hint_password">Passwort</string>
     <string name="backup_password_screen_permission_required">Für Sicherungsvorgänge sind Dateiberechtigungen erforderlich.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -185,6 +185,7 @@
     <string name="tokens">Tokens</string>
     <string name="swap_screen_invalid_vault">La transacción probablemente fallará, la bóveda no pudo cargarse.</string>
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
+    <string name="vault_settings_error_backup_failed">La copia de seguridad falló. No se guardó ningún archivo. Inténtalo de nuevo.</string>
     <string name="send_error_no_address">La dirección no es válida</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>
@@ -205,6 +206,7 @@
     <string name="import_file_screen_password_error">Contraseña incorrecta, inténtelo de nuevo.</string>
     <string name="add_vault_save">Guardar</string>
     <string name="backup_password_screen_enter_password">Introducir contraseña</string>
+    <string name="backup_password_screen_error_too_short">La contraseña debe tener al menos %1$d caracteres</string>
     <string name="import_file_screen_enter_password_sub">Esta contraseña se estableció al exportar el recurso compartido de la bóveda.</string>
     <string name="import_file_screen_hint_password">Contraseña</string>
     <string name="backup_password_screen_permission_required">Se requiere permiso de archivo para las operaciones de copia de seguridad.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -191,6 +191,7 @@
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
+    <string name="vault_settings_error_backup_failed">Sigurnosno kopiranje nije uspjelo. Nijedna datoteka nije spremljena. Pokušajte ponovno.</string>
     <string name="vault_settings_delete_vault_name">Ime sefa:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">ECDSA ključ:</string>
     <string name="vault_settings_delete_vault_eddsa_key">EdDSA ključ:</string>
@@ -204,6 +205,7 @@
     <string name="import_file_screen_password_error">Netočna lozinka, pokušajte ponovno</string>
     <string name="add_vault_save">Spremi</string>
     <string name="backup_password_screen_enter_password">Unesite lozinku</string>
+    <string name="backup_password_screen_error_too_short">Lozinka mora imati najmanje %1$d znakova</string>
     <string name="import_file_screen_enter_password_sub">Ova lozinka je postavljena prilikom izvoza dijeljenja trezora.</string>
     <string name="import_file_screen_hint_password">Lozinka</string>
     <string name="backup_password_screen_permission_required">Za sigurnosne kopije potrebno je dopuštenje datoteke.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -191,6 +191,7 @@
     <string name="verify_transaction_value">Valore</string>
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
+    <string name="vault_settings_error_backup_failed">Backup non riuscito. Nessun file è stato salvato. Riprova.</string>
     <string name="vault_settings_delete_vault_name">Nome Cassaforte:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">Chiave ECDSA:</string>
     <string name="vault_settings_delete_vault_eddsa_key">Chiave EdDSA:</string>
@@ -204,6 +205,7 @@
     <string name="import_file_screen_password_error">Password errata, riprova.</string>
     <string name="add_vault_save">Salva</string>
     <string name="backup_password_screen_enter_password">Inserisci la password</string>
+    <string name="backup_password_screen_error_too_short">La password deve contenere almeno %1$d caratteri</string>
     <string name="import_file_screen_enter_password_sub">Questa password è stata impostata al momento dell\'esportazione della condivisione del vault.</string>
     <string name="import_file_screen_hint_password">Password</string>
     <string name="backup_password_screen_permission_required">Per le operazioni di backup è richiesta l\'autorizzazione del file.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -165,6 +165,7 @@
     <string name="send_continue_button">계속</string>
     <string name="chain_account_view_swap">스왑</string>
     <string name="vault_settings_error_backup_file">오류가 발생했습니다</string>
+    <string name="vault_settings_error_backup_failed">백업에 실패했습니다. 파일이 저장되지 않았습니다. 다시 시도해 주세요.</string>
     <string name="vault_edit_this_name_already_exist">이 이름은 이미 존재합니다</string>
     <string name="send_screen_max">최대</string>
     <string name="ok">확인</string>
@@ -279,6 +280,7 @@
     <string name="import_file_screen_password_error">비밀번호가 틀렸습니다. 다시 시도해 주세요</string>
     <string name="add_vault_save">저장</string>
     <string name="backup_password_screen_enter_password">비밀번호 입력</string>
+    <string name="backup_password_screen_error_too_short">비밀번호는 최소 %1$d자 이상이어야 합니다</string>
     <string name="import_file_screen_enter_password_sub">이 비밀번호는 볼트 공유를 내보낼 때 설정되었습니다.</string>
     <string name="import_file_screen_hint_password">비밀번호</string>
     <string name="backup_password_screen_permission_required">백업 작업을 위해 파일 권한이 필요합니다.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -92,6 +92,7 @@
     <string name="circle_defi_control_info">Fondsen blijven volledig onder controle van je kluis. Circle-accounts zijn zelfbeheerd en rendement wordt gegenereerd via veilige off-chain schatkisten.</string>
     <string name="open_account_button">Account openen</string>
     <string name="vault_settings_error_backup_file">er is een fout opgetreden</string>
+    <string name="vault_settings_error_backup_failed">Back-up mislukt. Er is geen bestand opgeslagen. Probeer het opnieuw.</string>
     <string name="vault_edit_this_name_already_exist">deze naam bestaat al</string>
     <string name="send_screen_max">MAX</string>
     <string name="ok">OK</string>
@@ -203,6 +204,7 @@
     <string name="import_file_screen_password_error">Onjuist wachtwoord, probeer het opnieuw.</string>
     <string name="add_vault_save">Opslaan</string>
     <string name="backup_password_screen_enter_password">Voer wachtwoord in</string>
+    <string name="backup_password_screen_error_too_short">Het wachtwoord moet minstens %1$d tekens bevatten</string>
     <string name="import_file_screen_enter_password_sub">Dit wachtwoord is ingesteld toen de kluis werd geëxporteerd.</string>
     <string name="import_file_screen_hint_password">Wachtwoord</string>
     <string name="backup_password_screen_permission_required">Voor back-upbewerkingen zijn bestandsrechten vereist.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -191,6 +191,7 @@
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
+    <string name="vault_settings_error_backup_failed">O backup falhou. Nenhum ficheiro foi guardado. Tente novamente.</string>
     <string name="vault_settings_delete_vault_name">Nome do Cofre:</string>
     <string name="vault_settings_delete_vault_ecdsa_key">Chave ECDSA:</string>
     <string name="vault_settings_delete_vault_eddsa_key">Chave EdDSA:</string>
@@ -205,6 +206,7 @@
     <string name="import_file_screen_password_error">Palavra-passe incorreta, tente novamente.</string>
     <string name="add_vault_save">Guardar</string>
     <string name="backup_password_screen_enter_password">Introduza a senha</string>
+    <string name="backup_password_screen_error_too_short">A senha deve ter pelo menos %1$d caracteres</string>
     <string name="import_file_screen_enter_password_sub">Esta palavra-passe foi definida quando a partilha do cofre foi exportada.</string>
     <string name="import_file_screen_hint_password">Palavra-passe</string>
     <string name="backup_password_screen_permission_required">A permissão de ficheiro é necessária para operações de cópia de segurança.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -92,6 +92,7 @@
     <string name="circle_defi_control_info">Средства остаются полностью под контролем вашего хранилища. Счета Circle являются самостоятельными, а доход генерируется через безопасные внесетевые казначейства.</string>
     <string name="open_account_button">Открыть счет</string>
     <string name="vault_settings_error_backup_file">произошла ошибка</string>
+    <string name="vault_settings_error_backup_failed">Не удалось создать резервную копию. Файл не был сохранён. Пожалуйста, попробуйте ещё раз.</string>
     <string name="vault_edit_this_name_already_exist">это имя уже существует</string>
     <string name="send_screen_max">МАКС</string>
     <string name="ok">ОК</string>
@@ -204,6 +205,7 @@
     <string name="import_file_screen_password_error">Неверный пароль, попробуйте еще раз.</string>
     <string name="add_vault_save">Сохранить</string>
     <string name="backup_password_screen_enter_password">Введите пароль</string>
+    <string name="backup_password_screen_error_too_short">Пароль должен содержать не менее %1$d символов</string>
     <string name="import_file_screen_enter_password_sub">Этот пароль был установлен при экспорте общего доступа к хранилищу.</string>
     <string name="import_file_screen_hint_password">Пароль</string>
     <string name="backup_password_screen_permission_required">Для операций резервного копирования требуется разрешение на доступ к файлу.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -179,6 +179,7 @@
 
     <!-- Vault Settings Errors -->
     <string name="vault_settings_error_backup_file">发生错误</string>
+    <string name="vault_settings_error_backup_failed">备份失败。未保存任何文件。请重试。</string>
     <string name="vault_edit_this_name_already_exist">此名称已存在</string>
 
     <!-- Send Screen -->
@@ -368,6 +369,7 @@
     <string name="import_file_screen_password_error">密码错误，请重试</string>
     <string name="add_vault_save">保存</string>
     <string name="backup_password_screen_enter_password">输入密码</string>
+    <string name="backup_password_screen_error_too_short">密码至少需要 %1$d 个字符</string>
     <string name="import_file_screen_enter_password_sub">此密码是在导出共享保险库时设置的。</string>
     <string name="import_file_screen_hint_password">密码</string>
     <string name="backup_password_screen_permission_required">备份操作需要文件权限。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="send_percent" translatable="false">%d%%</string>
     <string name="chain_account_view_swap">Swap</string>
     <string name="vault_settings_error_backup_file">An error occurred</string>
+    <string name="vault_settings_error_backup_failed">Backup failed. No file was saved. Please try again.</string>
     <string name="vault_edit_this_name_already_exist">This name already exists</string>
     <string name="send_screen_max">MAX</string>
     <string name="ok">OK</string>
@@ -287,6 +288,7 @@
     <string name="import_file_screen_password_error">Incorrect password, try again</string>
     <string name="add_vault_save">Save</string>
     <string name="backup_password_screen_enter_password">Enter Password</string>
+    <string name="backup_password_screen_error_too_short">Password must be at least %1$d characters</string>
     <string name="import_file_screen_enter_password_sub">This password was set when the vault share was exported.</string>
     <string name="import_file_screen_hint_password">Password</string>
     <string name="backup_password_screen_permission_required">File permission is required for backup operations.</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.ui.models
 
 import android.net.Uri
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.common.AppZipEntry
@@ -22,6 +24,7 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,6 +38,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -173,5 +177,66 @@ internal class BackupPasswordViewModelTest {
             vaultsLoaded.complete(Unit)
             requestedFileName shouldBe "vaults_backup.zip"
             collectJob.cancel()
+        }
+
+    @Test
+    fun `a password shorter than the minimum keeps the next button disabled and shows a length error`() =
+        runTest(testDispatcher) {
+            // Regression test for issue #5197: a too-short backup password used to validate as
+            // Valid, enabling Next and letting a weak/failing export proceed.
+            coEvery { vaultRepository.get(any()) } returns testVault("vault-1")
+            coEvery { vaultRepository.getAll() } returns listOf(testVault("vault-1"))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.passwordTextFieldState.setTextAndPlaceCursorAtEnd("abc")
+            vm.confirmPasswordTextFieldState.setTextAndPlaceCursorAtEnd("abc")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            vm.state.value.isNextButtonEnabled shouldBe false
+            vm.state.value.passwordErrorMessage.shouldNotBeNull()
+        }
+
+    @Test
+    fun `a matching password meeting the minimum length enables the next button`() =
+        runTest(testDispatcher) {
+            coEvery { vaultRepository.get(any()) } returns testVault("vault-1")
+            coEvery { vaultRepository.getAll() } returns listOf(testVault("vault-1"))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.passwordTextFieldState.setTextAndPlaceCursorAtEnd("abcd")
+            vm.confirmPasswordTextFieldState.setTextAndPlaceCursorAtEnd("abcd")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            vm.state.value.isNextButtonEnabled shouldBe true
+            vm.state.value.passwordErrorMessage.shouldBeNull()
+        }
+
+    @Test
+    fun `a failed export deletes the empty document and surfaces a persistent error`() =
+        runTest(testDispatcher) {
+            // Regression test for issue #5197: when a backup fails, the 0 KB file SAF already
+            // created must be removed and the user must see a clear, persistent error instead of
+            // being left with a broken archive and only a transient snackbar.
+            val vaults = listOf(testVault("a"), testVault("b"))
+            coEvery { vaultRepository.get("vault-1") } returns vaults.first()
+            coEvery { vaultRepository.getAll() } returns vaults
+            every { createVaultBackup(any(), any()) } returns null
+
+            val vm = createViewModel()
+            val uri = mockk<Uri>()
+
+            vm.saveContentToUriResult(uri, "application/zip")
+
+            coVerify(timeout = 5_000) { deleteBackupDocument(uri) }
+            coVerify(exactly = 0) { saveBackupToUri(any(), any<List<AppZipEntry>>()) }
+
+            advanceUntilIdle()
+            vm.state.value.error.shouldNotBeNull()
         }
 }


### PR DESCRIPTION
## Summary

The **Export Vaults** flow (both the All-Vaults `.zip` and single-vault `.vult` paths) could leave the user with a broken **0 KB archive** and no clear error. Two independent gaps, both fixed here:

1. **No length validation on the backup PIN/password.** `PasswordViewModelDelegate.validatePasswords()` only checked non-empty + matching, so a 1-character password validated as `Valid` and enabled **Next**.
2. **The 0 KB file was left on disk on failure.** SAF creates the empty file as soon as a save location is picked; on any export failure the app showed only a transient, generic snackbar and never deleted that empty file — leaving an archive that looks fine but can't be imported.

> Note: this is distinct from #5177, which fixed the empty-vault-list race (#5173). That fix never reaches the failure path here, because when `backupAllVaults` fails early, `saveBackupToUri` (and its zero-entry guard) is never called.

## Changes

- **Length validation** — new `PasswordState.TooShort(minLength)` and a `minLength` parameter on `validatePasswords()` (defaults to the prior non-empty rule, so the other flows sharing this delegate are unaffected). Backup enforces a minimum of **4** characters, surfaced as an **inline** field error that keeps **Next** disabled until met.
- **Failure cleanup** — `saveContentToUriResult()` now calls `deleteBackupDocument(uri)` on any export failure, so no 0 KB/broken archive is left behind.
- **Clearer error** — export failures now surface through the **persistent error dialog** (with a Try-again action) instead of an easy-to-miss transient snackbar.
- **Localization** — added `backup_password_screen_error_too_short` and `vault_settings_error_backup_failed` to the default locale and all 9 translated locales, matching each locale's established terminology.

## Key files

- `ui/screens/backup/PasswordViewModelDelegate.kt` — length validation
- `ui/models/BackupPasswordViewModel.kt` — min-length wiring, failure cleanup, persistent error

## Test plan

- Added 3 regression tests to `BackupPasswordViewModelTest`:
  - too-short password → Next stays disabled + inline length error
  - matching password ≥ minimum → Next enabled, no error
  - failed export → `deleteBackupDocument(uri)` called, `saveBackupToUri` never called, persistent error set
- `./gradlew :app:testDebugUnitTest --tests BackupPasswordViewModelTest` → 5 tests, 0 failures, 0 skipped
- `./gradlew :app:ktfmtCheck` passes

Closes #5197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for backup passwords that are too short, with clearer error messages.
  * Improved backup failure handling by showing a persistent error state instead of a transient message.
  * Cleaned up incomplete backup files when saving fails.

* **New Features**
  * Added localized error messages for backup failure and minimum password length across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->