### PR TITLE
fix(keysign): friendly message for unfunded Cosmos accounts

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimBlockedReason
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
@@ -119,6 +120,7 @@ import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
 import com.vultisig.wallet.ui.screens.keygen.SelectVaultTypeScreenPreview
+import com.vultisig.wallet.ui.screens.keysign.KeysignErrorScreen
 import com.vultisig.wallet.ui.screens.keysign.KeysignView
 import com.vultisig.wallet.ui.screens.peer.PeerDiscoveryScreen
 import com.vultisig.wallet.ui.screens.qbtc.QbtcClaimScreen
@@ -282,6 +284,8 @@ class PreviewActivity : ComponentActivity() {
                     "vault_detail_no_mldsa" -> VaultDetailPreview(withMldsa = false)
                     "vault_detail_mldsa" -> VaultDetailPreview(withMldsa = true)
                     "error_screen_after" -> ErrorScreenAfterPreview()
+                    "qbtc_unknown_address_before" -> QbtcUnknownAddressBeforePreview()
+                    "qbtc_unknown_address_after" -> QbtcUnknownAddressAfterPreview()
                     "chain_selection" -> ChainSelectionClipPreview()
                     "verify_send_empty_memo" -> VerifySendEmptyMemoPreview()
                     else -> SwapConfirmPreview()
@@ -336,6 +340,42 @@ private fun ErrorScreenAfterPreview() {
             ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = {}),
         onBack = {},
     )
