### PR TITLE
fix(swap): stop placeholder skeletons blinking on empty amount

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -10,6 +10,7 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
@@ -365,12 +366,27 @@ constructor(
                 selectedDstId = selectedDstId,
                 addresses = addresses,
                 uiState = _uiState,
-                // With an empty/zero amount there is nothing to quote, so loading a not-yet-held
-                // token's account must not raise the quote skeletons — that reproduces the blink
-                // this gate removes on the pipeline side (#5296 review).
-                hasQuotableAmount = srcAmount?.let { it > BigDecimal.ZERO } ?: false,
+                // Raise the quote skeletons while loading a not-yet-held token's account only when
+                // the pair the pick forms could actually be quoted — a positive amount AND a
+                // routable (distinct, provider-backed) pair, mirroring the pipeline's own
+                // isPairRoutable && amount>0 gate. A bare amount>0 check would still blink over an
+                // unroutable or same-token pair before updatePairSupport catches it (#5296 review).
+                isSelectionQuotable = { selectedToken ->
+                    isSelectionQuotable(targetArg, selectedToken)
+                },
             )
         }
+    }
+
+    private fun isSelectionQuotable(targetArg: String, selectedToken: Coin): Boolean {
+        val amount = srcAmount ?: return false
+        if (amount <= BigDecimal.ZERO) return false
+        val (src, dst) =
+            when (targetArg) {
+                ARG_SELECTED_SRC_TOKEN_ID -> selectedToken to selectedDst.value?.account?.token
+                else -> selectedSrc.value?.account?.token to selectedToken
+            }
+        return src != null && dst != null && quotePipeline.isPairRoutable(src, dst)
     }
 
     fun flipSelectedTokens() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -365,6 +365,10 @@ constructor(
                 selectedDstId = selectedDstId,
                 addresses = addresses,
                 uiState = _uiState,
+                // With an empty/zero amount there is nothing to quote, so loading a not-yet-held
+                // token's account must not raise the quote skeletons — that reproduces the blink
+                // this gate removes on the pipeline side (#5296 review).
+                hasQuotableAmount = srcAmount?.let { it > BigDecimal.ZERO } ?: false,
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -145,6 +145,10 @@ constructor(
     // SwapIsNotSupported only after the user typed an amount and waited out the debounce).
     private var isPairSupported = true
 
+    // A same-token pair is "supported" (no "no route" guidance while mid-pick) but has no provider
+    // and can never be quoted, so the loading gate keys off routability, not mere support (#5296).
+    private var isPairRoutable = false
+
     private val pairNotSupportedError = UiText.StringResource(R.string.swap_route_not_available)
 
     private val srcAmount: BigDecimal?
@@ -317,12 +321,13 @@ constructor(
                 }
                 .combine(refreshQuoteState) { input, _ -> input }
                 // A slippage or external-recipient change re-fetches with a different tolerance /
-                // routing, so raise isLoading to disable the Swap button until the new quote lands
-                // —
-                // otherwise the prior, differently-routed quote could be signed (#4858, review
-                // #4969). The onEach rides each flow individually, so the silent refresh timer
-                // above
-                // doesn't flash the spinner.
+                // routing, so — when there is actually something to quote — raise isLoading to
+                // disable the Swap button until the new quote lands, otherwise the prior,
+                // differently-routed quote could be signed (#4858, review #4969). Routed through
+                // startLoadingIfQuotable so an empty/zero amount stays quiet instead of blinking
+                // the
+                // skeletons (#5296). The onEach rides each flow individually, so the silent refresh
+                // timer above doesn't flash the spinner.
                 .combine(slippageBps.onEach { startLoadingIfQuotable() }) { input, _ -> input }
                 .combine(externalRecipient.onEach { startLoadingIfQuotable() }) { input, _ ->
                     input
@@ -463,15 +468,22 @@ constructor(
     }
 
     /**
-     * Raise the loading spinner only when there is genuinely a quote to fetch — a routable pair with
-     * a positive source amount. An empty or zero field has nothing to load, so gating here stops the
-     * destination/fee skeletons from flashing (isLoading true→false) on form open, a bare pair
-     * change, or a slippage/recipient change while the amount field is still empty (#4712).
+     * Reconciles quote-driven UI state with the current input on a trigger (typing, pair, slippage,
+     * or recipient change), ahead of the debounced fetch:
+     * - Routable pair (a real provider, so same-token is excluded) with a positive source amount:
+     *   raise the spinner so the destination/fee skeletons and disabled Swap button lead the fetch.
+     * - Nothing to quote (empty/zero field or an unroutable pair): leave the spinner off so the
+     *   skeletons never flash true→false (blink) on form open or a bare pair/slippage/recipient
+     *   change (#4712, #5296). If a resolved quote is still on screen, clear it now so a cleared or
+     *   zeroed amount disables Swap and drops the stale destination/fee immediately instead of
+     *   leaving them tappable until the 300ms debounce runs resetQuoteState (#5296 review).
      */
     private fun startLoadingIfQuotable() {
         val amount = srcAmount
-        if (isPairSupported && amount != null && amount > BigDecimal.ZERO) {
+        if (isPairRoutable && amount != null && amount > BigDecimal.ZERO) {
             isLoading = true
+        } else if (uiState.value.quoteDisplay.hasQuote) {
+            resetQuoteState()
         }
     }
 
@@ -569,9 +581,10 @@ constructor(
     private fun updatePairSupport(src: SendSrc, dst: SendSrc) {
         val srcToken = src.account.token
         val dstToken = dst.account.token
-        isPairSupported =
-            srcToken == dstToken ||
+        isPairRoutable =
+            srcToken != dstToken &&
                 swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isNotEmpty()
+        isPairSupported = srcToken == dstToken || isPairRoutable
         if (!isPairSupported) {
             resetQuoteState(error = pairNotSupportedError, cause = null, tag = null)
         } else if (uiState.value.formError == pairNotSupportedError) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -155,6 +155,19 @@ constructor(
     private val srcAmount: BigDecimal?
         get() = srcAmountState.text.toString().toBigDecimalOrNull()
 
+    /**
+     * True when the live field currently forms a quotable request: a routable pair (a real
+     * provider, so same-token is excluded) with a positive source amount. Shared by
+     * [startLoadingIfQuotable] and the late-result guard in [applyQuoteResult] so both agree on
+     * what "quotable" means, keeping zero/invalid amounts and unroutable pairs quiet on both the
+     * loading and result paths (#5296).
+     */
+    private val isLiveInputQuotable: Boolean
+        get() {
+            val amount = srcAmount
+            return isPairRoutable && amount != null && amount > BigDecimal.ZERO
+        }
+
     private var isLoading: Boolean
         get() = uiState.value.isLoading
         set(value) {
@@ -385,13 +398,15 @@ constructor(
         input: QuoteInput,
         result: SwapQuotePipelineResult.Success,
     ) {
-        // isAmountFieldEmpty is read once when resolveQuote is called, but the field can be cleared
+        // isAmountFieldEmpty is read once when resolveQuote is called, but the live input can
+        // change
         // while this fetch — queued on a prior debounce cycle — is still in flight, and
         // collectLatest
-        // can't cancel it until the empty input clears the debounce. Re-read the live field here so
+        // can't cancel it until the next input clears the debounce. Re-check the live input here so
         // a
-        // late-landing fetch drops the now-stale quote instead of resurrecting it (#5296 review).
-        if (srcAmountState.text.isEmpty()) {
+        // late-landing fetch for a now non-quotable field (cleared, zeroed, or an unroutable pair)
+        // drops the stale quote instead of resurrecting it (#5296 review).
+        if (!isLiveInputQuotable) {
             resetQuoteState()
             return
         }
@@ -491,8 +506,7 @@ constructor(
      *   leaving them tappable until the 300ms debounce runs resetQuoteState (#5296 review).
      */
     private fun startLoadingIfQuotable() {
-        val amount = srcAmount
-        if (isPairRoutable && amount != null && amount > BigDecimal.ZERO) {
+        if (isLiveInputQuotable) {
             isLoading = true
         } else if (uiState.value.quoteDisplay.hasQuote || uiState.value.isLoading) {
             // Clear a resolved quote OR a spinner we raised while a firm quote was still pending:

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenStandard
@@ -384,6 +385,17 @@ constructor(
         input: QuoteInput,
         result: SwapQuotePipelineResult.Success,
     ) {
+        // isAmountFieldEmpty is read once when resolveQuote is called, but the field can be cleared
+        // while this fetch — queued on a prior debounce cycle — is still in flight, and
+        // collectLatest
+        // can't cancel it until the empty input clears the debounce. Re-read the live field here so
+        // a
+        // late-landing fetch drops the now-stale quote instead of resurrecting it (#5296 review).
+        if (srcAmountState.text.isEmpty()) {
+            resetQuoteState()
+            return
+        }
+
         val (src, _) = input.address
 
         quoteState.provider = result.provider
@@ -482,7 +494,11 @@ constructor(
         val amount = srcAmount
         if (isPairRoutable && amount != null && amount > BigDecimal.ZERO) {
             isLoading = true
-        } else if (uiState.value.quoteDisplay.hasQuote) {
+        } else if (uiState.value.quoteDisplay.hasQuote || uiState.value.isLoading) {
+            // Clear a resolved quote OR a spinner we raised while a firm quote was still pending:
+            // clearing a quotable amount before its quote lands leaves hasQuote false, so gating
+            // only on hasQuote would strand isLoading = true for the rest of the debounce (#5296
+            // review).
             resetQuoteState()
         }
     }
@@ -569,6 +585,18 @@ constructor(
     }
 
     /**
+     * Whether [srcToken] → [dstToken] can actually be quoted: a distinct pair with at least one
+     * eligible provider. Same-token pairs are "supported" but never routable. Shared by the pair
+     * gate here and the token-selection loading gate so both key off the same predicate as
+     * [startLoadingIfQuotable]'s [isPairRoutable] flag, rather than a looser amount-only check
+     * (#5296 review). [SwapQuoteRepository.getEligibleProviders] is a local table lookup, so this
+     * is instant and safe to call on the selection path.
+     */
+    fun isPairRoutable(srcToken: Coin, dstToken: Coin): Boolean =
+        srcToken != dstToken &&
+            swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isNotEmpty()
+
+    /**
      * Resolves whether the selected source/destination pair has any eligible provider and surfaces
      * the "no route" guidance immediately on selection, instead of letting the quote pipeline throw
      * SwapIsNotSupported only after the user has typed an amount and waited for a quote (#4710).
@@ -581,9 +609,7 @@ constructor(
     private fun updatePairSupport(src: SendSrc, dst: SendSrc) {
         val srcToken = src.account.token
         val dstToken = dst.account.token
-        isPairRoutable =
-            srcToken != dstToken &&
-                swapQuoteRepository.getEligibleProviders(srcToken, dstToken).isNotEmpty()
+        isPairRoutable = isPairRoutable(srcToken, dstToken)
         isPairSupported = srcToken == dstToken || isPairRoutable
         if (!isPairSupported) {
             resetQuoteState(error = pairNotSupportedError, cause = null, tag = null)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -312,7 +312,7 @@ constructor(
                     // Unroutable pair: the "no route" guidance already showed on selection (#4710),
                     // so don't spin or fetch an indicative estimate for a pair we can't quote.
                     if (!isPairSupported) return@onEach
-                    isLoading = true
+                    startLoadingIfQuotable()
                     showIndicativeRate(input)
                 }
                 .combine(refreshQuoteState) { input, _ -> input }
@@ -323,8 +323,10 @@ constructor(
                 // #4969). The onEach rides each flow individually, so the silent refresh timer
                 // above
                 // doesn't flash the spinner.
-                .combine(slippageBps.onEach { isLoading = true }) { input, _ -> input }
-                .combine(externalRecipient.onEach { isLoading = true }) { input, _ -> input }
+                .combine(slippageBps.onEach { startLoadingIfQuotable() }) { input, _ -> input }
+                .combine(externalRecipient.onEach { startLoadingIfQuotable() }) { input, _ ->
+                    input
+                }
                 // Percentage / Max / paste skip the debounce (0ms); free typing still coalesces at
                 // 300ms so rapid edits fire a single quote fetch.
                 .debounce { input -> swapQuoteManager.quoteDebounceMillis(input.immediate) }
@@ -457,6 +459,19 @@ constructor(
                 isSwapDisabled = outcome.isSwapDisabled,
                 formError = outcome.formError,
             )
+        }
+    }
+
+    /**
+     * Raise the loading spinner only when there is genuinely a quote to fetch — a routable pair with
+     * a positive source amount. An empty or zero field has nothing to load, so gating here stops the
+     * destination/fee skeletons from flashing (isLoading true→false) on form open, a bare pair
+     * change, or a slippage/recipient change while the amount field is still empty (#4712).
+     */
+    private fun startLoadingIfQuotable() {
+        val amount = srcAmount
+        if (isPairSupported && amount != null && amount > BigDecimal.ZERO) {
+            isLoading = true
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTokenSelector.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTokenSelector.kt
@@ -158,6 +158,7 @@ constructor(
         selectedDstId: MutableStateFlow<String?>,
         addresses: MutableStateFlow<List<Address>>,
         uiState: MutableStateFlow<SwapFormUiModel>,
+        hasQuotableAmount: Boolean,
     ) {
         navigator.route(
             Route.SelectAsset(
@@ -180,6 +181,7 @@ constructor(
             selectedDstId,
             addresses,
             uiState,
+            hasQuotableAmount,
         )
     }
 
@@ -190,19 +192,25 @@ constructor(
         selectedDstId: MutableStateFlow<String?>,
         addresses: MutableStateFlow<List<Address>>,
         uiState: MutableStateFlow<SwapFormUiModel>,
+        hasQuotableAmount: Boolean,
     ) {
         val result = requestResultRepository.request<AssetSelected>(targetArg) ?: return
 
         if (result.isDisabled) {
-            uiState.update { it.copy(isLoading = true) }
+            // Only raise the shared loading flag when there is an amount to quote; otherwise
+            // loading
+            // a not-yet-held token's account would flash the destination/fee skeletons true→false
+            // over an empty field — the same blink the pipeline gate removes (#5296 review).
+            val showLoading = hasQuotableAmount
+            if (showLoading) uiState.update { it.copy(isLoading = true) }
             try {
                 val account = accountsRepository.loadAccount(vaultId, result.token)
                 updateAccountInAddresses(account, addresses)
-                uiState.update { it.copy(isLoading = false) }
+                if (showLoading) uiState.update { it.copy(isLoading = false) }
             } catch (e: Throwable) {
                 if (e is CancellationException) throw e
                 Timber.e(e, "Failed to load account for token")
-                uiState.update { it.copy(isLoading = false) }
+                if (showLoading) uiState.update { it.copy(isLoading = false) }
                 return
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTokenSelector.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTokenSelector.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.geometry.Offset
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.models.isSwapSupported
 import com.vultisig.wallet.data.repositories.AccountsRepository
@@ -158,7 +159,7 @@ constructor(
         selectedDstId: MutableStateFlow<String?>,
         addresses: MutableStateFlow<List<Address>>,
         uiState: MutableStateFlow<SwapFormUiModel>,
-        hasQuotableAmount: Boolean,
+        isSelectionQuotable: (Coin) -> Boolean,
     ) {
         navigator.route(
             Route.SelectAsset(
@@ -181,7 +182,7 @@ constructor(
             selectedDstId,
             addresses,
             uiState,
-            hasQuotableAmount,
+            isSelectionQuotable,
         )
     }
 
@@ -192,16 +193,23 @@ constructor(
         selectedDstId: MutableStateFlow<String?>,
         addresses: MutableStateFlow<List<Address>>,
         uiState: MutableStateFlow<SwapFormUiModel>,
-        hasQuotableAmount: Boolean,
+        isSelectionQuotable: (Coin) -> Boolean,
     ) {
         val result = requestResultRepository.request<AssetSelected>(targetArg) ?: return
 
         if (result.isDisabled) {
-            // Only raise the shared loading flag when there is an amount to quote; otherwise
-            // loading
-            // a not-yet-held token's account would flash the destination/fee skeletons true→false
-            // over an empty field — the same blink the pipeline gate removes (#5296 review).
-            val showLoading = hasQuotableAmount
+            // Only raise the shared loading flag when the pair the pick forms is actually quotable
+            // —
+            // a positive amount AND a routable (distinct, provider-backed) pair. Otherwise loading
+            // a
+            // not-yet-held token's account would flash the destination/fee skeletons true→false
+            // over
+            // a field that will never quote — the same blink the pipeline gate removes, and
+            // matching
+            // its isPairRoutable && amount>0 condition rather than a looser amount-only check
+            // (#5296
+            // review).
+            val showLoading = isSelectionQuotable(result.token)
             if (showLoading) uiState.update { it.copy(isLoading = true) }
             try {
                 val account = accountsRepository.loadAccount(vaultId, result.token)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.select.AssetSelected
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import io.mockk.coEvery
@@ -56,6 +57,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -108,6 +110,7 @@ internal class SwapFormViewModelTest {
     private lateinit var swapTokenSelector: SwapTokenSelector
     private lateinit var swapQuoteManager: SwapQuoteManager
     private lateinit var tokenSelectorAccountsRepository: AccountsRepository
+    private lateinit var requestResultRepository: RequestResultRepository
     private lateinit var tokenBalanceMapper: AccountToTokenBalanceUiModelMapper
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
 
@@ -184,7 +187,7 @@ internal class SwapFormViewModelTest {
                 mockk<com.vultisig.wallet.ui.models.send.TokenBalanceUiModel>(relaxed = true)
                     .apply { every { model } returns src }
             }
-        val requestResultRepository: RequestResultRepository = mockk(relaxed = true)
+        requestResultRepository = mockk(relaxed = true)
 
         swapTokenSelector =
             SwapTokenSelector(
@@ -1033,10 +1036,13 @@ internal class SwapFormViewModelTest {
                 )
             } returns createDefaultQuoteFetchResult()
 
-            val vm = createViewModelWithSwapTokens()
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
             advanceUntilIdle()
 
-            vm.srcAmountState.setTextAndPlaceCursorAtEnd("10")
+            // Type a single character so amountChanges reads free typing (immediate = false); a
+            // multi-character jump would trip the paste heuristic, caching immediate = true so the
+            // slippage refetch below debounces at 0ms and resolves before the assertion runs.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
@@ -1044,6 +1050,8 @@ internal class SwapFormViewModelTest {
 
             vm.setSlippageBps(300)
             runCurrent()
+            // runCurrent runs startLoadingIfQuotable's synchronous isLoading = true but stops well
+            // short of the 300ms typing debounce, so the spinner is still up when we assert.
             assertTrue(vm.uiState.value.isLoading)
         }
 
@@ -1070,10 +1078,13 @@ internal class SwapFormViewModelTest {
                 )
             } returns createDefaultQuoteFetchResult()
 
-            val vm = createViewModelWithSwapTokens()
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
             advanceUntilIdle()
 
-            vm.srcAmountState.setTextAndPlaceCursorAtEnd("10")
+            // A single character keeps the amount within the 10 ETH fixture balance so the
+            // insufficient-balance guard doesn't disable Swap, and reads as free typing rather than
+            // a paste.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
@@ -1090,6 +1101,272 @@ internal class SwapFormViewModelTest {
             assertTrue(vm.uiState.value.isSwapDisabled)
             assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
             assertFalse(vm.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `picking a not-yet-held token that forms a routable pair raises loading during account load`() =
+        runTest(mainDispatcher) {
+            // Positive control for the token-selection gate: with a positive amount and a routable
+            // resulting pair, loading a not-yet-held token's account must raise the shared spinner
+            // so
+            // the Swap button disables until the fresh quote lands. loadGate suspends the account
+            // load so the assertion lands while only the selection gate — not the later re-quote —
+            // has
+            // touched isLoading (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+            val loadGate = CompletableDeferred<Unit>()
+            coEvery { tokenSelectorAccountsRepository.loadAccount(any(), any()) } coAnswers
+                {
+                    loadGate.await()
+                    createAccount(USDC_COIN, BigInteger("1000000000"))
+                }
+            coEvery {
+                requestResultRepository.request<AssetSelected>(
+                    SwapTokenSelector.ARG_SELECTED_DST_TOKEN_ID
+                )
+            } returns AssetSelected(token = USDC_COIN, isDisabled = true)
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isLoading)
+
+            vm.selectDstToken()
+            advanceUntilIdle()
+            // Account load is parked on loadGate; selectedDstId is set only afterwards, so an
+            // isLoading true here is the selection gate's, not the subsequent re-quote's.
+            assertTrue(vm.uiState.value.isLoading)
+
+            loadGate.complete(Unit)
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `picking a not-yet-held token that forms an unroutable pair never raises loading during account load`() =
+        runTest(mainDispatcher) {
+            // Roman's edge case: hasQuotableAmount checking only amount>0 would still blink the
+            // skeletons while loading the account of a token whose resulting pair can never quote.
+            // The
+            // gate now mirrors the pipeline's isPairRoutable && amount>0, so an unroutable pick
+            // stays
+            // silent (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            // ETH → SOL has no provider: unroutable even though an amount is present.
+            every { swapQuoteRepository.getEligibleProviders(ETH_COIN, SOL_COIN) } returns
+                emptyList()
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+            val loadGate = CompletableDeferred<Unit>()
+            coEvery { tokenSelectorAccountsRepository.loadAccount(any(), any()) } coAnswers
+                {
+                    loadGate.await()
+                    createAccount(SOL_COIN, BigInteger("1000000000"))
+                }
+            coEvery {
+                requestResultRepository.request<AssetSelected>(
+                    SwapTokenSelector.ARG_SELECTED_DST_TOKEN_ID
+                )
+            } returns AssetSelected(token = SOL_COIN, isDisabled = true)
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isLoading)
+
+            vm.selectDstToken()
+            advanceUntilIdle()
+            assertFalse(
+                vm.uiState.value.isLoading,
+                "spinner blinked while loading an unroutable pick",
+            )
+
+            loadGate.complete(Unit)
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `picking a not-yet-held token that forms a same-token pair never raises loading during account load`() =
+        runTest(mainDispatcher) {
+            // Same-token pairs are "supported" but never routable, so — like the unroutable case —
+            // loading the pick's account must not spin even with a positive amount. Exercises the
+            // selectSrcToken() path (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+            val loadGate = CompletableDeferred<Unit>()
+            coEvery { tokenSelectorAccountsRepository.loadAccount(any(), any()) } coAnswers
+                {
+                    loadGate.await()
+                    createAccount(BTC_COIN, BigInteger("100000000"))
+                }
+            // Destination is BTC (createViewModelWithSwapTokens); picking BTC as the source forms a
+            // same-token pair.
+            coEvery {
+                requestResultRepository.request<AssetSelected>(
+                    SwapTokenSelector.ARG_SELECTED_SRC_TOKEN_ID
+                )
+            } returns AssetSelected(token = BTC_COIN, isDisabled = true)
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isLoading)
+
+            vm.selectSrcToken()
+            advanceUntilIdle()
+            assertFalse(
+                vm.uiState.value.isLoading,
+                "spinner blinked while loading a same-token pick",
+            )
+
+            loadGate.complete(Unit)
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `clearing a quotable amount before its quote resolves clears the loading spinner at once`() =
+        runTest(mainDispatcher) {
+            // startLoadingIfQuotable raises the spinner the moment a quotable amount is typed,
+            // before
+            // the firm quote lands (hasQuote still false). Clearing the field then must clear the
+            // spinner immediately — gating the reset on hasQuote alone would strand isLoading =
+            // true
+            // for the rest of the debounce (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            // A single character types as free input (300ms debounce), so the spinner is up while
+            // the
+            // firm quote is still pending.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+            assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("")
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+            assertFalse(
+                vm.uiState.value.isLoading,
+                "spinner stayed stuck after the field was cleared",
+            )
+            assertTrue(vm.uiState.value.isSwapDisabled)
+        }
+
+    @Test
+    fun `a fetch that lands after the field is cleared never resurrects the stale quote`() =
+        runTest(mainDispatcher) {
+            // collectLatest can't cancel an in-flight fetch from a prior debounce cycle until the
+            // empty input clears the debounce, so a late-landing quote could re-apply itself over
+            // the
+            // cleared field. applyQuoteResult re-reads the live field and drops it instead (#5296
+            // review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            val fetchGate = CompletableDeferred<Unit>()
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    fetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            // Past the 300ms debounce: collectLatest calls resolveQuote, which parks on fetchGate.
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+            assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
+
+            // Clear the field while the fetch is still in flight; the empty input is now sitting in
+            // the debounce, so the fetch above is not cancelled yet.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("")
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+
+            // Collect hasQuote across the fetch landing: the resurrection is a transient true
+            // before
+            // the empty input eventually resets, so a settled-state check alone would miss it.
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            fetchGate.complete(Unit)
+            advanceUntilIdle()
+            collectJob.cancel()
+
+            assertFalse(
+                quoteFlags.any { it },
+                "stale quote resurrected after the field was cleared",
+            )
+            assertTrue(vm.uiState.value.isSwapDisabled)
         }
 
     // endregion

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -1369,6 +1369,66 @@ internal class SwapFormViewModelTest {
             assertTrue(vm.uiState.value.isSwapDisabled)
         }
 
+    @Test
+    fun `a fetch that lands after the amount is zeroed never resurrects the stale quote`() =
+        runTest(mainDispatcher) {
+            // applyQuoteResult's live-input guard rejects every non-quotable field, not just an
+            // empty one: zeroing the amount while a prior-cycle fetch is still in flight must drop
+            // the late-landing quote just like clearing it does (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            val fetchGate = CompletableDeferred<Unit>()
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    fetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+            assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
+
+            // Zero the amount while the fetch is still in flight; the "0" input is now sitting in
+            // the
+            // debounce, so the fetch above is not cancelled yet but the live field is non-quotable.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0")
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            fetchGate.complete(Unit)
+            advanceUntilIdle()
+            collectJob.cancel()
+
+            assertFalse(
+                quoteFlags.any { it },
+                "stale quote resurrected after the amount was zeroed",
+            )
+            assertTrue(vm.uiState.value.isSwapDisabled)
+        }
+
     // endregion
 
     // region pair eligibility (#4710)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -931,6 +931,38 @@ internal class SwapFormViewModelTest {
             assertFalse(vm.uiState.value.isLoading)
         }
 
+    @Test
+    fun `empty amount never raises the loading spinner on form open`() =
+        runTest(mainDispatcher) {
+            // Supported pair, but no amount has been entered yet.
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            // The initial pair emission plus the slippage / external-recipient StateFlows all flow
+            // through the pipeline on subscription. With an empty amount field there is nothing to
+            // quote, so the spinner must stay off across the whole debounce window rather than
+            // flashing the destination/fee skeletons true→false (blink).
+            assertFalse(vm.uiState.value.isLoading)
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isLoading)
+
+            // No quote fetch is attempted for an empty field.
+            coVerify(exactly = 0) {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
+        }
+
     // endregion
 
     // region pair eligibility (#4710)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -932,22 +933,40 @@ internal class SwapFormViewModelTest {
         }
 
     @Test
-    fun `empty amount never raises the loading spinner on form open`() =
+    fun `empty or zero amount never raises the loading spinner across the debounce window`() =
         runTest(mainDispatcher) {
-            // Supported pair, but no amount has been entered yet.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+
             val vm = createViewModelWithSwapTokens()
             advanceUntilIdle()
 
+            // Collect every isLoading emission: advanceUntilIdle() settles the final value, so
+            // checking only the settled state would still pass a regression that flashed the
+            // spinner true→false mid-window. The blink is the transient true, so assert it never
+            // emits at all (#5296 review).
+            val loadingStates = mutableListOf(vm.uiState.value.isLoading)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { loadingStates += it.isLoading }
+                }
+
             // The initial pair emission plus the slippage / external-recipient StateFlows all flow
-            // through the pipeline on subscription. With an empty amount field there is nothing to
-            // quote, so the spinner must stay off across the whole debounce window rather than
-            // flashing the destination/fee skeletons true→false (blink).
-            assertFalse(vm.uiState.value.isLoading)
+            // through the pipeline on subscription; a bare "0" adds an amount trigger. With nothing
+            // quotable the spinner must stay off across the whole debounce window rather than
+            // flashing the destination/fee skeletons.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            vm.setSlippageBps(300)
+            vm.setExternalRecipient(null)
             advanceTimeBy(400)
             advanceUntilIdle()
-            assertFalse(vm.uiState.value.isLoading)
+            collectJob.cancel()
 
-            // No quote fetch is attempted for an empty field.
+            assertFalse(loadingStates.any { it }, "spinner blinked on an empty/zero amount")
+
+            // No quote fetch is attempted for a non-quotable field.
             coVerify(exactly = 0) {
                 swapQuoteManager.fetchBestQuote(
                     any(),
@@ -961,6 +980,116 @@ internal class SwapFormViewModelTest {
                     any(),
                 )
             }
+        }
+
+    @Test
+    fun `a same-token pair never raises the loading spinner even with a positive amount`() =
+        runTest(mainDispatcher) {
+            // Same source and destination token: the pair is "supported" (no route guidance while
+            // mid-pick) but has no provider, so it can never be quoted and must not spin (#5296).
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(ethAddressWithBalance(BigInteger("1000000000000000000"))),
+                    srcTokenId = ETH_COIN.id,
+                    dstTokenId = ETH_COIN.id,
+                )
+            advanceUntilIdle()
+
+            val loadingStates = mutableListOf(vm.uiState.value.isLoading)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { loadingStates += it.isLoading }
+                }
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("10")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            collectJob.cancel()
+
+            assertFalse(loadingStates.any { it }, "spinner blinked on a same-token pair")
+        }
+
+    @Test
+    fun `a slippage change with a positive amount still raises the loading spinner`() =
+        runTest(mainDispatcher) {
+            // The shared startLoadingIfQuotable() gate must keep the #4858/#4969 safety net: a
+            // slippage change re-routes the quote, so the Swap button has to disable (isLoading)
+            // until the new quote lands — otherwise the prior, differently-routed quote is
+            // signable.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("10")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isLoading)
+
+            vm.setSlippageBps(300)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `clearing the amount over a resolved quote disables swap and drops the stale quote at once`() =
+        runTest(mainDispatcher) {
+            // Before the debounce runs resetQuoteState ~300ms later, a cleared field must already
+            // disable Swap and drop the stale destination so the old, no-longer-valid quote can't
+            // be
+            // tapped (#5296 review).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns createDefaultQuoteFetchResult()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("10")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            assertTrue(vm.uiState.value.quoteDisplay.hasQuote)
+            assertFalse(vm.uiState.value.isSwapDisabled)
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("")
+            Snapshot.sendApplyNotifications()
+            // Advance well short of the 300ms debounce: the reset must land on the input onEach,
+            // not
+            // wait out the window that later runs resetQuoteState from collectLatest.
+            advanceTimeBy(100)
+
+            assertTrue(vm.uiState.value.isSwapDisabled)
+            assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
+            assertFalse(vm.uiState.value.isLoading)
         }
 
     // endregion


### PR DESCRIPTION
## Summary

Fixes the swap-form skeleton placeholders that **blink** (shimmer flashes on, then off) when the form is opened or when the source/destination token is changed while the amount field is empty — even though there is no data to load.

**Root cause** (`SwapQuotePipelineController`): `isLoading` was raised unconditionally at three points in the quote pipeline:
- The main input `onEach` fired for every emission, including the empty-field emission on form open / pair change.
- The `slippageBps` and `externalRecipient` StateFlows emit their initial values on subscription (form open), each flipping `isLoading = true`.

~300ms later `collectLatest` sees the empty field, `resolveQuote` returns `Empty`, and `resetQuoteState()` flips `isLoading = false`. That `true → false` round-trip with no data behind it is the visible blink.

**Fix:** a guarded helper `startLoadingIfQuotable()` that only raises the spinner when there is genuinely something to quote — a routable pair **and** a positive source amount — used at all three sites. Empty/zero fields now stay quiet on form open, on a bare pair/destination change, and on a slippage/recipient change. Real typing (positive amount) still shows the skeleton and fetches a quote exactly as before.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapFormViewModelTest"` — green
- [x] New regression test `empty amount never raises the loading spinner on form open` asserts `isLoading` stays `false` across the full debounce window and no quote is fetched for an empty field
- [x] Existing `calculateFees debounces amount changes` (spinner true while a real amount is loading) still passes — behavior preserved for positive amounts

Closes #5296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced brief swap loading/spinner flickers during form setup and when adjusting pair, slippage, or recipient while the source amount is empty or zero.
  * Loading and quote UI now trigger only for routable token pairs; when inputs become non-quotable, the UI clears stale quote/fee state and prevents late results from showing.
* **Tests**
  * Expanded debounce and edge-case coverage for spinner behavior, routability gating, and correct state clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->