### PR TITLE
fix(swap): resolve SwapKit UTXO signer by chain, not txType

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -122,67 +122,87 @@ object SigningHelper {
                     messages += message
                 }
                 is SwapPayload.SwapKit -> {
+                    val txType = swapPayload.data.txType
+                    // SwapKit's documented wire value for the whole UTXO family is the generic
+                    // "PSBT" — sometimes arriving blank when a peer's SDK omits `meta.txType` for
+                    // the non-Bitcoin variants. Android/iOS additionally stamp per-chain
+                    // PSBT_DOGE/PSBT_BCH/PSBT_DASH/PSBT_ZEC onto their own initiated swaps (kept
+                    // for backward compatibility). Either way the actual signer must come from the
+                    // payload's own `chain`, not from which literal happened to match, or a peer
+                    // that doesn't share the invented convention can't be joined.
                     messages +=
-                        when (swapPayload.data.txType) {
-                            // Segwit PSBT (BTC + LTC). CoinType is picked from the source chain;
-                            // the BIP-143 sighash + segwit serialization are otherwise identical.
-                            SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
-                                SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
-                                    .getPreSignedImageHash(
-                                        psbtBytes = swapPayload.data.txPayload,
-                                        targetAddress = swapPayload.data.targetAddress,
-                                        fromAmount = swapPayload.data.fromAmount,
-                                    )
-                            // Legacy P2PKH UTXO chains (DOGE / BCH / DASH). DOGE/DASH use classic
-                            // ECDSA sighashing; BCH adds SIGHASH_FORKID via its CoinType.
-                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE,
-                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH,
-                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ->
-                                SwapKitLegacyP2PKHSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
-                                    .getPreSignedImageHash(
-                                        psbtBytes = swapPayload.data.txPayload,
-                                        targetAddress = swapPayload.data.targetAddress,
-                                        fromAmount = swapPayload.data.fromAmount,
-                                    )
-                            // Transparent ZEC (Sapling-v4 body, ZIP-243 sighash).
-                            SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
-                                SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
-                                    .getPreSignedImageHash(
-                                        psbtBytes = swapPayload.data.txPayload,
-                                        targetAddress = swapPayload.data.targetAddress,
-                                        fromAmount = swapPayload.data.fromAmount,
-                                        zcashBranchId = payload.zcashBranchId,
-                                    )
-                            SwapKitSwapPayloadJson.TX_TYPE_TRON ->
-                                SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
-                                    .getPreSignedImageHash(swapPayload.data.txPayload)
-                            SwapKitSwapPayloadJson.TX_TYPE_SUI ->
-                                SwapKitSuiSigner(eddsaKey)
-                                    .getPreSignedImageHash(swapPayload.data.txPayload)
-                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
-                                SwapKitCardanoSigner(eddsaKey)
-                                    .getPreSignedImageHash(swapPayload.data.txPayload)
-                            // Deposit-only Cardano: no CBOR to sign — hash a plain ADA send to
-                            // targetAddress built from the blockChainSpecific, via the native path.
-                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
-                                CardanoHelper.getPreSignedImageHash(payload)
-                            // TON SwapKit is a plain native transfer to the deposit address. The
-                            // KeysignPayload already carries toAddress / toAmount / Ton specifics.
-                            // It reuses the native TonHelper path (no signTon, matching iOS).
-                            SwapKitSwapPayloadJson.TX_TYPE_TON ->
-                                TonHelper.getPreSignedImageHash(payload)
-                            // XRP is deposit-only: no SwapKit signer. SwapPayloadBuilder already
-                            // pointed the KeysignPayload's toAddress / toAmount / memo at the
-                            // deposit r-address, amount, and destination tag, so we reuse the
-                            // native RippleHelper path (which turns a numeric memo into the
-                            // destinationTag). Matches iOS, which lets XRP fall through to the
-                            // per-chain helper.
-                            SwapKitSwapPayloadJson.TX_TYPE_XRP ->
-                                RippleHelper.getPreSignedImageHash(payload)
-                            else ->
-                                error(
-                                    "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
-                                )
+                        if (SwapKitSwapPayloadJson.isUtxoPsbtTxType(txType)) {
+                            when (chain) {
+                                // Segwit PSBT (BTC + LTC). CoinType is picked from the source
+                                // chain; the BIP-143 sighash + segwit serialization are otherwise
+                                // identical.
+                                Chain.Bitcoin,
+                                Chain.Litecoin ->
+                                    SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
+                                        .getPreSignedImageHash(
+                                            psbtBytes = swapPayload.data.txPayload,
+                                            targetAddress = swapPayload.data.targetAddress,
+                                            fromAmount = swapPayload.data.fromAmount,
+                                        )
+                                // Legacy P2PKH UTXO chains (DOGE / BCH / DASH). DOGE/DASH use
+                                // classic ECDSA sighashing; BCH adds SIGHASH_FORKID via its
+                                // CoinType.
+                                Chain.BitcoinCash,
+                                Chain.Dogecoin,
+                                Chain.Dash ->
+                                    SwapKitLegacyP2PKHSigner(
+                                            ecdsaKey,
+                                            ecdsaChainCode,
+                                            chain.coinType,
+                                        )
+                                        .getPreSignedImageHash(
+                                            psbtBytes = swapPayload.data.txPayload,
+                                            targetAddress = swapPayload.data.targetAddress,
+                                            fromAmount = swapPayload.data.fromAmount,
+                                        )
+                                // Transparent ZEC (Sapling-v4 body, ZIP-243 sighash).
+                                Chain.Zcash ->
+                                    SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
+                                        .getPreSignedImageHash(
+                                            psbtBytes = swapPayload.data.txPayload,
+                                            targetAddress = swapPayload.data.targetAddress,
+                                            fromAmount = swapPayload.data.fromAmount,
+                                            zcashBranchId = payload.zcashBranchId,
+                                        )
+                                else -> error("Unsupported SwapKit txType for signing: $txType")
+                            }
+                        } else {
+                            when (txType) {
+                                SwapKitSwapPayloadJson.TX_TYPE_TRON ->
+                                    SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
+                                        .getPreSignedImageHash(swapPayload.data.txPayload)
+                                SwapKitSwapPayloadJson.TX_TYPE_SUI ->
+                                    SwapKitSuiSigner(eddsaKey)
+                                        .getPreSignedImageHash(swapPayload.data.txPayload)
+                                SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
+                                    SwapKitCardanoSigner(eddsaKey)
+                                        .getPreSignedImageHash(swapPayload.data.txPayload)
+                                // Deposit-only Cardano: no CBOR to sign — hash a plain ADA send to
+                                // targetAddress built from the blockChainSpecific, via the native
+                                // path.
+                                SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
+                                    CardanoHelper.getPreSignedImageHash(payload)
+                                // TON SwapKit is a plain native transfer to the deposit address.
+                                // The KeysignPayload already carries toAddress / toAmount / Ton
+                                // specifics. It reuses the native TonHelper path (no signTon,
+                                // matching iOS).
+                                SwapKitSwapPayloadJson.TX_TYPE_TON ->
+                                    TonHelper.getPreSignedImageHash(payload)
+                                // XRP is deposit-only: no SwapKit signer. SwapPayloadBuilder
+                                // already pointed the KeysignPayload's toAddress / toAmount / memo
+                                // at the deposit r-address, amount, and destination tag, so we
+                                // reuse the native RippleHelper path (which turns a numeric memo
+                                // into the destinationTag). Matches iOS, which lets XRP fall
+                                // through to the per-chain helper.
+                                SwapKitSwapPayloadJson.TX_TYPE_XRP ->
+                                    RippleHelper.getPreSignedImageHash(payload)
+                                else -> error("Unsupported SwapKit txType for signing: $txType")
+                            }
                         }
                 }
                 else -> Unit
@@ -385,66 +405,75 @@ object SigningHelper {
                 }
 
                 is SwapPayload.SwapKit -> {
-                    return when (swapPayload.data.txType) {
-                        SwapKitSwapPayloadJson.TX_TYPE_PSBT ->
-                            SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
-                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
-                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_DOGE,
-                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_BCH,
-                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH ->
-                            SwapKitLegacyP2PKHSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
-                                .getSignedTransaction(
-                                    psbtBytes = swapPayload.data.txPayload,
-                                    targetAddress = swapPayload.data.targetAddress,
-                                    fromAmount = swapPayload.data.fromAmount,
+                    val txType = swapPayload.data.txType
+                    // See the matching dispatcher in getKeysignMessages for why the UTXO family is
+                    // keyed off `chain` rather than `txType`.
+                    return if (SwapKitSwapPayloadJson.isUtxoPsbtTxType(txType)) {
+                        when (chain) {
+                            Chain.Bitcoin,
+                            Chain.Litecoin ->
+                                SwapKitBtcSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
+                                    .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                            Chain.BitcoinCash,
+                            Chain.Dogecoin,
+                            Chain.Dash ->
+                                SwapKitLegacyP2PKHSigner(ecdsaKey, ecdsaChainCode, chain.coinType)
+                                    .getSignedTransaction(
+                                        psbtBytes = swapPayload.data.txPayload,
+                                        targetAddress = swapPayload.data.targetAddress,
+                                        fromAmount = swapPayload.data.fromAmount,
+                                        signatures = signatures,
+                                    )
+                            Chain.Zcash ->
+                                SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
+                                    .getSignedTransaction(
+                                        psbtBytes = swapPayload.data.txPayload,
+                                        targetAddress = swapPayload.data.targetAddress,
+                                        fromAmount = swapPayload.data.fromAmount,
+                                        signatures = signatures,
+                                        zcashBranchId = keysignPayload.zcashBranchId,
+                                    )
+                            else -> error("Unsupported SwapKit txType for signing: $txType")
+                        }
+                    } else {
+                        when (txType) {
+                            SwapKitSwapPayloadJson.TX_TYPE_TRON ->
+                                SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
+                                    .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                            SwapKitSwapPayloadJson.TX_TYPE_SUI ->
+                                SwapKitSuiSigner(eddsaKey)
+                                    .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
+                                SwapKitCardanoSigner(eddsaKey)
+                                    .getSignedTransaction(swapPayload.data.txPayload, signatures)
+                            // Deposit-only Cardano: build & sign a plain ADA send to targetAddress
+                            // via the native Cardano path (same as a non-swap send).
+                            SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
+                                CardanoHelper.getSignedTransaction(
+                                    vaultHexPublicKey = eddsaKey,
+                                    vaultHexChainCode = vault.hexChainCode,
+                                    keysignPayload = keysignPayload,
                                     signatures = signatures,
                                 )
-                        SwapKitSwapPayloadJson.TX_TYPE_PSBT_ZEC ->
-                            SwapKitZcashSigner(ecdsaKey, ecdsaChainCode)
-                                .getSignedTransaction(
-                                    psbtBytes = swapPayload.data.txPayload,
-                                    targetAddress = swapPayload.data.targetAddress,
-                                    fromAmount = swapPayload.data.fromAmount,
+                            // TON SwapKit reuses the native TonHelper path (EdDSA), signing the
+                            // deposit transfer off the KeysignPayload's toAddress / toAmount —
+                            // matching iOS.
+                            SwapKitSwapPayloadJson.TX_TYPE_TON ->
+                                TonHelper.getSignedTransaction(
+                                    vaultHexPublicKey = eddsaKey,
+                                    payload = keysignPayload,
                                     signatures = signatures,
-                                    zcashBranchId = keysignPayload.zcashBranchId,
                                 )
-                        SwapKitSwapPayloadJson.TX_TYPE_TRON ->
-                            SwapKitTronSigner(ecdsaKey, ecdsaChainCode)
-                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
-                        SwapKitSwapPayloadJson.TX_TYPE_SUI ->
-                            SwapKitSuiSigner(eddsaKey)
-                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
-                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO_PREBUILT ->
-                            SwapKitCardanoSigner(eddsaKey)
-                                .getSignedTransaction(swapPayload.data.txPayload, signatures)
-                        // Deposit-only Cardano: build & sign a plain ADA send to targetAddress via
-                        // the native Cardano path (same as a non-swap send).
-                        SwapKitSwapPayloadJson.TX_TYPE_CARDANO ->
-                            CardanoHelper.getSignedTransaction(
-                                vaultHexPublicKey = eddsaKey,
-                                vaultHexChainCode = vault.hexChainCode,
-                                keysignPayload = keysignPayload,
-                                signatures = signatures,
-                            )
-                        // TON SwapKit reuses the native TonHelper path (EdDSA), signing the deposit
-                        // transfer off the KeysignPayload's toAddress / toAmount — matching iOS.
-                        SwapKitSwapPayloadJson.TX_TYPE_TON ->
-                            TonHelper.getSignedTransaction(
-                                vaultHexPublicKey = eddsaKey,
-                                payload = keysignPayload,
-                                signatures = signatures,
-                            )
-                        // XRP deposit-only: rebuild + sign a plain XRP Payment off the
-                        // KeysignPayload (toAddress / toAmount / memo) via the native RippleHelper.
-                        SwapKitSwapPayloadJson.TX_TYPE_XRP ->
-                            RippleHelper.getSignedTransaction(
-                                keysignPayload = keysignPayload,
-                                signatures = signatures,
-                            )
-                        else ->
-                            error(
-                                "Unsupported SwapKit txType for signing: ${swapPayload.data.txType}"
-                            )
+                            // XRP deposit-only: rebuild + sign a plain XRP Payment off the
+                            // KeysignPayload (toAddress / toAmount / memo) via the native
+                            // RippleHelper.
+                            SwapKitSwapPayloadJson.TX_TYPE_XRP ->
+                                RippleHelper.getSignedTransaction(
+                                    keysignPayload = keysignPayload,
+                                    signatures = signatures,
+                                )
+                            else -> error("Unsupported SwapKit txType for signing: $txType")
+                        }
                     }
                 }
                 else -> {}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -123,13 +123,8 @@ object SigningHelper {
                 }
                 is SwapPayload.SwapKit -> {
                     val txType = swapPayload.data.txType
-                    // SwapKit's documented wire value for the whole UTXO family is the generic
-                    // "PSBT" — sometimes arriving blank when a peer's SDK omits `meta.txType` for
-                    // the non-Bitcoin variants. Android/iOS additionally stamp per-chain
-                    // PSBT_DOGE/PSBT_BCH/PSBT_DASH/PSBT_ZEC onto their own initiated swaps (kept
-                    // for backward compatibility). Either way the actual signer must come from the
-                    // payload's own `chain`, not from which literal happened to match, or a peer
-                    // that doesn't share the invented convention can't be joined.
+                    // See SwapKitSwapPayloadJson.isUtxoPsbtTxType for why the UTXO family is keyed
+                    // off `chain` rather than `txType`.
                     messages +=
                         if (SwapKitSwapPayloadJson.isUtxoPsbtTxType(txType)) {
                             when (chain) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -76,9 +76,7 @@ data class SwapKitSwapPayloadJson(
          * `meta.txType` discriminator for the **legacy P2PKH** Dogecoin signing path. DOGE never
          * had segwit, so its UTXOs are classic P2PKH and need legacy (non-BIP-143) sighashing —
          * handled by [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] via
-         * `CoinType.DOGECOIN`. Android/iOS stamp this onto their own initiated swaps; kept for
-         * backward compatibility with in-flight swaps — the join-side dispatcher picks the signer
-         * from the payload's `chain`, not this literal (see [isUtxoPsbtTxType]).
+         * `CoinType.DOGECOIN`. Legacy; dispatch now keys off `chain` (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_DOGE = "PSBT_DOGE"
 
@@ -86,20 +84,16 @@ data class SwapKitSwapPayloadJson(
          * `meta.txType` discriminator for the **legacy P2PKH** Bitcoin Cash signing path. BCH uses
          * a BIP-143-style preimage with `SIGHASH_FORKID` over a legacy `scriptCode`; WalletCore's
          * `CoinType.BITCOINCASH` injects the right hash type, so it rides the same
-         * [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] as DOGE/DASH. Android/
-         * iOS stamp this onto their own initiated swaps; kept for backward compatibility with
-         * in-flight swaps — the join-side dispatcher picks the signer from the payload's `chain`,
-         * not this literal (see [isUtxoPsbtTxType]).
+         * [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] as DOGE/DASH. Legacy;
+         * dispatch now keys off `chain` (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_BCH = "PSBT_BCH"
 
         /**
          * `meta.txType` discriminator for the **legacy P2PKH** Dash signing path. DASH forked from
          * Bitcoin pre-0.12.x and has no segwit, so it uses legacy sighashing via `CoinType.DASH`
-         * through [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner]. Android/iOS
-         * stamp this onto their own initiated swaps; kept for backward compatibility with in-flight
-         * swaps — the join-side dispatcher picks the signer from the payload's `chain`, not this
-         * literal (see [isUtxoPsbtTxType]).
+         * through [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner]. Legacy;
+         * dispatch now keys off `chain` (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_DASH = "PSBT_DASH"
 
@@ -108,9 +102,7 @@ data class SwapKitSwapPayloadJson(
          * is wrapped in a BIP-174 envelope but the body is Sapling-v4 (extra version-group id,
          * expiry height, value-balance, shielded counts) and the sighash is ZIP-243; handled by
          * [com.vultisig.wallet.data.chains.helpers.SwapKitZcashSigner] via `CoinType.ZCASH` with
-         * the native branch id. Android/iOS stamp this onto their own initiated swaps; kept for
-         * backward compatibility with in-flight swaps — the join-side dispatcher picks the signer
-         * from the payload's `chain`, not this literal (see [isUtxoPsbtTxType]).
+         * the native branch id. Legacy; dispatch now keys off `chain` (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_ZEC = "PSBT_ZEC"
 
@@ -215,16 +207,10 @@ data class SwapKitSwapPayloadJson(
             )
 
         /**
-         * True when [txType] means "this is a UTXO-family PSBT" — SwapKit's documented wire value
-         * ([TX_TYPE_PSBT]) is the same generic string for every UTXO source chain, and sometimes
-         * arrives blank when a peer's SDK omits `meta.txType` for the non-Bitcoin variants. Also
-         * true for the legacy per-chain literals Android/iOS invent for their own initiated swaps.
-         * `SigningHelper` picks the actual signer from the payload's `chain`, not from which of
-         * these matched, so a peer that doesn't share the invented per-chain convention can still
-         * be joined. Compared case-insensitively:
-         * [txTypeOf][com.vultisig.wallet.data.repositories.swap.SwapKitQuoteSource] already treats
-         * SwapKit's own `meta.type` casing as unreliable on the quote side, so the join-side check
-         * must not be stricter than the side that decodes the same field.
+         * True when [txType] means "this is a UTXO-family PSBT": the documented wire value
+         * ([TX_TYPE_PSBT]), blank (a peer's SDK may omit `meta.txType`), or a legacy per-chain
+         * literal. `SigningHelper` then picks the signer from `chain`, not from which literal
+         * matched. Case-insensitive, matching the quote side's own distrust of `meta.type` casing.
          */
         fun isUtxoPsbtTxType(txType: String): Boolean =
             txType.isBlank() || txType.uppercase(Locale.ROOT) in UTXO_PSBT_TX_TYPES

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -75,8 +75,9 @@ data class SwapKitSwapPayloadJson(
          * `meta.txType` discriminator for the **legacy P2PKH** Dogecoin signing path. DOGE never
          * had segwit, so its UTXOs are classic P2PKH and need legacy (non-BIP-143) sighashing —
          * handled by [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] via
-         * `CoinType.DOGECOIN`. Distinct from [TX_TYPE_PSBT] so a cosigning peer (incl. iOS, which
-         * emits the same `"PSBT_DOGE"`) routes to the legacy compiler rather than the segwit path.
+         * `CoinType.DOGECOIN`. Android/iOS stamp this onto their own initiated swaps; kept for
+         * backward compatibility with in-flight swaps — the join-side dispatcher picks the signer
+         * from the payload's `chain`, not this literal (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_DOGE = "PSBT_DOGE"
 
@@ -84,16 +85,20 @@ data class SwapKitSwapPayloadJson(
          * `meta.txType` discriminator for the **legacy P2PKH** Bitcoin Cash signing path. BCH uses
          * a BIP-143-style preimage with `SIGHASH_FORKID` over a legacy `scriptCode`; WalletCore's
          * `CoinType.BITCOINCASH` injects the right hash type, so it rides the same
-         * [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] as DOGE/DASH. Mirrors
-         * iOS' `"PSBT_BCH"`.
+         * [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner] as DOGE/DASH. Android/
+         * iOS stamp this onto their own initiated swaps; kept for backward compatibility with
+         * in-flight swaps — the join-side dispatcher picks the signer from the payload's `chain`,
+         * not this literal (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_BCH = "PSBT_BCH"
 
         /**
          * `meta.txType` discriminator for the **legacy P2PKH** Dash signing path. DASH forked from
          * Bitcoin pre-0.12.x and has no segwit, so it uses legacy sighashing via `CoinType.DASH`
-         * through [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner]. Mirrors iOS'
-         * `"PSBT_DASH"`.
+         * through [com.vultisig.wallet.data.chains.helpers.SwapKitLegacyP2PKHSigner]. Android/iOS
+         * stamp this onto their own initiated swaps; kept for backward compatibility with in-flight
+         * swaps — the join-side dispatcher picks the signer from the payload's `chain`, not this
+         * literal (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_DASH = "PSBT_DASH"
 
@@ -102,7 +107,9 @@ data class SwapKitSwapPayloadJson(
          * is wrapped in a BIP-174 envelope but the body is Sapling-v4 (extra version-group id,
          * expiry height, value-balance, shielded counts) and the sighash is ZIP-243; handled by
          * [com.vultisig.wallet.data.chains.helpers.SwapKitZcashSigner] via `CoinType.ZCASH` with
-         * the native branch id. Mirrors iOS' `"PSBT_ZEC"`.
+         * the native branch id. Android/iOS stamp this onto their own initiated swaps; kept for
+         * backward compatibility with in-flight swaps — the join-side dispatcher picks the signer
+         * from the payload's `chain`, not this literal (see [isUtxoPsbtTxType]).
          */
         const val TX_TYPE_PSBT_ZEC = "PSBT_ZEC"
 
@@ -196,5 +203,26 @@ data class SwapKitSwapPayloadJson(
          * True when [txType] has a wired signing path in `SigningHelper`. See [SIGNABLE_TX_TYPES].
          */
         fun isSignableTxType(txType: String): Boolean = txType in SIGNABLE_TX_TYPES
+
+        private val UTXO_PSBT_TX_TYPES =
+            setOf(
+                TX_TYPE_PSBT,
+                TX_TYPE_PSBT_DOGE,
+                TX_TYPE_PSBT_BCH,
+                TX_TYPE_PSBT_DASH,
+                TX_TYPE_PSBT_ZEC,
+            )
+
+        /**
+         * True when [txType] means "this is a UTXO-family PSBT" — SwapKit's documented wire value
+         * ([TX_TYPE_PSBT]) is the same generic string for every UTXO source chain, and sometimes
+         * arrives blank when a peer's SDK omits `meta.txType` for the non-Bitcoin variants. Also
+         * true for the legacy per-chain literals Android/iOS invent for their own initiated swaps.
+         * `SigningHelper` picks the actual signer from the payload's `chain`, not from which of
+         * these matched, so a peer that doesn't share the invented per-chain convention can still
+         * be joined.
+         */
+        fun isUtxoPsbtTxType(txType: String): Boolean =
+            txType.isBlank() || txType in UTXO_PSBT_TX_TYPES
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.models
 
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.util.Locale
 
 /**
  * SwapKit-routed swap whose wire shape doesn't fit [EVMSwapPayloadJson] — BTC PSBT, TON transfer
@@ -220,9 +221,12 @@ data class SwapKitSwapPayloadJson(
          * true for the legacy per-chain literals Android/iOS invent for their own initiated swaps.
          * `SigningHelper` picks the actual signer from the payload's `chain`, not from which of
          * these matched, so a peer that doesn't share the invented per-chain convention can still
-         * be joined.
+         * be joined. Compared case-insensitively:
+         * [txTypeOf][com.vultisig.wallet.data.repositories.swap.SwapKitQuoteSource] already treats
+         * SwapKit's own `meta.type` casing as unreliable on the quote side, so the join-side check
+         * must not be stricter than the side that decodes the same field.
          */
         fun isUtxoPsbtTxType(txType: String): Boolean =
-            txType.isBlank() || txType in UTXO_PSBT_TX_TYPES
+            txType.isBlank() || txType.uppercase(Locale.ROOT) in UTXO_PSBT_TX_TYPES
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
@@ -136,4 +136,44 @@ class SigningHelperSwapKitUtxoDispatchTest {
             }
         assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
     }
+
+    @Test
+    fun `a blank txType on a non-UTXO chain still fails loudly rather than misdispatching`() {
+        val e =
+            assertThrows(IllegalStateException::class.java) {
+                SigningHelper.getKeysignMessages(swapKitKeysignPayload(Chain.Ethereum, ""), vault)
+            }
+        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+    }
+
+    @Test
+    fun `a lowercase generic psbt txType still dispatches to the legacy P2PKH signer`() {
+        // SwapKit's own casing isn't trusted on the quote-decoding side either
+        // (SwapKitQuoteSource normalizes response.meta.type to lowercase before matching) — the
+        // join-side check must not be stricter about a field it doesn't control.
+        assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+            SigningHelper.getKeysignMessages(swapKitKeysignPayload(Chain.Dogecoin, "psbt"), vault)
+        }
+    }
+
+    @Test
+    fun `Litecoin source with the generic PSBT txType is not misrouted to the else branch`() {
+        // SwapKitBtcSigner needs the WalletCore JNI (vaultAddress derivation) before it reaches its
+        // own empty-payload check, so this can't assert a specific signer exception headlessly like
+        // the other cases. It instead pins the one thing that must hold regardless of JNI
+        // availability: a typo dropping Chain.Litecoin from the Bitcoin/Litecoin dispatch arm would
+        // silently fall through to `else -> error("Unsupported SwapKit txType for signing: ...")` —
+        // assert that specific failure mode never fires.
+        val e =
+            assertThrows(Throwable::class.java) {
+                SigningHelper.getKeysignMessages(
+                    swapKitKeysignPayload(Chain.Litecoin, SwapKitSwapPayloadJson.TX_TYPE_PSBT),
+                    vault,
+                )
+            }
+        assertTrue(
+            e !is IllegalStateException ||
+                e.message?.contains("Unsupported SwapKit txType for signing") != true
+        )
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
@@ -62,7 +62,7 @@ class SigningHelperSwapKitUtxoDispatchTest {
                     vault,
                 )
             }
-        assertTrue(e.message!!.contains("empty"))
+        assertTrue(e.message?.contains("empty") == true)
     }
 
     @Test
@@ -122,7 +122,7 @@ class SigningHelperSwapKitUtxoDispatchTest {
                     vault,
                 )
             }
-        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+        assertTrue(e.message?.contains("Unsupported SwapKit txType for signing") == true)
     }
 
     @Test
@@ -134,7 +134,7 @@ class SigningHelperSwapKitUtxoDispatchTest {
                     vault,
                 )
             }
-        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+        assertTrue(e.message?.contains("Unsupported SwapKit txType for signing") == true)
     }
 
     @Test
@@ -143,7 +143,7 @@ class SigningHelperSwapKitUtxoDispatchTest {
             assertThrows(IllegalStateException::class.java) {
                 SigningHelper.getKeysignMessages(swapKitKeysignPayload(Chain.Ethereum, ""), vault)
             }
-        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+        assertTrue(e.message?.contains("Unsupported SwapKit txType for signing") == true)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperSwapKitUtxoDispatchTest.kt
@@ -1,0 +1,139 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression coverage for the join-side SwapKit UTXO signer dispatch: the signer must be picked
+ * from the payload's own `chain`, not from which `txType` literal happened to match. A peer that
+ * doesn't share Android/iOS's invented per-chain PSBT_DOGE/PSBT_BCH/PSBT_DASH/PSBT_ZEC convention
+ * sends the documented generic "PSBT" (sometimes blank) for every UTXO source chain.
+ *
+ * Every case below feeds an empty PSBT payload: each per-chain signer validates payload emptiness
+ * in pure JVM before touching the WalletCore JNI, so asserting the exact exception type thrown is
+ * enough to prove which signer was actually dispatched to, without needing the native library.
+ */
+class SigningHelperSwapKitUtxoDispatchTest {
+
+    private val vault = Vault(id = "v1", name = "Test Vault")
+
+    private fun swapKitKeysignPayload(chain: Chain, txType: String) =
+        KeysignPayload(
+            coin = Coin.EMPTY.copy(chain = chain),
+            toAddress = "",
+            toAmount = BigInteger.ZERO,
+            blockChainSpecific =
+                BlockChainSpecific.UTXO(byteFee = BigInteger.ONE, sendMaxAmount = false),
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.GG20,
+            wasmExecuteContractPayload = null,
+            swapPayload =
+                SwapPayload.SwapKit(
+                    SwapKitSwapPayloadJson(
+                        fromCoin = Coin.EMPTY.copy(chain = chain),
+                        toCoin = Coin.EMPTY.copy(chain = Chain.Ethereum),
+                        fromAmount = BigInteger.ONE,
+                        toAmountDecimal = BigDecimal.ONE,
+                        txType = txType,
+                        txPayload = ByteArray(0),
+                        targetAddress = "addr",
+                    )
+                ),
+        )
+
+    @Test
+    fun `Zcash source with the documented generic PSBT txType dispatches to the Zcash signer`() {
+        val e =
+            assertThrows(SwapKitZcashSignerException::class.java) {
+                SigningHelper.getKeysignMessages(
+                    swapKitKeysignPayload(Chain.Zcash, SwapKitSwapPayloadJson.TX_TYPE_PSBT),
+                    vault,
+                )
+            }
+        assertTrue(e.message!!.contains("empty"))
+    }
+
+    @Test
+    fun `Zcash source with a blank txType still dispatches to the Zcash signer`() {
+        // Mirrors a peer's SDK omitting `meta.txType` for the non-Bitcoin PSBT variants.
+        assertThrows(SwapKitZcashSignerException::class.java) {
+            SigningHelper.getKeysignMessages(swapKitKeysignPayload(Chain.Zcash, ""), vault)
+        }
+    }
+
+    @Test
+    fun `BitcoinCash source with the generic PSBT txType dispatches to the legacy P2PKH signer`() {
+        assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+            SigningHelper.getKeysignMessages(
+                swapKitKeysignPayload(Chain.BitcoinCash, SwapKitSwapPayloadJson.TX_TYPE_PSBT),
+                vault,
+            )
+        }
+    }
+
+    @Test
+    fun `Dogecoin source with a blank txType dispatches to the legacy P2PKH signer`() {
+        assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+            SigningHelper.getKeysignMessages(swapKitKeysignPayload(Chain.Dogecoin, ""), vault)
+        }
+    }
+
+    @Test
+    fun `Dash source with the legacy PSBT_DASH txType still dispatches to the legacy P2PKH signer`() {
+        // Backward compatibility: Android/iOS-initiated swaps still stamp this literal.
+        assertThrows(SwapKitLegacyP2PKHSignerException::class.java) {
+            SigningHelper.getKeysignMessages(
+                swapKitKeysignPayload(Chain.Dash, SwapKitSwapPayloadJson.TX_TYPE_PSBT_DASH),
+                vault,
+            )
+        }
+    }
+
+    @Test
+    fun `getSignedTransaction dispatches a blank txType Zcash source to the Zcash signer too`() {
+        assertThrows(SwapKitZcashSignerException::class.java) {
+            SigningHelper.getSignedTransaction(
+                keysignPayload = swapKitKeysignPayload(Chain.Zcash, ""),
+                vault = vault,
+                signatures = emptyMap(),
+                nonceAcc = BigInteger.ZERO,
+            )
+        }
+    }
+
+    @Test
+    fun `an unrecognized non-blank txType on a non-UTXO chain still fails loudly`() {
+        val e =
+            assertThrows(IllegalStateException::class.java) {
+                SigningHelper.getKeysignMessages(
+                    swapKitKeysignPayload(Chain.Ethereum, "SOMETHING_ELSE"),
+                    vault,
+                )
+            }
+        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+    }
+
+    @Test
+    fun `a PSBT-family txType on a non-UTXO chain still fails loudly rather than misdispatching`() {
+        val e =
+            assertThrows(IllegalStateException::class.java) {
+                SigningHelper.getKeysignMessages(
+                    swapKitKeysignPayload(Chain.Ethereum, SwapKitSwapPayloadJson.TX_TYPE_PSBT),
+                    vault,
+                )
+            }
+        assertTrue(e.message!!.contains("Unsupported SwapKit txType for signing"))
+    }
+}


### PR DESCRIPTION
## Summary

Joining a SwapKit swap sourced from Dogecoin/BitcoinCash/Dash/Zcash and initiated on another client (e.g. the browser extension) failed to sign — "Unsupported SwapKit txType for signing" or, for the plain generic `"PSBT"` value, silently dispatched to the wrong per-chain signer. `SigningHelper`'s SwapKit dispatch matched on the literal `txType` string, but the per-chain discriminators (`PSBT_DOGE`/`PSBT_BCH`/`PSBT_DASH`/`PSBT_ZEC`) are invented locally by Android (and iOS) only when the swap is quoted on-device — the commondata proto documents `tx_type` as SwapKit's `meta.txType` verbatim, which is the same generic `"PSBT"` for the whole UTXO family, and is sometimes blank.

Signer selection is now keyed off the payload's own `chain`, mirroring the pattern already used for native (non-swap) UTXO signing a few lines down in the same file, while still accepting the legacy per-chain strings so in-flight Android/iOS-initiated swaps keep working.

Closes #5167.

## Testing

- `./gradlew :data:ktfmtFormat`
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.chains.helpers.SigningHelperSwapKitUtxoDispatchTest"` — new regression suite; verified each dispatch-affecting case fails on the pre-fix code (wrong signer / `IllegalStateException`) and passes after
- `./gradlew :data:testDebugUnitTest` — full data module suite
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.swap.SwapKitErrorMappingTest" --tests "*SwapTransactionBuilder*"`
- `./gradlew :data:lintDebug`

## Screenshots

ZEC → POL:
![zcash quote](https://i.imgur.com/inKgaIh.png)

DOGE → POL:
![dogecoin quote](https://i.imgur.com/UxxC6c2.png)

BCH → POL:
![bitcoin cash quote](https://i.imgur.com/zA5IdLm.png)

DASH → POL:
![dash quote](https://i.imgur.com/Lkaktqp.png)

BTC → POL:
![bitcoin quote](https://i.imgur.com/MSvrm4k.png)

LTC → POL:
![litecoin quote](https://i.imgur.com/WnkUJF9.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SwapKit signing for UTXO-based chains by selecting the correct signer from the payload chain for both pre-sign hashing and final signing.
  * Correctly routes BTC/LTC, BCH/DOGE/DASH (legacy P2PKH), and Zcash, including when the transaction type is blank or provided as a generic PSBT value (case-insensitive).
  * Unsupported transaction types now fail consistently with a clearer error instead of misrouting.
* **Tests**
  * Added regression coverage for chain-based dispatch behavior and unsupported failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


