### PR TITLE
Terra fee: show gas_used × price on done screen (display parity with extension) (#5279)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/UpdateTerraDisplayFeeUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/UpdateTerraDisplayFeeUseCase.kt
@@ -1,0 +1,76 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.TokenValue
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+
+/**
+ * Recomputes the Terra network fee shown on the transaction-done screen from the confirmed tx's
+ * actual `gas_used`, mirroring the vultisig extension / iOS "gas used × min gas price" display.
+ *
+ * DISPLAY-ONLY. Terra (Cosmos) does NOT refund unused gas — the amount actually DEDUCTED is the
+ * declared `fee.amount` (the static 7500 uluna), not this number. This intentionally shows less
+ * than what left the balance, purely for cross-platform parity with the other clients' done
+ * screens; it does not change the signed fee. The real fix (lowering the deducted fee) needs every
+ * co-signer to honor a lowered gas_limit — see issue #5279. Mirrors [UpdateEvmActualFeeUseCase],
+ * except EVM genuinely refunds unused gas so there the recomputed value IS what was burned.
+ */
+internal class UpdateTerraDisplayFeeUseCase
+@Inject
+constructor(
+    private val cosmosApiFactory: CosmosApiFactory,
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
+) {
+
+    /**
+     * Returns the `gas_used × min-gas-price` fee estimate for [txHash], or null when not
+     * applicable: a non-Terra chain, no landed tx within the retry window, or a tx missing
+     * `gas_used`.
+     */
+    suspend operator fun invoke(txHash: String, chain: Chain, coin: Coin): EstimatedGasFee? {
+        if (chain != Chain.Terra) return null
+
+        val api = cosmosApiFactory.createCosmosApi(chain)
+        var gasUsed: BigInteger? = null
+        for (attempt in 1..MAX_RETRIES) {
+            gasUsed =
+                api.getTxStatus(txHash)?.txResponse?.gasUsed?.toBigIntegerOrNull()?.takeIf {
+                    it > BigInteger.ZERO
+                }
+            if (gasUsed != null) break
+            if (attempt < MAX_RETRIES) delay(RETRY_DELAY_MS)
+        }
+        val used = gasUsed ?: return null
+
+        // Truncate (DOWN), not round up: this is a cosmetic display, and the extension shows
+        // floor(gas_used × price) — e.g. 77779 × 0.025 = 1944.475 → 1944 uluna (0.001944 LUNA).
+        val effectiveFee =
+            (used.toBigDecimal() * TERRA_MIN_GAS_PRICE)
+                .setScale(0, RoundingMode.DOWN)
+                .toBigInteger()
+        return gasFeeToEstimatedFee(
+            GasFeeParams(
+                gasLimit = BigInteger.ONE,
+                gasFee =
+                    TokenValue(value = effectiveFee, unit = coin.ticker, decimals = coin.decimal),
+                selectedToken = coin,
+            )
+        )
+    }
+
+    private companion object {
+        // Terra (LUNA, phoenix-1) minimum gas price, 0.025 uluna/gas — the same rate the extension
+        // uses to render `gas_used × price`.
+        val TERRA_MIN_GAS_PRICE = BigDecimal("0.025")
+        const val MAX_RETRIES = 5
+        const val RETRY_DELAY_MS = 2_000L
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.FeatureFlagApi
 import com.vultisig.wallet.data.api.KeysignVerify
@@ -51,6 +52,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.KeysignBroadcastResult
 import com.vultisig.wallet.data.usecases.SaveKeysignTransactionHistoryUseCase
 import com.vultisig.wallet.data.usecases.UpdateEvmActualFeeUseCase
+import com.vultisig.wallet.data.usecases.UpdateTerraDisplayFeeUseCase
 import com.vultisig.wallet.data.usecases.tss.PullTssMessagesUseCase
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
@@ -261,6 +263,7 @@ constructor(
     @Assisted private val transactionHistoryData: TransactionHistoryData?,
     private val thorChainApi: ThorChainApi,
     private val evmApiFactory: EvmApiFactory,
+    private val cosmosApiFactory: CosmosApiFactory,
     private val broadcastTx: BroadcastTxUseCase,
     private val awaitApprovalConfirmation: AwaitApprovalConfirmationUseCase,
     private val explorerLinkRepository: ExplorerLinkRepository,
@@ -338,6 +341,8 @@ constructor(
     private val saveKeysignTransactionHistory =
         SaveKeysignTransactionHistoryUseCase(transactionHistoryRepository)
     private val updateEvmActualFee = UpdateEvmActualFeeUseCase(evmApiFactory, gasFeeToEstimatedFee)
+    private val updateTerraDisplayFee =
+        UpdateTerraDisplayFeeUseCase(cosmosApiFactory, gasFeeToEstimatedFee)
     private val broadcastKeysign =
         BroadcastKeysignUseCase(
             broadcastTx = broadcastTx,
@@ -904,7 +909,10 @@ constructor(
                             )
                         }
                     }
-                if (terminal != null) tryUpdateEvmActualFee(txHash, chain)
+                if (terminal != null) {
+                    tryUpdateEvmActualFee(txHash, chain)
+                    tryUpdateTerraDisplayFee(txHash, chain)
+                }
             }
     }
 
@@ -935,6 +943,38 @@ constructor(
                             sendTx.tx.copy(
                                 networkFeeTokenValue = estimatedFee.formattedTokenValue,
                                 networkFeeFiatValue = estimatedFee.formattedFiatValue,
+                            )
+                        )
+                )
+            }
+        }
+    }
+
+    /**
+     * After a Terra send confirms, replaces the done-screen fee with `gas_used × min-gas-price`, to
+     * match the vultisig extension / iOS display. DISPLAY-ONLY — Terra does not refund unused gas,
+     * so the amount actually deducted is still the declared `fee.amount`; this only aligns the
+     * shown number across clients (issue #5279). Falls back silently to the declared fee on any
+     * error.
+     */
+    internal fun tryUpdateTerraDisplayFee(txHash: String, chain: Chain) {
+        if (chain != Chain.Terra) return
+        val coin = keysignPayload?.coin ?: return
+
+        viewModelScope.safeLaunch(
+            onError = { e -> Timber.w(e, "Failed to update Terra display fee for %s", txHash) }
+        ) {
+            val displayFee = updateTerraDisplayFee(txHash, chain, coin) ?: return@safeLaunch
+            _state.update { current ->
+                val sendTx =
+                    current.transactionUiModel as? TransactionTypeUiModel.Send
+                        ?: return@update current
+                current.copy(
+                    transactionUiModel =
+                        TransactionTypeUiModel.Send(
+                            sendTx.tx.copy(
+                                networkFeeTokenValue = displayFee.formattedTokenValue,
+                                networkFeeFiatValue = displayFee.formattedFiatValue,
                             )
                         )
                 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -95,6 +95,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             transactionHistoryData = null,
             thorChainApi = mockk(relaxed = true),
             evmApiFactory = mockk(relaxed = true),
+            cosmosApiFactory = mockk(relaxed = true),
             broadcastTx = mockk(relaxed = true),
             explorerLinkRepository = mockk(relaxed = true),
             navigator = mockk<Navigator<Destination>>(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
@@ -88,6 +88,7 @@ internal class KeysignViewModelSaveTransactionHistoryTest {
             transactionHistoryData = transactionHistoryData,
             thorChainApi = mockk(relaxed = true),
             evmApiFactory = mockk(relaxed = true),
+            cosmosApiFactory = mockk(relaxed = true),
             broadcastTx = mockk(relaxed = true),
             explorerLinkRepository = mockk(relaxed = true),
             navigator = mockk<Navigator<Destination>>(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateTerraDisplayFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateTerraDisplayFeeTest.kt
@@ -2,14 +2,15 @@
 
 package com.vultisig.wallet.ui.models.keysign
 
-import com.vultisig.wallet.data.api.EvmApi
-import com.vultisig.wallet.data.api.EvmApiFactory
-import com.vultisig.wallet.data.api.models.EvmRpcResponseJson
-import com.vultisig.wallet.data.api.models.EvmTxStatusJson
+import com.vultisig.wallet.data.api.CosmosApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.models.cosmos.CosmosTxStatusJson
+import com.vultisig.wallet.data.api.models.cosmos.TxResponse
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.Vault
@@ -23,6 +24,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
@@ -37,76 +39,57 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-internal class KeysignViewModelTryUpdateEvmActualFeeTest {
+internal class KeysignViewModelTryUpdateTerraDisplayFeeTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private lateinit var evmApiFactory: EvmApiFactory
-    private lateinit var evmApi: EvmApi
+    private lateinit var cosmosApiFactory: CosmosApiFactory
+    private lateinit var cosmosApi: CosmosApi
     private lateinit var gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase
 
     private val vault = Vault(id = "v1", name = "Test Vault")
-    private val ethCoin =
+    private val lunaCoin =
         Coin(
-            chain = Chain.Ethereum,
-            ticker = "ETH",
-            logo = "eth",
-            address = "0xsender",
-            decimal = 18,
+            chain = Chain.Terra,
+            ticker = "LUNA",
+            logo = "luna",
+            address = "terra1sender",
+            decimal = 6,
             hexPublicKey = "",
-            priceProviderID = "ethereum",
+            priceProviderID = "terra-luna-2",
             contractAddress = "",
             isNativeToken = true,
         )
-    private val ethKeysignPayload =
+    private val lunaKeysignPayload =
         KeysignPayload(
-            coin = ethCoin,
-            toAddress = "0xdest",
+            coin = lunaCoin,
+            toAddress = "terra1dest",
             toAmount = BigInteger.ZERO,
             blockChainSpecific =
-                BlockChainSpecific.Ethereum(
-                    maxFeePerGasWei = BigInteger.ZERO,
-                    priorityFeeWei = BigInteger.ZERO,
-                    nonce = BigInteger.ZERO,
-                    gasLimit = BigInteger.valueOf(21000),
+                BlockChainSpecific.Cosmos(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    gas = BigInteger.valueOf(7500),
+                    ibcDenomTraces = null,
+                    transactionType =
+                        vultisig.keysign.v1.TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
                 ),
             vaultPublicKeyECDSA = "",
             vaultLocalPartyID = "",
             libType = null,
             wasmExecuteContractPayload = null,
         )
-    private val btcCoin =
-        Coin(
-            chain = Chain.Bitcoin,
-            ticker = "BTC",
-            logo = "btc",
-            address = "bc1qsender",
-            decimal = 8,
-            hexPublicKey = "",
-            priceProviderID = "bitcoin",
-            contractAddress = "",
-            isNativeToken = true,
-        )
-    private val btcKeysignPayload =
-        KeysignPayload(
-            coin = btcCoin,
-            toAddress = "bc1qdest",
-            toAmount = BigInteger.ZERO,
-            blockChainSpecific =
-                BlockChainSpecific.UTXO(byteFee = BigInteger.ONE, sendMaxAmount = false),
-            vaultPublicKeyECDSA = "",
-            vaultLocalPartyID = "",
-            libType = null,
-            wasmExecuteContractPayload = null,
-        )
+    private val gaiaCoin =
+        lunaCoin.copy(chain = Chain.GaiaChain, ticker = "ATOM", address = "cosmos1sender")
+    private val gaiaKeysignPayload = lunaKeysignPayload.copy(coin = gaiaCoin)
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        evmApiFactory = mockk(relaxed = true)
-        evmApi = mockk(relaxed = true)
+        cosmosApiFactory = mockk(relaxed = true)
+        cosmosApi = mockk(relaxed = true)
         gasFeeToEstimatedFee = mockk(relaxed = true)
-        every { evmApiFactory.createEvmApi(Chain.Ethereum) } returns evmApi
+        every { cosmosApiFactory.createCosmosApi(Chain.Terra) } returns cosmosApi
     }
 
     @AfterEach
@@ -129,8 +112,8 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
             isInitiatingDevice = false,
             transactionHistoryData = null,
             thorChainApi = mockk(relaxed = true),
-            evmApiFactory = evmApiFactory,
-            cosmosApiFactory = mockk(relaxed = true),
+            evmApiFactory = mockk(relaxed = true),
+            cosmosApiFactory = cosmosApiFactory,
             broadcastTx = mockk(relaxed = true),
             explorerLinkRepository = mockk(relaxed = true),
             navigator = mockk<Navigator<Destination>>(relaxed = true),
@@ -150,98 +133,90 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
         )
 
     @Test
-    fun `EVM receipt with both fee fields updates resolvedTransactionUiModel`() =
+    fun `Terra tx prices the fee at gas_used times min gas price and updates the model`() =
         runTest(testDispatcher) {
-            val vm = createViewModel(ethKeysignPayload)
+            val vm = createViewModel(lunaKeysignPayload)
             vm.updateUiStateForTesting {
                 it.copy(
                     transactionUiModel =
                         TransactionTypeUiModel.Send(
                             TransactionDetailsUiModel(
-                                networkFeeTokenValue = "0.001 ETH",
-                                networkFeeFiatValue = "~$3",
+                                networkFeeTokenValue = "0.0075 LUNA",
+                                networkFeeFiatValue = "$0.00035",
                             )
                         )
                 )
             }
-            coEvery { evmApi.getTxStatus("0xabc") } returns
-                EvmRpcResponseJson(
-                    id = 1,
-                    result =
-                        EvmTxStatusJson(
-                            status = "0x1",
-                            gasUsed = "0x5208",
-                            effectiveGasPrice = "0x3b9aca00",
-                        ),
+            // 77779 gas × 0.025 uluna/gas = 1944.475 → floor 1944 uluna (matches the extension).
+            coEvery { cosmosApi.getTxStatus("hash") } returns
+                CosmosTxStatusJson(
+                    txResponse = TxResponse(height = "1", txHash = "hash", gasUsed = "77779")
                 )
-            coEvery { gasFeeToEstimatedFee(any()) } returns
+            val params = slot<GasFeeParams>()
+            coEvery { gasFeeToEstimatedFee(capture(params)) } returns
                 EstimatedGasFee(
-                    formattedTokenValue = "0.00042 ETH",
-                    formattedFiatValue = "$1.50",
-                    tokenValue = TokenValue(value = BigInteger.ONE, unit = "ETH", decimals = 18),
-                    fiatValue = FiatValue(value = BigDecimal("1.50"), currency = "USD"),
+                    formattedTokenValue = "0.001944 LUNA",
+                    formattedFiatValue = "$0.00008",
+                    tokenValue =
+                        TokenValue(value = BigInteger.valueOf(1944), unit = "LUNA", decimals = 6),
+                    fiatValue = FiatValue(value = BigDecimal("0.00008"), currency = "USD"),
                 )
 
-            vm.tryUpdateEvmActualFee("0xabc", Chain.Ethereum)
+            vm.tryUpdateTerraDisplayFee("hash", Chain.Terra)
             advanceUntilIdle()
 
+            assertEquals(BigInteger.valueOf(1944), params.captured.gasFee.value)
             val model = vm.state.value.transactionUiModel as TransactionTypeUiModel.Send
-            assertEquals("0.00042 ETH", model.tx.networkFeeTokenValue)
-            assertEquals("$1.50", model.tx.networkFeeFiatValue)
+            assertEquals("0.001944 LUNA", model.tx.networkFeeTokenValue)
+            assertEquals("$0.00008", model.tx.networkFeeFiatValue)
         }
 
     @Test
-    fun `non-EVM chain skips RPC call entirely`() =
+    fun `non-Terra Cosmos chain skips the RPC call and leaves the model unchanged`() =
         runTest(testDispatcher) {
-            val vm = createViewModel(btcKeysignPayload)
+            val vm = createViewModel(gaiaKeysignPayload)
             vm.updateUiStateForTesting {
                 it.copy(
                     transactionUiModel =
                         TransactionTypeUiModel.Send(
-                            TransactionDetailsUiModel(networkFeeTokenValue = "0.0001 BTC")
+                            TransactionDetailsUiModel(networkFeeTokenValue = "0.0075 ATOM")
                         )
                 )
             }
 
-            vm.tryUpdateEvmActualFee("0xabc", Chain.Bitcoin)
+            vm.tryUpdateTerraDisplayFee("hash", Chain.GaiaChain)
             advanceUntilIdle()
 
-            coVerify(exactly = 0) { evmApiFactory.createEvmApi(any()) }
+            coVerify(exactly = 0) { cosmosApiFactory.createCosmosApi(any()) }
             val model = vm.state.value.transactionUiModel as TransactionTypeUiModel.Send
-            assertEquals("0.0001 BTC", model.tx.networkFeeTokenValue)
+            assertEquals("0.0075 ATOM", model.tx.networkFeeTokenValue)
         }
 
     @Test
-    fun `receipt missing effectiveGasPrice leaves model unchanged`() =
+    fun `tx missing gas_used leaves the declared fee unchanged`() =
         runTest(testDispatcher) {
-            val vm = createViewModel(ethKeysignPayload)
+            val vm = createViewModel(lunaKeysignPayload)
             vm.updateUiStateForTesting {
                 it.copy(
                     transactionUiModel =
                         TransactionTypeUiModel.Send(
                             TransactionDetailsUiModel(
-                                networkFeeTokenValue = "0.001 ETH",
-                                networkFeeFiatValue = "~$3",
+                                networkFeeTokenValue = "0.0075 LUNA",
+                                networkFeeFiatValue = "$0.00035",
                             )
                         )
                 )
             }
-            coEvery { evmApi.getTxStatus("0xabc") } returns
-                EvmRpcResponseJson(
-                    id = 1,
-                    result =
-                        EvmTxStatusJson(
-                            status = "0x1",
-                            gasUsed = "0x5208",
-                            effectiveGasPrice = null,
-                        ),
+            coEvery { cosmosApi.getTxStatus("hash") } returns
+                CosmosTxStatusJson(
+                    txResponse = TxResponse(height = "1", txHash = "hash", gasUsed = null)
                 )
 
-            vm.tryUpdateEvmActualFee("0xabc", Chain.Ethereum)
+            vm.tryUpdateTerraDisplayFee("hash", Chain.Terra)
             advanceUntilIdle()
 
             val model = vm.state.value.transactionUiModel as TransactionTypeUiModel.Send
-            assertEquals("0.001 ETH", model.tx.networkFeeTokenValue)
-            assertEquals("~$3", model.tx.networkFeeFiatValue)
+            assertEquals("0.0075 LUNA", model.tx.networkFeeTokenValue)
+            assertEquals("$0.00035", model.tx.networkFeeFiatValue)
         }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosTxStatusJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosTxStatusJson.kt
@@ -17,8 +17,10 @@ data class TxResponse(
     // Cosmos LCD (gRPC-gateway) omits zero-value fields, so a successfully executed tx has no
     // `code` in the JSON. Default to 0 (success) so deserialization of a landed tx doesn't throw.
     @SerialName("code") val code: Int = 0,
-    @SerialName("rawLog") val rawLog: String? = null,
-    @SerialName("gasUsed") val gasUsed: String? = null,
-    @SerialName("gasWanted") val gasWanted: String? = null,
+    // The Cosmos LCD (gRPC-gateway) serializes these in snake_case; the previous camelCase
+    // @SerialName values never matched, so rawLog/gasUsed/gasWanted always deserialized to null.
+    @SerialName("raw_log") val rawLog: String? = null,
+    @SerialName("gas_used") val gasUsed: String? = null,
+    @SerialName("gas_wanted") val gasWanted: String? = null,
     @SerialName("timestamp") val timestamp: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.chains.helpers.CosmosHelper
+import com.vultisig.wallet.data.chains.helpers.TerraHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -100,11 +101,12 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 .setScale(0, RoundingMode.FLOOR)
                 .toBigInteger()
 
-        // Chains whose sends WalletCore assembles as a native bank `MsgSend` (routed through
-        // CosmosHelper in SigningHelper), so the simulated unsigned tx matches the broadcast tx.
-        // Terra's native LUNA send is also a `MsgSend` (TerraHelper's native branch), so the
-        // CosmosHelper-built simulation matches it; TerraClassic and Terra token sends (CW20 /
-        // IBC) use different messages and are excluded (see [simulatedGasUsed]).
+        // Chains whose sends WalletCore assembles as a native bank `MsgSend`, so the simulated
+        // unsigned tx matches the broadcast tx. Most route through CosmosHelper; Terra's native
+        // LUNA
+        // send is a `MsgSend` too but is built by TerraHelper (its real signer — see
+        // [simulatedGasUsed]), since WalletCore's TERRAV2 signer rejects the CosmosHelper shape.
+        // TerraClassic and Terra token sends (CW20 / IBC) use different messages and are excluded.
         private val SIMULATION_SUPPORTED_CHAINS =
             setOf(
                 Chain.GaiaChain,
@@ -243,19 +245,34 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
             // sequence mismatch", so seed the unsigned tx with the live on-chain account state
             // instead of zeros — otherwise every funded account silently falls back to static gas.
             val account = api.getAccountNumber(coin.address)
+            val simulationPayload =
+                buildSimulationPayload(
+                    transaction = transaction,
+                    accountNumber = BigInteger(account.accountNumber ?: "0"),
+                    sequence = BigInteger(account.sequence ?: "0"),
+                )
+            // Terra native sends are assembled by TerraHelper (see SigningHelper), not
+            // CosmosHelper:
+            // WalletCore's TERRAV2 signer rejects the gas-limit-without-amount fee CosmosHelper
+            // emits
+            // for a zero-fee simulate tx ("Incorrect input parameter"). Simulating through the same
+            // builder that signs the real send also keeps the metered gas matched to the broadcast.
             val txBytes =
-                CosmosHelper(
-                        coinType = coin.coinType,
-                        denom = chain.feeUnit,
-                        gasLimit = staticLimit,
-                    )
-                    .getZeroSignedTransaction(
-                        buildSimulationPayload(
-                            transaction = transaction,
-                            accountNumber = BigInteger(account.accountNumber ?: "0"),
-                            sequence = BigInteger(account.sequence ?: "0"),
+                if (chain == Chain.Terra) {
+                    TerraHelper(
+                            coinType = coin.coinType,
+                            denom = chain.feeUnit,
+                            gasLimit = staticLimit,
                         )
-                    )
+                        .getZeroSignedTransaction(simulationPayload)
+                } else {
+                    CosmosHelper(
+                            coinType = coin.coinType,
+                            denom = chain.feeUnit,
+                            gasLimit = staticLimit,
+                        )
+                        .getZeroSignedTransaction(simulationPayload)
+                }
             api.simulate(txBytes)?.also { cachedSimulatedGas = CachedSimulatedGas(chain, it, now) }
         } catch (e: CancellationException) {
             throw e

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeService.kt
@@ -84,8 +84,27 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 .setScale(0, RoundingMode.CEILING)
                 .toBigInteger()
 
+        /**
+         * Inverse of [terraFeeAmount]: the largest gas limit whose minimum fee (`TERRA_GAS_PRICE ×
+         * limit`) is still covered by [feeAmount] (floor division). The initiator relays this
+         * alongside the signed fee amount so the broadcast declares `~gas_used × 1.3` instead of
+         * the static 300k ceiling, letting the fee bill the real gas cost instead of the full
+         * 300k-gas amount (issue #5279). Deriving the limit from the fee amount — rather than a
+         * second `/simulate` — keeps `feeAmount ≥ gasPrice × gasLimit` true by construction, so the
+         * shown, signed and relayed values can never disagree.
+         */
+        internal fun terraGasLimitForFeeAmount(feeAmount: BigInteger): BigInteger =
+            feeAmount
+                .toBigDecimal()
+                .divide(TERRA_GAS_PRICE, MathContext.DECIMAL64)
+                .setScale(0, RoundingMode.FLOOR)
+                .toBigInteger()
+
         // Chains whose sends WalletCore assembles as a native bank `MsgSend` (routed through
         // CosmosHelper in SigningHelper), so the simulated unsigned tx matches the broadcast tx.
+        // Terra's native LUNA send is also a `MsgSend` (TerraHelper's native branch), so the
+        // CosmosHelper-built simulation matches it; TerraClassic and Terra token sends (CW20 /
+        // IBC) use different messages and are excluded (see [simulatedGasUsed]).
         private val SIMULATION_SUPPORTED_CHAINS =
             setOf(
                 Chain.GaiaChain,
@@ -94,7 +113,16 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
                 Chain.Osmosis,
                 Chain.Noble,
                 Chain.Akash,
+                Chain.Terra,
             )
+
+        // Chains whose simulate-derived gas limit the initiator RELAYS (proto
+        // `CosmosSpecific.gas_limit`), so the broadcast tx declares that dynamic limit instead of
+        // the static one. For these the fee is priced at the dynamic limit with no static-amount
+        // floor — the on-chain minimum is `minGasPrice × dynamicLimit`, which the priced amount
+        // already meets. The static floor stays for every other chain, whose broadcast still
+        // declares the static limit (issue #5279 relies on the honor side shipped in #5191).
+        private val RELAYED_GAS_LIMIT_CHAINS = setOf(Chain.Terra)
     }
 
     override suspend fun calculateFees(transaction: BlockchainTransaction): Fee {
@@ -111,14 +139,23 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
         val gasUsed = simulatedGasUsed(transaction) ?: return staticFees
 
         val limit = gasUsed.toBigInteger().increaseByPercent(GAS_ADJUSTMENT_PERCENT)
-        val amount =
+        val pricedAmount =
             (limit.toBigDecimal() * simulatedGasPrice(chain, staticFees, staticLimit))
                 .setScale(0, RoundingMode.CEILING)
                 .toBigInteger()
+        val amount =
+            if (chain in RELAYED_GAS_LIMIT_CHAINS) {
+                // The initiator relays this dynamic `limit`, so the broadcast tx declares it (not
+                // the static one). The on-chain minimum is therefore `minGasPrice × dynamicLimit`
+                // = `pricedAmount`; applying the static-amount floor here would re-bill the full
+                // 300k-gas ceiling and reintroduce the overcharge (issue #5279).
+                pricedAmount
+            } else {
                 // The broadcast tx still declares the static `getChainGasLimit`, so the fee must
                 // cover at least the static per-chain amount (`minGasPrice × staticLimit`) or the
                 // mempool rejects it; never drop below that floor (issue #4847).
-                .max(staticFees.amount)
+                pricedAmount.max(staticFees.amount)
+            }
         return GasFees(limit = limit, amount = amount)
     }
 
@@ -181,7 +218,7 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
     /**
      * Simulates the unsigned transaction and returns `gas_info.gas_used`, or `null` to fall back to
      * the static gas limit. Only the chains whose sends WalletCore builds as native bank `MsgSend`
-     * are simulated; Terra/TerraClassic (TerraHelper, burn tax) and Qbtc (ML-DSA) keep their static
+     * are simulated; TerraClassic (TerraHelper, burn tax) and Qbtc (ML-DSA) keep their static
      * values.
      */
     private suspend fun simulatedGasUsed(transaction: BlockchainTransaction): Long? {
@@ -189,6 +226,12 @@ class CosmosFeeService(private val cosmosApiFactory: CosmosApiFactory) : FeeServ
         val chain = coin.chain
         if (chain !in SIMULATION_SUPPORTED_CHAINS) return null
         if (transaction !is Transfer) return null
+        // Only Terra's native LUNA send is a `MsgSend`; CW20 (`terra1…`) / IBC (`ibc/…`) token
+        // sends are wasm-execute / different messages, so a simulated `MsgSend` would under-measure
+        // their gas. Since Terra's fee is un-floored ([RELAYED_GAS_LIMIT_CHAINS]), an
+        // under-measurement can't be caught by the static floor — so never simulate a non-native
+        // Terra send.
+        if (chain == Chain.Terra && !coin.isNativeToken) return null
         val now = System.currentTimeMillis()
         cachedSimulatedGas?.let {
             if (it.chain == chain && now - it.fetchedAtMs < SIMULATED_GAS_TTL_MS) return it.gasUsed

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -52,8 +52,16 @@ class CosmosHelper(
         const val ATOM_DENOM = "uatom"
 
         // Cosmos `/simulate` skips signature verification, so a dummy r||s of the secp256k1
-        // signature size is enough for the ante handler to meter gas.
+        // signature size is enough for the ante handler to meter gas. Use a canonical non-zero
+        // placeholder (r = s = 1, in-range low-S scalars): some WalletCore signers (e.g. TERRAV2)
+        // reject an all-zero r||s as invalid during compile. The value is never verified.
         private const val SECP256K1_SIGNATURE_SIZE = 64
+
+        private val DUMMY_SIMULATE_SIGNATURE =
+            ByteArray(SECP256K1_SIGNATURE_SIZE).apply {
+                this[31] = 1 // r = 1
+                this[63] = 1 // s = 1
+            }
     }
 
     /**
@@ -67,7 +75,7 @@ class CosmosHelper(
         val input = getPreSignedInputData(keysignPayload)
         val publicKey =
             PublicKey(keysignPayload.coin.hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
-        val allSignatures = DataVector().apply { add(ByteArray(SECP256K1_SIGNATURE_SIZE)) }
+        val allSignatures = DataVector().apply { add(DUMMY_SIMULATE_SIGNATURE.copyOf()) }
         val allPublicKeys = DataVector().apply { add(publicKey.data()) }
         val compiled = compileWithSignatures(coinType, input, allSignatures, allPublicKeys)
         val output = Cosmos.SigningOutput.parseFrom(compiled).checkError()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TerraHelper.kt
@@ -10,6 +10,8 @@ import com.vultisig.wallet.data.models.transactionHash
 import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
 import com.vultisig.wallet.data.utils.Numeric
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import tss.KeysignResponse
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
@@ -27,6 +29,42 @@ class TerraHelper(
     private val denom: String,
     private val gasLimit: Long,
 ) {
+
+    companion object {
+        // Cosmos `/simulate` skips signature verification, so a dummy r||s of the secp256k1
+        // signature size is enough for the ante handler to meter gas. WalletCore's TERRAV2 signer,
+        // unlike the plain Cosmos signer, rejects an all-zero r||s as an invalid signature during
+        // compile ("Incorrect input parameter"), so use a canonical non-zero placeholder: r = s =
+        // 1,
+        // both in-range low-S scalars. The value is irrelevant — simulate never verifies it.
+        private const val SECP256K1_SIGNATURE_SIZE = 64
+
+        private val DUMMY_SIMULATE_SIGNATURE =
+            ByteArray(SECP256K1_SIGNATURE_SIZE).apply {
+                this[31] = 1 // r = 1
+                this[63] = 1 // s = 1
+            }
+    }
+
+    /**
+     * Builds the base64 `tx_bytes` of a zero-signature Terra transaction for
+     * `/cosmos/tx/v1beta1/simulate`. Terra native sends are assembled by [getPreSignedInputData]
+     * (not [CosmosHelper]) so the simulated tx matches the builder that signs the real send,
+     * keeping the metered gas aligned with the broadcast tx (issue #5279).
+     */
+    fun getZeroSignedTransaction(keysignPayload: KeysignPayload): String {
+        val input = getPreSignedInputData(keysignPayload)
+        val publicKey =
+            PublicKey(keysignPayload.coin.hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
+        val allSignatures = DataVector().apply { add(DUMMY_SIMULATE_SIGNATURE.copyOf()) }
+        val allPublicKeys = DataVector().apply { add(publicKey.data()) }
+        val compiled = compileWithSignatures(coinType, input, allSignatures, allPublicKeys)
+        val output = Cosmos.SigningOutput.parseFrom(compiled).checkError()
+        return Json.parseToJsonElement(output.serialized)
+            .jsonObject["tx_bytes"]
+            ?.jsonPrimitive
+            ?.content ?: error("Simulate payload missing tx_bytes")
+    }
 
     /**
      * Honor the relayed dynamic gas limit when an initiator set one; otherwise fall back to the

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.tonUserFriendlyAddress
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.cosmos.CosmosFeeService
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_ARBITRUM_TRANSFER
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
@@ -485,6 +486,24 @@ constructor(
                         else -> null
                     }
 
+                // Terra (LUNA) native sends: relay a gas limit sized to the (simulate-derived) fee
+                // amount so the broadcast declares ~gas_used×1.3 instead of the static 300k
+                // ceiling,
+                // billing the real gas cost instead of the full 300k-gas fee (issue #5279). Derived
+                // from the signed `gasFee.value` itself so `amount ≥ gasPrice × gas_limit` holds by
+                // construction and the shown / signed / relayed values agree. Honored by every
+                // co-signer (Android #5191, iOS #4692, Windows/SDK); FastVault signs the hash.
+                // Native
+                // only — CW20 / IBC Terra sends use a different message and keep the static limit.
+                val relayedGasLimit =
+                    if (
+                        chain == Chain.Terra &&
+                            token.isNativeToken &&
+                            transactionType == TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+                    ) {
+                        CosmosFeeService.terraGasLimitForFeeAmount(gasFee.value)
+                    } else null
+
                 BlockChainSpecificAndUtxo(
                     BlockChainSpecific.Cosmos(
                         accountNumber = BigInteger(account.accountNumber ?: "0"),
@@ -492,6 +511,7 @@ constructor(
                         gas = gasFee.value,
                         ibcDenomTraces = denomTrace,
                         transactionType = transactionType,
+                        gasLimit = relayedGasLimit,
                     )
                 )
             }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosTxStatusJsonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosTxStatusJsonTest.kt
@@ -1,0 +1,41 @@
+package com.vultisig.wallet.data.api.models.cosmos
+
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+internal class CosmosTxStatusJsonTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Trimmed real response from `GET /cosmos/tx/v1beta1/txs/{hash}` on a Terra LCD. The LCD
+    // serializes gas/raw_log in snake_case; this guards the [TxResponse] @SerialName values so the
+    // Terra done-screen fee (gas_used × price) can't silently fall back to null again.
+    @Test
+    fun `parses snake_case tx_response gas fields`() {
+        val body =
+            """
+            {
+              "tx": {},
+              "tx_response": {
+                "height": "21918262",
+                "txhash": "5CE8A7DCA376DB992405C0B26C7E4623F0E512CE8E2DD957F447B6E6C63D3093",
+                "code": 0,
+                "raw_log": "",
+                "gas_wanted": "300000",
+                "gas_used": "77779",
+                "timestamp": "2026-07-15T02:30:00Z"
+              }
+            }
+            """
+                .trimIndent()
+
+        val parsed = json.decodeFromString<CosmosTxStatusJson>(body)
+        val resp = parsed.txResponse!!
+
+        assertEquals("77779", resp.gasUsed)
+        assertEquals("300000", resp.gasWanted)
+        assertEquals(0, resp.code)
+        assertEquals("21918262", resp.height)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosFeeServiceTest.kt
@@ -100,6 +100,48 @@ class CosmosFeeServiceTest {
     }
 
     @Test
+    fun `terraGasLimitForFeeAmount inverts terraFeeAmount`() {
+        // floor(feeAmount / 0.025): 2877 uluna → 115_080 gas (the un-floored ~gas_used×1.3 fee).
+        assertEquals(
+            BigInteger("115080"),
+            CosmosFeeService.terraGasLimitForFeeAmount(BigInteger("2877")),
+        )
+        // the flat 7500 maps back to the static 300k limit — relaying it is a no-op, still valid.
+        assertEquals(
+            BigInteger("300000"),
+            CosmosFeeService.terraGasLimitForFeeAmount(BigInteger("7500")),
+        )
+    }
+
+    @Test
+    fun `relayed Terra gas limit is always covered by its fee amount`() {
+        // Core safety invariant of the #5279 fix: minGasPrice × relayedLimit ≤ signed fee amount,
+        // so a broadcast with the relayed (lower) gas_wanted can never be rejected "insufficient
+        // fee". Holds for any simulated gas because terraGasLimitForFeeAmount floor-divides.
+        val price = java.math.BigDecimal("0.025")
+        for (paddedLimit in listOf(50_000L, 88_516L, 115_071L, 250_000L)) {
+            val amount = CosmosFeeService.terraFeeAmount(paddedLimit)
+            val relayed = CosmosFeeService.terraGasLimitForFeeAmount(amount)
+            assertTrue(
+                price.multiply(relayed.toBigDecimal()) <= amount.toBigDecimal(),
+                "fee $amount must cover 0.025 × $relayed",
+            )
+        }
+    }
+
+    @Test
+    fun `non-native Terra token send keeps the static fee`() = runTest {
+        // CW20 / IBC Terra sends are not a native MsgSend, so they are never simulated and keep the
+        // static 300k limit + 7500 uluna (the un-floored simulated path is native-only).
+        val fee =
+            feeService.calculateDefaultFees(
+                transfer(Chain.Terra, contractAddress = "terra1token", isNativeToken = false)
+            ) as GasFees
+        assertEquals(BigInteger("300000"), fee.limit)
+        assertEquals(BigInteger("7500"), fee.amount)
+    }
+
+    @Test
     fun `Osmosis gas limit is 300000`() = runTest {
         val fee = feeService.calculateDefaultFees(transfer(Chain.Osmosis)) as GasFees
         assertEquals(BigInteger("300000"), fee.limit)


### PR DESCRIPTION
## Summary

Display-only alternative to #5291 for the Terra (LUNA) fee overcharge (#5279). After a Terra send confirms, this replaces the transaction-done **Network Fee** with `floor(gas_used × 0.025 uluna/gas)` — the same number the vultisig **extension** and **iOS** already show (e.g. **0.001944 LUNA** instead of the flat **0.0075**).

**Signing is untouched.** This is purely a display change, so it has none of the cross-platform risk of #5291.

## ⚠️ Important: this does NOT lower the fee you actually pay

Terra (Cosmos) does **not** refund unused gas — the amount actually deducted is the declared `fee.amount` (the static **7500 uluna**), regardless of `gas_used`. On-chain both recent test txs confirm it:

| Tx | On-chain `fee.amount` (burned) | `gas_limit` | `gas_used` |
|----|----|----|----|
| `79C9E911…451CB1` | 7500 uluna | 300000 | 77779 |
| `5CE8A7DC…3D3093` | 7500 uluna | 300000 | 77779 |

So this PR makes Android show `77779 × 0.025 = 0.001944` to **match the extension/iOS**, even though 0.0075 is what leaves the balance. It is **cross-platform consistency, not a real fee reduction** — the number shown is intentionally lower than what was deducted (exactly what the extension does today). The genuine fix (lowering the deducted fee) requires every co-signer to honor a relayed `gas_limit` and lives on `aminsato/5279_terra_dynamic_fee` (#5291), which is blocked until the extension/iOS release builds honor it.

## Why offer this

The real fix (#5291) is blocked and, worse, causes stuck signing when Android initiates against a non-honoring extension/iOS peer. This branch is a safe interim: it removes the visual inconsistency users see when comparing devices (extension 0.001944 vs Android 0.0075), with zero signing changes and zero regression risk.

**Decision needed (see #5291 thread):** is showing a fee lower than what's deducted acceptable for cross-platform parity? If not, close this and wait for the real fix.

## Changes

- `UpdateTerraDisplayFeeUseCase`: fetch the confirmed tx's `gas_used` (retrying briefly) and price it at Terra's min gas price (`floor`, to match the extension). Mirrors `UpdateEvmActualFeeUseCase` — except EVM genuinely refunds unused gas, so there the recomputed value really is what was burned.
- `KeysignViewModel`: inject `CosmosApiFactory`; run `tryUpdateTerraDisplayFee` alongside `tryUpdateEvmActualFee` once a terminal status is reached. Both initiator and pair devices poll status, so both refresh the shown fee.

## Verification

- Unit tests: `KeysignViewModelTryUpdateTerraDisplayFeeTest` (Terra prices at `gas_used × 0.025` = 1944 and updates the model; non-Terra chain is skipped; missing `gas_used` leaves the declared fee). Existing keysign VM tests updated for the new constructor param. All green.
- Path verified by inspection: Terra is in `TxStatusConfiguration`, and both devices reach `startForegroundPolling` (broadcast is not skipped for a normal send).

## Test plan

- [ ] Terra send (extension initiator + Android pair) → Android done screen shows `gas_used × 0.025` (~0.001944), matching the extension
- [ ] Terra send where status never confirms → done screen keeps the declared fee (0.0075), no crash
- [ ] Non-Terra Cosmos send (e.g. ATOM) → unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terra transaction fees now update on the completion screen using the confirmed transaction’s actual gas usage.
  - Terra native transfers now use dynamically calculated gas limits for more accurate fee handling.
  - Terra transaction simulation now uses chain-specific transaction construction.

- **Bug Fixes**
  - Prevented incorrect gas simulation for non-native Terra sends.
  - Corrected Cosmos LCD response parsing for gas and log fields, improving reliability of fee updates.

- **Tests**
  - Added coverage for Terra fee math, gas-limit safety, display-fee updates, and non-Terra/no-update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->