+}
+
+/**
+ * Reproduces the pre-#5043-fix keysign error screen for a QBTC/Cosmos `code=9` ("unknown address")
+ * broadcast rejection: the generic broadcast-rejected copy interpolates the node's raw_log
+ * verbatim, including its undecodable fee-payer address bytes.
+ */
+@Composable
+private fun QbtcUnknownAddressBeforePreview() {
+    KeysignErrorScreen(
+        errorMessage =
+            UiText.DynamicString(
+                "broadcast_failure: fee payer address: ��� does not exist: " + "unknown address"
+            ),
+        tryAgain = {},
+        onBack = {},
+    )
+}
+
+/**
+ * The fixed keysign error screen for the same `code=9` rejection: [CosmosBroadcastException.from]
+ * now tags it with [CosmosBroadcastException.UNKNOWN_ADDRESS_MARKER], so the screen shows a
+ * friendly "fund the wallet" message instead of the raw node text.
+ */
+@Composable
+private fun QbtcUnknownAddressAfterPreview() {
+    val message =
+        CosmosBroadcastException.from(
+                code = 9,
+                codespace = "sdk",
+                rawLog = "fee payer address: ��� does not exist: unknown address",
+                txHash = null,
+            )
+            .message
+            .orEmpty()
+    KeysignErrorScreen(errorMessage = UiText.DynamicString(message), tryAgain = {}, onBack = {})
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignErrorScreen.kt
@@ -72,36 +72,45 @@ internal fun resolveSigningError(rawMessage: String): SigningError {
                 errorState = ErrorState.WARNING,
             )
         rawMessage.contains(CosmosBroadcastException.BROADCAST_FAILURE_MARKER) -> {
-            // SEQUENCE_MISMATCH_MARKER is itself prefixed with BROADCAST_FAILURE_MARKER, so the
-            // sequence-mismatch check has to live inside the broadcast-failure branch — otherwise
-            // a future reorder of these two branches would silently route every sequence mismatch
-            // into the generic "rejected" copy.
-            if (rawMessage.contains(CosmosBroadcastException.SEQUENCE_MISMATCH_MARKER)) {
-                SigningError(
-                    title = stringResource(R.string.signing_error_transaction_failed_title),
-                    description = stringResource(R.string.signing_error_sequence_mismatch),
-                    errorState = ErrorState.WARNING,
-                )
-            } else {
-                val detail =
-                    rawMessage
-                        .substringAfter(CosmosBroadcastException.BROADCAST_FAILURE_MARKER)
-                        .trimStart(':', ' ')
-                        .let { raw ->
-                            if (raw.length > BROADCAST_DETAIL_MAX_LENGTH) {
-                                raw.take(BROADCAST_DETAIL_MAX_LENGTH).trimEnd() + "…"
-                            } else raw
-                        }
-                SigningError(
-                    title = stringResource(R.string.signing_error_transaction_failed_title),
-                    description =
-                        if (detail.isBlank()) {
-                            stringResource(R.string.signing_error_broadcast_rejected)
-                        } else {
-                            stringResource(R.string.signing_error_broadcast_rejected_s, detail)
-                        },
-                    errorState = ErrorState.CRITICAL,
-                )
+            // SEQUENCE_MISMATCH_MARKER and UNKNOWN_ADDRESS_MARKER are both prefixed with
+            // BROADCAST_FAILURE_MARKER, so those checks have to live inside the broadcast-failure
+            // branch — otherwise a future reorder would silently route them into the generic
+            // "rejected" copy, which for UNKNOWN_ADDRESS_MARKER would echo the node's raw_log
+            // (possibly undecodable address bytes) straight into the description.
+            when {
+                rawMessage.contains(CosmosBroadcastException.SEQUENCE_MISMATCH_MARKER) ->
+                    SigningError(
+                        title = stringResource(R.string.signing_error_transaction_failed_title),
+                        description = stringResource(R.string.signing_error_sequence_mismatch),
+                        errorState = ErrorState.WARNING,
+                    )
+                rawMessage.contains(CosmosBroadcastException.UNKNOWN_ADDRESS_MARKER) ->
+                    SigningError(
+                        title = stringResource(R.string.signing_error_transaction_failed_title),
+                        description = stringResource(R.string.signing_error_account_not_funded),
+                        errorState = ErrorState.WARNING,
+                    )
+                else -> {
+                    val detail =
+                        rawMessage
+                            .substringAfter(CosmosBroadcastException.BROADCAST_FAILURE_MARKER)
+                            .trimStart(':', ' ')
+                            .let { raw ->
+                                if (raw.length > BROADCAST_DETAIL_MAX_LENGTH) {
+                                    raw.take(BROADCAST_DETAIL_MAX_LENGTH).trimEnd() + "…"
+                                } else raw
+                            }
+                    SigningError(
+                        title = stringResource(R.string.signing_error_transaction_failed_title),
+                        description =
+                            if (detail.isBlank()) {
+                                stringResource(R.string.signing_error_broadcast_rejected)
+                            } else {
+                                stringResource(R.string.signing_error_broadcast_rejected_s, detail)
+                            },
+                        errorState = ErrorState.CRITICAL,
+                    )
+                }
             }
         }
         else ->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -279,6 +279,7 @@
     <string name="signing_error_token_account_not_found_s">Ihr %s-Token-Konto konnte nicht geladen werden. Bitte versuchen Sie es erneut.</string>
     <string name="signing_error_mixed_reshare">Gemischte Reshare-Signatur.\nBitte verwenden Sie Vault-Freigaben aus dem gleichen Reshare-Zyklus.</string>
     <string name="signing_error_sequence_mismatch">Die Konto-Sequenz hat sich geändert — bitte versuchen Sie es erneut.</string>
+    <string name="signing_error_account_not_funded">Dieses Konto existiert noch nicht on-chain.\nBitte füllen Sie zuerst das Wallet auf.</string>
     <string name="signing_error_broadcast_rejected">Transaktion vom Netzwerk abgelehnt.</string>
     <string name="signing_error_broadcast_rejected_s">Transaktion vom Netzwerk abgelehnt: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Schnelle Signatur</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -279,6 +279,7 @@
     <string name="signing_error_token_account_not_found_s">No se pudo cargar tu cuenta del token %s. Inténtalo de nuevo.</string>
     <string name="signing_error_mixed_reshare">Firma de recompartición mixta.\n Utilice recursos compartidos de bóveda del mismo ciclo de recompartición.</string>
     <string name="signing_error_sequence_mismatch">La secuencia de la cuenta ha cambiado — por favor, vuelva a intentarlo.</string>
+    <string name="signing_error_account_not_funded">Esta cuenta todavía no existe en cadena.\nPor favor, cargue la billetera primero.</string>
     <string name="signing_error_broadcast_rejected">Transacción rechazada por la red.</string>
     <string name="signing_error_broadcast_rejected_s">Transacción rechazada por la red: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Firma rápida</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -279,6 +279,7 @@
     <string name="signing_error_token_account_not_found_s">Nije moguće učitati vaš %s token račun. Pokušajte ponovno.</string>
     <string name="signing_error_mixed_reshare">Potpisivanje mješovitog ponovnog dijeljenja.\nUpotrijebite dijeljenja trezora istog ciklusa ponovnog dijeljenja.</string>
     <string name="signing_error_sequence_mismatch">Slijed računa je promijenjen — pokušajte ponovno.</string>
+    <string name="signing_error_account_not_funded">Ovaj račun još ne postoji on-chain.\nMolimo prvo uplatite novčanik.</string>
     <string name="signing_error_broadcast_rejected">Mreža je odbila transakciju.</string>
     <string name="signing_error_broadcast_rejected_s">Mreža je odbila transakciju: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Brzi znak</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -279,6 +279,7 @@
     <string name="signing_error_token_account_not_found_s">Impossibile caricare il tuo account token %s. Riprova.</string>
     <string name="signing_error_mixed_reshare">Firma di condivisione mista.\nUtilizzare condivisioni Vault dello stesso ciclo di condivisione.</string>
     <string name="signing_error_sequence_mismatch">La sequenza dell&#8217;account è cambiata — riprova.</string>
+    <string name="signing_error_account_not_funded">Questo account non esiste ancora on-chain.\nSi prega di finanziare prima il portafoglio.</string>
     <string name="signing_error_broadcast_rejected">Transazione rifiutata dalla rete.</string>
     <string name="signing_error_broadcast_rejected_s">Transazione rifiutata dalla rete: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Firma rapida</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -368,6 +368,7 @@
     <string name="signing_error_token_account_not_found_s">%s 토큰 계정을 불러올 수 없습니다. 다시 시도해 주세요.</string>
     <string name="signing_error_mixed_reshare">혼합 재공유 서명.\n동일한 재공유 주기의 볼트 공유를 사용해 주세요.</string>
     <string name="signing_error_sequence_mismatch">계정 시퀀스가 변경되었습니다 — 다시 시도해 주세요.</string>
+    <string name="signing_error_account_not_funded">이 계정은 아직 온체인에 존재하지 않습니다.\n먼저 지갑에 자금을 충전해 주세요.</string>
     <string name="signing_error_broadcast_rejected">네트워크가 거래를 거부했습니다.</string>
     <string name="signing_error_broadcast_rejected_s">네트워크가 거래를 거부했습니다: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">빠른 서명</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -278,6 +278,7 @@
     <string name="signing_error_token_account_not_found_s">Kan je %s-tokenaccount niet laden. Probeer het opnieuw.</string>
     <string name="signing_error_mixed_reshare">Gemengde Reshare-ondertekening.\nGebruik kluisshares van dezelfde Reshare-cyclus.</string>
     <string name="signing_error_sequence_mismatch">De accountvolgorde is gewijzigd — probeer het opnieuw.</string>
+    <string name="signing_error_account_not_funded">Dit account bestaat nog niet on-chain.\nSchakel eerst geld in de wallet.</string>
     <string name="signing_error_broadcast_rejected">Transactie geweigerd door het netwerk.</string>
     <string name="signing_error_broadcast_rejected_s">Transactie geweigerd door het netwerk: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Snel teken</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -278,7 +278,7 @@
     <string name="signing_error_token_account_not_found_s">Kan je %s-tokenaccount niet laden. Probeer het opnieuw.</string>
     <string name="signing_error_mixed_reshare">Gemengde Reshare-ondertekening.\nGebruik kluisshares van dezelfde Reshare-cyclus.</string>
     <string name="signing_error_sequence_mismatch">De accountvolgorde is gewijzigd — probeer het opnieuw.</string>
-    <string name="signing_error_account_not_funded">Dit account bestaat nog niet on-chain.\nSchakel eerst geld in de wallet.</string>
+    <string name="signing_error_account_not_funded">Dit account bestaat nog niet on-chain.\nVul de wallet eerst aan.</string>
     <string name="signing_error_broadcast_rejected">Transactie geweigerd door het netwerk.</string>
     <string name="signing_error_broadcast_rejected_s">Transactie geweigerd door het netwerk: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Snel teken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -279,6 +279,7 @@
     <string name="signing_error_token_account_not_found_s">Não foi possível carregar a sua conta de token %s. Tente novamente.</string>
     <string name="signing_error_mixed_reshare">Assinatura mista de nova partilha. \nUtilizar partilhas do cofre do mesmo ciclo de nova partilha.</string>
     <string name="signing_error_sequence_mismatch">A sequência da conta foi alterada — por favor, tente novamente.</string>
+    <string name="signing_error_account_not_funded">Esta conta ainda não existe on-chain.\nPor favor, financie a carteira primeiro.</string>
     <string name="signing_error_broadcast_rejected">Transação rejeitada pela rede.</string>
     <string name="signing_error_broadcast_rejected_s">Transação rejeitada pela rede: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Sinal rápido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -278,6 +278,7 @@
     <string name="signing_error_token_account_not_found_s">Не удалось загрузить токен-аккаунт %s. Попробуйте ещё раз.</string>
     <string name="signing_error_mixed_reshare">Смешанное подписание Reshare.\nПожалуйста, используйте общие ресурсы хранилища одного и того же цикла Reshare.</string>
     <string name="signing_error_sequence_mismatch">Порядковый номер аккаунта изменился — пожалуйста, повторите попытку.</string>
+    <string name="signing_error_account_not_funded">Этот аккаунт ещё не существует в сети.\nПожалуйста, сначала пополните кошелек.</string>
     <string name="signing_error_broadcast_rejected">Транзакция отклонена сетью.</string>
     <string name="signing_error_broadcast_rejected_s">Транзакция отклонена сетью: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Быстрая подпись</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -516,6 +516,7 @@
     <string name="signing_error_token_account_not_found_s">无法加载您的 %s 代币账户。请重试。</string>
     <string name="signing_error_mixed_reshare">混合重新分享签名。\n请使用相同重新分享周期的保险库份额。</string>
     <string name="signing_error_sequence_mismatch">账户序列号已更改 — 请重试。</string>
+    <string name="signing_error_account_not_funded">此账户尚未在链上存在。\n请先为钱包充值。</string>
     <string name="signing_error_broadcast_rejected">交易被网络拒绝。</string>
     <string name="signing_error_broadcast_rejected_s">交易被网络拒绝：%s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@
     <string name="signing_error_token_account_not_found_s">Could not load your %s token account. Please try again.</string>
     <string name="signing_error_mixed_reshare">Mixed Reshare signing.\nPlease use vault shares of the same Reshare cycle.</string>
     <string name="signing_error_sequence_mismatch">Account sequence changed — please retry the transaction.</string>
+    <string name="signing_error_account_not_funded">This account doesn\'t exist on-chain yet.\nPlease fund the wallet first.</string>
     <string name="signing_error_broadcast_rejected">Transaction rejected by the network.</string>
     <string name="signing_error_broadcast_rejected_s">Transaction rejected by the network: %s</string>
     <string name="verify_transaction_fast_sign_btn_title">Fast Sign</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/CosmosBroadcastException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/CosmosBroadcastException.kt
@@ -8,10 +8,13 @@ import timber.log.Timber
  * Typed broadcast failure from a Cosmos SDK node (THORChain / MayaChain).
  *
  * The [message] starts with a stable English marker so UI layers can detect the failure category
- * without unpacking the raw HTTP body: [BROADCAST_FAILURE_MARKER] for any broadcast rejection, and
- * [SEQUENCE_MISMATCH_MARKER] when the node returned `codespace=sdk`/`code=32`. The remainder of the
- * message is the node-supplied [rawLog] (a short sentence), suitable as a fallback when no
- * localized copy matches the [code].
+ * without unpacking the raw HTTP body: [BROADCAST_FAILURE_MARKER] for any broadcast rejection,
+ * [SEQUENCE_MISMATCH_MARKER] when the node returned `codespace=sdk`/`code=32`, and
+ * [UNKNOWN_ADDRESS_MARKER] for `codespace=sdk`/`code=9` (the fee-payer account doesn't exist
+ * on-chain yet, e.g. a never-funded QBTC vault). The remainder of the message is the node-supplied
+ * [rawLog] (a short sentence), suitable as a fallback when no localized copy matches the [code] —
+ * that raw text can contain undecodable address bytes, so it's kept out of the primary UI
+ * description and only surfaced via the "Show exact error" disclosure.
  *
  * @param code Cosmos SDK error code returned by the node (e.g. 32 for invalid sequence).
  * @param codespace Cosmos SDK error namespace (e.g. "sdk").
@@ -36,12 +39,22 @@ class CosmosBroadcastException(
     val isSequenceMismatch: Boolean
         get() = codespace == SDK_CODESPACE && code == SDK_INVALID_SEQUENCE
 
+    /**
+     * True when the node rejected the broadcast with `codespace=sdk`/`code=9` (unknown address):
+     * the fee-payer account has no on-chain presence, most commonly because it has never received
+     * any funds.
+     */
+    val isUnknownAddress: Boolean
+        get() = codespace == SDK_CODESPACE && code == SDK_UNKNOWN_ADDRESS
+
     companion object {
         const val BROADCAST_FAILURE_MARKER = "broadcast_failure"
         const val SEQUENCE_MISMATCH_MARKER = "broadcast_failure:sequence_mismatch"
+        const val UNKNOWN_ADDRESS_MARKER = "broadcast_failure:unknown_address"
 
         private const val SDK_CODESPACE = "sdk"
         private const val SDK_INVALID_SEQUENCE = 32
+        private const val SDK_UNKNOWN_ADDRESS = 9
 
         /** Build a typed broadcast exception from a parsed Cosmos `tx_response` payload. */
         fun from(
@@ -51,8 +64,13 @@ class CosmosBroadcastException(
             txHash: String?,
         ): CosmosBroadcastException {
             val isSequenceMismatch = codespace == SDK_CODESPACE && code == SDK_INVALID_SEQUENCE
+            val isUnknownAddress = codespace == SDK_CODESPACE && code == SDK_UNKNOWN_ADDRESS
             val marker =
-                if (isSequenceMismatch) SEQUENCE_MISMATCH_MARKER else BROADCAST_FAILURE_MARKER
+                when {
+                    isSequenceMismatch -> SEQUENCE_MISMATCH_MARKER
+                    isUnknownAddress -> UNKNOWN_ADDRESS_MARKER
+                    else -> BROADCAST_FAILURE_MARKER
+                }
             val detail = rawLog?.takeIf { it.isNotBlank() }?.lineSequence()?.firstOrNull().orEmpty()
             val message = if (detail.isBlank()) marker else "$marker: $detail"
             return CosmosBroadcastException(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/CosmosBroadcastExceptionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/errors/CosmosBroadcastExceptionTest.kt
@@ -1,0 +1,127 @@
+package com.vultisig.wallet.data.api.errors
+
+import com.vultisig.wallet.data.api.errors.CosmosBroadcastException.Companion.BROADCAST_FAILURE_MARKER
+import com.vultisig.wallet.data.api.errors.CosmosBroadcastException.Companion.SEQUENCE_MISMATCH_MARKER
+import com.vultisig.wallet.data.api.errors.CosmosBroadcastException.Companion.UNKNOWN_ADDRESS_MARKER
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [CosmosBroadcastException.from] marker selection and [parseCosmosBroadcastResponse]
+ * rejection handling for issue #5043: a `codespace=sdk`/`code=9` rejection (fee-payer account
+ * doesn't exist on-chain, e.g. a never-funded QBTC vault) must route to [UNKNOWN_ADDRESS_MARKER] so
+ * the UI shows a friendly message instead of echoing the node's raw, potentially undecodable
+ * `raw_log` address bytes.
+ */
+class CosmosBroadcastExceptionTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `from tags code=9 codespace=sdk as unknown address`() {
+        val error =
+            CosmosBroadcastException.from(
+                code = 9,
+                codespace = "sdk",
+                rawLog = "fee payer address: ��� does not exist: unknown address",
+                txHash = null,
+            )
+
+        assertTrue(error.isUnknownAddress)
+        assertFalse(error.isSequenceMismatch)
+        assertTrue(error.message?.startsWith(UNKNOWN_ADDRESS_MARKER) == true)
+    }
+
+    @Test
+    fun `from keeps the raw detail after the marker for the Show exact error disclosure`() {
+        val error =
+            CosmosBroadcastException.from(
+                code = 9,
+                codespace = "sdk",
+                rawLog = "fee payer address: ��� does not exist: unknown address",
+                txHash = null,
+            )
+
+        assertEquals(
+            "$UNKNOWN_ADDRESS_MARKER: fee payer address: ��� does not exist: unknown address",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `from still tags code=32 codespace=sdk as sequence mismatch, not unknown address`() {
+        val error =
+            CosmosBroadcastException.from(
+                code = 32,
+                codespace = "sdk",
+                rawLog = "account sequence mismatch, expected 5, got 4",
+                txHash = null,
+            )
+
+        assertTrue(error.isSequenceMismatch)
+        assertFalse(error.isUnknownAddress)
+        assertTrue(error.message?.startsWith(SEQUENCE_MISMATCH_MARKER) == true)
+    }
+
+    @Test
+    fun `from falls back to the generic broadcast failure marker for an unrelated code`() {
+        val error =
+            CosmosBroadcastException.from(
+                code = 5,
+                codespace = "sdk",
+                rawLog = "insufficient funds",
+                txHash = null,
+            )
+
+        assertFalse(error.isSequenceMismatch)
+        assertFalse(error.isUnknownAddress)
+        assertTrue(error.message?.startsWith(BROADCAST_FAILURE_MARKER) == true)
+        assertFalse(error.message?.startsWith(UNKNOWN_ADDRESS_MARKER) == true)
+    }
+
+    @Test
+    fun `from does not treat code=9 from a non-sdk codespace as unknown address`() {
+        // Only the sdk codespace's registry assigns code 9 to ErrUnknownAddress; a module-specific
+        // codespace reusing the same numeric code is an unrelated error.
+        val error =
+            CosmosBroadcastException.from(
+                code = 9,
+                codespace = "wasm",
+                rawLog = "some wasm-specific error",
+                txHash = null,
+            )
+
+        assertFalse(error.isUnknownAddress)
+    }
+
+    @Test
+    fun `parseCosmosBroadcastResponse throws a typed unknown-address exception for a code=9 rejection`() {
+        // Mirrors the exact shape reported in issue #5043: HTTP 200 with a rejected tx_response.
+        val rawBody =
+            """
+            {
+              "tx_response": {
+                "txhash": "25DAFE0000000000000000000000000000000000000000000000000000002C96",
+                "code": 9,
+                "codespace": "sdk",
+                "raw_log": "fee payer address: ��� does not exist: unknown address"
+              }
+            }
+            """
+                .trimIndent()
+
+        val error =
+            assertThrows(CosmosBroadcastException::class.java) {
+                parseCosmosBroadcastResponse(rawBody, "TestTag", json)
+            }
+
+        assertEquals(9, error.code)
+        assertEquals("sdk", error.codespace)
+        assertTrue(error.isUnknownAddress)
+        assertTrue(error.message?.startsWith(UNKNOWN_ADDRESS_MARKER) == true)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.vultisig.wallet.data.usecases.txstatus
+
+import com.vultisig.wallet.data.models.Chain
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for issue #5043's "joined device polls a never-committed tx forever" concern.
+ * [PollingTxStatusUseCaseImpl] reads the wall clock directly (no injectable time source), so this
+ * test drives real (short) delays via a tiny [TxStatusConfiguration] instead of `runTest` virtual
+ * time — a `TestDispatcher`'s `delay()` skip wouldn't advance the `System.currentTimeMillis()` the
+ * use case actually checks the elapsed time against.
+ */
+class PollingTxStatusUseCaseTest {
+
+    private class AlwaysNotFoundStatusRepository : TransactionStatusRepository {
+        var callCount = 0
+            private set
+
+        override suspend fun checkTransactionStatus(
+            txHash: String,
+            chain: Chain,
+        ): TransactionResult {
+            callCount++
+            return TransactionResult.NotFound
+        }
+    }
+
+    private class FakeTxStatusConfigurationProvider(private val config: TxStatusConfiguration) :
+        TxStatusConfigurationProvider {
+        override fun getConfigurationForChain(chain: Chain) = config
+
+        override fun supportTxStatus(chain: Chain) = true
+    }
+
+    @Test
+    fun `invoke times out instead of polling forever when the tx is never found`() = runBlocking {
+        val repository = AlwaysNotFoundStatusRepository()
+        val useCase =
+            PollingTxStatusUseCaseImpl(
+                txStatusConfigurationProvider =
+                    FakeTxStatusConfigurationProvider(
+                        TxStatusConfiguration(pollIntervalSeconds = 1, maxWaitSeconds = 2)
+                    ),
+                transactionStatusRepository = repository,
+            )
+
+        // Bounds the test itself: if this ever regressed back to polling forever on NotFound, this
+        // would hang and fail with a TimeoutCancellationException instead of hanging the suite.
+        val results = withTimeout(10_000) { useCase(Chain.Qbtc, "deadbeef").toList() }
+
+        assertEquals(TransactionResult.TimedOut, results.last())
+        assertTrue(results.dropLast(1).all { it == TransactionResult.NotFound })
+        assertTrue(repository.callCount >= 1)
+    }
+}


### PR DESCRIPTION
Closes #5043

## Summary
A Cosmos SDK `code=9` (`ErrUnknownAddress`) broadcast rejection — the fee-payer account has no on-chain presence, e.g. a never-funded QBTC vault — fell through to the generic broadcast-rejected copy, which interpolates the node's `raw_log` verbatim. That raw text can contain undecodable address bytes rendered as garbled characters on the keysign error screen.

`CosmosBroadcastException` now tags `code=9`/`codespace=sdk` with a dedicated `UNKNOWN_ADDRESS_MARKER`, mirroring the existing `code=32` sequence-mismatch handling, and the keysign error screen shows a friendly "this account doesn't exist on-chain yet, fund the wallet first" message instead. Localized in all 10 supported locales.

The rest of #5043 was already fixed before this PR:
- The 0-balance vote pre-sign guard shipped in #5097.
- The cross-device broadcast divergence (initiator shows failed, joined device shows complete) was fixed in #5254 and #5266, which route Cosmos/QBTC through the same on-chain verify as every other chain.

Also added a regression test for the ticket's "joined device polls a never-committed tx forever" concern — it turned out to already be bounded by the existing per-chain `maxWaitSeconds` timeout config, so the test pins that behavior instead of changing it.

## Screenshots

Same code=9 rejection rendered via `PreviewActivity` (`qbtc_unknown_address_before` / `_after`).

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/agE6oKs.png) | ![after](https://i.imgur.com/vQ6Dgtw.png) |

"Show exact error" still recovers the raw node text for debugging (`Copy` / `Report Bug`):

![after expanded](https://i.imgur.com/lCrhM00.png)

## Testing
- `./gradlew :app:ktfmtFormat :data:ktfmtFormat` — no diff
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.errors.*" --tests "com.vultisig.wallet.data.usecases.txstatus.*" --tests "com.vultisig.wallet.data.api.txstatus.*"` — pass
- `./gradlew :app:compileDebugKotlin :data:compileDebugKotlin` — pass
- `./gradlew :app:lintDebug` — pass, no new findings
- Manual: installed debug build on an emulator, rendered both preview states via `PreviewActivity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing error handling for accounts that are not yet available on-chain (including “unknown address” rejections).
  * Preserved and better categorized broadcast rejection details to distinguish warning vs critical cases.
  * Improved transaction status handling when a transaction remains unavailable until polling times out.

* **Localization**
  * Added a new “account not funded/on-chain yet” error message across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->