### PR TITLE
fix(tron): operation-aware Verify header for freeze/unfreeze (#5274)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -73,6 +74,13 @@ internal data class TransactionDetailsUiModel(
     val dstAddressBookTitle: String? = null,
     val dstLabel: String? = null,
     val memo: String? = null,
+    /**
+     * Operation-aware label rendered above the amount on the Verify screen. Null falls back to the
+     * generic "You're sending" header. Set for non-send operations routed through the Send form
+     * (e.g. TRON freeze/unfreeze) so the pre-signing checkpoint states the true intent instead of
+     * misreporting a stake/unstake as a plain send.
+     */
+    @StringRes val headerTitleRes: Int? = null,
     // XRP destination tag (decimal), shown as its own row alongside the memo.
     val destinationTag: String? = null,
     val signAmino: String? = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -1,5 +1,8 @@
 package com.vultisig.wallet.ui.models.mappers
 
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
+import com.vultisig.wallet.data.blockchain.tron.TronStakingOperation
 import com.vultisig.wallet.data.chains.helpers.RippleDestinationTag
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.Chain
@@ -28,8 +31,34 @@ constructor(
                 ?: if (from.token.chain == Chain.Ripple)
                     RippleDestinationTag.parseCanonicalDestinationTag(from.memo)?.toString()
                 else null
+        // TRON freeze/unfreeze is routed through the Send form and carries its operation only as an
+        // internal memo prefix ("FREEZE:<resource>" / "UNFREEZE:<resource>"). Surface that as an
+        // operation-aware Verify header and drop the raw prefix so it doesn't leak into the Memo
+        // row.
+        val tronStakingOperation =
+            if (from.token.chain == Chain.Tron) {
+                from.memo
+                    ?.let { TRON_STAKING_MEMO_REGEX.matchEntire(it) }
+                    ?.groupValues
+                    ?.get(1)
+                    ?.let { prefix ->
+                        TronStakingOperation.entries.firstOrNull { it.memoPrefix == prefix }
+                    }
+            } else null
+
         val memo =
-            if (from.token.chain == Chain.Ripple && from.memo == destinationTag) null else from.memo
+            when {
+                from.token.chain == Chain.Ripple && from.memo == destinationTag -> null
+                tronStakingOperation != null -> null
+                else -> from.memo
+            }
+
+        val headerTitleRes =
+            when (tronStakingOperation) {
+                TronStakingOperation.FREEZE -> R.string.tron_freeze_screen_title
+                TronStakingOperation.UNFREEZE -> R.string.tron_unfreeze_screen_title
+                null -> null
+            }
 
         return TransactionDetailsUiModel(
             token =
@@ -42,6 +71,7 @@ constructor(
             dstAddress = from.dstAddress,
             dstLabel = from.dstLabel,
             memo = memo,
+            headerTitleRes = headerTitleRes,
             destinationTag = destinationTag,
             signAmino = from.signAmino,
             signDirect = from.signDirect,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -33,23 +33,23 @@ constructor(
                 else null
         // TRON freeze/unfreeze is routed through the Send form and carries its operation only as an
         // internal memo prefix ("FREEZE:<resource>" / "UNFREEZE:<resource>"). Surface that as an
-        // operation-aware Verify header and drop the raw prefix so it doesn't leak into the Memo
-        // row.
+        // operation-aware Verify header, but keep the captured resource (BANDWIDTH/ENERGY) in the
+        // Memo row so the signed contract field stays visible. Gate on the native token so a TRC20
+        // send that merely echoes a matching memo isn't mislabeled as a staking operation.
+        val tronStakingMatch =
+            if (from.token.chain == Chain.Tron && from.token.isNativeToken)
+                from.memo?.let { TRON_STAKING_MEMO_REGEX.matchEntire(it) }
+            else null
         val tronStakingOperation =
-            if (from.token.chain == Chain.Tron) {
-                from.memo
-                    ?.let { TRON_STAKING_MEMO_REGEX.matchEntire(it) }
-                    ?.groupValues
-                    ?.get(1)
-                    ?.let { prefix ->
-                        TronStakingOperation.entries.firstOrNull { it.memoPrefix == prefix }
-                    }
-            } else null
+            tronStakingMatch?.groupValues?.get(1)?.let { prefix ->
+                TronStakingOperation.entries.firstOrNull { it.memoPrefix == prefix }
+            }
+        val tronStakingResource = tronStakingMatch?.groupValues?.get(2)
 
         val memo =
             when {
                 from.token.chain == Chain.Ripple && from.memo == destinationTag -> null
-                tronStakingOperation != null -> null
+                tronStakingOperation != null -> tronStakingResource
                 else -> from.memo
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -237,7 +237,10 @@ internal fun VerifySendScreen(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         VsOverviewToken(
-                            header = stringResource(R.string.verify_deposit_sending),
+                            header =
+                                stringResource(
+                                    tx.headerTitleRes ?: R.string.verify_deposit_sending
+                                ),
                             valuedToken = tx.token,
                             shape = RoundedCornerShape(0.dp),
                             modifier = Modifier.fillMaxWidth(),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapperTronStakingTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapperTronStakingTest.kt
@@ -40,7 +40,7 @@ internal class TransactionToUiModelMapperTronStakingTest {
         )
 
     @Test
-    fun `unfreeze surfaces the unfreeze header and hides the internal memo prefix`() = runTest {
+    fun `unfreeze surfaces the unfreeze header and keeps the resource in the memo`() = runTest {
         every { mapTokenValueToDecimalUiString(any()) } returns "0"
 
         val uiModel =
@@ -52,11 +52,11 @@ internal class TransactionToUiModelMapperTronStakingTest {
                 )
 
         uiModel.headerTitleRes shouldBe R.string.tron_unfreeze_screen_title
-        uiModel.memo shouldBe null
+        uiModel.memo shouldBe TronResourceType.BANDWIDTH.name
     }
 
     @Test
-    fun `freeze surfaces the freeze header and hides the internal memo prefix`() = runTest {
+    fun `freeze surfaces the freeze header and keeps the resource in the memo`() = runTest {
         every { mapTokenValueToDecimalUiString(any()) } returns "0"
 
         val uiModel =
@@ -68,7 +68,18 @@ internal class TransactionToUiModelMapperTronStakingTest {
                 )
 
         uiModel.headerTitleRes shouldBe R.string.tron_freeze_screen_title
-        uiModel.memo shouldBe null
+        uiModel.memo shouldBe TronResourceType.ENERGY.name
+    }
+
+    @Test
+    fun `a TRC20 send that echoes a staking memo is not mislabeled as staking`() = runTest {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+
+        val stakingMemo = tronStakingMemo(TronStakingOperation.FREEZE, TronResourceType.ENERGY)
+        val uiModel = mapper().invoke(tronTransaction(stakingMemo, token = trc20))
+
+        uiModel.headerTitleRes shouldBe null
+        uiModel.memo shouldBe stakingMemo
     }
 
     @Test
@@ -81,17 +92,17 @@ internal class TransactionToUiModelMapperTronStakingTest {
         uiModel.memo shouldBe "gm"
     }
 
-    private fun tronTransaction(memo: String?): Transaction =
+    private fun tronTransaction(memo: String?, token: Coin = trx): Transaction =
         Transaction(
             id = "tx-1",
             vaultId = "vault-1",
             chainId = Chain.Tron.id,
-            token = trx,
+            token = token,
             srcAddress = "Towner",
             dstAddress = "Tdest",
-            tokenValue = TokenValue(value = BigInteger.TEN, token = trx),
+            tokenValue = TokenValue(value = BigInteger.TEN, token = token),
             fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
-            gasFee = TokenValue(value = BigInteger.ONE, token = trx),
+            gasFee = TokenValue(value = BigInteger.ONE, token = token),
             totalGas = "0",
             memo = memo,
             estimatedFee = "0",
@@ -110,6 +121,13 @@ internal class TransactionToUiModelMapperTronStakingTest {
                 priceProviderID = "tron",
                 contractAddress = "",
                 isNativeToken = true,
+            )
+
+        val trc20 =
+            trx.copy(
+                ticker = "USDT",
+                contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                isNativeToken = false,
             )
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapperTronStakingTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapperTronStakingTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.mappers
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.tron.TronResourceType
+import com.vultisig.wallet.data.blockchain.tron.TronStakingOperation
+import com.vultisig.wallet.data.blockchain.tron.tronStakingMemo
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * TRON freeze/unfreeze is routed through the Send form and carries its operation only as an
+ * internal memo prefix. The Verify screen builds off [TransactionToUiModelMapper]; without
+ * operation-aware mapping it would report a stake/unstake as a plain send and leak the raw
+ * "UNFREEZE:BANDWIDTH" prefix into the Memo row (issue #5274).
+ */
+internal class TransactionToUiModelMapperTronStakingTest {
+
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk(relaxed = true)
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper =
+        mockk(relaxed = true)
+
+    private fun mapper() =
+        TransactionToUiModelMapperImpl(
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+        )
+
+    @Test
+    fun `unfreeze surfaces the unfreeze header and hides the internal memo prefix`() = runTest {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+
+        val uiModel =
+            mapper()
+                .invoke(
+                    tronTransaction(
+                        tronStakingMemo(TronStakingOperation.UNFREEZE, TronResourceType.BANDWIDTH)
+                    )
+                )
+
+        uiModel.headerTitleRes shouldBe R.string.tron_unfreeze_screen_title
+        uiModel.memo shouldBe null
+    }
+
+    @Test
+    fun `freeze surfaces the freeze header and hides the internal memo prefix`() = runTest {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+
+        val uiModel =
+            mapper()
+                .invoke(
+                    tronTransaction(
+                        tronStakingMemo(TronStakingOperation.FREEZE, TronResourceType.ENERGY)
+                    )
+                )
+
+        uiModel.headerTitleRes shouldBe R.string.tron_freeze_screen_title
+        uiModel.memo shouldBe null
+    }
+
+    @Test
+    fun `a plain TRON send keeps the generic header and its memo`() = runTest {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+
+        val uiModel = mapper().invoke(tronTransaction("gm"))
+
+        uiModel.headerTitleRes shouldBe null
+        uiModel.memo shouldBe "gm"
+    }
+
+    private fun tronTransaction(memo: String?): Transaction =
+        Transaction(
+            id = "tx-1",
+            vaultId = "vault-1",
+            chainId = Chain.Tron.id,
+            token = trx,
+            srcAddress = "Towner",
+            dstAddress = "Tdest",
+            tokenValue = TokenValue(value = BigInteger.TEN, token = trx),
+            fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+            gasFee = TokenValue(value = BigInteger.ONE, token = trx),
+            totalGas = "0",
+            memo = memo,
+            estimatedFee = "0",
+            blockChainSpecific = mockk<BlockChainSpecific.Tron>(relaxed = true),
+        )
+
+    private companion object {
+        val trx =
+            Coin(
+                chain = Chain.Tron,
+                ticker = "TRX",
+                logo = "trx",
+                address = "Towner",
+                decimal = 6,
+                hexPublicKey = "hex",
+                priceProviderID = "tron",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+    }
+}


### PR DESCRIPTION
## Summary
The Verify screen is the last human checkpoint before signing. TRON freeze/unfreeze is routed through the Send form and carries its operation only as an internal memo prefix (`FREEZE:<resource>` / `UNFREEZE:<resource>`). By the Verify layer that prefix populates `tx.memo` and no operation signal survives, so the screen:

- showed the generic **"You're sending"** header — misrepresenting a stake/unstake as a plain send, and
- leaked the raw prefix as a **"Memo: UNFREEZE:ENERGY"** row (internal plumbing on a signing screen).

Fixes #5274.

## Changes
- `TransactionDetailsUiModel` — added `@StringRes headerTitleRes: Int?` (null → generic "You're sending" fallback).
- `TransactionToUiModelMapper` — detects the TRON staking memo via the existing `TRON_STAKING_MEMO_REGEX`, maps the operation to the same labels the Send form uses (`Freeze TRON` / `Unfreeze TRON`), and nulls the internal memo so it no longer renders as a Memo row.
- `VerifySendScreen` — header now reads `tx.headerTitleRes ?: R.string.verify_deposit_sending`.

## Scope
First cut is the Send-form path (TRON freeze/unfreeze), matching the issue. `VerifyDepositScreen` uses a different model with its own `operation` field and is untouched. `TronStakingOperation` currently has only FREEZE/UNFREEZE (no WITHDRAW), so those two are covered.

## Test plan
- New unit test `TransactionToUiModelMapperTronStakingTest` (3 cases): unfreeze → unfreeze header + memo hidden; freeze → freeze header + memo hidden; plain TRON send → generic header + memo preserved. `:app:testDebugUnitTest` green.
- Manual: Vault → DeFi tab → TRON → Unfreeze → amount → Continue → Verify.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/s2O99VG.png) | ![after](https://i.imgur.com/b5HAIb5.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operation-specific headers for TRON staking transactions (Freeze/Unfreeze) and display resource-focused memos.
* **Bug Fixes**
  * Updated transaction verification to use the new header when available, otherwise fall back to the standard title.
  * Ensured TRC20 staking memos are not misclassified as TRON staking.
* **Tests**
  * Added automated coverage for TRON Freeze/Unfreeze memo parsing and standard memo passthrough behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->