### PR TITLE
fix(keysign): recover DKLS-family signature from relay on failure (#5314)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -414,6 +414,11 @@ class DKLSKeysign(
             throw e
         } catch (e: Exception) {
             println("Failed to sign message ($messageToSign), error: ${e.localizedMessage}")
+            val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
+            keySignVerify.checkKeysignComplete(msgHash)?.let {
+                signatures[messageToSign] = it
+                return
+            }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else 3
             if (attempt < maxRetries) {
                 keysignOneMessageWithRetry(attempt + 1, messageToSign)

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -417,6 +417,13 @@ class DKLSKeysign(
             val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
             keySignVerify.checkKeysignComplete(msgHash)?.let {
                 signatures[messageToSign] = it
+                // Recovery bypasses the normal pullInboundMessages success path, so clear any
+                // "waiting for peer" state ourselves — otherwise the screen stays pinned on
+                // WaitingForPeer through broadcast.
+                if (waitingNotified) {
+                    waitingNotified = false
+                    onPeersResumed?.invoke()
+                }
                 return
             }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else 3

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
@@ -125,6 +125,13 @@ class MldsaKeysign(
             val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
             keySignVerify.checkKeysignComplete(msgHash)?.let {
                 signatures[messageToSign] = it
+                // Recovery bypasses the normal pullInboundMessages success path, so clear any
+                // "waiting for peer" state ourselves — otherwise the screen stays pinned on
+                // WaitingForPeer through broadcast.
+                if (waitingNotified) {
+                    waitingNotified = false
+                    onPeersResumed?.invoke()
+                }
                 return
             }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else MAX_PROTOCOL_RETRIES

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
@@ -122,6 +122,11 @@ class MldsaKeysign(
             throw e
         } catch (e: Exception) {
             Timber.e(e, "Failed to sign message (%s)", messageToSign)
+            val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
+            keySignVerify.checkKeysignComplete(msgHash)?.let {
+                signatures[messageToSign] = it
+                return
+            }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else MAX_PROTOCOL_RETRIES
             if (attempt < maxRetries) {
                 keysignOneMessage(attempt + 1, messageToSign)

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -417,6 +417,11 @@ class SchnorrKeysign(
             throw e
         } catch (e: Exception) {
             println("Failed to sign message ($messageToSign), error: ${e.localizedMessage}")
+            val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
+            keySignVerify.checkKeysignComplete(msgHash)?.let {
+                signatures[messageToSign] = it
+                return
+            }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else 3
             if (attempt < maxRetries) {
                 keysignOneMessageWithRetry(attempt + 1, messageToSign)

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -420,6 +420,13 @@ class SchnorrKeysign(
             val keySignVerify = KeysignVerify(mediatorURL, sessionID, sessionApi)
             keySignVerify.checkKeysignComplete(msgHash)?.let {
                 signatures[messageToSign] = it
+                // Recovery bypasses the normal pullInboundMessages success path, so clear any
+                // "waiting for peer" state ourselves — otherwise the screen stays pinned on
+                // WaitingForPeer through broadcast.
+                if (waitingNotified) {
+                    waitingNotified = false
+                    onPeersResumed?.invoke()
+                }
                 return
             }
             val maxRetries = if (heardFromEver.isEmpty()) 1 else 3

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
@@ -5,9 +5,9 @@ import com.vultisig.wallet.data.common.md5
 import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.Vault
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
 import io.mockk.mockk
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -151,13 +151,9 @@ class DklsFamilyRelayRecoveryTest {
                 encryption = mockk(relaxed = true),
             )
 
-        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+        shouldThrow<RuntimeException> { keysign.keysignWithRetry() }
 
-        assertTrue(
-            expectedMsgHash in sessionApi.completionLookups,
-            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
-                "but lookups were ${sessionApi.completionLookups}",
-        )
+        sessionApi.completionLookups shouldContain expectedMsgHash
     }
 
     @Test
@@ -176,13 +172,9 @@ class DklsFamilyRelayRecoveryTest {
                 encryption = mockk(relaxed = true),
             )
 
-        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+        shouldThrow<RuntimeException> { keysign.keysignWithRetry() }
 
-        assertTrue(
-            expectedMsgHash in sessionApi.completionLookups,
-            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
-                "but lookups were ${sessionApi.completionLookups}",
-        )
+        sessionApi.completionLookups shouldContain expectedMsgHash
     }
 
     @Test
@@ -201,12 +193,8 @@ class DklsFamilyRelayRecoveryTest {
                 encryption = mockk(relaxed = true),
             )
 
-        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+        shouldThrow<RuntimeException> { keysign.keysignWithRetry() }
 
-        assertTrue(
-            expectedMsgHash in sessionApi.completionLookups,
-            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
-                "but lookups were ${sessionApi.completionLookups}",
-        )
+        sessionApi.completionLookups shouldContain expectedMsgHash
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
@@ -1,0 +1,212 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.common.md5
+import com.vultisig.wallet.data.mediator.Message
+import com.vultisig.wallet.data.models.KeyShare
+import com.vultisig.wallet.data.models.Vault
+import io.mockk.mockk
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #5314: when a DKLS-family signing attempt fails or times out (e.g. a
+ * relay message is lost to a transport error), the device must consult the relay for an
+ * already-completed signature via `KeysignVerify.checkKeysignComplete` before giving up — mirroring
+ * the legacy GG20 fallback in `KeysignViewModel.signMessageWithRetry`. Without this fallback a
+ * device whose local session never reaches `isFinished` fails with "signatures empty" even though
+ * the peer already posted the full signature to the relay.
+ *
+ * These tests pin the *wiring*: on failure the relay IS queried, and with the correct `msgHash` key
+ * (matching each class's `markLocalPartyKeysignComplete(msgHash, …)` write) — not the raw
+ * `messageToSign`. They deliberately do not assert the recovered signature is stored, because
+ * `tss.KeysignResponse` is a JNI/native type whose static initializer loads the native `gojni`
+ * library and therefore cannot be constructed — or even mocked — on the host JVM. This is the same
+ * constraint that makes `SessionApiBodyReadTest` skip `checkKeysignComplete`, and the reason the
+ * [FakeSessionApi] below is hand-written rather than a mockk (mockk eagerly resolves the
+ * `tss.KeysignResponse` return type and crashes with UnsatisfiedLinkError).
+ */
+class DklsFamilyRelayRecoveryTest {
+
+    private val message = "abc123deadbeef"
+    private val expectedMsgHash = message.md5()
+
+    private fun vault() =
+        Vault(
+            id = "vault-id",
+            name = "test-vault",
+            pubKeyECDSA = "pub-ecdsa",
+            pubKeyEDDSA = "pub-eddsa",
+            pubKeyMLDSA = "pub-mldsa",
+            localPartyID = "deviceA",
+            keyshares = listOf(KeyShare("pub-ecdsa", "share")),
+        )
+
+    /**
+     * A [SessionApi] whose setup-message fetch always fails (simulating the failed/lost round that
+     * drops the device into its catch block) and that records every `checkKeysignComplete` lookup.
+     * The lookup itself throws ("relay has no signature yet"), so `KeysignVerify` returns null and
+     * the ceremony ultimately rethrows — without ever constructing a native `tss.KeysignResponse`.
+     */
+    private class FakeSessionApi : SessionApi {
+        val completionLookups = mutableListOf<String>()
+
+        override suspend fun getSetupMessage(
+            serverUrl: String,
+            sessionId: String,
+            messageId: String?,
+        ): String = throw RuntimeException("transport error")
+
+        override suspend fun checkKeysignComplete(
+            serverUrl: String,
+            messageId: String,
+        ): tss.KeysignResponse {
+            completionLookups += messageId
+            throw RuntimeException("not complete yet")
+        }
+
+        override suspend fun checkCommittee(serverUrl: String, sessionId: String): List<String> =
+            unexpected("checkCommittee")
+
+        override suspend fun startSession(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: List<String>,
+        ) = unexpected("startSession")
+
+        override suspend fun startWithCommittee(
+            serverUrl: String,
+            sessionId: String,
+            committee: List<String>,
+        ) = unexpected("startWithCommittee")
+
+        override suspend fun markLocalPartyComplete(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: List<String>,
+        ) = unexpected("markLocalPartyComplete")
+
+        override suspend fun getCompletedParties(
+            serverUrl: String,
+            sessionId: String,
+        ): List<String> = unexpected("getCompletedParties")
+
+        override suspend fun getParticipants(serverUrl: String, sessionId: String): List<String> =
+            unexpected("getParticipants")
+
+        override suspend fun sendTssMessage(
+            serverUrl: String,
+            messageId: String?,
+            message: Message,
+        ) = unexpected("sendTssMessage")
+
+        override suspend fun getTssMessages(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: String,
+            messageId: String?,
+        ): List<Message> = unexpected("getTssMessages")
+
+        override suspend fun deleteTssMessage(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: String,
+            msgHash: String,
+            messageId: String?,
+        ) = unexpected("deleteTssMessage")
+
+        override suspend fun markLocalPartyKeysignComplete(
+            serverUrl: String,
+            messageId: String,
+            sig: tss.KeysignResponse,
+        ) = unexpected("markLocalPartyKeysignComplete")
+
+        override suspend fun uploadSetupMessage(
+            serverUrl: String,
+            sessionId: String,
+            message: String,
+            messageId: String?,
+        ) = unexpected("uploadSetupMessage")
+
+        private fun unexpected(name: String): Nothing =
+            error("Unexpected SessionApi call in test: $name")
+    }
+
+    @Test
+    fun `DKLS queries the relay with msgHash on signing failure`() = runTest {
+        val sessionApi = FakeSessionApi()
+        val keysign =
+            DKLSKeysign(
+                keysignCommittee = listOf("deviceA", "deviceB"),
+                mediatorURL = "http://relay.example",
+                sessionID = "session-1",
+                messageToSign = listOf(message),
+                vault = vault(),
+                encryptionKeyHex = "00".repeat(32),
+                chainPath = "m/44'/60'/0'/0/0",
+                isInitiateDevice = false,
+                sessionApi = sessionApi,
+                encryption = mockk(relaxed = true),
+            )
+
+        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+
+        assertTrue(
+            expectedMsgHash in sessionApi.completionLookups,
+            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
+                "but lookups were ${sessionApi.completionLookups}",
+        )
+    }
+
+    @Test
+    fun `Schnorr queries the relay with msgHash on signing failure`() = runTest {
+        val sessionApi = FakeSessionApi()
+        val keysign =
+            SchnorrKeysign(
+                keysignCommittee = listOf("deviceA", "deviceB"),
+                mediatorURL = "http://relay.example",
+                sessionID = "session-1",
+                messageToSign = listOf(message),
+                vault = vault(),
+                encryptionKeyHex = "00".repeat(32),
+                isInitiateDevice = false,
+                sessionApi = sessionApi,
+                encryption = mockk(relaxed = true),
+            )
+
+        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+
+        assertTrue(
+            expectedMsgHash in sessionApi.completionLookups,
+            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
+                "but lookups were ${sessionApi.completionLookups}",
+        )
+    }
+
+    @Test
+    fun `MLDSA queries the relay with msgHash on signing failure`() = runTest {
+        val sessionApi = FakeSessionApi()
+        val keysign =
+            MldsaKeysign(
+                keysignCommittee = listOf("deviceA", "deviceB"),
+                mediatorURL = "http://relay.example",
+                sessionID = "session-1",
+                messageToSign = listOf(message),
+                vault = vault(),
+                encryptionKeyHex = "00".repeat(32),
+                isInitiateDevice = false,
+                sessionApi = sessionApi,
+                encryption = mockk(relaxed = true),
+            )
+
+        assertFailsWith<RuntimeException> { keysign.keysignWithRetry() }
+
+        assertTrue(
+            expectedMsgHash in sessionApi.completionLookups,
+            "expected the relay to be queried with msgHash=$expectedMsgHash, " +
+                "but lookups were ${sessionApi.completionLookups}",
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/KeysignVerify.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/KeysignVerify.kt
@@ -1,21 +1,39 @@
 package com.vultisig.wallet.data.api
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class KeysignVerify(serverAddress: String, sessionId: String, private val sessionApi: SessionApi) {
     private val serverURL = "$serverAddress/complete/$sessionId/keysign"
 
+    /**
+     * Publishes the completed signature so peers stuck behind a dropped relay message can recover
+     * it via [checkKeysignComplete]. This is a POST, so the shared Ktor client does not auto-retry
+     * it (unlike the idempotent recovery GET); a single transport blip here would strand every
+     * other peer with "signatures empty". Reposting the same [sig] under the same [messageId] is
+     * idempotent at the relay, so we retry the write ourselves before giving up.
+     */
     suspend fun markLocalPartyKeysignComplete(messageId: String, sig: tss.KeysignResponse) {
         withContext(Dispatchers.IO) {
-            try {
-                sessionApi.markLocalPartyKeysignComplete(serverURL, messageId, sig)
-                Timber.tag("KeysignVerify").d("markLocalPartyKeysignComplete")
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                Timber.tag("KeysignVerify")
-                    .d("markLocalPartyKeysignComplete error: ${e.stackTraceToString()}")
+            repeat(MAX_MARK_COMPLETE_RETRIES) { attempt ->
+                try {
+                    sessionApi.markLocalPartyKeysignComplete(serverURL, messageId, sig)
+                    Timber.tag("KeysignVerify").d("markLocalPartyKeysignComplete")
+                    return@withContext
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    Timber.tag("KeysignVerify")
+                        .d(
+                            "markLocalPartyKeysignComplete error (attempt %d): %s",
+                            attempt + 1,
+                            e.stackTraceToString(),
+                        )
+                    if (attempt < MAX_MARK_COMPLETE_RETRIES - 1) {
+                        delay(MARK_COMPLETE_BACKOFF_MS)
+                    }
+                }
             }
         }
     }
@@ -31,5 +49,10 @@ class KeysignVerify(serverAddress: String, sessionId: String, private val sessio
             }
             return@withContext null
         }
+    }
+
+    private companion object {
+        const val MAX_MARK_COMPLETE_RETRIES = 3
+        const val MARK_COMPLETE_BACKOFF_MS = 1000L
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitBtcSigner.kt
@@ -66,11 +66,44 @@ internal class SwapKitBtcSigner(
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
         val signBitcoin = decodeToSignBitcoin(psbtBytes)
+        val pubKeyBytes = derivedPublicKeyBytes()
+        val derSignatureBySighash = signatures.mapValues { it.value.derSignature }
+        verifySignatures(signBitcoin, pubKeyBytes, derSignatureBySighash)
         return compileSignedTransaction(
             signBitcoin = signBitcoin,
-            pubKeyBytes = derivedPublicKeyBytes(),
-            derSignatureBySighash = signatures.mapValues { it.value.derSignature },
+            pubKeyBytes = pubKeyBytes,
+            derSignatureBySighash = derSignatureBySighash,
         )
+    }
+
+    /**
+     * Reject any MPC signature that does not verify against the derived vault pubkey over the
+     * sighash it is keyed by — the same gate [UtxoHelper.getSignedTransaction] applies before it
+     * compiles. These signatures can arrive from the relay (a peer's completed keysign recovered on
+     * failure), so verify them cryptographically here instead of trusting the source: a mismatched
+     * signature is caught locally rather than spliced into a doomed broadcast. Kept out of the pure
+     * [compileSignedTransaction] so its serialization stays headless-testable without WalletCore.
+     */
+    private fun verifySignatures(
+        signBitcoin: SignBitcoin,
+        pubKeyBytes: ByteArray,
+        derSignatureBySighash: Map<String, String>,
+    ) {
+        val publicKey = PublicKey(pubKeyBytes, PublicKeyType.SECP256K1)
+        for (sighash in utxo.computeOurSighashes(signBitcoin)) {
+            val key = Numeric.toHexStringNoPrefix(sighash)
+            val derSignature =
+                derSignatureBySighash[key]
+                    ?: throw SwapKitBtcSignerException(
+                        "Missing signature for sighash ${key.take(16)}…"
+                    )
+            if (!publicKey.verifyAsDER(Numeric.hexStringToByteArray(derSignature), sighash)) {
+                throw SwapKitBtcSignerException(
+                    "SwapKit BTC signature for sighash ${key.take(16)}… does not verify against the " +
+                        "vault key"
+                )
+            }
+        }
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
@@ -223,7 +223,7 @@ object TonHelper {
         signatures: Map<String, KeysignResponse>,
     ): SignedTransactionResult {
         val pubKeyData = vaultHexPublicKey.hexToByteArray()
-        PublicKey(pubKeyData, PublicKeyType.ED25519)
+        val publicKey = PublicKey(pubKeyData, PublicKeyType.ED25519)
         val inputData = getPreSignedInputData(payload)
         val hashes = TransactionCompiler.preImageHashes(CoinType.TON, inputData)
         val preSigningOutput =
@@ -236,6 +236,13 @@ object TonHelper {
         val signature =
             signatures[Numeric.toHexStringNoPrefix(preSigningOutput.data.toByteArray())]
                 ?.getSignature() ?: throw Exception("Signature not found")
+
+        // Verify against the vault key before broadcast, matching every sibling EdDSA helper. The
+        // signature can arrive from the relay (DKLS-family recovery), so gate it cryptographically
+        // rather than trusting the source.
+        if (!publicKey.verify(signature, preSigningOutput.data.toByteArray())) {
+            throw Exception("Invalid signature")
+        }
 
         allSignatures.add(signature)
         publicKeys.add(pubKeyData)


### PR DESCRIPTION
## Summary

Fixes #5314.

### Transaction hash
https://explorer.zksync.io/tx/0x16e66d34ac74a01dd52f2b436958911f829618e31cad15ce3078940d7e8e9cd1

During a DKLS-family keysign, a single relay message lost to a transport error (a ktor `HttpRequestRetry` connection-reuse race → `EOFException: Channel is already closed`) can leave one device permanently stuck on the "Signing" screen while the peer completes successfully. The stuck device's local session never reaches `isFinished`, so it times out and fails with **"signatures empty"** — even though the completed 2-of-2 signature has been on the relay the whole time (the successful peer posts it via `markLocalPartyKeysignComplete`). This is especially serious when the stuck device is the one responsible for broadcasting.

The root cause: the `catch` blocks in `DKLSKeysign`, `SchnorrKeysign`, and `MldsaKeysign` only **retry or rethrow** — they never query the relay for an already-completed signature, unlike the legacy GG20 path (`KeysignViewModel.signMessageWithRetry`) which already does this correctly.

## Changes

- On a signing failure/timeout, each of the three DKLS-family keysign classes now calls `KeysignVerify.checkKeysignComplete(msgHash)` **before** retrying/rethrowing. If the relay already holds the signature, it is stored in `signatures` and the ceremony completes successfully.
- The lookup uses **`msgHash`** (not the raw `messageToSign`), matching each class's `markLocalPartyKeysignComplete(msgHash, …)` write key.
- Mirrors the existing GG20 fallback pattern; the GG20 path is left unchanged.

## Test plan

- [x] `./gradlew assembleDebug` compiles (`:app:compileDebugKotlin` green)
- [x] New regression test `DklsFamilyRelayRecoveryTest` — asserts that on a signing failure the relay **is** queried, with the correct `msgHash` key, across all three keysign classes. Without the fix `checkKeysignComplete` is never called and the test fails.

### Note on test scope

The test pins the *wiring* (the relay lookup happens with the right key) rather than asserting the recovered signature is stored, because `tss.KeysignResponse` is a JNI/native type whose static initializer loads the native `gojni` library and cannot be constructed — or even mocked — on the host JVM. This is the same constraint that makes the existing `SessionApiBodyReadTest` skip `checkKeysignComplete`. Full positive-path coverage would require an instrumented (emulator) test.

## Cross-platform note

The same structural gap exists in iOS `DKLSKeysign.swift` (catch block is retry-or-throw, no `checkKeysignComplete`). This PR covers the Android fix only; a corresponding iOS issue should be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - After a signing failure in DKLS, Schnorr, and MLDSA, the app now re-checks whether the signature was already completed remotely; if so, it saves the result and stops further retries.
  - Improved reliability when publishing “local party keysign complete” by retrying transient failures with a short backoff.
  - Swap Kit BTC transactions now verify all expected MPC signatures match the derived vault public key before compiling.
  - TON transactions now explicitly validate the signature cryptographically before compiling.
- **Tests**
  - Added a regression suite covering DKLS-family relay lookup on signing failure and confirming completion checks use the message hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->