### PR TITLE
fix(solana): gate tx-status err check to finalized commitment only

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProvider.kt
@@ -14,19 +14,20 @@ internal class SolanaStatusProvider @Inject constructor(private val solanaApi: S
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
             val status = solanaApi.checkStatus(txHash)?.result?.value?.firstOrNull()
-            when {
+            when (status?.confirmationStatus) {
                 // A landed tx with `err` set executed but reverted (swap slippage, insufficient
                 // funds, etc.). Report failure instead of treating a finalized-but-failed tx as
-                // confirmed (matches iOS).
-                status?.err != null -> TransactionResult.Failed(status.err.toString())
-                else ->
-                    when (status?.confirmationStatus) {
-                        "finalized" -> TransactionResult.Confirmed
-                        "confirmed",
-                        "processed",
-                        null -> TransactionResult.Pending
-                        else -> TransactionResult.NotFound
-                    }
+                // confirmed (matches iOS). Only finalized is terminal: roughly 5% of blocks at
+                // processed/confirmed never finalize, so an `err` seen at those earlier levels
+                // can still change before finality and must not be reported as a permanent
+                // Failed (matches iOS, which nests its own err check inside `finalized` too).
+                "finalized" ->
+                    if (status.err != null) TransactionResult.Failed(status.err.toString())
+                    else TransactionResult.Confirmed
+                "confirmed",
+                "processed",
+                null -> TransactionResult.Pending
+                else -> TransactionResult.NotFound
             }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SolanaStatusProviderTest.kt
@@ -47,15 +47,21 @@ class SolanaStatusProviderTest {
     }
 
     @Test
-    fun `err set while only processed still returns Failed`() = runTest {
+    fun `err set while only processed returns Pending, not a terminal Failed`() = runTest {
         val err = JsonPrimitive("AccountInUse")
         coEvery { solanaApi.checkStatus(any()) } returns
             response(SolanaSignatureStatus(confirmationStatus = "processed", err = err))
 
-        assertEquals(
-            TransactionResult.Failed(err.toString()),
-            provider.checkStatus("h", Chain.Solana),
-        )
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
+    }
+
+    @Test
+    fun `err set while only confirmed returns Pending, not a terminal Failed`() = runTest {
+        val err = JsonPrimitive("AccountInUse")
+        coEvery { solanaApi.checkStatus(any()) } returns
+            response(SolanaSignatureStatus(confirmationStatus = "confirmed", err = err))
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
     }
 
     @Test
@@ -79,4 +85,14 @@ class SolanaStatusProviderTest {
 
         assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Solana))
     }
+
+    @Test
+    fun `err set with an unrecognized confirmationStatus returns NotFound, ignoring err`() =
+        runTest {
+            val err = JsonPrimitive("AccountInUse")
+            coEvery { solanaApi.checkStatus(any()) } returns
+                response(SolanaSignatureStatus(confirmationStatus = "unknown", err = err))
+
+            assertEquals(TransactionResult.NotFound, provider.checkStatus("h", Chain.Solana))
+        }
 }


### PR DESCRIPTION
## Summary

`SolanaStatusProvider.checkStatus` treated a non-null `err` on the signature status as an immediately terminal `Failed` result regardless of confirmation level. Roughly 5% of Solana blocks at processed/confirmed level never finalize (they can be forked out and re-included with a different outcome), so a transient `err` observed at that early, unsettled level could permanently mis-report a transaction that goes on to actually confirm — the polling loop treats `Failed` as terminal and never re-checks. The code's own comment claimed this matched iOS; it did not, since iOS nests its `err` check strictly inside the `finalized` case.

`err` is now only consulted once `confirmationStatus == "finalized"`; `confirmed`/`processed`/`null` all report `Pending` regardless of `err`, matching iOS.

Closes #5231.

## Testing
- `./gradlew assembleDebug`
- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest`
- `./gradlew :app:lintDebug :data:lintDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction status handling now treats non-final Solana confirmations as pending, even when an error is present.
  * Only finalized transactions with an error are marked as failed; unrecognized statuses are reported as not found.
* **Tests**
  * Updated coverage to reflect the new status behavior for processed, confirmed, and unrecognized transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->