### PR TITLE
fix(sei): map SEI to the Ethereum coin type

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/utils/SeiEvmCoinTypeTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/utils/SeiEvmCoinTypeTest.kt
@@ -1,0 +1,43 @@
+package com.vultisig.wallet.data.utils
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.coinType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.CoinType
+
+/**
+ * Pins the SEI EVM coin-type contract.
+ *
+ * SEI is EVM-compatible and reuses the Ethereum coin type (secp256k1, derivation path
+ * `m/44'/60'/0'/0/0`, 0x address format), exactly like Hyperliquid — matching iOS and desktop. Its
+ * real EVM chainId (1329) is applied through [compatibleChainId] rather than WalletCore's default.
+ * This guards against SEI regressing to WalletCore's native SEI coin type (Cosmos path
+ * `m/44'/118'/…`, chainId defaulting to Ethereum's `1`), which would derive a different key and
+ * break cross-platform co-signing.
+ */
+class SeiEvmCoinTypeTest {
+
+    @Test
+    fun sei_mapsToEthereumCoinType() {
+        assertEquals(CoinType.ETHEREUM, Chain.Sei.coinType)
+    }
+
+    @Test
+    fun sei_usesEthereumDerivationPath() {
+        assertEquals("m/44'/60'/0'/0/0", Chain.Sei.coinType.derivationPath())
+    }
+
+    @Test
+    fun sei_usesSeiEvmChainId() {
+        // 1329 is applied via the override, not WalletCore's Ethereum default of "1".
+        assertEquals("1329", Chain.Sei.coinType.compatibleChainId(Chain.Sei))
+    }
+
+    @Test
+    fun ethereumAndHyperliquid_chainIdsUnaffected() {
+        // Regression guard for the shared ETHEREUM branch in compatibleChainId.
+        assertEquals("1", Chain.Ethereum.coinType.compatibleChainId(Chain.Ethereum))
+        assertEquals("999", Chain.Hyperliquid.coinType.compatibleChainId(Chain.Hyperliquid))
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -122,7 +122,12 @@ val Chain.coinType: CoinType
             Chain.Zcash -> CoinType.ZCASH
             Chain.Cardano -> CoinType.CARDANO
             Chain.Mantle -> CoinType.MANTLE
-            Chain.Sei -> CoinType.SEI
+            // SEI is EVM-compatible: it reuses the Ethereum coin type (secp256k1, derivation
+            // path m/44'/60'/0'/0/0, 0x address format) exactly like Hyperliquid below. Its EVM
+            // chainId (1329) is applied via compatibleChainId. Mapping straight to ETHEREUM keeps
+            // the derivation path/address/coin type consistent with iOS and desktop, which also
+            // map SEI to the Ethereum coin type.
+            Chain.Sei -> CoinType.ETHEREUM
             Chain.Hyperliquid -> CoinType.ETHEREUM
             Chain.Qbtc -> CoinType.COSMOS
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinType.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinType.kt
@@ -47,10 +47,12 @@ val CoinType.compatibleType: CoinType
 
 fun CoinType.compatibleChainId(chain: Chain? = null): String =
     when (this) {
-        CoinType.SEI -> "1329"
+        // SEI and Hyperliquid reuse the Ethereum coin type (see Chain.coinType), so their real EVM
+        // chainIds are applied here rather than via WalletCore's chainId().
         CoinType.ETHEREUM ->
             when (chain) {
-                Chain.Hyperliquid -> "999" // override when WC has no cointype
+                Chain.Hyperliquid -> "999"
+                Chain.Sei -> "1329"
                 else -> this.chainId()
             }
         else -> this.chainId()


### PR DESCRIPTION
## Summary

### Transaction hash
https://seiscan.io/tx/0xfb1126f760c33caedb276a48621e63d777a45aff52e913c866a37cc22d89f479

SEI is EVM-compatible (chainId **1329**, secp256k1, `0x` addresses, derivation path `m/44'/60'/0'/0/0`), but it was mapped to WalletCore's native `CoinType.SEI`, whose raw `derivationPath()` is the **Cosmos** path `m/44'/118'/0'/0/0`. That mismatch was patched over with `compatibleType` / `compatibleDerivationPath` / `compatibleChainId` overrides — but only some call sites applied them, so the raw Cosmos path could leak through code paths that used `derivationPath()` directly.

Fix it at the root: map `Chain.Sei -> CoinType.ETHEREUM` (`Chain.kt`), exactly like `Chain.Hyperliquid` right below it, and matching **iOS and desktop**, which also resolve SEI to the Ethereum coin type. The SEI EVM chainId (1329) is applied through `compatibleChainId`'s ETHEREUM branch, mirroring Hyperliquid's `999`.

## Why it's safe (address-preserving)

Address derivation already routed SEI through `compatibleDerivationPath` (→ `m/44'/60'`) + `compatibleType` (→ `ETHEREUM`), so the derived SEI address does **not** change — this only corrects the leaky raw-path call sites and keeps the derivation path consistent across platforms.

## Changes

- `Chain.kt`: `Chain.Sei -> CoinType.ETHEREUM`
- `CoinType.kt`: move the `1329` chainId override into `compatibleChainId`'s ETHEREUM branch (alongside Hyperliquid's `999`)
- `SeiEvmCoinTypeTest`: pins `Chain.Sei -> ETHEREUM`, path `m/44'/60'/0'/0/0`, and chainId `1329`

## Test plan

- [x] compiles (`:app` / `:data` / androidTest)
- [x] SEI send signs and broadcasts on device (tx above)
- [x] iOS ↔ Android SEI co-sign works

> The separate iOS/Android ↔ extension/desktop SEI co-sign failure is a different issue on the desktop side, tracked at vultisig/vultisig-windows#4369, and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)