### PR TITLE
fix(keysign): sha256-hash cosmos custom messages to match iOS/Windows

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -5,12 +5,14 @@ package com.vultisig.wallet.data.chains.helpers
 import com.vultisig.wallet.data.api.swapAggregators.OneInchSwap
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
+import com.vultisig.wallet.data.common.toSha256ByteArray
 import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.crypto.TonHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.TssKeysignType
 import com.vultisig.wallet.data.models.Vault
@@ -53,14 +55,24 @@ object SigningHelper {
             } else {
                 messagePayload.message.toByteArray()
             }
-        val isEddsa =
-            messagePayload.chain?.let { raw ->
-                runCatching { Chain.fromRaw(raw).TssKeysignType == TssKeyType.EDDSA }
-                    .getOrDefault(false)
-            } ?: false
-        // EdDSA chains (e.g. TON) deliver the precomputed digest directly; signing it again
-        // through keccak256 would diverge from the initiator's hash list.
-        val bytes = if (isEddsa) processedBytes else processedBytes.toKeccak256ByteArray()
+        val chain =
+            messagePayload.chain?.let { raw -> runCatching { Chain.fromRaw(raw) }.getOrNull() }
+        // Match the message digest to the chain, mirroring iOS
+        // (CustomMessagePayload.keysignMessages) and Windows (getCustomMessageHex.ts):
+        //  - Cosmos-family chains (incl. THORChain/Maya) sign the sha256 of the message
+        //    (Keplr ADR-36 signArbitrary over the StdSignDoc bytes). Previously these were
+        //    keccak256'd, so the digest — and the md5 message-ID derived from it — diverged
+        //    from the iOS/Windows/CLI initiator and cross-platform co-signing 404'd.
+        //  - EdDSA chains (e.g. Solana, TON) deliver the precomputed digest — sign it raw.
+        //  - Everything else (EVM, Tron) signs the keccak256.
+        val bytes = when {
+            chain?.standard == TokenStandard.COSMOS || chain?.standard == TokenStandard.THORCHAIN ->
+                processedBytes.toSha256ByteArray()
+            chain?.TssKeysignType == TssKeyType.EDDSA ->
+                processedBytes
+            else ->
+                processedBytes.toKeccak256ByteArray()
+        }
         return listOf(bytes.toHexString())
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.common
 
 import com.google.protobuf.ByteString
 import com.vultisig.wallet.data.utils.Numeric
+import java.security.MessageDigest
 import org.bouncycastle.jcajce.provider.digest.Keccak
 
 fun ByteArray.toKeccak256(): String {
@@ -11,6 +12,10 @@ fun ByteArray.toKeccak256(): String {
 fun ByteArray.toKeccak256ByteArray(): ByteArray {
     val digest = Keccak.Digest256()
     return digest.digest(this)
+}
+
+fun ByteArray.toSha256ByteArray(): ByteArray {
+    return MessageDigest.getInstance("SHA-256").digest(this)
 }
 
 fun ByteArray.toByteString(): ByteString {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
+import com.vultisig.wallet.data.common.toSha256ByteArray
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -61,6 +62,30 @@ class SigningHelperCustomMessageTest {
         val messages = SigningHelper.getKeysignMessages(payload)
 
         val expected = hexMessage.toHexBytes().toHexString()
+        messages shouldBe listOf(expected)
+    }
+
+    @Test
+    fun `cosmos-family chain message is sha256-hashed, not keccak256`() {
+        // THORChain/Maya/Cosmos custom messages (Keplr ADR-36 signArbitrary) must be sha256'd
+        // to match iOS/Windows/CLI; keccak256 here 404s cross-platform co-signing.
+        val hexMessage = "0xabcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
+        val payload = CustomMessagePayload(method = "sign", message = hexMessage, chain = "THORChain")
+
+        val messages = SigningHelper.getKeysignMessages(payload)
+
+        messages shouldBe listOf(hexMessage.toHexBytes().toSha256ByteArray().toHexString())
+        messages shouldNotBe listOf(hexMessage.toHexBytes().toKeccak256ByteArray().toHexString())
+    }
+
+    @Test
+    fun `native Cosmos chain plain-text message is sha256-hashed`() {
+        val payload =
+            CustomMessagePayload(method = "sign", message = "Hello Vultisig", chain = "Cosmos")
+
+        val messages = SigningHelper.getKeysignMessages(payload)
+
+        val expected = "Hello Vultisig".toByteArray().toSha256ByteArray().toHexString()
         messages shouldBe listOf(expected)
     }
 


### PR DESCRIPTION
## Problem

`SigningHelper.getKeysignMessages(CustomMessagePayload)` keccak256's the message for every non-EdDSA chain. But cosmos-family chains (THORChain, Maya, Cosmos, …) sign the **sha256** of the message — Keplr ADR-36 `signArbitrary` over the `StdSignDoc` bytes — so the Android digest, and the `md5(message)` relay message-ID derived from it, diverges from:

- **iOS** — `CustomMessagePayload.keysignMessages`
- **Windows / extension** — `getCustomMessageHex.ts` (`match(getChainKind, { evm: keccak256, cosmos: sha256, … })`)
- the CLI initiator

As a result an Android device **cannot co-sign a cosmos custom message** with any of those platforms: it fetches the relay setup/round messages under a different message-ID than the initiator wrote, so the keysign rounds 404 and the session times out.

## Fix

Route the digest by chain kind, mirroring `getCustomMessageHex.ts`:

| chain kind | digest |
|---|---|
| cosmos-family (`COSMOS`, `THORCHAIN`) | sha256 |
| EdDSA (Solana, TON, …) | raw (precomputed digest) |
| everything else (EVM, Tron) | keccak256 |

Adds `ByteArray.toSha256ByteArray()`. Behavior for EVM / EdDSA / typed-data is unchanged; only cosmos-family custom messages change (keccak256 → sha256), bringing Android to parity with iOS and Windows.

## Testing

Added unit tests in `SigningHelperCustomMessageTest` (cosmos → sha256, and cosmos ≠ keccak256). Not built locally (no Android SDK in this environment) — relying on CI for the full build + test run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message signing so Cosmos-family and THORChain messages use the correct hashing method.
  * Improved handling for EdDSA-based chains to preserve their expected signing bytes.
  * Keccak-256 remains the default for other supported chains.

* **Tests**
  * Added coverage for Cosmos and THORChain signing behavior to verify the new hashing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->