### PR TITLE
fix(send): reject an invalid recipient with a visible error (#5361)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -61,8 +61,10 @@ internal class AddressManager(
     val isDstAddressComplete: StateFlow<Boolean> = _isDstAddressComplete.asStateFlow()
 
     // True when a non-empty recipient failed chain validation and couldn't resolve to a valid
-    // address. Drives the inline "not a valid address for this chain" error; false while empty,
-    // resolving, or valid. Chain-general: every send chain validates through the same path below.
+    // address. Drives the inline "not a valid address for this chain" error; false once the input
+    // is valid or empty. While name resolution is in flight the flag holds its previous value, so a
+    // standing error stays put until the new input resolves instead of blinking off and back on.
+    // Chain-general: every send chain validates through the same path below.
     private val _invalidAddress = MutableStateFlow(false)
     val invalidAddress: StateFlow<Boolean> = _invalidAddress.asStateFlow()
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -60,6 +60,12 @@ internal class AddressManager(
     private val _isDstAddressComplete = MutableStateFlow(false)
     val isDstAddressComplete: StateFlow<Boolean> = _isDstAddressComplete.asStateFlow()
 
+    // True when a non-empty recipient failed chain validation and couldn't resolve to a valid
+    // address. Drives the inline "not a valid address for this chain" error; false while empty,
+    // resolving, or valid. Chain-general: every send chain validates through the same path below.
+    private val _invalidAddress = MutableStateFlow(false)
+    val invalidAddress: StateFlow<Boolean> = _invalidAddress.asStateFlow()
+
     private val _onAddressValidated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val onAddressValidated: SharedFlow<Unit> = _onAddressValidated.asSharedFlow()
 
@@ -144,6 +150,7 @@ internal class AddressManager(
                     _dstAddressLabel.value = null
                 }
                 _resolvedDstAddress.value = addressStr
+                _invalidAddress.value = false
                 _onAddressValidated.tryEmit(Unit)
             }
             addressStr.isNotEmpty() -> {
@@ -155,6 +162,7 @@ internal class AddressManager(
             else -> {
                 _resolvedDstAddress.value = null
                 _dstAddressLabel.value = null
+                _invalidAddress.value = false
             }
         }
     }
@@ -186,6 +194,7 @@ internal class AddressManager(
             addressFieldState.setTextAndPlaceCursorAtEnd(decoded.classicAddress)
         }
         _resolvedDstAddress.value = decoded.classicAddress
+        _invalidAddress.value = false
         // Surface the pasted X-address as the label so Verify/Done show what the user entered.
         _dstAddressLabel.value = originalInput
         _onAddressValidated.tryEmit(Unit)
@@ -200,11 +209,13 @@ internal class AddressManager(
             if (chainAccountAddressRepository.isValid(chain, resolved)) {
                 _dstAddressLabel.value = addressStr
                 _resolvedDstAddress.value = resolved
+                _invalidAddress.value = false
                 addressFieldState.setTextAndPlaceCursorAtEnd(resolved)
                 _onAddressValidated.tryEmit(Unit)
             } else {
                 _resolvedDstAddress.value = null
                 _dstAddressLabel.value = null
+                _invalidAddress.value = true
             }
         } catch (e: CancellationException) {
             throw e
@@ -214,6 +225,7 @@ internal class AddressManager(
             Timber.w(e, "Failed to resolve address %s on %s", addressStr, chain)
             _resolvedDstAddress.value = null
             _dstAddressLabel.value = null
+            _invalidAddress.value = true
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -436,6 +436,23 @@ internal class SendFormGraph(
             }
         }
         scope.launch {
+            addressManager.invalidAddress.collect { invalid ->
+                uiState.update {
+                    it.copy(
+                        dstAddressError =
+                            if (invalid) {
+                                UiText.StringResource(
+                                    com.vultisig.wallet.R.string
+                                        .send_error_invalid_recipient_address
+                                )
+                            } else {
+                                null
+                            }
+                    )
+                }
+            }
+        }
+        scope.launch {
             amountManager.reapingError.collect { error ->
                 uiState.update { it.copy(reapingError = error) }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
@@ -96,6 +96,23 @@ internal data class SendFormUiModel(
 )
 
 /**
+ * Whether the recipient field is user-editable. Unbond draws from a specific bonded node and
+ * prefills a locked node address; every other flow lets the user type, paste or scan a recipient.
+ */
+internal val SendFormUiModel.isDstAddressEditable: Boolean
+    get() = defiType != DeFiNavActions.UNBOND
+
+/**
+ * Whether an invalid recipient should block the form.
+ *
+ * Only an address the user can actually correct blocks: a locked Unbond node address offers no
+ * retype, paste or scan path, so blocking there would strand the flow with no way out. The inline
+ * error still renders, and UnbondStrategy rejects an invalid node address at submit.
+ */
+internal val SendFormUiModel.isDstAddressBlocking: Boolean
+    get() = dstAddressError != null && isDstAddressEditable
+
+/**
  * Whether the Continue action should be disabled for the current form state.
  *
  * The gas-fee-loading gate applies to every flow: while the network fee is (re)computing —
@@ -109,15 +126,15 @@ internal data class SendFormUiModel(
  * Continue cannot enable before the frozen balance loads — otherwise submit coerces the still-null
  * balance to zero and falsely rejects a fundable unfreeze.
  *
- * An invalid recipient ([dstAddressError] set) also disables Continue so the flow can't proceed
- * from an address that failed chain validation — the inline error is the visible reason, and
- * correcting the field clears it and re-enables Continue.
+ * An invalid recipient the user can correct ([isDstAddressBlocking]) also disables Continue so the
+ * flow can't proceed from an address that failed chain validation — the inline error is the visible
+ * reason, and correcting the field clears it and re-enables Continue.
  *
  * @return true when Continue must stay disabled.
  */
 internal fun SendFormUiModel.isContinueDisabled(): Boolean =
     isLoading ||
-        dstAddressError != null ||
+        isDstAddressBlocking ||
         (showGasFee && isGasFeeLoading) ||
         (tronResourceType != null && (!isAmountValid || isTronFrozenBalancesLoading))
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
@@ -109,10 +109,15 @@ internal data class SendFormUiModel(
  * Continue cannot enable before the frozen balance loads — otherwise submit coerces the still-null
  * balance to zero and falsely rejects a fundable unfreeze.
  *
+ * An invalid recipient ([dstAddressError] set) also disables Continue so the flow can't proceed
+ * from an address that failed chain validation — the inline error is the visible reason, and
+ * correcting the field clears it and re-enables Continue.
+ *
  * @return true when Continue must stay disabled.
  */
 internal fun SendFormUiModel.isContinueDisabled(): Boolean =
     isLoading ||
+        dstAddressError != null ||
         (showGasFee && isGasFeeLoading) ||
         (tronResourceType != null && (!isAmountValid || isTronFrozenBalancesLoading))
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAddressSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAddressSection.kt
@@ -142,7 +142,8 @@ internal fun FoldableDestinationAddressWidget(
 ) {
     FoldableSection(
         expanded = state.expandedSection == SendSections.Address,
-        complete = state.isDstAddressComplete,
+        // A filled-in but invalid recipient is not complete — no checkmark while the error shows.
+        complete = state.isDstAddressComplete && state.dstAddressError == null,
         title = stringResource(R.string.add_address_address_title),
         onToggle = { onExpandSection(SendSections.Address) },
         completeTitleContent = { AddressCompleteTitleContent(addressFieldState) },
@@ -237,7 +238,8 @@ internal fun FoldableBondDestinationAddress(
 ) {
     FoldableSection(
         expanded = state.expandedSection == SendSections.Address,
-        complete = state.isDstAddressComplete,
+        // A filled-in but invalid recipient is not complete — no checkmark while the error shows.
+        complete = state.isDstAddressComplete && state.dstAddressError == null,
         title = stringResource(R.string.add_address_address_title),
         onToggle = { onExpandSection(SendSections.Address) },
         completeTitleContent = { AddressCompleteTitleContent(addressFieldState) },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
@@ -45,6 +45,7 @@ import com.vultisig.wallet.ui.models.send.AmountFraction
 import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendSections
 import com.vultisig.wallet.ui.models.send.isContinueDisabled
+import com.vultisig.wallet.ui.models.send.isDstAddressBlocking
 import com.vultisig.wallet.ui.screens.deposit.components.AutoCompoundToggle
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.theme.Theme
@@ -101,8 +102,13 @@ internal fun FoldableAmountWidget(
     FoldableSection(
         expanded = isCircleMode || state.expandedSection == SendSections.Amount,
         onToggle = {
+            // A blocking recipient error keeps Address expanded: collapsing it would hide the only
+            // visible reason Continue is disabled.
             if (
-                !isCircleMode && state.isDstAddressComplete && addressFieldState.text.isNotEmpty()
+                !isCircleMode &&
+                    state.isDstAddressComplete &&
+                    !state.isDstAddressBlocking &&
+                    addressFieldState.text.isNotEmpty()
             ) {
                 onExpandSection(SendSections.Amount)
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
@@ -49,6 +49,7 @@ import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendFormViewModel
 import com.vultisig.wallet.ui.models.send.SendSections
 import com.vultisig.wallet.ui.models.send.isContinueDisabled
+import com.vultisig.wallet.ui.models.send.isDstAddressEditable
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.tron.TronResourceTypeTab
@@ -432,7 +433,7 @@ private fun SendFormContent(
                 onAddressProviderBookClick = onProviderBookClick,
                 // Unbond draws from a specific bonded node; the amount ceiling is frozen to that
                 // node at navigation, so the address must stay locked to keep them in sync.
-                isAddressEditable = state.defiType != DeFiNavActions.UNBOND,
+                isAddressEditable = state.isDstAddressEditable,
             )
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -193,6 +193,7 @@
     <string name="camera_permission_open_settings">Einstellungen öffnen</string>
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
+    <string name="send_error_invalid_recipient_address">Dieser Empfänger ist keine gültige Adresse für dieses Netzwerk.</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
     <string name="vault_settings_error_backup_failed">Backup fehlgeschlagen. Es wurde keine Datei gespeichert. Bitte versuchen Sie es erneut.</string>
     <string name="vault_settings_delete_vault_name">Tresorname:</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -193,7 +193,7 @@
     <string name="camera_permission_open_settings">Einstellungen öffnen</string>
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
-    <string name="send_error_invalid_recipient_address">Dieser Empfänger ist keine gültige Adresse für dieses Netzwerk.</string>
+    <string name="send_error_invalid_recipient_address">Dieser Empfänger ist keine gültige Adresse für diese Blockchain.</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
     <string name="vault_settings_error_backup_failed">Backup fehlgeschlagen. Es wurde keine Datei gespeichert. Bitte versuchen Sie es erneut.</string>
     <string name="vault_settings_delete_vault_name">Tresorname:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -190,7 +190,7 @@
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
     <string name="vault_settings_error_backup_failed">La copia de seguridad falló. No se guardó ningún archivo. Inténtalo de nuevo.</string>
     <string name="send_error_no_address">La dirección no es válida</string>
-    <string name="send_error_invalid_recipient_address">Ese destinatario no es una dirección válida para esta red.</string>
+    <string name="send_error_invalid_recipient_address">Ese destinatario no es una dirección válida para esta cadena.</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>
     <string name="vault_accounts_account_assets">%1$s activos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -190,6 +190,7 @@
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
     <string name="vault_settings_error_backup_failed">La copia de seguridad falló. No se guardó ningún archivo. Inténtalo de nuevo.</string>
     <string name="send_error_no_address">La dirección no es válida</string>
+    <string name="send_error_invalid_recipient_address">Ese destinatario no es una dirección válida para esta red.</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>
     <string name="vault_accounts_account_assets">%1$s activos</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -193,6 +193,7 @@
     <string name="camera_permission_open_settings">Otvori postavke</string>
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
+    <string name="send_error_invalid_recipient_address">Taj primatelj nije valjana adresa za ovu mrežu.</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
     <string name="vault_settings_error_backup_failed">Sigurnosno kopiranje nije uspjelo. Nijedna datoteka nije spremljena. Pokušajte ponovno.</string>
     <string name="vault_settings_delete_vault_name">Ime sefa:</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -193,7 +193,7 @@
     <string name="camera_permission_open_settings">Otvori postavke</string>
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
-    <string name="send_error_invalid_recipient_address">Taj primatelj nije valjana adresa za ovu mrežu.</string>
+    <string name="send_error_invalid_recipient_address">Taj primatelj nije valjana adresa za ovaj lanac.</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
     <string name="vault_settings_error_backup_failed">Sigurnosno kopiranje nije uspjelo. Nijedna datoteka nije spremljena. Pokušajte ponovno.</string>
     <string name="vault_settings_delete_vault_name">Ime sefa:</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -193,6 +193,7 @@
     <string name="camera_permission_open_settings">Apri impostazioni</string>
     <string name="verify_transaction_value">Valore</string>
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
+    <string name="send_error_invalid_recipient_address">Quel destinatario non è un indirizzo valido per questa rete.</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
     <string name="vault_settings_error_backup_failed">Backup non riuscito. Nessun file è stato salvato. Riprova.</string>
     <string name="vault_settings_delete_vault_name">Nome Cassaforte:</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -193,7 +193,7 @@
     <string name="camera_permission_open_settings">Apri impostazioni</string>
     <string name="verify_transaction_value">Valore</string>
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
-    <string name="send_error_invalid_recipient_address">Quel destinatario non è un indirizzo valido per questa rete.</string>
+    <string name="send_error_invalid_recipient_address">Quel destinatario non è un indirizzo valido per questa catena.</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
     <string name="vault_settings_error_backup_failed">Backup non riuscito. Nessun file è stato salvato. Riprova.</string>
     <string name="vault_settings_delete_vault_name">Nome Cassaforte:</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -173,6 +173,7 @@
     <string name="send_error_no_token">토큰이 선택되지 않았습니다</string>
     <string name="send_error_no_gas_fee">가스 수수료 없음</string>
     <string name="send_error_no_address">주소가 유효하지 않습니다</string>
+    <string name="send_error_invalid_recipient_address">해당 수신자는 이 네트워크에 유효한 주소가 아닙니다.</string>
     <string name="send_error_no_amount">금액은 양수여야 합니다</string>
     <string name="send_error_too_many_decimals">금액은 소수점 이하 최대 %1$d자리까지 입력할 수 있습니다</string>
     <string name="send_error_invalid_operator_fee">운영자 수수료는 0에서 10000 베이시스 포인트 사이의 유효한 숫자여야 합니다</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -173,7 +173,7 @@
     <string name="send_error_no_token">토큰이 선택되지 않았습니다</string>
     <string name="send_error_no_gas_fee">가스 수수료 없음</string>
     <string name="send_error_no_address">주소가 유효하지 않습니다</string>
-    <string name="send_error_invalid_recipient_address">해당 수신자는 이 네트워크에 유효한 주소가 아닙니다.</string>
+    <string name="send_error_invalid_recipient_address">해당 수신자는 이 체인에 유효한 주소가 아닙니다.</string>
     <string name="send_error_no_amount">금액은 양수여야 합니다</string>
     <string name="send_error_too_many_decimals">금액은 소수점 이하 최대 %1$d자리까지 입력할 수 있습니다</string>
     <string name="send_error_invalid_operator_fee">운영자 수수료는 0에서 10000 베이시스 포인트 사이의 유효한 숫자여야 합니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -101,7 +101,7 @@
     <string name="send_error_no_token">Geen token geselecteerd</string>
     <string name="send_error_no_gas_fee">Geen gasvergoeding</string>
     <string name="send_error_no_address">Adres is ongeldig</string>
-    <string name="send_error_invalid_recipient_address">Die ontvanger is geen geldig adres voor dit netwerk.</string>
+    <string name="send_error_invalid_recipient_address">Die ontvanger is geen geldig adres voor deze keten.</string>
     <string name="send_error_no_amount">Het bedrag moet een positief getal zijn</string>
     <string name="send_error_too_many_decimals">Het bedrag mag maximaal %1$d decimalen hebben</string>
     <string name="send_error_invalid_operator_fee">Operatorkosten moeten een geldig getal tussen 0 en 10000 basispunten zijn</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -101,6 +101,7 @@
     <string name="send_error_no_token">Geen token geselecteerd</string>
     <string name="send_error_no_gas_fee">Geen gasvergoeding</string>
     <string name="send_error_no_address">Adres is ongeldig</string>
+    <string name="send_error_invalid_recipient_address">Die ontvanger is geen geldig adres voor dit netwerk.</string>
     <string name="send_error_no_amount">Het bedrag moet een positief getal zijn</string>
     <string name="send_error_too_many_decimals">Het bedrag mag maximaal %1$d decimalen hebben</string>
     <string name="send_error_invalid_operator_fee">Operatorkosten moeten een geldig getal tussen 0 en 10000 basispunten zijn</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -193,7 +193,7 @@
     <string name="camera_permission_open_settings">Abrir configurações</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
-    <string name="send_error_invalid_recipient_address">Esse destinatário não é um endereço válido para esta rede.</string>
+    <string name="send_error_invalid_recipient_address">Esse destinatário não é um endereço válido para esta cadeia.</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
     <string name="vault_settings_error_backup_failed">O backup falhou. Nenhum ficheiro foi guardado. Tente novamente.</string>
     <string name="vault_settings_delete_vault_name">Nome do Cofre:</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -193,6 +193,7 @@
     <string name="camera_permission_open_settings">Abrir configurações</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
+    <string name="send_error_invalid_recipient_address">Esse destinatário não é um endereço válido para esta rede.</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
     <string name="vault_settings_error_backup_failed">O backup falhou. Nenhum ficheiro foi guardado. Tente novamente.</string>
     <string name="vault_settings_delete_vault_name">Nome do Cofre:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -101,6 +101,7 @@
     <string name="send_error_no_token">Токен не выбран</string>
     <string name="send_error_no_gas_fee">Нет платы за газ</string>
     <string name="send_error_no_address">Адрес недействителен</string>
+    <string name="send_error_invalid_recipient_address">Этот получатель не является действительным адресом для этой сети.</string>
     <string name="send_error_no_amount">Сумма должна быть положительным числом</string>
     <string name="send_error_too_many_decimals">Сумма может содержать не более %1$d знаков после запятой</string>
     <string name="send_error_invalid_operator_fee">Комиссия оператора должна быть действительным числом от 0 до 10000 базисных пунктов</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -193,6 +193,7 @@
     <string name="send_error_no_token">未选择代币</string>
     <string name="send_error_no_gas_fee">无燃料费</string>
     <string name="send_error_no_address">地址无效</string>
+    <string name="send_error_invalid_recipient_address">该收款人不是此网络的有效地址。</string>
     <string name="send_error_no_amount">金额必须是正数</string>
     <string name="send_error_too_many_decimals">金额最多可保留 %1$d 位小数</string>
     <string name="send_error_invalid_operator_fee">运营商费用必须是0到10000基点之间的有效数字</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -193,7 +193,7 @@
     <string name="send_error_no_token">未选择代币</string>
     <string name="send_error_no_gas_fee">无燃料费</string>
     <string name="send_error_no_address">地址无效</string>
-    <string name="send_error_invalid_recipient_address">该收款人不是此网络的有效地址。</string>
+    <string name="send_error_invalid_recipient_address">该收款人不是此链的有效地址。</string>
     <string name="send_error_no_amount">金额必须是正数</string>
     <string name="send_error_too_many_decimals">金额最多可保留 %1$d 位小数</string>
     <string name="send_error_invalid_operator_fee">运营商费用必须是0到10000基点之间的有效数字</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,7 @@
     <string name="send_error_no_token">No token selected</string>
     <string name="send_error_no_gas_fee">No gas fees</string>
     <string name="send_error_no_address">Address is invalid</string>
+    <string name="send_error_invalid_recipient_address">That recipient is not a valid address for this chain.</string>
     <string name="send_error_no_amount">Amount must be a positive number</string>
     <string name="send_error_too_many_decimals">Amount can have at most %1$d decimal places</string>
     <string name="send_error_invalid_operator_fee">Operator fee must be a valid number between 0 and 10000 basis points</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
+import io.kotest.assertions.withClue
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -258,16 +259,141 @@ internal class AddressManagerTest {
             emissions.shouldBeEmpty()
         }
 
+    @Test
+    fun `ethereum txid pasted as recipient is flagged invalid`() =
+        runTest(mainDispatcher) {
+            // A transaction id has the shape of an address but is not a valid recipient.
+            val txid = "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, txid) } returns false
+            coEvery { addressParserRepository.resolveName(txid, Chain.Ethereum) } returns txid
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd(txid)
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.invalidAddress.value.shouldBeTrue()
+            manager.resolvedDstAddress.value.shouldBeNull()
+        }
+
+    @Test
+    fun `invalid recipient across representative chains is flagged`() =
+        runTest(mainDispatcher) {
+            val cases =
+                listOf(
+                    token(Chain.GaiaChain, "ATOM") to "not-a-cosmos-address",
+                    token(Chain.Bitcoin, "BTC") to "not-a-btc-address",
+                    token(Chain.Solana, "SOL") to "not-a-solana-address",
+                    token(Chain.Ripple, "XRP") to "not-an-xrp-address",
+                )
+
+            cases.forEach { (coin, badInput) ->
+                every { chainAccountAddressRepository.isValid(coin.chain, badInput) } returns false
+                coEvery { addressParserRepository.resolveName(badInput, coin.chain) } returns
+                    badInput
+
+                val field = TextFieldState()
+                val manager = build(backgroundScope, addressField = field)
+                manager.start()
+                selectedToken.value = coin
+
+                field.setTextAndPlaceCursorAtEnd(badInput)
+                Snapshot.sendApplyNotifications()
+                advanceTimeBy(400)
+                advanceUntilIdle()
+
+                withClue("${coin.chain} should flag $badInput as invalid") {
+                    manager.invalidAddress.value.shouldBeTrue()
+                }
+            }
+        }
+
+    @Test
+    fun `valid recipient clears a prior invalid flag`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "garbage") } returns false
+            coEvery { addressParserRepository.resolveName("garbage", Chain.Ethereum) } returns
+                "garbage"
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "0xabc") } returns true
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("garbage")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            manager.invalidAddress.value.shouldBeTrue()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.invalidAddress.value.shouldBeFalse()
+            manager.resolvedDstAddress.value shouldBe "0xabc"
+        }
+
+    @Test
+    fun `clearing the field clears the invalid flag`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "garbage") } returns false
+            coEvery { addressParserRepository.resolveName("garbage", Chain.Ethereum) } returns
+                "garbage"
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("garbage")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            manager.invalidAddress.value.shouldBeTrue()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.invalidAddress.value.shouldBeFalse()
+        }
+
+    @Test
+    fun `resolver failure flags the recipient invalid`() =
+        runTest(mainDispatcher) {
+            every { chainAccountAddressRepository.isValid(Chain.Ethereum, "explode.eth") } returns
+                false
+            coEvery { addressParserRepository.resolveName("explode.eth", Chain.Ethereum) } throws
+                IllegalStateException("rpc down")
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = ethToken()
+
+            addressFieldState.setTextAndPlaceCursorAtEnd("explode.eth")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.invalidAddress.value.shouldBeTrue()
+        }
+
     private fun TestScope.collectValidations(manager: AddressManager): MutableList<Unit> {
         val emissions = mutableListOf<Unit>()
         backgroundScope.launch { manager.onAddressValidated.collect { emissions += Unit } }
         return emissions
     }
 
-    private fun build(scope: CoroutineScope) =
+    private fun build(scope: CoroutineScope, addressField: TextFieldState = addressFieldState) =
         AddressManager(
             scope = scope,
-            addressFieldState = addressFieldState,
+            addressFieldState = addressField,
             providerBondFieldState = providerBondFieldState,
             destinationTagFieldState = destinationTagFieldState,
             selectedToken = selectedToken,
@@ -278,15 +404,17 @@ internal class AddressManagerTest {
             checkIfTokenSelectionRequired = { _, _ -> },
         )
 
-    private fun ethToken(): Coin =
+    private fun ethToken(): Coin = token(Chain.Ethereum, "ETH")
+
+    private fun token(chain: Chain, ticker: String): Coin =
         Coin(
-            chain = Chain.Ethereum,
-            ticker = "ETH",
+            chain = chain,
+            ticker = ticker,
             logo = "",
-            address = "0xself",
+            address = "self",
             decimal = 18,
             hexPublicKey = "",
-            priceProviderID = "ethereum",
+            priceProviderID = ticker.lowercase(),
             contractAddress = "",
             isNativeToken = true,
         )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormContinueGateTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormContinueGateTest.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.ui.models.send
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class SendFormContinueGateTest {
+
+    private val invalidRecipient =
+        UiText.StringResource(R.string.send_error_invalid_recipient_address)
+
+    private fun model(
+        dstAddressError: UiText? = null,
+        defiType: DeFiNavActions? = null,
+    ): SendFormUiModel =
+        SendFormUiModel(
+            dstAddressError = dstAddressError,
+            defiType = defiType,
+            isGasFeeLoading = false,
+        )
+
+    @Test
+    fun `invalid recipient blocks continue on a plain send`() {
+        val state = model(dstAddressError = invalidRecipient)
+
+        assertTrue(state.isDstAddressBlocking)
+        assertTrue(state.isContinueDisabled())
+    }
+
+    @Test
+    fun `valid recipient does not block continue`() {
+        val state = model()
+
+        assertFalse(state.isDstAddressBlocking)
+        assertFalse(state.isContinueDisabled())
+    }
+
+    @Test
+    fun `locked unbond node address never blocks continue`() {
+        val state = model(dstAddressError = invalidRecipient, defiType = DeFiNavActions.UNBOND)
+
+        assertFalse(state.isDstAddressEditable)
+        assertFalse(state.isDstAddressBlocking)
+        assertFalse(state.isContinueDisabled())
+    }
+
+    @Test
+    fun `bond keeps its editable address gated`() {
+        val state = model(dstAddressError = invalidRecipient, defiType = DeFiNavActions.BOND)
+
+        assertTrue(state.isDstAddressEditable)
+        assertTrue(state.isContinueDisabled())
+    }
+}


### PR DESCRIPTION
## Summary

A native send flow could accept an invalid recipient and leave **Continue** unavailable without explaining why. This surfaced with a **USDC send on Ethereum** where a transaction id was pasted where the recipient address belongs.

The inline-error slot (`dstAddressError` → `AddressInputSection`) already existed end-to-end but nothing ever populated it. This wires it, chain-general, on the single shared send path.

- **`AddressManager`** exposes `invalidAddress: StateFlow<Boolean>` — `true` when a non-empty recipient fails chain validation (`chainAccountAddressRepository.isValid`) **and** can't resolve to a valid address (ENS/name), `false` while empty, resolving, valid, or decoded from an XRP X-address.
- **`SendFormGraph`** maps `invalidAddress` onto `dstAddressError`, so the address field renders the inline error for every native send chain.
- **`isContinueDisabled()`** now also gates on `dstAddressError != null`, so the flow can't proceed from an invalid recipient — the inline error is the visible reason, and correcting the field clears it and re-enables Continue.
- New string `send_error_invalid_recipient_address` = _"That recipient is not a valid address for this chain."_ added to all 10 locales.

Submit already rejected an invalid recipient (`DefaultSendStrategy`), kept as defense in depth, so nothing builds, signs, or broadcasts from one.

## Acceptance criteria

- [x] Invalid-recipient UI and recovery are shared across native send flows, not a chain-specific screen (single `AddressManager` / `DefaultSendStrategy` path).
- [x] Covers an Ethereum/USDC send with a txid substituted for the address, plus Cosmos, UTXO, Solana and XRP invalid inputs.
- [x] Each case renders a human-readable error and prevents transaction construction/signing.
- [x] Valid replacement enables the flow normally.

## Test plan

- Send → Ethereum → paste a txid into **Send to** → inline error shows, red border, **Continue** disabled → replace with a valid address → error clears, Continue enables.
- Same on Cosmos (ATOM), Bitcoin, Solana, XRP with junk input.

Unit tests: `AddressManagerTest` — 5 new cases (eth txid, 4-chain matrix, valid clears, empty clears, resolver-failure). **18/18 green**.

## Screenshot

| Ethereum send, txid pasted |
|--------|
| ![after](https://i.imgur.com/fkgcYFg.png) |

Closes #5361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an explicit invalid-recipient error state in the send form, including correct clearing when the input becomes valid or is removed.
  * “Continue” is now blocked for invalid recipients, with correct exceptions for locked unbond flows.
  * Destination address “complete” indicators and amount section behavior no longer treat invalid recipients as complete.

* **Localization**
  * Added the “invalid recipient address” message to supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->