### PR TITLE
fix(swap): show Track button on feeless swaps (decouple link from swapFee)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -49,16 +49,15 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
             is SwapPayload.MayaChain ->
                 "https://www.explorer.mayachain.info/tx/${tx.removePrefix("0x")}"
             is SwapPayload.EVM -> {
-                if (payload.data.quote.tx.swapFee.toBigIntegerOrNull() != null) {
-                    if (
-                        payload.data.fromCoin.chain == payload.data.toCoin.chain &&
-                            payload.data.fromCoin.chain == Chain.Solana
-                    ) {
-                        "https://orb.helius.dev/tx/${tx}"
-                    } else "https://scan.li.fi/tx/${tx}"
-                } else {
-                    null
-                }
+                // The tracker exists independently of the affiliate `swapFee`; gating on it dropped
+                // the Track button for feeless routes (e.g. same-chain Solana Bonk -> SOL). Derive
+                // the link from src chain + tx hash, both always present for a broadcast swap.
+                if (
+                    payload.data.fromCoin.chain == payload.data.toCoin.chain &&
+                        payload.data.fromCoin.chain == Chain.Solana
+                ) {
+                    "https://orb.helius.dev/tx/${tx}"
+                } else "https://scan.li.fi/tx/${tx}"
             }
 
             else -> null

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepositoryImplTest.kt
@@ -105,9 +105,10 @@ class ExplorerLinkRepositoryImplTest {
     }
 
     @Test
-    fun `SwapKit-routed EVM on untrackable source chain falls back to source-chain path`() {
+    fun `SwapKit-routed EVM on untrackable source chain falls back to LiFi tracker`() {
         // Hyperliquid is EVM-shaped but outside SwapKit's /track catalogue, so the SwapKit branch
-        // is skipped and the existing EVM source-chain logic applies (empty swapFee -> null).
+        // is skipped and the EVM source-chain logic applies. The tracker no longer depends on
+        // swapFee, so a feeless route still gets a Track link.
         val link =
             repository.getSwapProgressLink(
                 "0xabc",
@@ -117,7 +118,35 @@ class ExplorerLinkRepositoryImplTest {
                     swapFee = "",
                 ),
             )
-        assertEquals(null, link)
+        assertEquals("https://scan.li.fi/tx/0xabc", link)
+    }
+
+    @Test
+    fun `same-chain Solana swap with empty swapFee still yields Helius Track link`() {
+        // Regression for #5202: feeless routes (swapFee defaults to "") must not drop the tracker.
+        val hash = "solanaTxHash123"
+        val link =
+            repository.getSwapProgressLink(
+                hash,
+                evmPayload(
+                    Chain.Solana,
+                    SwapProvider.ONEINCH.getSwapProviderId(),
+                    toChain = Chain.Solana,
+                    swapFee = "",
+                ),
+            )
+        assertEquals("https://orb.helius.dev/tx/$hash", link)
+    }
+
+    @Test
+    fun `non-SwapKit EVM route with empty swapFee still yields LiFi Track link`() {
+        val hash = "0xdeadbeef"
+        val link =
+            repository.getSwapProgressLink(
+                hash,
+                evmPayload(Chain.Ethereum, SwapProvider.LIFI.getSwapProviderId(), swapFee = ""),
+            )
+        assertEquals("https://scan.li.fi/tx/$hash", link)
     }
 
     @Test
@@ -145,11 +174,16 @@ class ExplorerLinkRepositoryImplTest {
             )
         )
 
-    private fun evmPayload(srcChain: Chain, provider: String, swapFee: String = "0") =
+    private fun evmPayload(
+        srcChain: Chain,
+        provider: String,
+        toChain: Chain = Chain.Solana,
+        swapFee: String = "0",
+    ) =
         SwapPayload.EVM(
             EVMSwapPayloadJson(
                 fromCoin = coin(srcChain),
-                toCoin = coin(Chain.Solana),
+                toCoin = coin(toChain),
                 fromAmount = BigInteger.ONE,
                 toAmountDecimal = BigDecimal.ONE,
                 quote =


### PR DESCRIPTION
## Summary
Fixes #5202. On the swap **"Transaction pending / complete"** done screen, the **Track** button was missing for feeless swaps — notably same-chain **Solana** swaps (e.g. Bonk → SOL).

The Track button renders only when `getSwapProgressLink()` returns a non-blank URL:
```kotlin
if (!progressLink.isNullOrBlank()) { VsButton(label = "Track", ...) }
```
For the `SwapPayload.EVM` branch the tracker URL was gated behind the affiliate `swapFee` parsing as a `BigInteger`. But `EVMSwapQuoteJson.swapFee` defaults to `""`, and `"".toBigIntegerOrNull() == null`, so any quote that omits a swap fee hit the `else null` branch → the valid tracker URL was silently dropped and the Track button disappeared.

## Fix
Drop the `swapFee` gate in the EVM branch. The tracker exists independently of the affiliate fee, so the link is now derived purely from the source chain + tx hash (both always present for a broadcast swap):
- same-chain Solana → `https://orb.helius.dev/tx/<hash>`
- otherwise → `https://scan.li.fi/tx/<hash>`

SwapKit-routed swaps are unaffected — they return earlier from the `track.swapkit.dev` branch before reaching this code.

## Test plan
- [x] `ExplorerLinkRepositoryImplTest`: updated the case that asserted the old buggy `null`; added regression coverage for same-chain Solana (Helius) and non-SwapKit EVM (LiFi) with empty `swapFee`.
- [ ] Device before/after: the done screen with vs without the Track button (pending a build environment with the Trust Wallet Core PAT + emulator).

> Note: unit tests could not be executed in the authoring environment (`androidx.work:work-testing` not fetchable / no GitHub Packages PAT). All cases were verified by tracing the logic; please confirm green in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swap progress tracking links are now shown more reliably for swaps even when fee details are unavailable.
  * Same-chain Solana swaps now open the correct tracking link.
  * EVM swap routes now consistently resolve to a transaction tracker instead of appearing missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->