### PR TITLE
fix: check swap inbound status before signing

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/FastSignPairedButtons.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/FastSignPairedButtons.kt
@@ -22,6 +22,7 @@ fun FastSignPairedButtons(
     onPairedSignClick: () -> Unit,
     modifier: Modifier = Modifier,
     state: VsButtonState = VsButtonState.Enabled,
+    isLoading: Boolean = false,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -35,6 +36,7 @@ fun FastSignPairedButtons(
             iconLeft = R.drawable.ic_paired_devices,
             variant = VsButtonVariant.Secondary,
             state = state,
+            isLoading = isLoading,
             onClick = onPairedSignClick,
         )
 
@@ -42,6 +44,7 @@ fun FastSignPairedButtons(
             label = stringResource(R.string.verify_transaction_fast_sign_btn_title),
             variant = VsButtonVariant.CTA,
             state = state,
+            isLoading = isLoading,
             onClick = onFastSignClick,
             modifier = Modifier.weight(1f),
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -27,7 +27,6 @@ import com.vultisig.wallet.ui.utils.resolveDstVaultName
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -284,14 +283,14 @@ constructor(
         val vault = vaultId ?: return
         viewModelScope.launch {
             password.value =
-                withContext(Dispatchers.IO) { vaultPasswordRepository.getPassword(vault) }
+                withContext(ioDispatcher) { vaultPasswordRepository.getPassword(vault) }
         }
     }
 
     private fun loadFastSign() {
         val vault = vaultId ?: return
         viewModelScope.launch {
-            val hasFastSign = withContext(Dispatchers.IO) { isVaultHasFastSignById(vault) }
+            val hasFastSign = withContext(ioDispatcher) { isVaultHasFastSignById(vault) }
             state.update { it.copy(hasFastSign = hasFastSign) }
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflight.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflight.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
+import com.vultisig.wallet.data.models.SwapTransaction
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.swapAssetName
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+/**
+ * Live, sign-time safety gate for native THORChain and MayaChain swaps.
+ *
+ * Quotes can become stale between the swap form and signing. Fetching the protocol's current
+ * inbound set here prevents spending source-chain gas on a deposit that the protocol will refund.
+ * The check deliberately fails closed when the inbound status cannot be verified.
+ */
+internal class SwapInboundHaltPreflight
+@Inject
+constructor(private val thorChainApi: ThorChainApi, private val mayaChainApi: MayaChainApi) {
+
+    suspend fun assertSourceChainNotHalted(transaction: SwapTransaction) {
+        val fetchInboundAddresses: suspend () -> List<THORChainInboundAddress> =
+            when (transaction.payload) {
+                is SwapPayload.ThorChain -> thorChainApi::getTHORChainInboundAddresses
+                is SwapPayload.MayaChain -> mayaChainApi::getInboundAddresses
+                else -> return
+            }
+
+        val inboundAddresses =
+            try {
+                fetchInboundAddresses()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Unable to verify swap inbound status; blocking native swap")
+                throw SwapException.TradingHalted(SIGNING_BLOCKED_MESSAGE)
+            }
+
+        val sourceChain = transaction.srcToken.chain.swapAssetName()
+        val inbound =
+            inboundAddresses.firstOrNull { it.chain.equals(sourceChain, ignoreCase = true) }
+
+        if (inbound?.let { it.halted || it.globalTradingPaused || it.chainTradingPaused } == true) {
+            throw SwapException.TradingHalted(SIGNING_BLOCKED_MESSAGE)
+        }
+    }
+
+    private companion object {
+        const val SIGNING_BLOCKED_MESSAGE = "Source-chain trading is halted or unavailable"
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SwapTransaction
@@ -224,10 +225,17 @@ constructor(
         state.update { it.copy(isSigning = true) }
         viewModelScope.safeLaunch(
             onError = { e ->
-                Timber.w(e, "Swap sign-time inbound preflight blocked signing")
-                state.update {
-                    it.copy(errorText = UiText.StringResource(R.string.swap_error_trading_halted))
-                }
+                // Only the preflight fails closed as a halt. A keysign/navigation failure must not
+                // masquerade as "trading halted", so it surfaces a generic error instead.
+                val errorMessage =
+                    if (e is SwapException.TradingHalted) {
+                        Timber.w(e, "Swap sign-time inbound preflight blocked signing")
+                        R.string.swap_error_trading_halted
+                    } else {
+                        Timber.e(e, "Swap keysign launch failed")
+                        R.string.error_view_default_title
+                    }
+                state.update { it.copy(errorText = UiText.StringResource(errorMessage)) }
             }
         ) {
             try {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -103,6 +103,7 @@ internal data class VerifySwapUiModel(
     val txScanStatus: TransactionScanStatus = TransactionScanStatus.NotStarted,
     val showScanningWarning: Boolean = false,
     val vaultName: String = "",
+    val isSigning: Boolean = false,
 ) {
     val hasAllConsents: Boolean
         get() =
@@ -122,6 +123,7 @@ constructor(
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
     private val securityScannerService: SecurityScannerContract,
     private val vaultRepository: VaultRepository,
+    private val inboundHaltPreflight: SwapInboundHaltPreflight,
 ) : ViewModel() {
 
     val state = MutableStateFlow(VerifySwapUiModel())
@@ -130,6 +132,7 @@ constructor(
     private val vaultId: VaultId = args.vaultId
     private val transactionId: String = args.transactionId
     private var _fastSign = false
+    private var transaction: SwapTransaction? = null
 
     private val _fastSignFlow = Channel<Boolean>()
     val fastSignFlow = _fastSignFlow.receiveAsFlow()
@@ -142,6 +145,7 @@ constructor(
                         navigator.back()
                         return@launch
                     }
+            this@VerifySwapViewModel.transaction = transaction
             val vault = vaultRepository.get(vaultId)
             val vaultName = vault?.name
             if (vaultName == null) {
@@ -204,23 +208,41 @@ constructor(
     }
 
     private fun keysign(keysignInitType: KeysignInitType) {
-        if (state.value.hasAllConsents) {
-            viewModelScope.launch {
-                launchKeysign(
-                    keysignInitType,
-                    transactionId,
-                    password.value,
-                    Route.Keysign.Keysign.TxType.Swap,
-                    vaultId,
-                )
-            }
-        } else {
+        if (!state.value.hasAllConsents) {
             state.update {
                 it.copy(
                     errorText =
                         UiText.StringResource(R.string.verify_transaction_error_not_enough_consent)
                 )
             }
+            return
+        }
+        if (state.value.isSigning) return
+
+        val transaction = transaction ?: return
+        state.update { it.copy(isSigning = true) }
+        viewModelScope.launch {
+            try {
+                inboundHaltPreflight.assertSourceChainNotHalted(transaction)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Swap sign-time inbound preflight blocked signing")
+                state.update {
+                    it.copy(
+                        errorText = UiText.StringResource(R.string.swap_error_trading_halted),
+                        isSigning = false,
+                    )
+                }
+                return@launch
+            }
+            launchKeysign(
+                keysignInitType,
+                transactionId,
+                password.value,
+                Route.Keysign.Keysign.TxType.Swap,
+                vaultId,
+            )
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.data.securityscanner.BLOCKAID_PROVIDER
 import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
 import com.vultisig.wallet.data.securityscanner.isChainSupported
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.mappers.SwapTransactionToUiModelMapper
@@ -221,28 +222,28 @@ constructor(
 
         val transaction = transaction ?: return
         state.update { it.copy(isSigning = true) }
-        viewModelScope.launch {
-            try {
-                inboundHaltPreflight.assertSourceChainNotHalted(transaction)
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                throw e
-            } catch (e: Exception) {
+        viewModelScope.safeLaunch(
+            onError = { e ->
                 Timber.w(e, "Swap sign-time inbound preflight blocked signing")
                 state.update {
-                    it.copy(
-                        errorText = UiText.StringResource(R.string.swap_error_trading_halted),
-                        isSigning = false,
-                    )
+                    it.copy(errorText = UiText.StringResource(R.string.swap_error_trading_halted))
                 }
-                return@launch
             }
-            launchKeysign(
-                keysignInitType,
-                transactionId,
-                password.value,
-                Route.Keysign.Keysign.TxType.Swap,
-                vaultId,
-            )
+        ) {
+            try {
+                inboundHaltPreflight.assertSourceChainNotHalted(transaction)
+                launchKeysign(
+                    keysignInitType,
+                    transactionId,
+                    password.value,
+                    Route.Keysign.Keysign.TxType.Swap,
+                    vaultId,
+                )
+            } finally {
+                // The verify ViewModel can remain alive when navigation is cancelled or fails.
+                // Always re-enable signing so a later attempt cannot be permanently dead-ended.
+                state.update { it.copy(isSigning = false) }
+            }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -140,6 +140,7 @@ internal fun VerifySwapScreen(
         scanStatus = state.txScanStatus,
         hasToShowWarningScanning = state.showScanningWarning,
         hasAllConsents = state.hasAllConsents,
+        isSigning = state.isSigning,
         consentAmount = state.consentAmount,
         consentReceiveAmount = state.consentReceiveAmount,
         consentAllowance = state.consentAllowance,
@@ -166,6 +167,7 @@ private fun VerifySwapScreen(
     scanStatus: TransactionScanStatus,
     hasToShowWarningScanning: Boolean,
     hasAllConsents: Boolean,
+    isSigning: Boolean,
     consentAmount: Boolean,
     consentReceiveAmount: Boolean,
     consentAllowance: Boolean,
@@ -183,6 +185,8 @@ private fun VerifySwapScreen(
     onContinueAnyway: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
+    val isSignEnabled = (!isConsentsEnabled || hasAllConsents) && !isSigning
+
     V2Scaffold(
         title = stringResource(R.string.verify_swap_swap_overview).takeIf { hasToolbar },
         onBackClick = onBackClick.takeIf { hasToolbar },
@@ -353,7 +357,7 @@ private fun VerifySwapScreen(
                         onFastSignClick = onFastSignClick,
                         onPairedSignClick = onConfirm,
                         state =
-                            if (isConsentsEnabled && !hasAllConsents) {
+                            if (!isSignEnabled) {
                                 VsButtonState.Disabled
                             } else {
                                 VsButtonState.Enabled
@@ -364,8 +368,7 @@ private fun VerifySwapScreen(
                         label = confirmTitle,
                         modifier = Modifier.fillMaxWidth(),
                         state =
-                            if (isConsentsEnabled && !hasAllConsents) VsButtonState.Disabled
-                            else VsButtonState.Enabled,
+                            if (!isSignEnabled) VsButtonState.Disabled else VsButtonState.Enabled,
                         onClick = onConfirm,
                     )
                 }
@@ -670,6 +673,7 @@ private fun VerifySwapScreenPreview() {
         hasToolbar = true,
         onBackClick = {},
         hasAllConsents = false,
+        isSigning = false,
         hasToShowWarningScanning = false,
         scanStatus = TransactionScanStatus.NotStarted,
         consentAmount = true,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -362,6 +362,7 @@ private fun VerifySwapScreen(
                             } else {
                                 VsButtonState.Enabled
                             },
+                        isLoading = isSigning,
                     )
                 } else {
                     VsButton(
@@ -369,6 +370,7 @@ private fun VerifySwapScreen(
                         modifier = Modifier.fillMaxWidth(),
                         state =
                             if (!isSignEnabled) VsButtonState.Disabled else VsButtonState.Enabled,
+                        isLoading = isSigning,
                         onClick = onConfirm,
                     )
                 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflightTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflightTest.kt
@@ -1,0 +1,101 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SwapTransaction
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class SwapInboundHaltPreflightTest {
+
+    private val thorChainApi = mockk<ThorChainApi>()
+    private val mayaChainApi = mockk<MayaChainApi>()
+    private val preflight = SwapInboundHaltPreflight(thorChainApi, mayaChainApi)
+
+    @Test
+    fun `THORChain route is blocked when its source chain inbound is halted`() = runTest {
+        val transaction = transaction(SwapPayload.ThorChain(mockk(relaxed = true)), Chain.Bitcoin)
+        coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "BTC", halted = true))
+
+        assertFailsWith<SwapException.TradingHalted> {
+            preflight.assertSourceChainNotHalted(transaction)
+        }
+        coVerify(exactly = 0) { mayaChainApi.getInboundAddresses() }
+    }
+
+    @Test
+    fun `MayaChain route is blocked when global trading is paused`() = runTest {
+        val transaction = transaction(SwapPayload.MayaChain(mockk(relaxed = true)), Chain.Ethereum)
+        coEvery { mayaChainApi.getInboundAddresses() } returns
+            listOf(inbound(chain = "eth", globalTradingPaused = true))
+
+        assertFailsWith<SwapException.TradingHalted> {
+            preflight.assertSourceChainNotHalted(transaction)
+        }
+        coVerify(exactly = 0) { thorChainApi.getTHORChainInboundAddresses() }
+    }
+
+    @Test
+    fun `native route proceeds when source chain inbound is active`() = runTest {
+        val transaction = transaction(SwapPayload.ThorChain(mockk(relaxed = true)), Chain.Bitcoin)
+        coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "BTC"))
+
+        preflight.assertSourceChainNotHalted(transaction)
+    }
+
+    @Test
+    fun `native route fails closed when inbound fetch fails`() = runTest {
+        val transaction = transaction(SwapPayload.MayaChain(mockk(relaxed = true)), Chain.Bitcoin)
+        coEvery { mayaChainApi.getInboundAddresses() } throws IllegalStateException("offline")
+
+        assertFailsWith<SwapException.TradingHalted> {
+            preflight.assertSourceChainNotHalted(transaction)
+        }
+    }
+
+    @Test
+    fun `non-native provider does not fetch inbound status`() = runTest {
+        val transaction = transaction(mockk<SwapPayload.EVM>(relaxed = true), Chain.Ethereum)
+
+        preflight.assertSourceChainNotHalted(transaction)
+
+        coVerify(exactly = 0) { thorChainApi.getTHORChainInboundAddresses() }
+        coVerify(exactly = 0) { mayaChainApi.getInboundAddresses() }
+    }
+
+    private fun transaction(swapPayload: SwapPayload, sourceChain: Chain): SwapTransaction =
+        mockk(relaxed = true) {
+            every { payload } returns swapPayload
+            every { srcToken } returns
+                mockk<Coin>(relaxed = true) { every { chain } returns sourceChain }
+        }
+
+    private fun inbound(
+        chain: String,
+        halted: Boolean = false,
+        globalTradingPaused: Boolean = false,
+        chainTradingPaused: Boolean = false,
+    ) =
+        THORChainInboundAddress(
+            chain = chain,
+            address = "inbound-address",
+            halted = halted,
+            globalTradingPaused = globalTradingPaused,
+            chainTradingPaused = chainTradingPaused,
+            chainLPActionsPaused = false,
+            gasRate = "1",
+            gasRateUnits = "satsperbyte",
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflightTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapInboundHaltPreflightTest.kt
@@ -56,6 +56,16 @@ internal class SwapInboundHaltPreflightTest {
     }
 
     @Test
+    fun `native route proceeds when source chain is absent from inbound response`() = runTest {
+        val transaction = transaction(SwapPayload.ThorChain(mockk(relaxed = true)), Chain.Bitcoin)
+        coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
+            listOf(inbound(chain = "ETH", halted = true))
+
+        // Matches the iOS gate: a missing entry is not treated as a confirmed source-chain halt.
+        preflight.assertSourceChainNotHalted(transaction)
+    }
+
+    @Test
     fun `native route fails closed when inbound fetch fails`() = runTest {
         val transaction = transaction(SwapPayload.MayaChain(mockk(relaxed = true)), Chain.Bitcoin)
         coEvery { mayaChainApi.getInboundAddresses() } throws IllegalStateException("offline")

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
@@ -264,6 +264,7 @@ internal class VerifySwapViewModelTest {
             advanceUntilIdle()
 
             vm.state.value.errorText.shouldNotBeNull()
+            vm.state.value.isSigning shouldBe false
             coVerify(exactly = 0) { launchKeysign(any(), any(), any(), any(), any()) }
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.ui.models.swap
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SwapTransaction
@@ -63,6 +64,7 @@ internal class VerifySwapViewModelTest {
     private lateinit var isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase
     private lateinit var securityScannerService: SecurityScannerContract
     private lateinit var vaultRepository: VaultRepository
+    private lateinit var inboundHaltPreflight: SwapInboundHaltPreflight
 
     /** Sets up mocks and test dispatcher before each test. */
     @BeforeEach
@@ -79,6 +81,7 @@ internal class VerifySwapViewModelTest {
         isVaultHasFastSignById = mockk(relaxed = true)
         securityScannerService = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
+        inboundHaltPreflight = mockk(relaxed = true)
         coEvery { isVaultHasFastSignById(any()) } returns false
         coEvery { vaultRepository.get(VAULT_ID) } returns mockk<Vault>(relaxed = true)
     }
@@ -101,6 +104,7 @@ internal class VerifySwapViewModelTest {
             isVaultHasFastSignById = isVaultHasFastSignById,
             securityScannerService = securityScannerService,
             vaultRepository = vaultRepository,
+            inboundHaltPreflight = inboundHaltPreflight,
         )
 
     /**
@@ -220,6 +224,44 @@ internal class VerifySwapViewModelTest {
                     VAULT_ID,
                 )
             }
+        }
+
+    /** A live inbound halt aborts paired signing and surfaces the existing trading-halted error. */
+    @Test
+    fun `joinKeySign blocks signing when the source chain becomes halted`() =
+        runTest(testDispatcher) {
+            givenSwap(approvalRequired = false)
+            coEvery { inboundHaltPreflight.assertSourceChainNotHalted(any()) } throws
+                SwapException.TradingHalted("halted")
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.consentAmount(true)
+            vm.consentReceiveAmount(true)
+            vm.joinKeySign()
+            advanceUntilIdle()
+
+            vm.state.value.errorText.shouldNotBeNull()
+            coVerify(exactly = 0) { launchKeysign(any(), any(), any(), any(), any()) }
+        }
+
+    /** The biometric path runs through the same live inbound safety gate. */
+    @Test
+    fun `authFastSign blocks signing when inbound status cannot be verified`() =
+        runTest(testDispatcher) {
+            givenSwap(approvalRequired = false)
+            coEvery { inboundHaltPreflight.assertSourceChainNotHalted(any()) } throws
+                IllegalStateException("network unavailable")
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.consentAmount(true)
+            vm.consentReceiveAmount(true)
+            vm.authFastSign()
+            advanceUntilIdle()
+
+            vm.state.value.errorText.shouldNotBeNull()
+            coVerify(exactly = 0) { launchKeysign(any(), any(), any(), any(), any()) }
         }
 
     private companion object {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
@@ -22,6 +22,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -157,6 +158,7 @@ internal class VerifySwapViewModelTest {
             vm.joinKeySign()
 
             vm.state.value.errorText.shouldBeNull()
+            vm.state.value.isSigning shouldBe false
             coVerify {
                 launchKeysign(
                     KeysignInitType.QR_CODE,
@@ -242,6 +244,7 @@ internal class VerifySwapViewModelTest {
             advanceUntilIdle()
 
             vm.state.value.errorText.shouldNotBeNull()
+            vm.state.value.isSigning shouldBe false
             coVerify(exactly = 0) { launchKeysign(any(), any(), any(), any(), any()) }
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -24,6 +24,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.path
@@ -311,6 +312,9 @@ constructor(
         httpClient
             .get("$MAYA_NODE_BASE/mayachain/inbound_addresses") {
                 header(xClientID, xClientIDValue)
+                // Inbound status drives a fail-closed halt gate, so it must never be served from
+                // the shared HttpCache if upstream ever starts sending cache headers.
+                header(HttpHeaders.CacheControl, "no-cache, no-store")
             }
             .bodyOrThrow()
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/MayaChainApi.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.api.models.cosmos.THORChainAccountResultJson
 import com.vultisig.wallet.data.api.models.cosmos.THORChainAccountValue
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteError
+import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
 import com.vultisig.wallet.data.chains.helpers.THORChainSwaps
 import com.vultisig.wallet.data.chains.helpers.THORChainSwaps.Companion.MAYA_STREAMING_INTERVAL
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
@@ -62,6 +63,8 @@ interface MayaChainApi {
     suspend fun getCacaoProvider(address: String): CacaoProviderResponse
 
     suspend fun getMayaConstants(): Map<String, Long>
+
+    suspend fun getInboundAddresses(): List<THORChainInboundAddress>
 
     suspend fun getAllNodes(): List<MayaNodeInfo>
 
@@ -303,6 +306,13 @@ constructor(
             throw e
         }
     }
+
+    override suspend fun getInboundAddresses(): List<THORChainInboundAddress> =
+        httpClient
+            .get("$MAYA_NODE_BASE/mayachain/inbound_addresses") {
+                header(xClientID, xClientIDValue)
+            }
+            .bodyOrThrow()
 
     override suspend fun getAllNodes(): List<MayaNodeInfo> =
         httpClient

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -54,6 +54,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
@@ -348,6 +349,9 @@ constructor(
         httpClient
             .get("$THORNODE_BASE/thorchain/inbound_addresses") {
                 header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE)
+                // Inbound status drives a fail-closed halt gate, so it must never be served from
+                // the shared HttpCache if upstream ever starts sending cache headers.
+                header(HttpHeaders.CacheControl, "no-cache, no-store")
             }
             .bodyOrThrow()
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
@@ -9,9 +9,11 @@ data class THORChainInboundAddress(
     @SerialName("chain") val chain: String,
     @SerialName("address") val address: String,
     @SerialName("halted") val halted: Boolean,
-    @SerialName("global_trading_paused") val globalTradingPaused: Boolean,
-    @SerialName("chain_trading_paused") val chainTradingPaused: Boolean,
-    @SerialName("chain_lp_actions_paused") val chainLPActionsPaused: Boolean,
+    // MayaChain omits pause fields when they are false, while THORChain currently emits them.
+    // Defaults keep the shared inbound model compatible with both protocols.
+    @SerialName("global_trading_paused") val globalTradingPaused: Boolean = false,
+    @SerialName("chain_trading_paused") val chainTradingPaused: Boolean = false,
+    @SerialName("chain_lp_actions_paused") val chainLPActionsPaused: Boolean = false,
     @SerialName("gas_rate") val gasRate: String,
     @SerialName("gas_rate_units") val gasRateUnits: String,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
@@ -14,6 +14,6 @@ data class THORChainInboundAddress(
     @SerialName("global_trading_paused") val globalTradingPaused: Boolean = false,
     @SerialName("chain_trading_paused") val chainTradingPaused: Boolean = false,
     @SerialName("chain_lp_actions_paused") val chainLPActionsPaused: Boolean = false,
-    @SerialName("gas_rate") val gasRate: String,
-    @SerialName("gas_rate_units") val gasRateUnits: String,
+    @SerialName("gas_rate") val gasRate: String = "",
+    @SerialName("gas_rate_units") val gasRateUnits: String = "",
 )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/MayaChainApiBodyReadTest.kt
@@ -216,6 +216,28 @@ class MayaChainApiBodyReadTest {
         assertEquals(1_000_000L, result["OUTBOUNDTRANSACTIONFEE"])
     }
 
+    @Test
+    fun `getInboundAddresses returns MayaChain halt status`() = runBlocking {
+        val body =
+            """
+            [{
+              "chain": "BTC",
+              "address": "bc1qinbound",
+              "halted": false,
+              "gas_rate": "1",
+              "gas_rate_units": "satsperbyte"
+            }]
+            """
+                .trimIndent()
+
+        val result = newApi(body).getInboundAddresses()
+
+        assertEquals(1, result.size)
+        assertEquals("BTC", result.single().chain)
+        assertEquals(false, result.single().globalTradingPaused)
+        assertEquals(false, result.single().chainTradingPaused)
+    }
+
     // -------------------------------------------------------------------------
     // getSwapQuotes — body fed into ThorChainSwapQuoteResponseJsonSerializer
     // Pins: the body is read and delegated to the serializer regardless of status, so a non-2xx


### PR DESCRIPTION
## What changed

- add a live sign-time inbound status preflight for native THORChain and MayaChain swaps
- query the source protocol directly and match the source chain's inbound entry
- block signing when `halted`, `global_trading_paused`, or `chain_trading_paused` is set
- fail closed when inbound status cannot be fetched or decoded
- disable signing controls while the preflight is running
- add MayaChain `/mayachain/inbound_addresses` API support and tolerate pause fields omitted when false

## Why

The quote flow can detect trading halts, but the quote may become stale before the user signs. Android previously launched keysign from the verify screen without re-checking live inbound status, which could spend source-chain gas on a deposit that THORChain or MayaChain would refund. This brings Android in line with the iOS sign-time safety gate.

## User impact

Users are prevented from signing native THORChain/MayaChain swaps when the source chain has halted after quote creation. If live status cannot be verified, signing stays blocked and the existing trading-halted message is shown so the user can retry later.

## Validation

- `./gradlew test`
- `./gradlew ktfmtCheck`
- focused ViewModel, halt-gate, and Maya inbound decoding tests

on chain tx link: https://runescan.io/tx/B49D413263AF186CBB7FB2C5EEC3AE552B9682B4D2847D1551504DE95230C4BC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added inbound trading preflight checks for native swaps to block signing when the source chain is halted or unavailable.
  * Added MayaChain inbound status fetching to support halt validation.
* **Bug Fixes**
  * Implemented “fail closed” verification: signing is blocked when inbound status can’t be confirmed.
* **UI Improvements**
  * Disabled swap CTAs while signing is in progress (including fast-sign paired buttons).
* **Tests**
  * Added/extended unit tests for halted/unavailable behavior and signing prevention.
* **Chores**
  * Updated network caching behavior and moved VerifyDepositViewModel background work to the injected I/O dispatcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->