### PR TITLE
fix(thorchain): Unbond confirmation label + formatted From/To

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -84,6 +84,8 @@ import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorRow
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
+import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.governance.GovernanceUiState
 import com.vultisig.wallet.ui.models.governance.ProposalStatus
 import com.vultisig.wallet.ui.models.governance.ProposalUi
@@ -117,6 +119,7 @@ import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsConten
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingPositionSkeleton
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
+import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
 import com.vultisig.wallet.ui.screens.keygen.SelectVaultTypeScreenPreview
@@ -288,6 +291,8 @@ class PreviewActivity : ComponentActivity() {
                     "qbtc_unknown_address_after" -> QbtcUnknownAddressAfterPreview()
                     "chain_selection" -> ChainSelectionClipPreview()
                     "verify_send_empty_memo" -> VerifySendEmptyMemoPreview()
+                    "unbond_verify_before" -> UnbondVerifyPreview(after = false)
+                    "unbond_verify_after" -> UnbondVerifyPreview(after = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -1212,6 +1217,39 @@ private fun BlockaidHeroVerifySendPreview() {
         onConfirmScanning = {},
         onDismissScanning = {},
         hasToolbar = true,
+    )
+}
+
+/**
+ * THORChain Unbond "Function overview" confirmation (#5301). [after] = false reproduces the
+ * reported bug: the generic "You're sending" header and raw `thor1…` From/To. [after] = true is the
+ * fix — "Unbonding" header and From/To formatted as "VaultName (address)" (the destination is the
+ * vault's own self-operated node, so it resolves to the vault name). Data mirrors the issue
+ * screenshot.
+ */
+@Composable
+private fun UnbondVerifyPreview(after: Boolean) {
+    val nodeAddress = "thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t"
+    val tx =
+        DepositTransactionUiModel(
+            token = ValuedToken(token = Coins.ThorChain.RUNE, value = "0", fiatValue = "$0.00"),
+            networkFeeTokenValue = "0.02 RUNE",
+            networkFeeFiatValue = "$0.00843",
+            srcAddress = nodeAddress,
+            dstAddress = nodeAddress,
+            srcVaultName = if (after) "Main Vault" else null,
+            dstVaultName = if (after) "Main Vault" else null,
+            memo = "UNBOND:$nodeAddress:75000000",
+            titleRes =
+                if (after) R.string.verify_deposit_unbonding else R.string.verify_deposit_sending,
+        )
+    VerifyDepositScreen(
+        state = VerifyDepositUiModel(depositTransactionUiModel = tx, isLoading = false),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -117,7 +117,7 @@ constructor(
                         nodeAddress = transaction.nodeAddress,
                         pairedAddress = transaction.pairedAddress,
                         pool = transaction.pool,
-                        titleRes = depositVerifyTitleRes(transaction.operation, transaction.memo),
+                        titleRes = depositVerifyTitleRes(transaction.operation),
                     )
 
                 state.update {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -127,7 +127,7 @@ constructor(
                 val depositTransactionUiModel =
                     mapTransactionToUiModel(transaction)
                         .withVaultLabels(
-                            vaultId = vaultId!!,
+                            vaultId = transaction.vaultId,
                             chain = transaction.srcToken.chain,
                             dstAddress = transaction.dstAddress,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -1,24 +1,32 @@
 package com.vultisig.wallet.ui.models.deposit
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import com.vultisig.wallet.ui.models.mappers.depositVerifyTitleRes
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SendDst
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.resolveDstVaultName
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -45,6 +53,7 @@ internal data class DepositTransactionUiModel(
     val pairedAddress: String = "",
     val pool: String = "",
     val validatorName: String = "",
+    @StringRes val titleRes: Int = R.string.verify_deposit_sending,
 )
 
 internal data class VerifyDepositUiModel(
@@ -70,6 +79,10 @@ constructor(
     private val depositTransactionRepository: DepositTransactionRepository,
     private val balanceRepository: BalanceRepository,
     private val vaultPasswordRepository: VaultPasswordRepository,
+    private val vaultRepository: VaultRepository,
+    private val addressBookRepository: AddressBookRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val launchKeysign: LaunchKeysignUseCase,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
 ) : ViewModel() {
@@ -104,13 +117,20 @@ constructor(
                         nodeAddress = transaction.nodeAddress,
                         pairedAddress = transaction.pairedAddress,
                         pool = transaction.pool,
+                        titleRes = depositVerifyTitleRes(transaction.operation, transaction.memo),
                     )
 
                 state.update {
                     it.copy(isLoading = true, depositTransactionUiModel = initialTransaction)
                 }
 
-                val depositTransactionUiModel = mapTransactionToUiModel(transaction)
+                val depositTransactionUiModel =
+                    mapTransactionToUiModel(transaction)
+                        .withVaultLabels(
+                            vaultId = vaultId!!,
+                            chain = transaction.srcToken.chain,
+                            dstAddress = transaction.dstAddress,
+                        )
                 state.update { it.copy(depositTransactionUiModel = depositTransactionUiModel) }
 
                 // Keep isLoading true (Sign button disabled) until the balance lookup resolves, so
@@ -133,6 +153,43 @@ constructor(
 
         loadFastSign()
         loadPassword()
+    }
+
+    /**
+     * Resolves the From/To labels so the confirmation renders "VaultName (address)" instead of a
+     * raw `thor1…` string, matching the Send verify screen (issue #5301). From is the signing
+     * vault; To resolves to a locally-stored vault when the destination is one (e.g. a
+     * self-operated node), else an address-book title, else the raw address.
+     */
+    private suspend fun DepositTransactionUiModel.withVaultLabels(
+        vaultId: String,
+        chain: Chain,
+        dstAddress: String,
+    ): DepositTransactionUiModel {
+        val allVaults = withContext(ioDispatcher) { vaultRepository.getAll() }
+        val srcVaultName = allVaults.find { it.id == vaultId }?.name
+        val dstVaultName =
+            dstAddress
+                .takeIf { it.isNotEmpty() }
+                ?.let {
+                    resolveDstVaultName(
+                        allVaults = allVaults,
+                        chain = chain,
+                        dstAddress = it,
+                        chainAccountAddressRepository = chainAccountAddressRepository,
+                        dispatcher = ioDispatcher,
+                    )
+                }
+        val dstAddressBookTitle =
+            if (dstVaultName == null && dstAddress.isNotEmpty()) {
+                addressBookRepository.getEntry(chain.id, dstAddress)?.title
+            } else null
+
+        return copy(
+            srcVaultName = srcVaultName,
+            dstVaultName = dstVaultName,
+            dstAddressBookTitle = dstAddressBookTitle,
+        )
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
@@ -8,6 +8,8 @@ import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.repositories.AddressBookRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
@@ -15,6 +17,7 @@ import com.vultisig.wallet.data.usecases.ThorchainMemoParser
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import com.vultisig.wallet.ui.utils.resolveDstVaultName
 import java.math.BigInteger
 import java.util.UUID
 import javax.inject.Inject
@@ -34,6 +37,8 @@ constructor(
     private val mapDepositTransactionToUiModel: DepositTransactionToUiModelMapper,
     private val mapDepositTransactionHistoryData: DepositTransactionHistoryDataMapper,
     private val thorchainMemoParser: ThorchainMemoParser,
+    private val addressBookRepository: AddressBookRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val feeResolver: JoinKeysignFeeResolver,
 ) {
 
@@ -120,7 +125,34 @@ constructor(
                 thorAddress = parsedThorMemo?.thorAddress.orEmpty(),
                 pool = parsedThorMemo?.pool.orEmpty(),
             )
-        val depositTransactionUiModel = mapDepositTransactionToUiModel(depositTransaction)
+        // Resolve the same From/To labels the initiator renders (issue #5301), so the joining
+        // co-signer sees "VaultName (address)" instead of raw thor1… addresses. Mirrors
+        // JoinSendUiModelBuilder's Send-side label resolution.
+        val allVaults = withContext(Dispatchers.IO) { vaultRepository.getAll() }
+        val srcVaultName = vault.name
+        val dstVaultName =
+            payload.toAddress
+                .takeIf { it.isNotEmpty() }
+                ?.let {
+                    resolveDstVaultName(
+                        allVaults = allVaults,
+                        chain = chain,
+                        dstAddress = it,
+                        chainAccountAddressRepository = chainAccountAddressRepository,
+                    )
+                }
+        val dstAddressBookTitle =
+            if (dstVaultName == null && payload.toAddress.isNotEmpty()) {
+                addressBookRepository.getEntry(chain.id, payload.toAddress)?.title
+            } else null
+
+        val depositTransactionUiModel =
+            mapDepositTransactionToUiModel(depositTransaction)
+                .copy(
+                    srcVaultName = srcVaultName,
+                    dstVaultName = dstVaultName,
+                    dstAddressBookTitle = dstAddressBookTitle,
+                )
         return JoinKeysignVerifyResult(
             verifyUiModel = VerifyUiModel.Deposit(VerifyDepositUiModel(depositTransactionUiModel)),
             transactionTypeUiModel = TransactionTypeUiModel.Deposit(depositTransactionUiModel),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
@@ -1,7 +1,10 @@
 package com.vultisig.wallet.ui.models.mappers
 
+import androidx.annotation.StringRes
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_UNBOND
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
@@ -11,6 +14,19 @@ import kotlinx.coroutines.flow.first
 
 internal interface DepositTransactionToUiModelMapper :
     SuspendMapperFunc<DepositTransaction, DepositTransactionUiModel>
+
+/**
+ * Resolves the "Function overview" header for a deposit: an Unbond reads "Unbonding" rather than
+ * the generic "You're sending", since it isn't a send (issue #5301). The send-side node-management
+ * flow leaves [operation] blank, so the Unbond memo prefix is honored as a fallback signal.
+ */
+@StringRes
+internal fun depositVerifyTitleRes(operation: String, memo: String): Int =
+    if (operation == OPERATION_UNBOND || memo.trimStart().startsWith("UNBOND", ignoreCase = true)) {
+        R.string.verify_deposit_unbonding
+    } else {
+        R.string.verify_deposit_sending
+    }
 
 internal class DepositTransactionUiModelMapperImpl
 @Inject
@@ -54,6 +70,7 @@ constructor(
             pairedAddress = from.pairedAddress,
             pool = from.pool,
             validatorName = from.validatorName.orEmpty(),
+            titleRes = depositVerifyTitleRes(from.operation, from.memo),
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
@@ -17,12 +17,14 @@ internal interface DepositTransactionToUiModelMapper :
 
 /**
  * Resolves the "Function overview" header for a deposit: an Unbond reads "Unbonding" rather than
- * the generic "You're sending", since it isn't a send (issue #5301). The send-side node-management
- * flow leaves [operation] blank, so the Unbond memo prefix is honored as a fallback signal.
+ * the generic "You're sending", since it isn't a send (issue #5301). Keyed off the structured
+ * [operation] alone — never the raw memo — so a Custom deposit whose free-text memo happens to
+ * start with "unbond" is not mislabeled. Every unbond producer sets the operation: the two
+ * UnbondStrategy paths on the initiator, and the joiner via ThorchainMemoParser.
  */
 @StringRes
-internal fun depositVerifyTitleRes(operation: String, memo: String): Int =
-    if (operation == OPERATION_UNBOND || memo.trimStart().startsWith("UNBOND", ignoreCase = true)) {
+internal fun depositVerifyTitleRes(operation: String): Int =
+    if (operation == OPERATION_UNBOND) {
         R.string.verify_deposit_unbonding
     } else {
         R.string.verify_deposit_sending
@@ -70,7 +72,7 @@ constructor(
             pairedAddress = from.pairedAddress,
             pool = from.pool,
             validatorName = from.validatorName.orEmpty(),
-            titleRes = depositVerifyTitleRes(from.operation, from.memo),
+            titleRes = depositVerifyTitleRes(from.operation),
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnbondStrategy.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.DepositMemo
 import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_UNBOND
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
@@ -155,6 +156,7 @@ internal class UnbondStrategy(
                                     .fiatFeesFor(gasFee, selectedToken)
                                     .formattedFiatValue,
                             blockChainSpecific = specific.blockChainSpecific,
+                            operation = OPERATION_UNBOND,
                         )
 
                     depositTransactionRepository.addTransaction(depositTx)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -141,7 +141,7 @@ internal fun VerifyDepositScreen(
                             .padding(all = 24.dp)
                 ) {
                     Text(
-                        text = stringResource(R.string.verify_deposit_sending),
+                        text = stringResource(tx.titleRes),
                         style = Theme.brockmann.headings.subtitle,
                         color = Theme.v2.colors.text.secondary,
                     )
@@ -173,7 +173,8 @@ internal fun VerifyDepositScreen(
                         ?.let {
                             VerifyCardDetails(
                                 title = stringResource(R.string.verify_transaction_from_title),
-                                subtitle = tx.srcAddress,
+                                subtitle = tx.srcVaultName ?: tx.srcAddress,
+                                bracketValue = tx.srcVaultName?.let { tx.srcAddress },
                             )
 
                             VerifyCardDivider(0.dp)
@@ -187,9 +188,11 @@ internal fun VerifyDepositScreen(
                         VerifyCardDivider(0.dp)
                     }
                     if (tx.dstAddress.isNotEmpty()) {
+                        val toDstLabel = tx.dstVaultName ?: tx.dstAddressBookTitle
                         VerifyCardDetails(
                             title = stringResource(R.string.verify_transaction_to_title),
-                            subtitle = tx.dstAddress,
+                            subtitle = toDstLabel ?: tx.dstAddress,
+                            bracketValue = toDstLabel?.let { tx.dstAddress },
                         )
                         VerifyCardDivider(0.dp)
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -200,7 +200,11 @@ internal fun VerifyDepositScreen(
                         VerifyCardDetails(title = stringResource(R.string.pool), subtitle = tx.pool)
                         VerifyCardDivider(0.dp)
                     }
-                    if (tx.nodeAddress.isNotEmpty()) {
+                    // Unbond sets dstAddress and nodeAddress to the same node address, so it
+                    // already
+                    // renders as the "To" row above; only show the Node address row when it adds a
+                    // distinct value (issue #5301).
+                    if (tx.nodeAddress.isNotEmpty() && tx.nodeAddress != tx.dstAddress) {
                         VerifyCardDetails(
                             title = stringResource(R.string.node_address),
                             subtitle = tx.nodeAddress,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -498,6 +498,7 @@
     <string name="slippage_hint">Slippage-Prozentsatz</string>
     <string name="verify_deposit_function_overview">Funktionsübersicht</string>
     <string name="verify_deposit_sending">Sie senden</string>
+    <string name="verify_deposit_unbonding">Entbinden</string>
     <string name="verify_deposit_network">Netzwerk</string>
     <string name="referral_invite_sheet_description">Teilen Sie Ihren einzigartigen Empfehlungscode, um Freunde einzuladen. Sie erhalten einen Rabatt und je mehr sie handeln, desto mehr verdienen Sie – direkt in Ihren Tresor geliefert.</string>
     <string name="referral_create_referral">Empfehlung erstellen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -498,6 +498,7 @@
     <string name="slippage_hint">Porcentaje de deslizamiento</string>
     <string name="verify_deposit_function_overview">Descripción general de funciones</string>
     <string name="verify_deposit_sending">Estás enviando</string>
+    <string name="verify_deposit_unbonding">Desvinculando</string>
     <string name="verify_deposit_network">Red</string>
     <string name="referral_invite_sheet_description">Comparte tu código de referido único para invitar a tus amigos. Ellos obtienen un descuento y cuanto más operen, más ganarás tú, directamente en tu bóveda.</string>
     <string name="referral_create_referral">Crear referencia</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -499,6 +499,7 @@
     <string name="slippage_hint">Postotak proklizavanja</string>
     <string name="verify_deposit_function_overview">Pregled funkcija</string>
     <string name="verify_deposit_sending">Šaljete</string>
+    <string name="verify_deposit_unbonding">Odvezivanje</string>
     <string name="verify_deposit_network">Mreža</string>
     <string name="referral_invite_sheet_description">Podijeli svoj jedinstveni kod preporuke i pozovi prijatelje. Oni dobivaju popust, a što više trguju, više zarađuješ – direktno dostavljeno u tvoj trezor.</string>
     <string name="referral_create_referral">Kreiraj preporuku</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -498,6 +498,7 @@
     <string name="slippage_hint">Percentuale di slippage</string>
     <string name="verify_deposit_function_overview">Panoramica delle funzioni</string>
     <string name="verify_deposit_sending">Stai inviando</string>
+    <string name="verify_deposit_unbonding">Svincolando</string>
     <string name="verify_deposit_network">Rete</string>
     <string name="referral_invite_sheet_description">Condividi il tuo codice di riferimento unico per invitare i tuoi amici. Loro riceveranno uno sconto e più operano, più guadagni tu, direttamente nel tuo deposito.</string>
     <string name="referral_create_referral">Crea referral</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -756,6 +756,7 @@
 
     <string name="verify_deposit_function_overview">함수 개요</string>
     <string name="verify_deposit_sending">보내는 중</string>
+    <string name="verify_deposit_unbonding">언본딩</string>
     <string name="verify_deposit_network">네트워크</string>
 
     <string name="referral_invite_sheet_description">고유한 추천 코드를 공유하여 친구를 초대하세요. 친구는 할인을 받고 거래할수록 더 많은 보상을 받습니다 — 볼트로 직접 전달됩니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -495,6 +495,7 @@
     <string name="slippage_hint">Slippage percentage</string>
     <string name="verify_deposit_function_overview">Functieoverzicht</string>
     <string name="verify_deposit_sending">Je verstuurt</string>
+    <string name="verify_deposit_unbonding">Ontbinden</string>
     <string name="verify_deposit_network">Netwerk</string>
     <string name="referral_invite_sheet_description">Deel je unieke verwijzingscode om vrienden uit te nodigen. Zij krijgen een korting en hoe meer ze handelen, hoe meer jij verdient - direct geleverd in je kluis.</string>
     <string name="referral_create_referral">Verwijzing maken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -496,6 +496,7 @@
     <string name="slippage_hint">Percentagem de slippage</string>
     <string name="verify_deposit_function_overview">Visão geral da função</string>
     <string name="verify_deposit_sending">Você está a enviar</string>
+    <string name="verify_deposit_unbonding">A desvincular</string>
     <string name="verify_deposit_network">Rede</string>
     <string name="referral_invite_sheet_description">Compartilhe seu código de referência exclusivo para convidar amigos. Eles recebem um desconto e, quanto mais eles negociarem, mais você ganha — entregue diretamente para o seu cofre.</string>
     <string name="referral_create_referral">Criar indicação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -497,6 +497,7 @@
     <string name="slippage_hint">Процент проскальзывания</string>
     <string name="verify_deposit_function_overview">Обзор функций</string>
     <string name="verify_deposit_sending">Вы отправляете</string>
+    <string name="verify_deposit_unbonding">Отвязка</string>
     <string name="verify_deposit_network">Сеть</string>
     <string name="referral_invite_sheet_description">Поделитесь своим уникальным реферальным кодом, чтобы пригласить друзей. Они получат скидку, а чем больше они торгуют, тем больше вы зарабатываете — напрямую в вашем хранилище.</string>
     <string name="referral_create_referral">Создать реферала</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -742,6 +742,7 @@
     <!-- Verify Deposit -->
     <string name="verify_deposit_function_overview">功能概览</string>
     <string name="verify_deposit_sending">您正在发送</string>
+    <string name="verify_deposit_unbonding">解绑中</string>
     <string name="verify_deposit_network">网络</string>
 
     <!-- Referral -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -764,6 +764,7 @@
 
     <string name="verify_deposit_function_overview">Function overview</string>
     <string name="verify_deposit_sending">You\'re sending</string>
+    <string name="verify_deposit_unbonding">Unbonding</string>
     <string name="verify_deposit_network">Network</string>
 
     <string name="referral_invite_sheet_description">Share your unique referral code to invite friends. They get a discount and the more they trade, the more you earn — directly delivered to your vault</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
@@ -8,9 +8,12 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.data.utils.NetworkErrorKind
 import com.vultisig.wallet.data.utils.NetworkException
@@ -62,6 +65,9 @@ internal class VerifyDepositViewModelTest {
     private lateinit var depositTransactionRepository: DepositTransactionRepository
     private lateinit var balanceRepository: BalanceRepository
     private lateinit var vaultPasswordRepository: VaultPasswordRepository
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var addressBookRepository: AddressBookRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var launchKeysign: LaunchKeysignUseCase
     private lateinit var isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase
 
@@ -76,6 +82,9 @@ internal class VerifyDepositViewModelTest {
         depositTransactionRepository = mockk(relaxed = true)
         balanceRepository = mockk(relaxed = true)
         vaultPasswordRepository = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        addressBookRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
         launchKeysign = mockk(relaxed = true)
         isVaultHasFastSignById = mockk(relaxed = true)
         // A relaxed mock can't synthesize the non-null DepositTransactionUiModel for this
@@ -99,6 +108,10 @@ internal class VerifyDepositViewModelTest {
             depositTransactionRepository = depositTransactionRepository,
             balanceRepository = balanceRepository,
             vaultPasswordRepository = vaultPasswordRepository,
+            vaultRepository = vaultRepository,
+            addressBookRepository = addressBookRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            ioDispatcher = testDispatcher,
             launchKeysign = launchKeysign,
             isVaultHasFastSignById = isVaultHasFastSignById,
         )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
@@ -4,10 +4,12 @@ package com.vultisig.wallet.ui.models.deposit
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -24,6 +26,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -209,6 +212,92 @@ internal class VerifyDepositViewModelTest {
 
             coVerify(exactly = 0) { balanceRepository.getTokenValue(any(), any()) }
             coVerify { launchKeysign(any(), any(), any(), any(), any()) }
+        }
+
+    /**
+     * Stubs a non-QBTC (ThorChain) deposit so the balance gate is skipped and the From/To label
+     * resolution (#5301) is the only work `init` does. [destination] is the raw dstAddress; [coins]
+     * are the current vault's enabled coins used to resolve the destination-vault label.
+     */
+    private fun givenThorDepositWithVault(
+        destination: String,
+        vaultName: String,
+        coins: List<Coin> = emptyList(),
+    ) {
+        val coin = mockk<Coin>(relaxed = true).apply { every { chain } returns Chain.ThorChain }
+        val tx =
+            mockk<DepositTransaction>(relaxed = true).apply {
+                every { srcToken } returns coin
+                every { vaultId } returns VAULT_ID
+                every { dstAddress } returns destination
+                every { estimatedFees } returns TokenValue(BigInteger.ZERO, "RUNE", 8)
+                every { srcTokenValue } returns TokenValue(BigInteger.ZERO, "RUNE", 8)
+            }
+        coEvery { depositTransactionRepository.getTransaction(TX_ID) } returns tx
+        coEvery { vaultRepository.getAll() } returns
+            listOf(Vault(id = VAULT_ID, name = vaultName, coins = coins))
+    }
+
+    private fun thorCoin(address: String): Coin =
+        mockk<Coin>(relaxed = true).apply {
+            every { chain } returns Chain.ThorChain
+            every { this@apply.address } returns address
+        }
+
+    /** From resolves to the signing vault's name; with no destination there is no To label. */
+    @Test
+    fun `resolves the source vault name for the From label`() =
+        runTest(testDispatcher) {
+            givenThorDepositWithVault(destination = "", vaultName = "Main Vault")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            val tx = vm.state.value.depositTransactionUiModel
+
+            tx.srcVaultName shouldBe "Main Vault"
+            tx.dstVaultName.shouldBeNull()
+            tx.dstAddressBookTitle.shouldBeNull()
+        }
+
+    /**
+     * A destination owned by a local vault (a self-operated node) resolves To to that vault name.
+     */
+    @Test
+    fun `resolves a local destination vault name for the To label`() =
+        runTest(testDispatcher) {
+            val node = "thor1node0000000000000000000000000000000node"
+            givenThorDepositWithVault(
+                destination = node,
+                vaultName = "Main Vault",
+                coins = listOf(thorCoin(node)),
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            val tx = vm.state.value.depositTransactionUiModel
+
+            tx.dstVaultName shouldBe "Main Vault"
+            tx.dstAddressBookTitle.shouldBeNull()
+        }
+
+    /** When no local vault owns the destination, To falls back to an address-book title. */
+    @Test
+    fun `falls back to the address book title when no vault owns the destination`() =
+        runTest(testDispatcher) {
+            val external = "thor1external000000000000000000000000external"
+            givenThorDepositWithVault(destination = external, vaultName = "Main Vault")
+            // The pubkey-derivation fallback in resolveDstVaultName must not match either.
+            coEvery { chainAccountAddressRepository.getAddress(any<Chain>(), any()) } returns
+                ("thor1someother" to "")
+            coEvery { addressBookRepository.getEntry(Chain.ThorChain.id, external) } returns
+                AddressBookEntry(Chain.ThorChain, external, "Savings")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            val tx = vm.state.value.depositTransactionUiModel
+
+            tx.dstVaultName.shouldBeNull()
+            tx.dstAddressBookTitle shouldBe "Savings"
         }
 
     private companion object {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
@@ -91,30 +91,62 @@ internal class DepositTransactionUiModelMapperTest {
     }
 
     @Test
-    fun `title ignores an unbond-shaped memo when the operation is not Unbond`() {
-        // A Custom deposit carries a free-text memo but a blank operation. The header must key off
-        // the structured operation alone so a memo that happens to start with "unbond" is not
-        // mislabeled "Unbonding" (#5301). Every real unbond producer sets the operation.
-        depositVerifyTitleRes(operation = "") shouldBe R.string.verify_deposit_sending
-    }
-
-    @Test
     fun `title falls back to the generic sending label for non-Unbond operations`() {
         depositVerifyTitleRes(OPERATION_BOND) shouldBe R.string.verify_deposit_sending
         depositVerifyTitleRes(operation = "") shouldBe R.string.verify_deposit_sending
     }
 
-    private fun transaction(estimateFeesFiat: String): DepositTransaction =
+    @Test
+    fun `mapped titleRes reads Unbonding when the operation is Unbond`() = runTest {
+        stubMapperDeps()
+
+        val uiModel = mapper().invoke(transaction(operation = OPERATION_UNBOND))
+
+        uiModel.titleRes shouldBe R.string.verify_deposit_unbonding
+    }
+
+    @Test
+    fun `mapped titleRes ignores an unbond-shaped memo when the operation is not Unbond`() =
+        runTest {
+            stubMapperDeps()
+
+            // A Custom deposit carries a free-text memo but a blank operation. The mapper must key
+            // off the structured operation alone so a memo that happens to start with "UNBOND" is
+            // not mislabeled "Unbonding" (#5301). Every real unbond producer sets the operation.
+            val uiModel =
+                mapper().invoke(transaction(operation = "", memo = "UNBOND:thor1abc:75000000"))
+
+            uiModel.titleRes shouldBe R.string.verify_deposit_sending
+        }
+
+    private fun stubMapperDeps() {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        every { mapTokenValueToStringWithUnit(any()) } returns "0 LUNC"
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(luna, any(), AppCurrency.USD) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+    }
+
+    private fun transaction(
+        estimateFeesFiat: String = "$1.23",
+        operation: String = "",
+        memo: String = "",
+    ): DepositTransaction =
         DepositTransaction(
             id = "tx-1",
             vaultId = "vault-1",
             srcToken = luna,
             srcAddress = "terra-src",
             srcTokenValue = srcValue,
-            memo = "",
+            memo = memo,
             dstAddress = "terra-dst",
             estimatedFees = feeValue,
             estimateFeesFiat = estimateFeesFiat,
+            operation = operation,
             blockChainSpecific = mockk<BlockChainSpecific>(relaxed = true),
         )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
@@ -87,23 +87,21 @@ internal class DepositTransactionUiModelMapperTest {
 
     @Test
     fun `title reads Unbonding when the operation is Unbond`() {
-        depositVerifyTitleRes(OPERATION_UNBOND, memo = "") shouldBe
-            R.string.verify_deposit_unbonding
+        depositVerifyTitleRes(OPERATION_UNBOND) shouldBe R.string.verify_deposit_unbonding
     }
 
     @Test
-    fun `title reads Unbonding for the send-flow Unbond memo when operation is blank`() {
-        // The node-management Unbond flow leaves operation blank; the UNBOND memo prefix is the
-        // fallback signal so the header still reads "Unbonding" (#5301).
-        depositVerifyTitleRes(operation = "", memo = "UNBOND:thor1node:75000000") shouldBe
-            R.string.verify_deposit_unbonding
+    fun `title ignores an unbond-shaped memo when the operation is not Unbond`() {
+        // A Custom deposit carries a free-text memo but a blank operation. The header must key off
+        // the structured operation alone so a memo that happens to start with "unbond" is not
+        // mislabeled "Unbonding" (#5301). Every real unbond producer sets the operation.
+        depositVerifyTitleRes(operation = "") shouldBe R.string.verify_deposit_sending
     }
 
     @Test
     fun `title falls back to the generic sending label for non-Unbond operations`() {
-        depositVerifyTitleRes(OPERATION_BOND, memo = "BOND:thor1node") shouldBe
-            R.string.verify_deposit_sending
-        depositVerifyTitleRes(operation = "", memo = "") shouldBe R.string.verify_deposit_sending
+        depositVerifyTitleRes(OPERATION_BOND) shouldBe R.string.verify_deposit_sending
+        depositVerifyTitleRes(operation = "") shouldBe R.string.verify_deposit_sending
     }
 
     private fun transaction(estimateFeesFiat: String): DepositTransaction =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionUiModelMapperTest.kt
@@ -2,10 +2,13 @@
 
 package com.vultisig.wallet.ui.models.mappers
 
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.OPERATION_BOND
+import com.vultisig.wallet.data.models.OPERATION_UNBOND
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.settings.AppCurrency
@@ -80,6 +83,27 @@ internal class DepositTransactionUiModelMapperTest {
         val uiModel = mapper().invoke(transaction(estimateFeesFiat = "$1.23"))
 
         uiModel.networkFeeFiatValue shouldBe "$1.23"
+    }
+
+    @Test
+    fun `title reads Unbonding when the operation is Unbond`() {
+        depositVerifyTitleRes(OPERATION_UNBOND, memo = "") shouldBe
+            R.string.verify_deposit_unbonding
+    }
+
+    @Test
+    fun `title reads Unbonding for the send-flow Unbond memo when operation is blank`() {
+        // The node-management Unbond flow leaves operation blank; the UNBOND memo prefix is the
+        // fallback signal so the header still reads "Unbonding" (#5301).
+        depositVerifyTitleRes(operation = "", memo = "UNBOND:thor1node:75000000") shouldBe
+            R.string.verify_deposit_unbonding
+    }
+
+    @Test
+    fun `title falls back to the generic sending label for non-Unbond operations`() {
+        depositVerifyTitleRes(OPERATION_BOND, memo = "BOND:thor1node") shouldBe
+            R.string.verify_deposit_sending
+        depositVerifyTitleRes(operation = "", memo = "") shouldBe R.string.verify_deposit_sending
     }
 
     private fun transaction(estimateFeesFiat: String): DepositTransaction =


### PR DESCRIPTION
## Summary

The THORChain **Unbond** "Function overview" confirmation mislabeled the action as **"You're sending"** and rendered the **From**/**To** vault address as a raw `thor1…` string.

The node-management Unbond flow builds its `DepositTransaction` on the send side, which leaves `operation` blank — so the header can't key off `operation` alone. This resolves the title from the operation **or** the `UNBOND` memo prefix, and formats From/To as **`VaultName (address)`** the same way the Send verify screen does (the destination of a self-operated node is the vault itself, so it resolves to the vault name).

Closes #5301

## Changes

- **`DepositTransactionToUiModelMapper`** — add `depositVerifyTitleRes(operation, memo)` → `verify_deposit_unbonding` for Unbond, else the generic `verify_deposit_sending`; expose it as a new `titleRes` on the UI model.
- **`VerifyDepositViewModel`** — resolve `srcVaultName` / `dstVaultName` / `dstAddressBookTitle` via the shared `resolveDstVaultName` util (injected `VaultRepository`, `AddressBookRepository`, `ChainAccountAddressRepository`, `@IoDispatcher`).
- **`VerifyDepositScreen`** — render `tx.titleRes` and format From/To as `VaultName (address)` using `VerifyCardDetails`' `bracketValue`.
- New string `verify_deposit_unbonding` across all 10 locales.
- Unit tests for the title resolver; `PreviewActivity` before/after previews.

Non-Unbond deposits keep "You're sending" and simply gain the cleaner `VaultName (address)` From/To formatting.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/Op1UWnw.png) | ![after](https://i.imgur.com/UcohV2O.png) |

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — new title-resolver tests + updated `VerifyDepositViewModelTest` green.
- [x] Device render (before/after above) via `PreviewActivity` on emulator.
- [ ] Manual mainnet smoke: unbond from a THORChain node position and confirm the "Function overview" reads "Unbonding" with `VaultName (address)` From/To.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added THORChain unbond verification preview support for new “before” and “after” screens.
  - Deposit verification UI now uses a dynamic header title (Unbonding vs Sending) and improved source/destination labeling via vault and address-book names.
- **Bug Fixes**
  - Refined “from/to” subtitles and bracket values for clearer context.
  - The node address row now shows only when it’s relevant (non-empty and different from the destination address).
- **Localization**
  - Added `verify_deposit_unbonding` string across supported languages.
- **Tests**
  - Expanded verification view model and mapper tests to cover unbonding title selection and label resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->