### PR TITLE
fix(ton): apply wallet-level bounceable to every TonConnect message

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -213,6 +213,73 @@ class ChainHelpersTest {
         assertEquals("", signingInput.getMessages(1).customPayload)
     }
 
+    /**
+     * Regression for the STON.fi swap that never finished co-signing: every TonConnect message must
+     * carry the wallet-level `tonSpecific.bounceable` flag, NOT a per-address value derived from
+     * the EQ/UQ friendly-address tag. The initiating device (browser extension / desktop) applies
+     * the global flag when it builds the DKLS setup message, so a co-signer that derived
+     * bounceability per-address produced a different pre-image hash — and therefore a different md5
+     * message-id — for any message sent to a UQ (non-bounceable) address, 404ing on the setup
+     * message forever.
+     */
+    @Test
+    fun tonConnectBounceableFollowsWalletFlagNotAddressPrefix() {
+        val coin =
+            Coin(
+                chain = "Ton",
+                ticker = "TON",
+                address = "UQCmBAnvlatV6yLWm391BEFTWP7jZX5mUFJ4Dc5TJAnvVgYi",
+                decimals = 9,
+                priceProviderId = "the-open-network",
+                isNativeToken = true,
+                hexPublicKey = HEX_PUBLIC_KEY_EDDSA,
+                logo = "ton",
+            )
+        val blockchainSpecific =
+            BlockchainSpecific(
+                tonSpecific =
+                    TonSpecific(
+                        sendMaxAmount = false,
+                        sequenceNumber = 0L,
+                        expireAt = 1753579977L,
+                        bounceable = true,
+                    )
+            )
+        // First goes to an EQ (bounceable) address, second to a UQ (non-bounceable) address — the
+        // per-address logic would have flagged these true/false; the wallet flag makes both true.
+        val destEq = "EQDa4VOnTYlLvDJ0gZjNYm5PXfSmmtL6Vs6A_CZEtXCNICq_"
+        val destUq = "UQCmBAnvlatV6yLWm391BEFTWP7jZX5mUFJ4Dc5TJAnvVgYi"
+
+        val payload =
+            KeysignPayload(
+                    coin = coin,
+                    toAddress = "",
+                    toAmount = "0",
+                    blockchainSpecific = blockchainSpecific,
+                    signData =
+                        SignData(
+                            signTon =
+                                SignTon(
+                                    tonMessages =
+                                        listOf(
+                                            TonMessage(to = destEq, amount = "37100000000"),
+                                            TonMessage(to = destUq, amount = "1000000"),
+                                        )
+                                )
+                        ),
+                    vaultPublicKeyEcdsa = HEX_PUBLIC_KEY,
+                    libType = "DKLS",
+                )
+                .toInternalKeySignPayload()
+
+        val inputData = TonHelper.getPreSignedInputData(payload)
+        val signingInput = TheOpenNetwork.SigningInput.parseFrom(inputData)
+
+        assertEquals(2, signingInput.messagesCount)
+        assertEquals(true, signingInput.getMessages(0).bounceable)
+        assertEquals(true, signingInput.getMessages(1).bounceable)
+    }
+
     @Test
     fun sendCosmosTest() {
         val transactions: List<TransactionData> = loadTransactionData(COSMOS_JSON_FILE)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPool.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPool.kt
@@ -60,4 +60,21 @@ object TonNominatorPool {
 
     /** Minimum deposit (in nanotons) for a pool whose `min_stake` is [minStakeNano]. */
     fun minimumDeposit(minStakeNano: BigInteger): BigInteger = minStakeNano + DEPOSIT_COMMISSION
+
+    /** Every deposit/withdraw comment across supported implementations. */
+    private val TRANSFER_COMMENTS: Set<String> =
+        setOfNotNull(
+            depositComment(IMPLEMENTATION_WHALES),
+            withdrawComment(IMPLEMENTATION_WHALES),
+            depositComment(IMPLEMENTATION_TF),
+            withdrawComment(IMPLEMENTATION_TF),
+        )
+
+    /**
+     * Whether [memo] is a nominator-pool deposit/withdraw comment. Such messages MUST be sent
+     * bounceable (see the class docs) so a message the pool rejects returns instead of being
+     * absorbed; the signing layer forces the bounce flag for these — matching the initiating device
+     * — so every co-signer reproduces an identical pre-image hash.
+     */
+    fun isTransferComment(memo: String?): Boolean = memo != null && memo in TRANSFER_COMMENTS
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.data.crypto
 
 import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.blockchain.ton.TonNominatorPool
 import com.vultisig.wallet.data.common.toHexByteArray
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SignedTransactionResult
@@ -113,11 +114,18 @@ object TonHelper {
 
         val mode = calculateSendMode(tonSpecific.sendMaxAmount)
 
+        // Nominator-pool deposits/withdrawals MUST be sent bounceable so a message the pool
+        // rejects (e.g. an uninitialized or mis-funded pool) bounces back instead of being
+        // absorbed (lost). tonSpecific.bounceable resolves to false for an uninitialized
+        // destination, so force the flag for pool comments — matching the initiating device
+        // which does the same — otherwise the pre-image hash diverges and the joiner 404s.
+        val bounceable = tonSpecific.bounceable || TonNominatorPool.isTransferComment(payload.memo)
+
         return TheOpenNetwork.Transfer.newBuilder()
             .setDest(toAddress.description())
             .setAmount(ByteString.copyFrom(amount.toHexString().toHexByteArray()))
             .setMode(mode)
-            .setBounceable(tonSpecific.bounceable)
+            .setBounceable(bounceable)
             .apply { payload.memo?.let { setComment(it) } }
             .build()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
@@ -83,15 +83,14 @@ object TonHelper {
         val toAddress = AnyAddress(msg.to, CoinType.TON)
         val amount = msg.amount.toLongOrNull() ?: 0L
         val mode = calculateSendMode(sendMaxAmount = false)
-        // TonConnect addresses encode bounceability in the user-friendly prefix:
-        // EQ = bounceable, UQ = non-bounceable. Raw "workchain:hex" form has no flag,
-        // so fall back to the wallet's default.
-        val bounceable =
-            when {
-                msg.to.startsWith("EQ") -> true
-                msg.to.startsWith("UQ") -> false
-                else -> tonSpecific.bounceable
-            }
+        // Apply the wallet-level bounceable flag from tonSpecific to every TonConnect message,
+        // matching the initiating device (browser extension / desktop) which builds the setup
+        // message that all co-signers must reproduce. It does NOT derive bounceability per-address
+        // from the EQ/UQ friendly-address tag. Deriving it per-address here diverged the pre-image
+        // hash from the initiator whenever a message targeted a UQ (non-bounceable) address — e.g.
+        // STON.fi's self/peer message in a swap — so the md5 message-id differed, the joiner 404'd
+        // on the setup message, and co-signing never completed.
+        val bounceable = tonSpecific.bounceable
 
         return TheOpenNetwork.Transfer.newBuilder()
             .setDest(toAddress.description())

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPoolTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ton/TonNominatorPoolTest.kt
@@ -47,4 +47,20 @@ internal class TonNominatorPoolTest {
     fun `withdraw fee is fixed at 0_2 TON`() {
         assertEquals(BigInteger.valueOf(200_000_000L), TonNominatorPool.WITHDRAW_FEE)
     }
+
+    @Test
+    fun `all deposit and withdraw comments are recognized as transfer comments`() {
+        assertTrue(TonNominatorPool.isTransferComment("Deposit"))
+        assertTrue(TonNominatorPool.isTransferComment("Withdraw"))
+        assertTrue(TonNominatorPool.isTransferComment("d"))
+        assertTrue(TonNominatorPool.isTransferComment("w"))
+    }
+
+    @Test
+    fun `non-pool memos are not transfer comments`() {
+        assertFalse(TonNominatorPool.isTransferComment(null))
+        assertFalse(TonNominatorPool.isTransferComment(""))
+        assertFalse(TonNominatorPool.isTransferComment("hello"))
+        assertFalse(TonNominatorPool.isTransferComment("deposit")) // case-sensitive
+    }
 }


### PR DESCRIPTION
**Proof (fixed swap, broadcast on-chain):** https://tonviewer.com/transaction/1f88b7cd71d55f9c544e2f3937dfed5a1772652ea606b64039574f6a11cec28e

## Problem

Multi-message TonConnect swaps initiated from the browser extension (e.g. a STON.fi swap) never finished co-signing. The mobile co-signer sat forever on `GET /router/setup-message` returning `404`, and the signing spinner never resolved.

## Root cause

In DKLS keysign the setup message is stored under a key of `md5(pre-image-hash)`. The initiator uploads under `md5(its hash)`; each co-signer fetches under `md5(its own hash)`. If a co-signer computes a **different** pre-image hash than the initiator, it polls a message-id that was never uploaded and 404s indefinitely.

The hashes diverged on the TON `bounceable` flag:

- **Initiator (browser extension / desktop)** applies the single wallet-level `tonSpecific.bounceable` to **every** TonConnect message.
- **Android** derived `bounceable` **per-message** from the friendly-address tag (`EQ → true`, `UQ → false`).

A swap whose message targets a `UQ` (non-bounceable) address — STON.fi attaches a self/peer message to a `UQ...` address — made Android flip that transfer to `bounceable=false` while the initiator kept `true`. Different transfer cell → different pre-image hash → different `md5` message-id → permanent `404` on the setup message.

Multi-message TonConnect is only ever initiated by the extension/desktop, so mobile is always the co-signer and must reproduce the initiator's hash.

## Fix

`TonHelper.buildTonConnectTransfer` now uses `tonSpecific.bounceable` for every TonConnect transfer instead of parsing the `EQ`/`UQ` prefix, matching the initiator's signing input byte-for-byte.

## Test plan

- Added `tonConnectBounceableFollowsWalletFlagNotAddressPrefix` regression: a `bounceable=true` payload whose second message targets a `UQ` address now yields `bounceable=true` on both transfers (previously `false` on the `UQ` one).
- Existing `tonConnectPayloadAndStateInitAreThreadedIntoSigningInput` and `sendTONTest` still pass (unaffected — they use `bounceable=false`).
- Verified end-to-end: STON.fi GRAM→USDT swap now signs and broadcasts (proof link above).

## Cross-platform note

iOS `Ton.swift` `isBounceable` has the same per-address derivation and would hit the same `404` co-signing an extension-initiated `UQ` swap. Tracking a matching iOS fix separately so all platforms stay hash-consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TON Connect transfers to consistently use the wallet’s bounceable setting for all signing messages, without deriving bounceability from destination address prefixes.
  * Improved nominator-pool comment transfers so bounceable is correctly set based on both the wallet/TON setting and supported comment types.
* **Tests**
  * Added a regression instrumentation test to verify bounceable behavior in TON signing payloads.
  * Expanded unit test coverage for recognizing valid nominator-pool transfer comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->