### PR TITLE
fix(swap): keep SwapKit swap fee zeroed on Cardano, hide the row (#5321)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
 import com.vultisig.wallet.data.usecases.getTierType
-import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.utils.UiText
 import java.math.BigDecimal
@@ -138,7 +137,6 @@ internal class SwapQuotePipeline(
     private val swapDiscountChecker: SwapDiscountChecker,
     private val swapGasCalculator: SwapGasCalculator,
     private val swapValidator: SwapValidator,
-    private val fiatValueToString: FiatValueToStringMapper,
 ) {
 
     /**
@@ -378,24 +376,25 @@ internal class SwapQuotePipeline(
                 tierType = vultResult.tierType,
             )
 
-        // SwapKit BTC settles by broadcasting the provider's PSBT, whose miner fee is the only
-        // network cost — and it is already surfaced as the UTXO plan network fee below. SwapKit
-        // reports that same deposit cost as its inbound fee, so counting it again as a swap fee
-        // would
-        // double-count the BTC network cost in the headline total (iOS shows it once). Zero the
-        // swap-fee contribution and the breakdown row so Total reconciles to Network Fee alone; the
+        // SwapKit UTXO-family sources (Bitcoin PSBT deposit, Cardano CBOR deposit) settle by
+        // broadcasting a deposit whose on-chain miner fee is the only network cost, already
+        // surfaced on the Network Fee row (BTC via the UTXO plan below; Cardano via the flat
+        // send-style plan fee — Cardano is excluded from the plan path in `isUtxoSwap`). SwapKit
+        // reports that same deposit cost as its wire inbound fee, so counting it again as a swap
+        // fee would double-count the source-chain network cost in the headline total. iOS discards
+        // the wire inbound fee for both families and shows the cost once as Network Fee
+        // (`SwapCryptoLogic.fee`), so zero the swap-fee contribution and its breakdown row; the
         // affiliate fee is already baked into expectedDstValue.
         val quote = quoteResult.quote
         val isSwapKitUtxoSwap =
-            quote is SwapQuote.SwapKit &&
-                srcToken.chain.standard == TokenStandard.UTXO &&
-                srcToken.chain != Chain.Cardano
+            quote is SwapQuote.SwapKit && srcToken.chain.standard == TokenStandard.UTXO
         val effectiveSwapFeeFiat =
             if (isSwapKitUtxoSwap) FiatValue(BigDecimal.ZERO, quoteResult.swapFeeFiat.currency)
             else quoteResult.swapFeeFiat
-        val feeText =
-            if (isSwapKitUtxoSwap) fiatValueToString(effectiveSwapFeeFiat, asFee = true)
-            else quoteResult.feeText
+        // Empty text hides the swap-fee breakdown row entirely (iOS `swapFeeString` returns
+        // `.empty` here): the deposit cost is already surfaced as the Network Fee, so there is no
+        // separate swap fee to show rather than a redundant "$0.00" row.
+        val feeText = if (isSwapKitUtxoSwap) "" else quoteResult.feeText
 
         val priceImpactDisplay = formatPriceImpact(quoteResult.priceImpact)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -331,7 +331,7 @@ internal class SwapQuotePipeline(
     }
 
     /** Builds the display-ready [SwapQuotePipelineResult.Success] from the winning quote. */
-    private suspend fun buildSuccess(
+    internal suspend fun buildSuccess(
         bestQuote: BestQuote,
         src: SendSrc,
         srcTokenValue: BigInteger,
@@ -387,7 +387,9 @@ internal class SwapQuotePipeline(
         // affiliate fee is already baked into expectedDstValue.
         val quote = quoteResult.quote
         val isSwapKitUtxoSwap =
-            quote is SwapQuote.SwapKit && srcToken.chain.standard == TokenStandard.UTXO
+            quote is SwapQuote.SwapKit &&
+                srcToken.chain.standard == TokenStandard.UTXO &&
+                srcToken.chain != Chain.Cardano
         val effectiveSwapFeeFiat =
             if (isSwapKitUtxoSwap) FiatValue(BigDecimal.ZERO, quoteResult.swapFeeFiat.currency)
             else quoteResult.swapFeeFiat

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -119,7 +119,6 @@ constructor(
             swapDiscountChecker = swapDiscountChecker,
             swapGasCalculator = swapGasCalculator,
             swapValidator = swapValidator,
-            fiatValueToString = fiatValueToString,
         )
 
     /** Mutable swap-quote state and the quote-coupled swap fee, shared with the ViewModel. */

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
@@ -166,21 +166,26 @@ internal fun SwapFeeBreakdown(
                                 } else null,
                         )
 
-                        val feeTitle =
-                            feeBreakdown.swapFeePercent?.let {
-                                stringResource(
-                                    R.string.swap_form_estimated_fees_with_percent_title,
-                                    it,
-                                )
-                            } ?: stringResource(R.string.swap_form_estimated_fees_title)
-                        FormDetails2(
-                            title = feeTitle,
-                            value = feeBreakdown.fee,
-                            placeholder =
-                                if (isLoading) {
-                                    { loadingPlaceholder() }
-                                } else null,
-                        )
+                        // A blank fee means the swap fee is zeroed (SwapKit UTXO/Cardano deposit
+                        // cost is already the Network Fee); hide the row entirely rather than show
+                        // a redundant "$0.00", matching iOS.
+                        if (feeBreakdown.fee.isNotBlank()) {
+                            val feeTitle =
+                                feeBreakdown.swapFeePercent?.let {
+                                    stringResource(
+                                        R.string.swap_form_estimated_fees_with_percent_title,
+                                        it,
+                                    )
+                                } ?: stringResource(R.string.swap_form_estimated_fees_title)
+                            FormDetails2(
+                                title = feeTitle,
+                                value = feeBreakdown.fee,
+                                placeholder =
+                                    if (isLoading) {
+                                        { loadingPlaceholder() }
+                                    } else null,
+                            )
+                        }
 
                         if (feeBreakdown.outboundFee != null) {
                             FormDetails2(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
@@ -49,7 +49,6 @@ internal class SwapQuotePipelineNetworkFeeTest {
             swapDiscountChecker = mockk(relaxed = true),
             swapGasCalculator = swapGasCalculator,
             swapValidator = swapValidator,
-            fiatValueToString = mockk(relaxed = true),
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
@@ -15,12 +15,11 @@ import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.utils.UiText
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -29,10 +28,12 @@ import org.junit.jupiter.api.Test
 /**
  * Covers the SwapKit swap-fee zeroing in [SwapQuotePipeline.buildSuccess] (#5321).
  *
- * SwapKit BTC broadcasts the provider's PSBT whose miner fee is already counted as the UTXO plan
- * network fee, so the duplicated inbound swap fee is zeroed to avoid double-counting. Cardano rides
- * in `TokenStandard.UTXO` but is not a secp256k1/PSBT UTXO chain and does not go through the UTXO
- * plan-fee path, so its swap fee must be shown, not zeroed.
+ * SwapKit UTXO-family sources (Bitcoin PSBT deposit, Cardano CBOR deposit) settle by broadcasting a
+ * deposit whose on-chain miner fee is the only network cost and is already surfaced on the Network
+ * Fee row. SwapKit reports that same deposit cost as its wire inbound fee, so counting it again as
+ * a swap fee would double-count the source-chain network cost. iOS discards the wire inbound fee
+ * for both families and shows the cost once as Network Fee, so both Bitcoin and Cardano zero the
+ * swap fee (the earlier Cardano carve-out reopened the double count).
  */
 internal class SwapQuotePipelineSwapKitFeeTest {
 
@@ -49,7 +50,6 @@ internal class SwapQuotePipelineSwapKitFeeTest {
             swapDiscountChecker = swapDiscountChecker,
             swapGasCalculator = mockk(relaxed = true),
             swapValidator = mockk(relaxed = true),
-            fiatValueToString = mockk(relaxed = true),
         )
 
     init {
@@ -72,12 +72,14 @@ internal class SwapQuotePipelineSwapKitFeeTest {
                     currentDiscountInfo = DiscountInfo(),
                 )
 
-            assertEquals(BigDecimal.ZERO, result.swapFeeFiat.value)
-            assertEquals("USD", result.swapFeeFiat.currency)
+            result.swapFeeFiat.value shouldBe BigDecimal.ZERO
+            result.swapFeeFiat.currency shouldBe "USD"
+            // Empty text hides the swap-fee breakdown row entirely (matches iOS).
+            result.feeText shouldBe ""
         }
 
     @Test
-    fun `keeps the SwapKit swap fee for a Cardano source (not a PSBT UTXO plan-fee swap) (#5321)`() =
+    fun `zeroes the SwapKit swap fee for a Cardano source (its deposit fee is the Network Fee) (#5321)`() =
         runTest {
             val ada = coin(Chain.Cardano)
             val result =
@@ -89,10 +91,13 @@ internal class SwapQuotePipelineSwapKitFeeTest {
                     currentDiscountInfo = DiscountInfo(),
                 )
 
-            assertEquals(swapFee, result.swapFeeFiat)
-            assertTrue(result.swapFeeFiat.value.signum() > 0)
-            // Cardano is not routed through the UTXO plan-fee path either.
-            assertTrue(!result.isUtxoSwap)
+            result.swapFeeFiat.value shouldBe BigDecimal.ZERO
+            result.swapFeeFiat.currency shouldBe "USD"
+            // Empty text hides the swap-fee breakdown row entirely (matches iOS).
+            result.feeText shouldBe ""
+            // Cardano is excluded from the Bitcoin UTXO plan-fee path; the flat send-style fee owns
+            // the Network Fee row.
+            result.isUtxoSwap shouldBe false
         }
 
     private fun bestSwapKitQuote(srcToken: Coin, txType: String): BestQuote {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
@@ -1,0 +1,160 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson.Companion.TX_TYPE_CARDANO_PREBUILT
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson.Companion.TX_TYPE_PSBT
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.ui.models.send.SendSrc
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the SwapKit swap-fee zeroing in [SwapQuotePipeline.buildSuccess] (#5321).
+ *
+ * SwapKit BTC broadcasts the provider's PSBT whose miner fee is already counted as the UTXO plan
+ * network fee, so the duplicated inbound swap fee is zeroed to avoid double-counting. Cardano rides
+ * in `TokenStandard.UTXO` but is not a secp256k1/PSBT UTXO chain and does not go through the UTXO
+ * plan-fee path, so its swap fee must be shown, not zeroed.
+ */
+internal class SwapQuotePipelineSwapKitFeeTest {
+
+    private val swapDiscountChecker: SwapDiscountChecker = mockk()
+
+    private val pipeline =
+        SwapQuotePipeline(
+            swapQuoteRepository = mockk(relaxed = true),
+            appCurrencyRepository = mockk(relaxed = true),
+            referralRepository = mockk(relaxed = true),
+            getDiscountBpsUseCase = mockk(relaxed = true),
+            convertTokenAndValueToTokenValue = mockk(relaxed = true),
+            swapQuoteManager = mockk(relaxed = true),
+            swapDiscountChecker = swapDiscountChecker,
+            swapGasCalculator = mockk(relaxed = true),
+            swapValidator = mockk(relaxed = true),
+            fiatValueToString = mockk(relaxed = true),
+        )
+
+    init {
+        coEvery { swapDiscountChecker.checkVultBpsDiscount(any(), any(), any()) } returns
+            VultDiscountResult(null, null, null)
+    }
+
+    private val swapFee = FiatValue(BigDecimal("1.50"), "USD")
+
+    @Test
+    fun `zeroes the SwapKit swap fee for a Bitcoin source (double-counted as the UTXO plan fee)`() =
+        runTest {
+            val btc = coin(Chain.Bitcoin)
+            val result =
+                pipeline.buildSuccess(
+                    bestQuote = bestSwapKitQuote(btc, TX_TYPE_PSBT),
+                    src = sendSrc(btc),
+                    srcTokenValue = BigInteger.valueOf(1_000),
+                    tokenValue = TokenValue(BigInteger.valueOf(1_000), btc),
+                    currentDiscountInfo = DiscountInfo(),
+                )
+
+            assertEquals(BigDecimal.ZERO, result.swapFeeFiat.value)
+            assertEquals("USD", result.swapFeeFiat.currency)
+        }
+
+    @Test
+    fun `keeps the SwapKit swap fee for a Cardano source (not a PSBT UTXO plan-fee swap) (#5321)`() =
+        runTest {
+            val ada = coin(Chain.Cardano)
+            val result =
+                pipeline.buildSuccess(
+                    bestQuote = bestSwapKitQuote(ada, TX_TYPE_CARDANO_PREBUILT),
+                    src = sendSrc(ada),
+                    srcTokenValue = BigInteger.valueOf(1_000),
+                    tokenValue = TokenValue(BigInteger.valueOf(1_000), ada),
+                    currentDiscountInfo = DiscountInfo(),
+                )
+
+            assertEquals(swapFee, result.swapFeeFiat)
+            assertTrue(result.swapFeeFiat.value.signum() > 0)
+            // Cardano is not routed through the UTXO plan-fee path either.
+            assertTrue(!result.isUtxoSwap)
+        }
+
+    private fun bestSwapKitQuote(srcToken: Coin, txType: String): BestQuote {
+        val quote =
+            SwapQuote.SwapKit(
+                expectedDstValue = TokenValue(BigInteger.valueOf(400), srcToken),
+                fees = TokenValue(BigInteger.valueOf(9), srcToken),
+                expiredAt = Clock.System.now(),
+                data =
+                    SwapKitSwapPayloadJson(
+                        fromCoin = srcToken,
+                        toCoin = srcToken,
+                        fromAmount = BigInteger.valueOf(1_000),
+                        toAmountDecimal = BigDecimal("0.004"),
+                        txType = txType,
+                        txPayload = ByteArray(0),
+                        targetAddress = "deposit-address",
+                    ),
+                subProvider = "THORChain",
+            )
+        return BestQuote(
+            candidate =
+                QuoteCandidate(SwapProvider.SWAPKIT, vultBPSDiscount = null, referral = null),
+            result =
+                QuoteFetchResult(
+                    quote = quote,
+                    provider = SwapProvider.SWAPKIT,
+                    providerUiText = UiText.DynamicString("SwapKit"),
+                    srcFiatValueText = "0",
+                    estimatedDstTokenValue = "0",
+                    estimatedDstFiatValue = "0",
+                    comparableDstFiat = BigDecimal.ZERO,
+                    feeText = "$1.50",
+                    swapFeeFiat = swapFee,
+                ),
+        )
+    }
+
+    private fun coin(chain: Chain) =
+        Coin(
+            chain = chain,
+            ticker = chain.raw,
+            logo = "",
+            address = "addr",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = chain.raw,
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun sendSrc(coin: Coin): SendSrc {
+        val account =
+            Account(
+                token = coin,
+                tokenValue = TokenValue(BigInteger.valueOf(1_000_000_000L), coin),
+                fiatValue = null,
+                price = null,
+            )
+        return SendSrc(
+            Address(chain = coin.chain, address = coin.address, accounts = listOf(account)),
+            account,
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -45,7 +45,7 @@ enum class Chain(val raw: ChainId, val standard: TokenStandard, val feeUnit: Str
     Dogecoin("Dogecoin", UTXO, "Doge/vbyte"),
     Dash("Dash", UTXO, "DASH/vbyte"),
     Zcash("Zcash", UTXO, "ZEC/vbyte"),
-    Cardano("Cardano", UTXO, "ADA/vbyte"),
+    Cardano("Cardano", UTXO, "Lovelace"),
     GaiaChain("Cosmos", COSMOS, "uatom"),
     Kujira("Kujira", COSMOS, "ukuji"),
     Dydx("Dydx", COSMOS, "adydx"),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.chains.helpers.UtxoHelper
 import com.vultisig.wallet.data.crypto.SuiHelper
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapTransaction
 import com.vultisig.wallet.data.models.TokenStandard
@@ -32,7 +33,15 @@ class SecurityScannerTransactionFactory(
             TokenStandard.EVM -> createEVMSecurityScannerTransaction(transaction)
             TokenStandard.SOL -> createSOLSecurityScannerTransaction(transaction)
             TokenStandard.SUI -> createSUISecurityScannerTransaction(transaction)
-            TokenStandard.UTXO -> createBTCSecurityScannerTransaction(transaction)
+            // Cardano rides in TokenStandard.UTXO but is ed25519 + CBOR, not a Bitcoin proto; the
+            // BTC path would build a Bitcoin tx for it. Unreachable today (Cardano isn't a Blockaid
+            // supported chain) — guard so it can't slip through if that list ever widens.
+            TokenStandard.UTXO ->
+                if (chain == Chain.Cardano) {
+                    throw SecurityScannerException("Security Scanner: Not supported ${chain.name}")
+                } else {
+                    createBTCSecurityScannerTransaction(transaction)
+                }
             else -> throw SecurityScannerException("Security Scanner: Not supported ${chain.name}")
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/wallet/Swaps.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/wallet/Swaps.kt
@@ -19,6 +19,11 @@ internal object Swaps {
     ): List<String> {
         val preImageHashes = TransactionCompiler.preImageHashes(coinType, inputData)
 
+        // Cardano rides in TokenStandard.UTXO but signs ed25519 + CBOR, not secp256k1 + PSBT.
+        // Its pre-image is not a Bitcoin proto; it presigns via CardanoHelper and never reaches
+        // here. Guard so a future swap route can't silently parse a Cardano pre-image as Bitcoin.
+        check(chain != Chain.Cardano) { "Cardano pre-image must be built via CardanoHelper" }
+
         return when (chain.standard) {
             TokenStandard.UTXO -> {
                 val preSigningOutput =


### PR DESCRIPTION
## Summary

SwapKit's fee for UTXO-family sources (Bitcoin PSBT, Cardano CBOR) is the **source-chain deposit cost**, which is already surfaced on the **Network Fee** row. Counting it again as a Swap Fee double-counts the same on-chain cost.

The earlier approach carved Cardano out of the swap-fee zeroing (`isSwapKitUtxoSwap`), which reopened that double count and diverged from iOS. Verified against the running macOS app: a Cardano → ETH SwapKit swap shows **no Swap Fee row** — just Network Fee (the ADA deposit cost, shown once), the VULT discount, and Price Impact.

This PR:
- **Re-zeroes** the Cardano SwapKit swap fee (treats it like Bitcoin), so the ADA deposit cost is counted once as Network Fee — no double count.
- **Hides** the swap-fee breakdown row entirely when zeroed (empty `feeText`) instead of rendering a redundant `$0.00`, mirroring iOS `SwapCryptoLogic.fee` / `swapFeeString`. Applies to Bitcoin SwapKit too.
- Removes the now-unused `fiatValueToString` dependency from `SwapQuotePipeline`.
- Keeps the independent correctness fixes: Cardano `feeUnit` → `Lovelace`, and the Cardano guards in `Swaps.getPreSignedImageHash` / `SecurityScannerTransactionFactory`.

## iOS parity

`SwapCryptoLogic.fee` (iOS) for UTXO/Cardano SwapKit returns the transaction-plan fee (Network Fee) and discards the wire inbound fee; `inboundFeeDecimal` returns `.zero`, so the Swap Fee row is empty. This PR mirrors that behaviour.

## Test plan

- `SwapQuotePipelineSwapKitFeeTest` — Bitcoin and Cardano both assert the swap fee is zeroed and `feeText == ""` (row hidden).
- `SwapQuotePipelineNetworkFeeTest` — updated for the constructor change.
- Full `ui.models.swap.*` unit tests green.
- macOS app cross-check: Cardano → ETH SwapKit shows Network Fee only, no Swap Fee row.

Closes #5321


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SwapKit swap-fee handling for UTXO-family quotes: swap-fee amount is zeroed and the fee breakdown row is hidden instead of showing “$0.00”.
  * Updated Cardano fee unit display to **Lovelace**.
  * Improved handling of Cardano in security-scanner and pre-signed image hash flows to prevent unsupported Bitcoin-style processing.
* **UI**
  * Only renders the expanded “estimated fees” row when the fee value is non-blank.
* **Tests**
  * Added/updated coverage for SwapKit fee and network-fee scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->