### PR TITLE
fix(ton): surface action-phase failures instead of false Confirmed

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
@@ -201,4 +201,28 @@ data class TransactionJson(
 data class TonTransactionDescriptionJson(
     @SerialName("aborted") val aborted: Boolean? = null,
     @SerialName("destroyed") val destroyed: Boolean? = null,
+    @SerialName("compute_ph") val computePhase: TonComputePhaseJson? = null,
+    @SerialName("action") val actionPhase: TonActionPhaseJson? = null,
+)
+
+/**
+ * TVM compute phase of a TON transaction. A `null` [exitCode] means the message carried no compute
+ * phase (a plain transfer to a wallet), which is not a failure. Exit codes 0 and 1 are the TVM
+ * success conventions; any other code is a revert.
+ */
+@Serializable data class TonComputePhaseJson(@SerialName("exit_code") val exitCode: Int? = null)
+
+/**
+ * Action phase of a TON transaction — where the wallet contract actually emits its outgoing
+ * transfer message(s). Because every Vultisig TON send is signed with `IGNORE_ACTION_PHASE_ERRORS`,
+ * an action that can't be carried out (e.g. insufficient balance for value+fees) is silently
+ * skipped instead of aborting the transaction, so these fields — not `aborted` — are what reveal a
+ * transfer that never moved any funds.
+ */
+@Serializable
+data class TonActionPhaseJson(
+    @SerialName("success") val success: Boolean? = null,
+    @SerialName("no_funds") val noFunds: Boolean? = null,
+    @SerialName("result_code") val resultCode: Int? = null,
+    @SerialName("skipped_actions") val skippedActions: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.chains.ton.TonActionPhaseJson
 import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.chains.ton.TonComputePhaseJson
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
@@ -14,10 +16,17 @@ class TonStatusProvider @Inject constructor(private val tonApi: TonApi) :
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
             val tx = tonApi.getTsStatus(txHash).transactions.firstOrNull()
+            val description = tx?.description
             when {
                 tx == null -> TransactionResult.NotFound
-                tx.description == null -> TransactionResult.Pending
-                tx.description.aborted == true -> TransactionResult.Failed("Transaction aborted")
+                description == null -> TransactionResult.Pending
+                description.aborted == true -> TransactionResult.Failed("Transaction aborted")
+                description.computePhase.hasFailed() ->
+                    TransactionResult.Failed(
+                        "Compute phase reverted (exit code ${description.computePhase?.exitCode})"
+                    )
+                description.actionPhase.hasFailed() ->
+                    TransactionResult.Failed("Action phase failed — transfer not executed")
                 else -> TransactionResult.Confirmed
             }
         } catch (e: CancellationException) {
@@ -26,4 +35,24 @@ class TonStatusProvider @Inject constructor(private val tonApi: TonApi) :
             Timber.w(e, "TON status check failed for %s", txHash)
             TransactionResult.Pending
         }
+}
+
+/**
+ * A TON compute phase signals success with TVM exit codes 0 and 1; any other non-null code is a
+ * revert. A `null` exit code means the message had no compute phase (a plain transfer) and is not a
+ * failure. Mirrors the iOS/SDK resolver.
+ */
+private fun TonComputePhaseJson?.hasFailed(): Boolean =
+    this?.exitCode?.let { it != 0 && it != 1 } == true
+
+/**
+ * The action phase is where the wallet emits its outgoing transfer(s). Since every Vultisig TON
+ * send is signed with `IGNORE_ACTION_PHASE_ERRORS`, a transfer that can't be paid for is silently
+ * skipped rather than aborting the transaction — the wallet tx lands un-aborted with the seqno
+ * consumed but no funds moved. Treat a skipped / unfunded / unsuccessful action phase as a failure
+ * so the user isn't shown a false "Confirmed".
+ */
+private fun TonActionPhaseJson?.hasFailed(): Boolean {
+    if (this == null) return false
+    return success == false || noFunds == true || (skippedActions ?: 0) > 0
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProviderTest.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.chains.ton.TonActionPhaseJson
 import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.chains.ton.TonComputePhaseJson
 import com.vultisig.wallet.data.api.chains.ton.TonStatusResult
 import com.vultisig.wallet.data.api.chains.ton.TonTransactionDescriptionJson
 import com.vultisig.wallet.data.api.chains.ton.TransactionJson
@@ -10,6 +12,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
 class TonStatusProviderTest {
@@ -84,6 +87,108 @@ class TonStatusProviderTest {
     }
 
     @Test
+    fun `compute phase exit code 1 returns Confirmed`() = runTest {
+        // TVM treats exit codes 0 and 1 as success.
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    computePhase = TonComputePhaseJson(exitCode = 1),
+                )
+            )
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("hash", Chain.Ton))
+    }
+
+    @Test
+    fun `compute phase revert returns Failed`() = runTest {
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    computePhase = TonComputePhaseJson(exitCode = 37),
+                )
+            )
+
+        val result = provider.checkStatus("hash", Chain.Ton)
+
+        assertEquals(TransactionResult.Failed("Compute phase reverted (exit code 37)"), result)
+    }
+
+    @Test
+    fun `action phase out of funds returns Failed even when not aborted`() = runTest {
+        // The core bug: IGNORE_ACTION_PHASE_ERRORS leaves the tx un-aborted while the
+        // transfer action is silently skipped for lack of funds — no funds actually moved.
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    computePhase = TonComputePhaseJson(exitCode = 0),
+                    actionPhase = TonActionPhaseJson(success = true, noFunds = true),
+                )
+            )
+
+        val result = provider.checkStatus("hash", Chain.Ton)
+
+        assertEquals(
+            TransactionResult.Failed("Action phase failed — transfer not executed"),
+            result,
+        )
+    }
+
+    @Test
+    fun `action phase with skipped actions returns Failed`() = runTest {
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    actionPhase = TonActionPhaseJson(success = true, skippedActions = 1),
+                )
+            )
+
+        assertEquals(
+            TransactionResult.Failed("Action phase failed — transfer not executed"),
+            provider.checkStatus("hash", Chain.Ton),
+        )
+    }
+
+    @Test
+    fun `action phase not successful returns Failed`() = runTest {
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    actionPhase = TonActionPhaseJson(success = false),
+                )
+            )
+
+        assertEquals(
+            TransactionResult.Failed("Action phase failed — transfer not executed"),
+            provider.checkStatus("hash", Chain.Ton),
+        )
+    }
+
+    @Test
+    fun `successful compute and action phases return Confirmed`() = runTest {
+        coEvery { tonApi.getTsStatus(any()) } returns
+            statusWith(
+                TonTransactionDescriptionJson(
+                    aborted = false,
+                    computePhase = TonComputePhaseJson(exitCode = 0),
+                    actionPhase =
+                        TonActionPhaseJson(
+                            success = true,
+                            noFunds = false,
+                            resultCode = 0,
+                            skippedActions = 0,
+                        ),
+                )
+            )
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("hash", Chain.Ton))
+    }
+
+    @Test
     fun `api exception returns Pending`() = runTest {
         coEvery { tonApi.getTsStatus(any()) } throws RuntimeException("network error")
 
@@ -91,4 +196,45 @@ class TonStatusProviderTest {
 
         assertEquals(TransactionResult.Pending, result)
     }
+
+    @Test
+    fun `deserializes a real toncenter response and confirms a successful tx`() = runTest {
+        // Verbatim shape from api.vultisig.com/ton v3/transactions (extra fields included) to prove
+        // the compute_ph/action @SerialName mappings match production JSON and that unknown keys
+        // are
+        // tolerated the same way the ktor client tolerates them.
+        val realJson =
+            """
+            {
+              "transactions": [
+                {
+                  "hash": "ly7MV9j/7YxLIJECJyURsKthTLOJKtoYP6sMJLi/H8E=",
+                  "description": {
+                    "type": "ord",
+                    "aborted": false,
+                    "destroyed": false,
+                    "storage_ph": { "storage_fees_collected": "0", "status_change": "unchanged" },
+                    "compute_ph": {
+                      "skipped": false, "success": true, "gas_used": "0",
+                      "mode": 0, "exit_code": 0, "vm_steps": 66
+                    },
+                    "action": {
+                      "success": true, "valid": true, "no_funds": false,
+                      "status_change": "unchanged", "result_code": 0, "tot_actions": 1,
+                      "skipped_actions": 0, "msgs_created": 1
+                    }
+                  }
+                }
+              ]
+            }
+            """
+                .trimIndent()
+        val decoded = Json { ignoreUnknownKeys = true }.decodeFromString<TonStatusResult>(realJson)
+        coEvery { tonApi.getTsStatus(any()) } returns decoded
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("hash", Chain.Ton))
+    }
+
+    private fun statusWith(description: TonTransactionDescriptionJson) =
+        TonStatusResult(transactions = listOf(TransactionJson(description = description)))
 }


