### PR TITLE
fix(send): re-clamp Max to current balance/fee at submit (#5316)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -176,11 +176,33 @@ internal class DefaultSendStrategy(
                         )
                     }
 
-                    val tokenAmountInt =
-                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
-
                     val srcAddress = selectedToken.address
                     val isMaxAmount = tokenAmount.compareTo(amountManager.currentMaxAmount) == 0
+
+                    // "Max" is a one-shot snapshot: it captures the balance and gas fee at tap
+                    // time and never re-clamps if either moves before submit (a cached balance
+                    // correcting downward after network hydration, or EVM gas rising). A stale-high
+                    // snapshot then exceeds what's actually spendable and submit validation rejects
+                    // it as "insufficient" — which is why a max send can force the user to leave
+                    // some tokens behind. Re-derive the amount from the CURRENT balance and fee,
+                    // clamping DOWN only so we never send more than the user saw. Standard sends
+                    // only: DeFi flows (staking/unbond/frozen TRX) carry different balance
+                    // semantics and compute their own max.
+                    val tokenAmountInt =
+                        tokenAmount.movePointRight(selectedToken.decimal).toBigInteger().let {
+                            entered ->
+                            if (isMaxAmount && defiTypeProvider() == null) {
+                                val available =
+                                    getAvailableTokenBalance(selectedAccount, gasFee.value)?.value
+                                if (available != null && available > BigInteger.ZERO) {
+                                    entered.coerceAtMost(available)
+                                } else {
+                                    entered
+                                }
+                            } else {
+                                entered
+                            }
+                        }
 
                     if (chain == Chain.Tron) {
                         val isTronStakingOp =
@@ -337,9 +359,12 @@ internal class DefaultSendStrategy(
                                 )
 
                         if (selectedTokenValue.value < tokenAmountInt) {
+                            // Token gas is paid in the native coin, not this token, so this is a
+                            // pure token-balance shortfall — keep the message free of any "with
+                            // fees" framing that would wrongly suggest reserving tokens for gas.
                             throw InvalidTransactionDataException(
                                 UiText.FormattedText(
-                                    R.string.send_error_insufficient_native_balance_with_fees,
+                                    R.string.send_error_insufficient_token_balance,
                                     listOf(selectedToken.ticker),
                                 )
                             )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -173,6 +173,7 @@
     <string name="send_error_insufficient_balance">Unzureichende Mittel</string>
     <string name="send_error_msca_not_deployed">MSCA-Konto noch nicht bereitgestellt, bitte versuchen Sie es erneut</string>
     <string name="send_error_insufficient_native_balance_with_fees">Unzureichendes %1$s-Guthaben</string>
+    <string name="send_error_insufficient_token_balance">Unzureichendes %1$s-Guthaben</string>
     <string name="send_error_insufficient_frozen_balance">Betrag überschreitet eingefrorenes %1$s-Guthaben</string>
     <string name="verify_swap_agree_receive_amount">Ich bin mit dem Mindestbetrag einverstanden, den ich erhalte</string>
     <string name="swap_form_estimated_fees_title">Swap Gebühr</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -107,6 +107,7 @@
     <string name="send_error_insufficient_balance">Fondos insuficientes</string>
     <string name="send_error_msca_not_deployed">La cuenta MSCA aún no está desplegada, por favor inténtelo de nuevo</string>
     <string name="send_error_insufficient_native_balance_with_fees">Saldo de %1$s insuficiente</string>
+    <string name="send_error_insufficient_token_balance">Saldo de %1$s insuficiente</string>
     <string name="send_error_insufficient_frozen_balance">El importe supera el saldo congelado de %1$s</string>
     <string name="settings_screen_language">Idioma</string>
     <string name="settings_screen_currency">Moneda</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -173,6 +173,7 @@
     <string name="send_error_insufficient_balance">Nedostatna sredstva</string>
     <string name="send_error_msca_not_deployed">MSCA račun još nije raspoređen, molimo pokušajte ponovo</string>
     <string name="send_error_insufficient_native_balance_with_fees">Nedovoljno %1$s salda</string>
+    <string name="send_error_insufficient_token_balance">Nedovoljno %1$s salda</string>
     <string name="send_error_insufficient_frozen_balance">Iznos premašuje zamrznuti %1$s saldo</string>
     <string name="verify_swap_agree_receive_amount">Slažem se s minimalnim iznosom koji ću dobiti</string>
     <string name="swap_form_estimated_fees_title">Naknada za zamjenu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -173,6 +173,7 @@
     <string name="send_error_insufficient_balance">Fondi insufficienti</string>
     <string name="send_error_msca_not_deployed">Account MSCA non ancora distribuito, riprova</string>
     <string name="send_error_insufficient_native_balance_with_fees">Saldo %1$s insufficiente</string>
+    <string name="send_error_insufficient_token_balance">Saldo %1$s insufficiente</string>
     <string name="send_error_insufficient_frozen_balance">L\'importo supera il saldo %1$s congelato</string>
     <string name="verify_swap_agree_receive_amount">Accetto l\'importo minimo che riceverò</string>
     <string name="swap_form_estimated_fees_title">Commissione di cambio</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -180,6 +180,7 @@
     <string name="send_error_insufficient_balance">잔액 부족</string>
     <string name="send_error_msca_not_deployed">MSCA 계정이 아직 배포되지 않았습니다. 다시 시도해 주세요</string>
     <string name="send_error_insufficient_native_balance_with_fees">%1$s 잔액 부족</string>
+    <string name="send_error_insufficient_token_balance">%1$s 잔액 부족</string>
     <string name="send_error_insufficient_frozen_balance">금액이 동결된 %1$s 잔액을 초과합니다</string>
     <string name="settings_screen_language">언어</string>
     <string name="settings_screen_currency">통화</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -106,6 +106,7 @@
     <string name="send_error_insufficient_balance">Onvoldoende saldo</string>
     <string name="send_error_msca_not_deployed">MSCA-account nog niet geïmplementeerd, probeer het opnieuw</string>
     <string name="send_error_insufficient_native_balance_with_fees">Onvoldoende %1$s saldo</string>
+    <string name="send_error_insufficient_token_balance">Onvoldoende %1$s saldo</string>
     <string name="send_error_insufficient_frozen_balance">Bedrag overschrijdt bevroren %1$s saldo</string>
     <string name="settings_screen_language">Taal</string>
     <string name="settings_screen_currency">Valuta</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -173,6 +173,7 @@
     <string name="send_error_insufficient_balance">Fundos insuficientes</string>
     <string name="send_error_msca_not_deployed">Conta MSCA ainda não implantada, tente novamente</string>
     <string name="send_error_insufficient_native_balance_with_fees">Saldo de %1$s insuficiente</string>
+    <string name="send_error_insufficient_token_balance">Saldo de %1$s insuficiente</string>
     <string name="send_error_insufficient_frozen_balance">O valor excede o saldo %1$s congelado</string>
     <string name="verify_swap_agree_receive_amount">Concordo com o valor mínimo que receberei</string>
     <string name="swap_form_estimated_fees_title">Taxa de swap</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -106,6 +106,7 @@
     <string name="send_error_insufficient_balance">Недостаточно средств</string>
     <string name="send_error_msca_not_deployed">Аккаунт MSCA ещё не развёрнут, пожалуйста, попробуйте снова</string>
     <string name="send_error_insufficient_native_balance_with_fees">Недостаточный баланс %1$s</string>
+    <string name="send_error_insufficient_token_balance">Недостаточный баланс %1$s</string>
     <string name="send_error_insufficient_frozen_balance">Сумма превышает замороженный баланс %1$s</string>
     <string name="settings_screen_language">Язык</string>
     <string name="settings_screen_currency">Валюта</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -200,6 +200,7 @@
     <string name="send_error_insufficient_balance">资金不足</string>
     <string name="send_error_msca_not_deployed">MSCA账户尚未部署，请重试</string>
     <string name="send_error_insufficient_native_balance_with_fees">%1$s 余额不足</string>
+    <string name="send_error_insufficient_token_balance">%1$s 余额不足</string>
     <string name="send_error_insufficient_frozen_balance">金额超过已冻结的 %1$s 余额</string>
 
     <!-- Settings Screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="send_error_insufficient_balance">Insufficient funds</string>
     <string name="send_error_msca_not_deployed">MSCA account not deployed yet, please try again</string>
     <string name="send_error_insufficient_native_balance_with_fees">Insufficient %1$s balance</string>
+    <string name="send_error_insufficient_token_balance">Insufficient %1$s balance</string>
     <string name="send_error_insufficient_frozen_balance">Amount exceeds frozen %1$s balance</string>
     <string name="settings_screen_language">Language</string>
     <string name="settings_screen_currency">Currency</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -564,6 +564,257 @@ internal class DefaultSendStrategyTest {
         }
     }
 
+    /**
+     * Race 1 (#5316): the non-native "Max" snapshot is captured against a stale-high cached
+     * balance, then network hydration corrects the balance downward before submit. The stale field
+     * must be re-clamped to the CURRENT balance so the send succeeds instead of failing
+     * "insufficient" — which is what forced users to leave some USDT behind.
+     */
+    @Test
+    fun `submit re-clamps a stale non-native Max down to the current balance`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val usdtCoin = usdtCoin()
+            // Balance already corrected downward (123.400000) by the time submit runs.
+            val account =
+                Account(
+                    token = usdtCoin,
+                    tokenValue = TokenValue(BigInteger("123400000"), usdtCoin),
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+            // Field still holds the stale-high Max snapshot (123.456789).
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("123.456789")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Ethereum,
+                    gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin()),
+                    dstAddress = "0xdest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            accounts.value =
+                listOf(
+                    Account(
+                        token = ethCoin(),
+                        tokenValue = TokenValue(BigInteger("1000000000000000000"), ethCoin()),
+                        fiatValue = null,
+                        price = null,
+                    )
+                )
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                    isThorchainRouterDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = BigInteger.ONE,
+                        priorityFeeWei = BigInteger.ONE,
+                        nonce = BigInteger.ZERO,
+                        gasLimit = BigInteger.valueOf(65000),
+                    )
+                )
+            every { amountManager.currentMaxAmount } returns BigDecimal("123.456789")
+            // Non-native: the use case returns the full (already-corrected) token balance.
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(BigInteger("123400000"), usdtCoin)
+            coEvery { gasFeeToEstimatedFee(any()) } returns
+                EstimatedGasFee(
+                    formattedFiatValue = "$0.10",
+                    formattedTokenValue = "0.0001 ETH",
+                    tokenValue = TokenValue(BigInteger.ONE, ethCoin()),
+                    fiatValue = mockk(relaxed = true),
+                )
+
+            val captured = slot<Transaction>()
+            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            // Clamped down from 123.456789 to the current 123.400000 balance.
+            assertEquals(BigInteger("123400000"), captured.captured.tokenValue.value)
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * Race 2 (#5316): an EVM native "Max" reuses the cached gas fee, so the filled amount is
+     * `balance − cachedFee`. If gas rises before submit, `balance − freshFee` drops below it. The
+     * amount must be re-clamped to the current available balance so the send succeeds.
+     */
+    @Test
+    fun `submit re-clamps a stale native EVM Max down when gas rises`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val ethCoin = ethCoin()
+            val account =
+                Account(
+                    token = ethCoin,
+                    tokenValue = TokenValue(BigInteger("1000000000000000000"), ethCoin), // 1.0 ETH
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+            // Max was filled as balance − cachedFee = 0.9990 ETH.
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.999")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Ethereum,
+                    gasFee = TokenValue(BigInteger("1500000000000000"), ethCoin), // fresh 0.0015
+                    dstAddress = "0xdest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                    isThorchainRouterDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = BigInteger.ONE,
+                        priorityFeeWei = BigInteger.ONE,
+                        nonce = BigInteger.ZERO,
+                        gasLimit = BigInteger.valueOf(21000),
+                    )
+                )
+            every { amountManager.currentMaxAmount } returns BigDecimal("0.999")
+            // Fresh available = balance − freshFee = 0.9985 ETH (< the filled 0.999).
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(BigInteger("998500000000000000"), ethCoin)
+            coEvery { gasFeeToEstimatedFee(any()) } returns
+                EstimatedGasFee(
+                    formattedFiatValue = "$0.10",
+                    formattedTokenValue = "0.0015 ETH",
+                    tokenValue = TokenValue(BigInteger.ONE, ethCoin),
+                    fiatValue = mockk(relaxed = true),
+                )
+
+            val captured = slot<Transaction>()
+            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            // Clamped down from 0.999 to the current 0.9985 available.
+            assertEquals(BigInteger("998500000000000000"), captured.captured.tokenValue.value)
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * A non-native over-entry (not a Max snapshot) is a pure token-balance shortfall — gas is paid
+     * in the native coin — so it must surface the token-balance error, not the "with fees" one that
+     * wrongly implies reserving tokens for gas.
+     */
+    @Test
+    fun `submit blocks non-native over-entry with the token-balance error`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val usdtCoin = usdtCoin()
+            val account =
+                Account(
+                    token = usdtCoin,
+                    tokenValue = TokenValue(BigInteger("100000000"), usdtCoin), // 100 USDT
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("150") // more than the 100 balance
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Ethereum,
+                    gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin()),
+                    dstAddress = "0xdest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            accounts.value =
+                listOf(
+                    Account(
+                        token = ethCoin(),
+                        tokenValue = TokenValue(BigInteger("1000000000000000000"), ethCoin()),
+                        fiatValue = null,
+                        price = null,
+                    )
+                )
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                    isThorchainRouterDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = BigInteger.ONE,
+                        priorityFeeWei = BigInteger.ONE,
+                        nonce = BigInteger.ZERO,
+                        gasLimit = BigInteger.valueOf(65000),
+                    )
+                )
+            // Not a Max: no clamp, so the over-entry reaches the balance check.
+            every { amountManager.currentMaxAmount } returns BigDecimal.ZERO
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertEquals(
+                R.string.send_error_insufficient_token_balance,
+                (lastError as UiText.FormattedText).resId,
+            )
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
     private fun xrpCoin(): Coin =
         Coin(
             chain = Chain.Ripple,


### PR DESCRIPTION
Fixes #5316

## Problem

"Max" on the Send screen was a **one-shot snapshot** — it captured the balance and gas fee at tap time, wrote them into the amount field, and never re-clamped when either moved before submit. Nothing re-derives the field between tap and Continue, so two races made a max send fail with "insufficient balance":

1. **Non-native tokens (e.g. USDT):** a stale-high *cached* balance fills the field, then network hydration corrects the balance downward. The field keeps the old larger number, so submit's strict balance check rejects it. This is exactly the reported *"I need to leave some USDT in the wallet in order to work."*
2. **EVM native coins:** Max reuses the *cached* gas fee (`balance − cachedFee`). If gas rises before Continue, submit's `balance − freshFee` drops below the filled amount → rejected.

An aggravating factor: the non-native token-balance shortfall surfaced the `..._native_balance_with_fees` error string, whose "with fees" framing wrongly teaches users to reserve *tokens* for gas — precisely the wrong mental model the user described.

## Fix

- When the amount equals the Max snapshot on a **standard send**, re-derive it from the **current** balance and fee at submit via `getAvailableTokenBalance`, clamping **down only** so we never send more than the user saw. One change covers both races. DeFi flows (staking / unbond / frozen TRX) are excluded — they carry different balance semantics and compute their own max.
- Route the non-native token-balance shortfall to a new `send_error_insufficient_token_balance` string (added to all 10 locales) — same visible wording, but without the misleading "with fees" key.

For reference, iOS re-fetches balance+fee and recomputes max on the Verify screen; Windows re-caps native max at keysign build (`refineKeysignAmount`). Android was the only platform with no submit-time re-clamp.

## Test plan

- `./gradlew :app:compileDebugKotlin` — passes
- Added 3 regression tests to `DefaultSendStrategyTest`:
  - non-native Max re-clamps down when the balance corrects downward (Race 1)
  - native EVM Max re-clamps down when gas rises (Race 2)
  - non-native over-entry surfaces the new token-balance error string
- Full class: **11 tests, 0 failures** (1 pre-existing XRP JNI test skipped in the JVM env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “Max” send amounts are now rechecked against the latest available balance, including updated gas fees, before submission.
  - Improved validation for insufficient token balances with clearer, token-specific error messages.
  - Added localized messages for supported languages.

- **Tests**
  - Added coverage for stale “Max” amounts, increased gas costs, and token over-entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->