### PR TITLE
fix(thorchain): read on-chain sRUJI receipt for Staked RUJI amount

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -438,14 +438,25 @@ constructor(
             throw Exception("Could not fetch balances: ${response.errors}")
         }
 
-        val stake = response.data?.node?.stakingV2?.firstOrNull() ?: return RujiStakeBalances()
+        // stakingV2 can hold several positions (e.g. TCY and RUJI); pick the RUJI one rather than
+        // the first, or the amount/rewards get read from an unrelated position.
+        val stake =
+            response.data?.node?.stakingV2?.firstOrNull {
+                it.bonded.asset.metadata?.symbol.equals(RUJI_STAKE_SYMBOL, ignoreCase = true)
+            }
 
-        val stakeAmount = stake.bonded.amount.toBigIntegerOrNull() ?: BigInteger.ZERO
-        val stakeTicker = stake.bonded.asset.metadata?.symbol ?: ""
-        val rewardsAmount = stake.pendingRevenue?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
-        val rewardsTicker = stake.pendingRevenue?.asset?.metadata?.symbol ?: DEFAULT_REWARDS_TICKER
+        val bondedAmount = stake?.bonded?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        // The on-chain x/staking-x/ruji receipt is the source of truth for what the vault holds;
+        // the GraphQL `bonded` field can report 0 even when receipts are held. Prefer the receipt
+        // (a successful zero stays zero), falling back to `bonded` only when the balance read
+        // failed. Mirrors vultisig-windows #4337.
+        val stakeAmount = readRujiReceiptBalance(address) ?: bondedAmount
+
+        val stakeTicker = stake?.bonded?.asset?.metadata?.symbol ?: RUJI_STAKE_SYMBOL
+        val rewardsAmount = stake?.pendingRevenue?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        val rewardsTicker = stake?.pendingRevenue?.asset?.metadata?.symbol ?: DEFAULT_REWARDS_TICKER
         val apr =
-            runCatching { (stake.pool?.summary?.apr?.value ?: "0.0").toDouble() }.getOrDefault(0.0)
+            runCatching { (stake?.pool?.summary?.apr?.value ?: "0.0").toDouble() }.getOrDefault(0.0)
 
         return RujiStakeBalances(
             stakeAmount = stakeAmount,
@@ -455,6 +466,26 @@ constructor(
             apr = apr,
         )
     }
