### PR TITLE
fix(cardano): emit Conway-era 4-element tx envelope with is_valid flag

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
@@ -243,10 +243,12 @@ object CardanoHelper {
             )
 
         val output = Cardano.SigningOutput.parseFrom(compileWithSignature).checkError()
-        var transactionHash =
-            CardanoUtils.calculateCardanoTransactionHash(output.encoded.toByteArray())
+        // WalletCore emits the legacy 3-element envelope; Conway-era nodes require the 4-element
+        // form with an is_valid flag. Splicing it in doesn't touch the signed body (element 0).
+        val encoded = CardanoUtils.addIsValidFlag(output.encoded.toByteArray())
+        val transactionHash = CardanoUtils.calculateCardanoTransactionHash(encoded)
         return SignedTransactionResult(
-            rawTransaction = output.encoded.toByteArray().toHexString(),
+            rawTransaction = encoded.toHexString(),
             transactionHash = transactionHash,
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -53,6 +53,39 @@ object CardanoUtils {
         return Bech32.encode("addr", addressData)
     }
 
+    /**
+     * Upgrades a legacy 3-element Cardano transaction envelope `[body, witness_set,
+     * auxiliary_data]` (emitted by WalletCore) to the Conway-era 4-element form `[body,
+     * witness_set, is_valid, auxiliary_data]` by splicing `is_valid = true` (0xf5) before the
+     * auxiliary_data. Safe post-signing: the vkey signature and tx_id cover only the body (element
+     * 0), which is left byte-for-byte untouched. Already-4-element envelopes are returned
+     * unchanged.
+     */
+    fun addIsValidFlag(encoded: ByteArray): ByteArray {
+        require(encoded.isNotEmpty()) { "empty Cardano transaction" }
+        when (encoded[0].toInt() and 0xFF) {
+            0x84 -> return encoded // already Conway-era 4-element array
+            0x83 -> {} // legacy 3-element array — needs is_valid
+            else -> error("unexpected Cardano tx array header: 0x%02x".format(encoded[0]))
+        }
+
+        val afterBody = findEndOfCBORItem(encoded, 1)
+        val afterWitness = findEndOfCBORItem(encoded, afterBody)
+
+        return ByteArray(encoded.size + 1).also { out ->
+            out[0] = 0x84.toByte()
+            System.arraycopy(encoded, 1, out, 1, afterWitness - 1) // body + witness_set
+            out[afterWitness] = 0xF5.toByte() // is_valid = true
+            System.arraycopy(
+                encoded,
+                afterWitness,
+                out,
+                afterWitness + 1,
+                encoded.size - afterWitness,
+            )
+        }
+    }
+
     fun calculateCardanoTransactionHash(transactionData: ByteArray): String {
         return try {
             val transactionBodyData = extractCardanoTransactionBody(transactionData)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -175,6 +175,19 @@ object CardanoUtils {
                 index
             }
 
+            6 -> { // Tag (e.g. Conway-era set tag 258): tag number, then one tagged data item
+                index +=
+                    when (additionalInfo) {
+                        in 0..23 -> 0
+                        24 -> 1
+                        25 -> 2
+                        26 -> 4
+                        27 -> 8
+                        else -> error("Unsupported additional info for tag")
+                    }
+                findEndOfCBORItem(bytes, index)
+            }
+
             7 -> { // Simple value or float
                 index +
                     when (additionalInfo) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -80,4 +80,39 @@ class CardanoUtilsTest {
             }
         assertEquals("chain code must be 32 bytes, got 33", ex.message)
     }
+
+    // Real signed envelope from a native ADA send that a Conway-era node rejected: a 3-element
+    // array [body, witness_set, auxiliary_data(=f6 null)] that must become a 4-element array with
+    // is_valid=true (f5) spliced before the trailing f6.
+    private val legacyEnvelopeHex =
+        "83a4008182582052e86a3e604ef6600f45d1cdb434eacbbaeffc763b02dd6d83bdbd8c825a01d2" +
+            "01018282581d61df45a39eb0282d2f6d0c1e46ea30452ba18eb86723739cdfbede9cbb1a001e8480" +
+            "82581d6150574c50e2c665f998457296a5d7ea1d789949d5e4e25adeee1a18251a026723d2021a00" +
+            "028900031a0b736d01a1008182582075be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf" +
+            "4ecd1ed9e645d55840f802b0a258b5af9c78dd5cc062bfb8d7984a432af1808a0dd7282051613ed1" +
+            "fc62d7e1953443177354137b29d6bf34bd6cf10c7eee442d1a448e3b497f12b00bf6"
+
+    private fun hex(s: String) = s.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    fun `addIsValidFlag upgrades legacy 3-element envelope, body hash unchanged`() {
+        val legacy = hex(legacyEnvelopeHex)
+        val upgraded = CardanoUtils.addIsValidFlag(legacy)
+
+        assertEquals(legacy.size + 1, upgraded.size)
+        assertEquals(0x84.toByte(), upgraded[0]) // array(4)
+        assertEquals(0xF5.toByte(), upgraded[upgraded.size - 2]) // is_valid = true
+        assertEquals(0xF6.toByte(), upgraded[upgraded.size - 1]) // auxiliary_data = null
+        // tx_id (blake2b of body element 0) must be identical before and after the splice.
+        assertEquals(
+            CardanoUtils.calculateCardanoTransactionHash(legacy),
+            CardanoUtils.calculateCardanoTransactionHash(upgraded),
+        )
+    }
+
+    @Test
+    fun `addIsValidFlag leaves an already-4-element envelope unchanged`() {
+        val upgraded = CardanoUtils.addIsValidFlag(hex(legacyEnvelopeHex))
+        assertEquals(upgraded.toList(), CardanoUtils.addIsValidFlag(upgraded).toList())
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -115,4 +115,20 @@ class CardanoUtilsTest {
         val upgraded = CardanoUtils.addIsValidFlag(hex(legacyEnvelopeHex))
         assertEquals(upgraded.toList(), CardanoUtils.addIsValidFlag(upgraded).toList())
     }
+
+    @Test
+    fun `addIsValidFlag walks a Conway tag-258 set in the witness without throwing`() {
+        // 83                      array(3)
+        //   a0                    body: empty map
+        //   a1 00 d9 0102 81      witness_set: { 0: tag(258) [ [h'00', h'00'] ] }
+        //      82 41 00 41 00
+        //   f6                    auxiliary_data: null
+        val legacy = hex("83a0a100d90102818241004100f6")
+        val upgraded = CardanoUtils.addIsValidFlag(legacy)
+
+        assertEquals(legacy.size + 1, upgraded.size)
+        assertEquals(0x84.toByte(), upgraded[0])
+        assertEquals(0xF5.toByte(), upgraded[upgraded.size - 2]) // is_valid spliced before aux
+        assertEquals(0xF6.toByte(), upgraded[upgraded.size - 1])
+    }
 }


### PR DESCRIPTION
## Summary
- Native ADA sends failed to submit on Conway-era nodes: WalletCore's `compileWithSignatures` emits the legacy 3-element Cardano envelope `[body, witness_set, aux_data]` (`0x83`), which current nodes reject.
- Added `CardanoUtils.addIsValidFlag` to splice `is_valid = true` (`0xf5`) into the envelope, producing the required 4-element form `[body, witness_set, is_valid, aux_data]` (`0x84`), and applied it in `CardanoHelper.getSignedTransaction` before broadcast.
- Safe post-signing: the vkey signature and tx_id cover only the body (element 0), which is left byte-for-byte untouched. Already-4-element envelopes (e.g. the SwapKit path) pass through unchanged.

## Issue
Closes #5268

## Test Plan
- [x] `CardanoUtilsTest` — upgrades a real rejected envelope, tx_id unchanged, idempotent on 4-element input
- [x] Manual: sign & broadcast a native ADA send against a Conway/Dijkstra node
- [ ] Lint passes (`./gradlew lint`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
On chain tx link: https://cardanoscan.io/transaction/c1160d3a7e19f3c097d04703b4d10f9827734cf37e56e8ec1936697fea26bf4b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cardano transactions are now encoded in the current format with the required validity flag.
  * Transaction hashes remain consistent while signed transaction data is updated.
  * Improved handling of tagged transaction data and already-updated transaction formats.

* **Tests**
  * Added coverage for legacy, current, and tagged Cardano transaction envelopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->