### PR TITLE
fix(cardano): recover loser device on duplicate-broadcast rejection

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -117,8 +117,17 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
 
                     ogmiosResponse.result?.transaction?.id
                         ?: run {
-                            val errorMessage = ogmiosResponse.error?.message ?: "Unknown error"
+                            // Ogmios can convey a submission error under HTTP 200. Mirror the 400
+                            // handling so a duplicate-broadcast rejection recovers regardless of
+                            // the
+                            // status Ogmios uses to report it.
+                            val dataError = ogmiosResponse.error?.data?.error
+                            val errorMessage =
+                                dataError ?: ogmiosResponse.error?.message ?: "Unknown error"
                             Timber.e("Cardano transaction submission failed: $errorMessage")
+                            if (dataError?.isAlreadyBroadcast() == true) {
+                                throw CardanoTransactionAlreadyBroadcastException(errorMessage)
+                            }
                             error("Failed to broadcast transaction: $errorMessage")
                         }
                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -24,6 +24,14 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import timber.log.Timber
 
+/**
+ * The Ogmios node rejected our broadcast because the inputs are already spent — its own message
+ * ("Transaction has probably already been included") is the duplicate-broadcast signal on the
+ * losing device of a multi-device keysign. Since the peer's byte-identical tx spent those exact
+ * inputs, our locally computed hash is canonical (issue #5337).
+ */
+class CardanoTransactionAlreadyBroadcastException(message: String) : Exception(message)
+
 interface CardanoApi {
     suspend fun getBalance(coin: Coin): BigInteger
 
@@ -124,8 +132,12 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                     // only treat a real duplicate submission as success.
                     val ogmiosError =
                         json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
-                    val errorMessage = ogmiosError.error?.message ?: "Unknown error"
+                    val dataError = ogmiosError.error?.data?.error
+                    val errorMessage = dataError ?: ogmiosError.error?.message ?: "Unknown error"
                     Timber.e("Cardano transaction submission failed: $errorMessage")
+                    if (dataError?.isAlreadyBroadcast() == true) {
+                        throw CardanoTransactionAlreadyBroadcastException(errorMessage)
+                    }
                     error("Failed to broadcast transaction: $errorMessage")
                 }
 
@@ -136,10 +148,17 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
             }
         } catch (t: Throwable) {
             if (t is CancellationException) throw t
+            if (t is CardanoTransactionAlreadyBroadcastException) throw t
             Timber.e(t, "Failed to broadcast Cardano transaction")
             error("Failed to broadcast transaction : ${t.message}")
         }
     }
