### PR TITLE
fix(broadcast): verify tx on-chain before treating dedup rejections as success

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
@@ -106,7 +106,21 @@ constructor(
                     .getSignedApproveTransaction(approvePayload, payload, signatures)
 
             val evmApi = evmApiFactory.createEvmApi(chain)
-            approveTxHash = evmApi.sendTransaction(signedApproveTransaction.rawTransaction)
+            approveTxHash =
+                try {
+                    evmApi.sendTransaction(signedApproveTransaction.rawTransaction)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A joined (losing) co-signer's approve broadcast can be rejected as a
+                    // duplicate. Fall back to the locally computed hash and let
+                    // awaitApprovalConfirmation verify it on-chain, so we surface a proper
+                    // ApprovalNotConfirmed result instead of a generic error screen. This never
+                    // fabricates success — confirmation is still gated below. The initiating
+                    // device re-throws so a genuine broadcast failure is surfaced.
+                    val localHash = signedApproveTransaction.transactionHash
+                    if (!isInitiatingDevice && localHash.isNotBlank()) localHash else throw e
+                }
 
             Timber.d("Approval tx broadcast: %s, awaiting confirmation", approveTxHash)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -116,14 +116,17 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                 }
 
                 HttpStatusCode.BadRequest -> {
+                    // A 400 (e.g. unknownOutputReferences) is a genuine rejection. The txid inside
+                    // unknownOutputReferences is the PARENT tx that created the spent input, not
+                    // the
+                    // tx we broadcast — returning it would report success under an unrelated hash.
+                    // Throw instead so BroadcastTxUseCase can verify our actual hash on-chain and
+                    // only treat a real duplicate submission as success.
                     val ogmiosError =
                         json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
-                    ogmiosError.error?.data?.unknownOutputReferences?.firstOrNull()?.transaction?.id
-                        ?: run {
-                            val errorMessage = ogmiosError.error?.message ?: "Unknown error"
-                            Timber.e("Cardano transaction submission failed: $errorMessage")
-                            error("Failed to broadcast transaction: $errorMessage")
-                        }
+                    val errorMessage = ogmiosError.error?.message ?: "Unknown error"
+                    Timber.e("Cardano transaction submission failed: $errorMessage")
+                    error("Failed to broadcast transaction: $errorMessage")
                 }
 
                 else -> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -19,7 +19,6 @@ import io.ktor.http.path
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -89,73 +88,57 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
     }
 
     override suspend fun broadcastTransaction(chain: String, signedTransaction: String): String? {
-        val payload = buildJsonObject {
-            put("jsonrpc", "2.0")
-            put("method", "submitTransaction")
-            put(
-                "params",
-                buildJsonObject {
-                    put("transaction", buildJsonObject { put("cbor", signedTransaction) })
-                },
-            )
-            put("id", 1)
-        }
-
-        repeat(SUBMIT_MAX_ATTEMPTS) { attempt ->
-            if (attempt > 0) delay(SUBMIT_RETRY_BACKOFF_MS)
-            try {
-                val response = httpClient.post(ogmiosUrl) { setBody(payload) }
-                val ogmiosResponse =
-                    when (response.status) {
-                        HttpStatusCode.OK -> response.bodyOrThrow<OgmiosTransactionResponse>()
-                        HttpStatusCode.BadRequest ->
-                            json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
-                        else -> {
-                            Timber.e("Failed to broadcast Cardano transaction: ${response.status}")
-                            error("Failed to broadcast transaction: ${response.status}")
-                        }
-                    }
-
-                ogmiosResponse.result?.transaction?.id?.let {
-                    return it
-                }
-
-                // Ogmios 3005 (era boundary, near a hard-fork) is transient; it advises retrying.
-                if (
-                    ogmiosResponse.error?.code == OGMIOS_ERROR_ERA_BOUNDARY &&
-                        attempt < SUBMIT_MAX_ATTEMPTS - 1
-                ) {
-                    Timber.w(
-                        "Cardano submit hit era boundary (3005); retrying %d/%d",
-                        attempt + 1,
-                        SUBMIT_MAX_ATTEMPTS,
-                    )
-                    return@repeat
-                }
-
-                // Any other failure (incl. unknownOutputReferences, whose txid is the PARENT tx
-                // that
-                // created the spent input, not the tx we broadcast) is a genuine rejection. Throw
-                // so
-                // BroadcastTxUseCase verifies our actual hash on-chain rather than reporting
-                // success
-                // under an unrelated hash.
-                val errorMessage = ogmiosResponse.error?.message ?: "Unknown error"
-                Timber.e("Cardano transaction submission failed: $errorMessage")
-                error("Failed to broadcast transaction: $errorMessage")
-            } catch (t: CancellationException) {
-                throw t
-            } catch (t: IllegalStateException) {
-                // Already-formatted rejection from the error() calls above — surface as-is.
-                throw t
-            } catch (t: Throwable) {
-                Timber.e(t, "Failed to broadcast Cardano transaction")
-                error("Failed to broadcast transaction : ${t.message}")
+        return try {
+            val payload = buildJsonObject {
+                put("jsonrpc", "2.0")
+                put("method", "submitTransaction")
+                put(
+                    "params",
+                    buildJsonObject {
+                        put("transaction", buildJsonObject { put("cbor", signedTransaction) })
+                    },
+                )
+                put("id", 1)
             }
+
+            val response = httpClient.post(ogmiosUrl) { setBody(payload) }
+
+            when (response.status) {
+                HttpStatusCode.OK -> {
+                    val ogmiosResponse = response.bodyOrThrow<OgmiosTransactionResponse>()
+
+                    ogmiosResponse.result?.transaction?.id
+                        ?: run {
+                            val errorMessage = ogmiosResponse.error?.message ?: "Unknown error"
+                            Timber.e("Cardano transaction submission failed: $errorMessage")
+                            error("Failed to broadcast transaction: $errorMessage")
+                        }
+                }
+
+                HttpStatusCode.BadRequest -> {
+                    // A 400 (e.g. unknownOutputReferences) is a genuine rejection. The txid inside
+                    // unknownOutputReferences is the PARENT tx that created the spent input, not
+                    // the
+                    // tx we broadcast — returning it would report success under an unrelated hash.
+                    // Throw instead so BroadcastTxUseCase can verify our actual hash on-chain and
+                    // only treat a real duplicate submission as success.
+                    val ogmiosError =
+                        json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
+                    val errorMessage = ogmiosError.error?.message ?: "Unknown error"
+                    Timber.e("Cardano transaction submission failed: $errorMessage")
+                    error("Failed to broadcast transaction: $errorMessage")
+                }
+
+                else -> {
+                    Timber.e("Failed to broadcast Cardano transaction: ${response.status}")
+                    error("Failed to broadcast transaction: ${response.status}")
+                }
+            }
+        } catch (t: Throwable) {
+            if (t is CancellationException) throw t
+            Timber.e(t, "Failed to broadcast Cardano transaction")
+            error("Failed to broadcast transaction : ${t.message}")
         }
-        error(
-            "Failed to broadcast transaction: era boundary persisted after $SUBMIT_MAX_ATTEMPTS attempts"
-        )
     }
 
     private suspend fun getCurrentSlot(): ULong {
@@ -183,12 +166,5 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                 setBody(requestBody)
             }
         return response.bodyOrThrow<List<CardanoTxStatusResponseJson>>().firstOrNull()
-    }
-
-    private companion object {
-        // Ogmios SubmitTransactionFailure<EraMismatch>: transient near an era boundary/hard-fork.
-        const val OGMIOS_ERROR_ERA_BOUNDARY = 3005
-        const val SUBMIT_MAX_ATTEMPTS = 3
-        const val SUBMIT_RETRY_BACKOFF_MS = 2_000L
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -19,6 +19,7 @@ import io.ktor.http.path
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -88,57 +89,73 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
     }
 
     override suspend fun broadcastTransaction(chain: String, signedTransaction: String): String? {
-        return try {
-            val payload = buildJsonObject {
-                put("jsonrpc", "2.0")
-                put("method", "submitTransaction")
-                put(
-                    "params",
-                    buildJsonObject {
-                        put("transaction", buildJsonObject { put("cbor", signedTransaction) })
-                    },
-                )
-                put("id", 1)
-            }
-
-            val response = httpClient.post(ogmiosUrl) { setBody(payload) }
-
-            when (response.status) {
-                HttpStatusCode.OK -> {
-                    val ogmiosResponse = response.bodyOrThrow<OgmiosTransactionResponse>()
-
-                    ogmiosResponse.result?.transaction?.id
-                        ?: run {
-                            val errorMessage = ogmiosResponse.error?.message ?: "Unknown error"
-                            Timber.e("Cardano transaction submission failed: $errorMessage")
-                            error("Failed to broadcast transaction: $errorMessage")
-                        }
-                }
-
-                HttpStatusCode.BadRequest -> {
-                    // A 400 (e.g. unknownOutputReferences) is a genuine rejection. The txid inside
-                    // unknownOutputReferences is the PARENT tx that created the spent input, not
-                    // the
-                    // tx we broadcast — returning it would report success under an unrelated hash.
-                    // Throw instead so BroadcastTxUseCase can verify our actual hash on-chain and
-                    // only treat a real duplicate submission as success.
-                    val ogmiosError =
-                        json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
-                    val errorMessage = ogmiosError.error?.message ?: "Unknown error"
-                    Timber.e("Cardano transaction submission failed: $errorMessage")
-                    error("Failed to broadcast transaction: $errorMessage")
-                }
-
-                else -> {
-                    Timber.e("Failed to broadcast Cardano transaction: ${response.status}")
-                    error("Failed to broadcast transaction: ${response.status}")
-                }
-            }
-        } catch (t: Throwable) {
-            if (t is CancellationException) throw t
-            Timber.e(t, "Failed to broadcast Cardano transaction")
-            error("Failed to broadcast transaction : ${t.message}")
+        val payload = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", "submitTransaction")
+            put(
+                "params",
+                buildJsonObject {
+                    put("transaction", buildJsonObject { put("cbor", signedTransaction) })
+                },
+            )
+            put("id", 1)
         }
+
+        repeat(SUBMIT_MAX_ATTEMPTS) { attempt ->
+            if (attempt > 0) delay(SUBMIT_RETRY_BACKOFF_MS)
+            try {
+                val response = httpClient.post(ogmiosUrl) { setBody(payload) }
+                val ogmiosResponse =
+                    when (response.status) {
+                        HttpStatusCode.OK -> response.bodyOrThrow<OgmiosTransactionResponse>()
+                        HttpStatusCode.BadRequest ->
+                            json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
+                        else -> {
+                            Timber.e("Failed to broadcast Cardano transaction: ${response.status}")
+                            error("Failed to broadcast transaction: ${response.status}")
+                        }
+                    }
+
+                ogmiosResponse.result?.transaction?.id?.let {
+                    return it
+                }
+
+                // Ogmios 3005 (era boundary, near a hard-fork) is transient; it advises retrying.
+                if (
+                    ogmiosResponse.error?.code == OGMIOS_ERROR_ERA_BOUNDARY &&
+                        attempt < SUBMIT_MAX_ATTEMPTS - 1
+                ) {
+                    Timber.w(
+                        "Cardano submit hit era boundary (3005); retrying %d/%d",
+                        attempt + 1,
+                        SUBMIT_MAX_ATTEMPTS,
+                    )
+                    return@repeat
+                }
+
+                // Any other failure (incl. unknownOutputReferences, whose txid is the PARENT tx
+                // that
+                // created the spent input, not the tx we broadcast) is a genuine rejection. Throw
+                // so
+                // BroadcastTxUseCase verifies our actual hash on-chain rather than reporting
+                // success
+                // under an unrelated hash.
+                val errorMessage = ogmiosResponse.error?.message ?: "Unknown error"
+                Timber.e("Cardano transaction submission failed: $errorMessage")
+                error("Failed to broadcast transaction: $errorMessage")
+            } catch (t: CancellationException) {
+                throw t
+            } catch (t: IllegalStateException) {
+                // Already-formatted rejection from the error() calls above — surface as-is.
+                throw t
+            } catch (t: Throwable) {
+                Timber.e(t, "Failed to broadcast Cardano transaction")
+                error("Failed to broadcast transaction : ${t.message}")
+            }
+        }
+        error(
+            "Failed to broadcast transaction: era boundary persisted after $SUBMIT_MAX_ATTEMPTS attempts"
+        )
     }
 
     private suspend fun getCurrentSlot(): ULong {
@@ -166,5 +183,12 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                 setBody(requestBody)
             }
         return response.bodyOrThrow<List<CardanoTxStatusResponseJson>>().firstOrNull()
+    }
+
+    private companion object {
+        // Ogmios SubmitTransactionFailure<EraMismatch>: transient near an era boundary/hard-fork.
+        const val OGMIOS_ERROR_ERA_BOUNDARY = 3005
+        const val SUBMIT_MAX_ATTEMPTS = 3
+        const val SUBMIT_RETRY_BACKOFF_MS = 2_000L
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
@@ -480,28 +481,31 @@ class EvmApiImp(
         val jsonObject = response.bodyOrThrow<SendTransactionJson>()
         if (jsonObject.error != null) {
             val message = jsonObject.error.message
-            if (
-                message.contains(ERROR_KNOWN) ||
-                    message.contains(ERROR_ALREADY_KNOWN) ||
-                    message.contains(ERROR_TEMPORARILY_BANNED) ||
-                    message.contains(ERROR_NONCE_TOO_LOW_NEXT) ||
-                    message.contains(ERROR_NONCE_TOO_LOW_RANGE) ||
-                    message.contains(ERROR_TX_ALREADY_EXISTS) ||
-                    message.contains(
-                        ERROR_NONCE_TOO_LOW_ADDRESS
-                    ) || // this message happens on layer 2
-                    message.contains(ERROR_TX_IN_MEMPOOL) ||
-                    message.contains(ERROR_EXISTING_TX) ||
-                    message.contains(ERROR_TX_IN_CACHE) ||
-                    message.contains(ERROR_CODE_10055)
-            ) {
-                // even the server returns an error , but this still consider as success
-                return Numeric.hexStringToByteArray(signedTransaction).toKeccak256()
-            } else {
-                throw Exception(responseBody)
+            val localHash = Numeric.hexStringToByteArray(signedTransaction).toKeccak256()
+            return when {
+                // The node already holds our exact signed bytes, so the deterministic keccak hash
+                // is the canonical on-chain id — safe to report without re-verifying.
+                ALREADY_BROADCAST_ERRORS.any { message.contains(it) } -> localHash
+                // "nonce too low" is ambiguous: either our own tx already mined, or a DIFFERENT tx
+                // consumed the nonce (stale spec-build nonce, another wallet on the same address).
+                // Only report success if OUR hash is actually on chain; otherwise surface the
+                // error.
+                NONCE_TOO_LOW_ERRORS.any { message.contains(it) } ->
+                    if (isTxMined(localHash)) localHash else throw Exception(responseBody)
+                else -> throw Exception(responseBody)
             }
         }
         return jsonObject.result ?: error("send transaction failed")
+    }
+
+    // Confirms a specific tx hash landed by looking up its receipt (present only once mined, which
+    // is exactly the "nonce too low" case). Retries briefly to absorb receipt propagation lag.
+    private suspend fun isTxMined(txHash: String): Boolean {
+        repeat(TX_MINED_ATTEMPTS) { attempt ->
+            if (attempt > 0) delay(TX_MINED_BACKOFF_MS)
+            if (getTxStatus(txHash)?.result != null) return true
+        }
+        return false
     }
 
     override suspend fun findCustomToken(contractAddress: String): List<CustomTokenResponse> {
@@ -733,17 +737,28 @@ class EvmApiImp(
         private const val FETCH_ADDRESS_PREFIX = "0x3b3b57de"
         private const val ENS_REGISTRY_ADDRESS = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
 
-        private const val ERROR_KNOWN = "known"
-        private const val ERROR_ALREADY_KNOWN = "already known"
-        private const val ERROR_TEMPORARILY_BANNED = "Transaction is temporarily banned"
-        private const val ERROR_NONCE_TOO_LOW_NEXT = "nonce too low: next nonce"
-        private const val ERROR_NONCE_TOO_LOW_RANGE = "nonce too low. allowed nonce range:"
-        private const val ERROR_TX_ALREADY_EXISTS = "transaction already exists"
-        private const val ERROR_NONCE_TOO_LOW_ADDRESS = "nonce too low: address"
-        private const val ERROR_TX_IN_MEMPOOL = "tx already in mempool"
-        private const val ERROR_EXISTING_TX = "existing tx"
-        private const val ERROR_TX_IN_CACHE = "tx already exists in cache"
-        private const val ERROR_CODE_10055 = "code=10055"
+        // Node already has our exact signed tx; the keccak hash of our bytes is canonical.
+        // ("already known" replaces the old bare "known", which also matched "unknown …".)
+        private val ALREADY_BROADCAST_ERRORS =
+            listOf(
+                "already known",
+                "Transaction is temporarily banned",
+                "transaction already exists",
+                "tx already in mempool",
+                "existing tx",
+                "tx already exists in cache",
+                "code=10055",
+            )
+        // Nonce already consumed — verify our hash landed before treating as success.
+        private val NONCE_TOO_LOW_ERRORS =
+            listOf(
+                "nonce too low: next nonce",
+                "nonce too low. allowed nonce range:",
+                "nonce too low: address", // this message happens on layer 2
+            )
+
+        private const val TX_MINED_ATTEMPTS = 3
+        private const val TX_MINED_BACKOFF_MS = 2_000L
 
         // OP-stack GasPriceOracle predeploy, identical across all OP-stack L2s.
         private const val OP_STACK_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -484,13 +484,18 @@ class EvmApiImp(
             val localHash = Numeric.hexStringToByteArray(signedTransaction).toKeccak256()
             return when {
                 // The node already holds our exact signed bytes, so the deterministic keccak hash
-                // is the canonical on-chain id — safe to report without re-verifying.
+                // is the canonical on-chain id — safe to report without re-verifying. Match the
+                // "known" concept case-insensitively ("already known", "known transaction: 0x…")
+                // while excluding the "unknown sender/block/method" collision, which is a real
+                // rejection.
+                message.contains("known", ignoreCase = true) &&
+                    !message.contains("unknown", ignoreCase = true) -> localHash
                 ALREADY_BROADCAST_ERRORS.any { message.contains(it) } -> localHash
-                // "nonce too low" is ambiguous: either our own tx already mined, or a DIFFERENT tx
-                // consumed the nonce (stale spec-build nonce, another wallet on the same address).
-                // Only report success if OUR hash is actually on chain; otherwise surface the
-                // error.
-                NONCE_TOO_LOW_ERRORS.any { message.contains(it) } ->
+                // Ambiguous errors: our own tx may have mined, or a DIFFERENT tx consumed the nonce
+                // (stale spec-build nonce, another wallet), or the tx-pool banned a permanently
+                // invalid tx. Only report success if OUR hash is actually on chain; otherwise
+                // surface the error.
+                VERIFY_BEFORE_SUCCESS_ERRORS.any { message.contains(it) } ->
                     if (isTxMined(localHash)) localHash else throw Exception(responseBody)
                 else -> throw Exception(responseBody)
             }
@@ -738,23 +743,22 @@ class EvmApiImp(
         private const val ENS_REGISTRY_ADDRESS = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
 
         // Node already has our exact signed tx; the keccak hash of our bytes is canonical.
-        // ("already known" replaces the old bare "known", which also matched "unknown …".)
         private val ALREADY_BROADCAST_ERRORS =
             listOf(
-                "already known",
-                "Transaction is temporarily banned",
                 "transaction already exists",
                 "tx already in mempool",
                 "existing tx",
                 "tx already exists in cache",
                 "code=10055",
             )
-        // Nonce already consumed — verify our hash landed before treating as success.
-        private val NONCE_TOO_LOW_ERRORS =
+        // Ambiguous — the nonce may be consumed by a different tx, or the tx-pool bans permanently
+        // invalid txs (Substrate), so verify our hash landed before treating as success.
+        private val VERIFY_BEFORE_SUCCESS_ERRORS =
             listOf(
                 "nonce too low: next nonce",
                 "nonce too low. allowed nonce range:",
                 "nonce too low: address", // this message happens on layer 2
+                "Transaction is temporarily banned",
             )
 
         private const val TX_MINED_ATTEMPTS = 3

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
@@ -178,7 +178,13 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
         return try {
             httpClient
                 .post(tronGrid) {
-                    url { path("tron", "walletsolidity", "gettransactionbyid") }
+                    // Full node (`wallet`), not `walletsolidity`: the solidified node only returns
+                    // a
+                    // tx after ~60s of confirmations, far longer than the recovery verify window,
+                    // so
+                    // it would report a just-broadcast tx as a failure. The full node returns it as
+                    // soon as it is accepted.
+                    url { path("tron", "wallet", "gettransactionbyid") }
                     setBody(mapOf("value" to txHash))
                 }
                 .bodyOrThrow<TronTransactionStatusResponse?>()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -191,7 +191,9 @@ constructor(
                             .broadcastTransaction(chain.name, tx.rawTransaction)
                             .orKnownHash(tx)
                     },
-                    verify = { hash -> cardanoApi.getTxStatus(hash)?.txHash?.isNotBlank() == true },
+                    // Koios tx_status echoes the queried hash back even for unknown txs, so
+                    // txHash is never blank; only a positive confirmation count proves it landed.
+                    verify = { hash -> (cardanoApi.getTxStatus(hash)?.numConfirmations ?: 0) > 0 },
                 )
         }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -81,40 +81,4 @@ class CardanoApiBroadcastTest {
             runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
         }
     }
-
-    // Ogmios 3005 (EraMismatch) is transient near a hard-fork; Ogmios advises retrying.
-    private val eraBoundaryError =
-        """{"error":{"code":3005,"message":"Failed to submit the transaction in the current era."}}"""
-
-    @Test
-    fun `broadcastTransaction retries era boundary (3005) and succeeds`() = runTest {
-        val api =
-            CardanoApiImpl(
-                httpClient =
-                    MockHttpClient.respondingWithSequence(
-                        HttpStatusCode.BadRequest to eraBoundaryError,
-                        HttpStatusCode.OK to """{"result":{"transaction":{"id":"abc123"}}}""",
-                    ),
-                json = json,
-            )
-
-        assertEquals(
-            "abc123",
-            api.broadcastTransaction(chain = "cardano", signedTransaction = "00"),
-        )
-    }
-
-    @Test
-    fun `broadcastTransaction throws when era boundary (3005) persists`() {
-        val api =
-            CardanoApiImpl(
-                httpClient =
-                    MockHttpClient.respondingWith(HttpStatusCode.BadRequest, eraBoundaryError),
-                json = json,
-            )
-
-        assertThrows(IllegalStateException::class.java) {
-            runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
-        }
-    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -81,4 +81,40 @@ class CardanoApiBroadcastTest {
             runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
         }
     }
+
+    // Ogmios 3005 (EraMismatch) is transient near a hard-fork; Ogmios advises retrying.
+    private val eraBoundaryError =
+        """{"error":{"code":3005,"message":"Failed to submit the transaction in the current era."}}"""
+
+    @Test
+    fun `broadcastTransaction retries era boundary (3005) and succeeds`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWithSequence(
+                        HttpStatusCode.BadRequest to eraBoundaryError,
+                        HttpStatusCode.OK to """{"result":{"transaction":{"id":"abc123"}}}""",
+                    ),
+                json = json,
+            )
+
+        assertEquals(
+            "abc123",
+            api.broadcastTransaction(chain = "cardano", signedTransaction = "00"),
+        )
+    }
+
+    @Test
+    fun `broadcastTransaction throws when era boundary (3005) persists`() {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(HttpStatusCode.BadRequest, eraBoundaryError),
+                json = json,
+            )
+
+        assertThrows(IllegalStateException::class.java) {
+            runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
+        }
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
  * pin the behavior that must be preserved across the body-read changes:
  * - **200 OK**: parsed via `body<OgmiosTransactionResponse>()` → `bodyOrThrow<...>()` — returns the
  *   transaction id.
- * - **400 BadRequest**: the error body is parsed (must not throw) to recover an already-known
- *   output reference — switches from `body<...>()` to a non-throwing
- *   `json.decodeFromString(bodyAsText())`.
- * - **400 BadRequest without recoverable reference**: surfaces an [IllegalStateException].
+ * - **400 BadRequest**: a genuine rejection. The txid in `unknownOutputReferences` is the PARENT tx
+ *   that created the spent input, not the tx we broadcast, so it must NOT be returned as success —
+ *   the error is surfaced ([IllegalStateException]) and `BroadcastTxUseCase` verifies our actual
+ *   hash on-chain instead (issue #5250).
  */
 class CardanoApiBroadcastTest {
 
@@ -45,7 +45,9 @@ class CardanoApiBroadcastTest {
     }
 
     @Test
-    fun `broadcastTransaction recovers id from unknownOutputReferences on BadRequest`() = runTest {
+    fun `broadcastTransaction throws on BadRequest with unknownOutputReferences`() {
+        // The txid inside unknownOutputReferences is the parent tx, not ours — returning it would
+        // report success under an unrelated hash, so this must surface as a rejection.
         val body =
             """
             {
@@ -59,9 +61,9 @@ class CardanoApiBroadcastTest {
                 .trimIndent()
         val api = newApi(HttpStatusCode.BadRequest, body)
 
-        val result = api.broadcastTransaction(chain = "cardano", signedTransaction = "00")
-
-        assertEquals("def456", result)
+        assertThrows(IllegalStateException::class.java) {
+            runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
+        }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBroadcastTest.kt
@@ -1,0 +1,74 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import io.ktor.http.HttpStatusCode
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Broadcast dedup/recovery behavior for [EvmApiImp.sendTransaction] (issue #5250): a dedup
+ * rejection must not be reported as success unless our actual tx is confirmed on-chain, and the old
+ * bare "known" substring (which also matched "unknown …") must no longer swallow rejections.
+ */
+class EvmApiBroadcastTest {
+
+    // Arbitrary signed-tx bytes; sendTransaction returns keccak256 of these on a dedup hit.
+    private val signedTx = "02f8"
+
+    private fun api(client: io.ktor.client.HttpClient) =
+        EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+    private fun errorResponse(message: String) =
+        HttpStatusCode.OK to """{"result":null,"error":{"message":"$message"}}"""
+
+    private fun receiptResponse(result: String) =
+        HttpStatusCode.OK to """{"id":1,"result":$result}"""
+
+    @Test
+    fun `already known is treated as success without an on-chain check`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(HttpStatusCode.OK, errorResponse("already known").second)
+        val hash = api(client).sendTransaction(signedTx)
+        assert(hash.startsWith("0x")) { "expected a keccak hash, got $hash" }
+    }
+
+    @Test
+    fun `unknown sender rejection is surfaced, not swallowed`() = runTest {
+        // "unknown sender" contains "known" — the old bare match wrongly reported it as success.
+        val client =
+            MockHttpClient.respondingWith(HttpStatusCode.OK, errorResponse("unknown sender").second)
+        assertFailsWith<Exception> { api(client).sendTransaction(signedTx) }
+    }
+
+    @Test
+    fun `nonce too low is success only when our hash is actually mined`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                errorResponse("nonce too low: next nonce 5"),
+                receiptResponse("""{"status":"0x1"}"""),
+            )
+        val hash = api(client).sendTransaction(signedTx)
+        assert(hash.startsWith("0x"))
+    }
+
+    @Test
+    fun `nonce too low is surfaced when our hash never lands (different tx consumed the nonce)`() =
+        runTest {
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    errorResponse("nonce too low: next nonce 5"),
+                    receiptResponse("null"), // receipt absent on every verify attempt
+                )
+            assertFailsWith<Exception> { api(client).sendTransaction(signedTx) }
+        }
+
+    @Test
+    fun `plain success returns the node-provided hash`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(HttpStatusCode.OK, """{"result":"0xabc","error":null}""")
+        assertEquals("0xabc", api(client).sendTransaction(signedTx))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBroadcastTest.kt
@@ -44,10 +44,27 @@ class EvmApiBroadcastTest {
     }
 
     @Test
+    fun `known transaction hash variant is treated as success without an on-chain check`() =
+        runTest {
+            // geth/Erigon emit "known transaction: 0x…"; the old bare "known" caught it, exact
+            // "already known" did not. Must stay a success (our exact bytes are already held).
+            val client =
+                MockHttpClient.respondingWith(
+                    HttpStatusCode.OK,
+                    errorResponse("known transaction: 0xabc").second,
+                )
+            val hash = api(client).sendTransaction(signedTx)
+            assert(hash.startsWith("0x")) { "expected a keccak hash, got $hash" }
+        }
+
+    @Test
     fun `nonce too low is success only when our hash is actually mined`() = runTest {
+        // error, then not-yet-mined (null receipt), then mined — exercises the retry loop so a
+        // regression to a single attempt or broken backoff fails.
         val client =
             MockHttpClient.respondingWithSequence(
                 errorResponse("nonce too low: next nonce 5"),
+                receiptResponse("null"),
                 receiptResponse("""{"status":"0x1"}"""),
             )
         val hash = api(client).sendTransaction(signedTx)


### PR DESCRIPTION
## Summary
The per-chain broadcast dedup heuristics accepted string evidence without an on-chain check, so genuine rejections could surface as success (issue #5250). This fixes the four self-contained cases:

- **EVM — bare `"known"` matched `"unknown"`** (`EvmApi.kt`): dropped the bare `"known"` substring, which also matched `"unknown sender/block/method"`. Such rejections now surface as failures instead of a fabricated success hash.
- **EVM — `"nonce too low"` accepted blind** (`EvmApi.kt`): *already-known* errors (our exact signed bytes are already held → the keccak hash is canonical) still return immediately; *nonce-too-low* is ambiguous (a **different** tx may have consumed the nonce), so we now confirm our own hash has a receipt (`isTxMined`, 3× retry) before reporting success, otherwise surface the error.
- **Cardano — recovery returned the wrong hash** (`CardanoApi.kt`): a 400 no longer extracts the parent txid from `unknownOutputReferences` (an unrelated outpoint reference). It throws so `BroadcastTxUseCase` verifies our *actual* `transactionHash` on-chain.
- **Tron — verify window couldn't work** (`TronApi.kt`): verify now hits the full node (`wallet/gettransactionbyid`) instead of `walletsolidity` (~60s solidify lag > the ~4–6s verify loop), so a just-broadcast tx confirms instead of false-failing.

### Deferred (need dedicated changes, not partial patches)
- **Sui**: the digest isn't precomputable from the raw tx, so `transactionHash` is blank and recovery structurally can't work — needs SDK support to expose the digest pre-broadcast.
- **Cosmos/QBTC code-32 joined-device recovery**: the blind trust lives in `BroadcastKeysignUseCase.recoverJoinedDeviceBroadcast` (sync, no API access). Doing it right means moving the on-chain verify into `BroadcastTxUseCase` and removing the separate joined-device path — a behavioral refactor of a money-path use case with existing tests.

## Issue
Refs #5250

## Test Plan
- [x] New unit tests: `EvmApiBroadcastTest` (5 cases — already-known, unknown-sender surfaced, nonce-too-low mined vs. not-mined, plain success)
- [x] `./gradlew :data:testDebugUnitTest` passes
- [ ] Lint passes (CI)
- [ ] Debug build succeeds (CI)

On chain txs: 
EVM: https://etherscan.io/tx/0xb3458c8dc8c79cf2f2fd6df24291e27a4c2bcb5393c5c3bf8d10e71558b635c6
Tron: https://tronscan.org/#/transaction/e6658f1b78a04af297d52e76e38f2e00b11f8e11323dc90a1e5401db30838469
Cardano: https://cardanoscan.io/transaction/c8c32f265bbbf8246234e3bbb1ea04c999ca71da5278f894e518a04eacf338f2
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM transaction broadcast handling for already-broadcast and “nonce too low” cases, including receipt verification when needed.
  * Updated Cardano broadcast behavior so BadRequest with `unknownOutputReferences` is treated as a real rejection (not a success).
  * Refined Cardano confirmation checks to rely on actual confirmation count.
  * Improved Tron transaction status checks by querying the correct full-node endpoint.
  * Enhanced ERC-20 approval broadcast fallback to reduce failures during duplicate-broadcast races.
* **Tests**
  * Added EVM broadcast recovery/deduplication coverage and tightened rejection/confirmation scenarios.
  * Updated Cardano broadcast tests to match the new rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->