### PR TITLE
fix(chain): make Coins the single source for chain identity

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/SecuredAssetStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/SecuredAssetStrategy.kt
@@ -14,10 +14,10 @@ import com.vultisig.wallet.data.models.GasFeeParams
 import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
-import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.getDustThreshold
 import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.isSecuredAssetEligible
+import com.vultisig.wallet.data.models.nativeTokenTicker
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.models.toValue
@@ -25,7 +25,6 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
-import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
@@ -245,7 +244,7 @@ internal class SecuredAssetStrategy(
     private fun validateBtcLikeAmount(tokenAmountInt: BigInteger, chain: Chain) {
         val minAmount = chain.getDustThreshold
         if (tokenAmountInt < minAmount) {
-            val symbol = chain.coinType.symbol
+            val symbol = chain.nativeTokenTicker
             val name = chain.raw
             val formattedMinAmount = chain.toValue(minAmount).toString()
             throw InvalidTransactionDataException(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/WithdrawSecuredAssetStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/WithdrawSecuredAssetStrategy.kt
@@ -64,6 +64,9 @@ internal class WithdrawSecuredAssetStrategy(
 
         val selectedSecureAsset = stateProvider().selectedSecuredAsset
 
+        // getChain() throws on an unrecognised ticker rather than silently defaulting to a chain —
+        // the DepositFormViewModel catch block turns that into a user-facing error instead of
+        // misrouting the withdrawal to the wrong chain.
         val secureAssetChain = selectedSecureAsset.ticker.getChain()
         val dstAddr =
             accountsRepository.loadAddress(vaultId, secureAssetChain).firstOrNull()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/ChainValidationService.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/ChainValidationService.kt
@@ -12,14 +12,13 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenValue
-import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.getDustThreshold
 import com.vultisig.wallet.data.models.hasReaping
+import com.vultisig.wallet.data.models.nativeTokenTicker
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.models.toValue
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
-import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
@@ -139,7 +138,7 @@ internal class ChainValidationService @Inject constructor(private val rippleApi:
     ) {
         val minAmount = chain.getDustThreshold
         if (tokenAmountInt < minAmount) {
-            val symbol = chain.coinType.symbol
+            val symbol = chain.nativeTokenTicker
             val name = chain.raw
             val formattedMinAmount = chain.toValue(minAmount).toString()
             throw InvalidTransactionDataException(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectNetworkViewModel.kt
@@ -9,13 +9,12 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
-import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.isSwapSupported
+import com.vultisig.wallet.data.models.nativeTokenTicker
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
-import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.ui.models.NetworkUiModel
 import com.vultisig.wallet.ui.models.consolidateEvm
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
@@ -112,7 +111,7 @@ constructor(
                         .filter { (chain) ->
                             val matchesQuery =
                                 chain.raw.contains(query, ignoreCase = true) ||
-                                    chain.coinType.symbol.contains(query, ignoreCase = true)
+                                    chain.nativeTokenTicker.contains(query, ignoreCase = true)
                             val matchesFilter =
                                 when (args.filters) {
                                     Filters.SwapAvailable -> chain.isSwapSupported

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -12,7 +12,6 @@ import com.vultisig.wallet.data.models.TokenStandard.TON
 import com.vultisig.wallet.data.models.TokenStandard.TRC20
 import com.vultisig.wallet.data.models.TokenStandard.UTXO
 import com.vultisig.wallet.data.utils.getDustThreshold
-import com.vultisig.wallet.data.utils.toValue
 import java.math.BigDecimal
 import java.math.BigInteger
 import wallet.core.jni.CoinType
@@ -515,6 +514,26 @@ val Chain.cosmosNativeDenom: String?
             else -> null
         }
 
-fun Chain.toValue(value: BigInteger): BigDecimal = coinType.toValue(value)
+/**
+ * The chain's native token as declared in [Coins] — the single source of truth for the native
+ * ticker and decimals.
+ *
+ * Prefer this (and [nativeTokenTicker] / [Chain.toValue]) over deriving `symbol`/`decimals` from
+ * [coinType]: several chains share a WalletCore [CoinType], so the WalletCore-derived values are
+ * wrong for display and amount math — MayaChain (CACAO/10 vs THORCHAIN's RUNE/8), Bittensor (TAO/9
+ * vs POLKADOT's DOT/10), and Qbtc (QBTC/8 vs COSMOS's ATOM/6).
+ */
+val Chain.nativeToken: Coin
+    get() =
+        Coins.coins[this]?.firstOrNull { it.isNativeToken }
+            ?: error("No native token registered in Coins for chain $name")
 
-fun Chain.toValue(value: BigDecimal): BigDecimal = coinType.toValue(value)
+/** Native token ticker from [Coins] — safe for display, unlike WalletCore's `coinType.symbol`. */
+val Chain.nativeTokenTicker: String
+    get() = nativeToken.ticker
+
+fun Chain.toValue(value: BigInteger): BigDecimal =
+    value.toBigDecimal().divide(BigDecimal.TEN.pow(nativeToken.decimal))
+
+fun Chain.toValue(value: BigDecimal): BigDecimal =
+    value.divide(BigDecimal.TEN.pow(nativeToken.decimal))

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinExtensions.kt
@@ -51,6 +51,10 @@ fun String.getChain(): Chain {
         "SEI" -> Chain.Sei
         "HYPE" -> Chain.Hyperliquid
         "QBTC" -> Chain.Qbtc
-        else -> Chain.ThorChain
+        else ->
+            error(
+                "Unknown native ticker '$this' — cannot resolve to a Chain. " +
+                    "A silent fallback here would misroute a fund path to the wrong chain."
+            )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinType.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/CoinType.kt
@@ -6,9 +6,20 @@ import java.math.BigInteger
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinTypeConfiguration
 
+/**
+ * WalletCore-internal symbol. UNSAFE for display: several [Chain]s share one WalletCore [CoinType],
+ * so this returns the wrong ticker for MayaChain (RUNE, not CACAO), Bittensor (DOT, not TAO), and
+ * Qbtc (ATOM, not QBTC). For a chain's display ticker use `Chain.nativeTokenTicker`, sourced from
+ * [com.vultisig.wallet.data.models.Coins] — the single source of truth.
+ */
 val CoinType.symbol
     get() = CoinTypeConfiguration.getSymbol(this)
 
+/**
+ * WalletCore-internal decimals. UNSAFE for amount math on shared-CoinType chains: MayaChain (8, not
+ * 10), Bittensor (10, not 9), Qbtc (6, not 8). For a chain's native amount conversion use
+ * `Chain.toValue`, which is sourced from [com.vultisig.wallet.data.models.Coins].
+ */
 val CoinType.decimals
     get() = CoinTypeConfiguration.getDecimals(this)
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/ChainIdentitySourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/ChainIdentitySourceTest.kt
@@ -1,0 +1,76 @@
+package com.vultisig.wallet.data.models
+
+import com.vultisig.wallet.data.utils.getChain
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression coverage for issue #5323 (chain-identity single-source).
+ *
+ * Two failure shapes, both a per-chain lookup with a silent wrong-value fallback:
+ * 1. [String.getChain] silently resolved any unknown ticker to ThorChain on a withdrawal path.
+ * 2. `Chain.coinType` derives symbol/decimals from WalletCore, which are wrong for chains that
+ *    share a WalletCore CoinType — [Coins] is the single source and must win via every reachable
+ *    accessor ([Chain.nativeTokenTicker], [Chain.nativeToken], [Chain.toValue]).
+ */
+class ChainIdentitySourceTest {
+
+    @Test
+    fun `getChain resolves known native tickers`() {
+        assertEquals(Chain.ThorChain, "RUNE".getChain())
+        assertEquals(Chain.MayaChain, "CACAO".getChain())
+        assertEquals(Chain.Bittensor, "TAO".getChain())
+        assertEquals(Chain.Qbtc, "QBTC".getChain())
+    }
+
+    @Test
+    fun `getChain throws on unknown ticker instead of defaulting to ThorChain`() {
+        val error = assertThrows(IllegalStateException::class.java) { "NOTATICKER".getChain() }
+        // The whole point of #5323: an unrecognised ticker must NOT silently become ThorChain.
+        assertEquals(false, error.message?.contains("ThorChain"))
+    }
+
+    @Test
+    fun `unknown ticker never silently resolves to any chain`() {
+        listOf("", "XYZ", "rune", "Cacao", "UNKNOWN").forEach { ticker ->
+            assertThrows(IllegalStateException::class.java) { ticker.getChain() }
+        }
+    }
+
+    @Test
+    fun `nativeTokenTicker sources display symbol from Coins for shared-CoinType chains`() {
+        assertEquals("CACAO", Chain.MayaChain.nativeTokenTicker)
+        assertEquals("TAO", Chain.Bittensor.nativeTokenTicker)
+        assertEquals("QBTC", Chain.Qbtc.nativeTokenTicker)
+    }
+
+    @Test
+    fun `nativeToken decimals come from Coins for shared-CoinType chains`() {
+        // WalletCore coinType.decimals is 8 / 10 / 6 for these (a 100x / 10x / 100x error) — Coins
+        // is the single source and must win.
+        assertEquals(10, Chain.MayaChain.nativeToken.decimal)
+        assertEquals(9, Chain.Bittensor.nativeToken.decimal)
+        assertEquals(8, Chain.Qbtc.nativeToken.decimal)
+    }
+
+    @Test
+    fun `Chain toValue converts using Coins decimals not WalletCore decimals`() {
+        // 1 CACAO = 10^10 base units; the buggy 10^8 path would return 100.
+        assertEquals(0, BigDecimal.ONE.compareTo(Chain.MayaChain.toValue(BigInteger.TEN.pow(10))))
+        // 1 TAO = 10^9 base units; the buggy 10^10 path would return 0.1.
+        assertEquals(0, BigDecimal.ONE.compareTo(Chain.Bittensor.toValue(BigInteger.TEN.pow(9))))
+        // 1 QBTC = 10^8 base units; the buggy 10^6 path would return 100.
+        assertEquals(0, BigDecimal.ONE.compareTo(Chain.Qbtc.toValue(BigInteger.TEN.pow(8))))
+    }
+
+    @Test
+    fun `every chain has exactly one native token in Coins`() {
+        Chain.entries.forEach { chain ->
+            val natives = Coins.coins[chain]?.filter { it.isNativeToken }.orEmpty()
+            assertEquals(1, natives.size, "Chain $chain must have exactly one native token")
+        }
+    }
+}


### PR DESCRIPTION
Closes #5323

## Problem

Two same-shaped chain-identity bugs — a per-chain lookup with a silent wrong-value fallback instead of a failure:

1. **`String.getChain()` silently resolved any unknown ticker to `Chain.ThorChain`.** Its only caller is `WithdrawSecuredAssetStrategy` — a fund path. A ticker rename anywhere upstream (the repo already has `UATOM`/`ATOM`, `MATIC`/`POL` drift) would silently reroute a secured-asset withdrawal to ThorChain instead of erroring.

2. **`coinType.symbol` / `coinType.decimals` disagree with `Coins.kt`.** Several chains share one WalletCore `CoinType`, so the WalletCore-derived values are wrong:

   | Chain | Coins.kt (correct) | via `coinType` | error |
   |---|---|---|---|
   | MayaChain | CACAO / 10 | RUNE / 8 | 100× |
   | Bittensor | TAO / 9 | DOT / 10 | 10× |
   | Qbtc | QBTC / 8 | ATOM / 6 | 100× |

   The amount side (`Chain.toValue`) is currently guarded only by an unrelated `getDustThreshold` check; the symbol side is live today for the network-search filter and the min-amount validation error.

## Fix

- `getChain()` now `error()`s on an unrecognized ticker. `DepositFormViewModel`'s catch turns that into a user-facing error rather than a misrouted withdrawal.
- Made `Coins.kt` the single source: added `Chain.nativeToken` / `Chain.nativeTokenTicker`, redefined `Chain.toValue` to use the Coins native decimals, and routed the three chain-variable `coinType.symbol` display sites (`SecuredAssetStrategy`, `ChainValidationService`, `SelectNetworkViewModel`) through `nativeTokenTicker`.
- Marked `CoinType.symbol` / `CoinType.decimals` with KDoc as WalletCore-internal and unsafe for display/amount math. Hardcoded `Chain.ThorChain.coinType.*` / `CoinType.THORCHAIN.*` usages are left as-is (correct by construction).

## Test plan

- New `ChainIdentitySourceTest` (7 tests, `:data:testDebugUnitTest`) — green:
  - `getChain` resolves known tickers and throws on unknown (asserting it does **not** become ThorChain).
  - MayaChain/Bittensor/Qbtc decimals (10/9/8), tickers (CACAO/TAO/QBTC), and `Chain.toValue` conversion via the reachable accessors.
  - Every chain has exactly one native token in `Coins`.
- `:app:compileDebugKotlin` and `:data` compile clean; ktfmt applied.

## Acceptance
- [x] `getChain()` throws instead of defaulting to ThorChain
- [x] `Coins.kt` is the single source of decimals and symbols for display/amount math
- [x] Test asserting MayaChain/Bittensor/Qbtc decimals and symbols via reachable accessors
- [x] Test asserting an unknown ticker does not resolve to ThorChain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected native token symbols and decimal handling for chains that share underlying coin types.
  * Minimum amount validation and amount conversions now use each chain’s registered native token details.
  * Unknown token tickers now produce a clear error instead of potentially selecting the wrong chain.
* **Improvements**
  * Network search now matches native token tickers more accurately.
  * Added safeguards to ensure each chain has a single, correctly configured native token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->