### PR TITLE
fix(cosmos): coalesce per-token bank-balance requests (#5161)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CosmosApi.kt
@@ -38,8 +38,11 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.util.encodeBase64
 import java.net.URLEncoder
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -126,6 +129,11 @@ constructor(
     private val cosmosThorChainResponseSerializer: CosmosThorChainResponseSerializer,
     private val customRpcRepository: CustomRpcRepository,
 ) : CosmosApiFactory {
+    // Shared across every CosmosApiImp this @Singleton factory hands out so the per-token
+    // bank-balance requests for one address collapse to a single round-trip. See
+    // CosmosBalanceCache.
+    private val balanceCache = CosmosBalanceCache()
+
     override fun createCosmosApi(chain: Chain): CosmosApi {
         val defaultApiUrl = CustomRpcDefaultEndpoint.cosmosUrl(chain)
 
@@ -139,7 +147,48 @@ constructor(
                 defaultApiUrl
             }
 
-        return CosmosApiImp(httpClient, apiUrl, json, cosmosThorChainResponseSerializer)
+        return CosmosApiImp(
+            httpClient,
+            apiUrl,
+            json,
+            cosmosThorChainResponseSerializer,
+            balanceCache,
+        )
+    }
+}
+
+/**
+ * Coalesces `/cosmos/bank/v1beta1/balances/{address}` reads. The bank endpoint returns every denom
+ * for an address in a single response, yet the balance layer calls it once per token — each picking
+ * one denom and discarding the rest — so opening the Select asset sheet fired ~N identical requests
+ * back-to-back (one per Cosmos token). A per-key [Mutex] gives concurrent in-flight sharing and a
+ * short TTL lets the sequential fan-out reuse the first response; a refresh past the window still
+ * hits the network. Mirrors the SimpleCache + per-key-mutex pattern already used by the DeFi
+ * balance path, but stores in a ConcurrentHashMap so reads across different keys stay thread-safe.
+ */
+internal class CosmosBalanceCache(private val ttlMs: Long = DEFAULT_TTL_MS) {
+
+    private class Entry(val value: List<CosmosBalance>, val expiresAt: Long)
+
+    private val entries = ConcurrentHashMap<String, Entry>()
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
+    suspend fun getOrFetch(
+        key: String,
+        fetch: suspend () -> List<CosmosBalance>,
+    ): List<CosmosBalance> =
+        locks
+            .computeIfAbsent(key) { Mutex() }
+            .withLock {
+                val now = System.currentTimeMillis()
+                entries[key]?.takeIf { now < it.expiresAt }?.value
+                    ?: fetch().also { entries[key] = Entry(it, now + ttlMs) }
+            }
+
+    companion object {
+        // Long enough to absorb the per-token fan-out for one address, short enough that a later
+        // manual refresh still fetches fresh balances.
+        private const val DEFAULT_TTL_MS = 10_000L
     }
 }
 
@@ -148,12 +197,15 @@ internal class CosmosApiImp(
     private val rpcEndpoint: String,
     private val json: Json,
     private val cosmosThorChainResponseSerializer: CosmosThorChainResponseSerializer,
+    private val balanceCache: CosmosBalanceCache = CosmosBalanceCache(),
 ) : CosmosApi {
-    override suspend fun getBalance(address: String): List<CosmosBalance> {
-        val response = httpClient.get("$rpcEndpoint/cosmos/bank/v1beta1/balances/$address")
-        val resp = response.bodyOrThrow<CosmosBalanceResponse>()
-        return resp.balances ?: emptyList()
-    }
+    override suspend fun getBalance(address: String): List<CosmosBalance> =
+        balanceCache.getOrFetch("$rpcEndpoint|$address") {
+            httpClient
+                .get("$rpcEndpoint/cosmos/bank/v1beta1/balances/$address")
+                .bodyOrThrow<CosmosBalanceResponse>()
+                .balances ?: emptyList()
+        }
 
     override suspend fun getAccountNumber(address: String): THORChainAccountValue {
         val response = httpClient.get("$rpcEndpoint/cosmos/auth/v1beta1/accounts/$address") {}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CosmosApiTest.kt
@@ -10,8 +10,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -150,13 +153,103 @@ class CosmosApiTest {
         assertNull(api.getTerraClassicBurnTaxRate())
     }
 
-    private fun cosmosApi(engine: MockEngine): CosmosApi {
+    @Test
+    fun `getBalance coalesces repeat calls for one address into a single request`() = runTest {
+        val requests = AtomicInteger()
+        val api =
+            cosmosApi(
+                MockEngine {
+                    requests.incrementAndGet()
+                    respond(
+                        content = """{"balances":[{"denom":"uatom","amount":"100"}]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        repeat(10) { assertEquals("uatom", api.getBalance("cosmos1abc").single().denom) }
+
+        assertEquals(1, requests.get())
+    }
+
+    @Test
+    fun `getBalance shares one in-flight request across concurrent callers`() = runTest {
+        val requests = AtomicInteger()
+        val api =
+            cosmosApi(
+                MockEngine {
+                    requests.incrementAndGet()
+                    respond(
+                        content = """{"balances":[{"denom":"uatom","amount":"100"}]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        val results = (1..10).map { async { api.getBalance("cosmos1abc") } }.awaitAll()
+
+        assertEquals(1, requests.get())
+        assertEquals(10, results.count { it.single().denom == "uatom" })
+    }
+
+    @Test
+    fun `getBalance keys the cache by address so different addresses each fetch`() = runTest {
+        val requests = AtomicInteger()
+        val api =
+            cosmosApi(
+                MockEngine {
+                    requests.incrementAndGet()
+                    respond(
+                        content = """{"balances":[{"denom":"uatom","amount":"100"}]}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            )
+
+        api.getBalance("cosmos1aaa")
+        api.getBalance("cosmos1bbb")
+
+        assertEquals(2, requests.get())
+    }
+
+    @Test
+    fun `getBalance refetches once the cache entry expires`() = runTest {
+        val requests = AtomicInteger()
+        val api =
+            cosmosApi(
+                engine =
+                    MockEngine {
+                        requests.incrementAndGet()
+                        respond(
+                            content = """{"balances":[{"denom":"uatom","amount":"100"}]}""",
+                            status = HttpStatusCode.OK,
+                            headers = jsonHeaders,
+                        )
+                    },
+                // ttl 0 => every entry is already expired, so caching never masks a stale balance.
+                balanceCache = CosmosBalanceCache(ttlMs = 0),
+            )
+
+        api.getBalance("cosmos1abc")
+        api.getBalance("cosmos1abc")
+
+        assertEquals(2, requests.get())
+    }
+
+    private fun cosmosApi(
+        engine: MockEngine,
+        balanceCache: CosmosBalanceCache = CosmosBalanceCache(),
+    ): CosmosApi {
         val json = Json { ignoreUnknownKeys = true }
         return CosmosApiImp(
             HttpClient(engine) { install(ContentNegotiation) { json(json) } },
             "https://example.test",
             json,
             CosmosThorChainResponseSerializerImpl(json),
+            balanceCache,
         )
     }
 }


### PR DESCRIPTION
## Summary

Opening the swap **Select asset** sheet for a Cosmos chain fired ~N identical
`GET /cosmos/bank/v1beta1/balances/{address}` requests — one per token (~10 for Cosmos: ATOM, KUJI, NAMI, USDC, …). The bank endpoint returns **every** denom for an address in a single response, so every call after the first was pure duplication.

Root cause: `BalanceRepository.getTokenValue` creates a **fresh `CosmosApiImp` per token** and calls `getBalance` on each, so no per-instance state could dedupe them.

## Fix

Add a shared `CosmosBalanceCache` in `CosmosApi.kt`:

- `ConcurrentHashMap` store + **per-key `Mutex`** (concurrent in-flight sharing) + **short TTL (10s)**, keyed by `"$rpcEndpoint|$address"`.
- The `@Singleton` `CosmosApiFactoryImp` holds **one** shared cache and injects it into every `CosmosApiImp`, so the per-token fan-out for an address collapses to a single round-trip — whether the calls arrive concurrently (mutex shares the in-flight fetch) or sequentially (TTL serves the first result).
- Mirrors the existing `SimpleCache` + per-key-mutex pattern already used by the DeFi balance path, but stores in a `ConcurrentHashMap` so reads across different keys stay thread-safe.
- The constructor param defaults to a fresh cache, so existing callers and tests are unaffected.

**Why it's safe:** `getBalance` is used only for balance display and token discovery (`CosmosBankCoinFinder`) — never in the signing/fee path (which uses `simulate` / `getAccountNumber`). On a fetch error nothing is cached, so it fails open and the next caller retries. A refresh past the TTL window still hits the network.

Applies to all Cosmos-SDK chains through this branch (Cosmos Hub, Kujira, dYdX, Osmosis, Terra, Noble, Akash, QBTC).

## Test plan

Added 4 unit tests to `CosmosApiTest.kt` (all green):

- [x] 10 sequential `getBalance` calls for one address → **1** HTTP request
- [x] 10 concurrent callers → **1** HTTP request, all receive the balance (in-flight sharing)
- [x] two different addresses → **2** requests (cache keyed by address)
- [x] `ttlMs = 0` → **2** requests on repeat (proves TTL gating; no stale masking)

`./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.CosmosApiTest"` passes; ktfmt applied.

Closes #5161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate balance requests by reusing recent Cosmos balance responses for a short time.
  * Improved handling of simultaneous balance lookups so multiple callers share the same in-flight request.
  * Ensured balance reads are kept separate per address, with fresh data fetched after cache expiry.

* **Tests**
  * Added coverage for sequential caching, concurrent request sharing, address-based separation, and cache expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->