### PR TITLE
fix(solana): correct System and Compute Budget instruction labels

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ParsedSolanaTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ParsedSolanaTransaction.kt
@@ -79,7 +79,7 @@ object SolanaTransactionParser {
         return knownPrograms[programId]
     }
 
-    private fun getInstructionType(programId: String, instructionData: ByteArray): String? {
+    internal fun getInstructionType(programId: String, instructionData: ByteArray): String? {
         if (instructionData.isEmpty()) return null
 
         val discriminator = instructionData[0].toInt() and 0xFF
@@ -87,10 +87,17 @@ object SolanaTransactionParser {
         if (programId == "11111111111111111111111111111111") {
             return when (discriminator) {
                 0 -> "Create Account"
+                1 -> "Assign"
                 2 -> "Transfer"
-                3 -> "Assign"
-                4 -> "Create Account With Seed"
-                9 -> "Transfer With Seed"
+                3 -> "Create Account With Seed"
+                4 -> "Advance Nonce Account"
+                5 -> "Withdraw Nonce Account"
+                6 -> "Initialize Nonce Account"
+                7 -> "Authorize Nonce Account"
+                8 -> "Allocate"
+                9 -> "Allocate With Seed"
+                10 -> "Assign With Seed"
+                11 -> "Transfer With Seed"
                 else -> "System ($discriminator)"
             }
         }
@@ -127,9 +134,10 @@ object SolanaTransactionParser {
 
         if (programId == "ComputeBudget111111111111111111111111111111") {
             return when (discriminator) {
-                0 -> "Request Heap Frame"
-                1 -> "Set Compute Unit Limit"
-                2 -> "Set Compute Unit Price"
+                0 -> "Unused"
+                1 -> "Request Heap Frame"
+                2 -> "Set Compute Unit Limit"
+                3 -> "Set Compute Unit Price"
                 else -> "Compute Budget ($discriminator)"
             }
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class SolanaTransactionParserTest {
+
+    private val systemProgramId = "11111111111111111111111111111111"
+    private val computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
+    private val tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    private val associatedTokenProgramId = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
+    private fun instructionType(programId: String, discriminator: Int): String? =
+        SolanaTransactionParser.getInstructionType(programId, byteArrayOf(discriminator.toByte()))
+
+    @Test
+    fun `System Program labels match the real SystemInstruction enum for every known discriminator`() {
+        val expectedLabelsByDiscriminator =
+            mapOf(
+                0 to "Create Account",
+                1 to "Assign",
+                2 to "Transfer",
+                3 to "Create Account With Seed",
+                4 to "Advance Nonce Account",
+                5 to "Withdraw Nonce Account",
+                6 to "Initialize Nonce Account",
+                7 to "Authorize Nonce Account",
+                8 to "Allocate",
+                9 to "Allocate With Seed",
+                10 to "Assign With Seed",
+                11 to "Transfer With Seed",
+            )
+
+        expectedLabelsByDiscriminator.forEach { (discriminator, expectedLabel) ->
+            assertEquals(
+                expectedLabel,
+                instructionType(systemProgramId, discriminator),
+                "discriminator $discriminator",
+            )
+        }
+    }
+
+    @Test
+    fun `System Program falls back to a numeric label for an unmapped discriminator`() {
+        assertEquals("System (12)", instructionType(systemProgramId, 12))
+    }
+
+    @Test
+    fun `Compute Budget labels match the real ComputeBudgetInstruction enum for every known discriminator`() {
+        val expectedLabelsByDiscriminator =
+            mapOf(
+                0 to "Unused",
+                1 to "Request Heap Frame",
+                2 to "Set Compute Unit Limit",
+                3 to "Set Compute Unit Price",
+            )
+
+        expectedLabelsByDiscriminator.forEach { (discriminator, expectedLabel) ->
+            assertEquals(
+                expectedLabel,
+                instructionType(computeBudgetProgramId, discriminator),
+                "discriminator $discriminator",
+            )
+        }
+    }
+
+    @Test
+    fun `Compute Budget SetComputeUnitPrice is no longer swallowed by the numeric fallback`() {
+        assertEquals("Set Compute Unit Price", instructionType(computeBudgetProgramId, 3))
+    }
+
+    @Test
+    fun `Compute Budget falls back to a numeric label for an unmapped discriminator`() {
+        assertEquals("Compute Budget (4)", instructionType(computeBudgetProgramId, 4))
+    }
+
+    @Test
+    fun `other program label tables are unaffected by the System and Compute Budget fix`() {
+        assertEquals("Initialize Mint", instructionType(tokenProgramId, 0))
+        assertEquals("Transfer Checked", instructionType(tokenProgramId, 12))
+        assertEquals(
+            "Create Associated Token Account",
+            instructionType(associatedTokenProgramId, 0),
+        )
+    }
+
+    @Test
+    fun `empty instruction data yields no instruction type`() {
+        assertNull(SolanaTransactionParser.getInstructionType(systemProgramId, byteArrayOf()))
+    }
+
+    @Test
+    fun `unknown program id yields no instruction type`() {
+        assertNull(instructionType("UnknownProgram11111111111111111111111111", 0))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
@@ -9,6 +9,7 @@ class SolanaTransactionParserTest {
     private val systemProgramId = "11111111111111111111111111111111"
     private val computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
     private val tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    private val token2022ProgramId = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
     private val associatedTokenProgramId = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 
     private fun instructionType(programId: String, discriminator: Int): String? =
@@ -79,6 +80,8 @@ class SolanaTransactionParserTest {
     fun `other program label tables are unaffected by the System and Compute Budget fix`() {
         assertEquals("Initialize Mint", instructionType(tokenProgramId, 0))
         assertEquals("Transfer Checked", instructionType(tokenProgramId, 12))
+        assertEquals("Initialize Mint", instructionType(token2022ProgramId, 0))
+        assertEquals("Transfer Checked", instructionType(token2022ProgramId, 12))
         assertEquals(
             "Create Associated Token Account",
             instructionType(associatedTokenProgramId, 0),


### PR DESCRIPTION
## Summary

Closes #5356. The dApp sign-review panel's discriminator-to-label lookup tables for the System Program and Compute Budget Program didn't match Solana's real on-chain instruction enums: several System Program entries were mislabeled, and the Compute Budget table was shifted by one index, so `SetComputeUnitPrice` - the most common priority-fee instruction in modern dApp transactions - fell back to a generic numeric placeholder instead of showing its real name.

- Corrected the System Program table to match `SystemInstruction`'s real discriminator order (`CreateAccount`, `Assign`, `Transfer`, `CreateAccountWithSeed`, `AdvanceNonceAccount`, `WithdrawNonceAccount`, `InitializeNonceAccount`, `AuthorizeNonceAccount`, `Allocate`, `AllocateWithSeed`, `AssignWithSeed`, `TransferWithSeed`).
- Corrected the Compute Budget table to match `ComputeBudgetInstruction`'s real order (`Unused`, `RequestHeapFrame`, `SetComputeUnitLimit`, `SetComputeUnitPrice`).
- Token Program, Token-2022, and Associated Token Program tables are unchanged.
- This is a display-only label shown in the Instructions Summary panel; it doesn't affect what gets decoded, signed, or broadcast.

## Testing

- `./gradlew :data:testDebugUnitTest --tests "*SolanaTransactionParserTest"` - new tests covering every discriminator in both corrected tables, the numeric fallback for out-of-range discriminators, and that the other programs' tables are unaffected.
- `./gradlew :data:ktfmtFormat` - clean, no changes.
- `./gradlew :data:lintDebug` - passes.
- `./gradlew assembleDebug` - succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction instruction labels for System and Compute Budget programs.
  * Expanded discriminator-to-label mappings and adjusted Compute Budget categorization to avoid incorrect numeric fallbacks.
  * Preserves existing behavior for other programs, unknown programs, and empty instruction data.

* **Tests**
  * Added coverage for recognized and unrecognized instruction discriminators.
  * Verified handling of unknown programs and empty transaction instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->