### PR TITLE
fix(thorchain): bRUNE/ybRUNE follow-ups — discovery, pricing & swap gating (#5275)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.isBuySupported
 import com.vultisig.wallet.data.models.isDepositSupported
+import com.vultisig.wallet.data.models.isLpToken
 import com.vultisig.wallet.data.models.isSwapSupported
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.repositories.AccountsRepository
@@ -151,7 +152,10 @@ constructor(
                                     it.copy(
                                         token = tokenUiModel,
                                         canDeposit = chain.isDepositSupported,
-                                        canSwap = chain.isSwapSupported,
+                                        // LP receipt tokens (e.g. bRUNE/ybRUNE) can't be a swap
+                                        // source; gate the button here too, not only in the asset
+                                        // pickers, so it can't be entered from this screen.
+                                        canSwap = chain.isSwapSupported && !token.isLpToken,
                                         canBuy = chain.isBuySupported,
                                         explorerUrl = explorerUrl,
                                     )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
@@ -82,6 +82,15 @@ interface VaultDao {
         coins.forEach { deleteFromDisabledCoin(vaultId = it.vaultId, coinId = it.id) }
     }
 
+    // Atomically swap a stale token for its corrected identity. Delete + enable run in one
+    // transaction so a mid-way failure can never leave the vault without the token; and when the
+    // corrected id is unchanged, the insert's REPLACE still wins because the delete precedes it.
+    @Transaction
+    suspend fun replaceToken(vaultId: String, oldTokenId: String, coin: CoinEntity) {
+        deleteTokenFromVault(vaultId, oldTokenId)
+        enableCoins(listOf(coin))
+    }
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertDisabledCoin(disabledCoin: DisabledCoinEntity)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -43,10 +43,15 @@ data class Coin(
 val Coin.isLpToken: Boolean
     get() =
         when (chain) {
-            Chain.ThorChain ->
-                contractAddress.startsWith("x/staking-") ||
-                    contractAddress.startsWith("x/nami-index-") ||
-                    contractAddress == "x/brune"
+            Chain.ThorChain -> {
+                // Compare on the lowercased denom so a persisted coin with non-canonical casing
+                // (e.g. a pre-canonicalization "x/BRUNE") is still recognized as an LP position and
+                // excluded from the swap pickers, matching the lowercase pricing path.
+                val addr = contractAddress.lowercase()
+                addr.startsWith("x/staking-") ||
+                    addr.startsWith("x/nami-index-") ||
+                    addr == "x/brune"
+            }
             Chain.MayaChain ->
                 contractAddress.startsWith("x/bow-") ||
                     contractAddress.startsWith("x/ghost-vault/") ||

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -422,6 +422,22 @@ constructor(
                         fetchTetherPrice()
                     }
 
+                // bRUNE and ybRUNE both price off RUNE-in-USD. Fetch it once up front (only when a
+                // RUNE-backed denom is present) so concurrent per-token async blocks don't each
+                // miss
+                // a cold cache and fire a duplicate live CoinGecko call for the same value.
+                val runeUsdPrice =
+                    if (
+                        matchingTokens.any {
+                            val denom = it.contractAddress.lowercase()
+                            denom == BRUNE_DENOM || denom == YBRUNE_DENOM
+                        }
+                    ) {
+                        runePriceUsd()
+                    } else {
+                        BigDecimal.ZERO
+                    }
+
                 val tokenIdToPrices = coroutineScope {
                     contracts
                         .zip(tokenIds)
@@ -434,7 +450,7 @@ constructor(
                                         when (token.contractAddress.lowercase()) {
                                             // bRUNE is ≥1:1 RUNE-backed with no THORChain pool, so
                                             // it tracks RUNE at parity.
-                                            BRUNE_DENOM -> runePriceUsd()
+                                            BRUNE_DENOM -> runeUsdPrice
                                             // ybRUNE is the auto-compounding bRUNE staking receipt:
                                             // NAV (liquid_bond_size / liquid_bond_shares) × bRUNE,
                                             // and bRUNE ≈ RUNE. Same mechanism as sTCY.
@@ -445,7 +461,7 @@ constructor(
                                                             contract
                                                         )
                                                     )
-                                                nav * runePriceUsd()
+                                                nav * runeUsdPrice
                                             }
                                             "x/staking-tcy" -> {
                                                 val tcyPriceUSD =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -433,7 +433,17 @@ constructor(
                             denom == BRUNE_DENOM || denom == YBRUNE_DENOM
                         }
                     ) {
-                        runePriceUsd()
+                        // This runs outside the per-token async guards, so a failure here would
+                        // abort the whole batch (NAMI, sTCY, …). Contain it and fall back to 0 —
+                        // the zero-price filter below then drops bRUNE/ybRUNE for this cycle
+                        // instead of overwriting their last-known good price.
+                        try {
+                            runePriceUsd()
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
+                            Timber.e(e, "Failed to fetch shared RUNE-in-USD price")
+                            BigDecimal.ZERO
+                        }
                     } else {
                         BigDecimal.ZERO
                     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -438,7 +438,7 @@ constructor(
                         // the zero-price filter below then drops bRUNE/ybRUNE for this cycle
                         // instead of overwriting their last-known good price.
                         try {
-                            runePriceUsd()
+                            runePriceUsd(currency)
                         } catch (e: Exception) {
                             if (e is kotlinx.coroutines.CancellationException) throw e
                             Timber.e(e, "Failed to fetch shared RUNE-in-USD price")
@@ -474,9 +474,7 @@ constructor(
                                                 nav * runeUsdPrice
                                             }
                                             "x/staking-tcy" -> {
-                                                val tcyPriceUSD =
-                                                    getCachedPrice("tcy", AppCurrency.USD)
-                                                        ?: getPriceByPriceProviderId("tcy")
+                                                val tcyPriceUSD = tcyPriceUsd(currency)
                                                 val nav =
                                                     navPerShareFromStatus(
                                                         thorApi.getThorchainTokenPriceByContract(
@@ -521,30 +519,58 @@ constructor(
             }
         }
 
-    private suspend fun runePriceUsd(): BigDecimal =
-        // Cache rows are keyed by Coin.id ("RUNE-THORChain"), not priceProviderID ("thorchain"), so
-        // the lookup must use the id or it can never hit and every call re-fetches live. The live
-        // fallback fetches RUNE explicitly in USD: getPriceByPriceProviderId returns the app
-        // currency, and callers multiply this result by tetherPrice (currency-per-USD), so a
-        // non-USD value here would double-apply FX.
-        getCachedPrice(Coins.ThorChain.RUNE.id, AppCurrency.USD) ?: fetchRunePriceUsdLive()
+    // RUNE-in-USD, used to price the RUNE-backed bRUNE/ybRUNE denoms.
+    // Cache rows are keyed by Coin.id ("RUNE-THORChain"), not priceProviderID ("thorchain"), so a
+    // lookup by provider id can never hit. The cached "usd" row is also only written while the app
+    // currency is USD and is never invalidated on a currency switch, so a non-USD user who once ran
+    // USD would otherwise read a frozen stale quote — only trust the cache while we are actually in
+    // USD, else fetch live. The live fallback fetches RUNE explicitly in USD
+    // (getPriceByPriceProviderId
+    // returns the app currency), and callers multiply by tetherPrice (currency-per-USD), so a
+    // non-USD value here would double-apply FX.
+    private suspend fun runePriceUsd(currency: String): BigDecimal {
+        if (currency.equals(AppCurrency.USD.ticker, ignoreCase = true)) {
+            getCachedPrice(Coins.ThorChain.RUNE.id, AppCurrency.USD)?.let {
+                return it
+            }
+        }
+        return fetchRunePriceUsdLive()
+    }
 
     private suspend fun fetchRunePriceUsdLive(): BigDecimal =
+        fetchCryptoPriceUsdLive(Coins.ThorChain.RUNE.priceProviderID)
+
+    // TCY-in-USD, used to price the sTCY staking receipt. Same rules as runePriceUsd: cache rows
+    // key
+    // on Coin.id ("TCY-THORChain"), not the "tcy" priceProviderID, and the cached usd row is only
+    // fresh while the app currency is USD. sTCY then multiplies this by NAV and the caller by
+    // tetherPrice, so a non-USD or provider-id-keyed value here would double-apply FX.
+    private suspend fun tcyPriceUsd(currency: String): BigDecimal {
+        if (currency.equals(AppCurrency.USD.ticker, ignoreCase = true)) {
+            getCachedPrice(Coins.ThorChain.TCY.id, AppCurrency.USD)?.let {
+                return it
+            }
+        }
+        return fetchCryptoPriceUsdLive(Coins.ThorChain.TCY.priceProviderID)
+    }
+
+    private suspend fun fetchCryptoPriceUsdLive(priceProviderId: String): BigDecimal =
         coinGeckoApi
-            .getCryptoPrices(
-                listOf(Coins.ThorChain.RUNE.priceProviderID),
-                listOf(AppCurrency.USD.ticker.lowercase()),
-            )
+            .getCryptoPrices(listOf(priceProviderId), listOf(AppCurrency.USD.ticker.lowercase()))
             .values
             .firstOrNull()
             ?.values
             ?.firstOrNull() ?: BigDecimal.ZERO
 
     // NAV per share from a `rujira-staking` `{"status":{}}` response:
-    // liquid_bond_size / liquid_bond_shares, falling back to 1 before any bonds exist.
+    // liquid_bond_size / liquid_bond_shares, falling back to 1 for a genuine pre-bond state (both
+    // fields present and zero). A malformed/empty 2xx leaves the fields at their "" default;
+    // pricing
+    // off that (nav = 1 → RUNE/TCY parity) would overwrite the accrued NAV price and slip past the
+    // caller's zero-filter, so treat an unparseable size/shares as 0 (dropped) instead.
     private fun navPerShareFromStatus(vaultData: VaultRedemptionResponseJson): BigDecimal {
-        val size = vaultData.data.liquidBondSize.toBigDecimalOrNull() ?: BigDecimal.ZERO
-        val shares = vaultData.data.liquidBondShares.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        val size = vaultData.data.liquidBondSize.toBigDecimalOrNull() ?: return BigDecimal.ZERO
+        val shares = vaultData.data.liquidBondShares.toBigDecimalOrNull() ?: return BigDecimal.ZERO
         return if (shares > BigDecimal.ZERO) {
             size.divide(shares, 8, RoundingMode.DOWN)
         } else {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -479,6 +479,12 @@ constructor(
                         }
                         .awaitAll()
                         .filterNotNull()
+                        // Drop zero prices rather than persist them. A transient failure (an
+                        // unparseable NAV, a rate-limited RUNE price) yields 0, and savePrices
+                        // only guards an empty currency map, so a $0 would overwrite the
+                        // last-known good price. signum() (not `!= ZERO`) is used so a scaled
+                        // zero like 0E-8 from a NAV division still counts as zero.
+                        .filter { (_, prices) -> prices.values.any { it.signum() != 0 } }
                         .toMap()
                 }
 
@@ -490,8 +496,23 @@ constructor(
         }
 
     private suspend fun runePriceUsd(): BigDecimal =
-        getCachedPrice(Coins.ThorChain.RUNE.priceProviderID, AppCurrency.USD)
-            ?: getPriceByPriceProviderId(Coins.ThorChain.RUNE.priceProviderID)
+        // Cache rows are keyed by Coin.id ("RUNE-THORChain"), not priceProviderID ("thorchain"), so
+        // the lookup must use the id or it can never hit and every call re-fetches live. The live
+        // fallback fetches RUNE explicitly in USD: getPriceByPriceProviderId returns the app
+        // currency, and callers multiply this result by tetherPrice (currency-per-USD), so a
+        // non-USD value here would double-apply FX.
+        getCachedPrice(Coins.ThorChain.RUNE.id, AppCurrency.USD) ?: fetchRunePriceUsdLive()
+
+    private suspend fun fetchRunePriceUsdLive(): BigDecimal =
+        coinGeckoApi
+            .getCryptoPrices(
+                listOf(Coins.ThorChain.RUNE.priceProviderID),
+                listOf(AppCurrency.USD.ticker.lowercase()),
+            )
+            .values
+            .firstOrNull()
+            ?.values
+            ?.firstOrNull() ?: BigDecimal.ZERO
 
     // NAV per share from a `rujira-staking` `{"status":{}}` response:
     // liquid_bond_size / liquid_bond_shares, falling back to 1 before any bonds exist.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -95,7 +95,15 @@ constructor(
                 val metaCache = mutableMapOf<String, DenomMetadata?>()
                 balances.mapNotNull {
                     if (it.denom in DEFI_ONLY_THORCHAIN_DENOMS) return@mapNotNull null
-                    if (enabledDenoms.isNotEmpty() && it.denom !in enabledDenoms)
+                    // The enabledDenoms gate keeps the wallet from auto-adding arbitrary bank
+                    // denoms the user never enabled. Curated liquid-bonding denoms are the
+                    // exception: they must surface the first time a wallet holds one, before any
+                    // manual enable, so they bypass the gate.
+                    if (
+                        enabledDenoms.isNotEmpty() &&
+                            it.denom !in enabledDenoms &&
+                            it.denom.lowercase() !in AUTO_DISCOVER_THORCHAIN_DENOMS
+                    )
                         return@mapNotNull null
                     val metadata =
                         metaCache.getOrPut(it.denom) { thorApi.getDenomMetaFromLCD(it.denom) }
@@ -153,10 +161,12 @@ constructor(
                         Coins.ThorChain.bRUNE.contractAddress -> {
                             symbol = Coins.ThorChain.bRUNE.ticker
                             contractAddress = Coins.ThorChain.bRUNE.contractAddress
+                            decimal = Coins.ThorChain.bRUNE.decimal
                         }
                         Coins.ThorChain.ybRUNE.contractAddress -> {
                             symbol = Coins.ThorChain.ybRUNE.ticker
                             contractAddress = Coins.ThorChain.ybRUNE.contractAddress
+                            decimal = Coins.ThorChain.ybRUNE.decimal
                         }
                     }
 
@@ -276,6 +286,14 @@ constructor(
 // The on-chain sRUJI receipt denom is "x/staking-x/ruji"; the legacy "x/staking-ruji" spelling is
 // kept defensively so the receipt stays excluded regardless of which the node reports.
 internal val DEFI_ONLY_THORCHAIN_DENOMS = setOf("x/staking-ruji", "x/staking-x/ruji")
+
+// Curated Rujira liquid-bonding denoms that must auto-surface the first time a wallet receives one,
+// before the user has manually enabled it. getRefreshTokens seeds enabledDenoms only from
+// vault.coins, so a fresh holder (who only ever seeded native RUNE) would otherwise have these
+// dropped by the enabledDenoms gate and never reach the canonicalization override. Stored lowercase
+// to match the canonical denom casing the balance response is compared against.
+internal val AUTO_DISCOVER_THORCHAIN_DENOMS =
+    setOf(Coins.ThorChain.bRUNE.contractAddress, Coins.ThorChain.ybRUNE.contractAddress)
 
 /**
  * Decodes the result of an ERC-20 `name()` / `symbol()` `eth_call` into text.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -60,6 +60,8 @@ interface VaultRepository {
     suspend fun deleteChainFromVault(vaultId: VaultId, chain: Chain)
 
     suspend fun addTokenToVault(vaultId: VaultId, token: Coin)
+
+    suspend fun replaceTokenInVault(vaultId: VaultId, oldToken: Coin, newToken: Coin)
 }
 
 internal class VaultRepositoryImpl
@@ -135,6 +137,10 @@ constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRe
 
     override suspend fun addTokenToVault(vaultId: String, token: Coin) {
         vaultDao.enableCoins(listOf(token.toCoinEntity(vaultId)))
+    }
+
+    override suspend fun replaceTokenInVault(vaultId: String, oldToken: Coin, newToken: Coin) {
+        vaultDao.replaceToken(vaultId, oldToken.id, newToken.toCoinEntity(vaultId))
     }
 
     private suspend fun VaultWithKeySharesAndTokens.toVault(): Vault {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -106,11 +106,21 @@ constructor(
         refreshToken: Coin,
         vault: Vault,
     ) {
-        val isTokenExist =
-            enabledCoinIds.any { enabledCoinId ->
+        val existing =
+            enabledCoinIds.firstOrNull { enabledCoinId ->
                 enabledCoinId.id.equals(refreshToken.id, ignoreCase = true)
             }
-        if (isTokenExist) return
+        if (existing != null) {
+            // The token is already tracked. The id match is case-insensitive, so a stale entry
+            // whose curated identity has since been corrected (e.g. a ticker recased from "BRUNE"
+            // to "bRUNE", or a canonicalized contractAddress/decimal) would otherwise be kept
+            // forever. Overwrite it with the freshly derived identity when they disagree.
+            if (existing.needsIdentityCorrection(refreshToken)) {
+                vaultRepository.deleteTokenFromVault(vault.id, existing)
+                vaultRepository.addTokenToVault(vault.id, refreshToken)
+            }
+            return
+        }
 
         val withSameContractCoin =
             enabledCoinIds.firstOrNull { enabledCoin ->
@@ -121,6 +131,14 @@ constructor(
 
         vaultRepository.addTokenToVault(vault.id, refreshToken)
     }
+
+    // True when a persisted coin's curated identity (case-sensitive ticker, contractAddress, or
+    // decimal) has drifted from the freshly derived one and should be overwritten. Deliberately
+    // excludes address/hexPublicKey, which are vault-derived and always match for the same id.
+    private fun Coin.needsIdentityCorrection(refreshToken: Coin): Boolean =
+        ticker != refreshToken.ticker ||
+            contractAddress != refreshToken.contractAddress ||
+            decimal != refreshToken.decimal
 
     companion object {
         const val ARG_VAULT_ID = "vault_id"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -113,8 +113,9 @@ constructor(
         if (existing != null) {
             // The token is already tracked. The id match is case-insensitive, so a stale entry
             // whose curated identity has since been corrected (e.g. a ticker recased from "BRUNE"
-            // to "bRUNE", or a canonicalized contractAddress/decimal) would otherwise be kept
-            // forever. Overwrite it with the freshly derived identity when they disagree.
+            // to "bRUNE", a recased contractAddress, or a drifted decimal) would otherwise be kept
+            // forever. Overwrite it with the freshly derived identity when they disagree — but only
+            // when it is genuinely the same token (see needsIdentityCorrection).
             if (existing.needsIdentityCorrection(refreshToken)) {
                 // Atomic swap: a mid-way failure must never drop the token, and a same-id
                 // correction (only contractAddress/decimal drifted) must not have its refreshed
@@ -134,13 +135,19 @@ constructor(
         vaultRepository.addTokenToVault(vault.id, refreshToken)
     }
 
-    // True when a persisted coin's curated identity (case-sensitive ticker, contractAddress, or
-    // decimal) has drifted from the freshly derived one and should be overwritten. Deliberately
-    // excludes address/hexPublicKey, which are vault-derived and always match for the same id.
-    private fun Coin.needsIdentityCorrection(refreshToken: Coin): Boolean =
-        ticker != refreshToken.ticker ||
+    // True when a persisted coin's curated identity (case-sensitive ticker, contractAddress casing,
+    // or decimal) has drifted from the freshly derived one and should be overwritten. Coin.id is
+    // ticker-based, so a provider that reports a *different* contract under an existing ticker must
+    // never trigger a correction — replacing the row would flip the send target to another contract
+    // on every refresh. Gate on the same contractAddress (case-insensitive) so only same-token
+    // recasing/decimal fixes survive. Deliberately excludes address/hexPublicKey, which are
+    // vault-derived and always match for the same id.
+    private fun Coin.needsIdentityCorrection(refreshToken: Coin): Boolean {
+        if (!contractAddress.equals(refreshToken.contractAddress, ignoreCase = true)) return false
+        return ticker != refreshToken.ticker ||
             contractAddress != refreshToken.contractAddress ||
             decimal != refreshToken.decimal
+    }
 
     companion object {
         const val ARG_VAULT_ID = "vault_id"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorker.kt
@@ -116,8 +116,10 @@ constructor(
             // to "bRUNE", or a canonicalized contractAddress/decimal) would otherwise be kept
             // forever. Overwrite it with the freshly derived identity when they disagree.
             if (existing.needsIdentityCorrection(refreshToken)) {
-                vaultRepository.deleteTokenFromVault(vault.id, existing)
-                vaultRepository.addTokenToVault(vault.id, refreshToken)
+                // Atomic swap: a mid-way failure must never drop the token, and a same-id
+                // correction (only contractAddress/decimal drifted) must not have its refreshed
+                // row deleted after being re-inserted.
+                vaultRepository.replaceTokenInVault(vault.id, existing, refreshToken)
             }
             return
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinIsLpTokenTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinIsLpTokenTest.kt
@@ -83,6 +83,18 @@ class CoinIsLpTokenTest {
     }
 
     @Test
+    fun `ThorChain bRUNE with non-canonical casing is still an LP token`() {
+        val c = coin(Chain.ThorChain, "bRUNE", "x/BRUNE")
+        assertTrue(c.isLpToken)
+    }
+
+    @Test
+    fun `ThorChain staking denom with non-canonical casing is still an LP token`() {
+        val c = coin(Chain.ThorChain, "sTCY", "X/STAKING-TCY")
+        assertTrue(c.isLpToken)
+    }
+
+    @Test
     fun `MayaChain x-brune is not an LP token`() {
         val c = coin(Chain.MayaChain, "bRUNE", "x/brune")
         assertFalse(c.isLpToken)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -210,6 +210,37 @@ internal class TokenPriceRepositoryImplTest {
     }
 
     @Test
+    fun `refreshing bRUNE and ybRUNE together fetches the live RUNE price at most once`() =
+        runTest {
+            // Cold RUNE cache + both denoms in one refresh: bRUNE and ybRUNE both price off
+            // RUNE-in-USD,
+            // so the live CoinGecko RUNE fetch must be shared, not fired once per token.
+            stubEmptyContractFallback()
+            coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns null
+            coEvery {
+                coinGeckoApi.getCryptoPrices(
+                    match { it.contains("thorchain") },
+                    match { it.contains("usd") },
+                )
+            } returns mapOf("thorchain" to mapOf("usd" to BigDecimal("5.0")))
+            // Any other id (e.g. the contract-fallback fan-out) resolves to nothing.
+            coEvery {
+                coinGeckoApi.getCryptoPrices(match { !it.contains("thorchain") }, any())
+            } returns emptyMap()
+            // ybRUNE NAV = 200 / 100 = 2.
+            coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+                redemption(bondSize = "200", bondShares = "100")
+
+            repository.refresh(listOf(bRune, ybRune))
+
+            assertPriceEquals("5", repository.getPrice(bRune, AppCurrency.USD).first())
+            assertPriceEquals("10", repository.getPrice(ybRune, AppCurrency.USD).first())
+            coVerify(exactly = 1) {
+                coinGeckoApi.getCryptoPrices(match { it.contains("thorchain") }, any())
+            }
+        }
+
+    @Test
     fun `does not persist a zero ybRUNE price when the NAV field is malformed`() = runTest {
         stubEmptyContractFallback()
         coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -257,6 +257,65 @@ internal class TokenPriceRepositoryImplTest {
     }
 
     @Test
+    fun `does not persist a nonzero parity price when the NAV status is empty`() = runTest {
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns "5.0"
+        // A malformed/empty 2xx leaves both bond fields at their "" default. NAV must resolve to 0
+        // (dropped), not 1 (RUNE parity), so it can't overwrite the last-known ybRUNE price.
+        coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+            redemption(bondSize = "", bondShares = "")
+
+        repository.refresh(listOf(ybRune))
+
+        coVerify(exactly = 0) { tokenPriceDao.insertTokenPrice(match { it.tokenId == ybRune.id }) }
+    }
+
+    private val sTcy = Coins.ThorChain.sTCY
+
+    @Test
+    fun `sTCY prices off the TCY cache keyed by coin id, not the tcy price provider`() = runTest {
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        // TCY-in-USD served from the cache, keyed by Coin.id ("TCY-THORChain") — a lookup by the
+        // "tcy" priceProviderID never hits, so this pins the coin-id path.
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.TCY.id, "usd") } returns "2.0"
+        // sTCY NAV = 200 / 100 = 2, so sTCY = 2 (TCY) × 2 (NAV) = 4.
+        coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+            redemption(bondSize = "200", bondShares = "100")
+
+        repository.refresh(listOf(sTcy))
+
+        assertPriceEquals("4", repository.getPrice(sTcy, AppCurrency.USD).first())
+    }
+
+    @Test
+    fun `sTCY live TCY fallback fetches TCY in USD and applies FX only once`() = runTest {
+        // Non-USD app currency, no cached TCY price: the live fallback must fetch TCY in USD and
+        // the
+        // caller applies the tether (currency-per-USD) rate exactly once. The old provider-id path
+        // returned the app currency and then multiplied by tether, so a EUR/JPY user saw sTCY
+        // roughly FX-times too high.
+        coEvery { appCurrencyRepository.currency } returns flowOf(AppCurrency.EUR)
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.TCY.id, "usd") } returns null
+        coEvery {
+            coinGeckoApi.getCryptoPrices(match { it.contains("tcy") }, match { it.contains("usd") })
+        } returns mapOf("tcy" to mapOf("usd" to BigDecimal("2.0")))
+        coEvery { coinGeckoApi.getCryptoPrices(match { it.contains("tether") }, any()) } returns
+            mapOf("tether" to mapOf("eur" to BigDecimal("0.9")))
+        // sTCY NAV = 200 / 100 = 2.
+        coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+            redemption(bondSize = "200", bondShares = "100")
+
+        repository.refresh(listOf(sTcy))
+
+        // 2 USD (TCY) × 2 (NAV) × 0.9 EUR/USD = 3.6 EUR. A double-applied FX would yield 3.24.
+        assertPriceEquals("3.6", repository.getPrice(sTcy, AppCurrency.EUR).first())
+    }
+
+    @Test
     fun `VaultRedemption response maps the liquid bond JSON fields`() = runTest {
         // Pins the @SerialName mapping for the {"status":{}} contract query: a renamed field would
         // otherwise deserialize to the empty-string default and silently price ybRUNE at parity.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -4,9 +4,11 @@ import com.vultisig.wallet.data.api.CoinGeckoApi
 import com.vultisig.wallet.data.api.LiQuestApi
 import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.VaultRedemptionResponseJson
 import com.vultisig.wallet.data.db.dao.TokenPriceDao
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -17,6 +19,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -125,5 +128,109 @@ internal class TokenPriceRepositoryImplTest {
 
         val price = repository.getPrice(ezEth, AppCurrency.USD).first()
         assertEquals(BigDecimal("3400.0"), price)
+    }
+
+    private val bRune = Coins.ThorChain.bRUNE
+    private val ybRune = Coins.ThorChain.ybRUNE
+
+    // Silences the CoinGecko/LiFi contract-address fallback that any THORChain bank denom (empty
+    // priceProviderID) is fanned through, so only fetchThorContractPrices sets bRUNE/ybRUNE prices.
+    private fun stubEmptyContractFallback() {
+        coEvery { coinGeckoApi.getContractsPrice(any(), any(), any()) } returns emptyMap()
+        coEvery { liQuestApi.getLifiContractPriceUsd(any(), any()) } throws
+            RuntimeException("no lifi")
+        coEvery { thorApi.getPools() } returns emptyList()
+    }
+
+    // BigDecimal.equals is scale-sensitive (5.0 != 5.00000000); compare by value instead.
+    private fun assertPriceEquals(expected: String, actual: BigDecimal) =
+        assertEquals(
+            0,
+            BigDecimal(expected).compareTo(actual),
+            "expected $expected but was $actual",
+        )
+
+    private fun redemption(bondSize: String, bondShares: String): VaultRedemptionResponseJson =
+        Json.decodeFromString(
+            """{"data":{"liquid_bond_size":"$bondSize","liquid_bond_shares":"$bondShares"}}"""
+        )
+
+    @Test
+    fun `bRUNE tracks RUNE at parity and ybRUNE is NAV times RUNE`() = runTest {
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        // RUNE price is served from the cache, keyed by Coin.id.
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns "5.0"
+        // ybRUNE NAV = 200 / 100 = 2.
+        coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+            redemption(bondSize = "200", bondShares = "100")
+
+        repository.refresh(listOf(bRune, ybRune))
+
+        assertPriceEquals("5", repository.getPrice(bRune, AppCurrency.USD).first())
+        assertPriceEquals("10", repository.getPrice(ybRune, AppCurrency.USD).first())
+    }
+
+    @Test
+    fun `runePriceUsd reads the cache by coin id, not price provider id`() = runTest {
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns "5.0"
+
+        repository.refresh(listOf(bRune))
+
+        assertPriceEquals("5", repository.getPrice(bRune, AppCurrency.USD).first())
+        // A correct cache hit means no live RUNE fetch was needed.
+        coVerify(exactly = 0) {
+            coinGeckoApi.getCryptoPrices(match { it.contains("thorchain") }, any())
+        }
+    }
+
+    @Test
+    fun `runePriceUsd live fallback fetches RUNE in USD and applies FX only once`() = runTest {
+        // Non-USD app currency, no cached RUNE price: the live fallback must fetch RUNE in USD and
+        // the caller applies the tether (currency-per-USD) rate exactly once.
+        coEvery { appCurrencyRepository.currency } returns flowOf(AppCurrency.EUR)
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns null
+        coEvery {
+            coinGeckoApi.getCryptoPrices(
+                match { it.contains("thorchain") },
+                match { it.contains("usd") },
+            )
+        } returns mapOf("thorchain" to mapOf("usd" to BigDecimal("5.0")))
+        coEvery { coinGeckoApi.getCryptoPrices(match { it.contains("tether") }, any()) } returns
+            mapOf("tether" to mapOf("eur" to BigDecimal("0.9")))
+
+        repository.refresh(listOf(bRune))
+
+        // 5 USD × 0.9 EUR/USD = 4.5 EUR. A double-applied FX would yield 4.05.
+        assertPriceEquals("4.5", repository.getPrice(bRune, AppCurrency.EUR).first())
+    }
+
+    @Test
+    fun `does not persist a zero ybRUNE price when the NAV field is malformed`() = runTest {
+        stubEmptyContractFallback()
+        coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+        coEvery { tokenPriceDao.getTokenPrice(Coins.ThorChain.RUNE.id, "usd") } returns "5.0"
+        // Unparseable bond size with positive shares → NAV 0 → price 0, which must not overwrite
+        // the
+        // last-known price.
+        coEvery { thorApi.getThorchainTokenPriceByContract(any()) } returns
+            redemption(bondSize = "n/a", bondShares = "100")
+
+        repository.refresh(listOf(ybRune))
+
+        coVerify(exactly = 0) { tokenPriceDao.insertTokenPrice(match { it.tokenId == ybRune.id }) }
+    }
+
+    @Test
+    fun `VaultRedemption response maps the liquid bond JSON fields`() = runTest {
+        // Pins the @SerialName mapping for the {"status":{}} contract query: a renamed field would
+        // otherwise deserialize to the empty-string default and silently price ybRUNE at parity.
+        val response = redemption(bondSize = "123", bondShares = "45")
+        assertEquals("123", response.data.liquidBondSize)
+        assertEquals("45", response.data.liquidBondShares)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -131,6 +131,56 @@ internal class TokenRepositoryImplTest {
         }
 
     @Test
+    fun `getTokensWithBalance surfaces bRUNE even when it is not in enabledDenoms`() = runTest {
+        // A fresh holder only ever seeded native RUNE, so enabledDenoms won't contain bRUNE. The
+        // curated liquid-bonding denom must bypass the gate and auto-surface anyway.
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(
+                CosmosBalance(denom = Coins.ThorChain.bRUNE.contractAddress, amount = "100"),
+                CosmosBalance(denom = "btc/btc", amount = "50"),
+            )
+        coEvery { thorApi.getDenomMetaFromLCD(any()) } returns null
+
+        val coins =
+            newRepository(thorApi)
+                .getTokensWithBalance(Chain.ThorChain, ADDRESS, enabledDenoms = setOf("rune"))
+
+        val bRune = coins.single { it.contractAddress == Coins.ThorChain.bRUNE.contractAddress }
+        assertEquals(Coins.ThorChain.bRUNE.ticker, bRune.ticker)
+        // A non-curated denom stays gated out.
+        assertTrue(coins.none { it.contractAddress == "btc/btc" })
+    }
+
+    @Test
+    fun `getTokensWithBalance canonicalizes bRUNE decimal to the curated value`() = runTest {
+        // The denom-metadata ladder reports a non-8 exponent; the curated override must reset
+        // decimal alongside ticker/contractAddress so the discovered coin can't disagree with the
+        // curated definition.
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(CosmosBalance(denom = Coins.ThorChain.bRUNE.contractAddress, amount = "100"))
+        coEvery { thorApi.getDenomMetaFromLCD(Coins.ThorChain.bRUNE.contractAddress) } returns
+            DenomMetadata(
+                base = Coins.ThorChain.bRUNE.contractAddress,
+                symbol = "x/brune",
+                display = null,
+                denomUnits =
+                    listOf(
+                        com.vultisig.wallet.data.api.models.DenomUnit(
+                            denom = "x/brune",
+                            exponent = 6,
+                        )
+                    ),
+            )
+
+        val coins = newRepository(thorApi).getTokensWithBalance(Chain.ThorChain, ADDRESS)
+
+        val bRune = coins.single()
+        assertEquals(Coins.ThorChain.bRUNE.decimal, bRune.decimal)
+    }
+
+    @Test
     fun `getTokensWithBalance for Terra delegates to the Cosmos bank coin finder`() = runTest {
         val cosmosBankCoinFinder: CosmosBankCoinFinder = mockk()
         val expected = listOf(Coins.Terra.ASTRO_IBC)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -181,6 +181,36 @@ internal class TokenRepositoryImplTest {
     }
 
     @Test
+    fun `getTokensWithBalance canonicalizes ybRUNE decimal to the curated value`() = runTest {
+        // ybRUNE shares the curated-override branch with bRUNE; guard it independently so a
+        // regression isolated to the ybRUNE case can't slip through.
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(CosmosBalance(denom = Coins.ThorChain.ybRUNE.contractAddress, amount = "100"))
+        coEvery { thorApi.getDenomMetaFromLCD(Coins.ThorChain.ybRUNE.contractAddress) } returns
+            DenomMetadata(
+                base = Coins.ThorChain.ybRUNE.contractAddress,
+                symbol = "x/ybrune",
+                display = null,
+                denomUnits =
+                    listOf(
+                        com.vultisig.wallet.data.api.models.DenomUnit(
+                            denom = "x/ybrune",
+                            exponent = 6,
+                        )
+                    ),
+            )
+
+        val coins =
+            newRepository(thorApi)
+                .getTokensWithBalance(Chain.ThorChain, ADDRESS, enabledDenoms = setOf("rune"))
+
+        val ybRune = coins.single { it.contractAddress == Coins.ThorChain.ybRUNE.contractAddress }
+        assertEquals(Coins.ThorChain.ybRUNE.ticker, ybRune.ticker)
+        assertEquals(Coins.ThorChain.ybRUNE.decimal, ybRune.decimal)
+    }
+
+    @Test
     fun `getTokensWithBalance for Terra delegates to the Cosmos bank coin finder`() = runTest {
         val cosmosBankCoinFinder: CosmosBankCoinFinder = mockk()
         val expected = listOf(Coins.Terra.ASTRO_IBC)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
@@ -112,6 +113,53 @@ internal class TokenRefreshWorkerTest {
         val result = buildWorker(inputData).doWork()
 
         assertEquals(ListenableWorker.Result.failure(), result)
+    }
+
+    @Test
+    fun `doWork corrects a stale ticker whose casing drifted from the curated identity`() =
+        runTest {
+            // A pre-canonicalization entry with the old uppercase ticker; the refreshed identity
+            // recases it. The ids match case-insensitively, so without a correction path the stale
+            // entry would be kept forever.
+            val stale =
+                Coin.EMPTY.copy(
+                    chain = Chain.ThorChain,
+                    ticker = "BRUNE",
+                    contractAddress = "x/brune",
+                )
+            val corrected = stale.copy(ticker = "bRUNE")
+            val vault = vault(id = "vault-5", coins = listOf(coin(Chain.ThorChain)))
+
+            coEvery { vaultRepository.getAll() } returns listOf(vault)
+            coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+            every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(listOf(stale))
+            coEvery { tokenRepository.getRefreshTokens(Chain.ThorChain, vault) } returns
+                listOf(corrected)
+            coEvery { vaultRepository.deleteTokenFromVault(any(), any()) } returns Unit
+            coEvery { vaultRepository.addTokenToVault(any(), any()) } returns Unit
+
+            buildWorker().doWork()
+
+            coVerify(exactly = 1) { vaultRepository.deleteTokenFromVault(vault.id, stale) }
+            coVerify(exactly = 1) { vaultRepository.addTokenToVault(vault.id, corrected) }
+        }
+
+    @Test
+    fun `doWork leaves an already-correct token untouched`() = runTest {
+        val existing =
+            Coin.EMPTY.copy(chain = Chain.ThorChain, ticker = "bRUNE", contractAddress = "x/brune")
+        val vault = vault(id = "vault-6", coins = listOf(coin(Chain.ThorChain)))
+
+        coEvery { vaultRepository.getAll() } returns listOf(vault)
+        coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+        every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(listOf(existing))
+        coEvery { tokenRepository.getRefreshTokens(Chain.ThorChain, vault) } returns
+            listOf(existing)
+
+        buildWorker().doWork()
+
+        coVerify(exactly = 0) { vaultRepository.deleteTokenFromVault(any(), any()) }
+        coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -145,15 +145,17 @@ internal class TokenRefreshWorkerTest {
         }
 
     @Test
-    fun `doWork corrects a token whose contractAddress and decimal drifted but ticker matches`() =
+    fun `doWork corrects a token whose contractAddress casing and decimal drifted but ticker matches`() =
         runTest {
-            // Ticker is unchanged (case identical); only the curated contractAddress/decimal moved.
-            // needsIdentityCorrection must still fire, exercising the non-ticker fields.
+            // Ticker is unchanged (case identical); the same contract was recased and the decimal
+            // moved. needsIdentityCorrection must still fire, exercising the non-ticker fields
+            // while
+            // staying on the same underlying contract (case-insensitive).
             val stale =
                 Coin.EMPTY.copy(
                     chain = Chain.ThorChain,
                     ticker = "bRUNE",
-                    contractAddress = "x/brune-old",
+                    contractAddress = "x/BRUNE",
                     decimal = 6,
                 )
             val corrected = stale.copy(contractAddress = "x/brune", decimal = 8)
@@ -171,6 +173,37 @@ internal class TokenRefreshWorkerTest {
             coVerify(exactly = 1) {
                 vaultRepository.replaceTokenInVault(vault.id, stale, corrected)
             }
+        }
+
+    @Test
+    fun `doWork does not hijack a token when a different contract shares an existing ticker`() =
+        runTest {
+            // Coin.id is ticker-based, so a second listing that a provider reports under an
+            // existing
+            // ticker matches the persisted coin by id. Because the contract genuinely differs (not
+            // just casing), the persisted send target must be left untouched — no replace, no
+            // delete/re-add that would flip it on every refresh.
+            val persisted =
+                Coin.EMPTY.copy(
+                    chain = Chain.ThorChain,
+                    ticker = "bRUNE",
+                    contractAddress = "x/brune",
+                )
+            val differentContract =
+                persisted.copy(contractAddress = "thor1adifferentcontractunderthesameticker")
+            val vault = vault(id = "vault-8", coins = listOf(coin(Chain.ThorChain)))
+
+            coEvery { vaultRepository.getAll() } returns listOf(vault)
+            coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+            every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(listOf(persisted))
+            coEvery { tokenRepository.getRefreshTokens(Chain.ThorChain, vault) } returns
+                listOf(differentContract)
+
+            buildWorker().doWork()
+
+            coVerify(exactly = 0) { vaultRepository.replaceTokenInVault(any(), any(), any()) }
+            coVerify(exactly = 0) { vaultRepository.deleteTokenFromVault(any(), any()) }
+            coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
         }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/workers/TokenRefreshWorkerTest.kt
@@ -135,13 +135,42 @@ internal class TokenRefreshWorkerTest {
             every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(listOf(stale))
             coEvery { tokenRepository.getRefreshTokens(Chain.ThorChain, vault) } returns
                 listOf(corrected)
-            coEvery { vaultRepository.deleteTokenFromVault(any(), any()) } returns Unit
-            coEvery { vaultRepository.addTokenToVault(any(), any()) } returns Unit
+            coEvery { vaultRepository.replaceTokenInVault(any(), any(), any()) } returns Unit
 
             buildWorker().doWork()
 
-            coVerify(exactly = 1) { vaultRepository.deleteTokenFromVault(vault.id, stale) }
-            coVerify(exactly = 1) { vaultRepository.addTokenToVault(vault.id, corrected) }
+            coVerify(exactly = 1) {
+                vaultRepository.replaceTokenInVault(vault.id, stale, corrected)
+            }
+        }
+
+    @Test
+    fun `doWork corrects a token whose contractAddress and decimal drifted but ticker matches`() =
+        runTest {
+            // Ticker is unchanged (case identical); only the curated contractAddress/decimal moved.
+            // needsIdentityCorrection must still fire, exercising the non-ticker fields.
+            val stale =
+                Coin.EMPTY.copy(
+                    chain = Chain.ThorChain,
+                    ticker = "bRUNE",
+                    contractAddress = "x/brune-old",
+                    decimal = 6,
+                )
+            val corrected = stale.copy(contractAddress = "x/brune", decimal = 8)
+            val vault = vault(id = "vault-7", coins = listOf(coin(Chain.ThorChain)))
+
+            coEvery { vaultRepository.getAll() } returns listOf(vault)
+            coEvery { vaultRepository.getDisabledCoinIds(vault.id) } returns emptyList()
+            every { vaultRepository.getEnabledTokens(vault.id) } returns flowOf(listOf(stale))
+            coEvery { tokenRepository.getRefreshTokens(Chain.ThorChain, vault) } returns
+                listOf(corrected)
+            coEvery { vaultRepository.replaceTokenInVault(any(), any(), any()) } returns Unit
+
+            buildWorker().doWork()
+
+            coVerify(exactly = 1) {
+                vaultRepository.replaceTokenInVault(vault.id, stale, corrected)
+            }
         }
 
     @Test
@@ -158,6 +187,7 @@ internal class TokenRefreshWorkerTest {
 
         buildWorker().doWork()
 
+        coVerify(exactly = 0) { vaultRepository.replaceTokenInVault(any(), any(), any()) }
         coVerify(exactly = 0) { vaultRepository.deleteTokenFromVault(any(), any()) }
         coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
     }


### PR DESCRIPTION
Closes #5275

Post-merge cleanup of the confirmed review gaps from #5264 (which merged via the queue before the requested-changes review landed). Each fix is scoped to its own function; the bRUNE = RUNE parity approximation and the already-shipped RUJI/KUJI/TCY paths are deliberately left untouched.

## What & why

**Discovery / identity** (`TokenRepository`, `TokenRefreshWorker`)
- Auto-discovery never fired for a new holder: `getRefreshTokens`' `enabledDenoms` gate is seeded only from `vault.coins`, and a fresh vault only seeds native RUNE, so a received bRUNE/ybRUNE denom was dropped before reaching the canonicalization block. Curated liquid-bonding denoms now bypass the gate.
- Legacy pre-#5264 entries kept the old uppercase `BRUNE`/`YBRUNE` forever — the refresh dedup matches ids case-insensitively and returned early. Added an identity-correction path that overwrites a persisted entry whose ticker/contractAddress/decimal has drifted.
- `decimal` is now reset in the canonicalization override alongside ticker/contractAddress.

**Swap gating** (`Coin.isLpToken`, `TokenDetailViewModel`)
- `isLpToken`'s ThorChain check was case-sensitive (`== "x/brune"`); now compares on the lowercased denom, matching the pricing path.
- The Token Detail Swap button had no `isLpToken` gate, so bRUNE/ybRUNE could be picked as a swap source from their own detail page even though the asset pickers exclude them. `canSwap` now also requires `!isLpToken`.

**Pricing** (`TokenPriceRepository`)
- `runePriceUsd()` read the cache by `priceProviderID` ("thorchain") while rows are keyed by `Coin.id` ("RUNE-THORChain"), so the cache branch never hit and every refresh re-fetched live. Now keyed by `Coin.id`.
- The live fallback returned RUNE in the app currency, which callers then multiplied by `tetherPrice` again (a JPY user saw ~150x). The fallback now fetches RUNE explicitly in USD.
- A transient failure (unparseable NAV, rate-limited RUNE) yields a 0 price, and `savePrices` only guarded an empty currency map — so a $0 overwrote the last-known good price. Zero prices are now dropped on the save path (via `signum()`, so a scaled `0E-8` from a NAV division still counts).

## Tests
- `TokenPriceRepositoryImplTest` — bRUNE parity & ybRUNE NAV×RUNE, cache-read-by-id, live-USD FX-applied-once, malformed-NAV zero-guard, redemption-JSON shape fixture.
- `TokenRepositoryImplTest` — auto-discovery bypass, decimal canonicalization.
- `TokenRefreshWorkerTest` — stale-ticker correction, no-op when already correct.
- `CoinIsLpTokenTest` — non-canonical casing still detected as LP.

`./gradlew :data:testDebugUnitTest` passes; `:app` and `:data` compile.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest`
- [x] `:app:compileDebugKotlin` / `:data` compile
- [ ] Device: receive first-ever bRUNE/ybRUNE → auto-surfaces on next refresh
- [ ] Device: pre-existing `BRUNE` entry shows corrected `bRUNE` after one refresh
- [ ] Device: bRUNE/ybRUNE Swap button disabled on the Token Detail screen
- [ ] Device: bRUNE/ybRUNE fiat value correct for a non-USD app currency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled swap actions for THORChain LP receipt tokens, including improved detection for non-canonical casing.
  - Prevented $0 (zero) derived prices from overwriting existing cached prices.
  - Improved THORChain bRUNE/ybRUNE and RUNE/sTCY pricing, including more consistent USD handling and better cache/refresh behavior.
  - Corrected token identity drift during refresh and ensured curated THORChain tokens surface automatically with accurate decimals.

- **Tests**
  - Added/expanded coverage for LP detection, curated token discovery/decimals, refresh identity correction, and bRUNE/ybRUNE pricing with NAV redemption edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->