### PR TITLE
Terra send overcharges: size the fee to actual gas, not the 300k ceiling (#5279)

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.chains.helpers.CosmosHelper
+import com.vultisig.wallet.data.chains.helpers.TerraHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -100,11 +101,12 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 .setScale(0, RoundingMode.FLOOR)
                 .toBigInteger()
 
-        // Chains whose sends WalletCore assembles as a native bank `MsgSend` (routed through
-        // CosmosHelper in SigningHelper), so the simulated unsigned tx matches the broadcast tx.
-        // Terra's native LUNA send is also a `MsgSend` (TerraHelper's native branch), so the
-        // CosmosHelper-built simulation matches it; TerraClassic and Terra token sends (CW20 /
-        // IBC) use different messages and are excluded (see [simulatedGasUsed]).
+        // Chains whose sends WalletCore assembles as a native bank `MsgSend`, so the simulated
+        // unsigned tx matches the broadcast tx. Most route through CosmosHelper; Terra's native
+        // LUNA
+        // send is a `MsgSend` too but is built by TerraHelper (its real signer — see
+        // [simulatedGasUsed]), since WalletCore's TERRAV2 signer rejects the CosmosHelper shape.
+        // TerraClassic and Terra token sends (CW20 / IBC) use different messages and are excluded.
         private val SIMULATION_SUPPORTED_CHAINS =
             setOf(
                 Chain.GaiaChain,
@@ -243,19 +245,34 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
             // sequence mismatch", so seed the unsigned tx with the live on-chain account state
             // instead of zeros — otherwise every funded account silently falls back to static gas.
             val account = api.getAccountNumber(coin.address)
+            val simulationPayload =
+                buildSimulationPayload(
+                    transaction = transaction,
+                    accountNumber = BigInteger(account.accountNumber ?: "0"),
+                    sequence = BigInteger(account.sequence ?: "0"),
+                )
+            // Terra native sends are assembled by TerraHelper (see SigningHelper), not
+            // CosmosHelper:
+            // WalletCore's TERRAV2 signer rejects the gas-limit-without-amount fee CosmosHelper
+            // emits
+            // for a zero-fee simulate tx ("Incorrect input parameter"). Simulating through the same
+            // builder that signs the real send also keeps the metered gas matched to the broadcast.
             val txBytes =
-                CosmosHelper(
-                        coinType = coin.coinType,
-                        denom = chain.feeUnit,
-                        gasLimit = staticLimit,
-                    )
-                    .getZeroSignedTransaction(
-                        buildSimulationPayload(
-                            transaction = transaction,
-                            accountNumber = BigInteger(account.accountNumber ?: "0"),
-                            sequence = BigInteger(account.sequence ?: "0"),
+                if (chain == Chain.Terra) {
+                    TerraHelper(
+                            coinType = coin.coinType,
+                            denom = chain.feeUnit,
+                            gasLimit = staticLimit,
                         )
-                    )
+                        .getZeroSignedTransaction(simulationPayload)
+                } else {
+                    CosmosHelper(
+                            coinType = coin.coinType,
+                            denom = chain.feeUnit,
+                            gasLimit = staticLimit,
+                        )
+                        .getZeroSignedTransaction(simulationPayload)
+                }
             api.simulate(txBytes)?.also { cachedSimulatedGas = CachedSimulatedGas(chain, it, now) }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -84,8 +84,27 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 .setScale(0, RoundingMode.CEILING)
                 .toBigInteger()
 
+        /**
+         * Inverse of [terraFeeAmount]: the largest gas limit whose minimum fee (`TERRA_GAS_PRICE ×
+         * limit`) is still covered by [feeAmount] (floor division). The initiator relays this
+         * alongside the signed fee amount so the broadcast declares `~gas_used × 1.3` instead of
+         * the static 300k ceiling, letting the fee bill the real gas cost instead of the full
+         * 300k-gas amount (issue #5279). Deriving the limit from the fee amount — rather than a
+         * second `/simulate` — keeps `feeAmount ≥ gasPrice × gasLimit` true by construction, so the
+         * shown, signed and relayed values can never disagree.
+         */
+        internal fun terraGasLimitForFeeAmount(feeAmount: BigInteger): BigInteger =
+            feeAmount
+                .toBigDecimal()
+                .divide(TERRA_GAS_PRICE, MathContext.DECIMAL64)
+                .setScale(0, RoundingMode.FLOOR)
+                .toBigInteger()
+
         // Chains whose sends WalletCore assembles as a native bank `MsgSend` (routed through
         // CosmosHelper in SigningHelper), so the simulated unsigned tx matches the broadcast tx.
+        // Terra's native LUNA send is also a `MsgSend` (TerraHelper's native branch), so the
+        // CosmosHelper-built simulation matches it; TerraClassic and Terra token sends (CW20 /
+        // IBC) use different messages and are excluded (see [simulatedGasUsed]).
         private val SIMULATION_SUPPORTED_CHAINS =
             setOf(
                 Chain.GaiaChain,
@@ -94,7 +113,16 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 Chain.Osmosis,
                 Chain.Noble,
                 Chain.Akash,
+                Chain.Terra,
             )
+
+        // Chains whose simulate-derived gas limit the initiator RELAYS (proto
+        // `CosmosSpecific.gas_limit`), so the broadcast tx declares that dynamic limit instead of
+        // the static one. For these the fee is priced at the dynamic limit with no static-amount
+        // floor — the on-chain minimum is `minGasPrice × dynamicLimit`, which the priced amount
+        // already meets. The static floor stays for every other chain, whose broadcast still
+        // declares the static limit (issue #5279 relies on the honor side shipped in #5191).
+        private val RELAYED_GAS_LIMIT_CHAINS = setOf(Chain.Terra)
     }
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
@@ -111,14 +139,23 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
         val gasUsed = simulatedGasUsed(transaction) ?: return staticFees
 
         val limit = gasUsed.toBigInteger().increaseByPercent(GAS_ADJUSTMENT_PERCENT)
-        val amount =
+        val pricedAmount =
             (limit.toBigDecimal() * simulatedGasPrice(chain, staticFees, staticLimit))
                 .setScale(0, RoundingMode.CEILING)
                 .toBigInteger()
+        val amount =
+            if (chain in RELAYED_GAS_LIMIT_CHAINS) {
+                // The initiator relays this dynamic `limit`, so the broadcast tx declares it (not
+                // the static one). The on-chain minimum is therefore `minGasPrice × dynamicLimit`
+                // = `pricedAmount`; applying the static-amount floor here would re-bill the full
+                // 300k-gas ceiling and reintroduce the overcharge (issue #5279).
+                pricedAmount
+            } else {
                 // The broadcast tx still declares the static `getChainGasLimit`, so the fee must
                 // cover at least the static per-chain amount (`minGasPrice × staticLimit`) or the
                 // mempool rejects it; never drop below that floor (issue #4847).
-                .max(staticFees.amount)
+                pricedAmount.max(staticFees.amount)
+            }
         return GasFees(limit = limit, amount = amount)
     }
 
@@ -181,7 +218,7 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
     /**
      * Simulates the unsigned transaction and returns `gas_info.gas_used`, or `null` to fall back to
      * the static gas limit. Only the chains whose sends WalletCore builds as native bank `MsgSend`
-     * are simulated; Terra/TerraClassic (TerraHelper, burn tax) and Qbtc (ML-DSA) keep their static
+     * are simulated; TerraClassic (TerraHelper, burn tax) and Qbtc (ML-DSA) keep their static
      * values.
      */
     private suspend fun simulatedGasUsed(transaction: BlockchainTransaction): Long? {
@@ -189,6 +226,12 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
         val chain = coin.chain
         if (chain !in SIMULATION_SUPPORTED_CHAINS) return null
         if (transaction !is Transfer) return null
+        // Only Terra's native LUNA send is a `MsgSend`; CW20 (`terra1…`) / IBC (`ibc/…`) token
+        // sends are wasm-execute / different messages, so a simulated `MsgSend` would under-measure
+        // their gas. Since Terra's fee is un-floored ([RELAYED_GAS_LIMIT_CHAINS]), an
+        // under-measurement can't be caught by the static floor — so never simulate a non-native
+        // Terra send.
+        if (chain == Chain.Terra && !coin.isNativeToken) return null
         val now = System.currentTimeMillis()
         cachedSimulatedGas?.let {
             if (it.chain == chain && now - it.fetchedAtMs < SIMULATED_GAS_TTL_MS) return it.gasUsed

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -52,8 +52,16 @@ class CosmosHelper(
         const val ATOM_DENOM = "uatom"
 
         // Cosmos `/simulate` skips signature verification, so a dummy r||s of the secp256k1
-        // signature size is enough for the ante handler to meter gas.
+        // signature size is enough for the ante handler to meter gas. Use a canonical non-zero
+        // placeholder (r = s = 1, in-range low-S scalars): some WalletCore signers (e.g. TERRAV2)
+        // reject an all-zero r||s as invalid during compile. The value is never verified.
         private const val SECP256K1_SIGNATURE_SIZE = 64
+
+        private val DUMMY_SIMULATE_SIGNATURE =
+            ByteArray(SECP256K1_SIGNATURE_SIZE).apply {
+                this[31] = 1 // r = 1
+                this[63] = 1 // s = 1
+            }
     }
 
     /**
@@ -67,7 +75,7 @@ class CosmosHelper(
         val input = getPreSignedInputData(keysignPayload)
         val publicKey =
             PublicKey(keysignPayload.coin.hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
-        val allSignatures = DataVector().apply { add(ByteArray(SECP256K1_SIGNATURE_SIZE)) }
+        val allSignatures = DataVector().apply { add(DUMMY_SIMULATE_SIGNATURE.copyOf()) }
         val allPublicKeys = DataVector().apply { add(publicKey.data()) }
         val compiled = compileWithSignatures(coinType, input, allSignatures, allPublicKeys)
         val output = Cosmos.SigningOutput.parseFrom(compiled).checkError()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
@@ -10,6 +10,8 @@ import com.vultisig.wallet.data.models.transactionHash
 import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
 import com.vultisig.wallet.data.utils.Numeric
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import tss.KeysignResponse
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
@@ -27,6 +29,42 @@ class TerraHelper(
     private val denom: String,
     private val gasLimit: Long,
 ) {
+
+    companion object {
+        // Cosmos `/simulate` skips signature verification, so a dummy r||s of the secp256k1
+        // signature size is enough for the ante handler to meter gas. WalletCore's TERRAV2 signer,
+        // unlike the plain Cosmos signer, rejects an all-zero r||s as an invalid signature during
+        // compile ("Incorrect input parameter"), so use a canonical non-zero placeholder: r = s =
+        // 1,
+        // both in-range low-S scalars. The value is irrelevant — simulate never verifies it.
+        private const val SECP256K1_SIGNATURE_SIZE = 64
+
+        private val DUMMY_SIMULATE_SIGNATURE =
+            ByteArray(SECP256K1_SIGNATURE_SIZE).apply {
+                this[31] = 1 // r = 1
+                this[63] = 1 // s = 1
+            }
+    }
+
+    /**
+     * Builds the base64 `tx_bytes` of a zero-signature Terra transaction for
+     * `/cosmos/tx/v1beta1/simulate`. Terra native sends are assembled by [getPreSignedInputData]
+     * (not [CosmosHelper]) so the simulated tx matches the builder that signs the real send,
+     * keeping the metered gas aligned with the broadcast tx (issue #5279).
+     */
+    fun getZeroSignedTransaction(keysignPayload: KeysignPayload): String {
+        val input = getPreSignedInputData(keysignPayload)
+        val publicKey =
+            PublicKey(keysignPayload.coin.hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
+        val allSignatures = DataVector().apply { add(DUMMY_SIMULATE_SIGNATURE.copyOf()) }
+        val allPublicKeys = DataVector().apply { add(publicKey.data()) }
+        val compiled = compileWithSignatures(coinType, input, allSignatures, allPublicKeys)
+        val output = Cosmos.SigningOutput.parseFrom(compiled).checkError()
+        return Json.parseToJsonElement(output.serialized)
+            .jsonObject["tx_bytes"]
+            ?.jsonPrimitive
+            ?.content ?: error("Simulate payload missing tx_bytes")
+    }
 
     /**
      * Honor the relayed dynamic gas limit when an initiator set one; otherwise fall back to the

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.tonUserFriendlyAddress
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.cosmos.CosmosFeeService
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_ARBITRUM_TRANSFER
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
@@ -485,6 +486,24 @@ constructor(
                         else -> null
                     }
 
+                // Terra (LUNA) native sends: relay a gas limit sized to the (simulate-derived) fee
+                // amount so the broadcast declares ~gas_used×1.3 instead of the static 300k
+                // ceiling,
+                // billing the real gas cost instead of the full 300k-gas fee (issue #5279). Derived
+                // from the signed `gasFee.value` itself so `amount ≥ gasPrice × gas_limit` holds by
+                // construction and the shown / signed / relayed values agree. Honored by every
+                // co-signer (Android #5191, iOS #4692, Windows/SDK); FastVault signs the hash.
+                // Native
+                // only — CW20 / IBC Terra sends use a different message and keep the static limit.
+                val relayedGasLimit =
+                    if (
+                        chain == Chain.Terra &&
+                            token.isNativeToken &&
+                            transactionType == TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+                    ) {
+                        CosmosFeeService.terraGasLimitForFeeAmount(gasFee.value)
+                    } else null
+
                 BlockChainSpecificAndUtxo(
                     BlockChainSpecific.Cosmos(
                         accountNumber = BigInteger(account.accountNumber ?: "0"),
@@ -492,6 +511,7 @@ constructor(
                         gas = gasFee.value,
                         ibcDenomTraces = denomTrace,
                         transactionType = transactionType,
+                        gasLimit = relayedGasLimit,
                     )
                 )
             }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -100,6 +100,48 @@ class CosmosFeeServiceTest {
     }
 
     @Test
+    fun `terraGasLimitForFeeAmount inverts terraFeeAmount`() {
+        // floor(feeAmount / 0.025): 2877 uluna → 115_080 gas (the un-floored ~gas_used×1.3 fee).
+        assertEquals(
+            BigInteger("115080"),
+            CosmosFeeService.terraGasLimitForFeeAmount(BigInteger("2877")),
+        )
+        // the flat 7500 maps back to the static 300k limit — relaying it is a no-op, still valid.
+        assertEquals(
+            BigInteger("300000"),
+            CosmosFeeService.terraGasLimitForFeeAmount(BigInteger("7500")),
+        )
+    }
+
+    @Test
+    fun `relayed Terra gas limit is always covered by its fee amount`() {
+        // Core safety invariant of the #5279 fix: minGasPrice × relayedLimit ≤ signed fee amount,
+        // so a broadcast with the relayed (lower) gas_wanted can never be rejected "insufficient
+        // fee". Holds for any simulated gas because terraGasLimitForFeeAmount floor-divides.
+        val price = java.math.BigDecimal("0.025")
+        for (paddedLimit in listOf(50_000L, 88_516L, 115_071L, 250_000L)) {
+            val amount = CosmosFeeService.terraFeeAmount(paddedLimit)
+            val relayed = CosmosFeeService.terraGasLimitForFeeAmount(amount)
+            assertTrue(
+                price.multiply(relayed.toBigDecimal()) <= amount.toBigDecimal(),
+                "fee $amount must cover 0.025 × $relayed",
+            )
+        }
+    }
+
+    @Test
+    fun `non-native Terra token send keeps the static fee`() = runTest {
+        // CW20 / IBC Terra sends are not a native MsgSend, so they are never simulated and keep the
+        // static 300k limit + 7500 uluna (the un-floored simulated path is native-only).
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(Chain.Terra, contractAddress = "terra1token", isNativeToken = false)
+            ) as GasFees
+        assertEquals(BigInteger("300000"), fee.limit)
+        assertEquals(BigInteger("7500"), fee.amount)
+    }
+
+    @Test
     fun `Osmosis gas limit is 300000`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Osmosis)) as GasFees
         assertEquals(BigInteger("300000"), fee.limit)


### PR DESCRIPTION
## Summary

A Terra (LUNA, phoenix-1) native send is billed a flat **7500 uluna** — the static 300k-gas ceiling priced at 0.025 uluna/gas — even though a `MsgSend` only meters ~78k gas. Cosmos deducts the declared `fee.amount` with no refund of unused gas, so every Terra send overpays ~2.6×.

This PR sizes the Terra fee to the actual simulated gas:
- Simulates the native send (like the other Cosmos chains), prices `fee.amount` at the simulated gas limit instead of the 300k ceiling, and relays that gas limit so the broadcast declares it.
- Fixes the on-device simulate path, which previously threw and silently reverted to the static fee.

## ⚠️ Status: DRAFT — blocked on cross-platform `gas_limit` honoring

**This must not merge until the extension (Windows/SDK) and iOS *release* builds honor `CosmosSpecific.gas_limit` for Terra.** Device testing on a real 2-device vault (Android + browser extension) showed:

| Scenario | Result |
|---|---|
| **Android initiator, extension pair** | ❌ **Signing hangs forever** — Android signs/relays a dynamic `gas_limit` (~67k) but the extension co-signer builds the SignDoc with the static 300k → MPC hash mismatch → stuck (fail-closed, no funds move). |
| **Extension initiator, Android pair** | ✅ Succeeds, but `fee.amount` is still the flat 7500 (extension has no fix). |

To lower Terra's `fee.amount` below 7500 you **must** lower `gas_wanted` below 300k, and `gas_wanted` is part of the SignDoc — so **every** co-signer must build the identical lowered value or the MPC signature fails (the proto comment on `CosmosSpecific.gas_limit` states this explicitly). There is no Android-only fix.

**Safe** for: FastVault / vultiserver vaults (server signs the raw hash blindly) and Android+Android.
**Breaks** for: Android + a non-honoring extension/iOS peer.

## On-chain evidence (both extension-initiated txs)

| Tx | Extension displayed | On-chain `fee.amount` (burned) | `gas_limit` | `gas_used` |
|----|----|----|----|----|
| `79C9E911…451CB1` | 0.001944 LUNA | **7500 uluna** | 300000 | 77779 |
| `5CE8A7DC…3D3093` | 0.001944 LUNA | **7500 uluna** | 300000 | 77779 |

The extension's "0.001944" is cosmetic (`gas_used × 0.025`); it still burns the flat 7500. Android correctly displays the real 7500.

## Changes

- `CosmosFeeService`: add Terra to the simulated set; add `RELAYED_GAS_LIMIT_CHAINS` so Terra's fee is priced at the dynamic limit with no static-amount floor; add `terraGasLimitForFeeAmount`. Route Terra's simulate build through `TerraHelper`.
- `TerraHelper`: add `getZeroSignedTransaction` (Terra native is built by TerraHelper, not CosmosHelper) with a canonical **non-zero** dummy signature — WalletCore's `TERRAV2` signer rejects an all-zero `r||s` during compile.
- `CosmosHelper`: use the same non-zero dummy signature, closing the identical latent all-zero bug for the other simulated Cosmos chains.
- `BlockChainSpecificRepository`: relay `CosmosSpecific.gas_limit` for Terra native sends.

## Verification

- On emulator, the Terra send form now estimates the dynamic fee (`/simulate` → `gas_used`, fee sized from it) instead of the flat 7500 — down from **0.0075** to **~0.0017 LUNA**.
- `:data:testDebugUnitTest` (`CosmosFeeServiceTest`) green; ktfmt applied.

## Known follow-ups before this can ship

1. **Cross-platform honoring** of `CosmosSpecific.gas_limit` for Terra must land in the extension and iOS release builds (the blocker above).
2. **Gas headroom**: Android's `/simulate` reported `gas_used = 51944` while real on-chain execution used `77779`. `GAS_ADJUSTMENT_PERCENT` (30%) sizes the limit to ~67.5k, **below** the real 77.7k → out-of-gas risk. The multiplier must be raised (~1.5×) and validated against real `gas_used`.

## Test plan

- [ ] Extension + iOS release builds confirmed to honor `gas_limit` for Terra
- [ ] `GAS_ADJUSTMENT_PERCENT` raised and validated so `gas_wanted` > real `gas_used`
- [ ] Android-initiated Terra send broadcasts with on-chain `fee.amount` ≈ dynamic (not 7500) and `code = 0`
- [ ] FastVault-paired Terra send completes end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terra fee and gas-limit calculations to ensure fees consistently cover relayed transactions.
  * Preserved static fees for non-native Terra token transfers.
  * Improved gas simulation accuracy for supported Terra transactions.
  * Enhanced transaction simulation reliability across Cosmos-based chains.

* **Tests**
  * Added coverage for Terra fee-to-gas conversion, relayed fee limits, and non-native token transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->