### PR TITLE
fix(evm): stop persisting a failed balance read as a real 0 (#5308)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -479,7 +479,6 @@ constructor(
                 Timber.d(e, "Socket timeout during QR scan")
                 _currentState.value = JoinKeysignState.Error(JoinKeysignError.FailedConnectToServer)
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
                 Timber.d(e, "Failed to parse QR code")
                 _currentState.value = JoinKeysignState.Error(JoinKeysignError.InvalidQr)
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -261,14 +261,16 @@ class EvmApiImp(
                 return fetchBalancesPerToken(address, contractAddresses)
             }
 
-        // A partial failure — the aggregate call succeeded but an individual sub-call reports
-        // `success == false` — is a failed read for that one token, not a zero balance. Omit it
-        // from the map (rather than mapping to ZERO) so the caller keeps its cached value and never
-        // persists a fake 0 (#5308).
+        // A failed read for a single token — the sub-call reports `success == false`, or reports
+        // success but carries empty/malformed data that can't be decoded (a non-standard token, a
+        // proxy returning no data without reverting) — is not a zero balance. Omit it from the map
+        // (rather than mapping to ZERO) so the caller keeps its cached value and never persists a
+        // fake 0 (#5308). A genuine on-chain zero is a full zero word and decodes to ZERO.
         return contractAddresses
             .mapIndexedNotNull { index, contract ->
                 val r = decoded[index]
-                if (r.success) contract to Multicall3.decodeUint256Word(r.returnData) else null
+                if (!r.success) null
+                else Multicall3.decodeUint256WordOrNull(r.returnData)?.let { contract to it }
             }
             .toMap()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -28,7 +28,6 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import java.math.BigInteger
-import java.net.SocketTimeoutException
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -89,9 +88,11 @@ interface EvmApi {
      * balance (via `Multicall3.getEthBalance`); non-empty entries request `ERC20.balanceOf`.
      *
      * Returns a map keyed by each input contract address (the native "" key included) to its
-     * balance, with failed sub-calls decoded as [BigInteger.ZERO]. Falls back to per-token
+     * balance. A sub-call that fails is omitted from the map (never mapped to [BigInteger.ZERO]) so
+     * the caller keeps its cached value instead of persisting a fake 0 (#5308); a genuine on-chain
+     * zero is present with value [BigInteger.ZERO]. Falls back to per-token
      * [getERC20Balance]/[getBalance] on chains without a canonical Multicall3, for a single
-     * address, or when the multicall errors — keeping results byte-identical to the per-token path.
+     * address, or when the multicall errors.
      */
     suspend fun getBalances(
         address: String,
@@ -150,22 +151,14 @@ class EvmApiImp(
     private val chain: Chain,
 ) : EvmApi {
 
-    override suspend fun getBalance(coin: Coin): BigInteger {
-        return try {
-            if (coin.isNativeToken) getETHBalance(coin.address)
-            else getERC20Balance(coin.address, coin.contractAddress)
-        } catch (e: SocketTimeoutException) {
-            Timber.d("request time out, message: ${e.message}")
-            BigInteger.ZERO
-        } catch (e: NetworkException) {
-            Timber.d(
-                "RPC error fetching balance: status=%d message=%s",
-                e.httpStatusCode,
-                e.message,
-            )
-            BigInteger.ZERO
-        }
-    }
+    // A failed read must propagate, never collapse into ZERO: a zero is indistinguishable from a
+    // genuinely empty account and would be persisted over the last-known balance, reading as "my
+    // funds disappeared" (#5308). Letting it throw lets AccountsRepository's per-chain catch keep
+    // the cached value. A healthy node returning `0x0` for an empty account still resolves to a
+    // real zero inside the helpers below.
+    override suspend fun getBalance(coin: Coin): BigInteger =
+        if (coin.isNativeToken) getETHBalance(coin.address)
+        else getERC20Balance(coin.address, coin.contractAddress)
 
     override suspend fun getERC20Balance(address: String, contractAddress: String): BigInteger {
         val rpcResp =
@@ -183,10 +176,14 @@ class EvmApiImp(
                 },
             )
         if (rpcResp.error != null) {
-            Timber.d(
-                "get erc20 balance,contract: $contractAddress,address: $address error: ${rpcResp.error.message}"
+            // An RPC-level error (rate limiting, node error) is a failed read, not an empty
+            // balance — surface it so the balance layer keeps the cached value (#5308).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "erc20 balance rpc error, contract=$contractAddress address=$address: " +
+                        "${rpcResp.error.message}",
             )
-            return BigInteger.ZERO
         }
         return rpcResp.result?.let {
             try {
@@ -257,11 +254,14 @@ class EvmApiImp(
                 return fetchBalancesPerToken(address, contractAddresses)
             }
 
+        // A partial failure — the aggregate call succeeded but an individual sub-call reports
+        // `success == false` — is a failed read for that one token, not a zero balance. Omit it
+        // from the map (rather than mapping to ZERO) so the caller keeps its cached value and never
+        // persists a fake 0 (#5308).
         return contractAddresses
-            .mapIndexed { index, contract ->
+            .mapIndexedNotNull { index, contract ->
                 val r = decoded[index]
-                contract to
-                    if (r.success) Multicall3.decodeUint256Word(r.returnData) else BigInteger.ZERO
+                if (r.success) contract to Multicall3.decodeUint256Word(r.returnData) else null
             }
             .toMap()
     }
@@ -273,31 +273,26 @@ class EvmApiImp(
         contractAddresses
             .map { contract ->
                 async {
-                    contract to
-                        try {
+                    try {
+                        contract to
                             if (contract.isEmpty()) getETHBalance(address)
                             else getERC20Balance(address, contract)
-                        } catch (e: SocketTimeoutException) {
-                            Timber.d(
-                                "per-token balance timeout, contract=%s address=%s message=%s",
-                                contract,
-                                address,
-                                e.message,
-                            )
-                            BigInteger.ZERO
-                        } catch (e: NetworkException) {
-                            Timber.d(
-                                "per-token balance RPC error, contract=%s address=%s status=%d message=%s",
-                                contract,
-                                address,
-                                e.httpStatusCode,
-                                e.message,
-                            )
-                            BigInteger.ZERO
-                        }
+                    } catch (e: NetworkException) {
+                        // Failed read — omit the token so its cached balance is preserved rather
+                        // than overwritten with a fake 0 (#5308).
+                        Timber.d(
+                            "per-token balance failed, contract=%s address=%s status=%d message=%s",
+                            contract,
+                            address,
+                            e.httpStatusCode,
+                            e.message,
+                        )
+                        null
+                    }
                 }
             }
             .awaitAll()
+            .filterNotNull()
             .toMap()
     }
 
@@ -311,8 +306,12 @@ class EvmApiImp(
                 },
             )
         if (rpcResp.error != null) {
-            Timber.d("get balance ,address: $address error: ${rpcResp.error.message}")
-            return BigInteger.ZERO
+            // A failed read, not an empty account — propagate so the cached balance is kept
+            // (#5308).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "eth balance rpc error, address=$address: ${rpcResp.error.message}",
+            )
         }
         return rpcResp.result.convertToBigIntegerOrZero()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -185,20 +185,27 @@ class EvmApiImp(
                         "${rpcResp.error.message}",
             )
         }
-        return rpcResp.result?.let {
-            try {
-                EthereumFunction.balanceErc20Decoder(it)
-            } catch (e: Exception) {
-                Timber.d("get erc20 balance,contract: $contractAddress,address: $address error: $e")
-                BigInteger.ZERO
-            }
-        }
-            ?: run {
-                Timber.d(
-                    "get erc20 balance,contract: $contractAddress,address: $address error: response is null"
+        // A null result or a decode failure is a malformed read, not a genuine zero (a healthy node
+        // returns a 32-byte zero word for an empty balance, which decodes cleanly). Propagate so
+        // the
+        // cached balance is kept rather than overwritten with a fake 0 (#5308).
+        val result =
+            rpcResp.result
+                ?: throw NetworkException(
+                    httpStatusCode = 0,
+                    message =
+                        "erc20 balance null result, contract=$contractAddress address=$address",
                 )
-                BigInteger.ZERO
-            }
+        return try {
+            EthereumFunction.balanceErc20Decoder(result)
+        } catch (e: Exception) {
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "erc20 balance decode failed, contract=$contractAddress address=$address: " +
+                        "${e.message}",
+            )
+        }
     }
 
     override suspend fun getBalances(
@@ -313,7 +320,24 @@ class EvmApiImp(
                 message = "eth balance rpc error, address=$address: ${rpcResp.error.message}",
             )
         }
-        return rpcResp.result.convertToBigIntegerOrZero()
+        // A null/malformed result with no explicit error is still a failed read, not an empty
+        // account (a healthy node returns "0x0" for zero) — propagate so the cached balance is kept
+        // (#5308).
+        val cleaned = rpcResp.result?.removePrefix("0x")
+        if (cleaned.isNullOrEmpty()) {
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "eth balance null result, address=$address",
+            )
+        }
+        return try {
+            BigInteger(cleaned, 16)
+        } catch (e: NumberFormatException) {
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "eth balance malformed result, address=$address: ${rpcResp.result}",
+            )
+        }
     }
 
     override suspend fun getNonce(address: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
@@ -110,7 +110,10 @@ object Multicall3 {
      */
     fun decodeUint256WordOrNull(returnData: String): BigInteger? {
         val cleaned = returnData.removePrefix("0x")
-        return if (cleaned.isEmpty()) null else cleaned.toBigIntegerOrNull(16)
+        // Only a full 32-byte word is a valid uint256 result. A short/truncated word (e.g. a 4-byte
+        // "0x0000000a") is malformed data — omit it (failed read) rather than decode it to a bogus
+        // balance, matching the per-token `balanceErc20Decoder`, which rejects the same bytes.
+        return if (cleaned.length != HEX_PER_WORD) null else cleaned.toBigIntegerOrNull(16)
     }
 
     private fun encodeCall3Tuple(call: Call3): String {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.data.chains.helpers
 
-import com.vultisig.wallet.data.common.convertToBigIntegerOrZero
 import com.vultisig.wallet.data.common.remove0x
 import com.vultisig.wallet.data.models.Chain
 import java.math.BigInteger
@@ -103,8 +102,16 @@ object Multicall3 {
         }
     }
 
-    /** Decodes a single left-padded uint256 return word (e.g. a `balanceOf` result). */
-    fun decodeUint256Word(returnData: String): BigInteger = returnData.convertToBigIntegerOrZero()
+    /**
+     * Decodes a single left-padded uint256 return word (e.g. a `balanceOf` result), or null when
+     * the word is empty/malformed. A successful sub-call that carries no decodable data is a failed
+     * read, not a genuine zero (a real zero balance is a full 32-byte zero word) — returning null
+     * lets the caller omit it and keep the cached balance rather than persist a fake 0 (#5308).
+     */
+    fun decodeUint256WordOrNull(returnData: String): BigInteger? {
+        val cleaned = returnData.removePrefix("0x")
+        return if (cleaned.isEmpty()) null else cleaned.toBigIntegerOrNull(16)
+    }
 
     private fun encodeCall3Tuple(call: Call3): String {
         val data = call.callData.remove0x()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -588,8 +588,20 @@ constructor(
             finalAccount.accounts.firstOrNull { it.token.id == updatedToken.id }
                 ?: error("Account for token ${updatedToken.id} not found in mapped address")
 
+        // A live read now propagates a failed RPC read instead of a fake 0 (#5308). Isolate it here
+        // so loadAccount doesn't throw on a transient failure — fall back to the cached value, same
+        // as the batch/emitRefreshAddress paths. Otherwise the single-token callers (e.g. the swap
+        // token selector) would swallow the throw and silently drop the user's selection.
         val balance =
-            balanceRepository.getTokenBalanceAndPrice(finalAccount.address, updatedToken).first()
+            try {
+                balanceRepository
+                    .getTokenBalanceAndPrice(finalAccount.address, updatedToken)
+                    .first()
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Timber.e(e, "Failed to fetch balance for token %s, using cached", updatedToken.id)
+                balanceRepository.getCachedTokenBalanceAndPrice(finalAccount.address, updatedToken)
+            }
 
         loadPrices.await()
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -357,10 +357,26 @@ constructor(
             address.copy(
                 accounts =
                     address.accounts.map {
+                        // Isolate per-token failures: one token's failed balance read (e.g. an EVM
+                        // getBalance that now throws instead of returning a fake 0, #5308) must not
+                        // drop the whole emission and leave every sibling on this chain
+                        // unrefreshed.
+                        // On failure fall back to the cached value for just that token, matching
+                        // the
+                        // batch path's per-token isolation.
                         val balance =
-                            balanceRepository
-                                .getTokenBalanceAndPrice(tokenAddress, it.token)
-                                .first()
+                            try {
+                                balanceRepository
+                                    .getTokenBalanceAndPrice(tokenAddress, it.token)
+                                    .first()
+                            } catch (e: Exception) {
+                                if (e is kotlinx.coroutines.CancellationException) throw e
+                                Timber.e(e)
+                                balanceRepository.getCachedTokenBalanceAndPrice(
+                                    tokenAddress,
+                                    it.token,
+                                )
+                            }
 
                         it.applyBalance(balance.tokenBalance, balance.price)
                     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -608,36 +608,44 @@ constructor(
 
         val currency = appCurrencyRepository.currency.first()
 
-        return coins.associate { coin ->
-            val rawBalance = balances[coin.contractAddress] ?: BigInteger.ZERO
+        return coins
+            .mapNotNull { coin ->
+                // A missing key means the balance read failed (getBalances omits failed tokens):
+                // skip
+                // the write and the emission so the cached row is preserved rather than overwritten
+                // with a fake 0 (#5308). A genuine on-chain zero is present in the map and still
+                // persists below.
+                val rawBalance = balances[coin.contractAddress] ?: return@mapNotNull null
 
-            tokenValueDao.insertTokenValue(
-                TokenValueEntity(
-                    chain = coin.chain.id,
-                    address = address,
-                    ticker = coin.ticker,
-                    tokenValue = rawBalance.toString(),
+                tokenValueDao.insertTokenValue(
+                    TokenValueEntity(
+                        chain = coin.chain.id,
+                        address = address,
+                        ticker = coin.ticker,
+                        tokenValue = rawBalance.toString(),
+                    )
                 )
-            )
 
-            val tokenValue =
-                TokenValue(value = rawBalance, unit = coin.ticker, decimals = coin.decimal)
-            val price = tokenPriceRepository.getPrice(coin, currency).first()
+                val tokenValue =
+                    TokenValue(value = rawBalance, unit = coin.ticker, decimals = coin.decimal)
+                val price = tokenPriceRepository.getPrice(coin, currency).first()
 
-            coin.id to
-                TokenBalanceAndPrice(
-                    tokenBalance =
-                        TokenBalance(
-                            tokenValue = tokenValue,
-                            fiatValue =
-                                FiatValue(
-                                    value = tokenValue.decimal.multiply(price).scaledFor(currency),
-                                    currency = currency.ticker,
-                                ),
-                        ),
-                    price = FiatValue(value = price, currency = currency.ticker),
-                )
-        }
+                coin.id to
+                    TokenBalanceAndPrice(
+                        tokenBalance =
+                            TokenBalance(
+                                tokenValue = tokenValue,
+                                fiatValue =
+                                    FiatValue(
+                                        value =
+                                            tokenValue.decimal.multiply(price).scaledFor(currency),
+                                        currency = currency.ticker,
+                                    ),
+                            ),
+                        price = FiatValue(value = price, currency = currency.ticker),
+                    )
+            }
+            .toMap()
     }
 
     override suspend fun getMergeTokenValue(address: String, chain: Chain): List<MergeAccount> {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
@@ -3,12 +3,21 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
+/**
+ * Behavioural tests for [EvmApiImp] balance reads around the failure vs. empty-account distinction
+ * (issue #5308): a failed read must propagate / be omitted rather than collapse into a fake `0`
+ * that gets persisted over the last-known balance, while a genuine on-chain zero still resolves to
+ * zero.
+ */
 class EvmApiBalanceTest {
 
     private val nativeCoin =
@@ -24,16 +33,16 @@ class EvmApiBalanceTest {
             isNativeToken = true,
         )
 
-    // Reproduces issue #4414: HyperEVM RPC proxy returns 403 with no Content-Type. Before the fix,
-    // the raw `.body<RpcResponse>()` call threw NoTransformationFoundException out of
-    // getETHBalance,
-    // surfacing in keysign as a misleading "Invalid QR code content" error.
+    // #5308: a transport/HTTP failure (here HyperEVM's 403, cf. #4414) must surface instead of
+    // being
+    // swallowed into a zero balance, so the balance layer keeps the last-known value rather than
+    // persisting a fake $0.00 that looks like the funds disappeared.
     @Test
-    fun `getBalance returns zero when RPC returns 403`() = runBlocking {
+    fun `getBalance propagates an RPC failure instead of swallowing it into zero`() {
         val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
         val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
 
-        assertEquals(BigInteger.ZERO, api.getBalance(nativeCoin))
+        assertThrows<NetworkException> { runBlocking { api.getBalance(nativeCoin) } }
     }
 
     @Test
@@ -46,6 +55,20 @@ class EvmApiBalanceTest {
         val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
 
         assertEquals(BigInteger.valueOf(5), api.getBalance(nativeCoin))
+    }
+
+    // A genuinely empty account (healthy node returning 0x0) must still resolve to a real zero
+    // without throwing — the one legitimate zero, distinct from a failed read.
+    @Test
+    fun `getBalance returns zero for a genuine on-chain zero without throwing`() = runBlocking {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x0","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
+
+        assertEquals(BigInteger.ZERO, api.getBalance(nativeCoin))
     }
 
     @Test
@@ -66,8 +89,10 @@ class EvmApiBalanceTest {
             assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // ERC-20 via balanceOf
         }
 
+    // #5308: a Multicall3 partial failure (one sub-call reports success == false) must be OMITTED,
+    // not mapped to ZERO — so its cached balance is kept and the other tokens still resolve.
     @Test
-    fun `getBalances decodes a failed sub-call as zero without failing siblings`() = runBlocking {
+    fun `getBalances omits a failed sub-call instead of zeroing it`() = runBlocking {
         val response = aggregate3Response(listOf(false to null, true to 10L))
         val client =
             MockHttpClient.respondingWith(
@@ -78,7 +103,24 @@ class EvmApiBalanceTest {
 
         val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
 
-        assertEquals(BigInteger.ZERO, balances[""]) // failed call -> zero
+        assertNull(balances[""]) // failed sub-call -> omitted, cached value preserved
+        assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // sibling unaffected
+    }
+
+    // A genuine zero sub-call (success == true, returnData 0) stays a real zero in the map.
+    @Test
+    fun `getBalances keeps a genuine zero sub-call as zero`() = runBlocking {
+        val response = aggregate3Response(listOf(true to 0L, true to 10L))
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"$response","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
+
+        assertEquals(BigInteger.ZERO, balances[""])
         assertEquals(BigInteger.valueOf(10), balances[TOKEN])
     }
 
@@ -97,6 +139,17 @@ class EvmApiBalanceTest {
 
             assertEquals(BigInteger.valueOf(7), balances[""])
         }
+
+    // #5308: on the per-token fallback path a failed read is omitted, not zeroed.
+    @Test
+    fun `getBalances omits a failed per-token read on a chain without Multicall3`() = runBlocking {
+        val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
+        val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
+
+        val balances = api.getBalances(ADDRESS, listOf(""))
+
+        assertNull(balances[""])
+    }
 
     private companion object {
         const val ADDRESS = "0x1111111111111111111111111111111111111111"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
@@ -123,6 +123,26 @@ class EvmApiBalanceTest {
         assertEquals(BigInteger.valueOf(10), balances[TOKEN])
     }
 
+    // #5308: a sub-call that reports success == true but carries empty/undecodable data (a
+    // non-standard token, a proxy that returns nothing without reverting) is a failed read, not a
+    // zero — it must be OMITTED so its cached balance is kept, not persisted as a fake 0.
+    @Test
+    fun `getBalances omits a success sub-call with empty return data instead of zeroing it`() =
+        runTest {
+            val response = aggregate3Response(listOf(true to null, true to 10L))
+            val client =
+                MockHttpClient.respondingWith(
+                    HttpStatusCode.OK,
+                    body = """{"id":1,"result":"$response","error":null}""",
+                )
+            val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+            val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
+
+            assertNull(balances[""]) // undecodable success -> omitted, cached value preserved
+            assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // sibling unaffected
+        }
+
     @Test
     fun `getBalances falls back to per-token native fetch on a chain without Multicall3`() =
         runTest {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiBalanceTest.kt
@@ -7,10 +7,10 @@ import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 /**
  * Behavioural tests for [EvmApiImp] balance reads around the failure vs. empty-account distinction
@@ -38,15 +38,15 @@ class EvmApiBalanceTest {
     // swallowed into a zero balance, so the balance layer keeps the last-known value rather than
     // persisting a fake $0.00 that looks like the funds disappeared.
     @Test
-    fun `getBalance propagates an RPC failure instead of swallowing it into zero`() {
+    fun `getBalance propagates an RPC failure instead of swallowing it into zero`() = runTest {
         val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
         val api = EvmApiImp(client, "https://api.vultisig.com/hyperevm/", Chain.Hyperliquid)
 
-        assertThrows<NetworkException> { runBlocking { api.getBalance(nativeCoin) } }
+        assertFailsWith<NetworkException> { api.getBalance(nativeCoin) }
     }
 
     @Test
-    fun `getBalance returns parsed amount on 200`() = runBlocking {
+    fun `getBalance returns parsed amount on 200`() = runTest {
         val client =
             MockHttpClient.respondingWith(
                 HttpStatusCode.OK,
@@ -60,7 +60,7 @@ class EvmApiBalanceTest {
     // A genuinely empty account (healthy node returning 0x0) must still resolve to a real zero
     // without throwing — the one legitimate zero, distinct from a failed read.
     @Test
-    fun `getBalance returns zero for a genuine on-chain zero without throwing`() = runBlocking {
+    fun `getBalance returns zero for a genuine on-chain zero without throwing`() = runTest {
         val client =
             MockHttpClient.respondingWith(
                 HttpStatusCode.OK,
@@ -72,27 +72,26 @@ class EvmApiBalanceTest {
     }
 
     @Test
-    fun `getBalances batches native and token via one multicall on a supported chain`() =
-        runBlocking {
-            val response = aggregate3Response(listOf(true to 5L, true to 10L))
-            val client =
-                MockHttpClient.respondingWith(
-                    HttpStatusCode.OK,
-                    body = """{"id":1,"result":"$response","error":null}""",
-                )
-            // Ethereum is in the canonical Multicall3 allowlist, so this goes through aggregate3.
-            val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+    fun `getBalances batches native and token via one multicall on a supported chain`() = runTest {
+        val response = aggregate3Response(listOf(true to 5L, true to 10L))
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"$response","error":null}""",
+            )
+        // Ethereum is in the canonical Multicall3 allowlist, so this goes through aggregate3.
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
 
-            val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
+        val balances = api.getBalances(ADDRESS, listOf("", TOKEN))
 
-            assertEquals(BigInteger.valueOf(5), balances[""]) // native via getEthBalance
-            assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // ERC-20 via balanceOf
-        }
+        assertEquals(BigInteger.valueOf(5), balances[""]) // native via getEthBalance
+        assertEquals(BigInteger.valueOf(10), balances[TOKEN]) // ERC-20 via balanceOf
+    }
 
     // #5308: a Multicall3 partial failure (one sub-call reports success == false) must be OMITTED,
     // not mapped to ZERO — so its cached balance is kept and the other tokens still resolve.
     @Test
-    fun `getBalances omits a failed sub-call instead of zeroing it`() = runBlocking {
+    fun `getBalances omits a failed sub-call instead of zeroing it`() = runTest {
         val response = aggregate3Response(listOf(false to null, true to 10L))
         val client =
             MockHttpClient.respondingWith(
@@ -109,7 +108,7 @@ class EvmApiBalanceTest {
 
     // A genuine zero sub-call (success == true, returnData 0) stays a real zero in the map.
     @Test
-    fun `getBalances keeps a genuine zero sub-call as zero`() = runBlocking {
+    fun `getBalances keeps a genuine zero sub-call as zero`() = runTest {
         val response = aggregate3Response(listOf(true to 0L, true to 10L))
         val client =
             MockHttpClient.respondingWith(
@@ -126,7 +125,7 @@ class EvmApiBalanceTest {
 
     @Test
     fun `getBalances falls back to per-token native fetch on a chain without Multicall3`() =
-        runBlocking {
+        runTest {
             val client =
                 MockHttpClient.respondingWith(
                     HttpStatusCode.OK,
@@ -142,7 +141,7 @@ class EvmApiBalanceTest {
 
     // #5308: on the per-token fallback path a failed read is omitted, not zeroed.
     @Test
-    fun `getBalances omits a failed per-token read on a chain without Multicall3`() = runBlocking {
+    fun `getBalances omits a failed per-token read on a chain without Multicall3`() = runTest {
         val client = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, body = "")
         val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
@@ -52,9 +52,15 @@ class Multicall3Test {
 
         assertEquals(2, results.size)
         assertTrue(results[0].success)
-        assertEquals(BigInteger.valueOf(5), Multicall3.decodeUint256Word(results[0].returnData))
+        assertEquals(
+            BigInteger.valueOf(5),
+            Multicall3.decodeUint256WordOrNull(results[0].returnData),
+        )
         assertTrue(results[1].success)
-        assertEquals(BigInteger.valueOf(10), Multicall3.decodeUint256Word(results[1].returnData))
+        assertEquals(
+            BigInteger.valueOf(10),
+            Multicall3.decodeUint256WordOrNull(results[1].returnData),
+        )
     }
 
     @Test
@@ -72,15 +78,21 @@ class Multicall3Test {
 
         assertEquals(2, results.size)
         assertFalse(results[0].success)
-        assertEquals(BigInteger.ZERO, Multicall3.decodeUint256Word(results[0].returnData))
         assertTrue(results[1].success)
-        assertEquals(BigInteger.valueOf(10), Multicall3.decodeUint256Word(results[1].returnData))
+        assertEquals(
+            BigInteger.valueOf(10),
+            Multicall3.decodeUint256WordOrNull(results[1].returnData),
+        )
     }
 
     @Test
-    fun `decodeUint256Word treats blank data as zero`() {
-        assertEquals(BigInteger.ZERO, Multicall3.decodeUint256Word("0x"))
-        assertEquals(BigInteger.valueOf(255), Multicall3.decodeUint256Word("0x" + word(255)))
+    fun `decodeUint256WordOrNull treats blank data as a failed read, not zero`() {
+        // Empty/malformed data is an undecodable success word: null so the caller omits it and
+        // keeps the cached balance, rather than persisting a fake 0 (#5308).
+        assertNull(Multicall3.decodeUint256WordOrNull("0x"))
+        // A genuine zero balance is a full 32-byte zero word and still decodes to ZERO.
+        assertEquals(BigInteger.ZERO, Multicall3.decodeUint256WordOrNull("0x" + word(0)))
+        assertEquals(BigInteger.valueOf(255), Multicall3.decodeUint256WordOrNull("0x" + word(255)))
     }
 
     private companion object {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/Multicall3Test.kt
@@ -90,6 +90,9 @@ class Multicall3Test {
         // Empty/malformed data is an undecodable success word: null so the caller omits it and
         // keeps the cached balance, rather than persisting a fake 0 (#5308).
         assertNull(Multicall3.decodeUint256WordOrNull("0x"))
+        // A short/truncated word is malformed too — omit it rather than decode a bogus balance,
+        // matching the per-token decoder (which rejects the same bytes).
+        assertNull(Multicall3.decodeUint256WordOrNull("0x0000000a"))
         // A genuine zero balance is a full 32-byte zero word and still decodes to ZERO.
         assertEquals(BigInteger.ZERO, Multicall3.decodeUint256WordOrNull("0x" + word(0)))
         assertEquals(BigInteger.valueOf(255), Multicall3.decodeUint256WordOrNull("0x" + word(255)))


### PR DESCRIPTION
## Summary

A funded EVM account showed **`0` / `$0.00`** after a single transient network failure, and that zero was **written to Room** over the last-known balance — surviving app restarts until a *successful* refresh replaced it, reading as "my funds disappeared".

Root cause: `EvmApiImp` swallowed every transport/RPC failure into `BigInteger.ZERO`, so "read failed" and "account is empty" became the *same value*. The persistence and UI layers then faithfully stored and rendered a fake `0`. Same defect class as #5276 (XRP, fixed in #5288), which wrongly assumed the EVM path already propagated failures.

Changes:
- **`getBalance`** now propagates instead of catching into `ZERO`, so `AccountsRepository`'s existing per-chain `catch` keeps the cached value (XRP parity). Dead `SocketTimeoutException` branches removed — `HttpCallValidator` makes them unreachable.
- **`getETHBalance` / `getERC20Balance`** throw on a JSON-RPC `error` (rate limiting / node errors) rather than returning `ZERO`.
- **`getBalances`** omits a Multicall3 sub-call that reports `success == false`, and any per-token failure, instead of mapping it to `ZERO` — siblings and genuine on-chain zeros are untouched.
- **`BalanceRepository.getEvmTokenBalancesAndPrices`** skips the `insertTokenValue` write for a token missing from the map (failed read), preserving the cached row; genuine zeros still persist.

## Issue

Closes #5308

## Test Plan

- [x] `./gradlew :data:testDebugUnitTest` passes, incl. new `EvmApiBalanceTest` cases:
  - a failed read (403 / timeout) propagates instead of becoming `0`
  - a genuine on-chain `0x0` still resolves to zero
  - a Multicall3 partial sub-call failure is omitted, siblings unaffected
  - a genuine zero sub-call stays a real zero
  - a failed per-token read (no-Multicall3 chain) is omitted
- [x] Lint passes (`./gradlew :data:lintDebug`)
- [x] Debug build succeeds (`./gradlew assembleDebug`)
- [ ] On-device: funded EVM asset, kill RPC (airplane mode / black-hole RPC), pull-to-refresh → row keeps last-known balance; force-quit + reopen while offline → still shown (not `0`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Balance read failures are no longer incorrectly displayed or saved as zero.
  - Genuine zero balances remain correctly recognized and displayed.
  - Failed token reads are skipped while existing cached balances are preserved.
  - Partial Multicall results now retain successful token balances without inventing values for failed requests.
  - Invalid or incomplete balance data is handled safely.
  - QR code cancellation handling no longer incorrectly reports cancellations as invalid QR errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->