### PR TITLE
fix(solana): confirm SPL token account by derivation on indexer lag

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -51,6 +51,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import timber.log.Timber
+import wallet.core.jni.SolanaAddress
 
 interface SolanaApi {
     suspend fun getBalance(address: String): BigInteger
@@ -90,13 +91,24 @@ interface SolanaApi {
     suspend fun checkStatus(txHash: String): SolanaRpcResponseJson<SolanaSignatureStatusesResult>?
 }
 
-internal class SolanaApiImp
-@Inject
-constructor(
+internal class SolanaApiImp(
     private val json: Json,
     private val httpClient: HttpClient,
     private val splTokenSerializer: SplTokenResponseJsonSerializer,
+    // Derives the associated-token-account address for (owner, mint) under the classic SPL or the
+    // Token-2022 program. Backed by WalletCore JNI in production; injected so the direct-derivation
+    // fallback in [getTokenAssociatedAccountByOwner] can be unit-tested without the native library,
+    // which is not loaded in JVM unit tests.
+    private val deriveAssociatedTokenAddress:
+        (owner: String, mint: String, token2022: Boolean) -> String?,
 ) : SolanaApi {
+
+    @Inject
+    constructor(
+        json: Json,
+        httpClient: HttpClient,
+        splTokenSerializer: SplTokenResponseJsonSerializer,
+    ) : this(json, httpClient, splTokenSerializer, ::deriveAssociatedTokenAddressWithWalletCore)
 
     private val rpcEndpoint = "https://api.vultisig.com/solana/"
     private val splTokensInfoEndpoint = "https://api.solana.fm/v1/tokens"
@@ -390,6 +402,28 @@ constructor(
         walletAddress: String,
         mintAddress: String,
     ): Pair<String?, Boolean> {
+        findAssociatedAccountViaOwner(walletAddress, mintAddress)?.let {
+            return it
+        }
+        // The primary getTokenAccountsByOwner lookup came back empty or failed. That can be a real
+        // "no account", but it can also be indexer/replica lag right after the ATA was created. If
+        // we trusted it, the sender would fail with a false "missing token account" error, and the
+        // recipient path would try to recreate an ATA that already exists — a non-idempotent op the
+        // on-chain program rejects. Derive the ATA directly and confirm with a point account-info
+        // lookup before concluding it truly does not exist. Mirrors iOS (SolanaService).
+        return findAssociatedAccountByDerivation(walletAddress, mintAddress)
+    }
+
+    /**
+     * Primary lookup: ask the indexer for the owner's associated token account for [mintAddress].
+     * Returns the (ATA address, isToken2022) pair when the index holds it, or null when the account
+     * is absent from the index or the RPC call fails — both of which route the caller to the
+     * direct-derivation fallback.
+     */
+    private suspend fun findAssociatedAccountViaOwner(
+        walletAddress: String,
+        mintAddress: String,
+    ): Pair<String, Boolean>? =
         try {
             val response =
                 httpClient.postRpc<SplAmountRpcResponseJson>(
@@ -403,27 +437,50 @@ constructor(
                         },
                 )
             if (response.error != null) {
-                Timber.d("getTokenAssociatedAccountByOwner error: ${response.error}")
-                return Pair(null, false)
+                Timber.tag("SolanaApiImp")
+                    .d("getTokenAssociatedAccountByOwner error: %s", response.error)
+                null
+            } else {
+                response.value?.value?.firstOrNull()?.let {
+                    Pair(it.pubKey, it.account.owner == TOKEN_PROGRAM_ID_2022)
+                }
             }
-            val value = response.value ?: error("getTokenAssociatedAccountByOwner error")
-            if (value.value.isEmpty()) {
-                Timber.d(
-                    "getTokenAssociatedAccountByOwner: no ATA found for %s / %s",
-                    walletAddress,
-                    mintAddress,
-                )
-                return Pair(null, false)
-            }
-            return Pair(
-                value.value[0].pubKey,
-                value.value[0].account.owner == TOKEN_PROGRAM_ID_2022,
-            )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e(e)
-            return Pair(null, false)
+            Timber.tag("SolanaApiImp").e(e, "getTokenAssociatedAccountByOwner failed")
+            null
         }
+
+    /**
+     * Fallback for when the index has no account or is unreachable: an ATA address is deterministic
+     * for a given (owner, mint, token program), so derive both the classic-SPL and Token-2022
+     * addresses and confirm on-chain existence with a direct account-info lookup. A given mint is
+     * owned by exactly one token program, so at most one derived address can exist. Returns
+     * (address, isToken2022) for the one that does, or (null, false) when neither exists.
+     */
+    private suspend fun findAssociatedAccountByDerivation(
+        walletAddress: String,
+        mintAddress: String,
+    ): Pair<String?, Boolean> {
+        for (isToken2022 in listOf(false, true)) {
+            val ata =
+                deriveAssociatedTokenAddress(walletAddress, mintAddress, isToken2022)?.takeIf {
+                    it.isNotEmpty()
+                } ?: continue
+            // A non-null owner means the account exists on-chain (every account has one); a missing
+            // account resolves the info value to null without an RPC error.
+            if (getAccountOwner(ata) != null) {
+                return Pair(ata, isToken2022)
+            }
+        }
+        Timber.tag("SolanaApiImp")
+            .d(
+                "getTokenAssociatedAccountByOwner: no ATA for %s / %s after direct-derivation fallback",
+                walletAddress,
+                mintAddress,
+            )
+        return Pair(null, false)
     }
 
     override suspend fun getAccountOwner(account: String): String? =
@@ -554,3 +611,19 @@ internal fun solanaBroadcastAction(
         else -> SolanaBroadcastAction.FATAL
     }
 }
+
+/**
+ * Derives the associated-token-account address for [owner] and [mint] under the classic SPL token
+ * program ([token2022] = false) or the Token-2022 program ([token2022] = true), via WalletCore.
+ * Returns null when WalletCore cannot derive it (e.g. a malformed owner address).
+ */
+private fun deriveAssociatedTokenAddressWithWalletCore(
+    owner: String,
+    mint: String,
+    token2022: Boolean,
+): String? =
+    runCatching {
+            val address = SolanaAddress(owner)
+            if (token2022) address.token2022Address(mint) else address.defaultTokenAddress(mint)
+        }
+        .getOrNull()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaAssociatedTokenAccountTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaAssociatedTokenAccountTest.kt
@@ -1,0 +1,224 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
+import com.vultisig.wallet.data.utils.SplTokenResponseJsonSerializerImpl
+import io.ktor.http.HttpStatusCode
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [SolanaApiImp.getTokenAssociatedAccountByOwner], focusing on the direct-derivation
+ * fallback that runs when the primary `getTokenAccountsByOwner` lookup comes back empty or fails
+ * (issue #5224). The WalletCore ATA derivation is injected as a fake that records its calls, so the
+ * tests assert both the returned pair and whether the fallback was reached — without the native
+ * library.
+ */
+class SolanaAssociatedTokenAccountTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        serializersModule = SerializersModule { contextual(BigIntegerSerializerImpl()) }
+    }
+
+    /** Records every (owner, mint, token2022) the fallback derives, in order. */
+    private val derivationCalls = mutableListOf<Triple<String, String, Boolean>>()
+
+    private val fakeDeriver: (String, String, Boolean) -> String? = { owner, mint, token2022 ->
+        derivationCalls += Triple(owner, mint, token2022)
+        if (token2022) TOKEN_2022_ATA else CLASSIC_ATA
+    }
+
+    private fun apiRespondingWith(vararg responses: Pair<HttpStatusCode, String>): SolanaApi =
+        SolanaApiImp(
+            json = json,
+            httpClient = MockHttpClient.respondingWithSequence(*responses),
+            splTokenSerializer = SplTokenResponseJsonSerializerImpl(json),
+            deriveAssociatedTokenAddress = fakeDeriver,
+        )
+
+    @Test
+    fun `primary lookup success returns the indexed account without a fallback`() = runTest {
+        val api = apiRespondingWith(HttpStatusCode.OK to tokenAccounts(INDEXED_ATA, SPL_PROGRAM))
+
+        val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+        assertEquals(INDEXED_ATA to false, result)
+        assertTrue(derivationCalls.isEmpty(), "happy path must not derive")
+    }
+
+    @Test
+    fun `primary lookup flags a Token-2022 account by its owning program`() = runTest {
+        val api =
+            apiRespondingWith(HttpStatusCode.OK to tokenAccounts(INDEXED_ATA, TOKEN_2022_PROGRAM))
+
+        val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+        assertEquals(INDEXED_ATA to true, result)
+        assertTrue(derivationCalls.isEmpty(), "happy path must not derive")
+    }
+
+    @Test
+    fun `empty primary lookup falls back to the derived classic ATA`() = runTest {
+        val api =
+            apiRespondingWith(
+                HttpStatusCode.OK to NO_TOKEN_ACCOUNTS,
+                HttpStatusCode.OK to accountInfo(owner = SPL_PROGRAM),
+            )
+
+        val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+        assertEquals(CLASSIC_ATA to false, result)
+        // Classic is derived and confirmed first, so Token-2022 is never derived.
+        assertEquals(listOf(Triple(OWNER, MINT, false)), derivationCalls)
+    }
+
+    @Test
+    fun `empty primary lookup falls back to the derived Token-2022 ATA when classic is absent`() =
+        runTest {
+            val api =
+                apiRespondingWith(
+                    HttpStatusCode.OK to NO_TOKEN_ACCOUNTS,
+                    HttpStatusCode.OK to ACCOUNT_ABSENT,
+                    HttpStatusCode.OK to accountInfo(owner = TOKEN_2022_PROGRAM),
+                )
+
+            val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+            assertEquals(TOKEN_2022_ATA to true, result)
+            assertEquals(
+                listOf(Triple(OWNER, MINT, false), Triple(OWNER, MINT, true)),
+                derivationCalls,
+            )
+        }
+
+    @Test
+    fun `empty primary lookup with neither derived ATA present reports no account`() = runTest {
+        val api =
+            apiRespondingWith(
+                HttpStatusCode.OK to NO_TOKEN_ACCOUNTS,
+                // Pinned as the response for both the classic and Token-2022 probes.
+                HttpStatusCode.OK to ACCOUNT_ABSENT,
+            )
+
+        val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+        assertEquals(null to false, result)
+        assertEquals(listOf(Triple(OWNER, MINT, false), Triple(OWNER, MINT, true)), derivationCalls)
+    }
+
+    @Test
+    fun `json-rpc error on the primary lookup still runs the derivation fallback`() = runTest {
+        val api =
+            apiRespondingWith(
+                HttpStatusCode.OK to TOKEN_ACCOUNTS_RPC_ERROR,
+                HttpStatusCode.OK to accountInfo(owner = SPL_PROGRAM),
+            )
+
+        val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+        assertEquals(CLASSIC_ATA to false, result)
+        assertEquals(listOf(Triple(OWNER, MINT, false)), derivationCalls)
+    }
+
+    @Test
+    fun `transport failure on the primary lookup falls back and reports no account gracefully`() =
+        runTest {
+            // Both the primary lookup and the fallback probes hit the failing transport, so the
+            // method must not propagate the error — it reports "no account" after trying to derive.
+            val api =
+                SolanaApiImp(
+                    json = json,
+                    httpClient = MockHttpClient.throwingIOException(IOException("boom")),
+                    splTokenSerializer = SplTokenResponseJsonSerializerImpl(json),
+                    deriveAssociatedTokenAddress = fakeDeriver,
+                )
+
+            val result = api.getTokenAssociatedAccountByOwner(OWNER, MINT)
+
+            assertEquals(null to false, result)
+            assertTrue(derivationCalls.isNotEmpty(), "fallback must be attempted on a throw")
+        }
+
+    @Test
+    fun `cancellation on the primary lookup propagates and skips the fallback`() = runTest {
+        val api =
+            SolanaApiImp(
+                json = json,
+                httpClient = MockHttpClient.throwing(CancellationException("cancelled")),
+                splTokenSerializer = SplTokenResponseJsonSerializerImpl(json),
+                deriveAssociatedTokenAddress = fakeDeriver,
+            )
+
+        val error =
+            runCatching { api.getTokenAssociatedAccountByOwner(OWNER, MINT) }.exceptionOrNull()
+
+        assertInstanceOf(CancellationException::class.java, error)
+        assertTrue(derivationCalls.isEmpty(), "cancellation must short-circuit before the fallback")
+    }
+
+    private fun tokenAccounts(pubKey: String, owner: String): String =
+        """
+        {
+          "error": null,
+          "result": {
+            "value": [
+              {
+                "pubkey": "$pubKey",
+                "account": {
+                  "data": { "parsed": { "info": { "tokenAmount": { "amount": "1" } } } },
+                  "owner": "$owner"
+                }
+              }
+            ]
+          }
+        }
+        """
+            .trimIndent()
+
+    private fun accountInfo(owner: String): String =
+        """
+        {
+          "result": { "value": { "owner": "$owner" } },
+          "error": null
+        }
+        """
+            .trimIndent()
+
+    private companion object {
+        const val OWNER = "OwnerWallet11111111111111111111111111111111"
+        const val MINT = "MintAddress111111111111111111111111111111111"
+        const val INDEXED_ATA = "IndexedAta1111111111111111111111111111111111"
+        const val CLASSIC_ATA = "ClassicAta1111111111111111111111111111111111"
+        const val TOKEN_2022_ATA = "Token2022Ata11111111111111111111111111111111"
+        const val SPL_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        const val TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+        val NO_TOKEN_ACCOUNTS =
+            """
+            { "error": null, "result": { "value": [] } }
+            """
+                .trimIndent()
+
+        val TOKEN_ACCOUNTS_RPC_ERROR =
+            """
+            { "error": { "message": "indexer unavailable" }, "result": null }
+            """
+                .trimIndent()
+
+        val ACCOUNT_ABSENT =
+            """
+            { "result": { "value": null }, "error": null }
+            """
+                .trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary

Sending an SPL token relies on `getTokenAssociatedAccountByOwner`, which made a single `getTokenAccountsByOwner` call and treated an empty or failed response as "the token account doesn't exist". When the RPC indexer lags — common right after an associated token account (ATA) is created — that caused two failures:

- the **sender** got a false "missing token account" error, and
- the **recipient** path tried to recreate an ATA that already exists, which the on-chain program rejects (account creation isn't idempotent).

Now, when the primary lookup comes back empty or fails, we derive the classic-SPL and Token-2022 associated-token addresses and confirm existence with a direct `getAccountInfo` call before concluding the account is missing. A successful primary lookup behaves exactly as before.

## Details

- The derivation reuses the same WalletCore calls (`defaultTokenAddress` / `token2022Address`) the signing path already uses to build recipient ATAs, so it yields the canonical, wallet-agnostic address regardless of how the vault was created — generated, imported seed, or Phantom-path import (that choice only affects the owner address, which is already resolved before this point).
- The derivation is injected as a constructor lambda (same pattern as `SolanaFeeService`) so the fallback is unit-tested without the native library; Hilt still builds the impl through the unchanged `@Inject` constructor.
- Follows iOS `SolanaService`; the Android fallback additionally covers the case where the primary call errors (iOS only handles an empty result). Windows has no fallback.

## Testing

- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.SolanaAssociatedTokenAccountTest"` — 8 tests pass
- `./gradlew :data:ktfmtFormat` — clean
- `./gradlew :app:assembleDebug` — passes

Closes #5224
