### PR TITLE
fix(evm): average two central samples for even-length priority-fee sets

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -30,6 +30,7 @@ import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.models.SplTokenDeserialized
 import com.vultisig.wallet.data.utils.SplTokenResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
+import com.vultisig.wallet.data.utils.median
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.get
@@ -703,23 +704,13 @@ internal enum class SolanaBroadcastAction {
 }
 
 /**
- * Median of [sortedFees] (ascending, strictly positive), or [fallback] when empty. Averages the two
- * central elements for an even-length list instead of picking the upper-middle one, matching iOS
- * (SolanaService.fetchRecentPrioritizationFees).
+ * Median of [sortedFees] (ascending, strictly positive), or [fallback] when empty. The even-length
+ * averaging behavior matches iOS (SolanaService.fetchRecentPrioritizationFees).
  */
 internal fun solanaMedianPriorityFee(
     sortedFees: List<BigInteger>,
     fallback: BigInteger,
-): BigInteger {
-    val size = sortedFees.size
-    if (size == 0) return fallback
-    val mid = size / 2
-    return if (size % 2 == 0) {
-        (sortedFees[mid - 1] + sortedFees[mid]) / BigInteger.valueOf(2)
-    } else {
-        sortedFees[mid]
-    }
-}
+): BigInteger = sortedFees.median() ?: fallback
 
 /**
  * Classifies a Solana `sendTransaction` error message into the action to take. `-32002` is Solana's

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.models.oneInchChainId
 import com.vultisig.wallet.data.models.supportsLegacyGas
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.increaseByPercent
+import com.vultisig.wallet.data.utils.median
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -385,18 +386,5 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
             DEFAULT_TOKEN_TRANSFER_LIMIT.increaseByPercent(40)
 
         val DEFAULT_ARBITRUM_TRANSFER = "160000".toBigInteger()
-    }
-}
-
-// Averages the two central elements for an even-length list instead of picking a single
-// upper-middle one; returns null for an empty list. Callers pair it with a chain-specific floor
-// via `maxOf(..., minFee)` so a missing sample degrades to that floor instead of throwing.
-private fun List<BigInteger>.median(): BigInteger? {
-    if (isEmpty()) return null
-    val mid = size / 2
-    return if (size % 2 == 0) {
-        (this[mid - 1] + this[mid]) / BigInteger.valueOf(2)
-    } else {
-        this[mid]
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -388,7 +388,15 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
     }
 }
 
-// Returns the mid-index element, or null for an empty list. Callers pair it with
-// a chain-specific floor via `maxOf(..., minFee)` so a missing sample degrades to
-// that floor instead of throwing.
-private fun List<BigInteger>.median(): BigInteger? = getOrNull(size / 2)
+// Averages the two central elements for an even-length list instead of picking a single
+// upper-middle one; returns null for an empty list. Callers pair it with a chain-specific floor
+// via `maxOf(..., minFee)` so a missing sample degrades to that floor instead of throwing.
+private fun List<BigInteger>.median(): BigInteger? {
+    if (isEmpty()) return null
+    val mid = size / 2
+    return if (size % 2 == 0) {
+        (this[mid - 1] + this[mid]) / BigInteger.valueOf(2)
+    } else {
+        this[mid]
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/BigIntegerExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/BigIntegerExtensions.kt
@@ -36,3 +36,17 @@ fun BigInteger.increaseByPercent(percent: Int): BigInteger =
 
 fun BigInteger.toValue(decimals: Int): BigDecimal =
     this.toBigDecimal().divide(BigDecimal.TEN.pow(decimals))
+
+/**
+ * Median of this list (already sorted ascending), or null when empty. Averages the two central
+ * elements for an even-length list instead of picking a single upper-middle one.
+ */
+fun List<BigInteger>.median(): BigInteger? {
+    if (isEmpty()) return null
+    val mid = size / 2
+    return if (size % 2 == 0) {
+        (this[mid - 1] + this[mid]) / BigInteger.valueOf(2)
+    } else {
+        this[mid]
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaMedianPriorityFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaMedianPriorityFeeTest.kt
@@ -1,6 +1,6 @@
 package com.vultisig.wallet.data.api
 
-import java.math.BigInteger
+import com.vultisig.wallet.data.utils.median
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -14,43 +14,8 @@ internal class SolanaMedianPriorityFeeTest {
     }
 
     @Test
-    fun `single sample returns that sample`() {
-        assertEquals(
-            500.toBigInteger(),
-            solanaMedianPriorityFee(listOf(500.toBigInteger()), fallback),
-        )
-    }
-
-    @Test
-    fun `odd sample count returns the middle element unchanged`() {
-        val samples = listOf(100, 200, 300).map { it.toBigInteger() }
-        assertEquals(200.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
-    }
-
-    @Test
-    fun `even sample count averages the two central elements`() {
-        // Ticket regression case: upper-middle (800) is wrong, true median is (200+800)/2 = 500.
+    fun `non-empty sample set delegates to the shared median calculation`() {
         val samples = listOf(100, 200, 800, 900).map { it.toBigInteger() }
-        assertEquals(500.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
-    }
-
-    @Test
-    fun `two samples averages both`() {
-        val samples = listOf(100, 300).map { it.toBigInteger() }
-        assertEquals(200.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
-    }
-
-    @Test
-    fun `even sample count with an odd sum truncates down instead of rounding`() {
-        val samples = listOf(100, 100, 201, 300).map { it.toBigInteger() }
-        // (100 + 201) / 2 = 150 (BigInteger division truncates toward zero for non-negative
-        // values).
-        assertEquals(150.toBigInteger(), solanaMedianPriorityFee(samples, fallback))
-    }
-
-    @Test
-    fun `large values do not overflow`() {
-        val samples = listOf(BigInteger("9999999999999999999"), BigInteger("10000000000000000001"))
-        assertEquals(BigInteger("10000000000000000000"), solanaMedianPriorityFee(samples, fallback))
+        assertEquals(samples.median(), solanaMedianPriorityFee(samples, fallback))
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -205,13 +205,41 @@ internal class EthereumFeeServiceTest {
     }
 
     @Test
-    fun `two-element fee history picks the upper midpoint`() = runTest {
-        // size/2 = 1 → second element
-        stubFeeHistory(listOf(gwei(2), gwei(8)))
+    fun `two-element fee history averages both elements instead of picking the upper midpoint`() =
+        runTest {
+            stubFeeHistory(listOf(gwei(2), gwei(8)))
+
+            val fee = service.calculateDefaultFees(transfer(Chain.Ethereum)) as Eip1559
+
+            assertEquals(gwei(5), fee.maxPriorityFeePerGas) // (2+8)/2 = 5, not the upper-midpoint 8
+        }
+
+    @Test
+    fun `ten-element fee history, matching the real getFeeHistory window, averages the two central elements`() =
+        runTest {
+            // getFeeHistory() always requests a fixed 10-block window, so the median must average
+            // indices 4 and 5 (mid-1, mid) rather than only index 5.
+            stubFeeHistory(
+                listOf(10, 20, 30, 40, 50, 60, 70, 80, 90, 100).map { gwei(it.toLong()) }
+            )
+
+            val fee = service.calculateDefaultFees(transfer(Chain.Ethereum)) as Eip1559
+
+            assertEquals(
+                gwei(55),
+                fee.maxPriorityFeePerGas,
+            ) // avg(50, 60) = 55, not the upper-midpoint 60
+        }
+
+    @Test
+    fun `even-length fee history with an odd sum truncates down instead of rounding`() = runTest {
+        // Both values clear the 1 GWEI floor so the averaged median (not the floor) is asserted.
+        stubFeeHistory(listOf(BigInteger("5000000000"), BigInteger("5000000001")))
 
         val fee = service.calculateDefaultFees(transfer(Chain.Ethereum)) as Eip1559
 
-        assertEquals(gwei(8), fee.maxPriorityFeePerGas)
+        // (5000000000 + 5000000001) / 2 = 5000000000 (BigInteger division truncates toward zero).
+        assertEquals(BigInteger("5000000000"), fee.maxPriorityFeePerGas)
     }
 
     // ---------- EIP-1559 fee assembly ----------

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/BigIntegerExtensionsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/BigIntegerExtensionsTest.kt
@@ -1,0 +1,59 @@
+package com.vultisig.wallet.data.utils
+
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+internal class BigIntegerExtensionsTest {
+
+    @Test
+    fun `median of an empty list is null`() {
+        assertNull(emptyList<BigInteger>().median())
+    }
+
+    @Test
+    fun `median of a single-element list is that element`() {
+        assertEquals(500.toBigInteger(), listOf(500.toBigInteger()).median())
+    }
+
+    @Test
+    fun `median of an odd-length list is the middle element`() {
+        val samples = listOf(100, 200, 300).map { it.toBigInteger() }
+        assertEquals(200.toBigInteger(), samples.median())
+    }
+
+    @Test
+    fun `median of an even-length list averages the two central elements`() {
+        // Regression case: the upper-middle element (800) is wrong; the true median is
+        // (200+800)/2 = 500.
+        val samples = listOf(100, 200, 800, 900).map { it.toBigInteger() }
+        assertEquals(500.toBigInteger(), samples.median())
+    }
+
+    @Test
+    fun `median of two elements averages both`() {
+        val samples = listOf(100, 300).map { it.toBigInteger() }
+        assertEquals(200.toBigInteger(), samples.median())
+    }
+
+    @Test
+    fun `median of an even-length list with an odd sum truncates down instead of rounding`() {
+        val samples = listOf(100, 100, 201, 300).map { it.toBigInteger() }
+        // (100 + 201) / 2 = 150 (BigInteger division truncates toward zero for non-negative
+        // values).
+        assertEquals(150.toBigInteger(), samples.median())
+    }
+
+    @Test
+    fun `median of a ten-element list matches the real getFeeHistory window shape`() {
+        val samples = listOf(10, 20, 30, 40, 50, 60, 70, 80, 90, 100).map { it.toBigInteger() }
+        assertEquals(55.toBigInteger(), samples.median()) // avg(50, 60) = 55
+    }
+
+    @Test
+    fun `median of large values does not overflow`() {
+        val samples = listOf(BigInteger("9999999999999999999"), BigInteger("10000000000000000001"))
+        assertEquals(BigInteger("10000000000000000000"), samples.median())
+    }
+}


### PR DESCRIPTION
Fixes #5376

`median()` indexed straight into `getOrNull(size / 2)`, which is the upper-middle element of the sorted `eth_feeHistory` reward list. That's correct for an odd sample count but wrong for an even one. `getFeeHistory()` always requests a fixed 10-block window, so this hit the buggy even-length path on effectively every quote for Polygon and every other chain routed through the catch-all `else` branch, not just as an edge case.

Fixed to average the two central elements when the sample count is even — same fix as the Solana sibling in #5375.

An existing test (`two-element fee history picks the upper midpoint`) was pinning the buggy behavior (asserting `gwei(8)` for `[2, 8]`); renamed and corrected to assert the true average (`gwei(5)`).

`solanaMedianPriorityFee` (Solana, #5375) and this EVM fix independently implemented the identical even-length-averaging math. Consolidated both into `List<BigInteger>.median()` in `BigIntegerExtensions.kt` so the two chains delegate to one implementation instead of maintaining two copies that could drift apart.

## Test plan
- Fixed the pre-existing regression test plus two new ones: a 10-element case matching the real `getFeeHistory` window shape, and an even-sum-is-odd case confirming truncation rather than rounding.
- New `BigIntegerExtensionsTest` (8 cases) is now the canonical test for the shared median algorithm; `SolanaMedianPriorityFeeTest` trimmed to the two cases specific to that wrapper (fallback-on-empty, delegation).
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeServiceTest" --tests "com.vultisig.wallet.data.api.SolanaMedianPriorityFeeTest" --tests "com.vultisig.wallet.data.utils.BigIntegerExtensionsTest" --tests "com.vultisig.wallet.data.api.SolanaApiBodyReadTest" --tests "com.vultisig.wallet.data.api.SolanaBroadcastActionTest"` — all green (77 tests).
- `./gradlew :data:lintDebug` — clean (checked explicitly this time, since the Solana sibling PR broke CI lint on `BigInteger.TWO` requiring API 33; this fix uses `BigInteger.valueOf(2)`, API 1).
- `./gradlew :data:ktfmtCheck` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee median calculations for both Ethereum and Solana when the sample count is even by averaging the two central values.
  * Preserved correct behavior for odd-sized samples and ensured empty inputs still use the configured fallback.
  * Ensured integer truncation behavior matches expected results for fractional averages.
* **Tests**
  * Expanded and updated median edge-case coverage to prevent regressions in fee-history calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->