### PR TITLE
fix(ripple): gate Confirmed on validated flag + meta.TransactionResult

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/RippleJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/RippleJson.kt
@@ -27,7 +27,11 @@ data class RippleBroadcastSuccessResultJson(
     @SerialName("status") val status: String,
     @SerialName("tx_json") val txJson: RippleBroadcastSuccessTransactionJson,
     @SerialName("validated") val validated: Boolean,
+    @SerialName("meta") val meta: RippleTxMetaJson? = null,
 )
+
+@Serializable
+data class RippleTxMetaJson(@SerialName("TransactionResult") val transactionResult: String? = null)
 
 @Serializable
 data class RippleBroadcastSuccessTransactionJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProvider.kt
@@ -13,11 +13,20 @@ class RippleStatusProvider @Inject constructor(private val rippleApi: RippleApi)
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
-            val tx = rippleApi.getTsStatus(txHash)
+            val result = rippleApi.getTsStatus(txHash)?.result
+            val engineResult = result?.meta?.transactionResult
             when {
-                tx == null -> TransactionResult.Pending
-                tx.result.status == "success" -> TransactionResult.Confirmed
-                else -> TransactionResult.Failed(tx.result.status)
+                // Not found yet, or found only in a not-yet-validated ledger: keep polling. A tx in
+                // an unvalidated ledger can still be dropped (LastLedgerSequence expiry, failed
+                // consensus), so it must not be reported terminally.
+                result == null || !result.validated -> TransactionResult.Pending
+                // Validated but outcome unknown (meta absent): don't claim success, keep polling.
+                engineResult == null -> TransactionResult.Pending
+                // Only tesSUCCESS delivered funds. A validated tec* result (tecUNFUNDED_PAYMENT,
+                // tecDST_TAG_NEEDED, …) burned the fee and delivered nothing — it is a real
+                // failure.
+                engineResult == "tesSUCCESS" -> TransactionResult.Confirmed
+                else -> TransactionResult.Failed(engineResult)
             }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProviderTest.kt
@@ -1,0 +1,89 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import RippleBroadcastSuccessResponseJson
+import RippleBroadcastSuccessResultJson
+import RippleBroadcastSuccessTransactionJson
+import RippleTxMetaJson
+import com.vultisig.wallet.data.api.RippleApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class RippleStatusProviderTest {
+
+    private val rippleApi = mockk<RippleApi>()
+    private val provider = RippleStatusProvider(rippleApi)
+
+    private fun response(validated: Boolean, transactionResult: String?) =
+        RippleBroadcastSuccessResponseJson(
+            result =
+                RippleBroadcastSuccessResultJson(
+                    hash = "h",
+                    status = "success",
+                    txJson =
+                        RippleBroadcastSuccessTransactionJson(
+                            account = "a",
+                            deliverMax = "1",
+                            destination = "d",
+                            fee = "10",
+                            flags = 0,
+                            lastLedgerSequence = 0,
+                            sequence = 0,
+                            signingPubKey = "k",
+                            transactionType = "Payment",
+                            txnSignature = "s",
+                        ),
+                    validated = validated,
+                    meta = transactionResult?.let { RippleTxMetaJson(transactionResult = it) },
+                )
+        )
+
+    @Test
+    fun `validated tesSUCCESS returns Confirmed`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } returns response(true, "tesSUCCESS")
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("h", Chain.Ripple))
+    }
+
+    @Test
+    fun `validated tec failure returns Failed with the code`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } returns response(true, "tecUNFUNDED_PAYMENT")
+
+        assertEquals(
+            TransactionResult.Failed("tecUNFUNDED_PAYMENT"),
+            provider.checkStatus("h", Chain.Ripple),
+        )
+    }
+
+    @Test
+    fun `unvalidated tesSUCCESS keeps polling (Pending), not terminal Confirmed`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } returns response(false, "tesSUCCESS")
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Ripple))
+    }
+
+    @Test
+    fun `validated but missing meta returns Pending, not Confirmed`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } returns response(true, null)
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Ripple))
+    }
+
+    @Test
+    fun `null response returns Pending`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } returns null
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Ripple))
+    }
+
+    @Test
+    fun `api exception returns Pending`() = runTest {
+        coEvery { rippleApi.getTsStatus(any()) } throws RuntimeException("net")
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Ripple))
+    }
+}


### PR DESCRIPTION
## Summary
- `RippleStatusProvider` marked a tx **Confirmed** on RPC-level `status == "success"`, which for the XRPL `tx` method only means the tx was *found* — not that it succeeded.
- Now Confirmed requires `validated == true` **AND** `meta.TransactionResult == "tesSUCCESS"`.
- Validated `tec*` results (`tecUNFUNDED_PAYMENT`, `tecDST_TAG_NEEDED`, …) → `Failed(code)` instead of a false-green Confirmed.
- Not-yet-validated or meta-absent → keep polling (`Pending`) instead of a terminal Confirmed that could later be dropped (LastLedgerSequence expiry / failed consensus).
- Added `meta` to the `tx` response model (`RippleTxMetaJson`); it was parsed nowhere before.
- Mirrors the Solana `finalized` gate.

## Issue
Closes #5248

On Chain Tx Link https://xrpscan.com/tx/F5E925EEF91BF62AB5487330B2D8365AB5C2DADCF01E12CC3CBAFDBB89C39CEA

## Test Plan
- [x] Added `RippleStatusProviderTest` covering both false-success modes (validated tec*, unvalidated tesSUCCESS, missing meta)
- [x] Lint / ktfmt passes
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ripple transaction status tracking by waiting for ledger validation before confirming transactions.
  * Correctly distinguishes successful, failed, pending, incomplete, and unavailable transaction responses.
  * Prevents missing transaction metadata or API errors from being incorrectly reported as failures.

* **Tests**
  * Added coverage for validated, unvalidated, failed, incomplete, null, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->