### PR TITLE
fix(swap): enable 1inch and KyberSwap on Base (#5255, #5256)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapProviderTable.kt
@@ -104,10 +104,12 @@ constructor(private val poolEligibility: SwapPoolEligibilityRepository) : SwapPr
                     thorchainPlusEvmAggregators
                 else evmAggregators
 
+            // 1inch (#5256) and KyberSwap (#5255) are same-chain aggregators live-confirmed on
+            // Base; iOS and the SDK both offer them here. This makes Base match the BSC/Avalanche
+            // EVM arm.
             Chain.Base ->
-                if (isThorEligible(Chain.Base, ticker, thorBaseTokens))
-                    setOf(SwapProvider.LIFI, SwapProvider.THORCHAIN, SwapProvider.SWAPKIT)
-                else setOf(SwapProvider.LIFI, SwapProvider.SWAPKIT)
+                if (isThorEligible(Chain.Base, ticker, thorBaseTokens)) thorchainPlusEvmAggregators
+                else evmAggregators
 
             Chain.Optimism,
             Chain.Polygon -> evmAggregators


### PR DESCRIPTION
## Summary
Base's arm in `SwapProviderTable.providersFor` has offered only LIFI/THORCHAIN/SWAPKIT since the table was created (#4313), while **iOS and the SDK both quote 1inch and KyberSwap on Base**. Android Base users were missing two live-confirmed same-chain aggregators for no documented reason.

Fixes #5255 (KyberSwap) and #5256 (1inch) — same file, same one-line arm, so bundled.

## Change
Both 1inch and Kyber are `sameChainOnly` aggregators. Adding them makes the Base arm identical to the existing BSC/Avalanche EVM pattern, so the arm now just reuses the shared `thorchainPlusEvmAggregators` / `evmAggregators` sets instead of a bespoke set literal:

```kotlin
Chain.Base ->
    if (isThorEligible(Chain.Base, ticker, thorBaseTokens)) thorchainPlusEvmAggregators
    else evmAggregators
```

- No cross-chain surface change: both providers are filtered out of cross-chain pairs via `sameChainOnly` in `eligibleProvidersFor`.
- Android's 1inch layer already maps `Chain.Base → 8453`; only the table lagged.

## Test plan
- [x] `SwapProviderTableTest` passes (SWAPKIT/THORCHAIN branches unaffected).
- [ ] Sanity-check one live Base 1inch and one live Base Kyber quote before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

on chain tx link: https://basescan.org/tx/0xd45e86f9fb97027c7403dad7e3c0d10820d9565f98780e4c536d89e8a62b247f
https://basescan.org/tx/0x9200b920eda30912df445d5a9748b0d5a623f2948f9c54586eb736c5f13cb1d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap provider selection on the Base network.
  - Added support for same-chain swaps through 1inch and KyberSwap when applicable.
  - Base now follows the same provider-routing behavior as other supported EVM networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->