### PR TITLE
fix(banner): restore Join-transaction banner slide-in for new requests

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.app.activity.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
@@ -165,9 +166,13 @@ private fun MainActivityContent(
             OfflineBanner(isOffline)
             // Reserve the banner's height so content sits below it while it is shown. This
             // AnimatedVisibility mirrors the overlay's enter/exit so the reserved space grows and
-            // collapses in step with the banner sliding in and out.
+            // collapses in step with the banner sliding in and out. Seed the transition from a
+            // false MutableTransitionState so the expand runs even when a notification is already
+            // present on the first composition, keeping it in step with the overlay's slide-in.
+            val reserveState = remember { MutableTransitionState(false) }
+            reserveState.targetState = foregroundNotification != null
             AnimatedVisibility(
-                visible = foregroundNotification != null,
+                visibleState = reserveState,
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
@@ -178,8 +183,14 @@ private fun MainActivityContent(
 
         // Banner drawn as overlay on top of navContent.
         key(lastNotification?.qrCodeData) {
+            // key(qrCodeData) disposes and recreates this node whenever a new request arrives, so
+            // it is born with visible == true and AnimatedVisibility(visible: Boolean) would skip
+            // its enter transition. Seeding a false MutableTransitionState and flipping targetState
+            // to true makes the slide-in run on the freshly keyed node.
+            val bannerState = remember { MutableTransitionState(false) }
+            bannerState.targetState = foregroundNotification != null
             AnimatedVisibility(
-                visible = foregroundNotification != null,
+                visibleState = bannerState,
                 enter = slideInVertically { -it },
                 exit = slideOutVertically { -it },
                 modifier =


### PR DESCRIPTION
## Summary
The foreground **"Join transaction"** banner popped in with **no entrance animation** whenever a new signing request arrived — the intended `slideInVertically { -it }` never played. Fixes #5201.

## Root cause
`MainActivityContent.kt` wraps the overlay `AnimatedVisibility` in `key(lastNotification?.qrCodeData)`:
- A new request changes `qrCodeData` → the `key(...)` **disposes and recreates** the `AnimatedVisibility` as a fresh node.
- `AnimatedVisibility(visible: Boolean, ...)` **does not run its enter transition on initial composition** when `visible` is already `true`. The re-keyed node is born `visible == true`, so the `slideInVertically` enter is skipped and the banner just pops in.

Exit/slide-out and swipe-to-dismiss were unaffected (they run while the node is alive). Silently broken since `d019ae7a3d`.

## Fix
Seed both `AnimatedVisibility` blocks from a `MutableTransitionState(false)` and drive them via `targetState = foregroundNotification != null`, so the `false → true` transition actually plays on the freshly keyed node:
- **Overlay banner** — the slide-in now runs on every new request.
- **Height-reserving spacer** (`expandVertically`) — mirrored so the reserved space grows in step, including the cold-start case where a notification is already present on the first frame (same enter-skip trap).

The `key(qrCodeData)` is kept, so the per-request swipe-offset reset behavior from #5001 / #5134 is preserved.

## Test plan
- [ ] New signing request arrives → banner slides in from the top (no pop-in)
- [ ] A second request arriving while one is shown → new banner slides in, content stays pushed down
- [ ] Swipe-to-dismiss (horizontal + upward) still settles off-screen with no snap-back / re-center (#5001 / #5134 regression check)
- [ ] Exit/slide-out on tap-through and clear still plays

## Before / After
_Device before/after pending — animation capture on emulator to follow._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Foreground notification banners now animate in more reliably when they appear.
  * The space reserved under the status bar now expands and collapses in sync with the banner.
  * If a notification is already present when the banner appears, the slide-in transition now plays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->