### PR TITLE
feat(ripple): SHA-512-half digest for XRPL custom-message co-signing

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.api.swapAggregators.OneInchSwap
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
 import com.vultisig.wallet.data.common.toSha256ByteArray
+import com.vultisig.wallet.data.common.toSha512ByteArray
 import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.crypto.TonHelper
@@ -64,11 +65,15 @@ object SigningHelper {
         //    keccak256'd, so the digest — and the md5 message-ID derived from it — diverged
         //    from the iOS/Windows/CLI initiator and cross-platform co-signing 404'd.
         //  - EdDSA chains (e.g. Solana, TON) deliver the precomputed digest — sign it raw.
+        //  - Ripple (XRPL GemWallet signMessage / ripple-keypairs) signs SHA-512-half — the
+        //    first 32 bytes of SHA-512 — of the message bytes. keccak256 here diverges from
+        //    the extension initiator's digest and cross-platform co-signing 404s.
         //  - Everything else (EVM, Tron) signs the keccak256.
         val bytes =
             when {
                 chain?.standard == TokenStandard.COSMOS ||
                     chain?.standard == TokenStandard.THORCHAIN -> processedBytes.toSha256ByteArray()
+                chain == Chain.Ripple -> processedBytes.toSha512ByteArray().copyOf(32)
                 chain?.TssKeysignType == TssKeyType.EDDSA -> processedBytes
                 else -> processedBytes.toKeccak256ByteArray()
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
@@ -18,6 +18,10 @@ fun ByteArray.toSha256ByteArray(): ByteArray {
     return MessageDigest.getInstance("SHA-256").digest(this)
 }
 
+fun ByteArray.toSha512ByteArray(): ByteArray {
+    return MessageDigest.getInstance("SHA-512").digest(this)
+}
+
 fun ByteArray.toByteString(): ByteString {
     return ByteString.copyFrom(this)
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
@@ -5,6 +5,7 @@ package com.vultisig.wallet.data.chains.helpers
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
 import com.vultisig.wallet.data.common.toSha256ByteArray
+import com.vultisig.wallet.data.common.toSha512ByteArray
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -88,6 +89,38 @@ class SigningHelperCustomMessageTest {
 
         val expected = "Hello Vultisig".toByteArray().toSha256ByteArray().toHexString()
         messages shouldBe listOf(expected)
+    }
+
+    @Test
+    fun `Ripple plain-text message is SHA-512-half hashed, not keccak256`() {
+        // XRPL (GemWallet signMessage) custom messages sign SHA-512-half — the first 32 bytes of
+        // SHA-512 — of the message bytes, matching the vultisig-windows initiator
+        // (getCustomMessageHex.ts `ripple` branch). keccak256 here 404s cross-platform co-signing.
+        val payload =
+            CustomMessagePayload(method = "sign", message = "Hello Vultisig", chain = "Ripple")
+
+        val messages = SigningHelper.getKeysignMessages(payload)
+
+        val expected = "Hello Vultisig".toByteArray().toSha512ByteArray().copyOf(32).toHexString()
+        messages shouldBe listOf(expected)
+        messages shouldNotBe
+            listOf("Hello Vultisig".toByteArray().toKeccak256ByteArray().toHexString())
+    }
+
+    @Test
+    fun `Ripple digest is byte-identical to the vultisig-windows extension contract`() {
+        // Pinned reference vectors: SHA-512-half of the message bytes, computed independently of
+        // the app helpers, matching vultisig-windows getCustomMessageHex.ts (windows#4399).
+        val utf8Payload =
+            CustomMessagePayload(method = "sign", message = "Hello Vultisig", chain = "Ripple")
+        SigningHelper.getKeysignMessages(utf8Payload) shouldBe
+            listOf("3bc2707498315edae0bf63ea75bf2433a0fdee71e888461b55fe9d05662ae437")
+
+        // "0x56756c7469736967" decodes to the ASCII bytes of "Vultisig" before hashing.
+        val hexPayload =
+            CustomMessagePayload(method = "sign", message = "0x56756c7469736967", chain = "Ripple")
+        SigningHelper.getKeysignMessages(hexPayload) shouldBe
+            listOf("f969dba15308c6b017e02c91e06e577e8c69cb291bdf44a819f184ad66e627dc")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds the missing **Ripple** branch to the custom-message keysign digest so a Secure (multi-device) Vault can co-sign an XRPL off-chain `signMessage` initiated by the browser extension.
- XRPL (GemWallet `signMessage`) messages sign **SHA-512-half** — the first 32 bytes of SHA-512 — of the message bytes. Android had no Ripple branch, so a `chain: Ripple` message fell through to the `else → keccak256` path. The digest (and the md5 message-ID derived from it) diverged from the initiator, so the Android co-signer could not locate the setup message and cross-platform co-signing 404'd — the same failure class already documented in this method for `eth_signTypedData_v4` / Cosmos.
- Mirrors the shared digest contract in vultisig-windows `getCustomMessageHex.ts` (`ripple: () => sha512(bytes).slice(0, 32)`), added in vultisig/vultisig-windows#4399.

## Changes

- `ByteArrayExtensions.kt`: add `toSha512ByteArray()` alongside `toSha256ByteArray()`.
- `SigningHelper.getKeysignMessages(CustomMessagePayload)`: add `chain == Chain.Ripple -> processedBytes.toSha512ByteArray().copyOf(32)` before the `else`. No behavior change for any other chain.

## Scope notes

- Only affects **Secure Vaults** (extension initiator + Android co-signer). Fast Vaults co-sign with VultiServer, so Android is never invoked.
- Co-signer digest only — DER encoding + uppercasing remain the initiator's responsibility; no signature-format change here.
- Out of scope: originating `signMessage` on Android, XRPL dApp **transaction** co-signing (already shipped via `RippleHelper`), and any confirmation-screen display.

## Test plan

- `./gradlew :data:testDebugUnitTest --tests "*.SigningHelperCustomMessageTest"` — green.
- New unit tests:
  - `Ripple plain-text message is SHA-512-half hashed, not keccak256` — behavioral assertion.
  - `Ripple digest is byte-identical to the vultisig-windows extension contract` — pins two reference vectors (UTF-8 and `0x`-hex inputs) computed independently, proving byte-for-byte parity with the merged Windows contract.

Closes #5341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ripple-specific message hashing using SHA-512-half for signing message IDs.

* **Bug Fixes**
  * Corrected Ripple message digest generation for both plain-text and hexadecimal message inputs.

* **Tests**
  * Added coverage and reference checks to verify Ripple digest compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->