### PR TITLE
fix(qbtc): size Claimable QBTC header badge to match Figma (#5072)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -225,10 +227,10 @@ private fun QbtcClaimHeroCard(totalEligibleSats: Long) {
             painter = painterResource(R.drawable.qbtc_claim_hero),
             contentDescription = null,
             modifier =
-                Modifier.align(Alignment.TopEnd)
-                    .width(200.78.dp)
-                    .height(206.dp)
-                    .offset(x = 31.78.dp, y = (-17).dp),
+                Modifier.align(Alignment.BottomEnd)
+                    .requiredWidth(200.78.dp)
+                    .requiredHeight(206.dp)
+                    .offset(x = 30.dp, y = 30.dp),
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(6.dp),


### PR DESCRIPTION
Closes #5072

## Summary

Fixes the **Claimable QBTC** header card mismatch from #5072.

The QBTC coin badge used `width()/height()`, which the header card's fixed **118dp** height clamped down as a max constraint — so the badge rendered small and fully contained instead of the large, edge-bleeding badge in the Figma spec.

Switching to **`requiredWidth`/`requiredHeight`** lets the drawable keep its intended `200.78 × 206` size and its concentric gold ring bleed past the card edge (clipped by the card's rounded shape, matching Figma's `overflow-clip`).

## Mismatch checklist (from the issue)

- ✅ **1. Coin badge size/position** — fixed here (size no longer clamped; badge bleeds off the edge).
- ✅ **2. Title/amount vertical layout** — already conformed: the group uses `Arrangement.spacedBy(6.dp)` + `Alignment.CenterStart`, matching Figma's `gap-6 / items-start / justify-center` inside the 118dp banner. No change needed.
- ✅ **3. Amount typography** — already conformed: `Theme.satoshi.price.title1` = Satoshi Medium, 28sp, line-height 34, letter-spacing −0.56, exactly the Figma `Price/Title 1` token. The title uses `Theme.brockmann.body.l.medium` = Brockmann Medium 18/28/−0.09 (`Body L (Medium)`). No change needed.

## Design reference

Figma: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=74880-112667&m=dev

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/dPVBRgr.png) | ![after](https://i.imgur.com/psRxdHS.png) |

## Test plan

- [x] Verify the Claimable QBTC header badge renders large and bleeds off the card edge (clipped to the rounded corners).
- [x] Title/amount block stays tightly grouped and vertically centered.
- [x] Amount renders in Satoshi Medium per the `Price/Title 1` token.