### PR TITLE
fix(keysign): skip branded splash on notification cold start (#5269)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -16,6 +16,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
@@ -25,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -84,9 +88,13 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         // Handle notification tap when app was killed — ViewModel awaits navigation readiness.
-        intent?.getStringExtra(VultisigFirebaseMessagingService.QR_CODE_DATA)?.let {
-            mainViewModel.onPushNotificationReceived(it)
-        }
+        // Track whether this cold start was launched by a keysign notification, so we can skip
+        // the branded AnimatedSplash replay and make the cold path match the warm onNewIntent path.
+        val launchedFromKeysignNotification =
+            intent?.getStringExtra(VultisigFirebaseMessagingService.QR_CODE_DATA)?.let {
+                mainViewModel.onPushNotificationReceived(it)
+                true
+            } ?: false
 
         val systemBarStyle =
             SystemBarStyle.auto(
@@ -110,29 +118,37 @@ class MainActivity : AppCompatActivity() {
                     val navController = rememberNavController()
 
                     val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
-                    var showSplash by remember { mutableStateOf(true) }
+                    var showSplash by remember { mutableStateOf(!launchedFromKeysignNotification) }
 
-                    if (showSplash) {
-                        AnimatedSplash(
-                            isLoading = isLoading,
-                            onSplashComplete = { showSplash = false },
-                        )
-                    } else {
-                        var isNavigationReady by remember { mutableStateOf(false) }
+                    when {
+                        showSplash ->
+                            AnimatedSplash(
+                                isLoading = isLoading,
+                                onSplashComplete = { showSplash = false },
+                            )
+                        // Keysign notification cold start: skip the branded splash. The NavHost
+                        // captures its start destination on first composition, so hold on a plain
+                        // background until it resolves rather than starting on the stale Home
+                        // default, then route straight into the keysign flow.
+                        isLoading ->
+                            Box(Modifier.fillMaxSize().background(colors.backgrounds.primary))
+                        else -> {
+                            var isNavigationReady by remember { mutableStateOf(false) }
 
-                        if (isNavigationReady) {
-                            CheckDeeplink(mainViewModel::openUri)
+                            if (isNavigationReady) {
+                                CheckDeeplink(mainViewModel::openUri)
+                            }
+
+                            CheckUpdates()
+
+                            MainActivityContent(
+                                navController = navController,
+                                mainViewModel = mainViewModel,
+                                snackbarFlow = snackbarFlow,
+                                startDestination = screen,
+                                onNavigationReady = { isNavigationReady = true },
+                            )
                         }
-
-                        CheckUpdates()
-
-                        MainActivityContent(
-                            navController = navController,
-                            mainViewModel = mainViewModel,
-                            snackbarFlow = snackbarFlow,
-                            startDestination = screen,
-                            onNavigationReady = { isNavigationReady = true },
-                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Closes #5269.

When the OS has reclaimed the process, tapping a keysign push notification **cold-starts** `MainActivity`, which replays the full branded `AnimatedSplash` before the keysign flow appears — so the cold path looks like the app restarting from scratch. The warm `onNewIntent` path (process still alive) shows no splash at all.

This makes the cold notification path match the warm path:
- Track whether `onCreate` was launched from a keysign notification (the `qr_code_data` extra is present) and, if so, **skip `AnimatedSplash`**.
- Because `SetupNavGraph`'s `NavHost` captures its start destination on first composition, hold on a plain background while the destination resolves (`isLoading`) rather than starting on the stale `Route.Home` default — then route straight into the keysign flow via the existing `onPushNotificationReceived` (which awaits navigation readiness).

Only the keysign cold-start path changes; every other launch (normal app open) still shows the splash exactly as before.

## Scope
Single file: `app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt`.

## Test plan
Reproduced path 3 from the issue on an emulator by simulating the FCM `PendingIntent` after killing the process:

```
adb shell am force-stop com.vultisig.wallet
adb shell am start -n com.vultisig.wallet/.app.activity.MainActivity \
  --es message "<keysign-deeplink>" -f 0x34000000   # NEW_TASK|CLEAR_TOP|SINGLE_TOP
```

Burst screencaps confirm:
- **Normal cold start (control):** branded `AnimatedSplash` plays (logo → "Vultisig" wordmark).
- **Notification cold start (fixed):** no branded splash — plain background briefly while the start destination resolves, then straight into content; the notification handler runs end-to-end (a non-matching test vault correctly surfaces the "Vault not found" snackbar; a real payload routes into `Keysign.Join`).

Verified `:app:compileDebugKotlin` green and ktfmt applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup when opened from a key-signing notification.
  * Prevented the branded splash screen from appearing during this notification-based launch flow.
  * Added a smoother loading state before navigating to the appropriate screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->