### PR TITLE
feat(solana): sign and broadcast dApp transaction batches

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -202,6 +202,9 @@ class PreviewActivity : ComponentActivity() {
                     "choose_vault" -> SelectVaultTypeScreenPreview()
                     "content_row" -> ContentRowPreview()
                     "solana_display" -> SolanaDisplayPreview()
+                    "solana_batch_verify" -> SolanaBatchVerifySendPreview(transactionCount = 2)
+                    "solana_batch_verify_before" ->
+                        SolanaBatchVerifySendPreview(transactionCount = 1)
                     "ton_display_single" -> TonDisplayPreview(messageCount = 1)
                     "ton_display_multi" -> TonDisplayPreview(messageCount = 4)
                     "verify_ton_jetton_before" -> VerifyTonJettonPreview(decoded = false)
@@ -738,6 +741,57 @@ private fun BondFormMayaPreview() {
         operatorFeeFieldState = TextFieldState(),
         tokenAmountFieldState = TextFieldState(),
         lpUnitsFieldState = TextFieldState("0"),
+    )
+}
+
+/**
+ * Two unsigned System Program transfers (0.25 SOL and 0.1 SOL to different recipients), the shape a
+ * dApp `signAllTransactions` batch arrives in. Valid legacy wire format so WalletCore decodes real
+ * instructions on expansion.
+ */
+private val SOLANA_BATCH_PREVIEW_TXS =
+    listOf(
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+            "AAAAAAAAAAABAAEDfowIh2C/3h3dzzLBfyCbgkLuUqrxMfrNiNDqLG0LBvIr5RSn91UOtIIAsZJK" +
+            "26JaVZJJXZnPHQdXahEOnHb/fAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4" +
+            "IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAgIAAQwCAAAAgLLmDgAAAAA=",
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+            "AAAAAAAAAAABAAEDfowIh2C/3h3dzzLBfyCbgkLuUqrxMfrNiNDqLG0LBvJhSg5NXp2oPpX2ZykH" +
+            "RRz279NzOiYl6BcT8F6LrGfVoQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4" +
+            "IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAgIAAQwCAAAAAOH1BQAAAAA=",
+    )
+
+/**
+ * The joining device's verify screen for a dApp `signSolana` request. [transactionCount] = 1
+ * reproduces the pre-#5238 render, which surfaced only the first raw transaction of a batch.
+ */
+@Composable
+private fun SolanaBatchVerifySendPreview(transactionCount: Int) {
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        token =
+                            ValuedToken(token = Coins.Solana.SOL, value = "0", fiatValue = "$0.00"),
+                        srcAddress = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                        srcVaultName = "Main Vault",
+                        dstAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
+                        networkFeeFiatValue = "$0.01",
+                        networkFeeTokenValue = "0.000005 SOL",
+                        signSolana = SOLANA_BATCH_PREVIEW_TXS.take(transactionCount),
+                    )
+            ),
+        isConsentsEnabled = false,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
+        onConfirmScanning = {},
+        onDismissScanning = {},
+        hasToolbar = true,
     )
 }
 

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -205,6 +205,10 @@ class PreviewActivity : ComponentActivity() {
                     "solana_batch_verify" -> SolanaBatchVerifySendPreview(transactionCount = 2)
                     "solana_batch_verify_before" ->
                         SolanaBatchVerifySendPreview(transactionCount = 1)
+                    "solana_batch_verify_expanded" ->
+                        SolanaBatchVerifySendPreview(transactionCount = 2, expanded = true)
+                    "solana_batch_verify_before_expanded" ->
+                        SolanaBatchVerifySendPreview(transactionCount = 1, expanded = true)
                     "ton_display_single" -> TonDisplayPreview(messageCount = 1)
                     "ton_display_multi" -> TonDisplayPreview(messageCount = 4)
                     "verify_ton_jetton_before" -> VerifyTonJettonPreview(decoded = false)
@@ -766,7 +770,7 @@ private val SOLANA_BATCH_PREVIEW_TXS =
  * reproduces the pre-#5238 render, which surfaced only the first raw transaction of a batch.
  */
 @Composable
-private fun SolanaBatchVerifySendPreview(transactionCount: Int) {
+private fun SolanaBatchVerifySendPreview(transactionCount: Int, expanded: Boolean = false) {
     VerifySendScreen(
         state =
             VerifyTransactionUiModel(
@@ -792,6 +796,7 @@ private fun SolanaBatchVerifySendPreview(transactionCount: Int) {
         onConfirmScanning = {},
         onDismissScanning = {},
         hasToolbar = true,
+        initiallyExpandedDetails = expanded,
     )
 }
 

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -748,11 +748,7 @@ private fun BondFormMayaPreview() {
     )
 }
 
-/**
- * Two unsigned System Program transfers (0.25 SOL and 0.1 SOL to different recipients), the shape a
- * dApp `signAllTransactions` batch arrives in. Valid legacy wire format so WalletCore decodes real
- * instructions on expansion.
- */
+// Two unsigned System Program transfers; valid wire format so WalletCore decodes real instructions.
 private val SOLANA_BATCH_PREVIEW_TXS =
     listOf(
         "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
@@ -765,10 +761,6 @@ private val SOLANA_BATCH_PREVIEW_TXS =
             "IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAgIAAQwCAAAAAOH1BQAAAAA=",
     )
 
-/**
- * The joining device's verify screen for a dApp `signSolana` request. [transactionCount] = 1
- * reproduces the pre-#5238 render, which surfaced only the first raw transaction of a batch.
- */
 @Composable
 private fun SolanaBatchVerifySendPreview(transactionCount: Int, expanded: Boolean = false) {
     VerifySendScreen(

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
@@ -46,6 +46,10 @@ internal sealed interface KeysignBroadcastResult {
      * @property swapProgressLink Swap-progress deep link, or null when not a swap.
      * @property approveTxHash Hash of the preceding approval, empty when not applicable.
      * @property approveTxLink Explorer link for [approveTxHash], empty when not applicable.
+     * @property additionalTxHashes Hashes of the remaining transactions when the keysign produced a
+     *   batch (Solana `signAndSendAllTransactions`, issue #5238); empty otherwise. They are
+     *   persisted to history alongside [txHash], which stays the primary hash driving the done
+     *   screen and status polling.
      */
     data class Broadcasted(
         val chain: Chain,
@@ -54,14 +58,17 @@ internal sealed interface KeysignBroadcastResult {
         val swapProgressLink: String?,
         val approveTxHash: String,
         val approveTxLink: String,
+        val additionalTxHashes: List<String> = emptyList(),
     ) : KeysignBroadcastResult
 }
 
 /**
  * Orchestrates the broadcast tail of a keysign: submits and confirms an optional ERC-20 approval,
- * assembles and broadcasts the signed transaction, and invalidates the balance caches. The
+ * assembles and broadcasts the signed transaction(s), and invalidates the balance caches. The
  * duplicate-broadcast race between co-signers is resolved one layer down in [BroadcastTxUseCase],
- * which verifies the tx is actually on chain before treating a rejection as success.
+ * which verifies the tx is actually on chain before treating a rejection as success. A Solana dApp
+ * `signAndSendAllTransactions` batch broadcasts every assembled transaction sequentially in payload
+ * order (issue #5238).
  *
  * Extracted from `KeysignViewModel` so the broadcast/recover logic can be unit-tested in isolation.
  * The use case has no UI dependencies: it returns a [KeysignBroadcastResult] that the ViewModel
@@ -155,15 +162,21 @@ constructor(
             nonceAcc++
         }
 
-        val signedTx =
-            SigningHelper.getSignedTransaction(
+        val signedTxs =
+            SigningHelper.getSignedTransactions(
                 keysignPayload = payload,
                 vault = vault,
                 signatures = signatures,
                 nonceAcc = nonceAcc,
             )
 
-        val txHash = broadcastTx(chain = chain, tx = signedTx)
+        // A Solana dApp batch assembles one signed transaction per raw transaction; broadcast
+        // them in payload order like the extension does, failing fast so a rejected transaction
+        // surfaces as an error instead of being silently skipped. Transactions broadcast before
+        // a mid-batch failure stay on chain but are not persisted locally — same trade-off as
+        // the extension, which races the identical batch and usually lands it in full.
+        val txHashes = signedTxs.map { broadcastTx(chain = chain, tx = it) }
+        val txHash = txHashes.first()
 
         Timber.d("transaction hash: %s", txHash)
         var txLink = ""
@@ -196,6 +209,7 @@ constructor(
                 if (approveTxHash.isNotEmpty())
                     explorerLinkRepository.getTransactionLink(chain, approveTxHash)
                 else "",
+            additionalTxHashes = txHashes.drop(1).filterNotNull(),
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
@@ -46,10 +46,8 @@ internal sealed interface KeysignBroadcastResult {
      * @property swapProgressLink Swap-progress deep link, or null when not a swap.
      * @property approveTxHash Hash of the preceding approval, empty when not applicable.
      * @property approveTxLink Explorer link for [approveTxHash], empty when not applicable.
-     * @property additionalTxHashes Hashes of the remaining transactions when the keysign produced a
-     *   batch (Solana `signAndSendAllTransactions`, issue #5238); empty otherwise. They are
-     *   persisted to history alongside [txHash], which stays the primary hash driving the done
-     *   screen and status polling.
+     * @property additionalTxHashes Remaining hashes of a Solana batch keysign (issue #5238); empty
+     *   otherwise.
      */
     data class Broadcasted(
         val chain: Chain,
@@ -66,9 +64,7 @@ internal sealed interface KeysignBroadcastResult {
  * Orchestrates the broadcast tail of a keysign: submits and confirms an optional ERC-20 approval,
  * assembles and broadcasts the signed transaction(s), and invalidates the balance caches. The
  * duplicate-broadcast race between co-signers is resolved one layer down in [BroadcastTxUseCase],
- * which verifies the tx is actually on chain before treating a rejection as success. A Solana dApp
- * `signAndSendAllTransactions` batch broadcasts every assembled transaction sequentially in payload
- * order (issue #5238).
+ * which verifies the tx is actually on chain before treating a rejection as success.
  *
  * Extracted from `KeysignViewModel` so the broadcast/recover logic can be unit-tested in isolation.
  * The use case has no UI dependencies: it returns a [KeysignBroadcastResult] that the ViewModel
@@ -170,11 +166,8 @@ constructor(
                 nonceAcc = nonceAcc,
             )
 
-        // A Solana dApp batch assembles one signed transaction per raw transaction; broadcast
-        // them in payload order like the extension does, failing fast so a rejected transaction
-        // surfaces as an error instead of being silently skipped. Transactions broadcast before
-        // a mid-batch failure stay on chain but are not persisted locally — same trade-off as
-        // the extension, which races the identical batch and usually lands it in full.
+        // Broadcast sequentially, fail-fast: a rejected tx aborts the rest, and any earlier ones
+        // already broadcast stay on chain but aren't persisted locally (issue #5238).
         val txHashes = signedTxs.map { broadcastTx(chain = chain, tx = it) }
         val txHash = txHashes.first()
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
@@ -37,8 +37,12 @@ import com.vultisig.wallet.ui.theme.Theme
 import timber.log.Timber
 
 @Composable
-fun SignSolanaDisplayView(rawTransactions: List<String>, modifier: Modifier = Modifier) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+fun SignSolanaDisplayView(
+    rawTransactions: List<String>,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(14.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
@@ -35,12 +35,10 @@ import com.vultisig.wallet.data.chains.helpers.ParsedSolanaTransaction
 import com.vultisig.wallet.data.chains.helpers.SolanaTransactionParser
 import com.vultisig.wallet.ui.theme.Theme
 import timber.log.Timber
-import vultisig.keysign.v1.SignSolana
 
 @Composable
-fun SignSolanaDisplayView(signSolana: SignSolana, modifier: Modifier = Modifier) {
+fun SignSolanaDisplayView(rawTransactions: List<String>, modifier: Modifier = Modifier) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
-    val rawTransactions = signSolana.rawTransactions
 
     Column(
         verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -130,6 +128,9 @@ private fun InstructionsSummarySection(
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             instructions.forEachIndexed { index, instruction ->
+                if (index > 0) {
+                    UiHorizontalDivider(color = Theme.v2.colors.border.normal)
+                }
                 InstructionRow(instruction = instruction, index = index)
             }
         }
@@ -198,7 +199,14 @@ private val PREVIEW_INSTRUCTIONS =
             instructionType = "Transfer",
             accountsCount = 2,
             dataLength = 12,
-        )
+        ),
+        ParsedSolanaTransaction.ParsedInstruction(
+            programId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            programName = "Token Program",
+            instructionType = "Transfer Checked",
+            accountsCount = 4,
+            dataLength = 10,
+        ),
     )
 
 private val PREVIEW_RAW_TRANSACTIONS =
@@ -221,5 +229,5 @@ private fun PreviewSignSolanaInstructionsSection() {
 @Preview
 @Composable
 private fun PreviewSignSolanaDisplayView() {
-    SignSolanaDisplayView(signSolana = SignSolana(rawTransactions = PREVIEW_RAW_TRANSACTIONS))
+    SignSolanaDisplayView(rawTransactions = PREVIEW_RAW_TRANSACTIONS)
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -87,7 +87,11 @@ internal data class TransactionDetailsUiModel(
     val destinationTag: String? = null,
     val signAmino: String? = null,
     val signDirect: String? = null,
-    val signSolana: String? = null,
+    /**
+     * Base64 raw transactions of a dApp-supplied `signSolana` request, one entry per transaction of
+     * a `signAllTransactions` batch (issue #5238). Empty for non-Solana-dApp transactions.
+     */
+    val signSolana: List<String> = emptyList(),
     /**
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB (SignSui), for verify display.
      */

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -87,10 +87,7 @@ internal data class TransactionDetailsUiModel(
     val destinationTag: String? = null,
     val signAmino: String? = null,
     val signDirect: String? = null,
-    /**
-     * Base64 raw transactions of a dApp-supplied `signSolana` request, one entry per transaction of
-     * a `signAllTransactions` batch (issue #5238). Empty for non-Solana-dApp transactions.
-     */
+    /** Base64 raw txs of a dApp signSolana batch (issue #5238); empty for non-Solana-dApp txs. */
     val signSolana: List<String> = emptyList(),
     /**
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB (SignSui), for verify display.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
@@ -173,7 +173,7 @@ constructor(
         val signDirect =
             payload.signDirect?.let { json.encodeToString(parseCosmosMessage(it)) } ?: ""
 
-        val signSolana = payload.signSolana?.rawTransactions?.firstOrNull() ?: ""
+        val signSolana = payload.signSolana?.rawTransactions.orEmpty()
         val signSui = payload.signSui?.unsignedTxMsg?.takeIf { it.isNotEmpty() }
         val signRipple = payload.signRipple?.rawJson?.takeIf { it.isNotBlank() }
         val transaction =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -841,6 +841,18 @@ constructor(
                         )
                     }
                     saveTransactionHistory(txHash, result.chain)
+                    // A Solana dApp batch broadcasts several transactions; the extra ones are
+                    // persisted to history — each with its own explorer link, not the primary
+                    // tx's — while [txHash] stays the primary hash driving the done screen and
+                    // status polling.
+                    result.additionalTxHashes.forEach { hash ->
+                        saveTransactionHistory(
+                            txHash = hash,
+                            chain = result.chain,
+                            explorerUrl =
+                                explorerLinkRepository.getTransactionLink(result.chain, hash),
+                        )
+                    }
                     if (txStatusConfigurationProvider.supportTxStatus(result.chain)) {
                         startForegroundPolling(txHash, result.chain)
                     } else {
@@ -867,12 +879,20 @@ constructor(
         }
     }
 
-    internal suspend fun saveTransactionHistory(txHash: String, chain: Chain) {
+    /**
+     * [explorerUrl] overrides the state-derived link for the extra transactions of a Solana dApp
+     * batch, whose ViewModel state only carries the primary tx's link.
+     */
+    internal suspend fun saveTransactionHistory(
+        txHash: String,
+        chain: Chain,
+        explorerUrl: String? = null,
+    ) {
         saveKeysignTransactionHistory(
             vaultId = vault.id,
             txHash = txHash,
             chain = chain,
-            explorerUrl = _state.value.let { it.swapProgressLink ?: it.txLink },
+            explorerUrl = explorerUrl ?: _state.value.let { it.swapProgressLink ?: it.txLink },
             transactionHistoryData = transactionHistoryData,
             // Polkadot extrinsics are mortal: persist the head block at broadcast so the status
             // poller can scan the absolute inclusion window instead of a head-relative one that

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -841,33 +841,25 @@ constructor(
                         )
                     }
                     saveTransactionHistory(txHash, result.chain)
-                    // A Solana dApp batch broadcasts several transactions; the extra ones are
-                    // persisted to history — each with its own explorer link, not the primary
-                    // tx's — while [txHash] stays the primary hash driving the done screen and
-                    // status polling.
-                    result.additionalTxHashes.forEach { hash ->
-                        saveTransactionHistory(
-                            txHash = hash,
-                            chain = result.chain,
-                            explorerUrl =
-                                explorerLinkRepository.getTransactionLink(result.chain, hash),
-                        )
-                    }
-                    if (txStatusConfigurationProvider.supportTxStatus(result.chain)) {
-                        startForegroundPolling(txHash, result.chain)
-                    } else {
-                        _state.update {
-                            it.copy(
-                                signingState =
-                                    KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
-                            )
-                        }
-                    }
+                }
+                // A Solana dApp batch broadcasts several transactions; the extra ones are
+                // persisted to history independently of the primary hash — each with its own
+                // explorer link, not the primary tx's — while [txHash] stays the primary hash
+                // driving the done screen and status polling.
+                result.additionalTxHashes.forEach { hash ->
+                    saveTransactionHistory(
+                        txHash = hash,
+                        chain = result.chain,
+                        explorerUrl = explorerLinkRepository.getTransactionLink(result.chain, hash),
+                    )
+                }
+                if (txHash != null && txStatusConfigurationProvider.supportTxStatus(result.chain)) {
+                    startForegroundPolling(txHash, result.chain)
                 } else {
-                    // The broadcast succeeded but produced no hash. Land on the terminal
-                    // "broadcasted" state instead of leaving signingState at the last signing
-                    // state forever (infinite spinner → the user may force-retry and double-send).
-                    // Without a hash we cannot save history or poll status.
+                    // Either the chain has no status polling or the broadcast produced no
+                    // primary hash. Land on the terminal "broadcasted" state instead of leaving
+                    // signingState at the last signing state forever (infinite spinner → the
+                    // user may force-retry and double-send).
                     _state.update {
                         it.copy(
                             signingState =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -842,10 +842,9 @@ constructor(
                     }
                     saveTransactionHistory(txHash, result.chain)
                 }
-                // A Solana dApp batch broadcasts several transactions; the extra ones are
-                // persisted to history independently of the primary hash — each with its own
-                // explorer link, not the primary tx's — while [txHash] stays the primary hash
-                // driving the done screen and status polling.
+                // Persisted outside the txHash != null gate: the extra transactions of a batch
+                // were broadcast in their own right, so a missing primary hash must not skip
+                // their history rows.
                 result.additionalTxHashes.forEach { hash ->
                     saveTransactionHistory(
                         txHash = hash,
@@ -856,10 +855,9 @@ constructor(
                 if (txHash != null && txStatusConfigurationProvider.supportTxStatus(result.chain)) {
                     startForegroundPolling(txHash, result.chain)
                 } else {
-                    // Either the chain has no status polling or the broadcast produced no
-                    // primary hash. Land on the terminal "broadcasted" state instead of leaving
-                    // signingState at the last signing state forever (infinite spinner → the
-                    // user may force-retry and double-send).
+                    // Land on the terminal "broadcasted" state instead of leaving signingState
+                    // at the last signing state forever (infinite spinner → the user may
+                    // force-retry and double-send).
                     _state.update {
                         it.copy(
                             signingState =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -842,9 +842,7 @@ constructor(
                     }
                     saveTransactionHistory(txHash, result.chain)
                 }
-                // Persisted outside the txHash != null gate: the extra transactions of a batch
-                // were broadcast in their own right, so a missing primary hash must not skip
-                // their history rows.
+                // Outside the txHash-null gate: batch extras were broadcast in their own right.
                 result.additionalTxHashes.forEach { hash ->
                     saveTransactionHistory(
                         txHash = hash,
@@ -855,9 +853,8 @@ constructor(
                 if (txHash != null && txStatusConfigurationProvider.supportTxStatus(result.chain)) {
                     startForegroundPolling(txHash, result.chain)
                 } else {
-                    // Land on the terminal "broadcasted" state instead of leaving signingState
-                    // at the last signing state forever (infinite spinner → the user may
-                    // force-retry and double-send).
+                    // Land on "broadcasted" instead of leaving signingState stuck (infinite
+                    // spinner → user may double-send by retrying).
                     _state.update {
                         it.copy(
                             signingState =
@@ -869,10 +866,7 @@ constructor(
         }
     }
 
-    /**
-     * [explorerUrl] overrides the state-derived link for the extra transactions of a Solana dApp
-     * batch, whose ViewModel state only carries the primary tx's link.
-     */
+    /** [explorerUrl] overrides the state-derived link, needed for a batch's non-primary hashes. */
     internal suspend fun saveTransactionHistory(
         txHash: String,
         chain: Chain,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -356,7 +356,10 @@ internal fun VerifySendScreen(
                         ?.let {
                             VerifyCardDivider(0.dp)
 
-                            SignSolanaDisplayView(rawTransactions = it)
+                            SignSolanaDisplayView(
+                                rawTransactions = it,
+                                initiallyExpanded = initiallyExpandedDetails,
+                            )
                         }
 
                     tx.signSui

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -353,13 +353,11 @@ internal fun VerifySendScreen(
                             )
                         }
                     tx.signSolana
-                        ?.takeIf { it.isNotBlank() }
+                        .takeIf { it.isNotEmpty() }
                         ?.let {
                             VerifyCardDivider(0.dp)
 
-                            SignSolanaDisplayView(
-                                signSolana = SignSolana(rawTransactions = listOf(it))
-                            )
+                            SignSolanaDisplayView(signSolana = SignSolana(rawTransactions = it))
                         }
 
                     tx.signSui

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -66,7 +66,6 @@ import com.vultisig.wallet.ui.screens.swap.VerifyCardDetails
 import com.vultisig.wallet.ui.screens.swap.VerifyCardDivider
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
-import vultisig.keysign.v1.SignSolana
 
 @Composable
 internal fun VerifySendScreen(viewModel: VerifyTransactionViewModel = hiltViewModel()) {
@@ -357,7 +356,7 @@ internal fun VerifySendScreen(
                         ?.let {
                             VerifyCardDivider(0.dp)
 
-                            SignSolanaDisplayView(signSolana = SignSolana(rawTransactions = it))
+                            SignSolanaDisplayView(rawTransactions = it)
                         }
 
                     tx.signSui

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
@@ -122,14 +122,17 @@ internal class BroadcastKeysignBatchTest {
     @Test
     fun `single transaction yields no additional hashes`() =
         runTest(testDispatcher) {
-            every { SigningHelper.getSignedTransactions(payload, vault, any(), any()) } returns
-                listOf(tx1)
+            val singlePayload =
+                payload.copy(signSolana = SignSolana(rawTransactions = listOf("AAA=")))
+            every {
+                SigningHelper.getSignedTransactions(singlePayload, vault, any(), any())
+            } returns listOf(tx1)
             coEvery { broadcastTx(Chain.Solana, tx1) } returns "hash1"
 
             val result =
                 createUseCase()(
                     vault = vault,
-                    payload = payload,
+                    payload = singlePayload,
                     signatures = emptyMap(),
                     isInitiatingDevice = false,
                 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
@@ -33,9 +33,8 @@ import org.junit.jupiter.api.Test
 import vultisig.keysign.v1.SignSolana
 
 /**
- * A Solana dApp `signAndSendAllTransactions` batch assembles one signed transaction per raw
- * transaction of the payload; the broadcast tail must submit every one of them in payload order
- * instead of failing after the ceremony (issue #5238).
+ * A Solana `signAndSendAllTransactions` batch must broadcast every assembled tx, in order
+ * (issue #5238).
  */
 internal class BroadcastKeysignBatchTest {
 
@@ -142,10 +141,7 @@ internal class BroadcastKeysignBatchTest {
             broadcasted.additionalTxHashes shouldBe emptyList()
         }
 
-    /**
-     * Mirrors the extension's sequential fail-fast broadcast: a rejected transaction surfaces as an
-     * error instead of being silently skipped, and the remaining transactions are not sent.
-     */
+    // Mirrors the extension's fail-fast broadcast: a rejection errors out, the rest go unsent.
     @Test
     fun `failing broadcast mid-batch propagates and skips the remaining transactions`() =
         runTest(testDispatcher) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
@@ -1,0 +1,177 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.chains.helpers.SigningHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.usecases.BroadcastKeysignUseCase
+import com.vultisig.wallet.data.usecases.BroadcastTxUseCase
+import com.vultisig.wallet.data.usecases.KeysignBroadcastResult
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import java.math.BigInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignSolana
+
+/**
+ * A Solana dApp `signAndSendAllTransactions` batch assembles one signed transaction per raw
+ * transaction of the payload; the broadcast tail must submit every one of them in payload order
+ * instead of failing after the ceremony (issue #5238).
+ */
+internal class BroadcastKeysignBatchTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val vault = Vault(id = "v1", name = "Test Vault")
+
+    private val tx1 = SignedTransactionResult(rawTransaction = "raw1", transactionHash = "hash1")
+    private val tx2 = SignedTransactionResult(rawTransaction = "raw2", transactionHash = "hash2")
+    private val tx3 = SignedTransactionResult(rawTransaction = "raw3", transactionHash = "hash3")
+
+    private val payload =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Solana,
+                    ticker = "SOL",
+                    logo = "",
+                    address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                    decimal = 9,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
+            toAmount = BigInteger.ZERO,
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "",
+                    priorityFee = BigInteger.ZERO,
+                    priorityLimit = BigInteger.ZERO,
+                    fromAddressPubKey = null,
+                    toAddressPubKey = null,
+                    programId = false,
+                ),
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+            signSolana = SignSolana(rawTransactions = listOf("AAA=", "BBB=", "CCC=")),
+        )
+
+    private lateinit var broadcastTx: BroadcastTxUseCase
+
+    @BeforeEach
+    fun setUp() {
+        broadcastTx = mockk()
+        mockkObject(SigningHelper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SigningHelper)
+    }
+
+    @Test
+    fun `batch broadcasts every signed transaction in payload order`() =
+        runTest(testDispatcher) {
+            every { SigningHelper.getSignedTransactions(payload, vault, any(), any()) } returns
+                listOf(tx1, tx2, tx3)
+            coEvery { broadcastTx(Chain.Solana, tx1) } returns "hash1"
+            coEvery { broadcastTx(Chain.Solana, tx2) } returns "hash2"
+            coEvery { broadcastTx(Chain.Solana, tx3) } returns "hash3"
+
+            val result =
+                createUseCase()(
+                    vault = vault,
+                    payload = payload,
+                    signatures = emptyMap(),
+                    isInitiatingDevice = false,
+                )
+
+            val broadcasted = result.shouldBeInstanceOf<KeysignBroadcastResult.Broadcasted>()
+            broadcasted.txHash shouldBe "hash1"
+            broadcasted.additionalTxHashes shouldBe listOf("hash2", "hash3")
+            coVerifyOrder {
+                broadcastTx(Chain.Solana, tx1)
+                broadcastTx(Chain.Solana, tx2)
+                broadcastTx(Chain.Solana, tx3)
+            }
+        }
+
+    @Test
+    fun `single transaction yields no additional hashes`() =
+        runTest(testDispatcher) {
+            every { SigningHelper.getSignedTransactions(payload, vault, any(), any()) } returns
+                listOf(tx1)
+            coEvery { broadcastTx(Chain.Solana, tx1) } returns "hash1"
+
+            val result =
+                createUseCase()(
+                    vault = vault,
+                    payload = payload,
+                    signatures = emptyMap(),
+                    isInitiatingDevice = false,
+                )
+
+            val broadcasted = result.shouldBeInstanceOf<KeysignBroadcastResult.Broadcasted>()
+            broadcasted.txHash shouldBe "hash1"
+            broadcasted.additionalTxHashes shouldBe emptyList()
+        }
+
+    /**
+     * Mirrors the extension's sequential fail-fast broadcast: a rejected transaction surfaces as an
+     * error instead of being silently skipped, and the remaining transactions are not sent.
+     */
+    @Test
+    fun `failing broadcast mid-batch propagates and skips the remaining transactions`() =
+        runTest(testDispatcher) {
+            every { SigningHelper.getSignedTransactions(payload, vault, any(), any()) } returns
+                listOf(tx1, tx2, tx3)
+            coEvery { broadcastTx(Chain.Solana, tx1) } returns "hash1"
+            val failure = RuntimeException("Transaction simulation failed")
+            coEvery { broadcastTx(Chain.Solana, tx2) } throws failure
+
+            shouldThrow<RuntimeException> {
+                    createUseCase()(
+                        vault = vault,
+                        payload = payload,
+                        signatures = emptyMap(),
+                        isInitiatingDevice = true,
+                    )
+                }
+                .message shouldBe failure.message
+
+            coVerify(exactly = 1) { broadcastTx(Chain.Solana, tx1) }
+            coVerify(exactly = 0) { broadcastTx(Chain.Solana, tx3) }
+        }
+
+    private fun createUseCase() =
+        BroadcastKeysignUseCase(
+            broadcastTx = broadcastTx,
+            awaitApprovalConfirmation = mockk(relaxed = true),
+            explorerLinkRepository = mockk(relaxed = true),
+            evmApiFactory = mockk(relaxed = true),
+            balanceRepository = mockk(relaxed = true),
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -35,6 +35,18 @@ internal class KeysignViewModelApplyBroadcastResultTest {
 
     private val vault = Vault(id = "v1", name = "Test Vault")
 
+    private val sendTxData =
+        SendTransactionHistoryData(
+            fromAddress = "0xsender",
+            toAddress = "0xdest",
+            amount = "1",
+            token = "ETH",
+            tokenLogo = "eth",
+            feeEstimate = "0.001",
+            memo = "",
+            fiatValue = "100",
+        )
+
     private lateinit var txStatusConfigurationProvider: TxStatusConfigurationProvider
     private lateinit var transactionHistoryRepository: TransactionHistoryRepository
     private lateinit var explorerLinkRepository: ExplorerLinkRepository
@@ -94,8 +106,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             val vm = createViewModel(transactionHistoryData = sendTxData)
 
             vm.applyBroadcastResult(
-                broadcasted(txHash = "0xhash1")
-                    .copy(additionalTxHashes = listOf("0xhash2", "0xhash3"))
+                broadcasted(txHash = "0xhash1", additionalTxHashes = listOf("0xhash2", "0xhash3"))
             )
 
             vm.state.value.txHash shouldBe "0xhash1"
@@ -123,7 +134,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             val vm = createViewModel(transactionHistoryData = sendTxData)
 
             vm.applyBroadcastResult(
-                broadcasted(txHash = null).copy(additionalTxHashes = listOf("0xhash2"))
+                broadcasted(txHash = null, additionalTxHashes = listOf("0xhash2"))
             )
 
             vm.state.value.signingState shouldBe
@@ -140,19 +151,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             genericData.captured.explorerUrl shouldBe "https://etherscan.io/tx/0xhash2"
         }
 
-    private val sendTxData =
-        SendTransactionHistoryData(
-            fromAddress = "0xsender",
-            toAddress = "0xdest",
-            amount = "1",
-            token = "ETH",
-            tokenLogo = "eth",
-            feeEstimate = "0.001",
-            memo = "",
-            fiatValue = "100",
-        )
-
-    private fun broadcasted(txHash: String?) =
+    private fun broadcasted(txHash: String?, additionalTxHashes: List<String> = emptyList()) =
         KeysignBroadcastResult.Broadcasted(
             chain = Chain.Ethereum,
             txHash = txHash,
@@ -160,6 +159,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             swapProgressLink = null,
             approveTxHash = "",
             approveTxLink = "",
+            additionalTxHashes = additionalTxHashes,
         )
 
     private fun createViewModel(transactionHistoryData: TransactionHistoryData? = null) =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -92,9 +92,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             }
         }
 
-    // A Solana dApp batch broadcasts several transactions; each one must land in history with its
-    // own explorer link, with the first hash staying the primary one driving the done screen
-    // (issue #5238).
+    // Each transaction of a batch must land in history with its own explorer link (issue #5238).
     @Test
     fun `broadcasted batch persists history for the primary and additional hashes`() =
         runTest(testDispatcher) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -3,15 +3,22 @@
 package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.CommonTransactionHistoryData
+import com.vultisig.wallet.data.models.SendTransactionHistoryData
+import com.vultisig.wallet.data.models.TransactionHistoryData
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.KeysignBroadcastResult
 import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -29,11 +36,15 @@ internal class KeysignViewModelApplyBroadcastResultTest {
     private val vault = Vault(id = "v1", name = "Test Vault")
 
     private lateinit var txStatusConfigurationProvider: TxStatusConfigurationProvider
+    private lateinit var transactionHistoryRepository: TransactionHistoryRepository
+    private lateinit var explorerLinkRepository: ExplorerLinkRepository
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         txStatusConfigurationProvider = mockk(relaxed = true)
+        transactionHistoryRepository = mockk(relaxed = true)
+        explorerLinkRepository = mockk(relaxed = true)
     }
 
     @AfterEach
@@ -69,6 +80,51 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             }
         }
 
+    // A Solana dApp batch broadcasts several transactions; each one must land in history with its
+    // own explorer link, with the first hash staying the primary one driving the done screen
+    // (issue #5238).
+    @Test
+    fun `broadcasted batch persists history for the primary and additional hashes`() =
+        runTest(testDispatcher) {
+            every { txStatusConfigurationProvider.supportTxStatus(any()) } returns false
+            every { explorerLinkRepository.getTransactionLink(Chain.Ethereum, any()) } answers
+                {
+                    "https://etherscan.io/tx/${secondArg<String>()}"
+                }
+            val vm = createViewModel(transactionHistoryData = sendTxData)
+
+            vm.applyBroadcastResult(
+                broadcasted(txHash = "0xhash1")
+                    .copy(additionalTxHashes = listOf("0xhash2", "0xhash3"))
+            )
+
+            vm.state.value.txHash shouldBe "0xhash1"
+            listOf("0xhash1", "0xhash2", "0xhash3").forEach { hash ->
+                val genericData = slot<CommonTransactionHistoryData>()
+                coVerify(exactly = 1) {
+                    transactionHistoryRepository.recordTransaction(
+                        vaultId = "v1",
+                        txHash = hash,
+                        txData = sendTxData,
+                        genericData = capture(genericData),
+                    )
+                }
+                genericData.captured.explorerUrl shouldBe "https://etherscan.io/tx/$hash"
+            }
+        }
+
+    private val sendTxData =
+        SendTransactionHistoryData(
+            fromAddress = "0xsender",
+            toAddress = "0xdest",
+            amount = "1",
+            token = "ETH",
+            tokenLogo = "eth",
+            feeEstimate = "0.001",
+            memo = "",
+            fiatValue = "100",
+        )
+
     private fun broadcasted(txHash: String?) =
         KeysignBroadcastResult.Broadcasted(
             chain = Chain.Ethereum,
@@ -79,7 +135,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             approveTxLink = "",
         )
 
-    private fun createViewModel() =
+    private fun createViewModel(transactionHistoryData: TransactionHistoryData? = null) =
         KeysignViewModel(
             vault = vault,
             keysignCommittee = emptyList(),
@@ -92,11 +148,11 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             customMessagePayload = null,
             transactionTypeUiModel = null,
             isInitiatingDevice = false,
-            transactionHistoryData = null,
+            transactionHistoryData = transactionHistoryData,
             thorChainApi = mockk(relaxed = true),
             evmApiFactory = mockk(relaxed = true),
             broadcastTx = mockk(relaxed = true),
-            explorerLinkRepository = mockk(relaxed = true),
+            explorerLinkRepository = explorerLinkRepository,
             navigator = mockk<Navigator<Destination>>(relaxed = true),
             sessionApi = mockk(relaxed = true),
             encryption = mockk(relaxed = true),
@@ -107,7 +163,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             txStatusPoller = mockk(relaxed = true),
             vaultRepository = mockk(relaxed = true),
             chainAccountAddressRepository = mockk(relaxed = true),
-            transactionHistoryRepository = mockk(relaxed = true),
+            transactionHistoryRepository = transactionHistoryRepository,
             balanceRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -128,14 +128,16 @@ internal class KeysignViewModelApplyBroadcastResultTest {
 
             vm.state.value.signingState shouldBe
                 KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+            val genericData = slot<CommonTransactionHistoryData>()
             coVerify(exactly = 1) {
                 transactionHistoryRepository.recordTransaction(
                     vaultId = "v1",
                     txHash = "0xhash2",
                     txData = sendTxData,
-                    genericData = any(),
+                    genericData = capture(genericData),
                 )
             }
+            genericData.captured.explorerUrl shouldBe "https://etherscan.io/tx/0xhash2"
         }
 
     private val sendTxData =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -113,6 +113,31 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             }
         }
 
+    // The additional hashes of a batch are real broadcast transactions in their own right — a
+    // missing primary hash must not skip their history rows.
+    @Test
+    fun `broadcasted batch with null primary hash still persists additional hashes`() =
+        runTest(testDispatcher) {
+            every { explorerLinkRepository.getTransactionLink(Chain.Ethereum, "0xhash2") } returns
+                "https://etherscan.io/tx/0xhash2"
+            val vm = createViewModel(transactionHistoryData = sendTxData)
+
+            vm.applyBroadcastResult(
+                broadcasted(txHash = null).copy(additionalTxHashes = listOf("0xhash2"))
+            )
+
+            vm.state.value.signingState shouldBe
+                KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+            coVerify(exactly = 1) {
+                transactionHistoryRepository.recordTransaction(
+                    vaultId = "v1",
+                    txHash = "0xhash2",
+                    txData = sendTxData,
+                    genericData = any(),
+                )
+            }
+        }
+
     private val sendTxData =
         SendTransactionHistoryData(
             fromAddress = "0xsender",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -346,6 +346,29 @@ object SigningHelper {
         return messages.sorted()
     }
 
+    /**
+     * Assembles every signed transaction the keysign produced. Only a Solana dApp
+     * `signAllTransactions` batch yields more than one transaction (issue #5238); every other
+     * payload shape assembles exactly one via [getSignedTransaction].
+     */
+    fun getSignedTransactions(
+        keysignPayload: KeysignPayload,
+        vault: Vault,
+        signatures: Map<String, tss.KeysignResponse>,
+        nonceAcc: BigInteger,
+    ): List<SignedTransactionResult> {
+        val chain = keysignPayload.coin.chain
+        if (
+            chain == Chain.Solana &&
+                keysignPayload.signSolana != null &&
+                keysignPayload.swapPayload == null
+        ) {
+            return SolanaHelper(vault.getEddsaSigningKey(chain))
+                .getSignedTransactions(keysignPayload, signatures)
+        }
+        return listOf(getSignedTransaction(keysignPayload, vault, signatures, nonceAcc))
+    }
+
     fun getSignedTransaction(
         keysignPayload: KeysignPayload,
         vault: Vault,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -347,11 +347,8 @@ object SigningHelper {
     }
 
     /**
-     * Assembles every signed transaction the keysign produced; the result always has at least one
-     * entry. Only a Solana dApp `signAndSendAllTransactions` batch yields more than one transaction
-     * (issue #5238); every other payload shape assembles exactly one via [getSignedTransaction]. A
-     * payload carrying a swap payload is hashed by its swap signer rather than the `signSolana`
-     * expansion (see [getKeysignMessages]), so it must keep routing through the singular path.
+     * Assembles every signed tx (>=1 entry); only a Solana dApp batch yields more than one
+     * (issue #5238).
      */
     fun getSignedTransactions(
         keysignPayload: KeysignPayload,
@@ -360,6 +357,8 @@ object SigningHelper {
         nonceAcc: BigInteger,
     ): List<SignedTransactionResult> {
         val chain = keysignPayload.coin.chain
+        // A swap payload is hashed by its swap signer, not the signSolana expansion, and must
+        // keep routing through the singular path below (mirrors getKeysignMessages).
         if (
             chain == Chain.Solana &&
                 keysignPayload.signSolana != null &&

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -347,9 +347,11 @@ object SigningHelper {
     }
 
     /**
-     * Assembles every signed transaction the keysign produced. Only a Solana dApp
-     * `signAllTransactions` batch yields more than one transaction (issue #5238); every other
-     * payload shape assembles exactly one via [getSignedTransaction].
+     * Assembles every signed transaction the keysign produced; the result always has at least one
+     * entry. Only a Solana dApp `signAndSendAllTransactions` batch yields more than one transaction
+     * (issue #5238); every other payload shape assembles exactly one via [getSignedTransaction]. A
+     * payload carrying a swap payload is hashed by its swap signer rather than the `signSolana`
+     * expansion (see [getKeysignMessages]), so it must keep routing through the singular path.
      */
     fun getSignedTransactions(
         keysignPayload: KeysignPayload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -300,6 +300,31 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         return listOf(Numeric.toHexStringNoPrefix(preSigningOutput.data.toByteArray()))
     }
 
+    /**
+     * Assembles one signed transaction per raw transaction in a dApp `signSolana` payload. A
+     * `signAllTransactions` batch is hashed and signed in a single keysign ceremony, so assembly
+     * must deliver every transaction rather than just the first (issue #5238). A payload without
+     * `signSolana` assembles the single WalletCore-built transaction.
+     */
+    fun getSignedTransactions(
+        keysignPayload: KeysignPayload,
+        signatures: Map<String, tss.KeysignResponse>,
+    ): List<SignedTransactionResult> {
+        val signSolana =
+            keysignPayload.signSolana
+                ?: return listOf(getSignedTransaction(keysignPayload, signatures))
+        require(signSolana.rawTransactions.isNotEmpty()) {
+            "signSolana payload carries no raw transactions"
+        }
+        return signSolana.rawTransactions.map { base64Tx ->
+            signRawTransaction(
+                coinHexPubKey = keysignPayload.coin.hexPublicKey,
+                base64Transaction = base64Tx,
+                signatures = signatures,
+            )
+        }
+    }
+
     fun getSignedTransaction(
         keysignPayload: KeysignPayload,
         signatures: Map<String, tss.KeysignResponse>,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -302,9 +302,9 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
 
     /**
      * Assembles one signed transaction per raw transaction in a dApp `signSolana` payload. A
-     * `signAllTransactions` batch is hashed and signed in a single keysign ceremony, so assembly
-     * must deliver every transaction rather than just the first (issue #5238). A payload without
-     * `signSolana` assembles the single WalletCore-built transaction.
+     * `signAndSendAllTransactions` batch is hashed and signed in a single keysign ceremony, so
+     * assembly must deliver every transaction rather than just the first (issue #5238). A payload
+     * without `signSolana` assembles the single WalletCore-built transaction.
      */
     fun getSignedTransactions(
         keysignPayload: KeysignPayload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -301,10 +301,8 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
     }
 
     /**
-     * Assembles one signed transaction per raw transaction in a dApp `signSolana` payload. A
-     * `signAndSendAllTransactions` batch is hashed and signed in a single keysign ceremony, so
-     * assembly must deliver every transaction rather than just the first (issue #5238). A payload
-     * without `signSolana` assembles the single WalletCore-built transaction.
+     * One signed tx per signSolana raw transaction; a bare payload assembles the native WalletCore
+     * tx (issue #5238).
      */
     fun getSignedTransactions(
         keysignPayload: KeysignPayload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
@@ -20,10 +20,7 @@ data class Transaction(
     val memo: String?,
     val signAmino: String? = null,
     val signDirect: String? = null,
-    /**
-     * Base64 raw transactions of a dApp-supplied `signSolana` request, surfaced for verify display.
-     * Carries every transaction of a `signAllTransactions` batch (issue #5238).
-     */
+    /** Base64 raw txs of a dApp signSolana batch (issue #5238); one entry per transaction. */
     val signSolana: List<String> = emptyList(),
     /**
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB, surfaced for verify display.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
@@ -20,7 +20,11 @@ data class Transaction(
     val memo: String?,
     val signAmino: String? = null,
     val signDirect: String? = null,
-    val signSolana: String? = null,
+    /**
+     * Base64 raw transactions of a dApp-supplied `signSolana` request, surfaced for verify display.
+     * Carries every transaction of a `signAllTransactions` batch (issue #5238).
+     */
+    val signSolana: List<String> = emptyList(),
     /**
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB, surfaced for verify display.
      */

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperGetSignedTransactionsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperGetSignedTransactionsTest.kt
@@ -1,0 +1,60 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import io.kotest.assertions.throwables.shouldThrow
+import java.math.BigInteger
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignSolana
+
+class SigningHelperGetSignedTransactionsTest {
+
+    private val vault = Vault(id = "v1", name = "Test Vault")
+
+    private fun solanaPayload(signSolana: SignSolana) =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Solana,
+                    ticker = "SOL",
+                    logo = "",
+                    address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                    decimal = 9,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = "",
+            toAmount = BigInteger.ZERO,
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "",
+                    priorityFee = BigInteger.ZERO,
+                    priorityLimit = BigInteger.ZERO,
+                    fromAddressPubKey = null,
+                    toAddressPubKey = null,
+                    programId = false,
+                ),
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+            signSolana = signSolana,
+        )
+
+    // The empty-batch guard lives only in SolanaHelper.getSignedTransactions, so hitting it here
+    // proves the real dispatcher took the batch path, not the singular fallback.
+    @Test
+    fun `signSolana payload without a swap payload routes through the batch path`() {
+        val payload = solanaPayload(SignSolana(rawTransactions = emptyList()))
+
+        shouldThrow<IllegalArgumentException> {
+            SigningHelper.getSignedTransactions(payload, vault, emptyMap(), BigInteger.ZERO)
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -153,14 +153,10 @@ class SolanaHelperTest {
         assertEquals("Malformed compact-u16 in Solana transaction", error.message)
     }
 
-    /**
-     * A `signSolana` payload with an empty batch has nothing to assemble; it must fail with a clear
-     * message instead of returning an empty result. The guard runs before any WalletCore call, so
-     * it is exercised without the native library.
-     */
+    // The guard runs before any WalletCore call, so it is exercised without the native library.
     @Test
     fun `signSolana batch with no raw transactions is rejected before assembly`() {
-        val payload = solPayload(SignSolana(rawTransactions = emptyList()))
+        val payload = rawTxPayload()
 
         val error =
             assertThrows<IllegalArgumentException> {
@@ -169,14 +165,9 @@ class SolanaHelperTest {
         assertEquals("signSolana payload carries no raw transactions", error.message)
     }
 
-    /**
-     * The single-transaction assembly keeps its strict contract: a `signAllTransactions` batch must
-     * go through [SolanaHelper.getSignedTransactions], which delivers every transaction
-     * (issue #5238).
-     */
     @Test
     fun `single-transaction assembly rejects a multi-transaction batch`() {
-        val payload = solPayload(SignSolana(rawTransactions = listOf("AAA=", "BBB=")))
+        val payload = rawTxPayload("AAA=", "BBB=")
 
         val error =
             assertThrows<IllegalArgumentException> {
@@ -259,36 +250,4 @@ class SolanaHelperTest {
         )
 
     private fun base64Of(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
-
-    private fun solPayload(signSolana: SignSolana) =
-        KeysignPayload(
-            coin =
-                Coin(
-                    chain = Chain.Solana,
-                    ticker = "SOL",
-                    logo = "",
-                    address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
-                    decimal = 9,
-                    hexPublicKey = "",
-                    priceProviderID = "",
-                    contractAddress = "",
-                    isNativeToken = true,
-                ),
-            toAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
-            toAmount = BigInteger.ZERO,
-            blockChainSpecific =
-                BlockChainSpecific.Solana(
-                    recentBlockHash = "",
-                    priorityFee = BigInteger.ZERO,
-                    priorityLimit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
-                    fromAddressPubKey = null,
-                    toAddressPubKey = null,
-                    programId = false,
-                ),
-            vaultPublicKeyECDSA = "",
-            vaultLocalPartyID = "",
-            libType = SigningLibType.GG20,
-            wasmExecuteContractPayload = null,
-            signSolana = signSolana,
-        )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelperTest.kt
@@ -154,6 +154,38 @@ class SolanaHelperTest {
     }
 
     /**
+     * A `signSolana` payload with an empty batch has nothing to assemble; it must fail with a clear
+     * message instead of returning an empty result. The guard runs before any WalletCore call, so
+     * it is exercised without the native library.
+     */
+    @Test
+    fun `signSolana batch with no raw transactions is rejected before assembly`() {
+        val payload = solPayload(SignSolana(rawTransactions = emptyList()))
+
+        val error =
+            assertThrows<IllegalArgumentException> {
+                SolanaHelper("").getSignedTransactions(payload, signatures = emptyMap())
+            }
+        assertEquals("signSolana payload carries no raw transactions", error.message)
+    }
+
+    /**
+     * The single-transaction assembly keeps its strict contract: a `signAllTransactions` batch must
+     * go through [SolanaHelper.getSignedTransactions], which delivers every transaction
+     * (issue #5238).
+     */
+    @Test
+    fun `single-transaction assembly rejects a multi-transaction batch`() {
+        val payload = solPayload(SignSolana(rawTransactions = listOf("AAA=", "BBB=")))
+
+        val error =
+            assertThrows<IllegalArgumentException> {
+                SolanaHelper("").getSignedTransaction(payload, signatures = emptyMap())
+            }
+        assertEquals("Expected exactly one Solana raw transaction", error.message)
+    }
+
+    /**
      * A raw Solana transaction envelope: `[shortvec count][count × zeroed 64-byte slot][message]`.
      */
     private fun rawTransaction(signatureCount: Int, message: ByteArray): ByteArray {
@@ -227,4 +259,36 @@ class SolanaHelperTest {
         )
 
     private fun base64Of(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+
+    private fun solPayload(signSolana: SignSolana) =
+        KeysignPayload(
+            coin =
+                Coin(
+                    chain = Chain.Solana,
+                    ticker = "SOL",
+                    logo = "",
+                    address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                    decimal = 9,
+                    hexPublicKey = "",
+                    priceProviderID = "",
+                    contractAddress = "",
+                    isNativeToken = true,
+                ),
+            toAddress = "3xM8c79mk7fvcz5ENZgMbChPJGWZAjFqwdDzZp4R2gHR",
+            toAmount = BigInteger.ZERO,
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "",
+                    priorityFee = BigInteger.ZERO,
+                    priorityLimit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
+                    fromAddressPubKey = null,
+                    toAddressPubKey = null,
+                    programId = false,
+                ),
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+            signSolana = signSolana,
+        )
 }


### PR DESCRIPTION
Closes #5238

## Summary

A dApp `signAllTransactions` / `signAndSendAllTransactions` request with more than one raw Solana transaction already completed the full keysign ceremony — `getPreSignedImageHash` hashes every transaction and all N hashes get signed — but assembly (`SolanaHelper.getSignedTransaction`) only delivered the first one, so the whole batch was discarded with an opaque Signing Error after the user had approved on the phone. This adds batch support end to end instead of the fail-fast guard the ticket originally scoped:

- `SolanaHelper.getSignedTransactions` assembles one signed transaction per raw transaction (empty batches rejected with a clear message); `SigningHelper.getSignedTransactions` routes `signSolana` payloads through it and wraps every other payload's single result, so no other chain changes behavior
- `BroadcastKeysignUseCase` broadcasts the batch sequentially in payload order, fail-fast, matching the extension's `chainPromises` semantics; the per-tx duplicate-broadcast recovery still applies, so racing the extension's copies of the same batch is safe
- The first hash stays the primary one driving the done screen and status polling; the remaining hashes are persisted to transaction history, each with its own explorer link
- The verify screen now shows every transaction of the batch (`Transaction.signSolana` is now `List<String>`); previously a joiner reviewing a 3-tx batch only saw the first transaction. `SignSolanaDisplayView` takes the raw-transaction list directly (matching its SignTon/SignSui siblings) and separates instruction rows with a hairline divider
- `signAllTransactions` (`skipBroadcast=true`) is untouched — the phone never assembles or broadcasts on that path

The wire format is unchanged (`SignSolana.raw_transactions` was already `repeated`), and the extension needs no changes — it compiles and returns its own copies to the dApp. iOS has the same single-transaction assembly guard (`Solana.swift`, `rawTransactions.count == 1`) and needs the equivalent fix for extension + iOS-phone pairings.

## Before / After

Verify screen on the joining device for a 2-transaction dApp batch. Before, only the first transaction of the batch was surfaced for review; now every transaction's instructions and raw bytes are shown, with a hairline divider separating the instruction rows.

| | Before | After |
|---|--------|-------|
| Collapsed (entry point) | ![before-collapsed](https://i.imgur.com/oxHk3tl.png) | ![after-collapsed](https://i.imgur.com/lMbQvKJ.png) |
| Expanded | ![before-expanded](https://i.imgur.com/C8UoD5t.png) | ![after-expanded](https://i.imgur.com/4zjgLC3.png) |

## Testing

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — 3516 tests, green
- `./gradlew assembleDebug` — green
- `./gradlew :app:lintDebug` — green

New tests:
- `SolanaHelperTest` — empty batch rejected before any WalletCore call; single-transaction assembly keeps its strict one-tx contract
- `BroadcastKeysignBatchTest` — batch broadcasts every signed transaction in payload order, first hash primary + rest as `additionalTxHashes`, mid-batch failure propagates and skips the rest
- `KeysignViewModelApplyBroadcastResultTest` — every hash of a batch lands in transaction history with its own explorer link

Known follow-ups (out of scope here): dependent batches (tx2 consuming state created by tx1) can fail phone-side preflight before tx1 confirms — the shared Solana broadcast path would need a confirmation gap or skipPreflight for later batch items; the raw-transaction display flattens instruction numbering across the batch without per-transaction headers; the done screen shows only the primary hash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signing and broadcasting multiple Solana transactions from a single request.
  * Solana verification screens now display all transactions in a batch, with expandable details.
  * Additional transaction hashes are retained in transaction history with explorer links.

* **Bug Fixes**
  * Improved handling of empty or invalid Solana transaction batches.
  * Batch broadcasts now stop immediately if one transaction fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->