### PR TITLE
feat(keysign): co-sign dApp XRPL transactions (SignRipple) #5298

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -149,7 +149,8 @@ constructor(
                                 listOf(mapTokenValueToStringWithUnit(summary.tokenValue)),
                             )
                         is KeysignTransactionSummary.DappTransaction ->
-                            UiText.DynamicString(summary.summary)
+                            summary.summary?.let { UiText.DynamicString(it) }
+                                ?: UiText.StringResource(R.string.ripple_dapp_transaction)
                         null -> UiText.Empty
                     }
                 _foregroundNotification.value =

--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainViewModel.kt
@@ -148,6 +148,8 @@ constructor(
                                 R.string.notification_banner_send_summary,
                                 listOf(mapTokenValueToStringWithUnit(summary.tokenValue)),
                             )
+                        is KeysignTransactionSummary.DappTransaction ->
+                            UiText.DynamicString(summary.summary)
                         null -> UiText.Empty
                     }
                 _foregroundNotification.value =

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GetKeysignTransactionSummaryUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GetKeysignTransactionSummaryUseCase.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.usecases
 
+import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
 import com.vultisig.wallet.data.common.DeepLinkHelper
 import com.vultisig.wallet.data.mappers.KeysignMessageFromProtoMapper
 import com.vultisig.wallet.data.models.TokenValue
@@ -15,6 +16,13 @@ internal sealed interface KeysignTransactionSummary {
         KeysignTransactionSummary
 
     data class Send(val tokenValue: TokenValue) : KeysignTransactionSummary
+
+    /**
+     * A dApp-supplied transaction signed verbatim (e.g. an XRPL `signRipple` OfferCreate/Payment),
+     * where the native `toAmount` is 0. [summary] is a pre-decoded one-line description of the real
+     * operation so the notification banner reads the true terms instead of "Send 0 XRP".
+     */
+    data class DappTransaction(val summary: String) : KeysignTransactionSummary
 }
 
 internal interface GetKeysignTransactionSummaryUseCase :
