### PR TITLE
fix(solana): re-read stake accounts via getAccountInfo to stop flipping Defi state

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -17,6 +17,8 @@ import com.vultisig.wallet.data.api.models.SolanaProgramAccountJson
 import com.vultisig.wallet.data.api.models.SolanaProgramAccountsResponseJson
 import com.vultisig.wallet.data.api.models.SolanaRpcResponseJson
 import com.vultisig.wallet.data.api.models.SolanaSignatureStatusesResult
+import com.vultisig.wallet.data.api.models.SolanaStakeAccountDataJson
+import com.vultisig.wallet.data.api.models.SolanaStakeAccountInfoResponseJson
 import com.vultisig.wallet.data.api.models.SolanaVoteAccountsResponseJson
 import com.vultisig.wallet.data.api.models.SolanaVoteAccountsResultJson
 import com.vultisig.wallet.data.api.models.SplAmountRpcResponseJson
@@ -113,9 +115,11 @@ interface SolanaApi {
     suspend fun getVoteAccounts(): SolanaVoteAccountsResultJson?
 
     /**
-     * `getProgramAccounts` against the Stake program, filtered to the stake accounts whose
-     * withdrawer authority is [ownerAddress] (`dataSize` + `memcmp`). Returns the parsed accounts,
-     * or an empty list on RPC failure. Never stale-cached — always a fresh read.
+     * The owner's stake accounts (withdrawer authority [ownerAddress]). Discovers the pubkeys with
+     * `getProgramAccounts` (`dataSize` + `memcmp`), then re-reads each account's live state with
+     * `getAccountInfo` to avoid the lagging secondary index some RPC providers serve
+     * `getProgramAccounts` from. Returns them in discovery order, or an empty list on RPC failure.
+     * Never stale-cached — always a fresh read.
      */
     suspend fun getStakeAccounts(ownerAddress: String): List<SolanaProgramAccountJson>
 }
@@ -637,7 +641,14 @@ internal class SolanaApiImp(
 
     override suspend fun getStakeAccounts(ownerAddress: String): List<SolanaProgramAccountJson> =
         try {
-            val resp =
+            // Discover the owner's stake-account pubkeys via getProgramAccounts, but take ONLY the
+            // addresses. Many RPC providers serve getProgramAccounts from a lagging secondary
+            // index,
+            // so its parsed delegation/deactivation fields flip between refreshes right after a
+            // stake/unstake (observed on the Defi screen). Each account's live state is re-read
+            // below
+            // with getAccountInfo — a direct bank read with no index lag. (vultisig-ios #4821)
+            val discovery =
                 httpClient.postRpc<SolanaProgramAccountsResponseJson>(
                     rpcEndpoint,
                     "getProgramAccounts",
@@ -663,12 +674,51 @@ internal class SolanaApiImp(
                             }
                         },
                 )
-            resp.error?.let { Timber.tag("SolanaApiImp").w("getProgramAccounts RPC error: %s", it) }
-            resp.result
+            discovery.error?.let {
+                Timber.tag("SolanaApiImp").w("getProgramAccounts RPC error: %s", it)
+            }
+            val pubkeys = discovery.result.map { it.pubkey }
+            val byPubkey =
+                coroutineScope {
+                        pubkeys
+                            .map { pubkey -> async { pubkey to getStakeAccountInfo(pubkey) } }
+                            .awaitAll()
+                    }
+                    .toMap()
+            // Preserve discovery order; drop any that stopped resolving (e.g. closed between
+            // discovery and the follow-up read).
+            pubkeys.mapNotNull { pubkey ->
+                byPubkey[pubkey]?.let { SolanaProgramAccountJson(pubkey = pubkey, account = it) }
+            }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Timber.tag("SolanaApiImp").e(e, "Error getting stake accounts for %s", ownerAddress)
             emptyList()
+        }
+
+    /**
+     * Live state of a single stake account via getAccountInfo (jsonParsed). Null on RPC failure.
+     */
+    private suspend fun getStakeAccountInfo(pubkey: String): SolanaStakeAccountDataJson? =
+        try {
+            val response =
+                httpClient.postRpc<SolanaStakeAccountInfoResponseJson>(
+                    url = rpcEndpoint,
+                    method = "getAccountInfo",
+                    params =
+                        buildJsonArray {
+                            add(pubkey)
+                            addJsonObject { put("encoding", "jsonParsed") }
+                        },
+                )
+            response.error?.let {
+                Timber.tag("SolanaApiImp").w("getAccountInfo RPC error for %s: %s", pubkey, it)
+            }
+            response.result?.value
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Timber.tag("SolanaApiImp").e(e, "Error reading stake account %s", pubkey)
+            null
         }
 
     companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SolanaJson.kt
@@ -140,6 +140,19 @@ data class SolanaProgramAccountJson(
     @SerialName("account") val account: SolanaStakeAccountDataJson,
 )
 
+// getAccountInfo (jsonParsed) for a single stake account. Its `value` is the same shape as the
+// `account` field of a getProgramAccounts row, so it reuses SolanaStakeAccountDataJson.
+@Serializable
+data class SolanaStakeAccountInfoResponseJson(
+    @SerialName("error") val error: JsonObject? = null,
+    @SerialName("result") val result: SolanaStakeAccountInfoResultJson? = null,
+)
+
+@Serializable
+data class SolanaStakeAccountInfoResultJson(
+    @SerialName("value") val value: SolanaStakeAccountDataJson? = null
+)
+
 @Serializable
 data class SolanaStakeAccountDataJson(
     @SerialName("lamports") @Contextual val lamports: BigInteger,


### PR DESCRIPTION
## Summary
- Port of [vultisig-ios #4821](https://github.com/vultisig/vultisig-ios/pull/4821).
- The Solana Defi staked list fetched stake accounts with a single `getProgramAccounts` (jsonParsed) call and bound its parsed state straight to the UI. Many RPC providers serve `getProgramAccounts` from a **lagging secondary index**, so its `delegation`/`deactivationEpoch` fields flip between refreshes right after a stake/unstake — the staked list showed unstable/stale state.
- `SolanaApi.getStakeAccounts` now uses `getProgramAccounts` only to **discover** the owner's stake-account pubkeys, then re-reads each account's **live** state via `getAccountInfo` — a direct bank read with no index lag. Reads run concurrently and results are returned in **discovery order**; accounts that stop resolving (e.g. closed between discovery and the follow-up read) are dropped.
- Downstream `SolanaStakingService`/UI is unchanged — the fresh reads are re-wrapped as `SolanaProgramAccountJson`.

## Notes
- Cost goes 1 → 1 + N requests (N = stake accounts held); the re-reads run in parallel. Fine for the handful a vault typically holds.

## Test Plan
- [ ] Open the Solana Defi screen with an active stake account; refresh repeatedly — state (active/deactivating/inactive) stays stable
- [ ] Stake, then verify the new account appears with correct state
- [ ] Deactivate, then verify the row reflects deactivating/cooldown across refreshes
- [ ] Vault with no stake accounts returns an empty list (no error)
- [ ] Lint passes (`./gradlew lint`)
- [ ] Debug build succeeds (`./gradlew assembleDebug`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana stake account retrieval by checking each account’s latest live state.
  * Excluded stake accounts that are no longer available during retrieval.
  * Preserved the order in which stake accounts are discovered.
  * Improved handling of Solana RPC errors and interrupted requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->