### PR TITLE
fix(swap): show chain indicator on both swap-overview token rows

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -188,6 +188,7 @@ class PreviewActivity : ComponentActivity() {
             OnBoardingComposeTheme {
                 when (screen) {
                     "swap_confirm" -> SwapConfirmPreview()
+                    "swap_confirm_chain" -> SwapChainIndicatorPreview()
                     "swap_confirm_disabled" -> SwapConfirmPreview(allConsents = false)
                     "swap_confirm_external_recipient" ->
                         SwapConfirmPreview(
@@ -692,6 +693,48 @@ private fun SwapConfirmPreview(allConsents: Boolean = true, externalRecipient: S
                             recommendations = "",
                         )
                     ),
+                vaultName = "Main Vault",
+            ),
+        hasToolbar = true,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
+    )
+}
+
+/**
+ * Swap overview with a native From asset (BTC) and a token To asset (USDC on Ethereum). Before the
+ * fix the From row omits the "on <chain>" indicator that the To row shows; after the fix both rows
+ * render it, so the two sides communicate their chain consistently.
+ */
+@Composable
+private fun SwapChainIndicatorPreview() {
+    val btcCoin = Coins.Bitcoin.BTC
+    val usdcCoin = Coins.Ethereum.USDC
+    val ethCoin = Coins.Ethereum.ETH
+
+    val tx =
+        SwapTransactionUiModel(
+            src = ValuedToken(token = btcCoin, value = "0.05", fiatValue = "$3,820.00"),
+            dst = ValuedToken(token = usdcCoin, value = "3,810.42", fiatValue = "$3,810.42"),
+            networkFee = ValuedToken(token = ethCoin, value = "0.0024", fiatValue = "$6.15"),
+            providerFee = ValuedToken(token = ethCoin, value = "0.0045", fiatValue = "$11.52"),
+            totalFee = "$17.67",
+            networkFeeFormatted = "0.0024 ETH ($6.15)",
+            providerFeeFormatted = "0.0045 ETH ($11.52)",
+            hasConsentAllowance = false,
+        )
+
+    VerifySwapScreen(
+        state =
+            VerifySwapUiModel(
+                tx = tx,
+                consentAmount = true,
+                consentReceiveAmount = true,
+                consentAllowance = false,
+                hasFastSign = true,
+                txScanStatus = TransactionScanStatus.NotStarted,
                 vaultName = "Main Vault",
             ),
         hasToolbar = true,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -45,7 +45,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.getProviderLogo
-import com.vultisig.wallet.data.models.isLayer2
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.swapAssetName
@@ -384,7 +383,9 @@ internal fun SwapToken(
 ) {
     val token = valuedToken.token
     val value = valuedToken.value
-    val shouldShowOnChainLogo = isSwap && (!token.isNativeToken || token.chain.isLayer2)
+    // Show the "on <chain>" indicator on both swap rows so the From and To sides communicate
+    // their chain consistently — including native assets on their own L1.
+    val shouldShowOnChainLogo = isSwap
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Summary

On the **Swap overview** screen the **From** token row omitted the `on <chain>` indicator while the **To** row showed it, so the two sides of the swap communicated their chain inconsistently.

The indicator was gated on `isSwap && (!token.isNativeToken || token.chain.isLayer2)`, which hid it for native assets on their own L1. On a native→token swap (e.g. BTC → USDC on Ethereum) the native From asset had no chain label while the token To asset did.

## Changes

- `VerifySwapScreen.kt` — gate the `on <chain>` indicator on `isSwap` alone, so both swap rows always render it. Removed the now-unused `isLayer2` import.
- `PreviewActivity.kt` — added a `swap_confirm_chain` debug preview (native From / token To) used to capture the renders below.

The only other `SwapToken` caller (verify-deposit) uses the default `isSwap = false` and is unaffected.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/sUj8kdE.png) | ![after](https://i.imgur.com/aHgwNKR.png) |

In *before*, only the To row (`USDC`) shows `on ETH`; the From row (`BTC`) has no indicator. In *after*, the From row shows `on BTC`, matching the To row.

## Test plan

- Open a swap with a native source and a token destination (e.g. BTC → USDC), reach the Swap overview, and confirm both rows show the `on <chain>` indicator.

Closes #5339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a swap confirmation preview showing chain indicators for both native and token assets.
  * Swap rows now consistently display the relevant network, including native assets.

* **Bug Fixes**
  * Improved chain visibility in swap confirmation screens for clearer transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->