### PR TITLE
fix(deposit): correct From/To/pool on Mint LP transaction-complete screen

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -154,6 +154,7 @@ import com.vultisig.wallet.ui.screens.transaction.SendTxOverviewScreen
 import com.vultisig.wallet.ui.screens.transaction.TransactionHistoryEmptyState
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfo
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfoType
+import com.vultisig.wallet.ui.screens.transaction.toUiTransactionInfo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
@@ -198,6 +199,7 @@ class PreviewActivity : ComponentActivity() {
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
+                    "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "empty_referral" -> EmptyReferralBanner(onClickedCreateReferral = {})
                     "fast_vault_verification" -> FastVaultVerificationPreview()
@@ -1104,6 +1106,42 @@ private fun SendTxDonePreview() {
                 networkFeeFiatValue = "$6.15",
             ),
         isTransactionDetailVisible = false,
+        onTransactionDetailVisibleChange = {},
+    )
+}
+
+@Composable
+private fun DepositMintDonePreview() {
+    SendTxOverviewScreen(
+        showToolbar = true,
+        showSaveToAddressBook = false,
+        transactionHash = "EEBE3...69B9B",
+        transactionLink = "",
+        transactionStatus = TransactionStatus.Confirmed,
+        onComplete = {},
+        onBack = {},
+        onAddToAddressBook = {},
+        tx =
+            TransactionTypeUiModel.Deposit(
+                    DepositTransactionUiModel(
+                        token =
+                            ValuedToken(
+                                token = Coins.MayaChain.CACAO,
+                                value = "1 CACAO",
+                                fiatValue = "$0.12",
+                            ),
+                        srcAddress = "maya12a9rpf9u2ul4x7nde8um6z3zm",
+                        srcVaultName = "AE_QBTC_SAM",
+                        dstAddress = "",
+                        operation = "Mint",
+                        pool = "ARB.GLD-0XAFD091F140C21770F4E5D53D26B2859AE97555AA",
+                        memo = "+:ARB.GLD-0XAFD091F140C21770F4E5D53D26B2859AE97555AA",
+                        networkFeeTokenValue = "0.2 CACAO",
+                        networkFeeFiatValue = "$0.02",
+                    )
+                )
+                .toUiTransactionInfo(),
+        isTransactionDetailVisible = true,
         onTransactionDetailVisibleChange = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -616,7 +616,9 @@ constructor(
                 )
 
             isDepositPayload(payload) ->
-                applyVerifyResult(joinDepositUiModelBuilder.build(payload, vaultId))
+                // Resolve against _currentVault (post auto-switch), matching the swap/send builders
+                // and the done-screen, so a vault-switched ceremony shows one From name everywhere.
+                applyVerifyResult(joinDepositUiModelBuilder.build(payload, _currentVault.id))
 
             else -> {
                 val sendResult =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -353,14 +353,7 @@ constructor(
         // skip the destination-gated label block below and would show a raw address (issue #5351).
         transactionTypeUiModel?.let { model ->
             _state.update {
-                it.copy(
-                    transactionUiModel =
-                        model.withResolvedLabels(
-                            srcVaultName = vault.name,
-                            dstVaultName = null,
-                            dstAddressBookTitle = null,
-                        )
-                )
+                it.copy(transactionUiModel = model.withResolvedSrcVaultName(vault.name))
             }
         }
 
@@ -1037,6 +1030,26 @@ private fun TransactionTypeUiModel.addressBookTarget(): AddressBookTarget? {
         }
     return if (dstAddress.isBlank()) null else AddressBookTarget(chain, dstAddress)
 }
+
+/**
+ * Sets only the source vault name, leaving any destination labels the joiner already resolved
+ * intact. Used up front for destination-less deposits (e.g. a Mint LP add-liquidity) so the From
+ * row renders "VaultName (address)" without a raw-address flash on the To row.
+ */
+private fun TransactionTypeUiModel.withResolvedSrcVaultName(
+    srcVaultName: String
+): TransactionTypeUiModel =
+    when (this) {
+        is TransactionTypeUiModel.Send ->
+            TransactionTypeUiModel.Send(tx.copy(srcVaultName = srcVaultName))
+        is TransactionTypeUiModel.Deposit ->
+            TransactionTypeUiModel.Deposit(
+                depositTransactionUiModel.copy(srcVaultName = srcVaultName)
+            )
+        is TransactionTypeUiModel.Swap ->
+            TransactionTypeUiModel.Swap(swapTransactionUiModel.copy(srcVaultName = srcVaultName))
+        else -> this
+    }
 
 /** Returns a copy of this model with the resolved From/To labels applied (Send or Deposit only). */
 private fun TransactionTypeUiModel.withResolvedLabels(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -348,6 +348,22 @@ constructor(
         )
 
     init {
+        // Resolve the signing vault's name up front so the From row renders "VaultName (address)"
+        // even for deposits with no destination — e.g. a Mint LP add-liquidity — which otherwise
+        // skip the destination-gated label block below and would show a raw address (issue #5351).
+        transactionTypeUiModel?.let { model ->
+            _state.update {
+                it.copy(
+                    transactionUiModel =
+                        model.withResolvedLabels(
+                            srcVaultName = vault.name,
+                            dstVaultName = null,
+                            dstAddressBookTitle = null,
+                        )
+                )
+            }
+        }
+
         // Both Send and Deposit done-screens resolve the same destination labels + "Add to Address
         // Book" affordance, so a Cosmos staking deposit renders identically on the initiator and a
         // joining device (issue #4939).

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.chains.helpers.RippleDappTx
+import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.CopyIcon
@@ -133,17 +134,40 @@ internal fun SendTxOverviewScreen(
                         )
                     }
                 } else {
-                    VsOverviewToken(
-                        header =
-                            if (tx.type == UiTransactionInfoType.Send) {
-                                stringResource(R.string.tx_overview_screen_tx_send)
-                            } else {
-                                stringResource(R.string.tx_overview_screen_tx_deposit)
-                            },
-                        valuedToken = tx.token,
-                        shape = RoundedCornerShape(24.dp),
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier.fillMaxWidth(),
-                    )
+                    ) {
+                        VsOverviewToken(
+                            header =
+                                if (tx.type == UiTransactionInfoType.Send) {
+                                    stringResource(R.string.tx_overview_screen_tx_send)
+                                } else {
+                                    stringResource(R.string.tx_overview_screen_tx_deposit)
+                                },
+                            valuedToken = tx.token,
+                            shape = RoundedCornerShape(24.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        // Surface the minted LP pool that the pre-sign overview shows, so a Mint
+                        // add-liquidity done screen isn't left showing only the deposited token
+                        // with no indication of what was minted (issue #5351).
+                        if (tx.operation == OPERATION_MINT && tx.pool.isNotEmpty()) {
+                            UiSpacer(8.dp)
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.lp_destination_format,
+                                        tx.pool.substringBefore('-'),
+                                        tx.token.token.ticker,
+                                    ),
+                                style = Theme.brockmann.headings.title3,
+                                color = Theme.v2.colors.text.primary,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
                 }
             }
         },
@@ -165,9 +189,12 @@ internal fun SendTxOverviewScreen(
                 )
 
                 // A dApp XRPL tx carries no native destination (`toAddress` is empty); the
-                // recipient,
-                // when any, is inside the decoded summary above, so skip the empty "To" row.
-                if (tx.signRipple == null) {
+                // recipient, when any, is inside the decoded summary above. Some deposits (e.g. a
+                // Mint LP add-liquidity) likewise carry no destination — the pool below is the
+                // target — so skip the "To" row entirely rather than render it with an empty value
+                // (issue #5351).
+                val hasDestination = tx.to.isNotEmpty() || tx.toLabel != null
+                if (tx.signRipple == null && hasDestination) {
                     VerifyCardDivider(size = 1.dp)
 
                     if (showSaveToAddressBook) {
@@ -193,6 +220,12 @@ internal fun SendTxOverviewScreen(
                             bracketValue = tx.toLabel?.let { tx.to },
                         )
                     }
+                }
+
+                if (tx.pool.isNotEmpty()) {
+                    VerifyCardDivider(size = 1.dp)
+
+                    VerifyCardDetails(title = stringResource(R.string.pool), subtitle = tx.pool)
                 }
 
                 if (tx.memo.isNotEmpty()) {
@@ -380,10 +413,13 @@ private fun PreviewSendTxOverviewScreen(isTransactionDetailVisible: Boolean) {
                     depositTransactionUiModel =
                         DepositTransactionUiModel(
                             token = ValuedToken.Empty,
-                            srcAddress = "abx123abx123abx123abx123ab",
+                            srcAddress = "maya12a9rpf9u2ul4x7nde8um6z3zm",
+                            srcVaultName = "AE_QBTC_SAM",
                             networkFeeFiatValue = "",
-                            memo = "sdfsdfsdfsdfs",
-                            dstAddress = "abx123abx123abx123abx123ab",
+                            memo = "+:ARB.GLD-0XAFD091F140C21770F4E5D53D26B2859AE97555AA",
+                            operation = "Mint",
+                            pool = "ARB.GLD-0XAFD091F140C21770F4E5D53D26B2859AE97555AA",
+                            dstAddress = "",
                         )
                 )
                 .toUiTransactionInfo(),
@@ -404,6 +440,15 @@ internal data class UiTransactionInfo(
     val memo: String,
     val networkFeeTokenValue: String,
     val networkFeeFiatValue: String,
+    /**
+     * Structured deposit operation (e.g. Mint), used to surface the minted LP pool on the done
+     * screen. Empty for non-deposit transactions.
+     */
+    val operation: String = "",
+    /**
+     * Target liquidity pool for a deposit (e.g. `ARB.GLD-0x…`). Empty when not a pooled deposit.
+     */
+    val pool: String = "",
     val signMethod: String = "",
     val functionName: String? = null,
     val functionSignature: String? = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/UiModelOverviewExtensions.kt
@@ -43,6 +43,8 @@ internal fun TransactionTypeUiModel.toUiTransactionInfo(): UiTransactionInfo {
                 memo = this.depositTransactionUiModel.memo,
                 networkFeeFiatValue = this.depositTransactionUiModel.networkFeeFiatValue,
                 networkFeeTokenValue = this.depositTransactionUiModel.networkFeeTokenValue,
+                operation = this.depositTransactionUiModel.operation,
+                pool = this.depositTransactionUiModel.pool,
             )
         }
         is TransactionTypeUiModel.SignMessage -> {

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/transaction/DepositUiTransactionInfoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/transaction/DepositUiTransactionInfoTest.kt
@@ -79,8 +79,8 @@ internal class DepositUiTransactionInfoTest {
 
         info.operation shouldBe "Mint"
         info.pool shouldBe "ARB.GLD-0xAFD091"
-        // No destination on an add-liquidity mint — the pool above is the target, so the done
-        // screen hides the "To" row rather than rendering an empty value (issue #5351).
+        // An add-liquidity mint has no destination, so the mapper yields an empty `to` and a
+        // null `toLabel`.
         info.to shouldBe ""
         info.toLabel shouldBe null
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/transaction/DepositUiTransactionInfoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/transaction/DepositUiTransactionInfoTest.kt
@@ -62,4 +62,26 @@ internal class DepositUiTransactionInfoTest {
         info.fromLabel shouldBe null
         info.toLabel shouldBe null
     }
+
+    @Test
+    fun `mint deposit carries operation and pool and leaves destination empty`() {
+        val model =
+            TransactionTypeUiModel.Deposit(
+                DepositTransactionUiModel(
+                    srcAddress = "maya12a9r",
+                    dstAddress = "",
+                    operation = "Mint",
+                    pool = "ARB.GLD-0xAFD091",
+                )
+            )
+
+        val info = model.toUiTransactionInfo()
+
+        info.operation shouldBe "Mint"
+        info.pool shouldBe "ARB.GLD-0xAFD091"
+        // No destination on an add-liquidity mint — the pool above is the target, so the done
+        // screen hides the "To" row rather than rendering an empty value (issue #5351).
+        info.to shouldBe ""
+        info.toLabel shouldBe null
+    }
 }


### PR DESCRIPTION
## Summary

Closes #5351.

The MayaChain Mint (add-liquidity) deposit **Transaction complete** screen disagreed with the pre-sign **Function overview** in three ways. The transaction itself always succeeded — these were display-only defects.

The deposit done screen renders via `SendTxOverviewScreen` (fed by `TransactionTypeUiModel.toUiTransactionInfo()`). Three independent root causes:

- **From showed a raw address** instead of `VaultName (address)`. The initiator (`KeysignViewModel`) resolved the signing vault name only *inside* the destination-gated label block, which a mint deposit skips because it carries no destination. `srcVaultName` is now resolved up front, so From is vault-formatted regardless of whether a destination exists. (The join path already did this.)
- **To rendered as an empty row.** A mint deposit has no destination — the pool is the target — so the row is now hidden entirely rather than shown blank.
- **The minted pool was missing.** `operation` + `pool` are now carried through to the done screen, which renders the `→ POOL LP TOKEN` line under the token hero and a **Pool** row, matching the pre-sign overview.

## Changes

- `KeysignViewModel` — resolve `srcVaultName` before the destination-gated address-book lookup.
- `SendTxOverviewScreen` — hide the To row when there is no destination; add the LP-destination line and Pool row.
- `UiModelOverviewExtensions` / `UiTransactionInfo` — carry `operation` and `pool` for deposits.
- `PreviewActivity` — `deposit_mint_done` preview for on-device inspection.

## Test plan

- `DepositUiTransactionInfoTest` extended with a Mint LP case (operation/pool carried, destination empty). Full class green.
- On-device (PreviewActivity, `deposit_mint_done`): To row hidden, `→ ARB.GLD LP CACAO` line and Pool row present.
- Note: the vault-formatted From is a `KeysignViewModel` runtime fix; end-to-end confirmation of that label needs a real two-device MayaChain Mint keysign.


## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/G7lNmP3.png) | ![after](https://i.imgur.com/goxD4Ge.png) |

_Real Android renders (PreviewActivity, `deposit_mint_done`). Before: empty **To** row, no pool. After: **To** hidden, `→ ARB.GLD LP CACAO` line + **Pool** row. (The mock supplies `srcVaultName`, so From is vault-formatted in both — that fix lives in `KeysignViewModel` and is confirmed by unit test.)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deposit-mint preview/completion screen.
  * Enhanced mint/deposit transaction overviews to display the minted pool (and related operation details) when applicable.
* **Bug Fixes**
  * Improved “From” vault labeling for destination-less deposit/mint transactions.
  * Refined when “To”/destination rows are shown to better match decoded transaction details.
  * Ensured deposit ceremony verification consistently shows the same “From” label across steps.
* **Tests**
  * Added unit coverage for deposit-mint transaction info including operation and pool fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
