### PR TITLE
fix(swap): drop late quote resolved for a different amount on same pair

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -32,6 +32,8 @@ import kotlinx.datetime.Instant
 internal data class QuoteInput(
     val address: Pair<SendSrc, SendSrc>,
     val amount: BigDecimal?,
+    val slippageBps: Int?,
+    val externalRecipient: String?,
     // True when the change should bypass the typing debounce (percentage / Max / paste).
     val immediate: Boolean,
 )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -319,7 +319,13 @@ constructor(
                     updatePairSupport(src, dst)
                 }
                 .combine(amountChanges) { address, immediate ->
-                    QuoteInput(address = address, amount = srcAmount, immediate = immediate)
+                    QuoteInput(
+                        address = address,
+                        amount = srcAmount,
+                        slippageBps = slippageBps.value,
+                        externalRecipient = externalRecipient.value,
+                        immediate = immediate,
+                    )
                 }
                 // Fires on real user intent (typing, paste, percentage, token change) but not on
                 // the
@@ -342,9 +348,14 @@ constructor(
                 // the
                 // skeletons (#5296). The onEach rides each flow individually, so the silent refresh
                 // timer above doesn't flash the spinner.
-                .combine(slippageBps.onEach { startLoadingIfQuotable() }) { input, _ -> input }
-                .combine(externalRecipient.onEach { startLoadingIfQuotable() }) { input, _ ->
-                    input
+                .combine(slippageBps.onEach { startLoadingIfQuotable() }) { input, liveSlippageBps
+                    ->
+                    input.copy(slippageBps = liveSlippageBps)
+                }
+                .combine(externalRecipient.onEach { startLoadingIfQuotable() }) {
+                    input,
+                    liveExternalRecipient ->
+                    input.copy(externalRecipient = liveExternalRecipient)
                 }
                 // Percentage / Max / paste skip the debounce (0ms); free typing still coalesces at
                 // 300ms so rapid edits fire a single quote fetch.
@@ -371,8 +382,8 @@ constructor(
                                 referralCode = referralCode.value,
                                 currentDiscountInfo = uiState.value.discountInfo,
                                 selectedSrcTokenTitle = uiState.value.selectedSrcToken?.title,
-                                slippageBps = slippageBps.value,
-                                externalRecipient = externalRecipient.value,
+                                slippageBps = input.slippageBps,
+                                externalRecipient = input.externalRecipient,
                             )
                     ) {
                         SwapQuotePipelineResult.Empty -> resetQuoteState()
@@ -426,7 +437,9 @@ constructor(
                 liveAmount == null ||
                 liveAmount.compareTo(input.amount) != 0 ||
                 !inputSrc.hasSameQuoteEndpointAs(selectedSrc.value) ||
-                !inputDst.hasSameQuoteEndpointAs(selectedDst.value)
+                !inputDst.hasSameQuoteEndpointAs(selectedDst.value) ||
+                input.slippageBps != slippageBps.value ||
+                input.externalRecipient != externalRecipient.value
         if (isSuperseded) {
             discardSupersededQuoteResult()
             return

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -406,7 +406,20 @@ constructor(
         // a
         // late-landing fetch for a now non-quotable field (cleared, zeroed, or an unroutable pair)
         // drops the stale quote instead of resurrecting it (#5296 review).
-        if (!isLiveInputQuotable) {
+        //
+        // isLiveInputQuotable only asks "is something quotable now"; it can't catch a fetch that
+        // resolved for an earlier, still-positive amount on the same pair (type 5, pause past the
+        // debounce, resume to 56 before 5's fetch lands). Also require the live amount to still
+        // match the amount this fetch was resolved for, so a quote priced for the old amount can't
+        // be applied — and then signed with a mismatched memo / slippage floor — over the new one
+        // (#5310).
+        val liveAmount = srcAmount
+        if (
+            !isLiveInputQuotable ||
+                input.amount == null ||
+                liveAmount == null ||
+                liveAmount.compareTo(input.amount) != 0
+        ) {
             resetQuoteState()
             return
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -412,15 +412,23 @@ constructor(
         // debounce, resume to 56 before 5's fetch lands). Also require the live amount to still
         // match the amount this fetch was resolved for, so a quote priced for the old amount can't
         // be applied — and then signed with a mismatched memo / slippage floor — over the new one
-        // (#5310).
-        val liveAmount = srcAmount
-        if (
-            !isLiveInputQuotable ||
-                input.amount == null ||
-                liveAmount == null ||
-                liveAmount.compareTo(input.amount) != 0
-        ) {
+        // (#5310). Match the source/destination quote endpoints as well: changing to another
+        // routable pair with the same amount creates the same pre-debounce landing window.
+        if (!isLiveInputQuotable) {
             resetQuoteState()
+            return
+        }
+
+        val liveAmount = srcAmount
+        val (inputSrc, inputDst) = input.address
+        val isSuperseded =
+            input.amount == null ||
+                liveAmount == null ||
+                liveAmount.compareTo(input.amount) != 0 ||
+                !inputSrc.hasSameQuoteEndpointAs(selectedSrc.value) ||
+                !inputDst.hasSameQuoteEndpointAs(selectedDst.value)
+        if (isSuperseded) {
+            discardSupersededQuoteResult()
             return
         }
 
@@ -650,6 +658,47 @@ constructor(
     /** Clears the quote, swap fee, and quote-derived form state without surfacing an error. */
     fun resetQuoteState() {
         resetQuoteState(error = null, cause = null, tag = null)
+    }
+
+    private fun SendSrc.hasSameQuoteEndpointAs(live: SendSrc?): Boolean =
+        live != null &&
+            account.token == live.account.token &&
+            address.chain == live.address.chain &&
+            address.address == live.address.address
+
+    /**
+     * Drops quote state owned by an older request without disturbing the newer quotable request's
+     * spinner or indicative destination estimate. The newer request has already passed through
+     * [startLoadingIfQuotable] / [showIndicativeRate] and is waiting in the debounce, so a full
+     * [resetQuoteState] here would make that active request look idle until its fetch completes.
+     */
+    private fun discardSupersededQuoteResult() {
+        refreshQuoteJob?.cancel()
+        refreshQuoteJob = null
+        quoteState.reset()
+        uiState.update {
+            it.copy(
+                srcFiatValue = "0",
+                quoteDisplay =
+                    it.quoteDisplay.copy(
+                        provider = UiText.Empty,
+                        hasQuote = false,
+                        expiredAt = null,
+                    ),
+                feeBreakdown =
+                    it.feeBreakdown.copy(
+                        fee = "0",
+                        totalFee = "0",
+                        outboundFee = null,
+                        swapFeePercent = null,
+                        priceImpactPercent = null,
+                        priceImpactLevel = null,
+                    ),
+                discountInfo = DiscountInfo(),
+                isSwapDisabled = true,
+                formError = null,
+            )
+        }
     }
 
     private fun resetQuoteState(error: UiText?, cause: Throwable?, tag: String?) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -1440,11 +1440,23 @@ internal class SwapFormViewModelTest {
             // signable) over 56 (#5310).
             every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
                 listOf(SwapProvider.THORCHAIN)
-            coEvery { swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any()) } returns
-                IndicativeQuote(
-                    estimatedDstTokenValue = "newer-indicative",
-                    estimatedDstFiatValue = "$56.00",
-                )
+            // Distinct indicative per amount so the "newer-indicative" assertions actually prove
+            // 56's recompute replaced 1's estimate, rather than passing because both stubbed alike.
+            coEvery {
+                swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any())
+            } coAnswers
+                {
+                    if (arg<BigDecimal>(2).compareTo(BigDecimal.ONE) == 0)
+                        IndicativeQuote(
+                            estimatedDstTokenValue = "older-indicative",
+                            estimatedDstFiatValue = "$1.00",
+                        )
+                    else
+                        IndicativeQuote(
+                            estimatedDstTokenValue = "newer-indicative",
+                            estimatedDstFiatValue = "$56.00",
+                        )
+                }
             val firstFetchGate = CompletableDeferred<Unit>()
             coEvery {
                 swapQuoteManager.fetchBestQuote(
@@ -1512,11 +1524,23 @@ internal class SwapFormViewModelTest {
         runTest(mainDispatcher) {
             every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
                 listOf(SwapProvider.THORCHAIN)
-            coEvery { swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any()) } returns
-                IndicativeQuote(
-                    estimatedDstTokenValue = "new-pair-indicative",
-                    estimatedDstFiatValue = "$1.00",
-                )
+            // Distinct indicative per source token so "new-pair-indicative" proves the flipped pair
+            // recomputed its estimate, rather than passing because both pairs stubbed alike.
+            coEvery {
+                swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any())
+            } coAnswers
+                {
+                    if (arg<Coin>(0).id == ETH_COIN.id)
+                        IndicativeQuote(
+                            estimatedDstTokenValue = "old-pair-indicative",
+                            estimatedDstFiatValue = "$1.00",
+                        )
+                    else
+                        IndicativeQuote(
+                            estimatedDstTokenValue = "new-pair-indicative",
+                            estimatedDstFiatValue = "$1.00",
+                        )
+                }
             val firstFetchGate = CompletableDeferred<Unit>()
             var fetchCount = 0
             coEvery {
@@ -1555,6 +1579,11 @@ internal class SwapFormViewModelTest {
             assertEquals(BTC_COIN.id, vm.uiState.value.selectedSrcToken?.model?.account?.token?.id)
             assertEquals(ETH_COIN.id, vm.uiState.value.selectedDstToken?.model?.account?.token?.id)
             assertTrue(vm.uiState.value.isLoading)
+            // The flipped pair recomputed its own indicative estimate before the old fetch lands.
+            assertEquals(
+                "new-pair-indicative",
+                vm.uiState.value.quoteDisplay.estimatedDstTokenValue,
+            )
 
             val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
             val collectJob =
@@ -1575,6 +1604,123 @@ internal class SwapFormViewModelTest {
                 "new-pair-indicative",
                 vm.uiState.value.quoteDisplay.estimatedDstTokenValue,
             )
+        }
+
+    @Test
+    fun `a fetch with old slippage never applies after the tolerance changes`() =
+        runTest(mainDispatcher) {
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            val firstFetchGate = CompletableDeferred<Unit>()
+            var fetchCount = 0
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    fetchCount++
+                    if (fetchCount == 1) firstFetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+
+            // Tighten slippage while the Auto-slippage fetch is still in flight. The new tolerance
+            // is waiting in the debounce and must supersede the old memo / :LIM floor.
+            vm.setSlippageBps(100)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            firstFetchGate.complete(Unit)
+            runCurrent()
+            collectJob.cancel()
+
+            assertFalse(quoteFlags.any { it }, "quote fetched with abandoned slippage was applied")
+            assertTrue(vm.uiState.value.isLoading, "new slippage stopped loading")
+        }
+
+    @Test
+    fun `a fetch with the old recipient never applies after the recipient changes`() =
+        runTest(mainDispatcher) {
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            every { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            val firstFetchGate = CompletableDeferred<Unit>()
+            var fetchCount = 0
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    fetchCount++
+                    if (fetchCount == 1) firstFetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+
+            // Set a valid recipient while the vault-address fetch is still in flight. The new
+            // recipient is waiting in the debounce and must supersede the old routing payload.
+            vm.setExternalRecipient("bc1qnewrecipient")
+            runCurrent()
+            assertEquals("bc1qnewrecipient", pipelineRecipient?.value)
+            assertTrue(vm.uiState.value.isLoading)
+
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            firstFetchGate.complete(Unit)
+            runCurrent()
+            collectJob.cancel()
+
+            assertFalse(
+                quoteFlags.any { it },
+                "quote fetched for the abandoned recipient was applied",
+            )
+            assertTrue(vm.uiState.value.isLoading, "new recipient stopped loading")
         }
 
     // endregion

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -1440,6 +1440,11 @@ internal class SwapFormViewModelTest {
             // signable) over 56 (#5310).
             every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
                 listOf(SwapProvider.THORCHAIN)
+            coEvery { swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any()) } returns
+                IndicativeQuote(
+                    estimatedDstTokenValue = "newer-indicative",
+                    estimatedDstFiatValue = "$56.00",
+                )
             val firstFetchGate = CompletableDeferred<Unit>()
             coEvery {
                 swapQuoteManager.fetchBestQuote(
@@ -1477,6 +1482,9 @@ internal class SwapFormViewModelTest {
             vm.srcAmountState.setTextAndPlaceCursorAtEnd("56")
             Snapshot.sendApplyNotifications()
             runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+            assertTrue(vm.uiState.value.quoteDisplay.isDstEstimated)
+            assertEquals("newer-indicative", vm.uiState.value.quoteDisplay.estimatedDstTokenValue)
 
             // Land the 1-priced fetch before 56's debounce fires. Only runCurrent (not
             // advanceUntilIdle) so 56's own quote can't land and mask the check: applying the stale
@@ -1493,6 +1501,79 @@ internal class SwapFormViewModelTest {
             assertFalse(
                 quoteFlags.any { it },
                 "stale quote for the earlier amount was applied over the newer amount",
+            )
+            assertTrue(vm.uiState.value.isLoading, "newer amount stopped loading")
+            assertTrue(vm.uiState.value.quoteDisplay.isDstEstimated)
+            assertEquals("newer-indicative", vm.uiState.value.quoteDisplay.estimatedDstTokenValue)
+        }
+
+    @Test
+    fun `a fetch for the previous pair never applies after the pair changes with the same amount`() =
+        runTest(mainDispatcher) {
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery { swapQuoteManager.computeIndicativeQuote(any(), any(), any(), any()) } returns
+                IndicativeQuote(
+                    estimatedDstTokenValue = "new-pair-indicative",
+                    estimatedDstFiatValue = "$1.00",
+                )
+            val firstFetchGate = CompletableDeferred<Unit>()
+            var fetchCount = 0
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    fetchCount++
+                    if (fetchCount == 1) firstFetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+
+            // Keep the amount unchanged while moving from ETH -> BTC to BTC -> ETH. The pair change
+            // is now waiting in the debounce, so the first pair's fetch has not been cancelled yet.
+            vm.flipSelectedTokens()
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+            assertEquals(BTC_COIN.id, vm.uiState.value.selectedSrcToken?.model?.account?.token?.id)
+            assertEquals(ETH_COIN.id, vm.uiState.value.selectedDstToken?.model?.account?.token?.id)
+            assertTrue(vm.uiState.value.isLoading)
+
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            firstFetchGate.complete(Unit)
+            runCurrent()
+            collectJob.cancel()
+
+            assertFalse(
+                quoteFlags.any { it },
+                "stale quote for the previous pair was applied over the new pair",
+            )
+            assertTrue(vm.uiState.value.isLoading, "new pair stopped loading")
+            assertTrue(vm.uiState.value.quoteDisplay.isDstEstimated)
+            assertEquals(
+                "new-pair-indicative",
+                vm.uiState.value.quoteDisplay.estimatedDstTokenValue,
             )
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -1429,6 +1429,73 @@ internal class SwapFormViewModelTest {
             assertTrue(vm.uiState.value.isSwapDisabled)
         }
 
+    @Test
+    fun `a fetch that lands for an earlier amount never applies over a newer amount on the same pair`() =
+        runTest(mainDispatcher) {
+            // A fetch queued for an earlier amount (1) can resolve after the user has typed a
+            // different, still-positive amount (56) for the same pair, before 56's own debounce
+            // fires. isLiveInputQuotable alone (routable pair + positive amount) passes for 56, so
+            // applyQuoteResult must also match input.amount against the live field and drop the
+            // 1-priced quote — otherwise a quote/memo/slippage-floor computed for 1 is applied (and
+            // signable) over 56 (#5310).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            val firstFetchGate = CompletableDeferred<Unit>()
+            coEvery {
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } coAnswers
+                {
+                    // Gate only the first amount (1) so it can be made to land while 56 is still in
+                    // the debounce; any later amount resolves immediately.
+                    if (arg<BigDecimal>(8).compareTo(BigDecimal.ONE) == 0) firstFetchGate.await()
+                    createDefaultQuoteFetchResult()
+                }
+
+            val vm = createViewModelWithSwapTokens(ethBalance = BigInteger("10000000000000000000"))
+            advanceUntilIdle()
+
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("1")
+            Snapshot.sendApplyNotifications()
+            // Past the 300ms debounce: collectLatest resolves the quote for 1, parking on the gate.
+            advanceTimeBy(400)
+            runCurrent()
+            assertTrue(vm.uiState.value.isLoading)
+            assertFalse(vm.uiState.value.quoteDisplay.hasQuote)
+
+            // Change to a different, still-positive amount on the same pair. 56 is now sitting in
+            // the debounce, so the in-flight fetch for 1 is not cancelled yet.
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("56")
+            Snapshot.sendApplyNotifications()
+            runCurrent()
+
+            // Land the 1-priced fetch before 56's debounce fires. Only runCurrent (not
+            // advanceUntilIdle) so 56's own quote can't land and mask the check: applying the stale
+            // quote would be a transient hasQuote=true here.
+            val quoteFlags = mutableListOf(vm.uiState.value.quoteDisplay.hasQuote)
+            val collectJob =
+                backgroundScope.launch(mainDispatcher) {
+                    vm.uiState.collect { quoteFlags += it.quoteDisplay.hasQuote }
+                }
+            firstFetchGate.complete(Unit)
+            runCurrent()
+            collectJob.cancel()
+
+            assertFalse(
+                quoteFlags.any { it },
+                "stale quote for the earlier amount was applied over the newer amount",
+            )
+        }
+
     // endregion
 
     // region pair eligibility (#4710)


### PR DESCRIPTION
## Summary
- `applyQuoteResult`'s late-result guard only checked `isLiveInputQuotable` ("is *something* quotable now"), never whether the resolved fetch matched the amount currently in the field.
- A quote fetch queued for an earlier amount could resolve **after** the user typed a different, still-positive amount for the **same pair** (before that amount's own 300ms debounce fired), and be applied — since `collectLatest` can't cancel the in-flight fetch until the next debounced value arrives.
- Net effect: a swap could be staged (and, if tapped quickly, signed) where the on-chain transfer amount didn't match the amount the quote/memo/slippage-floor was computed for — e.g. a THORChain `:LIM:` minimum-output floor calibrated for a much smaller amount, **silently defeating slippage protection**.

## Fix
- Require the live amount to still match `input.amount` (scale-safe `compareTo`) before applying a resolved quote; drop it via `resetQuoteState()` otherwise. One extra clause on the existing choke-point guard every quote flows through.

## Issue
Closes #5310

## Test Plan
- [x] Added regression test `a fetch that lands for an earlier amount never applies over a newer amount on the same pair` — gates the amount-`1` fetch so it lands while `56` is still in the debounce, asserts the `1`-priced quote is never applied. Passes with the fix; without it the guard would flip `hasQuote` true.
- [x] Full `SwapFormViewModelTest` suite passes (`./gradlew :app:testDebugUnitTest`)
- [x] Manual: type an amount, pause >300ms, then extend it before the quote lands — verify the displayed/staged quote always matches the field

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented late or superseded swap quote results from overwriting newer UI state after amount, token pair, slippage, or external recipient changes.
  * Strengthened stale-quote detection (including endpoint changes and amount/null mismatches) and discards only outdated quote data while preserving the newest loading/indicative destination estimate.
  * Improved behavior when a resolved quote is no longer valid by clearing quote-derived details appropriately.

* **Tests**
  * Added regression coverage for delayed results after source amount changes, token pair flips, slippage updates, and external recipient updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->