@@ -40,15 +48,28 @@ constructor(
                 val payload = mapKeysignMessageFromProto(proto).payload ?: return null
 
                 val swap = payload.swapPayload
-                if (swap != null) {
-                    KeysignTransactionSummary.Swap(
-                        srcTokenValue = swap.srcTokenValue,
-                        dstTicker = swap.dstToken.ticker,
-                    )
-                } else {
-                    KeysignTransactionSummary.Send(
-                        tokenValue = TokenValue(payload.toAmount, payload.coin)
-                    )
+                val signRipple = payload.signRipple
+                when {
+                    swap != null ->
+                        KeysignTransactionSummary.Swap(
+                            srcTokenValue = swap.srcTokenValue,
+                            dstTicker = swap.dstToken.ticker,
+                        )
+
+                    // A dApp XRPL tx carries its real amounts in rawJson, not toAmount (which is
+                    // 0);
+                    // decode a readable summary so the banner doesn't say "Send 0 XRP".
+                    signRipple != null ->
+                        KeysignTransactionSummary.DappTransaction(
+                            summary =
+                                RippleDappTransactionDecoder.summarize(signRipple.rawJson)
+                                    ?: "XRPL Transaction"
+                        )
+
+                    else ->
+                        KeysignTransactionSummary.Send(
+                            tokenValue = TokenValue(payload.toAmount, payload.coin)
+                        )
                 }
             }
             .onFailure { Timber.w(it, "Failed to parse keysign transaction summary") }

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GetKeysignTransactionSummaryUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GetKeysignTransactionSummaryUseCase.kt
@@ -20,9 +20,10 @@ internal sealed interface KeysignTransactionSummary {
     /**
      * A dApp-supplied transaction signed verbatim (e.g. an XRPL `signRipple` OfferCreate/Payment),
      * where the native `toAmount` is 0. [summary] is a pre-decoded one-line description of the real
-     * operation so the notification banner reads the true terms instead of "Send 0 XRP".
+     * operation so the notification banner reads the true terms instead of "Send 0 XRP", or null
+     * when the JSON couldn't be decoded — the caller then supplies a localized fallback label.
      */
-    data class DappTransaction(val summary: String) : KeysignTransactionSummary
+    data class DappTransaction(val summary: String?) : KeysignTransactionSummary
 }
 
 internal interface GetKeysignTransactionSummaryUseCase :
@@ -57,13 +58,12 @@ constructor(
                         )
 
                     // A dApp XRPL tx carries its real amounts in rawJson, not toAmount (which is
-                    // 0);
-                    // decode a readable summary so the banner doesn't say "Send 0 XRP".
+                    // 0); decode a readable summary so the banner doesn't say "Send 0 XRP". A null
+                    // summary (undecodable JSON) is passed through so the caller can supply a
+                    // localized fallback rather than a hardcoded English literal here.
                     signRipple != null ->
                         KeysignTransactionSummary.DappTransaction(
-                            summary =
-                                RippleDappTransactionDecoder.summarize(signRipple.rawJson)
-                                    ?: "XRPL Transaction"
+                            summary = RippleDappTransactionDecoder.summarize(signRipple.rawJson)
                         )
 
                     else ->

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.components
 
+import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
 import com.vultisig.wallet.data.chains.helpers.RippleDappTx
+import com.vultisig.wallet.data.chains.helpers.RippleDappTxFieldKey
 import com.vultisig.wallet.ui.theme.Theme
 
 /**
@@ -80,7 +82,7 @@ fun SignRippleDisplayView(
             ) {
                 tx.fields.forEach { field ->
                     VerifyCardJsonDetails(
-                        title = field.label,
+                        title = stringResource(field.key.labelRes),
                         subtitle = field.value,
                         modifier = rowModifier,
                     )
@@ -96,6 +98,35 @@ fun SignRippleDisplayView(
         }
     }
 }
+
+/**
+ * Maps a semantic [RippleDappTxFieldKey] to its localized display label. The data-layer decoder
+ * stores only the key (never an English literal), so all user-facing wording lives here and is
+ * translated across every locale. Distinct issuer keys keep the label unambiguous (e.g. "Selling
+ * issuer" vs "Buying issuer").
+ */
+@get:StringRes
+private val RippleDappTxFieldKey.labelRes: Int
+    get() =
+        when (this) {
+            RippleDappTxFieldKey.TYPE -> R.string.qr_share_label_type
+            RippleDappTxFieldKey.FROM -> R.string.verify_transaction_from_title
+            RippleDappTxFieldKey.TO -> R.string.verify_transaction_to_title
+            RippleDappTxFieldKey.DESTINATION_TAG -> R.string.send_form_destination_tag
+            RippleDappTxFieldKey.AMOUNT -> R.string.deposit_screen_amount_title
+            RippleDappTxFieldKey.AMOUNT_ISSUER -> R.string.ripple_field_issuer
+            RippleDappTxFieldKey.SEND_MAX -> R.string.ripple_field_send_max
+            RippleDappTxFieldKey.SEND_MAX_ISSUER -> R.string.ripple_field_send_max_issuer
+            RippleDappTxFieldKey.DELIVER_MIN -> R.string.ripple_field_deliver_min
+            RippleDappTxFieldKey.DELIVER_MIN_ISSUER -> R.string.ripple_field_deliver_min_issuer
+            RippleDappTxFieldKey.SELLING -> R.string.ripple_field_selling
+            RippleDappTxFieldKey.SELLING_ISSUER -> R.string.ripple_field_selling_issuer
+            RippleDappTxFieldKey.BUYING -> R.string.ripple_field_buying
+            RippleDappTxFieldKey.BUYING_ISSUER -> R.string.ripple_field_buying_issuer
+            RippleDappTxFieldKey.LIMIT -> R.string.ripple_field_limit
+            RippleDappTxFieldKey.LIMIT_ISSUER -> R.string.ripple_field_limit_issuer
+            RippleDappTxFieldKey.FEE -> R.string.verify_transaction_network_fee
+        }
 
 private val rowModifier: Modifier
     @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
@@ -1,0 +1,123 @@
+package com.vultisig.wallet.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
+import com.vultisig.wallet.data.chains.helpers.RippleDappTx
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Verify-screen card for a dApp-supplied XRPL transaction (SignRipple). The raw JSON is signed
+ * verbatim, so there is no native `to_address` / `to_amount` to render as a normal send. Instead we
+ * show the decoded terms — type, source, destination, amounts, issuer — and always keep the raw
+ * JSON available in an expandable section so a co-signer is never shown a blank/misleading screen
+ * even when [RippleDappTx.fields] is empty (the JSON could not be decoded).
+ */
+@Composable
+fun SignRippleDisplayView(
+    tx: RippleDappTx,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        modifier = modifier.fillMaxWidth().padding(vertical = 10.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Absolute.SpaceBetween,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(R.string.ripple_transaction_summary),
+                style = Theme.brockmann.button.medium.regular,
+                color = Theme.v2.colors.text.tertiary,
+            )
+
+            IconButton(onClick = { isExpanded = !isExpanded }, modifier = Modifier.size(10.dp)) {
+                UiIcon(
+                    drawableResId = R.drawable.chevron,
+                    tint = Theme.v2.colors.neutrals.n100,
+                    size = 8.dp,
+                    modifier = Modifier.graphicsLayer(rotationZ = if (isExpanded) 180f else 0f),
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = isExpanded) {
+            Column(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                tx.fields.forEach { field ->
+                    VerifyCardJsonDetails(
+                        title = field.label,
+                        subtitle = field.value,
+                        modifier = rowModifier,
+                    )
+                }
+                // Always surface the raw JSON — it is the source of truth for what gets signed, and
+                // the sole content when decoding produced no fields.
+                VerifyCardJsonDetails(
+                    title = stringResource(R.string.raw_transaction_data),
+                    subtitle = tx.rawJson,
+                    modifier = rowModifier,
+                )
+            }
+        }
+    }
+}
+
+private val rowModifier: Modifier
+    @Composable
+    get() =
+        Modifier.fillMaxWidth()
+            .background(
+                color = Theme.v2.colors.variables.bordersLight,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .padding(horizontal = 12.dp)
+
+private const val PREVIEW_RIPPLE_JSON =
+    "{\"TransactionType\":\"Payment\",\"Account\":\"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY\"," +
+        "\"Destination\":\"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY\",\"Amount\":\"1500000\"," +
+        "\"SendMax\":{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\"," +
+        "\"value\":\"1.5\"},\"DestinationTag\":\"12345\"}"
+
+@Preview
+@Composable
+private fun PreviewSignRippleDisplayView() {
+    SignRippleDisplayView(
+        tx = RippleDappTransactionDecoder.decode(PREVIEW_RIPPLE_JSON),
+        initiallyExpanded = true,
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -96,6 +96,11 @@ sealed interface TransactionHistoryItemUiModel {
         val fiatValue: String?,
         val provider: String?,
         val feeEstimate: String?,
+        /**
+         * Decoded one-line summary of a dApp-supplied tx (e.g. XRPL signRipple), shown in place of
+         * the misleading native "0" amount when present. Null for ordinary sends.
+         */
+        val dappSummary: String? = null,
     ) : TransactionHistoryItemUiModel
 
     data class Swap(
@@ -379,6 +384,7 @@ constructor(
                     fiatValue = p.fiatValue,
                     provider = null,
                     feeEstimate = p.feeEstimate,
+                    dappSummary = p.dappSummary,
                 )
 
             is SwapTransactionHistoryData ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.chains.helpers.RippleDappTx
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.models.TransactionId
@@ -91,6 +92,12 @@ internal data class TransactionDetailsUiModel(
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB (SignSui), for verify display.
      */
     val signSui: String? = null,
+    /**
+     * Decoded terms of a dApp-supplied XRPL transaction (SignRipple), for verify display. Null for
+     * non-Ripple or native XRP sends. Carries the raw JSON so the screen can fall back to it when
+     * decoding yields no readable fields.
+     */
+    val signRipple: RippleDappTx? = null,
     /**
      * Per-message rows for a TonConnect signing request, each decoded from its BOC body into an
      * operation label, real recipient, forward amount, and the raw payload. Empty for non-TON or

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -157,6 +157,7 @@ internal data class VerifyTransactionUiModel(
     val transaction: TransactionDetailsUiModel = TransactionDetailsUiModel(),
     val consentAddress: Boolean = false,
     val consentAmount: Boolean = false,
+    val consentDappTransaction: Boolean = false,
     val errorText: UiText? = null,
     val hasFastSign: Boolean = false,
     val txScanStatus: TransactionScanStatus = TransactionScanStatus.NotStarted,
@@ -164,7 +165,13 @@ internal data class VerifyTransactionUiModel(
     val isLoadingFees: Boolean = false,
 ) {
     val hasAllConsents: Boolean
-        get() = consentAddress && consentAmount
+        // A dApp XRPL tx (signRipple) has no native recipient/amount — an OfferCreate has no
+        // Destination and the native amount is 0 — so the "right address"/"amount is correct"
+        // consents are meaningless there. Gate it on a single "reviewed the details" consent
+        // instead; native sends keep the two-checkbox flow.
+        get() =
+            if (transaction.signRipple != null) consentDappTransaction
+            else consentAddress && consentAmount
 }
 
 /**
@@ -235,6 +242,10 @@ constructor(
 
     fun checkConsentAmount(checked: Boolean) {
         viewModelScope.launch { _uiState.update { it.copy(consentAmount = checked) } }
+    }
+
+    fun checkConsentDappTransaction(checked: Boolean) {
+        viewModelScope.launch { _uiState.update { it.copy(consentDappTransaction = checked) } }
     }
 
     fun authFastSign() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
@@ -161,6 +161,7 @@ constructor(
 
         val signSolana = payload.signSolana?.rawTransactions?.firstOrNull() ?: ""
         val signSui = payload.signSui?.unsignedTxMsg?.takeIf { it.isNotEmpty() }
+        val signRipple = payload.signRipple?.rawJson?.takeIf { it.isNotBlank() }
         val transaction =
             Transaction(
                 id = UUID.randomUUID().toString(),
@@ -180,6 +181,7 @@ constructor(
                 signDirect = signDirect,
                 signSolana = signSolana,
                 signSui = signSui,
+                signRipple = signRipple,
             )
 
         val transactionToUiModel = mapTransactionToUiModel(transaction)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSendUiModelBuilder.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
 import com.vultisig.wallet.data.chains.helpers.UtxoHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.GasFeeParams
@@ -107,21 +108,34 @@ constructor(
             )
 
         val nativeCoin = withContext(Dispatchers.IO) { tokenRepository.getNativeToken(chain.id) }
+        // A dApp XRPL tx is signed verbatim, so the fee that is actually paid is the `Fee` baked
+        // into its raw JSON — not a live re-estimate. Surface that exact value so an inflated Fee
+        // is
+        // visible on the co-signer's Verify screen instead of being masked by a normal-looking
+        // RippleFeeService estimate.
+        val rippleDappFeeDrops =
+            payload.signRipple?.rawJson?.let { RippleDappTransactionDecoder.feeDrops(it) }
         val gasFee =
-            if (chain.standard == TokenStandard.UTXO && chain != Chain.Cardano) {
-                val utxoHelper = UtxoHelper.getHelper(vault, payloadToken.coinType)
-                val plan = utxoHelper.getBitcoinTransactionPlan(payload)
-                if (plan.error != SigningError.OK) {
-                    Timber.e("UTXO plan error: ${plan.error.name}")
+            when {
+                chain.standard == TokenStandard.UTXO && chain != Chain.Cardano -> {
+                    val utxoHelper = UtxoHelper.getHelper(vault, payloadToken.coinType)
+                    val plan = utxoHelper.getBitcoinTransactionPlan(payload)
+                    if (plan.error != SigningError.OK) {
+                        Timber.e("UTXO plan error: ${plan.error.name}")
+                    }
+                    TokenValue(value = BigInteger.valueOf(plan.fee), token = nativeCoin)
                 }
-                TokenValue(value = BigInteger.valueOf(plan.fee), token = nativeCoin)
-            } else {
-                feeResolver.resolveJoinKeysignNetworkFee(
-                    payload = payload,
-                    chain = chain,
-                    nativeCoin = nativeCoin,
-                    blockchainTransaction = blockchainTransaction,
-                )
+
+                rippleDappFeeDrops != null ->
+                    TokenValue(value = rippleDappFeeDrops, token = nativeCoin)
+
+                else ->
+                    feeResolver.resolveJoinKeysignNetworkFee(
+                        payload = payload,
+                        chain = chain,
+                        nativeCoin = nativeCoin,
+                        blockchainTransaction = blockchainTransaction,
+                    )
             }
 
         val totalGasAndFee =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToHistoryDataMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToHistoryDataMapper.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.ui.models.mappers
 
+import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
+import com.vultisig.wallet.data.chains.helpers.RippleDappTxFieldKey
 import com.vultisig.wallet.data.mappers.MapperFunc
 import com.vultisig.wallet.data.models.SendTransactionHistoryData
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
@@ -11,15 +13,26 @@ internal interface SendTransactionHistoryDataMapper :
 internal class SendTransactionHistoryDataMapperImpl @Inject constructor() :
     SendTransactionHistoryDataMapper {
 
-    override fun invoke(from: TransactionDetailsUiModel) =
-        SendTransactionHistoryData(
+    override fun invoke(from: TransactionDetailsUiModel): SendTransactionHistoryData {
+        // A dApp XRPL tx (signRipple) has native amount 0 and — for offers/trust lines — no wire
+        // recipient. Persist the decoded one-line summary and the JSON's real Destination so the
+        // history row keeps its true meaning after a restart instead of downgrading to "0 XRP → ".
+        val rippleDapp = from.signRipple
+        val dappSummary = rippleDapp?.let { RippleDappTransactionDecoder.summarize(it.rawJson) }
+        val toAddress =
+            rippleDapp?.value(RippleDappTxFieldKey.TO)?.takeIf { it.isNotBlank() }
+                ?: from.dstAddress
+
+        return SendTransactionHistoryData(
             fromAddress = from.srcAddress,
-            toAddress = from.dstAddress,
+            toAddress = toAddress,
             amount = from.token.value,
             token = from.token.token.ticker,
             tokenLogo = from.token.token.logo,
             feeEstimate = from.networkFeeTokenValue,
             memo = from.memo.orEmpty(),
             fiatValue = from.token.fiatValue,
+            dappSummary = dappSummary,
         )
+    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToHistoryDataMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToHistoryDataMapper.kt
@@ -19,9 +19,17 @@ internal class SendTransactionHistoryDataMapperImpl @Inject constructor() :
         // history row keeps its true meaning after a restart instead of downgrading to "0 XRP → ".
         val rippleDapp = from.signRipple
         val dappSummary = rippleDapp?.let { RippleDappTransactionDecoder.summarize(it.rawJson) }
+        // For a dApp XRPL tx the recipient must come only from the decoded JSON `Destination`.
+        // Offers/trust lines have none, so leave it empty rather than falling back to the wire
+        // `dstAddress` — a relay could set that to a trusted label/vault while the signed JSON
+        // sends elsewhere, making the history row's recipient a decoy. Native sends keep
+        // dstAddress.
         val toAddress =
-            rippleDapp?.value(RippleDappTxFieldKey.TO)?.takeIf { it.isNotBlank() }
-                ?: from.dstAddress
+            if (rippleDapp != null) {
+                rippleDapp.value(RippleDappTxFieldKey.TO).orEmpty()
+            } else {
+                from.dstAddress
+            }
 
         return SendTransactionHistoryData(
             fromAddress = from.srcAddress,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/TransactionToUiModelMapper.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.mappers
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
 import com.vultisig.wallet.data.blockchain.tron.TronStakingOperation
+import com.vultisig.wallet.data.chains.helpers.RippleDappTransactionDecoder
 import com.vultisig.wallet.data.chains.helpers.RippleDestinationTag
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.Chain
@@ -77,6 +78,10 @@ constructor(
             signDirect = from.signDirect,
             signSolana = from.signSolana,
             signSui = from.signSui,
+            signRipple =
+                from.signRipple
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { RippleDappTransactionDecoder.decode(it) },
             networkFeeFiatValue = from.estimatedFee,
             networkFeeTokenValue = from.totalGas,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -288,18 +288,26 @@ internal fun VerifySendScreen(
                         bracketValue = tx.srcVaultName?.let { tx.srcAddress },
                     )
 
-                    VerifyCardDivider(0.dp)
+                    // For a dApp XRPL tx the native `To` comes from the wire `toAddress`, which is
+                    // not the value being signed — the real recipient (if any) lives in the raw
+                    // JSON `Destination` and is rendered by SignRippleDisplayView below. Showing
+                    // the
+                    // wire address here would let a relay display a trusted label/vault while the
+                    // signed JSON sends elsewhere, so suppress the native To row for signRipple.
+                    if (tx.signRipple == null) {
+                        VerifyCardDivider(0.dp)
 
-                    val toDstLabel =
-                        tx.dstVaultName
-                            ?: tx.dstAddressBookTitle
-                            ?: tx.dstContractLabel
-                            ?: tx.dstLabel
-                    VerifyCardDetails(
-                        title = stringResource(R.string.verify_transaction_to_title),
-                        subtitle = toDstLabel ?: tx.dstAddress,
-                        bracketValue = toDstLabel?.let { tx.dstAddress },
-                    )
+                        val toDstLabel =
+                            tx.dstVaultName
+                                ?: tx.dstAddressBookTitle
+                                ?: tx.dstContractLabel
+                                ?: tx.dstLabel
+                        VerifyCardDetails(
+                            title = stringResource(R.string.verify_transaction_to_title),
+                            subtitle = toDstLabel ?: tx.dstAddress,
+                            bracketValue = toDstLabel?.let { tx.dstAddress },
+                        )
+                    }
 
                     // A memo that merely echoes the destination tag is signed as tag-only, so it is
                     // not shown as a separate Memo row (it appears in the Destination Tag row

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -107,6 +107,7 @@ internal fun VerifySendScreen(viewModel: VerifyTransactionViewModel = hiltViewMo
         confirmTitle = stringResource(R.string.keysign_sign_transaction),
         onConsentAddress = viewModel::checkConsentAddress,
         onConsentAmount = viewModel::checkConsentAmount,
+        onConsentDappTransaction = viewModel::checkConsentDappTransaction,
         onConfirm = viewModel::joinKeySign,
         onBackClick = viewModel::back,
         onFastSignClick = viewModel::fastSign,
@@ -126,6 +127,7 @@ internal fun VerifySendScreen(
     dappMetadata: DAppMetadata? = null,
     onConsentAddress: (Boolean) -> Unit = {},
     onConsentAmount: (Boolean) -> Unit = {},
+    onConsentDappTransaction: (Boolean) -> Unit = {},
     onBackClick: () -> Unit = {},
     onConfirmScanning: () -> Unit = {},
     onDismissScanning: () -> Unit = {},
@@ -505,17 +507,32 @@ internal fun VerifySendScreen(
 
                 if (isConsentsEnabled) {
                     Column(modifier = Modifier.fillMaxWidth()) {
-                        VsCheckField(
-                            title = stringResource(R.string.verify_transaction_consent_address),
-                            isChecked = state.consentAddress,
-                            onCheckedChange = onConsentAddress,
-                        )
+                        if (state.transaction.signRipple != null) {
+                            // A dApp XRPL tx has no native recipient/amount to attest to, so show a
+                            // single "reviewed the details" consent instead of the address/amount
+                            // pair, which would ask the co-signer to confirm values that aren't
+                            // what's being signed.
+                            VsCheckField(
+                                title =
+                                    stringResource(
+                                        R.string.verify_transaction_consent_dapp_transaction
+                                    ),
+                                isChecked = state.consentDappTransaction,
+                                onCheckedChange = onConsentDappTransaction,
+                            )
+                        } else {
+                            VsCheckField(
+                                title = stringResource(R.string.verify_transaction_consent_address),
+                                isChecked = state.consentAddress,
+                                onCheckedChange = onConsentAddress,
+                            )
 
-                        VsCheckField(
-                            title = stringResource(R.string.verify_transaction_consent_amount),
-                            isChecked = state.consentAmount,
-                            onCheckedChange = onConsentAmount,
-                        )
+                            VsCheckField(
+                                title = stringResource(R.string.verify_transaction_consent_amount),
+                                isChecked = state.consentAmount,
+                                onCheckedChange = onConsentAmount,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -36,6 +36,7 @@ import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.monoToneLogo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
+import com.vultisig.wallet.ui.components.SignRippleDisplayView
 import com.vultisig.wallet.ui.components.SignSolanaDisplayView
 import com.vultisig.wallet.ui.components.SignSuiDisplayView
 import com.vultisig.wallet.ui.components.SignTonDisplayView
@@ -236,16 +237,45 @@ internal fun VerifySendScreen(
                         functionName = heroTitle,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        VsOverviewToken(
-                            header =
-                                stringResource(
-                                    tx.headerTitleRes ?: R.string.verify_deposit_sending
-                                ),
-                            valuedToken = tx.token,
-                            shape = RoundedCornerShape(0.dp),
-                            modifier = Modifier.fillMaxWidth(),
-                            withContainer = false,
-                        )
+                        val rippleDapp = tx.signRipple
+                        if (rippleDapp != null) {
+                            // A dApp XRPL transaction has no native send amount (`toAmount` is 0),
+                            // so a "You're sending 0 XRP" hero would be misleading. Show the
+                            // operation type instead; the decoded Selling / Buying / Issuer terms
+                            // render in the summary card below.
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.ripple_dapp_transaction),
+                                    style = Theme.brockmann.supplementary.captionSmall,
+                                    color = Theme.v2.colors.text.tertiary,
+                                    textAlign = TextAlign.Center,
+                                    maxLines = 1,
+                                )
+                                UiSpacer(12.dp)
+                                Text(
+                                    text =
+                                        rippleDapp.transactionType
+                                            ?: stringResource(R.string.ripple_dapp_transaction),
+                                    style = Theme.brockmann.headings.title2,
+                                    color = Theme.v2.colors.text.primary,
+                                    textAlign = TextAlign.Center,
+                                )
+                            }
+                        } else {
+                            VsOverviewToken(
+                                header =
+                                    stringResource(
+                                        tx.headerTitleRes ?: R.string.verify_deposit_sending
+                                    ),
+                                valuedToken = tx.token,
+                                shape = RoundedCornerShape(0.dp),
+                                modifier = Modifier.fillMaxWidth(),
+                                withContainer = false,
+                            )
+                        }
                     }
 
                     UiSpacer(12.dp)
@@ -333,6 +363,14 @@ internal fun VerifySendScreen(
                                 initiallyExpanded = initiallyExpandedDetails,
                             )
                         }
+
+                    tx.signRipple?.let {
+                        VerifyCardDivider(0.dp)
+
+                        // Expanded by default: the decoded terms are the primary content for a
+                        // dApp XRPL tx (the hero shows no amount), mirroring the extension summary.
+                        SignRippleDisplayView(tx = it, initiallyExpanded = true)
+                    }
 
                     tx.tonMessages
                         .takeIf { it.isNotEmpty() }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
@@ -73,34 +73,41 @@ internal fun SendTransactionCard(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         TokenCircle(logo = item.tokenLogo, ticker = item.token, size = 24)
-                        SendAmountText(amount = item.amount, token = item.token)
+                        if (item.dappSummary != null) {
+                            DappSummaryText(summary = item.dappSummary)
+                        } else {
+                            SendAmountText(amount = item.amount, token = item.token)
+                        }
                     }
 
-                    UiSpacer(size = 8.dp)
+                    // A dApp offer/trust-line tx has no recipient — skip the empty "To" row.
+                    if (item.toAddress.isNotBlank()) {
+                        UiSpacer(size = 8.dp)
 
-                    ToSeparator(modifier = Modifier.fillMaxWidth())
+                        ToSeparator(modifier = Modifier.fillMaxWidth())
 
-                    UiSpacer(size = 8.dp)
+                        UiSpacer(size = 8.dp)
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.wallet),
-                            contentDescription = null,
-                            tint = Theme.v2.colors.text.tertiary,
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Text(
-                            text = item.toAddress,
-                            style = Theme.brockmann.supplementary.caption,
-                            color = Theme.v2.colors.text.secondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f),
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.wallet),
+                                contentDescription = null,
+                                tint = Theme.v2.colors.text.tertiary,
+                                modifier = Modifier.size(24.dp),
+                            )
+                            Text(
+                                text = item.toAddress,
+                                style = Theme.brockmann.supplementary.caption,
+                                color = Theme.v2.colors.text.secondary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
                     }
 
                     if (!item.provider.isNullOrEmpty()) {
@@ -126,10 +133,17 @@ internal fun SendTransactionCard(
                                         color = Theme.v2.colors.text.primary,
                                     )
                                 }
-                                SendAmountText(amount = item.amount, token = item.token)
+                                if (item.dappSummary != null) {
+                                    DappSummaryText(summary = item.dappSummary)
+                                } else {
+                                    SendAmountText(amount = item.amount, token = item.token)
+                                }
                             }
                         }
-                        SendAddressPill(address = item.toAddress.abbreviateAddress())
+                        // Offers/trust-line dApp txs carry no recipient — skip the empty "To" pill.
+                        if (item.toAddress.isNotBlank()) {
+                            SendAddressPill(address = item.toAddress.abbreviateAddress())
+                        }
                     }
                 }
             }
@@ -142,6 +156,18 @@ internal fun SendTransactionCard(
             }
         }
     }
+}
+
+@Composable
+private fun DappSummaryText(summary: String, modifier: Modifier = Modifier) {
+    Text(
+        text = summary,
+        style = Theme.brockmann.body.s.medium,
+        color = Theme.v2.colors.text.primary,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -24,9 +24,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.chains.helpers.RippleDappTx
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.CopyIcon
+import com.vultisig.wallet.ui.components.SignRippleDisplayView
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsOverviewToken
@@ -104,22 +106,55 @@ internal fun SendTxOverviewScreen(
                 functionName = tx.functionName,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                VsOverviewToken(
-                    header =
-                        if (tx.type == UiTransactionInfoType.Send) {
-                            stringResource(R.string.tx_overview_screen_tx_send)
-                        } else {
-                            stringResource(R.string.tx_overview_screen_tx_deposit)
-                        },
-                    valuedToken = tx.token,
-                    shape = RoundedCornerShape(24.dp),
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                val rippleDapp = tx.signRipple
+                if (rippleDapp != null) {
+                    // A dApp XRPL transaction has no native send amount (`toAmount` is 0), so show
+                    // the operation type instead of a misleading "0 XRP"; the decoded terms render
+                    // in the summary card below.
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.ripple_dapp_transaction),
+                            style = Theme.brockmann.supplementary.captionSmall,
+                            color = Theme.v2.colors.text.tertiary,
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                        )
+                        UiSpacer(12.dp)
+                        Text(
+                            text =
+                                rippleDapp.transactionType
+                                    ?: stringResource(R.string.ripple_dapp_transaction),
+                            style = Theme.brockmann.headings.title2,
+                            color = Theme.v2.colors.text.primary,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                } else {
+                    VsOverviewToken(
+                        header =
+                            if (tx.type == UiTransactionInfoType.Send) {
+                                stringResource(R.string.tx_overview_screen_tx_send)
+                            } else {
+                                stringResource(R.string.tx_overview_screen_tx_deposit)
+                            },
+                        valuedToken = tx.token,
+                        shape = RoundedCornerShape(24.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         },
         detailContent = {
             Column {
                 TransactionStatusRow(transactionStatus)
+
+                tx.signRipple?.let { rippleDapp ->
+                    VerifyCardDivider(size = 1.dp)
+                    SignRippleDisplayView(tx = rippleDapp, initiallyExpanded = true)
+                }
 
                 VerifyCardDivider(size = 1.dp)
 
@@ -129,30 +164,35 @@ internal fun SendTxOverviewScreen(
                     bracketValue = tx.fromLabel?.let { tx.from },
                 )
 
-                VerifyCardDivider(size = 1.dp)
+                // A dApp XRPL tx carries no native destination (`toAddress` is empty); the
+                // recipient,
+                // when any, is inside the decoded summary above, so skip the empty "To" row.
+                if (tx.signRipple == null) {
+                    VerifyCardDivider(size = 1.dp)
 
-                if (showSaveToAddressBook) {
-                    Column {
+                    if (showSaveToAddressBook) {
+                        Column {
+                            VerifyCardDetails(
+                                title = stringResource(R.string.tx_overview_screen_tx_to),
+                                subtitle = tx.toLabel ?: tx.to,
+                                bracketValue = tx.toLabel?.let { tx.to },
+                            )
+
+                            UiSpacer(8.dp)
+
+                            AddToAddressBookButton(
+                                modifier = Modifier.align(Alignment.End),
+                                onClick = onAddToAddressBook,
+                            )
+                            UiSpacer(size = 12.dp)
+                        }
+                    } else {
                         VerifyCardDetails(
                             title = stringResource(R.string.tx_overview_screen_tx_to),
                             subtitle = tx.toLabel ?: tx.to,
                             bracketValue = tx.toLabel?.let { tx.to },
                         )
-
-                        UiSpacer(8.dp)
-
-                        AddToAddressBookButton(
-                            modifier = Modifier.align(Alignment.End),
-                            onClick = onAddToAddressBook,
-                        )
-                        UiSpacer(size = 12.dp)
                     }
-                } else {
-                    VerifyCardDetails(
-                        title = stringResource(R.string.tx_overview_screen_tx_to),
-                        subtitle = tx.toLabel ?: tx.to,
-                        bracketValue = tx.toLabel?.let { tx.to },
-                    )
                 }
 
                 if (tx.memo.isNotEmpty()) {
@@ -379,6 +419,12 @@ internal data class UiTransactionInfo(
      * Carried through from [com.vultisig.wallet.ui.models.TransactionDetailsUiModel.heroContent].
      */
     val heroContent: HeroContent? = null,
+    /**
+     * Decoded terms of a dApp-supplied XRPL transaction (SignRipple). When present the done screen
+     * shows the decoded summary (Type / Selling / Buying / Issuer) instead of a "0 XRP" hero — the
+     * native `toAmount` is 0 because the real amounts live in the raw JSON.
+     */
+    val signRipple: RippleDappTx? = null,
 )
 
 internal enum class UiTransactionInfoType {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
@@ -27,6 +27,7 @@ internal fun TransactionTypeUiModel.toUiTransactionInfo(): UiTransactionInfo {
                 approvalSpender = this.tx.approvalSpender,
                 approvalTokenTicker = this.tx.approvalTokenTicker,
                 heroContent = this.tx.heroContent,
+                signRipple = this.tx.signRipple,
             )
         }
         is TransactionTypeUiModel.Deposit -> {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1136,6 +1136,8 @@
     <string name="transaction_status_checking_transaction">Transaktion wird geprüft…</string>
     <string name="raw_transaction_data">Rohdaten der Transaktion</string>
     <string name="sui_raw_transaction">Sui-Transaktion</string>
+    <string name="ripple_dapp_transaction">XRPL-Transaktion</string>
+    <string name="ripple_transaction_summary">Transaktionsübersicht</string>
     <string name="sui_sender">Von</string>
     <string name="solana_raw_transaction">Solana-Rohdaten der Transaktion</string>
     <string name="solana_instructions_summary">Transaktionsanweisungen – Übersicht</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1138,6 +1138,17 @@
     <string name="sui_raw_transaction">Sui-Transaktion</string>
     <string name="ripple_dapp_transaction">XRPL-Transaktion</string>
     <string name="ripple_transaction_summary">Transaktionsübersicht</string>
+    <string name="ripple_field_issuer">Emittent</string>
+    <string name="ripple_field_send_max">Sende-Maximum</string>
+    <string name="ripple_field_send_max_issuer">Sende-Maximum-Emittent</string>
+    <string name="ripple_field_deliver_min">Liefer-Minimum</string>
+    <string name="ripple_field_deliver_min_issuer">Liefer-Minimum-Emittent</string>
+    <string name="ripple_field_selling">Verkauf</string>
+    <string name="ripple_field_selling_issuer">Verkaufs-Emittent</string>
+    <string name="ripple_field_buying">Kauf</string>
+    <string name="ripple_field_buying_issuer">Kauf-Emittent</string>
+    <string name="ripple_field_limit">Limit</string>
+    <string name="ripple_field_limit_issuer">Limit-Emittent</string>
     <string name="sui_sender">Von</string>
     <string name="solana_raw_transaction">Solana-Rohdaten der Transaktion</string>
     <string name="solana_instructions_summary">Transaktionsanweisungen – Übersicht</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,7 @@
     <string name="verify_transaction_amount_title">Menge</string>
     <string name="verify_transaction_consent_address">Ich sende an die richtige Adresse</string>
     <string name="verify_transaction_consent_amount">Die Menge ist korrekt</string>
+    <string name="verify_transaction_consent_dapp_transaction">Ich habe die Transaktionsdetails überprüft</string>
     <string name="transaction_done_title">Fertig</string>
     <string name="transaction_done_overview">Übersicht</string>
     <string name="transaction_done_complete">Fortfahren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1134,6 +1134,8 @@
     <string name="transaction_status_checking_transaction">Comprobando transacción…</string>
     <string name="raw_transaction_data">Datos de transacciones sin procesar</string>
     <string name="sui_raw_transaction">Transacción de Sui</string>
+    <string name="ripple_dapp_transaction">Transacción de XRPL</string>
+    <string name="ripple_transaction_summary">Resumen de la transacción</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transacción sin procesar de Solana</string>
     <string name="solana_instructions_summary">Resumen de instrucciones de transacción</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -121,6 +121,7 @@
     <string name="verify_transaction_amount_title">Cantidad</string>
     <string name="verify_transaction_consent_address">Estoy enviando a la dirección correcta</string>
     <string name="verify_transaction_consent_amount">La cantidad es correcta</string>
+    <string name="verify_transaction_consent_dapp_transaction">He revisado los detalles de la transacción</string>
     <string name="verify_transaction_error_not_enough_consent">Por favor, revise todos los consentimientos</string>
     <string name="transaction_done_title">Hecho</string>
     <string name="transaction_done_overview">Resumen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1136,6 +1136,17 @@
     <string name="sui_raw_transaction">Transacción de Sui</string>
     <string name="ripple_dapp_transaction">Transacción de XRPL</string>
     <string name="ripple_transaction_summary">Resumen de la transacción</string>
+    <string name="ripple_field_issuer">Emisor</string>
+    <string name="ripple_field_send_max">Envío máximo</string>
+    <string name="ripple_field_send_max_issuer">Emisor del envío máximo</string>
+    <string name="ripple_field_deliver_min">Entrega mínima</string>
+    <string name="ripple_field_deliver_min_issuer">Emisor de la entrega mínima</string>
+    <string name="ripple_field_selling">Venta</string>
+    <string name="ripple_field_selling_issuer">Emisor de venta</string>
+    <string name="ripple_field_buying">Compra</string>
+    <string name="ripple_field_buying_issuer">Emisor de compra</string>
+    <string name="ripple_field_limit">Límite</string>
+    <string name="ripple_field_limit_issuer">Emisor del límite</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transacción sin procesar de Solana</string>
     <string name="solana_instructions_summary">Resumen de instrucciones de transacción</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1139,6 +1139,8 @@
     <string name="transaction_status_checking_transaction">Provjera transakcije…</string>
     <string name="raw_transaction_data">Sirovi podaci o transakciji</string>
     <string name="sui_raw_transaction">Sui transakcija</string>
+    <string name="ripple_dapp_transaction">XRPL transakcija</string>
+    <string name="ripple_transaction_summary">Sažetak transakcije</string>
     <string name="sui_sender">Od</string>
     <string name="solana_raw_transaction">Solana Sirova transakcija</string>
     <string name="solana_instructions_summary">Sažetak uputa transakcije</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -102,6 +102,7 @@
     <string name="verify_transaction_amount_title">Iznos</string>
     <string name="verify_transaction_consent_address">Šaljem na pravu adresu</string>
     <string name="verify_transaction_consent_amount">Iznos je točan</string>
+    <string name="verify_transaction_consent_dapp_transaction">Pregledao sam pojedinosti transakcije</string>
     <string name="transaction_done_title">Gotovo</string>
     <string name="transaction_done_overview">Pregled</string>
     <string name="transaction_done_complete">Dovršeno</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1141,6 +1141,17 @@
     <string name="sui_raw_transaction">Sui transakcija</string>
     <string name="ripple_dapp_transaction">XRPL transakcija</string>
     <string name="ripple_transaction_summary">Sažetak transakcije</string>
+    <string name="ripple_field_issuer">Izdavatelj</string>
+    <string name="ripple_field_send_max">Maksimalno slanje</string>
+    <string name="ripple_field_send_max_issuer">Izdavatelj maksimalnog slanja</string>
+    <string name="ripple_field_deliver_min">Minimalna isporuka</string>
+    <string name="ripple_field_deliver_min_issuer">Izdavatelj minimalne isporuke</string>
+    <string name="ripple_field_selling">Prodaja</string>
+    <string name="ripple_field_selling_issuer">Izdavatelj prodaje</string>
+    <string name="ripple_field_buying">Kupnja</string>
+    <string name="ripple_field_buying_issuer">Izdavatelj kupnje</string>
+    <string name="ripple_field_limit">Limit</string>
+    <string name="ripple_field_limit_issuer">Izdavatelj limita</string>
     <string name="sui_sender">Od</string>
     <string name="solana_raw_transaction">Solana Sirova transakcija</string>
     <string name="solana_instructions_summary">Sažetak uputa transakcije</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1138,6 +1138,17 @@
     <string name="sui_raw_transaction">Transazione Sui</string>
     <string name="ripple_dapp_transaction">Transazione XRPL</string>
     <string name="ripple_transaction_summary">Riepilogo della transazione</string>
+    <string name="ripple_field_issuer">Emittente</string>
+    <string name="ripple_field_send_max">Invio massimo</string>
+    <string name="ripple_field_send_max_issuer">Emittente invio massimo</string>
+    <string name="ripple_field_deliver_min">Consegna minima</string>
+    <string name="ripple_field_deliver_min_issuer">Emittente consegna minima</string>
+    <string name="ripple_field_selling">Vendita</string>
+    <string name="ripple_field_selling_issuer">Emittente vendita</string>
+    <string name="ripple_field_buying">Acquisto</string>
+    <string name="ripple_field_buying_issuer">Emittente acquisto</string>
+    <string name="ripple_field_limit">Limite</string>
+    <string name="ripple_field_limit_issuer">Emittente limite</string>
     <string name="sui_sender">Da</string>
     <string name="solana_raw_transaction">Transazioni grezze Solana</string>
     <string name="solana_instructions_summary">Riepilogo istruzioni della transazione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1136,6 +1136,8 @@
     <string name="transaction_status_checking_transaction">Verifica della transazione in corso…</string>
     <string name="raw_transaction_data">Dati grezzi sulle transazioni</string>
     <string name="sui_raw_transaction">Transazione Sui</string>
+    <string name="ripple_dapp_transaction">Transazione XRPL</string>
+    <string name="ripple_transaction_summary">Riepilogo della transazione</string>
     <string name="sui_sender">Da</string>
     <string name="solana_raw_transaction">Transazioni grezze Solana</string>
     <string name="solana_instructions_summary">Riepilogo istruzioni della transazione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -102,6 +102,7 @@
     <string name="verify_transaction_amount_title">Quantità</string>
     <string name="verify_transaction_consent_address">Sto inviando all\'indirizzo corretto</string>
     <string name="verify_transaction_consent_amount">La quantità è corretta</string>
+    <string name="verify_transaction_consent_dapp_transaction">Ho esaminato i dettagli della transazione</string>
     <string name="transaction_done_title">Fatto</string>
     <string name="transaction_done_overview">Panoramica</string>
     <string name="transaction_done_complete">Completo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -196,6 +196,7 @@
     <string name="verify_transaction_value">금액</string>
     <string name="verify_transaction_consent_address">올바른 주소로 보내고 있습니다</string>
     <string name="verify_transaction_consent_amount">금액이 정확합니다</string>
+    <string name="verify_transaction_consent_dapp_transaction">거래 세부 정보를 검토했습니다</string>
     <string name="verify_transaction_error_not_enough_consent">모든 동의 항목을 확인해 주세요</string>
     <string name="camera_permission_open_settings">설정 열기</string>
     <string name="transaction_done_title">완료</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1168,6 +1168,17 @@
     <string name="sui_raw_transaction">Sui 거래</string>
     <string name="ripple_dapp_transaction">XRPL 거래</string>
     <string name="ripple_transaction_summary">거래 요약</string>
+    <string name="ripple_field_issuer">발행자</string>
+    <string name="ripple_field_send_max">최대 전송</string>
+    <string name="ripple_field_send_max_issuer">최대 전송 발행자</string>
+    <string name="ripple_field_deliver_min">최소 전달</string>
+    <string name="ripple_field_deliver_min_issuer">최소 전달 발행자</string>
+    <string name="ripple_field_selling">판매</string>
+    <string name="ripple_field_selling_issuer">판매 발행자</string>
+    <string name="ripple_field_buying">구매</string>
+    <string name="ripple_field_buying_issuer">구매 발행자</string>
+    <string name="ripple_field_limit">한도</string>
+    <string name="ripple_field_limit_issuer">한도 발행자</string>
     <string name="sui_sender">보내는 주소</string>
     <string name="solana_raw_transaction">Solana 원시 거래</string>
     <string name="solana_instructions_summary">거래 명령어 요약</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1166,6 +1166,8 @@
     <string name="transaction_status_checking_transaction">거래 확인 중…</string>
     <string name="raw_transaction_data">원시 거래 데이터</string>
     <string name="sui_raw_transaction">Sui 거래</string>
+    <string name="ripple_dapp_transaction">XRPL 거래</string>
+    <string name="ripple_transaction_summary">거래 요약</string>
     <string name="sui_sender">보내는 주소</string>
     <string name="solana_raw_transaction">Solana 원시 거래</string>
     <string name="solana_instructions_summary">거래 명령어 요약</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1133,6 +1133,17 @@
     <string name="sui_raw_transaction">Sui-transactie</string>
     <string name="ripple_dapp_transaction">XRPL-transactie</string>
     <string name="ripple_transaction_summary">Transactieoverzicht</string>
+    <string name="ripple_field_issuer">Uitgever</string>
+    <string name="ripple_field_send_max">Max. verzending</string>
+    <string name="ripple_field_send_max_issuer">Uitgever max. verzending</string>
+    <string name="ripple_field_deliver_min">Min. levering</string>
+    <string name="ripple_field_deliver_min_issuer">Uitgever min. levering</string>
+    <string name="ripple_field_selling">Verkoop</string>
+    <string name="ripple_field_selling_issuer">Uitgever verkoop</string>
+    <string name="ripple_field_buying">Aankoop</string>
+    <string name="ripple_field_buying_issuer">Uitgever aankoop</string>
+    <string name="ripple_field_limit">Limiet</string>
+    <string name="ripple_field_limit_issuer">Uitgever limiet</string>
     <string name="sui_sender">Van</string>
     <string name="solana_raw_transaction">Solana Ruwe transactie</string>
     <string name="solana_instructions_summary">Overzicht transactie-instructies</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -121,6 +121,7 @@
     <string name="verify_transaction_value">Waarde</string>
     <string name="verify_transaction_consent_address">Ik stuur naar het juiste adres</string>
     <string name="verify_transaction_consent_amount">Het bedrag is correct</string>
+    <string name="verify_transaction_consent_dapp_transaction">Ik heb de transactiedetails gecontroleerd</string>
     <string name="verify_transaction_error_not_enough_consent">Controleer alle toestemmingen</string>
     <string name="camera_permission_open_settings">Instellingen openen</string>
     <string name="transaction_done_title">Gedaan</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1131,6 +1131,8 @@
     <string name="transaction_status_checking_transaction">Transactie controleren…</string>
     <string name="raw_transaction_data">Ruwe transactiegegevens</string>
     <string name="sui_raw_transaction">Sui-transactie</string>
+    <string name="ripple_dapp_transaction">XRPL-transactie</string>
+    <string name="ripple_transaction_summary">Transactieoverzicht</string>
     <string name="sui_sender">Van</string>
     <string name="solana_raw_transaction">Solana Ruwe transactie</string>
     <string name="solana_instructions_summary">Overzicht transactie-instructies</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1135,6 +1135,8 @@
    <string name="transaction_status_checking_transaction">A verificar transação…</string>
     <string name="raw_transaction_data">Dados brutos de transação</string>
     <string name="sui_raw_transaction">Transação Sui</string>
+    <string name="ripple_dapp_transaction">Transação XRPL</string>
+    <string name="ripple_transaction_summary">Resumo da transação</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transação bruta de Solana</string>
     <string name="solana_instructions_summary">Resumo das instruções da transação</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -106,6 +106,7 @@
     <string name="verify_transaction_amount_title">Montante</string>
     <string name="verify_transaction_consent_address">Estou enviando para o endereço correto</string>
     <string name="verify_transaction_consent_amount">A quantidade está correta</string>
+    <string name="verify_transaction_consent_dapp_transaction">Revisei os detalhes da transação</string>
     <string name="transaction_done_title">Concluído</string>
     <string name="transaction_done_overview">Visão geral</string>
     <string name="transaction_done_complete">Continuar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1137,6 +1137,17 @@
     <string name="sui_raw_transaction">Transação Sui</string>
     <string name="ripple_dapp_transaction">Transação XRPL</string>
     <string name="ripple_transaction_summary">Resumo da transação</string>
+    <string name="ripple_field_issuer">Emissor</string>
+    <string name="ripple_field_send_max">Envio máximo</string>
+    <string name="ripple_field_send_max_issuer">Emissor do envio máximo</string>
+    <string name="ripple_field_deliver_min">Entrega mínima</string>
+    <string name="ripple_field_deliver_min_issuer">Emissor da entrega mínima</string>
+    <string name="ripple_field_selling">Venda</string>
+    <string name="ripple_field_selling_issuer">Emissor da venda</string>
+    <string name="ripple_field_buying">Compra</string>
+    <string name="ripple_field_buying_issuer">Emissor da compra</string>
+    <string name="ripple_field_limit">Limite</string>
+    <string name="ripple_field_limit_issuer">Emissor do limite</string>
     <string name="sui_sender">De</string>
     <string name="solana_raw_transaction">Transação bruta de Solana</string>
     <string name="solana_instructions_summary">Resumo das instruções da transação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -121,6 +121,7 @@
     <string name="verify_transaction_value">Стоимость</string>
     <string name="verify_transaction_consent_address">Я отправляю на правильный адрес</string>
     <string name="verify_transaction_consent_amount">Сумма верна</string>
+    <string name="verify_transaction_consent_dapp_transaction">Я проверил детали транзакции</string>
     <string name="verify_transaction_error_not_enough_consent">Пожалуйста, проверьте все согласия</string>
     <string name="camera_permission_open_settings">Открыть настройки</string>
     <string name="transaction_done_title">Готово</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1141,6 +1141,17 @@
     <string name="sui_raw_transaction">Транзакция Sui</string>
     <string name="ripple_dapp_transaction">Транзакция XRPL</string>
     <string name="ripple_transaction_summary">Сводка транзакции</string>
+    <string name="ripple_field_issuer">Эмитент</string>
+    <string name="ripple_field_send_max">Макс. отправка</string>
+    <string name="ripple_field_send_max_issuer">Эмитент макс. отправки</string>
+    <string name="ripple_field_deliver_min">Мин. доставка</string>
+    <string name="ripple_field_deliver_min_issuer">Эмитент мин. доставки</string>
+    <string name="ripple_field_selling">Продажа</string>
+    <string name="ripple_field_selling_issuer">Эмитент продажи</string>
+    <string name="ripple_field_buying">Покупка</string>
+    <string name="ripple_field_buying_issuer">Эмитент покупки</string>
+    <string name="ripple_field_limit">Лимит</string>
+    <string name="ripple_field_limit_issuer">Эмитент лимита</string>
     <string name="sui_sender">От</string>
     <string name="solana_raw_transaction">Исходные данные транзакции Соланы</string>
     <string name="solana_instructions_summary">Сводка инструкций транзакции</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1139,6 +1139,8 @@
     <string name="transaction_status_checking_transaction">Проверка транзакции…</string>
     <string name="raw_transaction_data">Исходные данные транзакции</string>
     <string name="sui_raw_transaction">Транзакция Sui</string>
+    <string name="ripple_dapp_transaction">Транзакция XRPL</string>
+    <string name="ripple_transaction_summary">Сводка транзакции</string>
     <string name="sui_sender">От</string>
     <string name="solana_raw_transaction">Исходные данные транзакции Соланы</string>
     <string name="solana_instructions_summary">Сводка инструкций транзакции</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -222,6 +222,7 @@
     <string name="verify_transaction_value">价值</string>
     <string name="verify_transaction_consent_address">我正在发送到正确的地址</string>
     <string name="verify_transaction_consent_amount">金额正确</string>
+    <string name="verify_transaction_consent_dapp_transaction">我已核对交易详情</string>
     <string name="verify_transaction_error_not_enough_consent">请检查所有同意项</string>
 
     <!-- Camera & QR -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1469,6 +1469,17 @@
     <string name="sui_raw_transaction">Sui 交易</string>
     <string name="ripple_dapp_transaction">XRPL 交易</string>
     <string name="ripple_transaction_summary">交易摘要</string>
+    <string name="ripple_field_issuer">发行方</string>
+    <string name="ripple_field_send_max">最大发送额</string>
+    <string name="ripple_field_send_max_issuer">最大发送额发行方</string>
+    <string name="ripple_field_deliver_min">最小交付额</string>
+    <string name="ripple_field_deliver_min_issuer">最小交付额发行方</string>
+    <string name="ripple_field_selling">卖出</string>
+    <string name="ripple_field_selling_issuer">卖出发行方</string>
+    <string name="ripple_field_buying">买入</string>
+    <string name="ripple_field_buying_issuer">买入发行方</string>
+    <string name="ripple_field_limit">限额</string>
+    <string name="ripple_field_limit_issuer">限额发行方</string>
     <string name="sui_sender">从</string>
     <string name="solana_raw_transaction">Solana 原始交易数据</string>
     <string name="solana_instructions_summary">交易指令摘要</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1467,6 +1467,8 @@
     <string name="transaction_status_checking_transaction">正在检查交易……</string>
     <string name="raw_transaction_data">原始交易数据</string>
     <string name="sui_raw_transaction">Sui 交易</string>
+    <string name="ripple_dapp_transaction">XRPL 交易</string>
+    <string name="ripple_transaction_summary">交易摘要</string>
     <string name="sui_sender">从</string>
     <string name="solana_raw_transaction">Solana 原始交易数据</string>
     <string name="solana_instructions_summary">交易指令摘要</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1194,6 +1194,17 @@
     <string name="sui_raw_transaction">Sui Transaction</string>
     <string name="ripple_dapp_transaction">XRPL Transaction</string>
     <string name="ripple_transaction_summary">Transaction summary</string>
+    <string name="ripple_field_issuer">Issuer</string>
+    <string name="ripple_field_send_max">Send max</string>
+    <string name="ripple_field_send_max_issuer">Send max issuer</string>
+    <string name="ripple_field_deliver_min">Deliver min</string>
+    <string name="ripple_field_deliver_min_issuer">Deliver min issuer</string>
+    <string name="ripple_field_selling">Selling</string>
+    <string name="ripple_field_selling_issuer">Selling issuer</string>
+    <string name="ripple_field_buying">Buying</string>
+    <string name="ripple_field_buying_issuer">Buying issuer</string>
+    <string name="ripple_field_limit">Limit</string>
+    <string name="ripple_field_limit_issuer">Limit issuer</string>
     <string name="sui_sender">From</string>
     <string name="solana_raw_transaction">Solana Raw Transaction</string>
     <string name="solana_instructions_summary">Transaction Instructions Summary</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="verify_transaction_value">Value</string>
     <string name="verify_transaction_consent_address">I’m sending to the right address</string>
     <string name="verify_transaction_consent_amount">The amount is correct</string>
+    <string name="verify_transaction_consent_dapp_transaction">I have reviewed the transaction details</string>
     <string name="verify_transaction_error_not_enough_consent">Please check all consents</string>
     <string name="camera_permission_open_settings">Open Settings</string>
     <string name="transaction_done_title">Done</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1192,6 +1192,8 @@
     <string name="transaction_status_checking_transaction">Checking transaction…</string>
     <string name="raw_transaction_data">Raw Transaction Data</string>
     <string name="sui_raw_transaction">Sui Transaction</string>
+    <string name="ripple_dapp_transaction">XRPL Transaction</string>
+    <string name="ripple_transaction_summary">Transaction summary</string>
     <string name="sui_sender">From</string>
     <string name="solana_raw_transaction">Solana Raw Transaction</string>
     <string name="solana_instructions_summary">Transaction Instructions Summary</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/RippleJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/RippleJson.kt
@@ -36,16 +36,25 @@ data class RippleBroadcastSuccessResultJson(
 @Serializable
 data class RippleTxMetaJson(@SerialName("TransactionResult") val transactionResult: String? = null)
 
+/**
+ * A validated XRPL transaction's `tx_json`. Every field is nullable/defaulted: XRPL only emits the
+ * fields a given `TransactionType` actually uses — a `Payment` carries `Destination`/`DeliverMax`,
+ * while an `OfferCreate` carries `TakerGets`/`TakerPays` and no `Destination` at all. Making these
+ * non-null broke status polling for every non-Payment type (co-signed dApp OfferCreate/TrustSet/…):
+ * the `tx` response deserialization threw `MissingFieldException`, which `RippleStatusProvider`
+ * swallowed as `Pending`, so a `tesSUCCESS` transaction was reported pending forever. Status only
+ * reads `validated` + `meta.TransactionResult`, so the exact `tx_json` shape is display-only.
+ */
 @Serializable
 data class RippleBroadcastSuccessTransactionJson(
-    @SerialName("Account") val account: String,
-    @SerialName("DeliverMax") val deliverMax: String,
-    @SerialName("Destination") val destination: String,
-    @SerialName("Fee") val fee: String,
-    @SerialName("Flags") val flags: Int,
-    @SerialName("LastLedgerSequence") val lastLedgerSequence: Int,
-    @SerialName("Sequence") val sequence: Int,
-    @SerialName("SigningPubKey") val signingPubKey: String,
-    @SerialName("TransactionType") val transactionType: String,
-    @SerialName("TxnSignature") val txnSignature: String,
+    @SerialName("Account") val account: String? = null,
+    @SerialName("DeliverMax") val deliverMax: String? = null,
+    @SerialName("Destination") val destination: String? = null,
+    @SerialName("Fee") val fee: String? = null,
+    @SerialName("Flags") val flags: Int? = null,
+    @SerialName("LastLedgerSequence") val lastLedgerSequence: Int? = null,
+    @SerialName("Sequence") val sequence: Int? = null,
+    @SerialName("SigningPubKey") val signingPubKey: String? = null,
+    @SerialName("TransactionType") val transactionType: String? = null,
+    @SerialName("TxnSignature") val txnSignature: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransaction.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import java.math.BigDecimal
+import java.math.BigInteger
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -8,8 +9,33 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import timber.log.Timber
 
-/** A single decoded label/value row of a dApp-supplied XRPL transaction, for the verify screen. */
-data class RippleDappTxField(val label: String, val value: String)
+/**
+ * Semantic identifier of a decoded XRPL field row. The data layer stores this key (never an English
+ * display label) so the Compose layer can map it to a localized string. Distinct issuer keys make
+ * clear which amount an `Issuer` row belongs to (e.g. [SELLING_ISSUER] vs [BUYING_ISSUER]).
+ */
+enum class RippleDappTxFieldKey {
+    TYPE,
+    FROM,
+    TO,
+    DESTINATION_TAG,
+    AMOUNT,
+    AMOUNT_ISSUER,
+    SEND_MAX,
+    SEND_MAX_ISSUER,
+    DELIVER_MIN,
+    DELIVER_MIN_ISSUER,
+    SELLING,
+    SELLING_ISSUER,
+    BUYING,
+    BUYING_ISSUER,
+    LIMIT,
+    LIMIT_ISSUER,
+    FEE,
+}
+
+/** A single decoded key/value row of a dApp-supplied XRPL transaction, for the verify screen. */
+data class RippleDappTxField(val key: RippleDappTxFieldKey, val value: String)
 
 /**
  * Human-readable decode of a dApp-supplied XRPL transaction ([SignRipple.rawJson]).
@@ -22,15 +48,15 @@ data class RippleDappTx(
     val fields: List<RippleDappTxField>,
     val rawJson: String,
 ) {
-    /** Value of the decoded field with [label], or null if absent. */
-    fun value(label: String): String? = fields.firstOrNull { it.label == label }?.value
+    /** Value of the decoded field with [key], or null if absent. */
+    fun value(key: RippleDappTxFieldKey): String? = fields.firstOrNull { it.key == key }?.value
 }
 
 /**
  * Decodes the raw XRPL transaction JSON a dApp hands the co-signer (via `SignRipple`) into readable
  * terms — type, source, destination, amounts (`Amount` / `SendMax` / `DeliverMin` / `TakerGets` /
- * `TakerPays`), issuer and destination tag. Pure (no JNI, no Android), so the verify screen renders
- * decoded terms and it stays unit-testable.
+ * `TakerPays`), issuer, destination tag and the signed `Fee`. Pure (no JNI, no Android), so the
+ * verify screen renders decoded terms and it stays unit-testable.
  *
  * Never throws: on any parse failure it returns an empty [RippleDappTx.fields] carrying the
  * original [rawJson], so the UI can fall back to the raw JSON.
@@ -53,23 +79,79 @@ object RippleDappTransactionDecoder {
 
         val transactionType = obj.stringOrNull("TransactionType")
         val fields = buildList {
-            transactionType?.let { add(RippleDappTxField("Type", it)) }
-            obj.stringOrNull("Account")?.let { add(RippleDappTxField("From", it)) }
-            obj.stringOrNull("Destination")?.let { add(RippleDappTxField("To", it)) }
-            obj.stringOrNull("DestinationTag")?.let {
-                add(RippleDappTxField("Destination Tag", it))
+            transactionType?.let { add(RippleDappTxField(RippleDappTxFieldKey.TYPE, it)) }
+            obj.stringOrNull("Account")?.let {
+                add(RippleDappTxField(RippleDappTxFieldKey.FROM, it))
             }
-            addAmount(key = "Amount", label = "Amount", obj = obj)
-            addAmount(key = "SendMax", label = "Send max", obj = obj)
-            addAmount(key = "DeliverMin", label = "Deliver min", obj = obj)
+            obj.stringOrNull("Destination")?.let {
+                add(RippleDappTxField(RippleDappTxFieldKey.TO, it))
+            }
+            obj.stringOrNull("DestinationTag")?.let {
+                add(RippleDappTxField(RippleDappTxFieldKey.DESTINATION_TAG, it))
+            }
+            addAmount(
+                key = "Amount",
+                amountKey = RippleDappTxFieldKey.AMOUNT,
+                issuerKey = RippleDappTxFieldKey.AMOUNT_ISSUER,
+                obj = obj,
+            )
+            addAmount(
+                key = "SendMax",
+                amountKey = RippleDappTxFieldKey.SEND_MAX,
+                issuerKey = RippleDappTxFieldKey.SEND_MAX_ISSUER,
+                obj = obj,
+            )
+            addAmount(
+                key = "DeliverMin",
+                amountKey = RippleDappTxFieldKey.DELIVER_MIN,
+                issuerKey = RippleDappTxFieldKey.DELIVER_MIN_ISSUER,
+                obj = obj,
+            )
             // OfferCreate: TakerGets is what the account sells, TakerPays what it buys. Match the
             // extension's Selling / Buying wording rather than the raw XRPL field names.
-            addAmount(key = "TakerGets", label = "Selling", obj = obj)
-            addAmount(key = "TakerPays", label = "Buying", obj = obj)
-            obj.stringOrNull("LimitAmount")?.let { add(RippleDappTxField("Limit", it)) }
+            addAmount(
+                key = "TakerGets",
+                amountKey = RippleDappTxFieldKey.SELLING,
+                issuerKey = RippleDappTxFieldKey.SELLING_ISSUER,
+                obj = obj,
+            )
+            addAmount(
+                key = "TakerPays",
+                amountKey = RippleDappTxFieldKey.BUYING,
+                issuerKey = RippleDappTxFieldKey.BUYING_ISSUER,
+                obj = obj,
+            )
+            // TrustSet's LimitAmount is an issued-currency object; handle it the same way.
+            addAmount(
+                key = "LimitAmount",
+                amountKey = RippleDappTxFieldKey.LIMIT,
+                issuerKey = RippleDappTxFieldKey.LIMIT_ISSUER,
+                obj = obj,
+            )
+            // The Fee that is actually signed (drops). Surfaced so the verify screen shows the real
+            // network fee baked into the JSON rather than a live re-estimate (a malicious inflated
+            // Fee must be visible, not masked by a normal-looking estimate).
+            obj.stringOrNull("Fee")?.let {
+                add(RippleDappTxField(RippleDappTxFieldKey.FEE, formatXrpDrops(it)))
+            }
         }
 
         return RippleDappTx(transactionType = transactionType, fields = fields, rawJson = rawJson)
+    }
+
+    /**
+     * The signed `Fee` in drops, or null when absent/unparseable. This is the fee actually encoded
+     * in the raw JSON that gets signed verbatim, so the verify screen surfaces it instead of a live
+     * network re-estimate that could hide a dApp-inflated fee.
+     */
+    fun feeDrops(rawJson: String): BigInteger? {
+        val obj =
+            try {
+                json.parseToJsonElement(rawJson).jsonObject
+            } catch (e: Exception) {
+                return null
+            }
+        return obj.stringOrNull("Fee")?.toBigIntegerOrNull()
     }
 
     /**
@@ -84,18 +166,19 @@ object RippleDappTransactionDecoder {
         val type = tx.transactionType ?: return null
         return when (type) {
             "OfferCreate" -> {
-                val gets = tx.value("Selling")
-                val pays = tx.value("Buying")
+                val gets = tx.value(RippleDappTxFieldKey.SELLING)
+                val pays = tx.value(RippleDappTxFieldKey.BUYING)
                 if (gets != null && pays != null) "$type: $gets → $pays" else type
             }
-            "Payment" -> tx.value("Amount")?.let { "$type: $it" } ?: type
+            "Payment" -> tx.value(RippleDappTxFieldKey.AMOUNT)?.let { "$type: $it" } ?: type
             else -> type
         }
     }
 
     private fun MutableList<RippleDappTxField>.addAmount(
         key: String,
-        label: String,
+        amountKey: RippleDappTxFieldKey,
+        issuerKey: RippleDappTxFieldKey,
         obj: JsonObject,
     ) {
         val element = obj[key] ?: return
@@ -103,7 +186,7 @@ object RippleDappTransactionDecoder {
         if (primitive != null) {
             // A bare string/number amount is XRP in drops.
             primitive.contentOrNull?.let { drops ->
-                add(RippleDappTxField(label, formatXrpDrops(drops)))
+                add(RippleDappTxField(amountKey, formatXrpDrops(drops)))
             }
             return
         }
@@ -113,8 +196,8 @@ object RippleDappTransactionDecoder {
         val currency = amountObj.stringOrNull("currency")
         val issuer = amountObj.stringOrNull("issuer")
         if (value != null && currency != null) {
-            add(RippleDappTxField(label, "$value $currency"))
-            issuer?.let { add(RippleDappTxField("Issuer", it)) }
+            add(RippleDappTxField(amountKey, "$value $currency"))
+            issuer?.let { add(RippleDappTxField(issuerKey, it)) }
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransaction.kt
@@ -1,0 +1,131 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import java.math.BigDecimal
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import timber.log.Timber
+
+/** A single decoded label/value row of a dApp-supplied XRPL transaction, for the verify screen. */
+data class RippleDappTxField(val label: String, val value: String)
+
+/**
+ * Human-readable decode of a dApp-supplied XRPL transaction ([SignRipple.rawJson]).
+ *
+ * [fields] is empty when the JSON can't be decoded into known terms — the verify screen then falls
+ * back to showing [rawJson] verbatim so a co-signer is never left with a blank/misleading screen.
+ */
+data class RippleDappTx(
+    val transactionType: String?,
+    val fields: List<RippleDappTxField>,
+    val rawJson: String,
+) {
+    /** Value of the decoded field with [label], or null if absent. */
+    fun value(label: String): String? = fields.firstOrNull { it.label == label }?.value
+}
+
+/**
+ * Decodes the raw XRPL transaction JSON a dApp hands the co-signer (via `SignRipple`) into readable
+ * terms — type, source, destination, amounts (`Amount` / `SendMax` / `DeliverMin` / `TakerGets` /
+ * `TakerPays`), issuer and destination tag. Pure (no JNI, no Android), so the verify screen renders
+ * decoded terms and it stays unit-testable.
+ *
+ * Never throws: on any parse failure it returns an empty [RippleDappTx.fields] carrying the
+ * original [rawJson], so the UI can fall back to the raw JSON.
+ */
+object RippleDappTransactionDecoder {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // XRPL native amounts are integer drops; 1 XRP = 1_000_000 drops.
+    private val DROPS_PER_XRP = BigDecimal(1_000_000)
+
+    fun decode(rawJson: String): RippleDappTx {
+        val obj =
+            try {
+                json.parseToJsonElement(rawJson).jsonObject
+            } catch (e: Exception) {
+                Timber.w("Failed to decode SignRipple rawJson for display: %s", e.message)
+                return RippleDappTx(transactionType = null, fields = emptyList(), rawJson = rawJson)
+            }
+
+        val transactionType = obj.stringOrNull("TransactionType")
+        val fields = buildList {
+            transactionType?.let { add(RippleDappTxField("Type", it)) }
+            obj.stringOrNull("Account")?.let { add(RippleDappTxField("From", it)) }
+            obj.stringOrNull("Destination")?.let { add(RippleDappTxField("To", it)) }
+            obj.stringOrNull("DestinationTag")?.let {
+                add(RippleDappTxField("Destination Tag", it))
+            }
+            addAmount(key = "Amount", label = "Amount", obj = obj)
+            addAmount(key = "SendMax", label = "Send max", obj = obj)
+            addAmount(key = "DeliverMin", label = "Deliver min", obj = obj)
+            // OfferCreate: TakerGets is what the account sells, TakerPays what it buys. Match the
+            // extension's Selling / Buying wording rather than the raw XRPL field names.
+            addAmount(key = "TakerGets", label = "Selling", obj = obj)
+            addAmount(key = "TakerPays", label = "Buying", obj = obj)
+            obj.stringOrNull("LimitAmount")?.let { add(RippleDappTxField("Limit", it)) }
+        }
+
+        return RippleDappTx(transactionType = transactionType, fields = fields, rawJson = rawJson)
+    }
+
+    /**
+     * A one-line, human-readable summary of a dApp-supplied XRPL transaction, for the keysign
+     * notification banner where the native `toAmount` is 0 (the real amounts live in the JSON).
+     * Returns null when the JSON can't be decoded into a known type, so callers can fall back.
+     *
+     * Examples: `OfferCreate: 1 XRP → 2.5 USD`, `Payment: 1 XRP`, `TrustSet`.
+     */
+    fun summarize(rawJson: String): String? {
+        val tx = decode(rawJson)
+        val type = tx.transactionType ?: return null
+        return when (type) {
+            "OfferCreate" -> {
+                val gets = tx.value("Selling")
+                val pays = tx.value("Buying")
+                if (gets != null && pays != null) "$type: $gets → $pays" else type
+            }
+            "Payment" -> tx.value("Amount")?.let { "$type: $it" } ?: type
+            else -> type
+        }
+    }
+
+    private fun MutableList<RippleDappTxField>.addAmount(
+        key: String,
+        label: String,
+        obj: JsonObject,
+    ) {
+        val element = obj[key] ?: return
+        val primitive = element as? JsonPrimitive
+        if (primitive != null) {
+            // A bare string/number amount is XRP in drops.
+            primitive.contentOrNull?.let { drops ->
+                add(RippleDappTxField(label, formatXrpDrops(drops)))
+            }
+            return
+        }
+        // An issued-currency amount is an object: { currency, issuer, value }.
+        val amountObj = element as? JsonObject ?: return
+        val value = amountObj.stringOrNull("value")
+        val currency = amountObj.stringOrNull("currency")
+        val issuer = amountObj.stringOrNull("issuer")
+        if (value != null && currency != null) {
+            add(RippleDappTxField(label, "$value $currency"))
+            issuer?.let { add(RippleDappTxField("Issuer", it)) }
+        }
+    }
+
+    private fun formatXrpDrops(drops: String): String =
+        try {
+            "${BigDecimal(drops).divide(DROPS_PER_XRP).stripTrailingZeros().toPlainString()} XRP"
+        } catch (e: NumberFormatException) {
+            // Not a plain drops integer — show the raw value rather than dropping the row.
+            drops
+        }
+
+    private fun JsonObject.stringOrNull(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
@@ -10,6 +10,10 @@ import com.vultisig.wallet.data.tss.getSignature
 import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
 import com.vultisig.wallet.data.utils.Numeric
 import java.security.MessageDigest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import timber.log.Timber
 import wallet.core.jni.CoinType
 import wallet.core.jni.DataVector
@@ -23,8 +27,24 @@ object RippleHelper {
 
     const val DEFAULT_EXISTENTIAL_DEPOSIT = 1000000
 
+    private val rawJsonParser = Json { ignoreUnknownKeys = true }
+
     fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
         require(keysignPayload.coin.chain == Chain.Ripple) { "Coin is not XRP" }
+
+        // dApp-supplied XRPL transaction (via the extension's GemWallet provider): the raw JSON is
+        // already a complete transaction — Account, Fee, Sequence, LastLedgerSequence and amounts
+        // are baked in — so sign it verbatim through WalletCore's rawJson path. Every co-signer
+        // rebuilds identical signing bytes from the same JSON, matching the extension and
+        // @vultisig/core-mpc byte-for-byte. Reconstructing an OperationPayment from
+        // toAddress/toAmount would diverge and produce a non-matching MPC signature.
+        keysignPayload.signRipple?.let { signRipple ->
+            return buildDappRawJsonInputData(
+                rawJson = signRipple.rawJson,
+                expectedAccount = keysignPayload.coin.address,
+                hexPublicKey = keysignPayload.coin.hexPublicKey,
+            )
+        }
 
         val rippleSpecific =
             keysignPayload.blockChainSpecific as? BlockChainSpecific.Ripple
@@ -156,6 +176,61 @@ object RippleHelper {
             error("Failed to create JSON string ${e.message}")
         }
     }
+
+    /**
+     * Builds the WalletCore [Ripple.SigningInput] for a dApp-supplied transaction ([SignRipple]),
+     * signing the raw JSON verbatim. Fails closed first: rejects any transaction whose `Account`
+     * differs from this vault's derived XRP address, so a co-signer can never sign a spend from an
+     * account other than its own — the same defense as `@vultisig/core-mpc` 1.11.0.
+     *
+     * Only [setRawJson] and [setPublicKey] are set: the JSON is the source of truth for every tx
+     * field, and the vault ECDSA public key (identical across all co-signers) is what WalletCore
+     * embeds as `SigningPubKey` and hashes into the pre-image — so every device produces the same
+     * signing bytes.
+     */
+    private fun buildDappRawJsonInputData(
+        rawJson: String,
+        expectedAccount: String,
+        hexPublicKey: String,
+    ): ByteArray {
+        verifyDappTransactionAccount(rawJson, expectedAccount)
+
+        val publicKey = PublicKey(hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
+
+        return Ripple.SigningInput.newBuilder()
+            .setRawJson(rawJson)
+            .setPublicKey(ByteString.copyFrom(publicKey.data()))
+            .build()
+            .toByteArray()
+    }
+
+    /**
+     * Fail-closed guard for a dApp-supplied [SignRipple] transaction: throws unless the JSON's
+     * `Account` equals this vault's derived XRP [expectedAccount]. Pure (no JNI), so it is
+     * unit-testable independently of WalletCore.
+     */
+    internal fun verifyDappTransactionAccount(rawJson: String, expectedAccount: String) {
+        require(rawJson.isNotBlank()) { "SignRipple rawJson is empty" }
+        val account =
+            parseRawJsonAccount(rawJson)
+                ?: error("SignRipple rawJson has no readable Account field")
+        require(account == expectedAccount) {
+            "SignRipple Account $account does not match this vault's XRP address $expectedAccount"
+        }
+    }
+
+    /** Extracts the XRPL `Account` from a raw transaction JSON, or null if absent/unparseable. */
+    internal fun parseRawJsonAccount(rawJson: String): String? =
+        try {
+            rawJsonParser
+                .parseToJsonElement(rawJson)
+                .jsonObject["Account"]
+                ?.jsonPrimitive
+                ?.contentOrNull
+        } catch (e: Exception) {
+            Timber.e("Failed to parse SignRipple rawJson: %s", e.message)
+            null
+        }
 
     fun getPreSignedImageHash(keysignPayload: KeysignPayload): List<String> {
         val inputData = getPreSignedInputData(keysignPayload)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelpter.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.tss.getSignatureWithRecoveryID
 import com.vultisig.wallet.data.utils.Numeric
 import java.security.MessageDigest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -28,6 +29,26 @@ object RippleHelper {
     const val DEFAULT_EXISTENTIAL_DEPOSIT = 1000000
 
     private val rawJsonParser = Json { ignoreUnknownKeys = true }
+
+    /**
+     * XRPL transaction types this wallet will co-sign for a dApp. A swap is an `OfferCreate`
+     * (optionally paired with `OfferCancel`); `Payment` and `TrustSet` round out the common
+     * surface. Anything outside this set — `AccountSet`, `SetRegularKey`, `SignerListSet`,
+     * `EscrowCreate`, hooks — is refused so a dApp (or a tampering relay) cannot slip a
+     * key-rotation or account-takeover past a co-signer who thinks they are approving a trade. This
+     * mirrors the Windows/extension `sanitizeRippleDappTx` allowlist; extend deliberately.
+     */
+    private val ALLOWED_DAPP_TRANSACTION_TYPES =
+        setOf("Payment", "OfferCreate", "OfferCancel", "TrustSet")
+
+    /**
+     * Signing-mechanics fields a dApp/relay has no business setting on an unsigned request:
+     * `SigningPubKey` is filled from the vault key at signing time, `TxnSignature` is the signature
+     * we are about to produce, and `Signers` is a multi-sign envelope irrelevant to single-sig MPC.
+     * Their presence means the raw JSON was tampered with, so we refuse rather than sign around
+     * them.
+     */
+    private val FORBIDDEN_DAPP_FIELDS = setOf("TxnSignature", "Signers", "SigningPubKey")
 
     fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
         require(keysignPayload.coin.chain == Chain.Ripple) { "Coin is not XRP" }
@@ -193,7 +214,7 @@ object RippleHelper {
         expectedAccount: String,
         hexPublicKey: String,
     ): ByteArray {
-        verifyDappTransactionAccount(rawJson, expectedAccount)
+        verifyDappTransaction(rawJson, expectedAccount)
 
         val publicKey = PublicKey(hexPublicKey.hexToByteArray(), PublicKeyType.SECP256K1)
 
@@ -205,17 +226,47 @@ object RippleHelper {
     }
 
     /**
-     * Fail-closed guard for a dApp-supplied [SignRipple] transaction: throws unless the JSON's
-     * `Account` equals this vault's derived XRP [expectedAccount]. Pure (no JNI), so it is
-     * unit-testable independently of WalletCore.
+     * Fail-closed guard for a dApp-supplied [SignRipple] transaction, verbatim-signed so this is
+     * the only gate between the wire and the signer. Throws unless:
+     * - the `TransactionType` is on the [ALLOWED_DAPP_TRANSACTION_TYPES] allowlist — a
+     *   `SetRegularKey`/`SignerListSet`/`EscrowCreate`/etc. is refused even when its `Account` is
+     *   our own vault (public info), so a tampering relay can't get an account-takeover co-signed
+     *   under the guise of a trade;
+     * - the JSON's `Account` equals this vault's derived XRP [expectedAccount], so a co-signer
+     *   never signs a spend from an account other than its own;
+     * - no signing-mechanics field ([FORBIDDEN_DAPP_FIELDS]) is present, which would mean the JSON
+     *   was tampered with after the initiator sanitized it.
+     *
+     * Pure (no JNI), so it is unit-testable independently of WalletCore. Mirrors the Windows
+     * `sanitizeRippleDappTx` defense.
      */
-    internal fun verifyDappTransactionAccount(rawJson: String, expectedAccount: String) {
+    internal fun verifyDappTransaction(rawJson: String, expectedAccount: String) {
         require(rawJson.isNotBlank()) { "SignRipple rawJson is empty" }
+        val obj =
+            try {
+                rawJsonParser.parseToJsonElement(rawJson).jsonObject
+            } catch (e: Exception) {
+                Timber.e("Failed to parse SignRipple rawJson: %s", e.message)
+                error("SignRipple rawJson is not a valid JSON object")
+            }
+
+        val transactionType =
+            (obj["TransactionType"] as? JsonPrimitive)?.contentOrNull
+                ?: error("SignRipple rawJson has no readable TransactionType field")
+        require(transactionType in ALLOWED_DAPP_TRANSACTION_TYPES) {
+            "SignRipple TransactionType $transactionType is not supported"
+        }
+
         val account =
-            parseRawJsonAccount(rawJson)
+            (obj["Account"] as? JsonPrimitive)?.contentOrNull
                 ?: error("SignRipple rawJson has no readable Account field")
         require(account == expectedAccount) {
             "SignRipple Account $account does not match this vault's XRP address $expectedAccount"
+        }
+
+        val tamperedField = FORBIDDEN_DAPP_FIELDS.firstOrNull { obj.containsKey(it) }
+        require(tamperedField == null) {
+            "SignRipple rawJson carries a signing-mechanics field ($tamperedField); refusing to sign"
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -150,13 +150,13 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
 
                     // A dApp-supplied XRPL transaction (`signRipple`) is signed verbatim from its
                     // raw JSON via WalletCore's `rawJson` path — Fee / Sequence /
-                    // LastLedgerSequence are already encoded in the JSON, so the initiator omits
-                    // `rippleSpecific`. Stand in an empty placeholder so [RippleHelper], which
-                    // casts
-                    // `blockChainSpecific` to `Ripple`, has a value to read; its fields go unused
-                    // on
-                    // the signRipple path.
-                    from.signRipple != null ->
+                    // LastLedgerSequence are already encoded in the JSON. The Windows/extension
+                    // initiator still populates `rippleSpecific` (it runs `getChainSpecific` for
+                    // every chain), so honour it when present via the `rippleSpecific` branch below
+                    // rather than discarding the live sequence/fee the wire carries. Only stand in
+                    // an empty placeholder when it is genuinely absent, so [RippleHelper] — which
+                    // casts `blockChainSpecific` to `Ripple` — always has a value to read.
+                    from.signRipple != null && from.rippleSpecific == null ->
                         BlockChainSpecific.Ripple(
                             sequence = 0uL,
                             gas = 0uL,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -53,6 +53,7 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             signSolana = from.signSolana,
             signTon = from.signTon,
             signSui = from.signSui,
+            signRipple = from.signRipple,
             signBitcoin = from.signBitcoin,
             swapPayload =
                 when {
@@ -145,6 +146,22 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                             referenceGasPrice = BigInteger.ZERO,
                             gasBudget = BigInteger.ZERO,
                             coins = emptyList(),
+                        )
+
+                    // A dApp-supplied XRPL transaction (`signRipple`) is signed verbatim from its
+                    // raw JSON via WalletCore's `rawJson` path — Fee / Sequence /
+                    // LastLedgerSequence are already encoded in the JSON, so the initiator omits
+                    // `rippleSpecific`. Stand in an empty placeholder so [RippleHelper], which
+                    // casts
+                    // `blockChainSpecific` to `Ripple`, has a value to read; its fields go unused
+                    // on
+                    // the signRipple path.
+                    from.signRipple != null ->
+                        BlockChainSpecific.Ripple(
+                            sequence = 0uL,
+                            gas = 0uL,
+                            lastLedgerSequence = 0uL,
+                            destinationTag = null,
                         )
 
                     from.ethereumSpecific != null ->

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -281,6 +281,14 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
             // relay gap. Fixing them is deliberately out of scope for this Solana PR (untested on
             // those chains); tracked as a separate follow-up so any regression stays bisectable.
             signSolana = keysignPayload.signSolana,
+            // Same round-trip requirement: the dApp's raw XRPL transaction must reach the peer
+            // co-signer verbatim. Without relaying it, a co-signer receives signRipple == null and
+            // rebuilds a native OperationPayment from toAddress/toAmount — its signing bytes
+            // diverge
+            // from the initiator's, the DKLS setup message (keyed by md5(hash)) 404s, and the
+            // co-sign never completes. The inbound [KeysignPayloadProtoMapper] already reads it;
+            // this makes the mapping symmetric. Required for Secure Vault XRPL dApp co-signing.
+            signRipple = keysignPayload.signRipple,
             erc20ApprovePayload =
                 if (approvePayload is ERC20ApprovePayload) {
                     Erc20ApprovePayload(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SendTransactionHistoryData.kt
@@ -42,6 +42,15 @@ data class SendTransactionHistoryData(
     val feeEstimate: String,
     val memo: String,
     val fiatValue: String,
+    /**
+     * One-line decoded description of a dApp-supplied transaction signed verbatim (e.g. an XRPL
+     * `signRipple` OfferCreate/TrustSet/cross-currency Payment), whose native [amount] is `0` and
+     * whose real terms live in the signed raw JSON. Persisted so the row survives an app restart as
+     * its true operation instead of downgrading to a blank/generic native row. Default `null` (and
+     * serialized into the JSON `payload` column) so legacy rows stay readable with no Room
+     * migration.
+     */
+    val dappSummary: String? = null,
 ) : TransactionHistoryData
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Transaction.kt
@@ -25,6 +25,8 @@ data class Transaction(
      * Base64 `TransactionData` BCS bytes of a dApp-supplied Sui PTB, surfaced for verify display.
      */
     val signSui: String? = null,
+    /** Raw XRPL transaction JSON of a dApp-supplied `SignRipple`, surfaced for verify display. */
+    val signRipple: String? = null,
     val estimatedFee: String,
     val blockChainSpecific: BlockChainSpecific,
     val utxos: List<UtxoInfo> = emptyList(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/KeysignPayload.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
 import java.math.BigInteger
 import vultisig.keysign.v1.SignAmino
 import vultisig.keysign.v1.SignBitcoin
+import vultisig.keysign.v1.SignRipple
 import vultisig.keysign.v1.SignSolana
 import vultisig.keysign.v1.SignSui
 import vultisig.keysign.v1.SignTon
@@ -39,6 +40,16 @@ data class KeysignPayload(
      * gas budget and recipients are already baked into the bytes).
      */
     val signSui: SignSui? = null,
+    /**
+     * Pre-built XRPL transaction supplied by an external dApp (via the extension's GemWallet
+     * provider) — an `OfferCreate`, cross-currency `Payment`, `TrustSet`, etc. Carries the raw
+     * transaction JSON to sign verbatim; when present, [RippleHelper] builds its signing input via
+     * WalletCore's `rawJson` path instead of reconstructing an `OperationPayment` from
+     * `toAddress`/`toAmount`, so every co-signer produces byte-identical bytes (matching the
+     * extension and `@vultisig/core-mpc`). The Ripple [blockChainSpecific] slot is an empty
+     * placeholder — sequence, fee and last-ledger-sequence are already baked into the JSON.
+     */
+    val signRipple: SignRipple? = null,
     /**
      * Structured Bitcoin PSBT payload supplied by an external dApp for co-signing. When present,
      * the UTXO signing path uses these inputs/outputs directly and bypasses WalletCore tx planning;

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/RippleStatusProviderTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
 class RippleStatusProviderTest {
@@ -85,5 +86,30 @@ class RippleStatusProviderTest {
         coEvery { rippleApi.getTsStatus(any()) } throws RuntimeException("net")
 
         assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Ripple))
+    }
+
+    /**
+     * A validated OfferCreate `tx` response carries no `Destination`/`DeliverMax`/`Flags` in its
+     * `tx_json` (those are Payment-only). This must still deserialize — otherwise the strict
+     * decoder throws `MissingFieldException`, `getTsStatus` propagates it, and the status is
+     * reported `Pending` forever even though the co-signed dApp offer settled `tesSUCCESS`.
+     */
+    @Test
+    fun `validated OfferCreate tx_json without Payment fields deserializes`() {
+        val json = Json { ignoreUnknownKeys = true }
+        // Trimmed from a real xrplcluster `tx` response for a co-signed OfferCreate.
+        val raw =
+            """{"result":{"hash":"57064A9","status":"success","validated":true,""" +
+                """"meta":{"TransactionResult":"tesSUCCESS"},""" +
+                """"tx_json":{"Account":"rsFTwHnK6RxhGdM2FRKCey9fvLTg5tonsD","Fee":"20",""" +
+                """"Sequence":92804008,"TakerGets":"1000000",""" +
+                """"TakerPays":{"currency":"USD","issuer":"rvYAfWj","value":"2.5"},""" +
+                """"TransactionType":"OfferCreate","TxnSignature":"3045","ledger_index":105633235}}}"""
+
+        val parsed = json.decodeFromString<RippleBroadcastSuccessResponseJson>(raw)
+
+        assertEquals(true, parsed.result.validated)
+        assertEquals("tesSUCCESS", parsed.result.meta?.transactionResult)
+        assertEquals("OfferCreate", parsed.result.txJson?.transactionType)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransactionDecoderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransactionDecoderTest.kt
@@ -1,13 +1,14 @@
 package com.vultisig.wallet.data.chains.helpers
 
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class RippleDappTransactionDecoderTest {
 
-    private fun value(tx: RippleDappTx, label: String): String? =
-        tx.fields.firstOrNull { it.label == label }?.value
+    private fun value(tx: RippleDappTx, key: RippleDappTxFieldKey): String? = tx.value(key)
 
     @Test
     fun `decodes a native XRP Payment with drops converted to XRP`() {
@@ -19,11 +20,11 @@ class RippleDappTransactionDecoderTest {
         val tx = RippleDappTransactionDecoder.decode(json)
 
         assertEquals("Payment", tx.transactionType)
-        assertEquals("rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY", value(tx, "From"))
-        assertEquals("rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY", value(tx, "To"))
-        assertEquals("12345", value(tx, "Destination Tag"))
+        assertEquals("rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY", value(tx, RippleDappTxFieldKey.FROM))
+        assertEquals("rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY", value(tx, RippleDappTxFieldKey.TO))
+        assertEquals("12345", value(tx, RippleDappTxFieldKey.DESTINATION_TAG))
         // 1_500_000 drops = 1.5 XRP
-        assertEquals("1.5 XRP", value(tx, "Amount"))
+        assertEquals("1.5 XRP", value(tx, RippleDappTxFieldKey.AMOUNT))
     }
 
     @Test
@@ -35,23 +36,68 @@ class RippleDappTransactionDecoderTest {
 
         val tx = RippleDappTransactionDecoder.decode(json)
 
-        assertEquals("25 USD", value(tx, "Amount"))
-        assertEquals("rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", value(tx, "Issuer"))
+        assertEquals("25 USD", value(tx, RippleDappTxFieldKey.AMOUNT))
+        assertEquals(
+            "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            value(tx, RippleDappTxFieldKey.AMOUNT_ISSUER),
+        )
     }
 
     @Test
-    fun `decodes an OfferCreate DEX swap with TakerGets and TakerPays`() {
+    fun `decodes an OfferCreate DEX swap with distinct selling and buying issuers`() {
         val json =
             """{"TransactionType":"OfferCreate","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
-                """"TakerGets":"5000000",""" +
-                """"TakerPays":{"currency":"USD","issuer":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q","value":"10"}}"""
+                """"TakerGets":{"currency":"EUR","issuer":"rSellIssuer000000000000000000000","value":"5"},""" +
+                """"TakerPays":{"currency":"USD","issuer":"rBuyIssuer0000000000000000000000","value":"10"}}"""
 
         val tx = RippleDappTransactionDecoder.decode(json)
 
         assertEquals("OfferCreate", tx.transactionType)
-        assertEquals("5 XRP", value(tx, "Selling"))
-        assertEquals("10 USD", value(tx, "Buying"))
-        assertEquals("rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", value(tx, "Issuer"))
+        assertEquals("5 EUR", value(tx, RippleDappTxFieldKey.SELLING))
+        assertEquals(
+            "rSellIssuer000000000000000000000",
+            value(tx, RippleDappTxFieldKey.SELLING_ISSUER),
+        )
+        assertEquals("10 USD", value(tx, RippleDappTxFieldKey.BUYING))
+        assertEquals(
+            "rBuyIssuer0000000000000000000000",
+            value(tx, RippleDappTxFieldKey.BUYING_ISSUER),
+        )
+    }
+
+    @Test
+    fun `decodes the signed Fee as XRP`() {
+        val json =
+            """{"TransactionType":"Payment","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1000000","Fee":"12"}"""
+
+        val tx = RippleDappTransactionDecoder.decode(json)
+
+        // 12 drops = 0.000012 XRP
+        assertEquals("0.000012 XRP", value(tx, RippleDappTxFieldKey.FEE))
+        assertEquals(BigInteger.valueOf(12), RippleDappTransactionDecoder.feeDrops(json))
+    }
+
+    @Test
+    fun `feeDrops is null when Fee is absent or unparseable`() {
+        val noFee = """{"TransactionType":"Payment","Account":"rB5","Amount":"1000000"}"""
+        assertNull(RippleDappTransactionDecoder.feeDrops(noFee))
+        assertNull(RippleDappTransactionDecoder.feeDrops("not-json{"))
+    }
+
+    @Test
+    fun `decodes a TrustSet LimitAmount object`() {
+        val json =
+            """{"TransactionType":"TrustSet","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"LimitAmount":{"currency":"USD","issuer":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q","value":"100"}}"""
+
+        val tx = RippleDappTransactionDecoder.decode(json)
+
+        assertEquals("100 USD", value(tx, RippleDappTxFieldKey.LIMIT))
+        assertEquals(
+            "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            value(tx, RippleDappTxFieldKey.LIMIT_ISSUER),
+        )
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransactionDecoderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleDappTransactionDecoderTest.kt
@@ -1,0 +1,98 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RippleDappTransactionDecoderTest {
+
+    private fun value(tx: RippleDappTx, label: String): String? =
+        tx.fields.firstOrNull { it.label == label }?.value
+
+    @Test
+    fun `decodes a native XRP Payment with drops converted to XRP`() {
+        val json =
+            """{"TransactionType":"Payment","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1500000",""" +
+                """"DestinationTag":"12345"}"""
+
+        val tx = RippleDappTransactionDecoder.decode(json)
+
+        assertEquals("Payment", tx.transactionType)
+        assertEquals("rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY", value(tx, "From"))
+        assertEquals("rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY", value(tx, "To"))
+        assertEquals("12345", value(tx, "Destination Tag"))
+        // 1_500_000 drops = 1.5 XRP
+        assertEquals("1.5 XRP", value(tx, "Amount"))
+    }
+
+    @Test
+    fun `decodes an issued-currency amount into value plus issuer`() {
+        val json =
+            """{"TransactionType":"Payment","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY",""" +
+                """"Amount":{"currency":"USD","issuer":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q","value":"25"}}"""
+
+        val tx = RippleDappTransactionDecoder.decode(json)
+
+        assertEquals("25 USD", value(tx, "Amount"))
+        assertEquals("rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", value(tx, "Issuer"))
+    }
+
+    @Test
+    fun `decodes an OfferCreate DEX swap with TakerGets and TakerPays`() {
+        val json =
+            """{"TransactionType":"OfferCreate","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"TakerGets":"5000000",""" +
+                """"TakerPays":{"currency":"USD","issuer":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q","value":"10"}}"""
+
+        val tx = RippleDappTransactionDecoder.decode(json)
+
+        assertEquals("OfferCreate", tx.transactionType)
+        assertEquals("5 XRP", value(tx, "Selling"))
+        assertEquals("10 USD", value(tx, "Buying"))
+        assertEquals("rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", value(tx, "Issuer"))
+    }
+
+    @Test
+    fun `summarize renders an OfferCreate as gets to pays`() {
+        val json =
+            """{"TransactionType":"OfferCreate","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"TakerGets":"1000000",""" +
+                """"TakerPays":{"currency":"USD","issuer":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q","value":"2.5"}}"""
+
+        assertEquals("OfferCreate: 1 XRP → 2.5 USD", RippleDappTransactionDecoder.summarize(json))
+    }
+
+    @Test
+    fun `summarize renders a Payment with its amount`() {
+        val json =
+            """{"TransactionType":"Payment","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",""" +
+                """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1000000"}"""
+
+        assertEquals("Payment: 1 XRP", RippleDappTransactionDecoder.summarize(json))
+    }
+
+    @Test
+    fun `summarize falls back to the bare type for other transactions`() {
+        val json =
+            """{"TransactionType":"TrustSet","Account":"rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY"}"""
+
+        assertEquals("TrustSet", RippleDappTransactionDecoder.summarize(json))
+    }
+
+    @Test
+    fun `summarize returns null for undecodable JSON`() {
+        assertEquals(null, RippleDappTransactionDecoder.summarize("not-json{"))
+    }
+
+    @Test
+    fun `malformed JSON yields empty fields but keeps the raw JSON for fallback`() {
+        val raw = "definitely-not-json{"
+        val tx = RippleDappTransactionDecoder.decode(raw)
+
+        assertTrue(tx.fields.isEmpty())
+        assertEquals(raw, tx.rawJson)
+        assertEquals(null, tx.transactionType)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
@@ -15,16 +15,24 @@ class RippleHelperTest {
             """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1500000"}"""
 
     @Test
-    fun `verifyDappTransactionAccount passes when Account matches the vault address`() {
+    fun `verifyDappTransaction passes when Account matches the vault address`() {
         // Must not throw.
-        RippleHelper.verifyDappTransactionAccount(rawJson(vaultXrpAddress), vaultXrpAddress)
+        RippleHelper.verifyDappTransaction(rawJson(vaultXrpAddress), vaultXrpAddress)
     }
 
     @Test
-    fun `verifyDappTransactionAccount rejects a transaction spending a different account`() {
+    fun `verifyDappTransaction passes for every allowlisted transaction type`() {
+        listOf("Payment", "OfferCreate", "OfferCancel", "TrustSet").forEach { type ->
+            val json = """{"TransactionType":"$type","Account":"$vaultXrpAddress"}"""
+            RippleHelper.verifyDappTransaction(json, vaultXrpAddress)
+        }
+    }
+
+    @Test
+    fun `verifyDappTransaction rejects a transaction spending a different account`() {
         val ex =
             assertThrows(IllegalArgumentException::class.java) {
-                RippleHelper.verifyDappTransactionAccount(
+                RippleHelper.verifyDappTransaction(
                     rawJson("rHacKerAcCounTxxxxxxxxxxxxxxxxxxxxx"),
                     vaultXrpAddress,
                 )
@@ -33,9 +41,55 @@ class RippleHelperTest {
     }
 
     @Test
-    fun `verifyDappTransactionAccount rejects JSON with no Account field`() {
+    fun `verifyDappTransaction rejects a SetRegularKey even for the vault's own account`() {
+        // A key-rotation whose Account is our own (public) address must not slip through the guard
+        // just because the Account matches — the type is not on the allowlist.
+        val json =
+            """{"TransactionType":"SetRegularKey","Account":"$vaultXrpAddress",""" +
+                """"RegularKey":"rAttackerKeyxxxxxxxxxxxxxxxxxxxxxxx"}"""
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                RippleHelper.verifyDappTransaction(json, vaultXrpAddress)
+            }
+        assertEquals(true, ex.message?.contains("is not supported"))
+    }
+
+    @Test
+    fun `verifyDappTransaction rejects an EscrowCreate off the allowlist`() {
+        val json =
+            """{"TransactionType":"EscrowCreate","Account":"$vaultXrpAddress","Amount":"1000000"}"""
+        assertThrows(IllegalArgumentException::class.java) {
+            RippleHelper.verifyDappTransaction(json, vaultXrpAddress)
+        }
+    }
+
+    @Test
+    fun `verifyDappTransaction rejects a tampered signing-mechanics field`() {
+        val json =
+            """{"TransactionType":"Payment","Account":"$vaultXrpAddress",""" +
+                """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1500000",""" +
+                """"TxnSignature":"DEADBEEF"}"""
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                RippleHelper.verifyDappTransaction(json, vaultXrpAddress)
+            }
+        assertEquals(true, ex.message?.contains("signing-mechanics field"))
+    }
+
+    @Test
+    fun `verifyDappTransaction rejects JSON with no TransactionType`() {
         assertThrows(IllegalStateException::class.java) {
-            RippleHelper.verifyDappTransactionAccount(
+            RippleHelper.verifyDappTransaction(
+                """{"Account":"$vaultXrpAddress","Amount":"1"}""",
+                vaultXrpAddress,
+            )
+        }
+    }
+
+    @Test
+    fun `verifyDappTransaction rejects JSON with no Account field`() {
+        assertThrows(IllegalStateException::class.java) {
+            RippleHelper.verifyDappTransaction(
                 """{"TransactionType":"Payment","Amount":"1"}""",
                 vaultXrpAddress,
             )
@@ -43,9 +97,9 @@ class RippleHelperTest {
     }
 
     @Test
-    fun `verifyDappTransactionAccount rejects blank rawJson`() {
+    fun `verifyDappTransaction rejects blank rawJson`() {
         assertThrows(IllegalArgumentException::class.java) {
-            RippleHelper.verifyDappTransactionAccount("   ", vaultXrpAddress)
+            RippleHelper.verifyDappTransaction("   ", vaultXrpAddress)
         }
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/RippleHelperTest.kt
@@ -1,10 +1,63 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalStdlibApi::class)
 class RippleHelperTest {
+
+    private val vaultXrpAddress = "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY"
+
+    private fun rawJson(account: String) =
+        """{"TransactionType":"Payment","Account":"$account",""" +
+            """"Destination":"rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrsGbY","Amount":"1500000"}"""
+
+    @Test
+    fun `verifyDappTransactionAccount passes when Account matches the vault address`() {
+        // Must not throw.
+        RippleHelper.verifyDappTransactionAccount(rawJson(vaultXrpAddress), vaultXrpAddress)
+    }
+
+    @Test
+    fun `verifyDappTransactionAccount rejects a transaction spending a different account`() {
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                RippleHelper.verifyDappTransactionAccount(
+                    rawJson("rHacKerAcCounTxxxxxxxxxxxxxxxxxxxxx"),
+                    vaultXrpAddress,
+                )
+            }
+        assertEquals(true, ex.message?.contains("does not match"))
+    }
+
+    @Test
+    fun `verifyDappTransactionAccount rejects JSON with no Account field`() {
+        assertThrows(IllegalStateException::class.java) {
+            RippleHelper.verifyDappTransactionAccount(
+                """{"TransactionType":"Payment","Amount":"1"}""",
+                vaultXrpAddress,
+            )
+        }
+    }
+
+    @Test
+    fun `verifyDappTransactionAccount rejects blank rawJson`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            RippleHelper.verifyDappTransactionAccount("   ", vaultXrpAddress)
+        }
+    }
+
+    @Test
+    fun `parseRawJsonAccount extracts the Account field`() {
+        assertEquals(vaultXrpAddress, RippleHelper.parseRawJsonAccount(rawJson(vaultXrpAddress)))
+    }
+
+    @Test
+    fun `parseRawJsonAccount returns null for malformed JSON`() {
+        assertNull(RippleHelper.parseRawJsonAccount("not-json{"))
+    }
 
     /**
      * Canonical XRPL transaction ID derivation, checked against a real validated transaction


### PR DESCRIPTION
## Summary

Adds Secure Vault **co-signer** support for XRPL dApp transactions (`SignRipple`).

**Closes #5298.**

XRPL dApps hand the wallet a full transaction as JSON (an `OfferCreate` DEX swap, a cross-currency `Payment`, etc.) via the extension's GemWallet provider; the browser extension initiates the keysign and the Android peer must co-sign the **exact same bytes**.

Previously `RippleHelper` always rebuilt the transaction from `toAddress`/`toAmount`/`BlockChainSpecific.Ripple` and never read a raw-JSON field, so a relayed dApp keysign produced a non-matching signature. This carries the dApp's raw XRPL transaction to the signer verbatim and signs it deterministically.

Mirrors the already-shipped pieces on the other platforms:
- Schema — `SignRipple { raw_json }` at `sign_ripple = 46` (commondata#99, merged)
- Signing — `@vultisig/core-mpc` 1.11.0 signs `signRipple.rawJson` verbatim and fails closed (vultisig-sdk#1190)
- Initiator + confirmation UI — vultisig-windows#4340 (merged)

Follows the same passthrough pattern Android already has for Sui dApp PTBs (`SuiHelper` + `signSui`).

## What changed

**Signing (data)**
- Advance the `commondata` submodule to the `SignRipple` schema
- Add `signRipple` to the domain `KeysignPayload`
- Wire both proto mappers, including the **outbound relay** (`PayloadToProtoMapper`) so peers actually receive `signRipple`
- `RippleHelper`: when `signRipple` is present, build the `Ripple.SigningInput` via `setRawJson(...)` (only rawJson + the vault pubkey) instead of reconstructing an `OperationPayment`; the native XRP send path is untouched

**Review UI**
- `RippleDappTransactionDecoder`: pure, never-throwing decode of the raw XRPL JSON into Type / Selling / Buying / Issuer / amounts (drops → XRP) / Fee, with a raw-JSON fallback so the screen is never blank
- `SignRippleDisplayView`: decoded "Transaction summary" card, matching the extension's confirmation UI
- Verify and Done screens render the operation instead of a misleading **"0 XRP"** hero, expand the summary, and drop the empty native "To" row
- Notification banner decodes the operation (e.g. `OfferCreate: 1 XRP → 2.5 USD`) instead of "Send 0 XRP"

## Review fixes

Follow-up commits addressing reviewer feedback (@rkokhatskyi) and CodeRabbit:

**Security / correctness**
- **Fail closed on a TransactionType allowlist** — only `Payment` / `OfferCreate` / `OfferCancel` / `TrustSet` are co-signable, and signing-mechanics fields (`TxnSignature`/`Signers`/`SigningPubKey`) are rejected, mirroring the Windows `sanitizeRippleDappTx` defense. A `SetRegularKey` whose `Account` is the vault's own (public) address can no longer be co-signed into an account takeover. This also neutralizes the "EscrowCreate renders as a Payment" concern — off-allowlist types can never reach signing.
- **Fee is verified, not re-estimated** — the Verify screen now surfaces the `Fee` actually baked into the signed rawJson (drops → XRP) instead of a live `RippleFeeService` estimate, so an inflated dApp fee is visible.
- **No decoy recipient** — the wire-derived native `To` row is suppressed for `signRipple`; the decoded rawJson `Destination` (the value being signed) is authoritative.
- **Honour the wire `rippleSpecific`** — the initiator always populates it, so the proto mapper no longer discards it for an empty placeholder.
- **`Account`** is still pinned to the vault's derived XRP address (unchanged).

**i18n / UX**
- Decoded field rows now carry semantic `RippleDappTxFieldKey` identifiers (with distinct issuer keys) resolved to localized strings in Compose; `ripple_field_*` added across all 10 locales.
- The dApp summary fallback is localized (`R.string.ripple_dapp_transaction`) instead of a hardcoded English literal.
- Co-signed `OfferCreate`/`TrustSet` rows persist a decoded `dappSummary` in transaction history, so they keep their meaning after a restart instead of downgrading to a blank native-XRP row.

## Resolved: co-signer Done screen stuck "pending"

Root-caused on-device: the `tx` status response was deserialized into a Payment-shaped model whose `tx_json` fields (`Destination`, `DeliverMax`, `Flags`, …) were non-nullable. A co-signed `OfferCreate` carries `TakerGets`/`TakerPays` and no `Destination`, so the strict decoder threw `MissingFieldException` on every poll; `RippleStatusProvider` swallowed it as `Pending` — leaving the Done screen "pending" forever even though the transaction settled `tesSUCCESS` on-chain.

Fixed by making every `tx_json` field nullable/defaulted (status only reads `validated` + `meta.TransactionResult`, so the shape is display-only). Verified against a real `OfferCreate` `tx` response; status now resolves to Confirmed.

## On-chain proof

Secure Vault XRPL `OfferCreate` initiated on the extension and **co-signed from Android**, landed on mainnet:

**[`0750BAFBE1788859141021DA743B5D434B8F1D90A05D6595F7C48C6DFC1407B1`](https://xrpscan.com/tx/0750BAFBE1788859141021DA743B5D434B8F1D90A05D6595F7C48C6DFC1407B1)** — `tesSUCCESS`, validated.

A successful co-sign is itself the byte-parity proof: if Android's signing input didn't match the extension's, the DKLS session would 404 and never complete.

## Co-signer review screen

| Android verify (decoded) |
|--------------------------|
| ![verify](https://i.imgur.com/UhRJnx5.png) |

## Test plan

- [x] `./gradlew assembleDebug`
- [x] Unit tests: fail-closed guard (allowlist / `SetRegularKey`-on-own-account / `EscrowCreate` / tampered field / Account mismatch / missing / blank), rawJson parse, decoder (native drops→XRP, issued-currency + distinct issuers, OfferCreate, TrustSet LimitAmount, Fee, malformed→fallback), one-line `summarize`, and non-Payment `tx` status deserialization
- [x] E2E on device: extension-initiated XRPL dApp OfferCreate co-signed from Android → `tesSUCCESS` on mainnet (hash above), Done screen resolves to Confirmed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for XRPL dApp SignRipple flows, including an expandable verification card with decoded details and raw transaction data.
  * Added Ripple-specific transaction banners, done-screen/details views, and consent checkbox for dApp transaction verification.
  * Added transaction-history support with a decoded one-line dApp summary and improved destination display handling.
* **Bug Fixes**
  * Fixed dApp pushes/decoding so they no longer show misleading generic send information when recipient details differ.
  * Improved XRPL response handling when returned JSON omits optional fields.
* **Tests**
  * Added/expanded unit tests for decoding, summarization, account validation, and malformed/partial JSON cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->