### PR TITLE
fix(keysign): reuse Schnorr setup message on retry

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -343,7 +343,7 @@ class SchnorrKeysign(
         try {
             val keysignSetupMsg: ByteArray
 
-            if (isInitiateDevice) {
+            if (isInitiateDevice && attempt == 0) {
                 keysignSetupMsg = getKeysignSetupMessage(messageToSign)
 
                 sessionApi.uploadSetupMessage(

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignSetupMessageRetryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignSetupMessageRetryTest.kt
@@ -1,0 +1,179 @@
+@file:OptIn(ExperimentalEncodingApi::class)
+
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.common.md5
+import com.vultisig.wallet.data.mediator.Message
+import com.vultisig.wallet.data.models.KeyShare
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.Encryption
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for issue #5327: the Schnorr initiator must only create and upload a fresh setup
+ * message on the first attempt. On a retry it has to reuse the setup message already on the relay
+ * by downloading it — otherwise a peer still mid-protocol on the previous setup message desyncs
+ * against a brand-new session. This mirrors the `isInitiateDevice && attempt == 0` guard used by
+ * `DklsKeysign` and `MldsaKeysign`.
+ *
+ * The test pins the upload-vs-download *decision* on a retry: with `attempt = 1` the initiator must
+ * call `getSetupMessage` (download) and must NOT call `uploadSetupMessage`. Were the `attempt == 0`
+ * guard removed, the initiator would take the upload branch and `getSetupMessage` would never be
+ * called — so this test fails. The signing rounds that follow the download touch the goschnorr JNI
+ * library, which is unavailable on the host JVM; the ceremony therefore throws once the decision
+ * has already been made, which is why the call is wrapped in [shouldThrowAny] and the assertions
+ * run afterwards on the recorded relay interactions. The [FakeSessionApi] is hand-written rather
+ * than a mockk because mockk eagerly resolves the native `tss.KeysignResponse` return type and
+ * crashes with UnsatisfiedLinkError (same constraint as [DklsFamilyRelayRecoveryTest]).
+ */
+class SchnorrKeysignSetupMessageRetryTest {
+
+    private val message = "abc123deadbeef"
+    private val expectedMsgHash = message.md5()
+
+    private fun vault() =
+        Vault(
+            id = "vault-id",
+            name = "test-vault",
+            pubKeyECDSA = "pub-ecdsa",
+            pubKeyEDDSA = "pub-eddsa",
+            pubKeyMLDSA = "pub-mldsa",
+            localPartyID = "deviceA",
+            keyshares = listOf(KeyShare("pub-eddsa", "share")),
+        )
+
+    /** Decryption that returns its ciphertext unchanged, so the test controls the setup bytes. */
+    private class IdentityEncryption : Encryption {
+        override fun encrypt(data: ByteArray, password: ByteArray): ByteArray = data
+
+        override fun decrypt(data: ByteArray, password: ByteArray): ByteArray? = data
+    }
+
+    /**
+     * A [SessionApi] that serves a stored setup message on download and records every download and
+     * upload so the test can assert which branch the initiator took on a retry.
+     */
+    private class FakeSessionApi(private val storedSetupMessage: String) : SessionApi {
+        val getSetupMessageCalls = mutableListOf<String?>()
+        val uploadCalls = mutableListOf<String?>()
+
+        override suspend fun getSetupMessage(
+            serverUrl: String,
+            sessionId: String,
+            messageId: String?,
+        ): String {
+            getSetupMessageCalls += messageId
+            return storedSetupMessage
+        }
+
+        override suspend fun uploadSetupMessage(
+            serverUrl: String,
+            sessionId: String,
+            message: String,
+            messageId: String?,
+        ) {
+            uploadCalls += messageId
+        }
+
+        override suspend fun checkKeysignComplete(
+            serverUrl: String,
+            messageId: String,
+        ): tss.KeysignResponse = throw RuntimeException("not complete yet")
+
+        override suspend fun checkCommittee(serverUrl: String, sessionId: String): List<String> =
+            unexpected("checkCommittee")
+
+        override suspend fun startSession(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: List<String>,
+        ) = unexpected("startSession")
+
+        override suspend fun startWithCommittee(
+            serverUrl: String,
+            sessionId: String,
+            committee: List<String>,
+        ) = unexpected("startWithCommittee")
+
+        override suspend fun markLocalPartyComplete(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: List<String>,
+        ) = unexpected("markLocalPartyComplete")
+
+        override suspend fun getCompletedParties(
+            serverUrl: String,
+            sessionId: String,
+        ): List<String> = unexpected("getCompletedParties")
+
+        override suspend fun getParticipants(serverUrl: String, sessionId: String): List<String> =
+            unexpected("getParticipants")
+
+        override suspend fun sendTssMessage(
+            serverUrl: String,
+            messageId: String?,
+            message: Message,
+        ) = unexpected("sendTssMessage")
+
+        override suspend fun getTssMessages(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: String,
+            messageId: String?,
+        ): List<Message> = unexpected("getTssMessages")
+
+        override suspend fun deleteTssMessage(
+            serverUrl: String,
+            sessionId: String,
+            localPartyId: String,
+            msgHash: String,
+            messageId: String?,
+        ) = unexpected("deleteTssMessage")
+
+        override suspend fun markLocalPartyKeysignComplete(
+            serverUrl: String,
+            messageId: String,
+            sig: tss.KeysignResponse,
+        ) = unexpected("markLocalPartyKeysignComplete")
+
+        private fun unexpected(name: String): Nothing =
+            error("Unexpected SessionApi call in test: $name")
+    }
+
+    @Test
+    fun `Schnorr initiator downloads the existing setup message on retry instead of re-uploading`() =
+        runTest {
+            // The stored setup message is decrypted by IdentityEncryption, so any base64 payload
+            // works.
+            val sessionApi =
+                FakeSessionApi(storedSetupMessage = Base64.encode(byteArrayOf(1, 2, 3)))
+            val keysign =
+                SchnorrKeysign(
+                    keysignCommittee = listOf("deviceA", "deviceB"),
+                    mediatorURL = "http://relay.example",
+                    sessionID = "session-1",
+                    messageToSign = listOf(message),
+                    vault = vault(),
+                    encryptionKeyHex = "00".repeat(32),
+                    isInitiateDevice = true,
+                    sessionApi = sessionApi,
+                    encryption = IdentityEncryption(),
+                )
+
+            // attempt = 1 is a retry: the ceremony fails later in the goschnorr JNI rounds, which
+            // are unavailable on the host JVM — but only after the download-vs-upload decision.
+            shouldThrowAny {
+                keysign.keysignOneMessageWithRetry(attempt = 1, messageToSign = message)
+            }
+
+            sessionApi.getSetupMessageCalls shouldContain expectedMsgHash
+            sessionApi.uploadCalls.shouldBeEmpty()
+        }
+}


### PR DESCRIPTION
## Summary

`SchnorrKeysign.keysignOneMessageWithRetry` regenerated and re-uploaded a fresh setup message on **every** retry, because the initiator's upload branch was missing the `attempt == 0` guard that `DklsKeysign` and `MldsaKeysign` already use:

- `DklsKeysign.kt`: `if (isInitiateDevice && attempt == 0)`
- `MldsaKeysign.obtainSetupMessage`: `if (isInitiateDevice && attempt == 0) …`

On a retry the initiator would push a brand-new setup message to the relay, so a peer still mid-protocol on the previous one desynced (it was signing against a different session).

The fix gates the initiator upload on the first attempt only. On any retry the initiator now falls through to the existing `else` branch and downloads the setup message already on the relay — identical to the DKLS/MLDSA behavior.

Pre-existing bug, surfaced during review of #5324. Closes #5327.

## Changes

- `SchnorrKeysign.kt`: `if (isInitiateDevice)` → `if (isInitiateDevice && attempt == 0)`
- Added `SchnorrKeysignSetupMessageRetryTest` pinning the upload-vs-download decision on a retry.

## Test plan

- [x] `SchnorrKeysignSetupMessageRetryTest` — on `attempt = 1` the initiator calls `getSetupMessage` (download) and never calls `uploadSetupMessage`. Verified the test **fails** when the `attempt == 0` guard is removed and **passes** with the fix.
- [x] Existing `DklsFamilyRelayRecoveryTest` still green.
- [ ] Multi-device EdDSA/Schnorr keysign smoke test across a forced retry (e.g. Solana/Polkadot send with two devices, toggling connectivity to trigger a retry) — verify a retrying initiator does not desync a peer. Requires physical multi-device signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Schnorr signing retries so subsequent attempts reuse the existing setup message instead of uploading it again.
  * Reduced the risk of retry failures caused by unnecessary setup-message uploads.

* **Tests**
  * Added coverage confirming the correct download behavior during signing retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->