### PR TITLE
fix(substrate): stop reporting success on a malformed broadcast body

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -126,19 +126,10 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
                 id = 1,
             )
         val response = httpClient.post(BITTENSOR_RPC_URL) { setBody(payload) }
-        // Read the RPC body regardless of HTTP status: the relay may surface "Already Imported"
-        // with a non-2xx status, and the duplicate rebroadcast from a second signing device must
-        // still resolve to null rather than throw.
-        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
-        if (responseContent.error != null) {
-            if (responseContent.error.message?.contains("Already Imported") == true) {
-                return null
-            }
-            throw Exception(
-                "Bittensor broadcast failed: ${responseContent.error.data ?: responseContent.error.message}"
-            )
-        }
-        return responseContent.result
+        // Read the RPC body regardless of HTTP status: the relay may surface the idempotent
+        // "already imported" error with a non-2xx status, and the duplicate rebroadcast from a
+        // second signing device must still resolve to null rather than throw.
+        return SubstrateBroadcast.classify(response.body<PolkadotBroadcastTransactionJson>())
     }
 
     override suspend fun getPartialFee(tx: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BittensorApi.kt
@@ -117,7 +117,7 @@ internal class BittensorApiImp @Inject constructor(private val httpClient: HttpC
     }
 
     override suspend fun broadcastTransaction(tx: String): String? {
-        // Broadcast stays manual due to error-field check
+        // Result/error interpretation is delegated to the shared SubstrateBroadcast classifier.
         val payload =
             RpcPayload(
                 jsonrpc = "2.0",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -178,16 +178,7 @@ internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpCl
         // Read the RPC body regardless of HTTP status: nodes may surface the idempotent
         // "already in pool" errors (1012/1013) with a non-2xx status, and the duplicate
         // rebroadcast from a second signing device must still resolve to null rather than throw.
-        val responseContent = response.body<PolkadotBroadcastTransactionJson>()
-        if (responseContent.error != null) {
-            if (responseContent.error.code == 1012 || responseContent.error.code == 1013) {
-                return null
-            }
-            throw Exception(
-                "Error broadcasting transaction: ${responseContent.error.data ?: responseContent.error.message}"
-            )
-        }
-        return responseContent.result
+        return SubstrateBroadcast.classify(response.body<PolkadotBroadcastTransactionJson>())
     }
 
     override suspend fun getPartialFee(tx: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcast.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcast.kt
@@ -1,0 +1,61 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotBroadcastTransactionErrorJson
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotBroadcastTransactionJson
+
+/** Thrown when a Substrate `author_submitExtrinsic` response cannot be interpreted as success. */
+internal class SubstrateBroadcastException(message: String) : Exception(message)
+
+/**
+ * Shared classifier for Substrate `author_submitExtrinsic` responses (Polkadot + Bittensor).
+ *
+ * The JSON-RPC envelope is overloaded three ways and each must be handled distinctly, otherwise a
+ * malformed body silently becomes a fabricated success:
+ * - `result` present -> the node accepted the extrinsic; return its hash.
+ * - idempotent error -> a peer / second signing device already submitted this extrinsic; return
+ *   null so the caller resolves to the locally known hash.
+ * - anything else -> unknown or failed: throw so the caller's recover-if-already-broadcast path
+ *   verifies on-chain instead of reporting success blindly.
+ *
+ * The `(null, null)` case — neither `result` nor `error`, e.g. a truncated or proxy-mangled body
+ * decoded under the production `explicitNulls = false` config — falls into the last bucket and must
+ * not be reported as success.
+ *
+ * Both API classes share one classifier so idempotency detection cannot drift between the chains.
+ */
+internal object SubstrateBroadcast {
+
+    // Substrate transaction-pool JSON-RPC error codes for an already-known / already-imported
+    // extrinsic (a harmless duplicate rebroadcast).
+    private val IDEMPOTENT_CODES = setOf(1012, 1013)
+
+    // Case-insensitive message fallbacks for nodes / proxies that normalize the numeric code away
+    // (e.g. Polkadot's api.vultisig.com/dot proxy) while preserving the human-readable message.
+    private val IDEMPOTENT_MESSAGES =
+        listOf("already imported", "already known", "temporarily banned")
+
+    /**
+     * @return the broadcast hash, or null for an idempotent duplicate.
+     * @throws SubstrateBroadcastException on a node error or an uninterpretable `(null, null)`
+     *   body.
+     */
+    fun classify(response: PolkadotBroadcastTransactionJson): String? {
+        val error = response.error
+        if (error != null) {
+            if (isIdempotent(error)) return null
+            throw SubstrateBroadcastException(
+                "Substrate broadcast failed: ${error.data ?: error.message}"
+            )
+        }
+        return response.result
+            ?: throw SubstrateBroadcastException(
+                "Substrate broadcast returned neither a result nor an error"
+            )
+    }
+
+    private fun isIdempotent(error: PolkadotBroadcastTransactionErrorJson): Boolean {
+        if (error.code in IDEMPOTENT_CODES) return true
+        val message = error.message?.lowercase() ?: return false
+        return IDEMPOTENT_MESSAGES.any { message.contains(it) }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcast.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcast.kt
@@ -25,14 +25,22 @@ internal class SubstrateBroadcastException(message: String) : Exception(message)
  */
 internal object SubstrateBroadcast {
 
-    // Substrate transaction-pool JSON-RPC error codes for an already-known / already-imported
-    // extrinsic (a harmless duplicate rebroadcast).
-    private val IDEMPOTENT_CODES = setOf(1012, 1013)
+    // Substrate transaction-pool JSON-RPC error code for an already-imported extrinsic (a harmless
+    // duplicate rebroadcast). Only 1013 (`AlreadyImported`) is idempotent. 1012
+    // (`TemporarilyBanned`) is deliberately excluded: upstream bans a transaction after it was
+    // reported invalid, so it is retriable and potentially invalid — treating it as a duplicate
+    // would fabricate success and skip the on-chain verification path. It must throw and flow
+    // through the caller's recover-if-already-broadcast path instead.
+    private val IDEMPOTENT_CODES = setOf(1013)
 
-    // Case-insensitive message fallbacks for nodes / proxies that normalize the numeric code away
-    // (e.g. Polkadot's api.vultisig.com/dot proxy) while preserving the human-readable message.
-    private val IDEMPOTENT_MESSAGES =
-        listOf("already imported", "already known", "temporarily banned")
+    // Canonical duplicate messages for nodes / proxies that normalize the numeric code away (e.g.
+    // Polkadot's api.vultisig.com/dot proxy) while preserving the human-readable message. Matched
+    // with word boundaries (case-insensitive) so an unrelated error merely containing these words
+    // is not misclassified as a harmless duplicate.
+    private val IDEMPOTENT_MESSAGE_PATTERNS =
+        listOf("already imported", "already known").map {
+            Regex("\\b${Regex.escape(it)}\\b", RegexOption.IGNORE_CASE)
+        }
 
     /**
      * @return the broadcast hash, or null for an idempotent duplicate.
@@ -55,7 +63,7 @@ internal object SubstrateBroadcast {
 
     private fun isIdempotent(error: PolkadotBroadcastTransactionErrorJson): Boolean {
         if (error.code in IDEMPOTENT_CODES) return true
-        val message = error.message?.lowercase() ?: return false
-        return IDEMPOTENT_MESSAGES.any { message.contains(it) }
+        val message = error.message ?: return false
+        return IDEMPOTENT_MESSAGE_PATTERNS.any { it.containsMatchIn(message) }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -179,9 +179,18 @@ constructor(
                     verify = { hash -> polkadotApi.isExtrinsicInChain(hash, VERIFY_SCAN_DEPTH) },
                 )
 
-            Chain.Bittensor -> {
-                bittensorApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
-            }
+            // Mirrors Polkadot: a malformed / truncated RPC body now throws instead of resolving to
+            // a fabricated success hash, so it must go through the recover path that verifies the
+            // extrinsic is actually on-chain (via the Bittensor status provider) before reporting
+            // success. A duplicate rebroadcast from a peer still resolves to the known hash.
+            Chain.Bittensor ->
+                recoverIfAlreadyBroadcast(
+                    tx = tx,
+                    broadcast = {
+                        bittensorApi.broadcastTransaction(tx.rawTransaction).orKnownHash(tx)
+                    },
+                    verify = { hash -> isLandedOnChain(hash, chain) },
+                )
 
             // Sui digest is not pre-computable from the raw transaction, so transactionHash
             // is always blank and recovery cannot work; broadcast directly.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
@@ -151,7 +151,7 @@ class BittensorApiBodyReadTest {
                 .trimIndent()
         val api = newApi(body)
 
-        assertThrows<Exception> { api.broadcastTransaction(tx = "0x01") }
+        assertThrows<SubstrateBroadcastException> { api.broadcastTransaction(tx = "0x01") }
     }
 
     @Test
@@ -196,6 +196,6 @@ class BittensorApiBodyReadTest {
                     .trimIndent()
             val api = newApi(body)
 
-            assertThrows<Exception> { api.broadcastTransaction(tx = "0x01") }
+            assertThrows<SubstrateBroadcastException> { api.broadcastTransaction(tx = "0x01") }
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Characterization tests for [BittensorApiImp] that call `.body<T>()` or go through the shared
@@ -107,5 +108,44 @@ class BittensorApiBodyReadTest {
             val result = api.broadcastTransaction(tx = "0x01")
 
             assertNull(result)
+        }
+
+    @Test
+    fun `broadcastTransaction resolves duplicate to null via numeric code 1012`() = runTest {
+        // Bittensor previously matched only the case-sensitive "Already Imported" string and
+        // ignored the numeric code on the wire; the shared classifier now recognizes 1012/1013 too.
+        val body =
+            """
+            {
+              "jsonrpc": "2.0",
+              "error": {
+                "code": 1012,
+                "message": "Priority is too low",
+                "data": null
+              },
+              "id": 1
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        assertNull(api.broadcastTransaction(tx = "0x01"))
+    }
+
+    @Test
+    fun `broadcastTransaction throws on a truncated body with neither result nor error`() =
+        runTest {
+            // (null, null) under explicitNulls=false must not be reported as a successful broadcast.
+            val body =
+                """
+            {
+              "jsonrpc": "2.0",
+              "id": 1
+            }
+            """
+                    .trimIndent()
+            val api = newApi(body)
+
+            assertThrows<Exception> { api.broadcastTransaction(tx = "0x01") }
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BittensorApiBodyReadTest.kt
@@ -111,16 +111,16 @@ class BittensorApiBodyReadTest {
         }
 
     @Test
-    fun `broadcastTransaction resolves duplicate to null via numeric code 1012`() = runTest {
+    fun `broadcastTransaction resolves duplicate to null via numeric code 1013`() = runTest {
         // Bittensor previously matched only the case-sensitive "Already Imported" string and
-        // ignored the numeric code on the wire; the shared classifier now recognizes 1012/1013 too.
+        // ignored the numeric code on the wire; the shared classifier now recognizes code 1013.
         val body =
             """
             {
               "jsonrpc": "2.0",
               "error": {
-                "code": 1012,
-                "message": "Priority is too low",
+                "code": 1013,
+                "message": "Transaction is already imported",
                 "data": null
               },
               "id": 1
@@ -133,9 +133,59 @@ class BittensorApiBodyReadTest {
     }
 
     @Test
+    fun `broadcastTransaction throws on temporarily-banned code 1012`() = runTest {
+        // 1012 is TemporarilyBanned, not a harmless duplicate: it must throw so the caller verifies
+        // on-chain rather than fabricating a success hash.
+        val body =
+            """
+            {
+              "jsonrpc": "2.0",
+              "error": {
+                "code": 1012,
+                "message": "Transaction is temporarily banned",
+                "data": null
+              },
+              "id": 1
+            }
+            """
+                .trimIndent()
+        val api = newApi(body)
+
+        assertThrows<Exception> { api.broadcastTransaction(tx = "0x01") }
+    }
+
+    @Test
+    fun `broadcastTransaction resolves duplicate to null on a non-2xx idempotent response`() =
+        runTest {
+            // The relay may surface the idempotent "already imported" error with a non-2xx HTTP
+            // status; broadcastTransaction reads the body regardless of status and must still
+            // resolve the duplicate rebroadcast to null rather than throw.
+            val body =
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "error": {
+                    "code": 1013,
+                    "message": "Transaction is already imported",
+                    "data": null
+                  },
+                  "id": 1
+                }
+                """
+                    .trimIndent()
+            val api =
+                BittensorApiImp(
+                    httpClient = MockHttpClient.respondingWith(HttpStatusCode.BadRequest, body)
+                )
+
+            assertNull(api.broadcastTransaction(tx = "0x01"))
+        }
+
+    @Test
     fun `broadcastTransaction throws on a truncated body with neither result nor error`() =
         runTest {
-            // (null, null) under explicitNulls=false must not be reported as a successful broadcast.
+            // (null, null) under explicitNulls=false must not be reported as a successful
+            // broadcast.
             val body =
                 """
             {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Characterization tests for [PolkadotApiImp] methods that call `response.body<T>()`. They pin the
@@ -182,5 +183,45 @@ class PolkadotApiBodyReadTest {
             val result = api.broadcastTransaction(tx = "0x01")
 
             assertNull(result)
+        }
+
+    @Test
+    fun `broadcastTransaction throws on a truncated body with neither result nor error`() {
+        // Under production explicitNulls=false a body missing both fields decodes to (null, null);
+        // it must not be reported as a successful broadcast.
+        val body =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1
+            }
+            """
+                .trimIndent()
+        val api = newApiWith(clientForPlainJson(body))
+
+        assertThrows<Exception> { runBlocking { api.broadcastTransaction(tx = "0x01") } }
+    }
+
+    @Test
+    fun `broadcastTransaction resolves duplicate to null via case-insensitive message fallback`() =
+        runBlocking {
+            // A proxy that normalizes the numeric code away but preserves the message must still be
+            // recognized as an idempotent duplicate.
+            val body =
+                """
+            {
+              "jsonrpc": "2.0",
+              "error": {
+                "code": 0,
+                "message": "Transaction ALREADY known",
+                "data": null
+              },
+              "id": 1
+            }
+            """
+                    .trimIndent()
+            val api = newApiWith(clientForPlainJson(body))
+
+            assertNull(api.broadcastTransaction(tx = "0x01"))
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
@@ -163,14 +163,14 @@ class PolkadotApiBodyReadTest {
     }
 
     @Test
-    fun `broadcastTransaction returns null when error code is 1012 already imported`() =
+    fun `broadcastTransaction returns null when error code is 1013 already imported`() =
         runBlocking {
             val body =
                 """
             {
               "jsonrpc": "2.0",
               "error": {
-                "code": 1012,
+                "code": 1013,
                 "message": "Already Imported",
                 "data": null
               },
@@ -183,6 +183,52 @@ class PolkadotApiBodyReadTest {
             val result = api.broadcastTransaction(tx = "0x01")
 
             assertNull(result)
+        }
+
+    @Test
+    fun `broadcastTransaction throws on temporarily-banned code 1012`() {
+        // 1012 is TemporarilyBanned, not AlreadyImported: a banned tx is retriable/potentially
+        // invalid and must throw so the caller verifies on-chain rather than fabricating success.
+        val body =
+            """
+            {
+              "jsonrpc": "2.0",
+              "error": {
+                "code": 1012,
+                "message": "Transaction is temporarily banned",
+                "data": null
+              },
+              "id": 1
+            }
+            """
+                .trimIndent()
+        val api = newApiWith(clientForPlainJson(body))
+
+        assertThrows<Exception> { runBlocking { api.broadcastTransaction(tx = "0x01") } }
+    }
+
+    @Test
+    fun `broadcastTransaction resolves duplicate to null on a non-2xx idempotent response`() =
+        runBlocking {
+            // Nodes may surface the idempotent 1013 error with a non-2xx status;
+            // broadcastTransaction
+            // reads the body regardless of status and must still resolve the duplicate to null.
+            val body =
+                """
+            {
+              "jsonrpc": "2.0",
+              "error": {
+                "code": 1013,
+                "message": "Transaction is already imported",
+                "data": null
+              },
+              "id": 1
+            }
+            """
+                    .trimIndent()
+            val api = newApiWith(MockHttpClient.respondingWith(HttpStatusCode.BadRequest, body))
+
+            assertNull(api.broadcastTransaction(tx = "0x01"))
         }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiBodyReadTest.kt
@@ -5,7 +5,7 @@ import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
@@ -49,7 +49,7 @@ class PolkadotApiBodyReadTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `getNonce returns parsed BigInteger result`() = runBlocking {
+    fun `getNonce returns parsed BigInteger result`() = runTest {
         val body =
             """
             {
@@ -71,7 +71,7 @@ class PolkadotApiBodyReadTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `getBlockHash returns hash string`() = runBlocking {
+    fun `getBlockHash returns hash string`() = runTest {
         val body =
             """
             {
@@ -94,7 +94,7 @@ class PolkadotApiBodyReadTest {
 
     @Test
     fun `getRuntimeVersion returns specVersion and transactionVersion as BigInteger pair`() =
-        runBlocking {
+        runTest {
             val body =
                 """
             {
@@ -120,7 +120,7 @@ class PolkadotApiBodyReadTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `getBlockHeader parses hex block number and returns BigInteger`() = runBlocking {
+    fun `getBlockHeader parses hex block number and returns BigInteger`() = runTest {
         // "0x186a0" = 100000 decimal
         val body =
             """
@@ -145,7 +145,7 @@ class PolkadotApiBodyReadTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `broadcastTransaction returns result hash when error is absent`() = runBlocking {
+    fun `broadcastTransaction returns result hash when error is absent`() = runTest {
         val body =
             """
             {
@@ -163,10 +163,9 @@ class PolkadotApiBodyReadTest {
     }
 
     @Test
-    fun `broadcastTransaction returns null when error code is 1013 already imported`() =
-        runBlocking {
-            val body =
-                """
+    fun `broadcastTransaction returns null when error code is 1013 already imported`() = runTest {
+        val body =
+            """
             {
               "jsonrpc": "2.0",
               "error": {
@@ -177,16 +176,16 @@ class PolkadotApiBodyReadTest {
               "id": 1
             }
             """
-                    .trimIndent()
-            val api = newApiWith(clientForPlainJson(body))
+                .trimIndent()
+        val api = newApiWith(clientForPlainJson(body))
 
-            val result = api.broadcastTransaction(tx = "0x01")
+        val result = api.broadcastTransaction(tx = "0x01")
 
-            assertNull(result)
-        }
+        assertNull(result)
+    }
 
     @Test
-    fun `broadcastTransaction throws on temporarily-banned code 1012`() {
+    fun `broadcastTransaction throws on temporarily-banned code 1012`() = runTest {
         // 1012 is TemporarilyBanned, not AlreadyImported: a banned tx is retriable/potentially
         // invalid and must throw so the caller verifies on-chain rather than fabricating success.
         val body =
@@ -204,12 +203,12 @@ class PolkadotApiBodyReadTest {
                 .trimIndent()
         val api = newApiWith(clientForPlainJson(body))
 
-        assertThrows<Exception> { runBlocking { api.broadcastTransaction(tx = "0x01") } }
+        assertThrows<SubstrateBroadcastException> { api.broadcastTransaction(tx = "0x01") }
     }
 
     @Test
     fun `broadcastTransaction resolves duplicate to null on a non-2xx idempotent response`() =
-        runBlocking {
+        runTest {
             // Nodes may surface the idempotent 1013 error with a non-2xx status;
             // broadcastTransaction
             // reads the body regardless of status and must still resolve the duplicate to null.
@@ -232,25 +231,27 @@ class PolkadotApiBodyReadTest {
         }
 
     @Test
-    fun `broadcastTransaction throws on a truncated body with neither result nor error`() {
-        // Under production explicitNulls=false a body missing both fields decodes to (null, null);
-        // it must not be reported as a successful broadcast.
-        val body =
-            """
+    fun `broadcastTransaction throws on a truncated body with neither result nor error`() =
+        runTest {
+            // Under production explicitNulls=false a body missing both fields decodes to (null,
+            // null);
+            // it must not be reported as a successful broadcast.
+            val body =
+                """
             {
               "jsonrpc": "2.0",
               "id": 1
             }
             """
-                .trimIndent()
-        val api = newApiWith(clientForPlainJson(body))
+                    .trimIndent()
+            val api = newApiWith(clientForPlainJson(body))
 
-        assertThrows<Exception> { runBlocking { api.broadcastTransaction(tx = "0x01") } }
-    }
+            assertThrows<SubstrateBroadcastException> { api.broadcastTransaction(tx = "0x01") }
+        }
 
     @Test
     fun `broadcastTransaction resolves duplicate to null via case-insensitive message fallback`() =
-        runBlocking {
+        runTest {
             // A proxy that normalizes the numeric code away but preserves the message must still be
             // recognized as an idempotent duplicate.
             val body =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcastTest.kt
@@ -33,14 +33,17 @@ class SubstrateBroadcastTest {
     }
 
     @Test
-    fun `idempotent code 1012 resolves to null`() {
+    fun `temporarily-banned code 1012 throws instead of resolving to a duplicate`() {
+        // 1012 is TemporarilyBanned (not AlreadyImported): the tx was banned after being reported
+        // invalid, so it is retriable and must flow through the on-chain recovery path, not be
+        // reported as a successful duplicate.
         val response =
             PolkadotBroadcastTransactionJson(
                 result = null,
-                error = error(1012, "Priority is too low"),
+                error = error(1012, "Transaction is temporarily banned"),
             )
 
-        assertNull(SubstrateBroadcast.classify(response))
+        assertThrows<SubstrateBroadcastException> { SubstrateBroadcast.classify(response) }
     }
 
     @Test
@@ -70,14 +73,28 @@ class SubstrateBroadcastTest {
     }
 
     @Test
-    fun `temporarily banned message resolves to null`() {
+    fun `temporarily banned message throws`() {
+        // A banned transaction is not a harmless duplicate; it must not be reported as success.
         val response =
             PolkadotBroadcastTransactionJson(
                 result = null,
                 error = error(6666, "Temporarily Banned"),
             )
 
-        assertNull(SubstrateBroadcast.classify(response))
+        assertThrows<SubstrateBroadcastException> { SubstrateBroadcast.classify(response) }
+    }
+
+    @Test
+    fun `unrelated error merely containing an idempotent word is not a duplicate`() {
+        // Word-boundary matching guards against substring false positives: an error that mentions
+        // e.g. "imported" in a different context must still throw rather than fabricate success.
+        val response =
+            PolkadotBroadcastTransactionJson(
+                result = null,
+                error = error(1010, "Extrinsic could not be imported: invalid signature"),
+            )
+
+        assertThrows<SubstrateBroadcastException> { SubstrateBroadcast.classify(response) }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SubstrateBroadcastTest.kt
@@ -1,0 +1,93 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotBroadcastTransactionErrorJson
+import com.vultisig.wallet.data.api.models.cosmos.PolkadotBroadcastTransactionJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Unit tests for the shared Substrate `author_submitExtrinsic` classifier used by both
+ * [PolkadotApiImp] and [BittensorApiImp]. Guards the fix for the `(null, null)` malformed-body hole
+ * where a body with neither `result` nor `error` was reported to the user as a successful
+ * broadcast.
+ */
+class SubstrateBroadcastTest {
+
+    private fun error(code: Int, message: String? = null, data: String? = null) =
+        PolkadotBroadcastTransactionErrorJson(code = code, message = message, data = data)
+
+    @Test
+    fun `accepts a present result and returns the hash`() {
+        val response = PolkadotBroadcastTransactionJson(result = "0xcafe", error = null)
+
+        assertEquals("0xcafe", SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `treats an unset (null, null) body as unknown and throws`() {
+        val response = PolkadotBroadcastTransactionJson(result = null, error = null)
+
+        assertThrows<SubstrateBroadcastException> { SubstrateBroadcast.classify(response) }
+    }
+
+    @Test
+    fun `idempotent code 1012 resolves to null`() {
+        val response =
+            PolkadotBroadcastTransactionJson(
+                result = null,
+                error = error(1012, "Priority is too low"),
+            )
+
+        assertNull(SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `idempotent code 1013 resolves to null`() {
+        val response = PolkadotBroadcastTransactionJson(result = null, error = error(1013))
+
+        assertNull(SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `case-variant already imported message resolves to null`() {
+        val response =
+            PolkadotBroadcastTransactionJson(result = null, error = error(6666, "ALREADY imported"))
+
+        assertNull(SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `already known message resolves to null`() {
+        val response =
+            PolkadotBroadcastTransactionJson(
+                result = null,
+                error = error(6666, "Transaction Already Known"),
+            )
+
+        assertNull(SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `temporarily banned message resolves to null`() {
+        val response =
+            PolkadotBroadcastTransactionJson(
+                result = null,
+                error = error(6666, "Temporarily Banned"),
+            )
+
+        assertNull(SubstrateBroadcast.classify(response))
+    }
+
+    @Test
+    fun `non-idempotent node error throws`() {
+        val response =
+            PolkadotBroadcastTransactionJson(
+                result = null,
+                error = error(1010, "Invalid Transaction"),
+            )
+
+        assertThrows<SubstrateBroadcastException> { SubstrateBroadcast.classify(response) }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.PolkadotApi
 import com.vultisig.wallet.data.api.RippleApi
 import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.SubstrateBroadcastException
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.chains.SuiApi
@@ -337,6 +338,73 @@ class BroadcastTxUseCaseTest {
         assertEquals(KNOWN_TRANSACTION_HASH, txHash)
     }
 
+    @Test
+    fun `bittensor uses broadcast hash when the extrinsic is accepted`() = runTest {
+        val bittensorApi = mockk<BittensorApi>()
+        coEvery { bittensorApi.broadcastTransaction(RAW_TRANSACTION) } returns BROADCAST_HASH
+
+        val txHash =
+            createUseCase(bittensorApi = bittensorApi)(Chain.Bittensor, signedTransaction())
+
+        assertEquals(BROADCAST_HASH, txHash)
+    }
+
+    @Test
+    fun `bittensor falls back to known hash on an idempotent duplicate rebroadcast`() = runTest {
+        val bittensorApi = mockk<BittensorApi>()
+        // A duplicate rebroadcast from a peer classifies to null; the local hash is canonical.
+        coEvery { bittensorApi.broadcastTransaction(RAW_TRANSACTION) } returns null
+
+        val txHash =
+            createUseCase(bittensorApi = bittensorApi)(Chain.Bittensor, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+        coVerify(exactly = 1) { bittensorApi.broadcastTransaction(RAW_TRANSACTION) }
+    }
+
+    @Test
+    fun `bittensor recovers with local hash when a malformed broadcast is already on chain`() =
+        runTest {
+            val bittensorApi = mockk<BittensorApi>()
+            val statusRepo = mockk<TransactionStatusRepository>()
+            coEvery { bittensorApi.broadcastTransaction(RAW_TRANSACTION) } throws
+                substrateBroadcastFailure()
+            coEvery {
+                statusRepo.checkTransactionStatus(KNOWN_TRANSACTION_HASH, Chain.Bittensor)
+            } returns TransactionResult.Confirmed
+
+            val txHash =
+                createUseCase(
+                    bittensorApi = bittensorApi,
+                    transactionStatusRepository = statusRepo,
+                )(Chain.Bittensor, signedTransaction())
+
+            assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+        }
+
+    @Test
+    fun `bittensor rethrows a malformed broadcast when the tx is not on chain`() = runTest {
+        val bittensorApi = mockk<BittensorApi>()
+        val statusRepo = mockk<TransactionStatusRepository>()
+        val failure = substrateBroadcastFailure()
+        coEvery { bittensorApi.broadcastTransaction(RAW_TRANSACTION) } throws failure
+        coEvery {
+            statusRepo.checkTransactionStatus(KNOWN_TRANSACTION_HASH, Chain.Bittensor)
+        } returns TransactionResult.Pending
+
+        val thrown =
+            assertFailsWith<SubstrateBroadcastException> {
+                createUseCase(
+                    bittensorApi = bittensorApi,
+                    transactionStatusRepository = statusRepo,
+                )(Chain.Bittensor, signedTransaction())
+            }
+        assertEquals(failure, thrown)
+        coVerify(exactly = 3) {
+            statusRepo.checkTransactionStatus(KNOWN_TRANSACTION_HASH, Chain.Bittensor)
+        }
+    }
+
     private fun blockchairResult(blockId: Int) =
         BlockChainStatusDeserialized.Result(
             BlockChairStatusResponse(
@@ -354,6 +422,7 @@ class BroadcastTxUseCaseTest {
         mayaChainApi: MayaChainApi = mockk(relaxed = true),
         cosmosApiFactory: CosmosApiFactory = mockk(relaxed = true),
         blockChairApi: BlockChairApi = mockk(relaxed = true),
+        bittensorApi: BittensorApi = mockk(relaxed = true),
         transactionStatusRepository: TransactionStatusRepository = mockk(relaxed = true),
     ) =
         BroadcastTxUseCaseImpl(
@@ -364,7 +433,7 @@ class BroadcastTxUseCaseTest {
             cosmosApiFactory = cosmosApiFactory,
             solanaApi = mockk<SolanaApi>(relaxed = true),
             polkadotApi = mockk<PolkadotApi>(relaxed = true),
-            bittensorApi = mockk<BittensorApi>(relaxed = true),
+            bittensorApi = bittensorApi,
             suiApi = mockk<SuiApi>(relaxed = true),
             tonApi = mockk<TonApi>(relaxed = true),
             rippleApi = mockk<RippleApi>(relaxed = true),
@@ -377,6 +446,9 @@ class BroadcastTxUseCaseTest {
         CosmosTxStatusJson(
             txResponse = TxResponse(height = "1", txHash = KNOWN_TRANSACTION_HASH, code = code)
         )
+
+    private fun substrateBroadcastFailure() =
+        SubstrateBroadcastException("Substrate broadcast returned neither a result nor an error")
 
     private fun sequenceMismatch() =
         CosmosBroadcastException.from(


### PR DESCRIPTION
Closes #5320


### Transaction hash
https://taostats.io/extrinsic/0xcafd2c16b579ec3e0c2ac1e38d08a148c8f242052c339f9f70beaad520091df0

## Problem

`broadcastTransaction` on both Substrate chains returns `String?`, and `null` was overloaded to mean two incompatible things:

- **intended** — a duplicate rebroadcast (the MPC peer already submitted this) → resolve to the known hash
- **unintended** — the response body had neither `result` nor `error` and we have no idea what happened

Under the production `Json { explicitNulls = false }` config, a truncated / gateway-mangled `author_submitExtrinsic` body decodes cleanly to `(null, null)`. Both cases flowed through `.orKnownHash(tx)` and were reported to the user as a **successful broadcast with a locally-computed hash** — for a transaction that may never have reached a node. Nothing verified on-chain. On Bittensor there was **no recovery/verify path at all**.

Bittensor's idempotency check was also weaker than Polkadot's: it matched only the case-sensitive string `"Already Imported"` and ignored the numeric code on the wire, while Polkadot matched only the numeric code with no message fallback.

## Fix

One shared classifier both chains call (mirrors iOS's `RpcService.BroadcastErrorClassifier`, so the two chains cannot drift):

- `result` present → return the hash
- idempotent error — codes `1012`/`1013` **or** case-insensitive `already imported` / `already known` / `temporarily banned` → return `null`
- `(null, null)` or any other error → **throw**

- **`SubstrateBroadcast.kt`** (new) — the classifier + `SubstrateBroadcastException`.
- **`PolkadotApi` / `BittensorApi`** — both `broadcastTransaction` delegate to it (uniform idempotency detection).
- **`BroadcastTxUseCase`** — wrapped **Bittensor** in `recoverIfAlreadyBroadcast` with an on-chain `verify` (via the Bittensor status provider), so a thrown malformed body now checks the extrinsic actually landed before claiming success — as Polkadot already did.

## Acceptance criteria

- [x] `(null, null)` body no longer reports success
- [x] Bittensor verifies on-chain before claiming success
- [x] Shared idempotency classifier used by both chains
- [x] Tests: truncated body, case-variant "already imported", codes 1012/1013 with an unexpected message

## Test plan

- `SubstrateBroadcastTest` (8 cases) — accept / `(null,null)` throws / codes 1012+1013 / case-variant message fallbacks / non-idempotent error throws.
- `PolkadotApiBodyReadTest` + `BittensorApiBodyReadTest` — added truncated-body-throws and code/message-fallback cases through the real kotlinx decode path (`explicitNulls = false`).
- All `:data` unit tests pass.

## Device verification (happy path, both chains)

Real Vultisig-signed self-sends broadcast and confirmed successful on-chain — the newly-wrapped Bittensor recover/verify path does not break normal sends:

| Chain | Call | Result | Explorer |
|---|---|---|---|
| Bittensor | `Balances.transfer_allow_death` | ✅ success (block 8654541) | https://taostats.io/extrinsic/0x9125336c984a40a3acbe6e954e9e05cb5cd1cf2dcd9551724524d7c93a4261fd |
| Polkadot AssetHub | `Balances.transfer_keep_alive` | ✅ success (block 18397944) | https://assethub-polkadot.subscan.io/extrinsic/0x9b9d5163ea147d78b76c5ab7711f3177886a77c1b3089b5099588528519ab29b |

Related: vultisig-sdk#1391 (the SDK's Bittensor resolver has the same missing-`result` hole).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction broadcast handling across supported Substrate-based networks.
  - Idempotent “already imported/known” submissions (e.g., JSON-RPC code **1013**) are now treated as non-failures.
  - “Temporarily banned” submissions (e.g., JSON-RPC code **1012**) and malformed/ambiguous responses now correctly fail instead of being misreported as success.
  - Bittensor broadcasts now only report success after the transaction is confirmed on-chain.

- **Tests**
  - Expanded coverage for duplicate handling, temporarily banned cases, malformed responses, non-2xx idempotent bodies, and classifier edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->