### PR TITLE
fix(ripple): stop returning the error string as the tx hash on broadcast failure

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.api
 
 import RippleBroadcastResponseResponseJson
+import RippleBroadcastResponseResponseResultJson
 import RippleBroadcastSuccessResponseJson
 import com.vultisig.wallet.data.api.models.RpcPayload
 import com.vultisig.wallet.data.models.Coin
@@ -34,50 +35,28 @@ interface RippleApi {
 internal class RippleApiImp @Inject constructor(private val http: HttpClient) : RippleApi {
 
     override suspend fun broadcastTransaction(tx: String): String {
-        try {
-            val payload =
-                RpcPayload(
-                    method = "submit",
-                    params = buildJsonArray { addJsonObject { put("tx_blob", tx) } },
-                )
-            val response = http.post(BASE_XRP_CLUSTER) { setBody(payload) }
-
-            val rpcResp = response.bodyOrThrow<RippleBroadcastResponseResponseJson>()
-
-            val engineResult = rpcResp.result.engineResult
-            val resultMessage = rpcResp.result.engineResultMessage
-            val hash = rpcResp.result.txJson?.hash
-
-            // A benign duplicate-broadcast race: the peer's identical transaction was already
-            // applied/queued, so the transaction is (or will be) on-chain and we can recover its
-            // hash rather than treat it as a failure.
-            val alreadyApplied =
-                resultMessage?.contains("The transaction was applied", ignoreCase = true) == true ||
-                    resultMessage.equals(
-                        "This sequence number has already passed.",
-                        ignoreCase = true,
-                    ) ||
-                    resultMessage.equals("The transaction is redundant.", ignoreCase = true)
-
-            if (engineResult == "tesSUCCESS" || alreadyApplied) {
-                if (!hash.isNullOrBlank()) {
-                    return hash
-                }
-                // Submitted but the node returned no hash. Don't invent one from the message; let
-                // the caller's on-chain recovery confirm using the locally computed hash instead.
-                error("XRP broadcast returned no transaction hash (engine_result=$engineResult)")
+        val result =
+            try {
+                val payload =
+                    RpcPayload(
+                        method = "submit",
+                        params = buildJsonArray { addJsonObject { put("tx_blob", tx) } },
+                    )
+                http
+                    .post(BASE_XRP_CLUSTER) { setBody(payload) }
+                    .bodyOrThrow<RippleBroadcastResponseResponseJson>()
+                    .result
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Timber.e(e, "Error in Broadcast XRP Transaction")
+                error(e.message ?: "Error in Broadcast XRP Transaction")
             }
 
-            // Any other engine result is a genuine rejection (e.g. temBAD_FEE, tecUNFUNDED). Throw
-            // the node's message instead of returning it as a fake txid, so the keysign surfaces
-            // the
-            // failure (matching iOS RippleService) rather than persisting the rejection text as a
-            // hash.
-            error(resultMessage ?: "XRP broadcast failed (engine_result=$engineResult)")
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
+        return try {
+            resolveBroadcastHash(result)
+        } catch (e: RippleBroadcastException) {
             Timber.e(e, "Error in Broadcast XRP Transaction")
-            error(e.message ?: "Error in Broadcast XRP Transaction")
+            throw e
         }
     }
 
@@ -155,6 +134,59 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
     private companion object {
         const val BASE_XRP_VULTISIG: String = "https://api.vultisig.com/ripple"
         const val BASE_XRP_CLUSTER: String = "https://xrplcluster.com"
+    }
+}
+
+private const val RIPPLE_ENGINE_RESULT_SUCCESS = "tesSUCCESS"
+
+/**
+ * Resolves an XRPL `submit` engine result into a trackable transaction hash, or throws a typed
+ * [RippleBroadcastException] carrying the real failure reason.
+ *
+ * XRPL echoes the deterministic `tx_json.hash` back regardless of the engine result. We return that
+ * hash for a successful submit (`tesSUCCESS`) and for a benign duplicate-broadcast race
+ * (`tefPAST_SEQ` / `tefALREADY`, or a node that only reports an "already applied/redundant"
+ * message) so on-chain recovery can verify it by hash without re-broadcasting. Every other engine
+ * result (`tem*`, `tec*`, other `tef*`, …) is a genuine rejection: we surface the engine code +
+ * message as an exception and never persist the engine message as a fake transaction id.
+ */
+internal fun resolveBroadcastHash(result: RippleBroadcastResponseResponseResultJson): String {
+    val trackable =
+        result.engineResult == RIPPLE_ENGINE_RESULT_SUCCESS ||
+            isDuplicateBroadcast(result.engineResult, result.engineResultMessage)
+
+    val hash = result.txJson?.hash
+    if (trackable && !hash.isNullOrBlank()) {
+        return hash
+    }
+    throw RippleBroadcastException(result.engineResult, result.engineResultMessage)
+}
+
+private fun isDuplicateBroadcast(engineResult: String, message: String?): Boolean {
+    if (engineResult == "tefPAST_SEQ" || engineResult == "tefALREADY") {
+        return true
+    }
+    // Fall back to the human-readable message for nodes/proxies that don't echo the engine code.
+    return message?.contains("The transaction was applied", ignoreCase = true) == true ||
+        message.equals("This sequence number has already passed.", ignoreCase = true) ||
+        message.equals("The transaction is redundant.", ignoreCase = true)
+}
+
+/**
+ * A genuine XRPL broadcast rejection. Carries the engine result code and message so the keysign
+ * flow surfaces the real reason instead of persisting a garbage transaction hash.
+ */
+internal class RippleBroadcastException(
+    val engineResult: String?,
+    val engineResultMessage: String?,
+) : Exception(buildRippleBroadcastMessage(engineResult, engineResultMessage))
+
+private fun buildRippleBroadcastMessage(code: String?, message: String?): String {
+    val resolvedCode = code?.takeIf { it.isNotBlank() } ?: "unknown"
+    return if (!message.isNullOrBlank()) {
+        "Ripple broadcast failed ($resolvedCode): $message"
+    } else {
+        "Ripple broadcast failed ($resolvedCode)"
     }
 }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ResolveBroadcastHashTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ResolveBroadcastHashTest.kt
@@ -1,0 +1,109 @@
+package com.vultisig.wallet.data.api
+
+import RippleBroadcastResponseResponseResultJson
+import RippleBroadcastResponseResponseTransactionJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Unit tests for [resolveBroadcastHash] — the XRPL `submit` engine-result classifier.
+ *
+ * Covers the failure paths from issue #5185: a genuine rejection must surface a typed
+ * [RippleBroadcastException] with the real reason, never the engine message returned as a fake
+ * transaction hash. Duplicate-broadcast races (`tefPAST_SEQ` / `tefALREADY`) resolve by the echoed
+ * hash so on-chain recovery verifies without re-broadcasting.
+ */
+class ResolveBroadcastHashTest {
+
+    private fun result(engineResult: String, message: String? = null, hash: String? = null) =
+        RippleBroadcastResponseResponseResultJson(
+            engineResult = engineResult,
+            engineResultMessage = message,
+            txJson = RippleBroadcastResponseResponseTransactionJson(hash = hash),
+        )
+
+    @Test
+    fun `tesSUCCESS returns echoed hash`() {
+        val hash =
+            resolveBroadcastHash(result("tesSUCCESS", "The transaction was applied.", "HASH1"))
+        assertEquals("HASH1", hash)
+    }
+
+    @Test
+    fun `tefPAST_SEQ duplicate resolves by hash`() {
+        val hash =
+            resolveBroadcastHash(
+                result("tefPAST_SEQ", "This sequence number has already passed.", "HASH2")
+            )
+        assertEquals("HASH2", hash)
+    }
+
+    @Test
+    fun `tefALREADY duplicate resolves by hash`() {
+        val hash =
+            resolveBroadcastHash(
+                result("tefALREADY", "The transaction is already in this ledger.", "HASH3")
+            )
+        assertEquals("HASH3", hash)
+    }
+
+    @Test
+    fun `already-applied message resolves by hash even when code is not recognized`() {
+        val hash = resolveBroadcastHash(result("terRETRY", "The transaction was applied.", "HASH4"))
+        assertEquals("HASH4", hash)
+    }
+
+    @Test
+    fun `tem malformed rejection throws typed error and never returns a hash`() {
+        val error =
+            assertThrows<RippleBroadcastException> {
+                resolveBroadcastHash(result("temBAD_FEE", "Fee must be positive.", hash = null))
+            }
+        assertEquals("temBAD_FEE", error.engineResult)
+        assertEquals("Fee must be positive.", error.engineResultMessage)
+        assertEquals("Ripple broadcast failed (temBAD_FEE): Fee must be positive.", error.message)
+    }
+
+    @Test
+    fun `tec claimed-cost failure throws even when a hash is echoed`() {
+        val error =
+            assertThrows<RippleBroadcastException> {
+                resolveBroadcastHash(
+                    result("tecUNFUNDED_PAYMENT", "Insufficient XRP balance.", "ONCHAINHASH")
+                )
+            }
+        assertEquals("tecUNFUNDED_PAYMENT", error.engineResult)
+    }
+
+    @Test
+    fun `tef rejection other than a duplicate throws`() {
+        val error =
+            assertThrows<RippleBroadcastException> {
+                resolveBroadcastHash(
+                    result("tefMAX_LEDGER", "Ledger sequence too high.", hash = null)
+                )
+            }
+        assertEquals("tefMAX_LEDGER", error.engineResult)
+    }
+
+    @Test
+    fun `success with blank hash throws instead of inventing a hash`() {
+        val error =
+            assertThrows<RippleBroadcastException> {
+                resolveBroadcastHash(
+                    result("tesSUCCESS", "The transaction was applied.", hash = "")
+                )
+            }
+        assertEquals("tesSUCCESS", error.engineResult)
+    }
+
+    @Test
+    fun `failure without message falls back to code-only description`() {
+        val error =
+            assertThrows<RippleBroadcastException> {
+                resolveBroadcastHash(result("telINSUF_FEE_P", message = null, hash = null))
+            }
+        assertEquals("Ripple broadcast failed (telINSUF_FEE_P)", error.message)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBodyReadTest.kt
@@ -53,10 +53,11 @@ class RippleApiBodyReadTest {
         assertEquals("RIPPLEHASH01", result)
     }
 
-    // A genuine rejection must throw, not return the engine result message as a fake txid — the
-    // keysign would otherwise persist the rejection text as a transaction hash and show success.
+    // A genuine rejection must throw a typed error carrying the engine code + message, not return
+    // the engine result message as a fake txid — the keysign would otherwise persist the rejection
+    // text as a transaction hash and show success.
     @Test
-    fun `broadcastTransaction throws engine_result_message when engineResult is a genuine rejection`() {
+    fun `broadcastTransaction throws typed RippleBroadcastException on a genuine rejection`() {
         val body =
             """
             {
@@ -73,11 +74,12 @@ class RippleApiBodyReadTest {
         val api = newApi(HttpStatusCode.OK, body)
 
         val error =
-            assertThrows<IllegalStateException> {
+            assertThrows<RippleBroadcastException> {
                 runBlocking { api.broadcastTransaction("signedtx") }
             }
 
-        assertEquals("Fee must be positive.", error.message)
+        assertEquals("temBAD_FEE", error.engineResult)
+        assertEquals("Fee must be positive.", error.engineResultMessage)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #5185. On an XRPL `submit` rejection the app previously returned the engine **error message as the transaction hash**, so the keysign flow persisted a garbage txid instead of surfacing the failure. This ports the iOS `RippleService` engine-result classification into Android.

- Extracts a pure, testable `resolveBroadcastHash(result)` (top-level, `internal`).
  - Returns the echoed `tx_json.hash` **only** for `tesSUCCESS` or a benign duplicate-broadcast race (`tefPAST_SEQ` / `tefALREADY`, or an already-applied/redundant message) so on-chain recovery can verify by hash without re-broadcasting.
  - Every other engine result (`tem*`, `tec*`, other `tef*`) throws a typed `RippleBroadcastException` carrying the engine code + message — never returns the message as a fake hash. Message format mirrors iOS: `Ripple broadcast failed (code): message`.
- `broadcastTransaction` performs the HTTP call inside a `try` (rewrapping non-broadcast errors), then classifies the result outside it. Genuine rejections are still logged with `Timber.e` at the API layer.

## Test plan

- New `ResolveBroadcastHashTest` (9 classification cases): `tesSUCCESS`/duplicate return the echoed hash; `tem*`/`tec*`/other `tef*` throw the typed exception with the correct `engineResult`/`engineResultMessage`; `tec*`-with-hash still throws; blank-hash success throws instead of inventing a hash; code-only fallback message.
- Updated `RippleApiBodyReadTest` rejection case to assert `RippleBroadcastException` and its fields.
- `:data:compileDebugKotlin` and ktfmt pass locally. (Unit tests run on CI — the local env cannot resolve `androidx.work:work-testing`.)

## Notes
Ports iOS `RippleService.broadcastTransaction`. Part of the XRP hardening set (#5184, #5186); related to #5170.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction submission handling so duplicate or already-applied broadcasts are treated more reliably.
  * Rejection failures now return clearer, structured error details instead of a generic failure.
  * Prevented blank or invented transaction hashes from being returned on unsuccessful submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->