### PR TITLE
fix(send): reject hex/scientific-notation amounts before signing (#5186)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -108,7 +108,7 @@ internal class AmountManager(
     }
 
     private suspend fun handleTokenInput(token: Coin, tokenString: String) {
-        val tokenDecimal = tokenString.toBigDecimalOrNull()
+        val tokenDecimal = tokenString.toPlainBigDecimalOrNull()
         _isMaxAmount.value = tokenDecimal?.compareTo(maxAmount) == 0 && maxAmount > BigDecimal.ZERO
 
         val fiatValue =
@@ -151,7 +151,7 @@ internal class AmountManager(
             return
         }
 
-        val tokenDecimal = tokenValue.toBigDecimalOrNull()
+        val tokenDecimal = tokenValue.toPlainBigDecimalOrNull()
         _isMaxAmount.value = tokenDecimal?.compareTo(maxAmount) == 0 && maxAmount > BigDecimal.ZERO
 
         lastTokenValueUserInput = tokenValue
@@ -164,7 +164,7 @@ internal class AmountManager(
         token: Coin,
         transform: (value: BigDecimal, price: BigDecimal, token: Coin) -> BigDecimal,
     ): String? {
-        val decimalValue = value.toBigDecimalOrNull() ?: return ""
+        val decimalValue = value.toPlainBigDecimalOrNull() ?: return ""
 
         val price =
             try {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AmountManager.kt
@@ -77,7 +77,7 @@ internal class AmountManager(
         if (value.length > TextFieldUtils.AMOUNT_MAX_LENGTH) {
             return UiText.StringResource(R.string.send_from_invalid_amount)
         }
-        val decimal = value.toBigDecimalOrNull()
+        val decimal = value.toPlainBigDecimalOrNull()
         if (decimal == null || decimal <= BigDecimal.ZERO) {
             return UiText.StringResource(R.string.send_error_no_amount)
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendAmountExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendAmountExtensions.kt
@@ -11,3 +11,25 @@ import java.math.BigDecimal
  */
 internal fun BigDecimal.hasExcessDecimals(decimals: Int): Boolean =
     stripTrailingZeros().scale() > decimals
+
+/**
+ * True when this string is a plain decimal number — digits and at most one decimal point.
+ *
+ * [String.toBigDecimalOrNull] also accepts scientific notation (`1e5`, `1E+2`), which the numeric
+ * amount keyboard cannot type but which reach the field unfiltered through non-IME paths — most
+ * notably a `vultisig://send?...&amount=1e5` deeplink, whose value is placed into the field
+ * programmatically and therefore skips the input filter on `TokenAmountInput`. Such a value would
+ * otherwise be parsed into a wrong signed amount. Hex (`0x1F`) already fails `toBigDecimalOrNull`,
+ * but is rejected here too for a single, explicit plain-decimal contract that mirrors the SDK.
+ */
+internal fun String.isPlainDecimal(): Boolean =
+    isNotEmpty() &&
+        count { it == '.' } <= 1 &&
+        any { it.isDigit() } &&
+        all { it.isDigit() || it == '.' }
+
+/**
+ * [String.toBigDecimalOrNull] restricted to plain decimals — rejects hex and scientific notation.
+ */
+internal fun String.toPlainBigDecimalOrNull(): BigDecimal? =
+    if (isPlainDecimal()) toBigDecimalOrNull() else null

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/AccountValidator.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.allowZeroGas
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.models.send.hasExcessDecimals
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asAddressInput
 import java.math.BigDecimal
@@ -52,7 +53,7 @@ internal class AccountValidator(
 
         val chain = selectedAccount.token.chain
 
-        val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+        val tokenAmount = tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
         if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/BondStrategy.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -97,7 +98,8 @@ internal class BondStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.models.send.SendFocusField
 import com.vultisig.wallet.ui.models.send.SendSections
 import com.vultisig.wallet.ui.models.send.selectGasFeeForFeeEstimation
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -132,7 +133,8 @@ internal class DefaultSendStrategy(
 
                     val selectedToken = selectedAccount.token
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/MintStrategy.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -72,7 +73,8 @@ internal class MintStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/RedeemStrategy.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.ChainValidationService
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -74,7 +75,8 @@ internal class RedeemStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -74,7 +75,8 @@ internal class StakeStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -86,7 +87,8 @@ internal class UnbondStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -74,7 +75,8 @@ internal class UnstakeStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/WithdrawUsdcCircleStrategy.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -68,7 +69,8 @@ internal class WithdrawUsdcCircleStrategy(
                         )
                     }
 
-                    val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()
+                    val tokenAmount =
+                        tokenAmountFieldState.text.toString().toPlainBigDecimalOrNull()
                     if (tokenAmount == null || tokenAmount <= BigDecimal.ZERO) {
                         throw InvalidTransactionDataException(
                             UiText.StringResource(R.string.send_error_no_amount)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AmountManagerTest.kt
@@ -83,6 +83,29 @@ internal class AmountManagerTest {
     }
 
     @Test
+    fun `validateTokenAmount rejects scientific notation`() {
+        val manager = build(emptyScope())
+        // Cannot be typed on the numeric keyboard, but reaches the field unfiltered via a
+        // vultisig://send deeplink amount; toBigDecimalOrNull would otherwise accept it.
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("1e5").stringId())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("1E+2").stringId())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("2.5e3").stringId())
+    }
+
+    @Test
+    fun `validateTokenAmount rejects hex notation`() {
+        val manager = build(emptyScope())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("0x1F").stringId())
+    }
+
+    @Test
+    fun `validateTokenAmount rejects signed values`() {
+        val manager = build(emptyScope())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("-5").stringId())
+        assertEquals(R.string.send_error_no_amount, manager.validateTokenAmount("+5").stringId())
+    }
+
+    @Test
     fun `validateTokenAmount over-length returns invalid_amount error`() {
         val manager = build(emptyScope())
         val tooLong = "1".repeat(TextFieldUtils.AMOUNT_MAX_LENGTH + 1)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendAmountExtensionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendAmountExtensionsTest.kt
@@ -1,0 +1,54 @@
+package com.vultisig.wallet.ui.models.send
+
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class SendAmountExtensionsTest {
+
+    @Test
+    fun `isPlainDecimal accepts plain decimals`() {
+        assertTrue("0".isPlainDecimal())
+        assertTrue("5".isPlainDecimal())
+        assertTrue("1000.12".isPlainDecimal())
+        assertTrue("0.000001".isPlainDecimal())
+        assertTrue(".5".isPlainDecimal())
+        assertTrue("5.".isPlainDecimal())
+    }
+
+    @Test
+    fun `isPlainDecimal rejects scientific notation`() {
+        assertFalse("1e5".isPlainDecimal())
+        assertFalse("1E5".isPlainDecimal())
+        assertFalse("1E+2".isPlainDecimal())
+        assertFalse("2.5e3".isPlainDecimal())
+    }
+
+    @Test
+    fun `isPlainDecimal rejects hex notation`() {
+        assertFalse("0x1F".isPlainDecimal())
+        assertFalse("1f".isPlainDecimal())
+    }
+
+    @Test
+    fun `isPlainDecimal rejects signs, separators and empties`() {
+        assertFalse("-5".isPlainDecimal())
+        assertFalse("+5".isPlainDecimal())
+        assertFalse("1,5".isPlainDecimal())
+        assertFalse("1.2.3".isPlainDecimal())
+        assertFalse("".isPlainDecimal())
+        assertFalse(".".isPlainDecimal())
+        assertFalse(" 1".isPlainDecimal())
+    }
+
+    @Test
+    fun `toPlainBigDecimalOrNull parses plain decimals and rejects hex or scientific`() {
+        assertEquals(BigDecimal("1000.12"), "1000.12".toPlainBigDecimalOrNull())
+        assertNull("1e5".toPlainBigDecimalOrNull())
+        assertNull("0x1F".toPlainBigDecimalOrNull())
+        assertNull("-5".toPlainBigDecimalOrNull())
+    }
+}


### PR DESCRIPTION
Closes #5186

Transaction hash
https://xrpscan.com/tx/D7C5B13CB977CF154F6CF2FCDF6C3D326CD8308BE7E1AEE569EAFDE3D7F7D2FB

## Problem
Send amount parsing uses `String.toBigDecimalOrNull()`, which accepts **scientific notation** (`1e5` → `100000`). The numeric amount keyboard can't type `e`/`x`, and `TokenAmountInput`'s `InputTransformation` strips non-decimal characters from typed and pasted input — but that filter only runs on IME/paste edits.

A `vultisig://send?...&amount=1e5` deeplink writes the amount into the field **programmatically** (`SendFormGraph` → `setTextAndPlaceCursorAtEnd`), bypassing the filter. `DeepLinkHelper.getAmount()` returns the raw query param with no validation, so a crafted link could feed a malformed/scientific value straight into the signed transaction. This is the same exposure fixed in `vultisig-sdk#973` (which routed parsing through the SDK's decimal-to-base-unit converter for all chains).

Hex (`0x1F`) already fails `toBigDecimalOrNull`; scientific notation was the live gap.

## Fix
Add a single plain-decimal contract and apply it at every amount-parse choke point:

- `String.isPlainDecimal()` / `String.toPlainBigDecimalOrNull()` in `SendAmountExtensions.kt` — digits and at most one decimal point; rejects hex, scientific, signs, separators.
- `AmountManager.validateTokenAmount()` — gates the UI error state and Continue button.
- All send/DeFi submit strategies that re-parse the field before building the signed amount: `DefaultSendStrategy`, `BondStrategy`, `UnbondStrategy`, `StakeStrategy`, `UnstakeStrategy`, `MintStrategy`, `RedeemStrategy`, `WithdrawUsdcCircleStrategy`, and the shared `AccountValidator`.

Plain decimals (including `.5`, `5.`, trailing zeros) are unaffected.

## Test plan
- [x] `SendAmountExtensionsTest` — plain accepted; `1e5` / `1E+2` / `2.5e3` / `0x1F` / `-5` / `+5` / `1,5` / `1.2.3` rejected.
- [x] `AmountManagerTest` — new cases assert scientific/hex/signed inputs return the invalid-amount error; existing valid-amount and precision tests still pass (22/22).
- [x] `./gradlew :app:compileDebugKotlin` and `:app:testDebugUnitTest --tests "*ui.models.send.*"` green.
- [ ] Device: `adb shell am start -a android.intent.action.VIEW -d "vultisig://send?assetChain=Ripple&assetTicker=XRP&toAddress=r...&amount=1e5"` — amount rejected, Continue disabled; `&amount=10.5` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send amount parsing to use plain-decimal validation, making token/fiat inputs more consistent across normal entry and other input paths.
  * Now rejects unsupported number formats such as scientific notation, hex notation, and signed values during amount validation.
* **Tests**
  * Added/expanded unit tests for plain-decimal parsing utilities and for rejecting invalid formats during send amount validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->