### PR TITLE
chore: bump targetSdk to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 114
         versionName = "1.0.114"
 


### PR DESCRIPTION
## Summary
- Bump `targetSdk` from 35 to 36 (Android 16) in `app/build.gradle.kts`

## Test Plan
- [x] Lint passes (`./gradlew lint`)
- [ ] Verify app behavior on Android 16 device/emulator (new runtime restrictions, e.g. edge-to-edge enforcement)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app to target Android SDK 36, supporting the latest platform requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->