### PR TITLE
test(solana): pin Phantom-vs-Default address derivation

### DIFF
--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ScanChainBalancesUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ScanChainBalancesUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.BalanceRepository
+import com.vultisig.wallet.data.repositories.DerivationPath
+import com.vultisig.wallet.data.repositories.TokenRepository
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for #4453: a Phantom-derived Solana wallet must resolve to a different address
+ * than the Default path for the same seed, or a Phantom import silently controls the wrong account.
+ * Exercises the real WalletCore derivation behind [ScanChainBalancesUseCase] (JNI), skipped when
+ * the native library is unavailable — same `skipIfJniUnavailable`/`assumeTrue` pattern as
+ * `UtxoHelperTest`. Expected addresses were pinned directly against WalletCore 4.7.0 (this module's
+ * exact dependency version).
+ */
+internal class ScanChainBalancesUseCaseTest {
+
+    // The standard all-"abandon" BIP-39 test mnemonic, no passphrase.
+    private val mnemonic =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon " +
+            "abandon about"
+
+    // Balance lookups are deliberately left unstubbed: any getNativeToken/getTokenValue call
+    // throws, and ScanChainBalancesUseCase already treats that as hasBalance = false, so this test
+    // can pin address derivation without wiring balance behavior for every scanned chain.
+    private val useCase =
+        ScanChainBalancesUseCaseImpl(
+            balanceRepository = mockk<BalanceRepository>(),
+            tokenRepository = mockk<TokenRepository>(),
+        )
+
+    @Test
+    fun `Solana Default and Phantom derivation paths pin to their known-correct addresses`() =
+        runTest {
+            try {
+                val solanaResults = useCase(mnemonic).filter { it.chain == Chain.Solana }
+
+                assertEquals(
+                    "GjJyeC1r2RgkuoCWMyPYkCWSGSGLcz266EaAkLA27AhL",
+                    solanaResults.first { it.derivationPath == DerivationPath.Default }.address,
+                )
+                assertEquals(
+                    "HAgk14JpMQLgt6rVgv7cBQFJWFto5Dqxi472uT3DKpqk",
+                    solanaResults.first { it.derivationPath == DerivationPath.Phantom }.address,
+                )
+            } catch (e: Throwable) {
+                skipIfJniUnavailable(e)
+            }
+        }
+
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+}


### PR DESCRIPTION
## Summary

Closes #5357. #4453 was a high-priority bug where importing a Phantom-derived Solana wallet could derive a different address than Phantom itself uses, since the Default and Phantom derivation paths weren't correctly dispatched. The fix landed in `ScanChainBalancesUseCase`/`DeriveChainKeyUseCase` but shipped without a pinned test, so a future regression in that dispatch would fail silently.

Adds `ScanChainBalancesUseCaseTest`, exercising the real (unmocked) `ScanChainBalancesUseCaseImpl` for a fixed BIP-39 test mnemonic and asserting the Solana address it derives for `DerivationPath.Default` and `DerivationPath.Phantom` against known-correct values. `BalanceRepository`/`TokenRepository` are left unstubbed on purpose — the use case already treats any balance-lookup failure as `hasBalance = false`, so the test only needs to pin address derivation.

Like the existing `UtxoHelperTest`/`SolanaHelperTest`, this calls into WalletCore's native library and is skipped via `assumeTrue` when the JNI library isn't available (e.g. on macOS dev machines). The expected addresses were verified directly against WalletCore 4.7.0 (this module's exact dependency version) via its WASM binding, and cross-checked with an independent SLIP-0010 derivation.

## Testing

- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.usecases.ScanChainBalancesUseCaseTest"` — passes (skips on this machine, no JNI; ran the exact same derivation through WalletCore's WASM build to confirm the pinned addresses independently).
- `./gradlew :data:testDebugUnitTest` — full data module suite, green.
- ktfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Solana addresses from incorrectly matching between Default and Phantom derivation paths.

* **Tests**
  * Added regression coverage to verify correct Solana address derivation for Phantom-based wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->