### PR TITLE
fix(address-book): list vaults without the chain enabled in My Vaults (#5282)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheetViewModel.kt
@@ -17,6 +17,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -73,23 +74,30 @@ constructor(
         }
 
         viewModelScope.launch {
+            val chain = Chain.fromRaw(args.chainId)
             val vaults =
                 vaultRepository.getAll().mapNotNull { vault ->
-                    vault.coins
-                        .find { it.chain.id == args.chainId }
-                        ?.address
-                        ?.let { existingAddress ->
-                            AddressEntryUiModel(
-                                model =
-                                    AddressBookEntry(
-                                        chain = Chain.fromRaw(args.chainId),
-                                        address = existingAddress,
-                                        title = vault.name,
-                                    ),
-                                title = vault.name,
-                                subtitle = existingAddress,
-                            )
-                        }
+                    // Prefer the already-enabled coin's address; otherwise derive the address
+                    // from the vault's public key so vaults that haven't enabled this chain are
+                    // still selectable as a destination.
+                    val address =
+                        vault.coins.find { it.chain.id == args.chainId }?.address
+                            ?: try {
+                                chainAccountAddressRepository.getAddress(chain, vault).first
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (_: Exception) {
+                                null
+                            }
+
+                    address?.let {
+                        AddressEntryUiModel(
+                            model =
+                                AddressBookEntry(chain = chain, address = it, title = vault.name),
+                            title = vault.name,
+                            subtitle = it,
+                        )
+                    }
                 }
 
             state.update { it.copy(vaults = vaults) }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.hasPreGeneratedKey
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -18,9 +19,11 @@ import com.vultisig.wallet.ui.navigation.back
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class AddressBookBottomSheetUiModel(
     val addresses: List<AddressEntryUiModel> = emptyList(),
@@ -77,13 +80,20 @@ constructor(
             val chain = Chain.fromRaw(args.chainId)
             val vaults =
                 vaultRepository.getAll().mapNotNull { vault ->
+                    // KeyImport vaults can only use chains they hold a pre-generated key for;
+                    // skip the rest so they aren't offered as a destination they can never
+                    // view or spend on.
+                    if (!vault.hasPreGeneratedKey(chain)) return@mapNotNull null
+
                     // Prefer the already-enabled coin's address; otherwise derive the address
                     // from the vault's public key so vaults that haven't enabled this chain are
                     // still selectable as a destination.
                     val address =
                         vault.coins.find { it.chain.id == args.chainId }?.address
                             ?: try {
-                                chainAccountAddressRepository.getAddress(chain, vault).first
+                                withContext(Dispatchers.Default) {
+                                    chainAccountAddressRepository.getAddress(chain, vault).first
+                                }
                             } catch (e: CancellationException) {
                                 throw e
                             } catch (_: Exception) {


### PR DESCRIPTION
## Summary

Fixes #5282.

In **Send → Address Book → My Vaults**, only vaults that already had the selected asset's chain **enabled** were listed. A destination vault that can receive the token — every vault deterministically derives an address for every supported chain — was dropped if it hadn't explicitly enabled that chain, so it could not be picked as a recipient.

## Root cause

`AddressBookBottomSheetViewModel` built the "My Vaults" list solely from each vault's already-enabled `vault.coins`. Vaults with no coin for `args.chainId` were silently removed by `mapNotNull`.

## Fix

- Keep the enabled-coin address as the preferred source.
- Fall back to deriving the address from the vault's public key via `ChainAccountAddressRepository.getAddress(chain, vault)` when the chain isn't enabled, so every vault is selectable using its derived address.
- The derivation rethrows `CancellationException` and skips only genuinely un-derivable vaults, so one failure can't drop the whole list.

## Test plan

- [ ] Two vaults on device; Vault B does **not** have XRP enabled.
- [ ] Start a Send of XRP from Vault A → Address Book → My Vaults.
- [ ] Verify Vault B now appears, showing its derived XRP address, and can be selected as the destination.
- [ ] Verify vaults with the chain already enabled still show their existing address (no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address book behavior so eligible vaults can be shown and selected even if the chain-specific coin address hasn’t been enabled yet.
  * Added a smarter fallback for address display: if an existing address isn’t available, the app derives one to ensure the correct entries appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->