### PR TITLE
fix(solana): average two central samples for even-length priority-fee sets

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -715,7 +715,7 @@ internal fun solanaMedianPriorityFee(
     if (size == 0) return fallback
     val mid = size / 2
     return if (size % 2 == 0) {
-        (sortedFees[mid - 1] + sortedFees[mid]) / BigInteger.TWO
+        (sortedFees[mid - 1] + sortedFees[mid]) / BigInteger.valueOf(2)
     } else {
         sortedFees[mid]
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -224,7 +224,7 @@ internal class SolanaApiImp(
                     ?.filter { it > BigInteger.ZERO }
                     ?.sorted()
                     .orEmpty()
-            val median = if (nonZeroFees.isEmpty()) fallback else nonZeroFees[nonZeroFees.size / 2]
+            val median = solanaMedianPriorityFee(nonZeroFees, fallback)
             maxOf(median, fallback).coerceAtMost(MAX_PRIORITY_FEE_PRICE.toBigInteger())
         } catch (e: CancellationException) {
             throw e
@@ -700,6 +700,25 @@ internal enum class SolanaBroadcastAction {
     EXPIRED,
     /** Any other RPC error — not recoverable by resending. */
     FATAL,
+}
+
+/**
+ * Median of [sortedFees] (ascending, strictly positive), or [fallback] when empty. Averages the two
+ * central elements for an even-length list instead of picking the upper-middle one, matching iOS
+ * (SolanaService.fetchRecentPrioritizationFees).
+ */
+internal fun solanaMedianPriorityFee(
+    sortedFees: List<BigInteger>,
+    fallback: BigInteger,
+): BigInteger {
+    val size = sortedFees.size
+    if (size == 0) return fallback
+    val mid = size / 2
+    return if (size % 2 == 0) {
+        (sortedFees[mid - 1] + sortedFees[mid]) / BigInteger.TWO
+    } else {
+        sortedFees[mid]
+    }
 }
 
 /**

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaMedianPriorityFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaMedianPriorityFeeTest.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.data.api
+
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SolanaMedianPriorityFeeTest {
+
+    private val fallback = 1_000_000.toBigInteger()
+
+    @Test
+    fun `empty sample set returns the fallback`() {
+        assertEquals(fallback, solanaMedianPriorityFee(emptyList(), fallback))
+    }
+
+    @Test
+    fun `single sample returns that sample`() {
+        assertEquals(
+            500.toBigInteger(),
+            solanaMedianPriorityFee(listOf(500.toBigInteger()), fallback),
+        )
+    }
+
+    @Test
+    fun `odd sample count returns the middle element unchanged`() {
+        val samples = listOf(100, 200, 300).map { it.toBigInteger() }
+        assertEquals(200.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
+    }
+
+    @Test
+    fun `even sample count averages the two central elements`() {
+        // Ticket regression case: upper-middle (800) is wrong, true median is (200+800)/2 = 500.
+        val samples = listOf(100, 200, 800, 900).map { it.toBigInteger() }
+        assertEquals(500.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
+    }
+
+    @Test
+    fun `two samples averages both`() {
+        val samples = listOf(100, 300).map { it.toBigInteger() }
+        assertEquals(200.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
+    }
+
+    @Test
+    fun `even sample count with an odd sum truncates down instead of rounding`() {
+        val samples = listOf(100, 100, 201, 300).map { it.toBigInteger() }
+        // (100 + 201) / 2 = 150 (BigInteger division truncates toward zero for non-negative
+        // values).
+        assertEquals(150.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
+    }
+
+    @Test
+    fun `large values do not overflow`() {
+        val samples = listOf(BigInteger("9999999999999999999"), BigInteger("10000000000000000001"))
+        assertEquals(BigInteger("10000000000000000000"), solanaMedianPriorityFee(samples, fallback))
+    }
+}


### PR DESCRIPTION
Fixes #5344

`getMedianPriorityFee` indexed straight into `nonZeroFees[size / 2]`, which is the upper-middle element of the sorted list. That's correct for an odd sample count but wrong for an even one — for `[100, 200, 800, 900]` it returned 800 instead of the true median (200+800)/2 = 500, skewing the priority fee higher than intended.

Extracted the calculation into `solanaMedianPriorityFee` and fixed the even-length case to average the two central elements, matching iOS (`SolanaService.fetchRecentPrioritizationFees`).

## Test plan
- New unit tests in `SolanaMedianPriorityFeeTest`: empty set, single sample, odd counts, even counts (including the ticket's exact 4-sample regression case), an even-sum-is-odd case to confirm truncation rather than rounding, and large `BigInteger` values.
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.*" --tests "com.vultisig.wallet.data.blockchain.solana.*"` — all green.
- `./gradlew :data:ktfmtCheck` — clean.

Note: `EthereumFeeService.kt` has the identical `getOrNull(size / 2)` pattern for its own priority-fee median, affecting Polygon and other EVM chains. Left out of this PR since the ticket is scoped to Solana; filed as #5376. iOS has the same EVM bug (`RpcEvmService.swift` / `EvmServiceStruct.swift`), filed as vultisig-ios#4878. iOS and Windows Solana priority-fee code already averages correctly for even-length sets, so no cross-platform fix is needed there.