+
+    /**
+     * Reads the on-chain sRUJI staking-receipt balance (denom [STAKING_RUJI_DENOM]) for the given
+     * THORChain address. Mirrors how sTCY derives its amount from the receipt denom. Returns
+     * [BigInteger.ZERO] when the balance read succeeds but no receipt is held (a genuine zero), and
+     * `null` only when the read fails — so the caller can distinguish a real zero from an unknown
+     * balance and fall back to the GraphQL `bonded` amount only in the latter case.
+     */
+    private suspend fun readRujiReceiptBalance(address: String): BigInteger? =
+        try {
+            getBalance(address)
+                .firstOrNull { it.denom == STAKING_RUJI_DENOM }
+                ?.amount
+                ?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to read on-chain RUJI receipt balance; falling back to bonded")
+            null
+        }
 
     override suspend fun existsReferralCode(code: String): Boolean {
         val response =
@@ -727,6 +758,8 @@ constructor(
         }
         """
         private const val STAKING_TCY_DENOM = "x/staking-tcy"
+        private const val STAKING_RUJI_DENOM = "x/staking-x/ruji"
+        private const val RUJI_STAKE_SYMBOL = "RUJI"
         private const val DEFAULT_REWARDS_TICKER = "USDC"
         private const val THOR_CHAIN_NAME = "THOR"
         private const val TCY_STAKER_NOT_FOUND_ERROR = "TCYStaker doesn't exist"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -476,10 +476,23 @@ constructor(
      */
     private suspend fun readRujiReceiptBalance(address: String): BigInteger? =
         try {
-            getBalance(address)
-                .firstOrNull { it.denom == STAKING_RUJI_DENOM }
-                ?.amount
-                ?.toBigIntegerOrNull() ?: BigInteger.ZERO
+            val receipt = getBalance(address).firstOrNull { it.denom == STAKING_RUJI_DENOM }
+            when {
+                // No receipt held: a genuine zero balance.
+                receipt == null -> BigInteger.ZERO
+                // Receipt held but its amount is unparseable: treat as a read failure so the
+                // caller falls back to the GraphQL `bonded` amount rather than reporting a false
+                // zero.
+                else ->
+                    receipt.amount.toBigIntegerOrNull()
+                        ?: run {
+                            Timber.w(
+                                "RUJI receipt amount '%s' is unparseable; falling back to bonded",
+                                receipt.amount,
+                            )
+                            null
+                        }
+            }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -257,7 +257,9 @@ constructor(
 }
 
 // Denoms surfaced under the DeFi tab — must not be auto-discovered as wallet tokens.
-internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji")
+// The on-chain sRUJI receipt denom is "x/staking-x/ruji"; the legacy "x/staking-ruji" spelling is
+// kept defensively so the receipt stays excluded regardless of which the node reports.
+internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji", "x/staking-x/ruji")
 
 /**
  * Decodes the result of an ERC-20 `name()` / `symbol()` `eth_call` into text.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
@@ -383,6 +383,24 @@ class ThorChainApiImplTest {
         }
 
     @Test
+    fun `getRujiStakeBalance falls back to bonded when the receipt amount is unparseable`() =
+        runBlocking {
+            // The receipt entry exists but carries a garbage amount: this is a read failure, not a
+            // genuine zero, so we fall back to the GraphQL bonded amount rather than reporting
+            // zero.
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBody(bondedAmount = "42"),
+                    balancesBody =
+                        """{"balances":[{"denom":"x/staking-x/ruji","amount":"not-a-number"}]}""",
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger("42"), result.stakeAmount)
+        }
+
+    @Test
     fun `getRujiStakeBalance falls back to the RUJI position not TCY when the balances read fails`() =
         runBlocking {
             // Real-world shape: TCY position (bonded 0) precedes RUJI in stakingV2. When the

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
@@ -3,8 +3,19 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.appendIfNameAbsent
 import io.mockk.mockk
+import java.math.BigInteger
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -24,6 +35,9 @@ class ThorChainApiImplTest {
         ignoreUnknownKeys = true
         explicitNulls = false
     }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
 
     private fun newApi(httpStatus: HttpStatusCode, body: String): ThorChainApi =
         ThorChainApiImpl(
@@ -232,6 +246,176 @@ class ThorChainApiImplTest {
             ex.message?.startsWith(CosmosBroadcastException.SEQUENCE_MISMATCH_MARKER) == true,
         )
     }
+
+    /**
+     * Builds a [ThorChainApi] whose transport routes the RUJI GraphQL stake POST and the Cosmos
+     * bank balances GET to distinct bodies, so `getRujiStakeBalance` can be exercised end-to-end.
+     */
+    private fun newRujiApi(
+        stakeBody: String,
+        balancesBody: String,
+        balancesStatus: HttpStatusCode = HttpStatusCode.OK,
+    ): ThorChainApi {
+        val client =
+            HttpClient(
+                MockEngine { request ->
+                    if (request.url.encodedPath.contains("/balances/")) {
+                        respond(balancesBody, balancesStatus, jsonHeaders)
+                    } else {
+                        respond(stakeBody, HttpStatusCode.OK, jsonHeaders)
+                    }
+                }
+            ) {
+                install(ContentNegotiation) { json(json, ContentType.Any) }
+                install(DefaultRequest) {
+                    headers.appendIfNameAbsent(
+                        HttpHeaders.ContentType,
+                        ContentType.Application.Json.toString(),
+                    )
+                }
+            }
+        return ThorChainApiImpl(
+            httpClient = client,
+            thorChainSwapQuoteResponseJsonSerializer =
+                mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
+            json = json,
+        )
+    }
+
+    private fun rujiStakeBody(bondedAmount: String): String =
+        """
+        {
+          "data": {
+            "node": {
+              "merge": null,
+              "stakingV2": [
+                {
+                  "account": "thor1abc",
+                  "bonded": { "amount": "$bondedAmount", "asset": { "metadata": { "symbol": "RUJI" } } },
+                  "pendingRevenue": { "amount": "500", "asset": { "metadata": { "symbol": "USDC" } } },
+                  "pool": { "mergeAsset": null, "summary": { "apr": { "value": "0.12" } } }
+                }
+              ]
+            }
+          }
+        }
+        """
+            .trimIndent()
+
+    /**
+     * Mirrors the real Rujira response for a vault that stakes both TCY and RUJI: stakingV2 lists
+     * the TCY position first (with bonded 0), then the RUJI position. `getRujiStakeBalance` must
+     * pick the RUJI entry, not the first one.
+     */
+    private fun rujiStakeBodyWithTcyFirst(bondedRuji: String): String =
+        """
+        {
+          "data": {
+            "node": {
+              "merge": null,
+              "stakingV2": [
+                {
+                  "account": "thor1abc",
+                  "bonded": { "amount": "0", "asset": { "metadata": { "symbol": "TCY" } } },
+                  "pendingRevenue": { "amount": "999", "asset": { "metadata": { "symbol": "USDC" } } },
+                  "pool": { "mergeAsset": null, "summary": { "apr": { "value": "0.05" } } }
+                },
+                {
+                  "account": "thor1abc",
+                  "bonded": { "amount": "$bondedRuji", "asset": { "metadata": { "symbol": "RUJI" } } },
+                  "pendingRevenue": { "amount": "500", "asset": { "metadata": { "symbol": "USDC" } } },
+                  "pool": { "mergeAsset": null, "summary": { "apr": { "value": "0.12" } } }
+                }
+              ]
+            }
+          }
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun `getRujiStakeBalance prefers on-chain receipt balance over bonded when receipts are held`() =
+        runBlocking {
+            // bonded reads 0 (the reported bug), but the vault holds sRUJI receipts on-chain.
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBody(bondedAmount = "0"),
+                    balancesBody =
+                        """{"balances":[{"denom":"x/staking-x/ruji","amount":"12345"}]}""",
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger("12345"), result.stakeAmount)
+            assertEquals("RUJI", result.stakeTicker)
+        }
+
+    @Test
+    fun `getRujiStakeBalance keeps a successful zero receipt as zero instead of using bonded`() =
+        runBlocking {
+            // Balances read succeeds but holds no receipt (vault fully unstaked). Parity with
+            // vultisig-windows #4337: a successful zero stays zero; do NOT fall back to a stale
+            // non-zero bonded amount.
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBody(bondedAmount = "777"),
+                    balancesBody = """{"balances":[]}""",
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger.ZERO, result.stakeAmount)
+        }
+
+    @Test
+    fun `getRujiStakeBalance falls back to bonded only when the balances read fails`() =
+        runBlocking {
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBody(bondedAmount = "42"),
+                    balancesBody = "boom",
+                    balancesStatus = HttpStatusCode.InternalServerError,
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger("42"), result.stakeAmount)
+        }
+
+    @Test
+    fun `getRujiStakeBalance falls back to the RUJI position not TCY when the balances read fails`() =
+        runBlocking {
+            // Real-world shape: TCY position (bonded 0) precedes RUJI in stakingV2. When the
+            // balance read fails and we fall back to bonded, it must read RUJI's amount, not TCY's
+            // leading 0.
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBodyWithTcyFirst(bondedRuji = "7875733"),
+                    balancesBody = "boom",
+                    balancesStatus = HttpStatusCode.InternalServerError,
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger("7875733"), result.stakeAmount)
+            assertEquals("RUJI", result.stakeTicker)
+        }
+
+    @Test
+    fun `getRujiStakeBalance prefers receipt over RUJI bonded even with TCY listed first`() =
+        runBlocking {
+            val api =
+                newRujiApi(
+                    stakeBody = rujiStakeBodyWithTcyFirst(bondedRuji = "7875733"),
+                    balancesBody =
+                        """{"balances":[{"denom":"x/staking-x/ruji","amount":"41952462"}]}""",
+                )
+
+            val result = api.getRujiStakeBalance("thor1abc")
+
+            assertEquals(BigInteger("41952462"), result.stakeAmount)
+            assertEquals("RUJI", result.stakeTicker)
+        }
 
     @Test
     fun `broadcastTransaction throws with code -1 and preserves rawBody when tx_response is null`() {


### PR DESCRIPTION
## What

Fixes #5258 — **DeFi → Staked → "Staked RUJI"** showed `0` (or a wrong value) even when the vault held sRUJI staking-receipt tokens on-chain.

## Root causes

1. **`bonded` is unreliable.** `ThorChainApi.getRujiStakeBalance` read the staked amount from the Rujira GraphQL `bonded` field, which can report `0` even when `x/staking-x/ruji` receipt tokens are held on-chain.
2. **Wrong `stakingV2` entry.** The code used `stakingV2.firstOrNull()` with no filter. The GraphQL returns multiple positions (e.g. **TCY and RUJI**), so it often grabbed the TCY position (bonded `0`) and reported it as *Staked RUJI* — corrupting amount, rewards, and APR.
3. **Denom exclusion never matched.** `DEFI_ONLY_THORCHAIN_DENOMS` listed only `x/staking-ruji`, but the on-chain receipt denom is `x/staking-x/ruji`, so the receipt leaked into the wallet token list.

## Fix

- Select the **RUJI** position from `stakingV2` by symbol instead of taking the first.
- Prefer the **on-chain `x/staking-x/ruji` receipt balance** (the source of truth for what the vault holds), falling back to `bonded` only when the balance read **fails** — a successful zero stays zero. Mirrors the sTCY / `x/staking-tcy` pattern.
- Correct `DEFI_ONLY_THORCHAIN_DENOMS` to cover both `x/staking-ruji` and `x/staking-x/ruji`.

## Cross-platform parity

Matches the intended **vultisig-windows #4337** logic (`rujiStakeService.ts`): read the receipt via the balances endpoint and use `heldAmount ?? bondedAmount` with failure-only fallback; the receipt raw amount is displayed with RUJI decimals. Sibling of iOS #4794. Windows still uses `stakingV2[0]` — this PR additionally filters for the RUJI position so rewards/APR/ticker are read from the correct entry (displayed amount is unchanged in the common receipt path).

## Verification

Verified against a **live thornode** account: the receipt denom is exactly `x/staking-x/ruji`; a vault with `TCY(bonded 0)` + `RUJI(bonded 7875733)` positions holds receipt `41952462`.

## Test plan

- [x] 5 new unit tests in `ThorChainApiImplTest` (URL-routing mock: GraphQL stake POST vs Cosmos balances GET):
  - prefers receipt over bonded when receipts are held
  - keeps a successful zero receipt as zero (does not fall back to bonded)
  - falls back to bonded only when the balances read fails
  - selects the RUJI position (not the leading TCY) on fallback
  - prefers receipt over RUJI bonded even with TCY listed first
- [x] `./gradlew :data:testDebugUnitTest --tests ThorChainApiImplTest` → 16/16 green
- [ ] On-device check: DeFi → Staked → "Staked RUJI" shows the real staked amount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RUJI staking balance accuracy by preferring on-chain receipt balances when available.
  * Preserved genuine zero receipt balances without falling back to bonded amounts.
  * Added safer fallbacks to bonded values if on-chain balance reads fail or are unparseable.
  * Correctly selects the RUJI staking entry when multiple assets appear in the same staking list.
  * Updated DeFi-only RUJI denom exclusions to cover both legacy and receipt denom spellings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->