### PR TITLE
fix(hyperliquid): explorer link opens broken hypurrscan /tx/ page

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt
@@ -142,7 +142,10 @@ internal class ExplorerLinkRepositoryImpl @Inject constructor() : ExplorerLinkRe
                 Chain.Cardano -> "https://cardanoscan.io/"
                 Chain.Mantle -> "https://mantlescan.xyz/"
                 Chain.Sei -> "https://seiscan.io/"
-                Chain.Hyperliquid -> "https://hypurrscan.io/"
+                // hypurrscan serves HyperEVM txs only under /evm/tx/; its bare /tx/ path errors
+                // (code=358). hyperevmscan is Etherscan-style, so /tx/ and /address/ resolve via
+                // the generic paths below with no special-casing.
+                Chain.Hyperliquid -> "https://hyperevmscan.io/"
                 Chain.Qbtc -> "" // no public explorer yet
             }
 }


### PR DESCRIPTION
## Summary

Tapping a Hyperliquid (HyperEVM) transaction opened `https://hypurrscan.io/tx/<hash>`, which errors with a Server Error / "Unexpected error (code=358)" page. hypurrscan serves HyperEVM txs only under an `/evm/tx/` prefix, so the bare `/tx/` path — produced by the generic explorer path in `ExplorerLinkRepository` — never renders.

This switches the Hyperliquid explorer base from `hypurrscan.io` to `hyperevmscan.io`, an Etherscan-style explorer whose `/tx/<hash>` and `/address/<addr>` paths resolve through the existing generic cases. That fixes **both** transaction and address links with no special-casing.

## Changes

- `ExplorerLinkRepository.kt`: `Chain.Hyperliquid` base URL → `https://hyperevmscan.io/`

## Test plan

- Transaction link: `https://hyperevmscan.io/tx/<hash>` renders the tx ✅
- Address link: `https://hyperevmscan.io/address/<addr>` renders the account ✅

Closes #5305