+
+    // Ogmios reports spent inputs as "All inputs are spent. Transaction has probably already been
+    // included" — the loser of a duplicate-broadcast race, not a genuine rejection.
+    private fun String.isAlreadyBroadcast(): Boolean =
+        contains("already been included", ignoreCase = true) ||
+            contains("inputs are spent", ignoreCase = true)
 
     private suspend fun getCurrentSlot(): ULong {
         val response = httpClient.get(url) { url { path(apiV1Path, "tip") } }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.api.models.cardano.CardanoSlotResponseJson
 import com.vultisig.wallet.data.api.models.cardano.CardanoTxStatusResponseJson
 import com.vultisig.wallet.data.api.models.cardano.CardanoUtxoRequestJson
 import com.vultisig.wallet.data.api.models.cardano.CardanoUtxoResponseJson
+import com.vultisig.wallet.data.api.models.cardano.OgmiosError
 import com.vultisig.wallet.data.api.models.cardano.OgmiosTransactionResponse
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.payload.UtxoInfo
@@ -50,6 +51,11 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
     private val url: String = "https://api.koios.rest"
     private val apiV1Path: String = "api/v1"
     private val ogmiosUrl = "https://api.vultisig.com/ada/"
+
+    private companion object {
+        // Ogmios "UnknownOutputReference": the tx spends inputs the ledger no longer knows.
+        const val OGMIOS_UNKNOWN_OUTPUT_REFERENCE_CODE = 3117
+    }
 
     override suspend fun getBalance(coin: Coin): BigInteger {
 
@@ -121,11 +127,11 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                             // handling so a duplicate-broadcast rejection recovers regardless of
                             // the
                             // status Ogmios uses to report it.
-                            val dataError = ogmiosResponse.error?.data?.error
+                            val submitError = ogmiosResponse.error
                             val errorMessage =
-                                dataError ?: ogmiosResponse.error?.message ?: "Unknown error"
+                                submitError?.data?.error ?: submitError?.message ?: "Unknown error"
                             Timber.e("Cardano transaction submission failed: $errorMessage")
-                            if (dataError?.isAlreadyBroadcast() == true) {
+                            if (submitError?.isAlreadyBroadcast() == true) {
                                 throw CardanoTransactionAlreadyBroadcastException(errorMessage)
                             }
                             error("Failed to broadcast transaction: $errorMessage")
@@ -133,18 +139,18 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
                 }
 
                 HttpStatusCode.BadRequest -> {
-                    // A 400 (e.g. unknownOutputReferences) is a genuine rejection. The txid inside
+                    // Never report success from the error payload itself: the txid inside
                     // unknownOutputReferences is the PARENT tx that created the spent input, not
-                    // the
-                    // tx we broadcast — returning it would report success under an unrelated hash.
-                    // Throw instead so BroadcastTxUseCase can verify our actual hash on-chain and
-                    // only treat a real duplicate submission as success.
+                    // the tx we broadcast. Duplicate rejections throw the typed exception so
+                    // BroadcastTxUseCase recovers to OUR locally computed hash; everything else
+                    // throws generically and falls through to on-chain verification.
                     val ogmiosError =
                         json.decodeFromString<OgmiosTransactionResponse>(response.bodyAsText())
-                    val dataError = ogmiosError.error?.data?.error
-                    val errorMessage = dataError ?: ogmiosError.error?.message ?: "Unknown error"
+                    val submitError = ogmiosError.error
+                    val errorMessage =
+                        submitError?.data?.error ?: submitError?.message ?: "Unknown error"
                     Timber.e("Cardano transaction submission failed: $errorMessage")
-                    if (dataError?.isAlreadyBroadcast() == true) {
+                    if (submitError?.isAlreadyBroadcast() == true) {
                         throw CardanoTransactionAlreadyBroadcastException(errorMessage)
                     }
                     error("Failed to broadcast transaction: $errorMessage")
@@ -166,11 +172,18 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         }
     }
 
-    // Ogmios reports spent inputs as "All inputs are spent. Transaction has probably already been
-    // included" — the loser of a duplicate-broadcast race, not a genuine rejection.
-    private fun String.isAlreadyBroadcast(): Boolean =
-        contains("already been included", ignoreCase = true) ||
-            contains("inputs are spent", ignoreCase = true)
+    // Ogmios reports the loser of a duplicate-broadcast race in two stages, depending on how far
+    // the winner's byte-identical tx has progressed:
+    //  - mempool stage: 3997/UnexpectedMempoolError with "All inputs are spent. Transaction has
+    //    probably already been included"
+    //  - post-inclusion: 3117/UnknownOutputReference — the inputs no longer exist on the ledger
+    //    because the winner's tx consumed them.
+    // iOS (CardanoService.swift) and the shared SDK (broadcast/resolvers/cardano.ts) both treat
+    // 3117 as the duplicate signal against this same backend.
+    private fun OgmiosError.isAlreadyBroadcast(): Boolean =
+        code == OGMIOS_UNKNOWN_OUTPUT_REFERENCE_CODE ||
+            data?.error?.contains("already been included", ignoreCase = true) == true ||
+            data?.error?.contains("inputs are spent", ignoreCase = true) == true
 
     private suspend fun getCurrentSlot(): ULong {
         val response = httpClient.get(url) { url { path(apiV1Path, "tip") } }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -149,6 +149,9 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         } catch (t: Throwable) {
             if (t is CancellationException) throw t
             if (t is CardanoTransactionAlreadyBroadcastException) throw t
+            // Let fatal errors (OOM, StackOverflow) propagate rather than masking them as a
+            // broadcast rejection.
+            if (t is Error) throw t
             Timber.e(t, "Failed to broadcast Cardano transaction")
             error("Failed to broadcast transaction : ${t.message}")
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/OgmiosTransactionResponse.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/OgmiosTransactionResponse.kt
@@ -25,8 +25,9 @@ data class OgmiosError(
 
 @Serializable
 data class OgmiosErrorData(
+    @SerialName("error") val error: String? = null,
     @SerialName("unknownOutputReferences")
-    val unknownOutputReferences: List<UnknownOutputReference> = emptyList()
+    val unknownOutputReferences: List<UnknownOutputReference> = emptyList(),
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -92,11 +92,12 @@ object CardanoUtils {
             val txidHash = Utils.blake2bHash(transactionBodyData)
             txidHash.joinToString("") { "%02x".format(it) }
         } catch (e: Exception) {
-            Timber.e("Error parsing Cardano CBOR: ${e.message}")
-            val txidHash = Utils.blake2bHash(transactionData)
-            val fallbackHash = txidHash.joinToString("") { "%02x".format(it) }
-            Timber.w("Using fallback TX ID from COMPLETE transaction: $fallbackHash")
-            fallbackHash
+            // Fail closed: blake2b over the whole envelope is a txid that can never exist
+            // on-chain, and duplicate-broadcast recovery would report it as a success nothing can
+            // track. A blank hash makes every recovery path rethrow instead, while a normal
+            // broadcast still succeeds with the node-returned id.
+            Timber.e("Error parsing Cardano CBOR, no local txid available: ${e.message}")
+            ""
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.usecases
 import com.vultisig.wallet.data.api.BittensorApi
 import com.vultisig.wallet.data.api.BlockChairApi
 import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CardanoTransactionAlreadyBroadcastException
 import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.MayaChainApi
@@ -224,9 +225,17 @@ constructor(
                 recoverIfAlreadyBroadcast(
                     tx = tx,
                     broadcast = {
-                        cardanoApi
-                            .broadcastTransaction(chain.name, tx.rawTransaction)
-                            .orKnownHash(tx)
+                        try {
+                            cardanoApi
+                                .broadcastTransaction(chain.name, tx.rawTransaction)
+                                .orKnownHash(tx)
+                        } catch (e: CardanoTransactionAlreadyBroadcastException) {
+                            // Ogmios says the inputs are already spent by the peer's byte-identical
+                            // tx, so our locally computed hash is canonical. A Cardano block takes
+                            // ~20s, far longer than the verify window, so this node signal is the
+                            // only timely proof the tx landed (issue #5337).
+                            tx.transactionHash.takeIf { it.isNotBlank() } ?: throw e
+                        }
                     },
                     // Koios tx_status echoes the queried hash back even for unknown txs, so
                     // txHash is never blank; only a positive confirmation count proves it landed.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test
  *   that created the spent input, not the tx we broadcast, so it must NOT be returned as success —
  *   the error is surfaced ([IllegalStateException]) and `BroadcastTxUseCase` verifies our actual
  *   hash on-chain instead (issue #5250).
+ * - **Duplicate-broadcast signals** (code 3117/UnknownOutputReference or the spent-inputs mempool
+ *   error) throw [CardanoTransactionAlreadyBroadcastException] so recovery reports OUR local hash
+ *   (issue #5337).
  */
 class CardanoApiBroadcastTest {
 
@@ -78,6 +81,31 @@ class CardanoApiBroadcastTest {
                 "code": 3997,
                 "message": "The transaction couldn't be added to the mempool...",
                 "data": { "error": "All inputs are spent. Transaction has probably already been included" }
+              }
+            }
+            """
+                .trimIndent()
+        val api = newApi(HttpStatusCode.BadRequest, body)
+
+        assertThrows(CardanoTransactionAlreadyBroadcastException::class.java) {
+            runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
+        }
+    }
+
+    @Test
+    fun `broadcastTransaction throws AlreadyBroadcast on code 3117 UnknownOutputReference`() {
+        // Post-inclusion loser: the winner's byte-identical tx is already in a block, so the ledger
+        // no longer knows our inputs and Ogmios rejects with 3117/UnknownOutputReference. iOS and
+        // the shared SDK treat this code as the duplicate-broadcast signal against this backend.
+        val body =
+            """
+            {
+              "error": {
+                "code": 3117,
+                "message": "The transaction contains unknown UTxO references as inputs.",
+                "data": {
+                  "unknownOutputReferences": [ { "transaction": { "id": "def456" }, "index": 0 } ]
+                }
               }
             }
             """

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiBroadcastTest.kt
@@ -67,6 +67,29 @@ class CardanoApiBroadcastTest {
     }
 
     @Test
+    fun `broadcastTransaction throws AlreadyBroadcast on spent-inputs rejection`() {
+        // Loser of a multi-device keysign race: Ogmios says the inputs are spent because the peer's
+        // byte-identical tx already landed. This must be distinguishable so recovery reports the
+        // local hash as success instead of a hard failure (issue #5337).
+        val body =
+            """
+            {
+              "error": {
+                "code": 3997,
+                "message": "The transaction couldn't be added to the mempool...",
+                "data": { "error": "All inputs are spent. Transaction has probably already been included" }
+              }
+            }
+            """
+                .trimIndent()
+        val api = newApi(HttpStatusCode.BadRequest, body)
+
+        assertThrows(CardanoTransactionAlreadyBroadcastException::class.java) {
+            runTest { api.broadcastTransaction(chain = "cardano", signedTransaction = "00") }
+        }
+    }
+
+    @Test
     fun `broadcastTransaction throws on BadRequest error without output references`() {
         val body =
             """

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -117,6 +117,14 @@ class CardanoUtilsTest {
     }
 
     @Test
+    fun `calculateCardanoTransactionHash returns blank when the envelope cannot be parsed`() {
+        // A hash we can't derive must fail closed: a blake2b over the whole envelope would be a
+        // txid that never exists on-chain, and duplicate-broadcast recovery would report it as an
+        // untrackable success. Blank makes the recovery paths rethrow instead.
+        assertEquals("", CardanoUtils.calculateCardanoTransactionHash(hex("00")))
+    }
+
+    @Test
     fun `addIsValidFlag walks a Conway tag-258 set in the witness without throwing`() {
         // 83                      array(3)
         //   a0                    body: empty map

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.usecases
 import com.vultisig.wallet.data.api.BittensorApi
 import com.vultisig.wallet.data.api.BlockChairApi
 import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CardanoTransactionAlreadyBroadcastException
 import com.vultisig.wallet.data.api.CosmosApi
 import com.vultisig.wallet.data.api.CosmosApiFactory
 import com.vultisig.wallet.data.api.EvmApiFactory
@@ -405,6 +406,36 @@ class BroadcastTxUseCaseTest {
         }
     }
 
+    @Test
+    fun `recovers local hash when cardano rejects a duplicate broadcast`() = runTest {
+        // Loser device of a multi-device keysign: Ogmios rejects the byte-identical rebroadcast
+        // because the inputs are already spent. The tx is on-chain under our local hash, so we must
+        // report success even though it has 0 confirmations within the short verify window.
+        val cardanoApi = mockk<CardanoApi>(relaxed = true)
+        coEvery { cardanoApi.broadcastTransaction(Chain.Cardano.name, RAW_TRANSACTION) } throws
+            CardanoTransactionAlreadyBroadcastException("All inputs are spent")
+
+        val txHash = createUseCase(cardanoApi = cardanoApi)(Chain.Cardano, signedTransaction())
+
+        assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+        coVerify(exactly = 0) { cardanoApi.getTxStatus(any()) }
+    }
+
+    @Test
+    fun `propagates cardano rejection that is not a duplicate broadcast`() = runTest {
+        val cardanoApi = mockk<CardanoApi>(relaxed = true)
+        val failure = IllegalStateException("Failed to broadcast transaction: invalid transaction")
+        coEvery { cardanoApi.broadcastTransaction(Chain.Cardano.name, RAW_TRANSACTION) } throws
+            failure
+        coEvery { cardanoApi.getTxStatus(KNOWN_TRANSACTION_HASH) } returns null
+
+        val thrown =
+            assertFailsWith<IllegalStateException> {
+                createUseCase(cardanoApi = cardanoApi)(Chain.Cardano, signedTransaction())
+            }
+        assertEquals(failure, thrown)
+    }
+
     private fun blockchairResult(blockId: Int) =
         BlockChainStatusDeserialized.Result(
             BlockChairStatusResponse(
@@ -423,6 +454,7 @@ class BroadcastTxUseCaseTest {
         cosmosApiFactory: CosmosApiFactory = mockk(relaxed = true),
         blockChairApi: BlockChairApi = mockk(relaxed = true),
         bittensorApi: BittensorApi = mockk(relaxed = true),
+        cardanoApi: CardanoApi = mockk(relaxed = true),
         transactionStatusRepository: TransactionStatusRepository = mockk(relaxed = true),
     ) =
         BroadcastTxUseCaseImpl(
@@ -438,7 +470,7 @@ class BroadcastTxUseCaseTest {
             tonApi = mockk<TonApi>(relaxed = true),
             rippleApi = mockk<RippleApi>(relaxed = true),
             tronApi = mockk<TronApi>(relaxed = true),
-            cardanoApi = mockk<CardanoApi>(relaxed = true),
+            cardanoApi = cardanoApi,
             transactionStatusRepository = transactionStatusRepository,
         )
 


### PR DESCRIPTION
## Summary
On a multi-device Cardano (ADA) keysign, the device that loses the broadcast race rebroadcasts the peer's byte-identical signed tx. Ogmios rejects it with `All inputs are spent. Transaction has probably already been included`. The old recovery required `num_confirmations > 0`, but a Cardano block takes ~20s — far longer than the ~5s verify window — so the accepted tx never confirmed in time and the loser device showed **Transaction failed** for a swap that actually succeeded on-chain.

This treats that Ogmios error as the duplicate-broadcast signal it is:
- `CardanoApi.broadcastTransaction` throws a typed `CardanoTransactionAlreadyBroadcastException` when Ogmios's `data.error` reports the inputs are already spent / already included (surfaced past the outer catch, like `CancellationException`).
- The Cardano branch of `BroadcastTxUseCase` catches it and recovers to the locally computed hash — no need to wait a full block for a confirmation that can't arrive in the verify window. Since the peer's tx is byte-identical, its spent inputs prove our hash is canonical.
- Genuine rejections (`unknownOutputReferences`, other errors) still throw and fall through to on-chain verification unchanged.

On chain tx link: https://cardanoscan.io/transaction/077d743bd64fe0a966f435d1653d71d0a44e2b663d20bf9fa9c74a98992e5efb
## Issue
Closes #5337

## Test Plan
- [x] New unit tests pass (`./gradlew :data:testDebugUnitTest --tests "*CardanoApiBroadcastTest" --tests "*BroadcastTxUseCaseTest"`)
  - `CardanoApiBroadcastTest`: spent-inputs 400 → `CardanoTransactionAlreadyBroadcastException`; `unknownOutputReferences` and other 400s still throw `IllegalStateException`
  - `BroadcastTxUseCaseTest`: duplicate-broadcast rejection recovers the local hash (no `getTxStatus` wait); non-duplicate rejection propagates
- [x] Lint passes (`./gradlew :data:lint`)
- [ ] Manual: ADA→ETH SwapKit swap co-signed from two devices — both report success

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cardano transaction broadcasting by recognizing duplicate-broadcast and “already been included/inputs already spent” rejections.
  * Duplicate-broadcast responses now emit a dedicated already-broadcast signal so the use case can recover using the locally computed transaction hash when available.
  * Hardened local transaction hash calculation to “fail closed” (returns blank) when CBOR parsing fails.
  * Improved parsing of additional Ogmios error details from bad-request responses.

* **Tests**
  * Added/extended coverage for spent-input, duplicate-broadcast, and transaction-hash parsing failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->