### PR DESCRIPTION
## Problem

Every TON send is signed with `IGNORE_ACTION_PHASE_ERRORS` (`TonHelper.calculateSendMode` + the hardcoded jetton mode). When a transfer can't be paid for — e.g. `value + fees` exceeds balance under `PAY_FEES_SEPARATELY` — the action is **silently skipped** instead of aborting the transaction. The wallet tx lands **un-aborted** with the seqno consumed but **no funds moved**.

`TonStatusProvider` inspected only `description.aborted`, so the user was shown a false **Confirmed** while nothing was actually transferred.

Fixes #5249.

## Fix

Make the status provider **outcome-aware**. This is a **read-side change only** — the signing path (`TonHelper`) is deliberately left untouched so the TSS pre-image hash stays byte-identical across co-signing devices (changing send modes would diverge the hash and 404 joiners).

- Model the compute (`compute_ph`) and action phases of the transaction description.
- Report **Failed** when:
  - the compute phase reverted — exit code not in `{0, 1}` (matching the iOS/SDK resolver's TVM success convention), or
  - the action phase failed / ran out of funds / skipped an action (`success == false`, `no_funds == true`, or `skipped_actions > 0`).
- `aborted` handling and the "still indexing → keep polling" behaviour are unchanged, so existing successful flows are unaffected.

### Cross-platform note
Neither iOS nor the SDK currently inspect the **action** phase — they check only `aborted` + `compute_ph.exit_code` — so this also closes a cross-platform gap (sibling `vultisig-sdk#1119`).

### Known limitation
This catches native false-success and jetton sends that fail at the **wallet** level (can't afford the 0.08 TON carrier). It does **not** follow the jetton-wallet contract's *separate* transaction, so a failure inside the jetton-wallet (e.g. insufficient jetton balance → bounce) is out of scope here and would need out-message following.

## Test plan

- `./gradlew :data:testDebugUnitTest --tests "*.TonStatusProviderTest"` — 13 tests, all green.
- New coverage:
  - the exact bug: `aborted: false` + `no_funds: true` → **Failed**
  - compute revert (exit 37) → Failed; exit 0/1 → Confirmed
  - action `skipped_actions > 0` / `success == false` → Failed
  - fully-successful compute + action → Confirmed
  - a **verbatim production toncenter payload** decoded through the real kotlinx pipeline, proving the `compute_ph`/`action` `@SerialName` mappings match live data and unknown keys are tolerated.

### Reproduction note
Not reproducible via the native send form: it reserves a flat 0.05 TON and blocks `amount > balance − 0.05`, so the action phase always has ample headroom. The bug class manifests on paths that bypass that guard (TonConnect/dApp-supplied amounts, or a fee under-estimate). Verified via the unit tests + live-JSON parse rather than a device screenshot, which is the appropriate bar for a read-side status change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TON transaction status detection for compute-phase reverts and action-phase failures.
  * Transactions with insufficient funds, skipped actions, or unsuccessful actions are now correctly marked as failed.
  * Added clearer failure details, including relevant compute exit codes.
  * Successful TON transactions continue to be confirmed when all phases complete successfully.

* **Tests**
  * Expanded coverage for TON transaction phase outcomes and real-world response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->