### PR TITLE
chore: bump version to 1.0.114

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ fastlane/report.xml
 # Crush AI assistant
 .crush/
 .worktrees/
+scripts/release.sh

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 35
-        versionCode = 113
-        versionName = "1.0.113"
+        versionCode = 114
+        versionName = "1.0.114"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 


### PR DESCRIPTION
Bump versionCode to 114 / versionName to 1.0.114 for release v1.0.114.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app release version to 1.0.114.
  * Incremented the internal build number for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->