### PR TITLE
fix(ripple): don't show $0.00 on a balance-fetch network failure (#5276)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RippleApi.kt
@@ -79,25 +79,24 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
         return response.bodyOrThrow<RippleBroadcastSuccessResponseJson>()
     }
 
+    // A network failure (timeout / no connectivity) must propagate so the balance layer can keep
+    // the last-known value or surface a loading/error state — never swallow it into ZERO, which is
+    // indistinguishable from a genuinely empty account and reads as "the funds disappeared". An
+    // unfunded account returns an HTTP 200 with a null `account_data` (actNotFound), so it still
+    // resolves to zero here without throwing.
     override suspend fun getBalance(coin: Coin): BigInteger = supervisorScope {
-        try {
-            val accountInfoDeferred = async { fetchAccountsInfo(coin.address) }
-            val reservedBalanceDeferred = async { fetchServerState() }
+        val accountInfoDeferred = async { fetchAccountsInfo(coin.address) }
+        val reservedBalanceDeferred = async { fetchServerState() }
 
-            val accountInfo = accountInfoDeferred.await()
-            val reservedBalance = reservedBalanceDeferred.await()
+        val accountInfo = accountInfoDeferred.await()
+        val reservedBalance = reservedBalanceDeferred.await()
 
-            val balance = accountInfo?.getBalance() ?: BigInteger.ZERO
-            val ownerCount = accountInfo?.getOwnerCount() ?: BigInteger.ZERO
-            val accountReservedBalance =
-                reservedBalance.getBaseReserve() + (ownerCount * reservedBalance.getIncReserve())
+        val balance = accountInfo?.getBalance() ?: BigInteger.ZERO
+        val ownerCount = accountInfo?.getOwnerCount() ?: BigInteger.ZERO
+        val accountReservedBalance =
+            reservedBalance.getBaseReserve() + (ownerCount * reservedBalance.getIncReserve())
 
-            maxOf(balance - accountReservedBalance, BigInteger.ZERO)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e("Error in getBalance: ${e.message}")
-            BigInteger.ZERO
-        }
+        maxOf(balance - accountReservedBalance, BigInteger.ZERO)
     }
 
     override suspend fun fetchAccountsInfo(walletAddress: String): RippleAccountInfoResponseJson? {
@@ -118,8 +117,10 @@ internal class RippleApiImp @Inject constructor(private val http: HttpClient) : 
             response.bodyOrThrow<RippleAccountInfoResponseJson>()
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e("Error in fetchTokenAccountsByOwner: ${e.message}")
-            error(e.message ?: "Error in fetchTokenAccountsByOwner")
+            Timber.e(e, "Error in fetchAccountsInfo")
+            // Rethrow the original exception so its transport cause (timeout / no connectivity) is
+            // preserved for classification instead of being flattened into a generic error.
+            throw e
         }
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/RippleApiBalanceTest.kt
@@ -1,0 +1,112 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkErrorKind
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Behavioural tests for [RippleApiImp.getBalance] around the failure vs. empty-account distinction
+ * (issue #5276): a network failure must propagate instead of being swallowed into a zero balance,
+ * while a genuinely unfunded account still resolves to zero without throwing.
+ */
+class RippleApiBalanceTest {
+
+    private val rippleCoin =
+        Coin.EMPTY.copy(
+            chain = Chain.Ripple,
+            ticker = "XRP",
+            address = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            decimal = 6,
+            isNativeToken = true,
+        )
+
+    // A funded account nets the live balance against the base + owner-count reserves.
+    @Test
+    fun `getBalance returns balance minus reserves for a funded account`() = runBlocking {
+        val body =
+            """
+            {
+              "result": {
+                "account_data": { "Balance": "99000000", "OwnerCount": 3 },
+                "state": {
+                  "validated_ledger": {
+                    "reserve_base": 10000000,
+                    "reserve_inc": 2000000,
+                    "base_fee": 10
+                  },
+                  "load_base": 256,
+                  "load_factor": 256
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val api = RippleApiImp(MockHttpClient.respondingWith(HttpStatusCode.OK, body))
+
+        // 99000000 - (10000000 + 3 * 2000000) = 83000000
+        assertEquals(BigInteger("83000000"), api.getBalance(rippleCoin))
+    }
+
+    // An unfunded account (actNotFound) returns HTTP 200 with a null account_data, which must still
+    // resolve to a real zero — this is the one legitimate zero, distinct from a network failure.
+    @Test
+    fun `getBalance returns zero for an unfunded account without throwing`() = runBlocking {
+        val body =
+            """
+            {
+              "result": {
+                "state": {
+                  "validated_ledger": {
+                    "reserve_base": 10000000,
+                    "reserve_inc": 2000000,
+                    "base_fee": 10
+                  },
+                  "load_base": 256,
+                  "load_factor": 256
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val api = RippleApiImp(MockHttpClient.respondingWith(HttpStatusCode.OK, body))
+
+        assertEquals(BigInteger.ZERO, api.getBalance(rippleCoin))
+    }
+
+    // The core of #5276: a socket timeout must surface as a typed, classifiable failure so the
+    // balance layer keeps the last-known value / shows a loading state instead of committing a
+    // fake $0.00 that looks like the funds disappeared.
+    @Test
+    fun `getBalance propagates a timeout instead of swallowing it into zero`() {
+        val api =
+            RippleApiImp(MockHttpClient.throwingIOException(SocketTimeoutException("timeout")))
+
+        val error = assertThrows<NetworkException> { runBlocking { api.getBalance(rippleCoin) } }
+
+        assertEquals(NetworkErrorKind.Timeout, error.kind)
+    }
+
+    // fetchAccountsInfo must rethrow the original transport exception (not flatten it into a
+    // generic IllegalStateException) so the timeout/offline cause survives for classification.
+    @Test
+    fun `fetchAccountsInfo rethrows the original network exception preserving its kind`() {
+        val api =
+            RippleApiImp(MockHttpClient.throwingIOException(SocketTimeoutException("timeout")))
+
+        val error =
+            assertThrows<NetworkException> {
+                runBlocking { api.fetchAccountsInfo(rippleCoin.address) }
+            }
+
+        assertEquals(NetworkErrorKind.Timeout, error.kind)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #5276.

`RippleApi.getBalance()` caught **every** non-cancellation exception and returned `BigInteger.ZERO`. A network failure (e.g. `SocketTimeoutException` to `xrplcluster.com`) was therefore indistinguishable from a genuinely empty account, and the UI committed a false **`$0.00` / `0 XRP`** — which reads to the user as "the funds disappeared".

## Change

- **`getBalance()`** — no longer swallows failures into `ZERO`; the exception propagates. An unfunded account (`actNotFound`) still returns HTTP 200 with a null `account_data`, so it resolves to a real zero **without throwing** — the one legitimate zero.
- **`fetchAccountsInfo()`** — rethrows the original exception instead of flattening it into an `IllegalStateException` with no cause, so the transport kind (timeout / no connectivity) survives for `toNetworkErrorKind()` classification. Also fixed a stale copy-paste log tag.

## Why this is the right fix

`AccountsRepository.loadAddressBalances` already `catch`es a thrown balance error and **keeps the cached balance** rather than overwriting it, and both `ChainValidationService` XRP callers catch generic `Exception`. So propagating gives the exact behavior the issue asks for, and matches how EVM/Cosmos balances already behave (they never swallow to `ZERO`).

## Resulting UX on a network failure

| Situation | Before | After |
|---|---|---|
| Warm start (balance cached in Room) | `$0.00` | Last-known balance retained |
| Cold start / brand-new coin (no cache) | `$0.00` | Loading placeholder stays (no false zero) |

The issue's expected behavior listed *keep loading*, *show last-known cached*, or *explicit error/retry*. This PR delivers the first two; it does not add a dedicated error/retry indicator (that would require threading a per-chain error status through the balance UI).

## Tests

New `RippleApiBalanceTest` (4 tests, all green):
- funded account nets balance against reserves
- unfunded account resolves to `0` without throwing
- a socket timeout propagates as `NetworkException(kind = Timeout)`
- `fetchAccountsInfo` preserves the original error kind

Existing `RippleApiBodyReadTest` (5 tests) still pass. `./gradlew :data:testDebugUnitTest` green.

## Scope note

The issue notes other chains may share the `catch → return ZERO` pattern (Solana, Polkadot, Tron, Cardano, Bittensor, ThorChain, Ton). This PR is intentionally scoped to XRP, the reported chain; happy to follow up on the others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Ripple balance calculations to subtract required reserves and clamp results to non-negative values.
  * Unfunded accounts now return a zero balance without throwing.
  * Network/timeout failures are no longer swallowed; the original error type and timeout classification are propagated for consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->