### PR TITLE
fix(solana): count swap priority fee once, not twice

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
@@ -195,13 +195,12 @@ internal constructor(
     }
 
     private companion object {
-        // Base signature fee only: 0.000005 SOL (5000 lamports) per signature. The computed
-        // priority
-        // fee is added on top exactly once in calculateDefaultFees. Expressed in lamports (SOL has
-        // 9
-        // decimals) without CoinType so the arithmetic can be exercised in JVM unit tests, which
-        // have
-        // no WalletCore native library loaded.
+        // Base signature fee for the single-signer swap estimate: 5000 lamports (0.000005 SOL).
+        // The swap path signs one Jupiter-built tx with the vault key, so one signature is assumed;
+        // the priority fee is added on top exactly once in calculateDefaultFees.
+        // Expressed in raw lamports (SOL has 9 decimals) rather than via CoinType so the fee
+        // arithmetic can be exercised in JVM unit tests, which have no WalletCore native lib
+        // loaded.
         val BASE_SIGNATURE_FEE: BigInteger =
             "0.000005".toBigDecimal().movePointRight(9).toBigInteger()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeService.kt
@@ -190,15 +190,19 @@ internal constructor(
         return GasFees(
             price = dynamicFeePrice,
             limit = SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(),
-            amount = DEFAULT_COIN_TRANSFER_BASE_FEE + priorityAmount,
+            amount = BASE_SIGNATURE_FEE + priorityAmount,
         )
     }
 
     private companion object {
-        // 0.000105 SOL expressed in lamports (SOL has 9 decimals). Computed without CoinType so the
-        // service can be constructed and its fee arithmetic exercised in JVM unit tests, which have
+        // Base signature fee only: 0.000005 SOL (5000 lamports) per signature. The computed
+        // priority
+        // fee is added on top exactly once in calculateDefaultFees. Expressed in lamports (SOL has
+        // 9
+        // decimals) without CoinType so the arithmetic can be exercised in JVM unit tests, which
+        // have
         // no WalletCore native library loaded.
-        val DEFAULT_COIN_TRANSFER_BASE_FEE: BigInteger =
-            "0.000105".toBigDecimal().movePointRight(9).toBigInteger()
+        val BASE_SIGNATURE_FEE: BigInteger =
+            "0.000005".toBigDecimal().movePointRight(9).toBigInteger()
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaFeeServiceTest.kt
@@ -108,8 +108,8 @@ class SolanaFeeServiceTest {
             val fee = service.calculateFees(swap()) as GasFees
 
             // priorityAmount = 1_000_000 * 100_000 / 1_000_000 = 100_000 lamports
-            // amount = base(105_000) + 100_000 = 205_000
-            assertEquals(BigInteger.valueOf(205_000L), fee.amount)
+            // amount = base(5_000) + 100_000 = 105_000 (priority counted once, not doubled)
+            assertEquals(BigInteger.valueOf(105_000L), fee.amount)
             assertEquals(pricePerCu, fee.price)
             assertEquals(SOLANA_PRIORITY_FEE_LIMIT.toBigInteger(), fee.limit)
         }


### PR DESCRIPTION
## Summary
- `SolanaFeeService.calculateDefaultFees` (used for Solana swap fee estimates) added a freshly-computed priority fee on top of `DEFAULT_COIN_TRANSFER_BASE_FEE` (105000 lamports), which already bundled the base signature fee (5000) plus the floor priority fee (100000) — roughly doubling the displayed swap fee.
- Replaced that constant with a genuine base-only `BASE_SIGNATURE_FEE` (5000 lamports / 0.000005 SOL) so the priority fee is added exactly once.
- Corrected the regression test's expected value (`205_000` → `105_000`) and comment.
- Non-swap `calculateFees` path and priority-fee fetching left unchanged.

## Issue
Closes #5347

## Test Plan
- [x] `./gradlew :data:testDebugUnitTest --tests "*SolanaFeeServiceTest"` passes
- [ ] `./gradlew assembleDebug` succeeds

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Solana default fee estimation to use the base signature fee plus the computed priority component (instead of the prior base assumption).
  * Updated the swap default fee test expectation to match the corrected fee amount calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->