### PR TITLE
fix(swap): account for price impact so Total Fee is reconcilable (#5335)

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.clampDstFiatToSrcFiat
+import com.vultisig.wallet.ui.models.swap.formatPriceImpact
 import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
@@ -93,6 +94,12 @@ constructor(
             } else {
                 quotesFeesFiat
             }
+
+        // The liquidity component stays out of the fee total (it is already reflected in the
+        // destination amount), which on a thin route leaves most of what the user gave up
+        // unexplained. Surface it as its own Price Impact row, formatted as the swap form does
+        // (#5335).
+        val priceImpactDisplay = formatPriceImpact(from.priceImpact)
 
         // SwapTransaction carries no destination fiat, so it is recomputed here for the verify and
         // keysign screens. Apply the same value-preserving clamp the swap form uses (#4878) so an
@@ -177,6 +184,8 @@ constructor(
             vultBpsDiscountFiatValue = from.vultBpsDiscountFiatValue,
             referralBpsDiscount = from.referralBpsDiscount,
             referralBpsDiscountFiatValue = from.referralBpsDiscountFiatValue,
+            priceImpactPercent = priceImpactDisplay?.percent,
+            priceImpactLevel = priceImpactDisplay?.level,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -123,6 +123,7 @@ constructor(
                     vultBpsDiscountFiatValue = feeDisplay.vultBpsDiscountFiatValue,
                     referralBpsDiscount = feeDisplay.referralBpsDiscount,
                     referralBpsDiscountFiatValue = feeDisplay.referralBpsDiscountFiatValue,
+                    priceImpact = quote.priceImpact,
                     payload =
                         SwapPayload.ThorChain(
                             THORChainSwapPayload(
@@ -206,6 +207,7 @@ constructor(
                     vultBpsDiscountFiatValue = feeDisplay.vultBpsDiscountFiatValue,
                     referralBpsDiscount = feeDisplay.referralBpsDiscount,
                     referralBpsDiscountFiatValue = feeDisplay.referralBpsDiscountFiatValue,
+                    priceImpact = quote.priceImpact,
                     payload =
                         SwapPayload.MayaChain(
                             THORChainSwapPayload(
@@ -271,6 +273,7 @@ constructor(
                     vultBpsDiscountFiatValue = feeDisplay.vultBpsDiscountFiatValue,
                     referralBpsDiscount = feeDisplay.referralBpsDiscount,
                     referralBpsDiscountFiatValue = feeDisplay.referralBpsDiscountFiatValue,
+                    priceImpact = quote.priceImpact,
                     payload = SwapPayload.SwapKit(quote.data),
                 )
             }
@@ -379,6 +382,7 @@ constructor(
                     vultBpsDiscountFiatValue = feeDisplay.vultBpsDiscountFiatValue,
                     referralBpsDiscount = feeDisplay.referralBpsDiscount,
                     referralBpsDiscountFiatValue = feeDisplay.referralBpsDiscountFiatValue,
+                    priceImpact = quote.priceImpact,
                     payload =
                         SwapPayload.EVM(
                             EVMSwapPayloadJson(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -101,6 +101,11 @@ internal data class SwapTransactionUiModel(
     // when there's no referral (non-THORChain, or unavailable to a co-signer) (#5358).
     val referralBpsDiscount: Int? = null,
     val referralBpsDiscountFiatValue: String? = null,
+    // Price impact of the signed quote, formatted like the swap form's row (e.g. "-1.58%") with its
+    // quality tier. Null when the provider reports none (EVM aggregators) or on a co-signer that
+    // rebuilds the tx from the payload without a quote — the row is then hidden (#5335).
+    val priceImpactPercent: String? = null,
+    val priceImpactLevel: PriceImpactLevel? = null,
 )
 
 internal data class ValuedToken(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -68,6 +68,7 @@ import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.swap.VerifySwapViewModel
 import com.vultisig.wallet.ui.screens.send.EstimatedNetworkFee
+import com.vultisig.wallet.ui.screens.swap.components.PriceImpactRow
 import com.vultisig.wallet.ui.screens.swap.components.ReferralDiscountRow
 import com.vultisig.wallet.ui.screens.swap.components.VultDiscountRow
 import com.vultisig.wallet.ui.theme.Theme
@@ -338,6 +339,15 @@ private fun VerifySwapScreen(
                     ReferralDiscountRow(
                         referralBpsDiscount = tx.referralBpsDiscount,
                         fiatValue = tx.referralBpsDiscountFiatValue,
+                        modifier = Modifier.padding(vertical = 12.dp),
+                    )
+
+                    // The liquidity cost is baked into the quoted destination amount and so is
+                    // absent from Total Fee by design; showing it here keeps the signed estimate
+                    // honest about what the swap actually costs (#5335).
+                    PriceImpactRow(
+                        priceImpactPercent = tx.priceImpactPercent,
+                        priceImpactLevel = tx.priceImpactLevel,
                         modifier = Modifier.padding(vertical = 12.dp),
                     )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/PriceImpactRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/PriceImpactRow.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.ui.screens.swap.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Price Impact row shared by the swap form's fee breakdown, the verify screen and the
+ * completed-swap overview so the liquidity cost excluded from the fee total reads identically on
+ * all three (#5335). A no-op unless both the percentage and its tier are present — EVM aggregators
+ * report no impact, and a co-signer rebuilding the transaction from the payload has no quote to
+ * read it from.
+ */
+@Composable
+internal fun PriceImpactRow(
+    priceImpactPercent: String?,
+    priceImpactLevel: PriceImpactLevel?,
+    modifier: Modifier = Modifier,
+) {
+    if (priceImpactPercent == null || priceImpactLevel == null) return
+
+    val levelLabel =
+        when (priceImpactLevel) {
+            PriceImpactLevel.GOOD -> R.string.swap_price_impact_good
+            PriceImpactLevel.AVERAGE -> R.string.swap_price_impact_average
+            PriceImpactLevel.HIGH -> R.string.swap_price_impact_high
+        }
+    val levelColor =
+        when (priceImpactLevel) {
+            PriceImpactLevel.GOOD -> Theme.v2.colors.alerts.success
+            PriceImpactLevel.AVERAGE -> Theme.v2.colors.alerts.warning
+            PriceImpactLevel.HIGH -> Theme.v2.colors.alerts.error
+        }
+
+    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            text = stringResource(R.string.swap_form_price_impact_title),
+            color = Theme.v2.colors.text.tertiary,
+            style = Theme.brockmann.supplementary.caption,
+        )
+
+        Text(
+            text = "$priceImpactPercent (${stringResource(levelLabel)})",
+            color = levelColor,
+            style = Theme.brockmann.supplementary.caption,
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
@@ -37,7 +37,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.library.form.FormDetails2
 import com.vultisig.wallet.ui.models.swap.DiscountInfo
 import com.vultisig.wallet.ui.models.swap.FeeBreakdown
-import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
 import com.vultisig.wallet.ui.models.swap.QuoteDisplay
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
@@ -203,41 +202,10 @@ internal fun SwapFeeBreakdown(
                             fiatValue = discountInfo.referralBpsDiscountFiatValue,
                         )
 
-                        if (
-                            feeBreakdown.priceImpactPercent != null &&
-                                feeBreakdown.priceImpactLevel != null
-                        ) {
-                            val levelLabel =
-                                when (feeBreakdown.priceImpactLevel) {
-                                    PriceImpactLevel.GOOD -> R.string.swap_price_impact_good
-                                    PriceImpactLevel.AVERAGE -> R.string.swap_price_impact_average
-                                    PriceImpactLevel.HIGH -> R.string.swap_price_impact_high
-                                }
-                            val levelColor =
-                                when (feeBreakdown.priceImpactLevel) {
-                                    PriceImpactLevel.GOOD -> Theme.v2.colors.alerts.success
-                                    PriceImpactLevel.AVERAGE -> Theme.v2.colors.alerts.warning
-                                    PriceImpactLevel.HIGH -> Theme.v2.colors.alerts.error
-                                }
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.swap_form_price_impact_title),
-                                    color = Theme.v2.colors.text.tertiary,
-                                    style = Theme.brockmann.supplementary.caption,
-                                )
-
-                                Text(
-                                    text =
-                                        "${feeBreakdown.priceImpactPercent} " +
-                                            "(${stringResource(levelLabel)})",
-                                    color = levelColor,
-                                    style = Theme.brockmann.supplementary.caption,
-                                )
-                            }
-                        }
+                        PriceImpactRow(
+                            priceImpactPercent = feeBreakdown.priceImpactPercent,
+                            priceImpactLevel = feeBreakdown.priceImpactLevel,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -179,10 +179,25 @@ internal fun SwapTransactionOverviewScreen(
                     fiatGas = transactionTypeUiModel.networkFee.fiatValue,
                 )
 
-                TextDetails(
-                    title = stringResource(R.string.swap_form_estimated_fees_title),
-                    subtitle = transactionTypeUiModel.providerFee.fiatValue,
-                )
+                // Same Swap Fee rules as the verify screen (#5358): hidden for a SwapKit UTXO
+                // deposit whose cost is already the Network Fee, and "included in quoted rate" for
+                // 1inch. Rendering providerFee.fiatValue unconditionally showed a fee that is not
+                // part of totalFee, so the rows visibly failed to add up (#5335).
+                if (!transactionTypeUiModel.swapFeeHidden) {
+                    TextDetails(
+                        title =
+                            transactionTypeUiModel.swapFeePercent?.let {
+                                stringResource(
+                                    R.string.swap_form_estimated_fees_with_percent_title,
+                                    it,
+                                )
+                            } ?: stringResource(R.string.swap_form_estimated_fees_title),
+                        subtitle =
+                            if (transactionTypeUiModel.swapFeeIncludedInRate)
+                                stringResource(R.string.swap_form_estimated_fees_included_in_rate)
+                            else transactionTypeUiModel.providerFee.fiatValue,
+                    )
+                }
 
                 // Only THORChain / MayaChain report an outbound fee distinct from the swap fee.
                 transactionTypeUiModel.outboundFee?.let { outboundFee ->

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -42,6 +42,7 @@ import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.screens.send.EstimatedNetworkFee
 import com.vultisig.wallet.ui.screens.swap.VerifyCardDetails
 import com.vultisig.wallet.ui.screens.swap.VerifyCardDivider
+import com.vultisig.wallet.ui.screens.swap.components.PriceImpactRow
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
 
@@ -206,6 +207,16 @@ internal fun SwapTransactionOverviewScreen(
                         subtitle = outboundFee,
                     )
                 }
+
+                // Total Fee covers the fees charged on top of the swap; the liquidity cost is
+                // already reflected in the received amount, so it is reported separately here
+                // rather than folded in — otherwise the value the user gave up has no row at all
+                // and Total Fee reads as if it were the whole cost (#5335).
+                PriceImpactRow(
+                    priceImpactPercent = transactionTypeUiModel.priceImpactPercent,
+                    priceImpactLevel = transactionTypeUiModel.priceImpactLevel,
+                    modifier = Modifier.padding(vertical = 12.dp),
+                )
 
                 VerifyCardDivider(size = 1.dp)
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -182,6 +183,54 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
         uiModel.totalFee shouldBe "0.51"
     }
 
+    /**
+     * #5335: on a thin route the liquidity cost the user actually gave up dwarfs the fee total, but
+     * it is baked into the received amount and so contributes nothing to Total Fee. It must reach
+     * the screens as its own Price Impact row — without moving into the total, which stays exactly
+     * what it was.
+     */
+    @Test
+    fun `surfaces the quote's price impact without changing the fee total`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        coEvery { convertTokenValueToFiat(eth, srcValue, AppCurrency.USD) } returns usd("100")
+        coEvery { convertTokenValueToFiat(usdt, dstValue, AppCurrency.USD) } returns usd("99")
+        coEvery { convertTokenValueToFiat(usdt, totalFees, AppCurrency.USD) } returns usd("1.40")
+        coEvery { convertTokenValueToFiat(usdt, affiliateFee, AppCurrency.USD) } returns usd("0.00")
+        coEvery { convertTokenValueToFiat(usdt, outboundFee, AppCurrency.USD) } returns usd("1.18")
+
+        // 1.58% impact — the node reports it positive, the row shows what the user loses.
+        val uiModel = mapper().invoke(transaction(priceImpact = BigDecimal("0.0158")))
+
+        uiModel.priceImpactPercent shouldBe "-1.58%"
+        uiModel.priceImpactLevel shouldBe PriceImpactLevel.AVERAGE
+        // Unchanged from `splits affiliate and outbound…`: impact never enters the total.
+        uiModel.totalFee shouldBe "1.20"
+    }
+
+    @Test
+    fun `hides the price impact row when the provider reports none`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.toPlainString()
+            }
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        coEvery { tokenRepository.getNativeToken(eth.chain.id) } returns eth
+        coEvery { convertTokenValueToFiat(eth, oneInchGas, AppCurrency.USD) } returns usd("2.00")
+
+        val uiModel = mapper().invoke(oneInchTransaction())
+
+        uiModel.priceImpactPercent shouldBe null
+        uiModel.priceImpactLevel shouldBe null
+    }
+
     private fun swapKitUtxoTransaction(): RegularSwapTransaction =
         RegularSwapTransaction(
             id = "tx-swapkit-btc",
@@ -314,6 +363,7 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
     private fun transaction(
         swapFee: TokenValue? = affiliateFee,
         outboundFee: TokenValue? = SwapTransactionToUiModelMapperFeeBreakdownTest.outboundFee,
+        priceImpact: BigDecimal? = null,
     ): RegularSwapTransaction =
         RegularSwapTransaction(
             id = "tx-1",
@@ -348,6 +398,7 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
                 ),
             isApprovalRequired = false,
             gasFeeFiatValue = usd("0.02"),
+            priceImpact = priceImpact,
         )
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapTransaction.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import java.math.BigDecimal
 import java.math.BigInteger
 
 sealed interface SwapTransaction {
@@ -55,6 +56,15 @@ sealed interface SwapTransaction {
     val referralBpsDiscount: Int?
     val referralBpsDiscountFiatValue: String?
 
+    /**
+     * Fractional price impact of the quote the user signed (e.g. `0.0133` == 1.33%), or null when
+     * the provider reports none (EVM aggregators). This is the liquidity/slippage cost that is
+     * baked into [expectedDstTokenValue] and therefore deliberately excluded from the fee total —
+     * carrying it here lets the verify and completion screens show it as its own row so the value
+     * the user gave up is accounted for instead of unexplained (#5335).
+     */
+    val priceImpact: BigDecimal?
+
     data class RegularSwapTransaction(
         override val id: TransactionId,
         override val vaultId: String,
@@ -79,6 +89,7 @@ sealed interface SwapTransaction {
         override val vultBpsDiscountFiatValue: String? = null,
         override val referralBpsDiscount: Int? = null,
         override val referralBpsDiscountFiatValue: String? = null,
+        override val priceImpact: BigDecimal? = null,
         // User-chosen external recipient the output was routed to, or null when it goes to the
         // vault's own address. Surfaced on the verify screen so the destination is never a silent
         // default (#4858).


### PR DESCRIPTION
Closes #5335

## Problem

On the swap **Transaction complete** screen, Total Fee reconciles with neither the on-chain network fee nor the value the user actually lost. The reported LTC → ADA swap showed **$0.00051** against a **~$0.07** from/to delta — 137× smaller than what the swap really cost.

Investigating turned up **two** independent causes:

**1. Price Impact never survived the swap form.** The liquidity/slippage cost is baked into the quoted destination amount, so it is deliberately excluded from Total Fee (per #5334's must-not). But it was only ever *shown* on the swap form, because it lived on the quote pipeline and never reached `SwapTransaction` — so after signing, the dominant cost on a thin route had no row anywhere.

**2. The completion screen's rows don't add up.** #5373 (the #5334 fix) and #5364 (the #5358 fix) merged the same day. #5373 added the fee breakdown to `SwapTransactionOverviewScreen` rendering `providerFee.fiatValue` unconditionally, while #5364 taught the verify screen to honor `swapFeeHidden` / `swapFeeIncludedInRate`. The result: on a SwapKit UTXO deposit the completion screen lists a Swap Fee that contributes nothing to Total Fee — and that is precisely the LTC → ADA route in this issue.

## Approach

Of the two options the issue proposes, this takes the second — **keep the fee math, give the missing cost its own row**. Folding slippage into Total Fee is explicitly ruled out by #5334 ("do not change the `feesFiatForTotal + gasFeeFiatValue` computation or the intentional exclusion of the liquidity/slippage component"). **No fee value changes in this PR.**

## Changes

| File | What |
|---|---|
| `data/…/models/SwapTransaction.kt` | new in-memory `priceImpact: BigDecimal?`, carried like the #5358 fee/discount context |
| `SwapTransactionBuilder.kt` | `priceImpact = quote.priceImpact` in all four provider branches |
| `SwapTransactionToUiModelMapper.kt` | formats it via the existing `formatPriceImpact()` |
| `VerifySwapViewModel.kt` | `priceImpactPercent` / `priceImpactLevel` on `SwapTransactionUiModel` |
| `PriceImpactRow.kt` *(new)* | shared row; the swap form's inline block collapses into it |
| `VerifySwapScreen.kt` | Price Impact row above Total Fee |
| `SwapTransactionOverviewScreen.kt` | Price Impact row **+** the Swap Fee row now honors hidden / included-in-rate |

`SwapQuote.priceImpact` was already populated — THORChain/Maya derive it from `slippage_bps`, SwapKit from the route's `meta.priceImpact` — so there is no new network work. **No new strings**: the four the form uses (`swap_form_price_impact_title`, `swap_price_impact_good/average/high`) already exist in all 10 locales.

The co-signer path (`JoinSwapUiModelBuilder`) has no quote to read the impact from, so the row hides there — the same graceful degradation the VULT-tier and referral rows use.

## Testing

- 336 mapper + swap unit tests green offline, including 2 new ones in `SwapTransactionToUiModelMapperFeeBreakdownTest`:
  - price impact reaches the UI model (`-1.58%` / Average) **while `totalFee` stays `1.20`** — pinning that the fee math is untouched
  - a provider reporting no impact leaves both fields null, hiding the row
- `./gradlew :app:lintDebug` clean
- ktfmt applied

**In-app check** — swap **LTC → ADA** (the reported route), sign, then expand details on Transaction complete: there should be **no Swap Fee row**, **Total Fee should equal the Network Fee** exactly, and **Price Impact** should show what the route cost. A THORChain pair (e.g. BTC → ETH) shows the Price Impact row on both Verify and Transaction complete.

## Known limitation

1inch / Kyber / LiFi / Jupiter report no price impact, so the row stays hidden on those routes and Total Fee remains the only number there. That is an upstream data gap and matches iOS behavior.

## Checklist

- [x] Lint clean
- [x] Unit tests green
- [x] Self-reviewed against requirements
- [x] No secrets committed
- [x] Conventional commit messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added price impact details to swap verification, fee breakdowns, and transaction overview screens.
  - Displays the price impact percentage with a clear status indicator: good, average, or high.
  - Shows swap fee percentages and whether fees are included in the exchange rate.
  - Hides fee and price impact rows when relevant information is unavailable.

- **Bug Fixes**
  - Preserved total fee calculations while displaying price impact separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->