### PR TITLE
fix(send): hide empty Memo row on Send overview

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -280,6 +280,7 @@ class PreviewActivity : ComponentActivity() {
                     "vault_detail_mldsa" -> VaultDetailPreview(withMldsa = true)
                     "error_screen_after" -> ErrorScreenAfterPreview()
                     "chain_selection" -> ChainSelectionClipPreview()
+                    "verify_send_empty_memo" -> VerifySendEmptyMemoPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1158,6 +1159,36 @@ private fun ShareQrKeygenPreview() {
 private fun BlockaidHeroVerifySendPreview() {
     VerifySendScreen(
         state = blockaidHeroSendState(),
+        isConsentsEnabled = true,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
+    )
+}
+
+@Composable
+private fun VerifySendEmptyMemoPreview() {
+    val rune = Coins.ThorChain.RUNE
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        token = ValuedToken(token = rune, value = "10", fiatValue = "$45.00"),
+                        srcAddress = "thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqxf3l5h",
+                        srcVaultName = "Main Vault",
+                        dstAddress = "thor1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz9k8lqe",
+                        memo = "",
+                        networkFeeFiatValue = "$0.02",
+                        networkFeeTokenValue = "0.02 RUNE",
+                    )
+            ),
         isConsentsEnabled = true,
         confirmTitle = "Sign",
         onFastSignClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -268,7 +268,7 @@ internal fun VerifySendScreen(
                         bracketValue = toDstLabel?.let { tx.dstAddress },
                     )
 
-                    if (tx.memo != null) {
+                    if (!tx.memo.isNullOrBlank()) {
                         VerifyCardDivider(0.dp)
 
                         VerifyCardDetails(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -65,14 +65,13 @@ object SigningHelper {
         //    from the iOS/Windows/CLI initiator and cross-platform co-signing 404'd.
         //  - EdDSA chains (e.g. Solana, TON) deliver the precomputed digest — sign it raw.
         //  - Everything else (EVM, Tron) signs the keccak256.
-        val bytes = when {
-            chain?.standard == TokenStandard.COSMOS || chain?.standard == TokenStandard.THORCHAIN ->
-                processedBytes.toSha256ByteArray()
-            chain?.TssKeysignType == TssKeyType.EDDSA ->
-                processedBytes
-            else ->
-                processedBytes.toKeccak256ByteArray()
-        }
+        val bytes =
+            when {
+                chain?.standard == TokenStandard.COSMOS ||
+                    chain?.standard == TokenStandard.THORCHAIN -> processedBytes.toSha256ByteArray()
+                chain?.TssKeysignType == TssKeyType.EDDSA -> processedBytes
+                else -> processedBytes.toKeccak256ByteArray()
+            }
         return listOf(bytes.toHexString())
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
@@ -70,7 +70,8 @@ class SigningHelperCustomMessageTest {
         // THORChain/Maya/Cosmos custom messages (Keplr ADR-36 signArbitrary) must be sha256'd
         // to match iOS/Windows/CLI; keccak256 here 404s cross-platform co-signing.
         val hexMessage = "0xabcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
-        val payload = CustomMessagePayload(method = "sign", message = hexMessage, chain = "THORChain")
+        val payload =
+            CustomMessagePayload(method = "sign", message = hexMessage, chain = "THORChain")
 
         val messages = SigningHelper.getKeysignMessages(payload)
 


### PR DESCRIPTION
## Summary

On the **Send overview** (transaction confirmation) screen, the **Memo** row was rendered whenever `tx.memo` was non-null. Because an empty memo is an empty string (`""`) rather than `null`, the row showed up as a blank **Memo** label with no value, wasting vertical space in the summary card.

This changes the guard from `tx.memo != null` to `!tx.memo.isNullOrBlank()`, so the Memo row (and its divider) only appears when a memo is actually present.

Fixes #5234

## Changes

- `VerifySendScreen.kt` — guard the Memo row with `isNullOrBlank()`.
- `PreviewActivity.kt` — add a `verify_send_empty_memo` preview covering the empty-memo THORChain send case.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/IFtdkUk.png) | ![after](https://i.imgur.com/ACKxvgg.png) |

In *Before*, notice the empty **Memo** row between **To** and **Network**. In *After*, the row is gone and **To** flows directly into **Network**.

## Test Plan

- [x] Rendered `VerifySendScreen` with an empty memo via PreviewActivity — empty Memo row no longer appears.
- [x] Existing previews with a real memo still render the Memo row (unchanged behavior for non-blank memos).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send confirmation screens so empty or whitespace-only memos no longer appear as memo details.
  * Added a new preview for the empty-memo send flow to help verify the updated display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->