### PR TITLE
fix(sui): bound coin selection for cross-device keysign parity

### DIFF
--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/SuiHelperInputDataTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/SuiHelperInputDataTest.kt
@@ -1,0 +1,266 @@
+package com.vultisig.wallet.data.crypto
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vultisig.keysign.v1.SuiCoin
+import wallet.core.jni.proto.Sui
+
+/**
+ * Byte-level cross-device parity for Sui coin-object selection (issue #5252 / vultisig-ios#4734).
+ *
+ * These mirror iOS `SuiHelperInputDataTests.swift` fixture-for-fixture: the same owned-coins sets
+ * must produce the same `Sui.SigningInput` — the objects a send references and the gas object it
+ * pays from — so an Android and an iOS co-signer building the transaction from the shared payload
+ * converge on identical bytes. Runs instrumented because [SuiHelper.getPreSignedInputData] resolves
+ * the recipient through WalletCore's `AnyAddress` JNI.
+ *
+ * The pure-JVM selection-algorithm coverage lives in `SuiCoinSelectionTest`.
+ */
+class SuiHelperInputDataTest {
+
+    private val nativeType = "0x2::sui::SUI"
+    private val tokenType =
+        "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN"
+    private val address = "0x9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef"
+    private val hexPublicKey = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+
+    private fun coinObject(id: String, type: String, balance: String, version: String = "1") =
+        SuiCoin(
+            coinType = type,
+            coinObjectId = id,
+            version = version,
+            digest = "digest-$id",
+            balance = balance,
+            previousTransaction = "",
+        )
+
+    private fun suiCoin(isNative: Boolean) =
+        Coin(
+            chain = Chain.Sui,
+            ticker = if (isNative) "SUI" else "COIN",
+            logo = "sui",
+            address = address,
+            decimal = if (isNative) 9 else 8,
+            hexPublicKey = hexPublicKey,
+            priceProviderID = "sui",
+            contractAddress = if (isNative) "" else tokenType,
+            isNativeToken = isNative,
+        )
+
+    private fun payload(
+        coin: Coin,
+        coins: List<SuiCoin>,
+        amount: BigInteger,
+        gasBudget: BigInteger,
+    ) =
+        KeysignPayload(
+            coin = coin,
+            toAddress = address,
+            toAmount = amount,
+            blockChainSpecific =
+                BlockChainSpecific.Sui(
+                    referenceGasPrice = BigInteger.valueOf(1000),
+                    coins = coins,
+                    gasBudget = gasBudget,
+                ),
+            vaultPublicKeyECDSA = hexPublicKey,
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private fun signingInput(payload: KeysignPayload): Sui.SigningInput =
+        Sui.SigningInput.parseFrom(SuiHelper.getPreSignedInputData(payload))
+
+    // Native send merges the objects it needs.
+
+    @Test
+    fun nativeSendSelectsLargestObjectsCoveringAmountPlusGas() {
+        val coins =
+            listOf(
+                coinObject("0xa", nativeType, "1000000000"),
+                coinObject("0xb", nativeType, "2000000000"),
+                coinObject("0xc", nativeType, "3000000000"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(4_000_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(Sui.SigningInput.TransactionPayloadCase.PAY_SUI, input.transactionPayloadCase)
+        assertEquals(listOf("0xc", "0xb"), input.paySui.inputCoinsList.map { it.objectId })
+        assertEquals(listOf(4_000_000_000L), input.paySui.amountsList)
+    }
+
+    @Test
+    fun nativeSmallSendSelectsOnlyLargestObject() {
+        val coins =
+            listOf(
+                coinObject("0xa", nativeType, "1000000000"),
+                coinObject("0xb", nativeType, "2000000000"),
+                coinObject("0xc", nativeType, "3000000000"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(100_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(listOf("0xc"), input.paySui.inputCoinsList.map { it.objectId })
+    }
+
+    @Test
+    fun nativeNearMaxSendSelectsAllObjects() {
+        val coins =
+            listOf(
+                coinObject("0xa", nativeType, "1000000000"),
+                coinObject("0xb", nativeType, "2000000000"),
+                coinObject("0xc", nativeType, "3000000000"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(5_900_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(listOf("0xc", "0xb", "0xa"), input.paySui.inputCoinsList.map { it.objectId })
+    }
+
+    @Test
+    fun nativeDustyWalletReferencesOnlyNeededObjects() {
+        val coins = buildList {
+            add(coinObject("0xbig", nativeType, "10000000000"))
+            repeat(800) { add(coinObject("0xdust$it", nativeType, "1000")) }
+        }
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(1_000_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(listOf("0xbig"), input.paySui.inputCoinsList.map { it.objectId })
+        assertTrue(input.paySui.inputCoinsCount <= SuiHelper.MAX_INPUT_COIN_OBJECTS)
+    }
+
+    @Test
+    fun nativeSendExcludesLookAlikeObjects() {
+        val coins =
+            listOf(
+                coinObject("0xnative", nativeType, "5000000000"),
+                coinObject("0xlst", "0xb45f::xsui::XSUI", "9000000000"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(1_000_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(listOf("0xnative"), input.paySui.inputCoinsList.map { it.objectId })
+    }
+
+    // Token send selects a covering gas object.
+
+    @Test
+    fun tokenSendSelectsSmallestCoveringGasObject() {
+        val coins =
+            listOf(
+                coinObject("0xgasTooSmall", nativeType, "500000"),
+                coinObject("0xgasCovers", nativeType, "3000000"),
+                coinObject("0xgasBig", nativeType, "9000000"),
+                coinObject("0xtoken1", tokenType, "100"),
+                coinObject("0xtoken2", tokenType, "200"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(false),
+                    coins,
+                    BigInteger.valueOf(250),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(Sui.SigningInput.TransactionPayloadCase.PAY, input.transactionPayloadCase)
+        assertEquals(
+            setOf("0xtoken1", "0xtoken2"),
+            input.pay.inputCoinsList.map { it.objectId }.toSet(),
+        )
+        assertEquals("0xgasCovers", input.pay.gas.objectId)
+    }
+
+    @Test
+    fun tokenSendSelectsCoveringTokenObjects() {
+        val coins =
+            listOf(
+                coinObject("0xgas", nativeType, "5000000"),
+                coinObject("0xt1", tokenType, "100"),
+                coinObject("0xt2", tokenType, "200"),
+                coinObject("0xt3", tokenType, "300"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(false),
+                    coins,
+                    BigInteger.valueOf(550),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(
+            setOf("0xt1", "0xt2", "0xt3"),
+            input.pay.inputCoinsList.map { it.objectId }.toSet(),
+        )
+        assertEquals("0xgas", input.pay.gas.objectId)
+    }
+
+    @Test
+    fun tokenSmallSendSelectsOnlyLargestTokenObject() {
+        val coins =
+            listOf(
+                coinObject("0xgas", nativeType, "5000000"),
+                coinObject("0xt1", tokenType, "100"),
+                coinObject("0xt2", tokenType, "200"),
+                coinObject("0xt3", tokenType, "300"),
+            )
+        val input =
+            signingInput(
+                payload(
+                    suiCoin(false),
+                    coins,
+                    BigInteger.valueOf(250),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+
+        assertEquals(listOf("0xt3"), input.pay.inputCoinsList.map { it.objectId })
+        assertEquals("0xgas", input.pay.gas.objectId)
+    }
+}

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/SuiHelperInputDataTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/SuiHelperInputDataTest.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import java.math.BigInteger
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import vultisig.keysign.v1.SuiCoin
@@ -239,6 +240,73 @@ class SuiHelperInputDataTest {
             input.pay.inputCoinsList.map { it.objectId }.toSet(),
         )
         assertEquals("0xgas", input.pay.gas.objectId)
+    }
+
+    // A token send whose token objects are missing (e.g. a truncated coin page) must fail loudly,
+    // never fall through to a native PaySui transfer of the raw amount as a different asset.
+
+    @Test
+    fun tokenSendWithoutTokenObjectsFailsLoudly() {
+        val coins =
+            listOf(
+                coinObject("0xgas1", nativeType, "5000000"),
+                coinObject("0xgas2", nativeType, "9000000"),
+            )
+
+        assertThrows(IllegalStateException::class.java) {
+            signingInput(
+                payload(
+                    suiCoin(false),
+                    coins,
+                    BigInteger.valueOf(250),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+        }
+    }
+
+    // An under-funded selection is rejected at signing rather than emitting a transaction that only
+    // fails at broadcast after the full multi-device ceremony.
+
+    @Test
+    fun nativeSendRejectsUnderfundedSelection() {
+        val coins =
+            listOf(
+                coinObject("0xa", nativeType, "1000000000"),
+                coinObject("0xb", nativeType, "2000000000"),
+            )
+
+        assertThrows(IllegalStateException::class.java) {
+            signingInput(
+                payload(
+                    suiCoin(true),
+                    coins,
+                    BigInteger.valueOf(4_000_000_000L),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun tokenSendRejectsUnderfundedTokenSelection() {
+        val coins =
+            listOf(
+                coinObject("0xgas", nativeType, "9000000"),
+                coinObject("0xt1", tokenType, "100"),
+                coinObject("0xt2", tokenType, "200"),
+            )
+
+        assertThrows(IllegalStateException::class.java) {
+            signingInput(
+                payload(
+                    suiCoin(false),
+                    coins,
+                    BigInteger.valueOf(1000),
+                    BigInteger.valueOf(3_000_000L),
+                )
+            )
+        }
     }
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
@@ -78,32 +79,49 @@ constructor(private val http: HttpClient, private val json: Json) : SuiApi {
     }
 
     override suspend fun getAllCoins(address: String): List<SuiCoin> {
-        return http
-            .postRpc<RpcResponseJson>(
-                url = rpcUrl,
-                method = "suix_getAllCoins",
-                params = buildJsonArray { add(address) },
-            )
-            .result
-            ?.jsonObject
-            ?.get("data")
-            ?.jsonArray
-            ?.mapNotNull {
-                val coinType = it.jsonObject["coinType"]?.jsonPrimitive?.content
-                if (coinType != null) {
+        val allCoins = mutableListOf<SuiCoin>()
+        var cursor: String? = null
+
+        // suix_getAllCoins is paginated (default page ~50 objects). Follow nextCursor/hasNextPage
+        // so a wallet whose objects span multiple pages doesn't return a truncated set — otherwise
+        // a token whose objects all land on a later page is invisible here and a token send gets
+        // silently misclassified as a native SUI transfer. Mirrors iOS SuiService.getAllCoins.
+        do {
+            val result =
+                http
+                    .postRpc<RpcResponseJson>(
+                        url = rpcUrl,
+                        method = "suix_getAllCoins",
+                        params =
+                            buildJsonArray {
+                                add(address)
+                                cursor?.let { add(it) }
+                            },
+                    )
+                    .result
+                    ?.jsonObject ?: error("Failed to fetch all coins for sui")
+
+            result["data"]?.jsonArray?.forEach { element ->
+                val obj = element.jsonObject
+                val coinType = obj["coinType"]?.jsonPrimitive?.content ?: return@forEach
+                allCoins.add(
                     SuiCoin(
-                        coinObjectId = it.jsonObject["coinObjectId"]?.jsonPrimitive?.content ?: "",
-                        version = it.jsonObject["version"]?.jsonPrimitive?.content ?: "",
-                        digest = it.jsonObject["digest"]?.jsonPrimitive?.content ?: "",
-                        balance = it.jsonObject["balance"]?.jsonPrimitive?.content ?: "",
+                        coinObjectId = obj["coinObjectId"]?.jsonPrimitive?.content ?: "",
+                        version = obj["version"]?.jsonPrimitive?.content ?: "",
+                        digest = obj["digest"]?.jsonPrimitive?.content ?: "",
+                        balance = obj["balance"]?.jsonPrimitive?.content ?: "",
                         previousTransaction =
-                            it.jsonObject["previousTransaction"]?.jsonPrimitive?.content ?: "",
+                            obj["previousTransaction"]?.jsonPrimitive?.content ?: "",
                         coinType = coinType,
                     )
-                } else {
-                    null
-                }
-            } ?: error("Failed to fetch all coins for sui")
+                )
+            }
+
+            val hasNextPage = result["hasNextPage"]?.jsonPrimitive?.booleanOrNull ?: false
+            cursor = if (hasNextPage) result["nextCursor"]?.jsonPrimitive?.content else null
+        } while (cursor != null)
+
+        return allCoins
     }
 
     override suspend fun executeTransactionBlock(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/sui/SuiFeeService.kt
@@ -105,7 +105,17 @@ class SuiFeeService @Inject constructor(private val suiApi: SuiApi) : FeeService
             blockChainSpecific =
                 BlockChainSpecific.Sui(
                     referenceGasPrice = referenceGasPriceDeferred.await(),
-                    coins = allCoinsDeferred.await(),
+                    // Simulate over a covering subset (default budget) so the dry-run transaction
+                    // is
+                    // itself small enough to build on wallets with a scattered balance.
+                    coins =
+                        SuiHelper.selectPayloadCoins(
+                            allCoinsDeferred.await(),
+                            isNativeToken = coin.isNativeToken,
+                            contractAddress = coin.contractAddress,
+                            amount = toAmount,
+                            gasBudget = SUI_DEFAULT_GAS_BUDGET,
+                        ),
                     gasBudget = SUI_DEFAULT_GAS_BUDGET,
                 ),
             vaultPublicKeyECDSA = "",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -25,7 +25,49 @@ object SuiHelper {
     private val coinType = CoinType.SUI
     private val suiContractAddress = "0x2::sui::SUI"
 
-    private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
+    /**
+     * Sui accepts a coin type's address part in short (`0x2`) or zero-padded long (`0x000…002`)
+     * form, and RPC nodes are not consistent about which they return. Comparing the raw strings
+     * would classify the same coin differently on two devices — a native object read as a token
+     * object silently turns a `Pay` into a `PaySui`. Only the address is normalized (leading zeros
+     * stripped, lowercased); Move module and struct identifiers stay case-sensitive because
+     * `::coin::USDC` and `::coin::usdc` are genuinely different types. Mirrors iOS
+     * `SuiCoinType.normalize` and SDK `normalizeSuiCoinType` (vultisig-sdk#1275).
+     */
+    internal fun normalizeSuiCoinType(coinType: String): String {
+        val addressEnd = coinType.indexOf("::")
+        if (addressEnd < 0) return normalizeSuiAddress(coinType)
+        return normalizeSuiAddress(coinType.substring(0, addressEnd)) +
+            coinType.substring(addressEnd)
+    }
+
+    internal fun isSameSuiCoinType(lhs: String, rhs: String): Boolean =
+        normalizeSuiCoinType(lhs) == normalizeSuiCoinType(rhs)
+
+    private fun normalizeSuiAddress(address: String): String {
+        val hex = address.lowercase().removePrefix("0x").trimStart('0')
+        return "0x" + hex.ifEmpty { "0" }
+    }
+
+    private fun SuiCoin.isNativeSui(): Boolean = isSameSuiCoinType(coinType, suiContractAddress)
+
+    /**
+     * Upper bound on the coin objects a single send may reference. Sui rejects a transaction whose
+     * serialized size exceeds 128 KiB, and a `PaySui` send uses its entire input set as the gas
+     * payment — which Sui caps at 256 objects. Staying one under that cap keeps every send safely
+     * within both limits. Mirrors iOS `SuiConstants.maxInputCoinObjects`.
+     */
+    internal const val MAX_INPUT_COIN_OBJECTS = 255
+
+    /**
+     * How many of the largest native SUI objects to embed as gas candidates for a token send. The
+     * signer picks one to pay gas; carrying the largest few (rather than all, or just one) keeps
+     * the payload small while guaranteeing a covering object survives a re-estimated gas budget.
+     * Mirrors iOS `SuiConstants.gasCandidateObjectCount`.
+     */
+    internal const val GAS_CANDIDATE_OBJECT_COUNT = 5
+
+    internal fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
         require(keysignPayload.coin.chain == Chain.Sui) { "Coin is not SUI" }
 
         // dApp-supplied Programmable Transaction Block (Sui Wallet Standard): the base64
@@ -47,47 +89,46 @@ object SuiHelper {
 
         val toAddress = AnyAddress(keysignPayload.toAddress, coinType)
 
-        val (nonSuiObjectRef, suiObjectRefs) =
-            coins
-                .partition {
-                    it.coinType.equals(keysignPayload.coin.contractAddress) &&
-                        !it.coinType.equals(suiContractAddress)
-                }
-                .let { (notSui, sui) ->
-                    notSui.map {
-                        Sui.ObjectRef.newBuilder()
-                            .setObjectId(it.coinObjectId)
-                            .setVersion(it.version.toLong())
-                            .setObjectDigest(it.digest)
-                            .build()
-                    } to
-                        sui.filter { it.coinType.equals(suiContractAddress) }
-                            .map {
-                                Sui.ObjectRef.newBuilder()
-                                    .setObjectId(it.coinObjectId)
-                                    .setVersion(it.version.toLong())
-                                    .setObjectDigest(it.digest)
-                                    .build()
-                            }
-                }
-        val gascoin = selectSuiGasCoin(coins, gasBudget)
+        val suiObjects = coins.filter { it.isNativeSui() }
+        val tokenObjects =
+            coins.filter {
+                isSameSuiCoinType(it.coinType, keysignPayload.coin.contractAddress) &&
+                    !it.isNativeSui()
+            }
 
         val input =
-            if (nonSuiObjectRef.isNotEmpty()) {
+            if (tokenObjects.isNotEmpty()) {
+                    // Token send (Pay): reference only the largest token objects covering the
+                    // amount, and pay gas from a single native SUI object that covers the budget.
+                    val gasCoin = selectSuiGasCoin(coins, gasBudget)
+                    val gasObjectRef =
+                        selectSuiGasObjectRef(
+                            suiObjects.map { it.toObjectRef() },
+                            gasCoin?.coinObjectId,
+                        )
+                    val tokenInputCoins =
+                        selectInputCoins(tokenObjects, keysignPayload.toAmount).map {
+                            it.toObjectRef()
+                        }
                     Sui.SigningInput.newBuilder()
                         .setPay(
                             Sui.Pay.newBuilder()
-                                .setGas(selectSuiGasObjectRef(suiObjectRefs, gascoin?.coinObjectId))
-                                .addAllInputCoins(nonSuiObjectRef)
+                                .setGas(gasObjectRef)
+                                .addAllInputCoins(tokenInputCoins)
                                 .addAllRecipients(listOf(toAddress.description()))
                                 .addAllAmounts(listOf(keysignPayload.toAmount.toLong()))
                                 .build()
                         )
                 } else {
+                    // Native send (PaySui): the input set also pays gas (Sui gas-smashes it into
+                    // one coin), so cover amount + gas with the fewest largest objects.
+                    val target = keysignPayload.toAmount + gasBudget
+                    val nativeInputCoins =
+                        selectInputCoins(suiObjects, target).map { it.toObjectRef() }
                     Sui.SigningInput.newBuilder()
                         .setPaySui(
                             Sui.PaySui.newBuilder()
-                                .addAllInputCoins(suiObjectRefs)
+                                .addAllInputCoins(nativeInputCoins)
                                 .addAllRecipients(listOf(toAddress.description()))
                                 .addAllAmounts(listOf(keysignPayload.toAmount.toLong()))
                                 .build()
@@ -147,10 +188,103 @@ object SuiHelper {
             .toByteArray()
     }
 
+    /**
+     * The smallest native SUI object that covers [gasBudget], `coinObjectId` ascending as
+     * tie-break. The tie-break is a consensus requirement, not a preference: picking the first
+     * minimum in list order instead would let a device that sorts the same shared coin list
+     * differently choose a different gas object among equal-balance candidates, producing different
+     * transaction bytes. Mirrors iOS `SuiCoinType.selectGasObject` and SDK `selectSuiGasObject`.
+     */
     internal fun selectSuiGasCoin(coins: List<SuiCoin>, gasBudget: BigInteger): SuiCoin? =
         coins
-            .filter { it.coinType == suiContractAddress && it.balance.toBigInteger() >= gasBudget }
-            .minByOrNull { it.balance.toBigInteger() }
+            .filter { it.isNativeSui() && it.balanceOrZero() >= gasBudget }
+            .minWithOrNull(compareBy<SuiCoin> { it.balanceOrZero() }.thenBy { it.coinObjectId })
+
+    /**
+     * The fewest coin objects (largest balance first, `coinObjectId` ascending as tie-break) whose
+     * balances together cover [target], bounded by [maxObjects]. Selection is deterministic so
+     * every co-signing device selects the identical set and builds byte-identical transaction bytes
+     * — a cross-device keysign consensus requirement, not merely an optimization.
+     *
+     * Referencing every owned object is what trips Sui's 128 KiB transaction-size limit and, for a
+     * native `PaySui` send, the 256-object gas-payment cap ("serialized transaction size exceeded
+     * maximum") on wallets whose balance is scattered across many objects. Taking only the largest
+     * objects the send needs keeps the transaction small while still merging a scattered balance
+     * (Sui gas-smashes a native input set into one spendable coin).
+     *
+     * At least one object is always returned. If even [maxObjects] largest objects do not reach
+     * [target] they are still returned (best effort) — the caller decides how to handle an
+     * under-funded selection. Mirrors iOS `SuiCoinType.selectInputCoins` (vultisig-ios#4734).
+     */
+    internal fun selectInputCoins(
+        coins: List<SuiCoin>,
+        target: BigInteger,
+        maxObjects: Int = MAX_INPUT_COIN_OBJECTS,
+    ): List<SuiCoin> {
+        val sorted =
+            coins.sortedWith(
+                compareByDescending<SuiCoin> { it.balanceOrZero() }.thenBy { it.coinObjectId }
+            )
+
+        val selected = mutableListOf<SuiCoin>()
+        var accumulated = BigInteger.ZERO
+        for (coin in sorted) {
+            // Keep at least one object so a zero/near-zero-amount send still has an input;
+            // otherwise stop once the target is covered.
+            if (selected.isNotEmpty() && accumulated >= target) break
+            if (selected.size >= maxObjects) break
+            selected.add(coin)
+            accumulated += coin.balanceOrZero()
+        }
+        return selected
+    }
+
+    /**
+     * The minimal set of coin objects to embed in the keysign payload for a Sui send — exactly what
+     * [getPreSignedInputData] will consume. Bounding the embedded set keeps the pairing QR / TSS
+     * relay message small: on a wallet whose balance is spread across thousands of objects,
+     * embedding every one produces a payload too large to relay (the co-signer's poll 404s and the
+     * initiator's transaction data expires before signing can start).
+     *
+     * Native send: the largest native objects covering `amount + gasBudget` (the input set also
+     * pays gas). Token send: the largest token objects covering `amount`, plus the largest few
+     * native SUI objects as gas candidates (one is selected to pay gas at signing time). Mirrors
+     * iOS `SuiCoinType.selectPayloadCoins` (vultisig-ios#4734).
+     */
+    internal fun selectPayloadCoins(
+        coins: List<SuiCoin>,
+        isNativeToken: Boolean,
+        contractAddress: String,
+        amount: BigInteger,
+        gasBudget: BigInteger,
+    ): List<SuiCoin> {
+        val nativeObjects = coins.filter { it.isNativeSui() }
+
+        if (isNativeToken) {
+            return selectInputCoins(nativeObjects, amount + gasBudget)
+        }
+
+        val tokenObjects =
+            coins.filter { isSameSuiCoinType(it.coinType, contractAddress) && !it.isNativeSui() }
+        val selectedTokens = selectInputCoins(tokenObjects, amount)
+        val gasCandidates =
+            nativeObjects
+                .sortedWith(
+                    compareByDescending<SuiCoin> { it.balanceOrZero() }.thenBy { it.coinObjectId }
+                )
+                .take(GAS_CANDIDATE_OBJECT_COUNT)
+        return selectedTokens + gasCandidates
+    }
+
+    private fun SuiCoin.balanceOrZero(): BigInteger =
+        balance.toBigIntegerOrNull() ?: BigInteger.ZERO
+
+    private fun SuiCoin.toObjectRef(): Sui.ObjectRef =
+        Sui.ObjectRef.newBuilder()
+            .setObjectId(coinObjectId)
+            .setVersion(version.toLong())
+            .setObjectDigest(digest)
+            .build()
 
     internal fun selectSuiGasObjectRef(
         suiObjectRefs: List<Sui.ObjectRef>,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -31,8 +31,12 @@ object SuiHelper {
      * would classify the same coin differently on two devices — a native object read as a token
      * object silently turns a `Pay` into a `PaySui`. Only the address is normalized (leading zeros
      * stripped, lowercased); Move module and struct identifiers stay case-sensitive because
-     * `::coin::USDC` and `::coin::usdc` are genuinely different types. Mirrors iOS
-     * `SuiCoinType.normalize` and SDK `normalizeSuiCoinType` (vultisig-sdk#1275).
+     * `::coin::USDC` and `::coin::usdc` are genuinely distinct Move types.
+     *
+     * Mirrors the SDK `normalizeSuiCoinType` (vultisig-sdk#1275), which is likewise case-sensitive
+     * on the module/struct segments. This deliberately diverges from iOS `SuiCoinType.normalize`,
+     * which lowercases the entire coin type and so compares module/struct case-insensitively —
+     * matching iOS here would collapse those distinct Move types, which we do not want.
      */
     internal fun normalizeSuiCoinType(coinType: String): String {
         val addressEnd = coinType.indexOf("::")
@@ -97,24 +101,34 @@ object SuiHelper {
             }
 
         val input =
-            if (tokenObjects.isNotEmpty()) {
-                    // Token send (Pay): reference only the largest token objects covering the
-                    // amount, and pay gas from a single native SUI object that covers the budget.
+            if (!keysignPayload.coin.isNativeToken) {
+                    // Token send (Pay): branch on the coin's own native flag — the authoritative
+                    // signal the payload coins were selected with — not on whether token objects
+                    // happen to be present. A token send whose token objects are absent (e.g. a
+                    // truncated coin page) must fail loudly here, never fall through and silently
+                    // sign a native PaySui transfer of the raw amount as a different asset.
+                    check(tokenObjects.isNotEmpty()) {
+                        "No ${keysignPayload.coin.ticker} coin objects available for this SUI token send"
+                    }
+                    // Reference only the largest token objects covering the amount, and pay gas
+                    // from a single native SUI object that covers the budget.
                     val gasCoin = selectSuiGasCoin(coins, gasBudget)
                     val gasObjectRef =
                         selectSuiGasObjectRef(
                             suiObjects.map { it.toObjectRef() },
                             gasCoin?.coinObjectId,
                         )
-                    val tokenInputCoins =
-                        selectInputCoins(tokenObjects, keysignPayload.toAmount).map {
-                            it.toObjectRef()
-                        }
+                    val tokenInputCoins = selectInputCoins(tokenObjects, keysignPayload.toAmount)
+                    checkCoinsCover(
+                        tokenInputCoins,
+                        keysignPayload.toAmount,
+                        keysignPayload.coin.ticker,
+                    )
                     Sui.SigningInput.newBuilder()
                         .setPay(
                             Sui.Pay.newBuilder()
                                 .setGas(gasObjectRef)
-                                .addAllInputCoins(tokenInputCoins)
+                                .addAllInputCoins(tokenInputCoins.map { it.toObjectRef() })
                                 .addAllRecipients(listOf(toAddress.description()))
                                 .addAllAmounts(listOf(keysignPayload.toAmount.toLong()))
                                 .build()
@@ -123,12 +137,12 @@ object SuiHelper {
                     // Native send (PaySui): the input set also pays gas (Sui gas-smashes it into
                     // one coin), so cover amount + gas with the fewest largest objects.
                     val target = keysignPayload.toAmount + gasBudget
-                    val nativeInputCoins =
-                        selectInputCoins(suiObjects, target).map { it.toObjectRef() }
+                    val nativeInputCoins = selectInputCoins(suiObjects, target)
+                    checkCoinsCover(nativeInputCoins, target, keysignPayload.coin.ticker)
                     Sui.SigningInput.newBuilder()
                         .setPaySui(
                             Sui.PaySui.newBuilder()
-                                .addAllInputCoins(nativeInputCoins)
+                                .addAllInputCoins(nativeInputCoins.map { it.toObjectRef() })
                                 .addAllRecipients(listOf(toAddress.description()))
                                 .addAllAmounts(listOf(keysignPayload.toAmount.toLong()))
                                 .build()
@@ -213,8 +227,10 @@ object SuiHelper {
      * (Sui gas-smashes a native input set into one spendable coin).
      *
      * At least one object is always returned. If even [maxObjects] largest objects do not reach
-     * [target] they are still returned (best effort) — the caller decides how to handle an
-     * under-funded selection. Mirrors iOS `SuiCoinType.selectInputCoins` (vultisig-ios#4734).
+     * [target] they are still returned (best effort) so payload embedding can carry what the wallet
+     * has; the signing path then rejects a genuinely under-funded set via [checkCoinsCover] rather
+     * than emitting a transaction that would only fail at broadcast. Mirrors iOS
+     * `SuiCoinType.selectInputCoins` (vultisig-ios#4734).
      */
     internal fun selectInputCoins(
         coins: List<SuiCoin>,
@@ -278,6 +294,21 @@ object SuiHelper {
 
     private fun SuiCoin.balanceOrZero(): BigInteger =
         balance.toBigIntegerOrNull() ?: BigInteger.ZERO
+
+    /**
+     * Fails fast when the [selected] objects cannot cover [target] — the same fail-fast contract as
+     * [selectSuiGasObjectRef]. [selectInputCoins] returns a best-effort (possibly short) set so
+     * payload embedding stays lossless, so the signing path must guard here; otherwise an
+     * under-funded set would run the full multi-device keysign ceremony only to be rejected by the
+     * network at broadcast.
+     */
+    private fun checkCoinsCover(selected: List<SuiCoin>, target: BigInteger, ticker: String) {
+        val available = selected.fold(BigInteger.ZERO) { acc, coin -> acc + coin.balanceOrZero() }
+        check(available >= target) {
+            "Insufficient $ticker balance for this send: selected coin objects total $available " +
+                "but the transaction needs $target"
+        }
+    }
 
     private fun SuiCoin.toObjectRef(): Sui.ObjectRef =
         Sui.ObjectRef.newBuilder()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -32,6 +32,7 @@ import com.vultisig.wallet.data.chains.helpers.CardanoHelper
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
+import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenStandard
@@ -603,7 +604,17 @@ constructor(
                         BlockChainSpecific.Sui(
                             referenceGasPrice = suiFees.price,
                             gasBudget = suiFees.limit,
-                            coins = coinsDeferred.await(),
+                            // Embed only the coin objects the send needs, not every owned object —
+                            // an unbounded set bloats the pairing QR / TSS relay payload and fails
+                            // to relay on wallets whose balance is scattered across many objects.
+                            coins =
+                                SuiHelper.selectPayloadCoins(
+                                    coinsDeferred.await(),
+                                    isNativeToken = token.isNativeToken,
+                                    contractAddress = token.contractAddress,
+                                    amount = tokenAmountValue ?: BigInteger.ZERO,
+                                    gasBudget = suiFees.limit,
+                                ),
                         ),
                         utxos = emptyList(),
                     )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -607,13 +607,20 @@ constructor(
                             // Embed only the coin objects the send needs, not every owned object —
                             // an unbounded set bloats the pairing QR / TSS relay payload and fails
                             // to relay on wallets whose balance is scattered across many objects.
+                            //
+                            // Select against SUI_DEFAULT_GAS_BUDGET — the budget the fee dry-run
+                            // priced against — rather than the refined suiFees.limit. This keeps
+                            // the embedded object set identical to the one that was simulated, so
+                            // the broadcast transaction never carries an unpriced, larger input set
+                            // than the dry-run measured. The refined limit still becomes the tx's
+                            // gas ceiling above.
                             coins =
                                 SuiHelper.selectPayloadCoins(
                                     coinsDeferred.await(),
                                     isNativeToken = token.isNativeToken,
                                     contractAddress = token.contractAddress,
                                     amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    gasBudget = suiFees.limit,
+                                    gasBudget = SUI_DEFAULT_GAS_BUDGET,
                                 ),
                         ),
                         utxos = emptyList(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -600,27 +600,31 @@ constructor(
                     }
 
                     val suiFees = suiFeesDeferred.await()
+                    // Embed only the coin objects the send needs, not every owned object — an
+                    // unbounded set bloats the pairing QR / TSS relay payload and fails to relay on
+                    // wallets whose balance is scattered across many objects.
+                    //
+                    // Select against whichever budget is larger: the refined suiFees.limit that
+                    // becomes the transaction's gas ceiling, or SUI_DEFAULT_GAS_BUDGET that the fee
+                    // dry-run priced against. A native PaySui pays gas out of its own input set, so
+                    // Sui requires those objects to cover amount + gasBudget — selecting against a
+                    // smaller budget than the one signed with would reject a fully funded send.
+                    // Taking the max keeps the embedded set identical to the simulated one whenever
+                    // the refined budget lands under the default (the common case, so the broadcast
+                    // transaction carries no unpriced inputs), and only widens it by the objects
+                    // the higher ceiling genuinely needs.
+                    val payloadSelectionBudget = maxOf(SUI_DEFAULT_GAS_BUDGET, suiFees.limit)
                     BlockChainSpecificAndUtxo(
                         BlockChainSpecific.Sui(
                             referenceGasPrice = suiFees.price,
                             gasBudget = suiFees.limit,
-                            // Embed only the coin objects the send needs, not every owned object —
-                            // an unbounded set bloats the pairing QR / TSS relay payload and fails
-                            // to relay on wallets whose balance is scattered across many objects.
-                            //
-                            // Select against SUI_DEFAULT_GAS_BUDGET — the budget the fee dry-run
-                            // priced against — rather than the refined suiFees.limit. This keeps
-                            // the embedded object set identical to the one that was simulated, so
-                            // the broadcast transaction never carries an unpriced, larger input set
-                            // than the dry-run measured. The refined limit still becomes the tx's
-                            // gas ceiling above.
                             coins =
                                 SuiHelper.selectPayloadCoins(
                                     coinsDeferred.await(),
                                     isNativeToken = token.isNativeToken,
                                     contractAddress = token.contractAddress,
                                     amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    gasBudget = SUI_DEFAULT_GAS_BUDGET,
+                                    gasBudget = payloadSelectionBudget,
                                 ),
                         ),
                         utxos = emptyList(),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiCoinSelectionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiCoinSelectionTest.kt
@@ -1,0 +1,359 @@
+package com.vultisig.wallet.data.crypto
+
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SuiCoin
+
+/**
+ * Pins the deterministic coin-object selection [SuiHelper.selectInputCoins] /
+ * [SuiHelper.selectPayloadCoins] that keeps Android byte-identical to iOS (vultisig-ios#4734).
+ *
+ * In an MPC keysign every co-signing device independently recomputes the Sui transaction from the
+ * shared `KeysignPayload`; all devices must select the *same* coin objects in the *same* order or
+ * the signatures don't combine. Referencing every owned object also overflows Sui's 128 KiB size /
+ * 256-gas-object limits on wallets whose balance is scattered across many objects, so selection is
+ * both a consensus and a correctness requirement.
+ *
+ * The fixtures mirror iOS `SuiHelperInputDataTests.swift` at the selection level (the
+ * byte-identical `Sui.SigningInput` assertions live in the instrumented `SuiHelperInputDataTest`,
+ * which needs the WalletCore JNI).
+ */
+class SuiCoinSelectionTest {
+
+    private val nativeType = "0x2::sui::SUI"
+    private val tokenType =
+        "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN"
+
+    private fun coin(id: String, type: String, balance: String, version: String = "1"): SuiCoin =
+        SuiCoin(
+            coinType = type,
+            coinObjectId = id,
+            version = version,
+            digest = "digest-$id",
+            balance = balance,
+            previousTransaction = "",
+        )
+
+    private fun ids(coins: List<SuiCoin>): List<String> = coins.map { it.coinObjectId }
+
+    // Native send: cover amount + gas with the fewest largest objects.
+
+    @Test
+    fun `native send selects the largest objects covering amount plus gas`() {
+        val coins =
+            listOf(
+                coin("0xa", nativeType, "1000000000"),
+                coin("0xb", nativeType, "2000000000"),
+                coin("0xc", nativeType, "3000000000"),
+            )
+        // amount 4 SUI + gas: the two largest (3 + 2) cover it, the smallest is left out.
+        val selected =
+            SuiHelper.selectInputCoins(
+                coins,
+                target = BigInteger.valueOf(4_000_000_000L) + BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xc", "0xb"), ids(selected))
+    }
+
+    @Test
+    fun `native small send selects only the largest object`() {
+        val coins =
+            listOf(
+                coin("0xa", nativeType, "1000000000"),
+                coin("0xb", nativeType, "2000000000"),
+                coin("0xc", nativeType, "3000000000"),
+            )
+        val selected =
+            SuiHelper.selectInputCoins(
+                coins,
+                target = BigInteger.valueOf(100_000_000L) + BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xc"), ids(selected))
+    }
+
+    @Test
+    fun `native near-max send selects all objects`() {
+        val coins =
+            listOf(
+                coin("0xa", nativeType, "1000000000"),
+                coin("0xb", nativeType, "2000000000"),
+                coin("0xc", nativeType, "3000000000"),
+            )
+        val selected =
+            SuiHelper.selectInputCoins(
+                coins,
+                target = BigInteger.valueOf(5_900_000_000L) + BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xc", "0xb", "0xa"), ids(selected))
+    }
+
+    @Test
+    fun `dusty wallet references only the objects the send needs`() {
+        val coins = buildList {
+            add(coin("0xbig", nativeType, "10000000000"))
+            repeat(800) { add(coin("0xdust$it", nativeType, "1000")) }
+        }
+        val selected =
+            SuiHelper.selectInputCoins(
+                coins,
+                target = BigInteger.valueOf(1_000_000_000L) + BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xbig"), ids(selected))
+        assertTrue(selected.size <= SuiHelper.MAX_INPUT_COIN_OBJECTS)
+    }
+
+    @Test
+    fun `selection never exceeds the max object cap even when underfunded`() {
+        // 300 tiny objects can never cover the target; selection stops at the 255 cap.
+        val coins = List(300) { coin("0x${it.toString().padStart(4, '0')}", nativeType, "1") }
+        val selected = SuiHelper.selectInputCoins(coins, target = BigInteger.valueOf(1_000_000L))
+
+        assertEquals(SuiHelper.MAX_INPUT_COIN_OBJECTS, selected.size)
+    }
+
+    @Test
+    fun `equal balances break ties on objectId ascending for a stable order`() {
+        val coins =
+            listOf(
+                coin("0xc", nativeType, "1000"),
+                coin("0xa", nativeType, "1000"),
+                coin("0xb", nativeType, "1000"),
+            )
+        val selected = SuiHelper.selectInputCoins(coins, target = BigInteger.valueOf(2500L))
+
+        assertEquals(listOf("0xa", "0xb", "0xc"), ids(selected))
+    }
+
+    @Test
+    fun `always keeps at least one object for a zero-amount send`() {
+        val coins = listOf(coin("0xa", nativeType, "1000"), coin("0xb", nativeType, "2000"))
+        val selected = SuiHelper.selectInputCoins(coins, target = BigInteger.ZERO)
+
+        assertEquals(listOf("0xb"), ids(selected))
+    }
+
+    // Token send: cover token amount, plus the largest few native SUI as gas candidates.
+
+    @Test
+    fun `token send covers the amount with the fewest largest token objects`() {
+        val tokens =
+            listOf(
+                coin("0xt1", tokenType, "100"),
+                coin("0xt2", tokenType, "200"),
+                coin("0xt3", tokenType, "300"),
+            )
+        val selected = SuiHelper.selectInputCoins(tokens, target = BigInteger.valueOf(550L))
+
+        assertEquals(listOf("0xt3", "0xt2", "0xt1"), ids(selected))
+    }
+
+    @Test
+    fun `token small send selects only the largest token object`() {
+        val tokens =
+            listOf(
+                coin("0xt1", tokenType, "100"),
+                coin("0xt2", tokenType, "200"),
+                coin("0xt3", tokenType, "300"),
+            )
+        val selected = SuiHelper.selectInputCoins(tokens, target = BigInteger.valueOf(250L))
+
+        assertEquals(listOf("0xt3"), ids(selected))
+    }
+
+    // Payload bounding embeds only what the send consumes.
+
+    @Test
+    fun `payload coins for a native send are the covering native objects only`() {
+        val coins =
+            listOf(
+                coin("0xa", nativeType, "1000000000"),
+                coin("0xb", nativeType, "2000000000"),
+                coin("0xc", nativeType, "3000000000"),
+            )
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = true,
+                contractAddress = "",
+                amount = BigInteger.valueOf(100_000_000L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xc"), ids(selected))
+    }
+
+    @Test
+    fun `payload native selection excludes look-alike objects`() {
+        val coins =
+            listOf(
+                coin("0xnative", nativeType, "5000000000"),
+                coin("0xlst", "0xb45f::xsui::XSUI", "9000000000"),
+            )
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = true,
+                contractAddress = "",
+                amount = BigInteger.valueOf(1_000_000_000L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xnative"), ids(selected))
+    }
+
+    @Test
+    fun `payload coins for a token send are covering tokens plus the largest gas candidates`() {
+        val coins =
+            listOf(
+                coin("0xgasSmall", nativeType, "500000"),
+                coin("0xgasMid", nativeType, "3000000"),
+                coin("0xgasBig", nativeType, "9000000"),
+                coin("0xt1", tokenType, "100"),
+                coin("0xt2", tokenType, "200"),
+            )
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = false,
+                contractAddress = tokenType,
+                amount = BigInteger.valueOf(250L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        // Covering tokens (200 + 100) then the native gas candidates, largest first.
+        assertEquals(listOf("0xt2", "0xt1", "0xgasBig", "0xgasMid", "0xgasSmall"), ids(selected))
+    }
+
+    @Test
+    fun `payload token send caps gas candidates at the configured count`() {
+        val coins = buildList {
+            repeat(8) { add(coin("0xgas$it", nativeType, "${9000000 - it}")) }
+            add(coin("0xt1", tokenType, "1000"))
+        }
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = false,
+                contractAddress = tokenType,
+                amount = BigInteger.valueOf(500L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        val gasCandidates = selected.filter { it.coinType == nativeType }
+        assertEquals(SuiHelper.GAS_CANDIDATE_OBJECT_COUNT, gasCandidates.size)
+        // The five largest native objects, largest first.
+        assertEquals(
+            listOf("0xgas0", "0xgas1", "0xgas2", "0xgas3", "0xgas4"),
+            gasCandidates.map { it.coinObjectId },
+        )
+    }
+
+    @Test
+    fun `payload token gas candidates break balance ties on objectId ascending`() {
+        val coins =
+            listOf(
+                coin("0xgasD", nativeType, "9000000"),
+                coin("0xgasB", nativeType, "9000000"),
+                coin("0xgasC", nativeType, "9000000"),
+                coin("0xgasA", nativeType, "9000000"),
+                coin("0xt1", tokenType, "1000"),
+            )
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = false,
+                contractAddress = tokenType,
+                amount = BigInteger.valueOf(500L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xt1", "0xgasA", "0xgasB", "0xgasC", "0xgasD"), ids(selected))
+    }
+
+    // Coin-type normalization: short vs long address form must classify identically.
+
+    @Test
+    fun `long-form native coin type is treated as native`() {
+        val longNativeType = "0x" + "0".repeat(63) + "2::sui::SUI"
+        assertTrue(SuiHelper.isSameSuiCoinType(nativeType, longNativeType))
+    }
+
+    @Test
+    fun `coin type comparison keeps module and struct identifiers case-sensitive`() {
+        val lowerStruct =
+            "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::coin"
+        assertFalse(SuiHelper.isSameSuiCoinType(tokenType, lowerStruct))
+    }
+
+    @Test
+    fun `coin type comparison ignores address case and leading zeros`() {
+        val padded =
+            "0x005D4B302506645C37FF133B98C4B50A5AE14841659738D6D733D59D0D217A93BF::coin::COIN"
+        assertTrue(SuiHelper.isSameSuiCoinType(tokenType, padded))
+    }
+
+    @Test
+    fun `native selection matches long-form objects returned by the RPC`() {
+        val longNativeType = "0x" + "0".repeat(63) + "2::sui::SUI"
+        val coins =
+            listOf(
+                coin("0xa", longNativeType, "1000000000"),
+                coin("0xb", longNativeType, "5000000000"),
+            )
+        val selected =
+            SuiHelper.selectPayloadCoins(
+                coins,
+                isNativeToken = true,
+                contractAddress = "",
+                amount = BigInteger.valueOf(100_000_000L),
+                gasBudget = BigInteger.valueOf(3_000_000L),
+            )
+
+        assertEquals(listOf("0xb"), ids(selected))
+    }
+
+    // Gas-object pick: smallest covering object, objectId ascending as tie-break.
+
+    @Test
+    fun `gas coin is the smallest native object covering the budget`() {
+        val coins =
+            listOf(
+                coin("0xtooSmall", nativeType, "1000000"),
+                coin("0xbig", nativeType, "9000000"),
+                coin("0xsmallCover", nativeType, "3500000"),
+            )
+        val selected = SuiHelper.selectSuiGasCoin(coins, BigInteger.valueOf(3_000_000L))
+
+        assertEquals("0xsmallCover", selected?.coinObjectId)
+    }
+
+    @Test
+    fun `gas coin breaks balance ties on objectId ascending`() {
+        // Listed in an order whose first minimum is NOT the lowest objectId: a device that skipped
+        // the tie-break would pick 0xbbb here and diverge from iOS / the SDK.
+        val coins =
+            listOf(
+                coin("0xbbb", nativeType, "3500000"),
+                coin("0xaaa", nativeType, "3500000"),
+                coin("0xccc", nativeType, "9000000"),
+            )
+        val selected = SuiHelper.selectSuiGasCoin(coins, BigInteger.valueOf(3_000_000L))
+
+        assertEquals("0xaaa", selected?.coinObjectId)
+    }
+
+    @Test
+    fun `gas coin ignores non-native objects and returns null when none covers the budget`() {
+        val coins = listOf(coin("0xt1", tokenType, "9000000"), coin("0xa", nativeType, "1000000"))
+
+        assertNull(SuiHelper.selectSuiGasCoin(coins, BigInteger.valueOf(3_000_000L)))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
+import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
@@ -43,6 +44,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SuiCoin
 
 internal class BlockChainSpecificRepositoryImplTest {
 
@@ -350,6 +352,108 @@ internal class BlockChainSpecificRepositoryImplTest {
     }
 
     @Test
+    fun `SUI embedded coins cover the amount plus the refined gas budget they are signed with`() =
+        runTest {
+            // Refined budget above SUI_DEFAULT_GAS_BUDGET: selecting against the default alone
+            // would stop at amount + 3_000_000 and leave the signing-time coverage check —
+            // amount + gasBudget, the balance Sui requires a PaySui input set to hold — short on a
+            // fragmented but fully funded wallet.
+            val refinedBudget = BigInteger("4200000")
+            val amount = BigInteger("1000000")
+            val walletCoins = fragmentedNativeCoins(count = 12, balance = "1000000")
+            val result =
+                repository(
+                        suiApi = suiApi(referenceGasPrice = BigInteger("1"), coins = walletCoins),
+                        suiFeeService = suiFeeService(limit = refinedBudget),
+                    )
+                    .getSpecific(
+                        chain = Chain.Sui,
+                        address = SOURCE_ADDRESS,
+                        token = suiCoin(),
+                        gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                        tokenAmountValue = amount,
+                    )
+
+            val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+            assertEquals(refinedBudget, specific.gasBudget)
+            assertTrue(specific.coins.totalBalance() >= amount + refinedBudget)
+            // Still bounded — only the objects the send needs, not every owned object.
+            assertTrue(specific.coins.size < walletCoins.size)
+        }
+
+    @Test
+    fun `SUI embedded coins cover the padded default budget used when fee estimation fails`() =
+        runTest {
+            // The fallback budget is SUI_DEFAULT_GAS_BUDGET + 15%, so it too exceeds the budget the
+            // dry-run priced against and must drive the embedded selection.
+            val paddedDefault = SUI_DEFAULT_GAS_BUDGET.increaseByPercent(15)
+            val amount = BigInteger("1000000")
+            val result =
+                repository(
+                        suiApi =
+                            suiApi(
+                                referenceGasPrice = BigInteger("500"),
+                                coins = fragmentedNativeCoins(count = 12, balance = "1000000"),
+                            ),
+                        suiFeeService = failingFeeService(),
+                    )
+                    .getSpecific(
+                        chain = Chain.Sui,
+                        address = SOURCE_ADDRESS,
+                        token = suiCoin(),
+                        gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                        tokenAmountValue = amount,
+                    )
+
+            val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+            assertEquals(paddedDefault, specific.gasBudget)
+            assertTrue(specific.coins.totalBalance() >= amount + paddedDefault)
+        }
+
+    @Test
+    fun `SUI embedded coins stay the dry-run priced set when the refined budget is under default`() =
+        runTest {
+            // Refined budget below SUI_DEFAULT_GAS_BUDGET: the selection must stay at the default,
+            // the budget SuiFeeService dry-run priced, so the broadcast transaction carries no
+            // input objects the simulation never measured.
+            val refinedBudget = BigInteger("2000000")
+            val amount = BigInteger("1000000")
+            val walletCoins = fragmentedNativeCoins(count = 12, balance = "1000000")
+            val result =
+                repository(
+                        suiApi = suiApi(referenceGasPrice = BigInteger("1"), coins = walletCoins),
+                        suiFeeService = suiFeeService(limit = refinedBudget),
+                    )
+                    .getSpecific(
+                        chain = Chain.Sui,
+                        address = SOURCE_ADDRESS,
+                        token = suiCoin(),
+                        gasFee = TokenValue(BigInteger.ONE, suiCoin()),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                        tokenAmountValue = amount,
+                    )
+
+            val specific = result.blockChainSpecific as BlockChainSpecific.Sui
+            val pricedSet =
+                SuiHelper.selectPayloadCoins(
+                    walletCoins,
+                    isNativeToken = true,
+                    contractAddress = "",
+                    amount = amount,
+                    gasBudget = SUI_DEFAULT_GAS_BUDGET,
+                )
+            assertEquals(pricedSet.map { it.coinObjectId }, specific.coins.map { it.coinObjectId })
+        }
+
+    @Test
     fun `SUI specific falls back to padded default budget when fee service throws`() = runTest {
         val fallbackPrice = BigInteger("500")
         val result =
@@ -445,10 +549,27 @@ internal class BlockChainSpecificRepositoryImplTest {
         }
     }
 
-    private fun suiApi(referenceGasPrice: BigInteger): SuiApi = mockk {
-        coEvery { getReferenceGasPrice() } returns referenceGasPrice
-        coEvery { getAllCoins(any()) } returns emptyList()
-    }
+    private fun suiApi(referenceGasPrice: BigInteger, coins: List<SuiCoin> = emptyList()): SuiApi =
+        mockk {
+            coEvery { getReferenceGasPrice() } returns referenceGasPrice
+            coEvery { getAllCoins(any()) } returns coins
+        }
+
+    /** Native SUI objects of [balance] MIST each, so a send has to accumulate several of them. */
+    private fun fragmentedNativeCoins(count: Int, balance: String): List<SuiCoin> =
+        (1..count).map { index ->
+            SuiCoin(
+                coinType = "0x2::sui::SUI",
+                coinObjectId = "0x%064x".format(index),
+                version = index.toString(),
+                digest = "digest-$index",
+                balance = balance,
+                previousTransaction = "",
+            )
+        }
+
+    private fun List<SuiCoin>.totalBalance(): BigInteger =
+        fold(BigInteger.ZERO) { acc, coin -> acc + coin.balance.toBigInteger() }
 
     private fun suiFeeService(
         limit: BigInteger,


### PR DESCRIPTION
## Summary

A Sui send referenced **every** coin object the wallet owned, in RPC order. This PR selects only the fewest largest objects that cover the send, using an ordering that is byte-identical to the other platforms.

Two problems, one fix:

- **Size.** On a wallet whose balance is scattered across many objects, referencing all of them overruns Sui's 128 KiB transaction-size limit and — for a native `PaySui`, whose entire input set is the gas payment — the 256-object gas cap. The payload becomes too large to relay (co-signer polls `404`, initiator reports `Transaction data expired`), or the broadcast is rejected with `Size limit exceeded: serialized transaction size exceeded maximum of 131072`.
- **Consensus.** In MPC keysign every co-signing device independently rebuilds the transaction from the shared `KeysignPayload`. If two devices pick different objects, or the same objects in a different order, the transaction bytes differ and the signatures don't combine.

Closes #5252

## What changed

- `SuiHelper.selectInputCoins` — fewest largest objects covering the target, sorted **balance descending, `coinObjectId` ascending** as tie-break, capped at **255** (one under Sui's 256-object gas cap). Native `PaySui` target is `amount + gasBudget`; token `Pay` target is `amount`.
- `SuiHelper.selectPayloadCoins` — bounds what gets embedded in the payload: covering native objects for a native send; covering token objects plus the 5 largest native SUI gas candidates for a token send. Wired into both `BlockChainSpecificRepository` (real keysign) and `SuiFeeService` (dry run), which is what fixes the oversized-payload relay failure.
- `SuiHelper.selectSuiGasCoin` — still the smallest covering native object, now with `coinObjectId` ascending as tie-break.
- **Coin-type normalization** — Sui accepts a coin type's address in short (`0x2`) or zero-padded long (`0x000…002`) form and RPC nodes are inconsistent about which they return. The previous raw string compare would classify a native object as a token object on one device and not another; because the send branches on `tokenObjects.isNotEmpty()`, that silently turns a token `Pay` into a native `PaySui`. Only the address is normalized — `::module::Struct` identifiers stay case-sensitive, since `::coin::USDC` and `::coin::usdc` are genuinely different types.

## Cross-platform parity

The reference implementation is **[vultisig-sdk#1275](https://github.com/vultisig/vultisig-sdk/pull/1275)**, merged 2026-07-16, which also covers Windows via `@core`. The same algorithm is proposed for iOS in [vultisig-ios#4734](https://github.com/vultisig/vultisig-ios/pull/4734), which is held open pending this PR — merging here unblocks it.

Sort key, tie-breaks, the 255 cap, the 5-object gas-candidate count, and the gas-object pick all match the SDK.

**One deliberate deviation:** the SDK *throws* on an under-funded selection and when no object covers the gas budget; this PR stays best-effort (returns the capped set / `null`). `SuiFeeService` calls `selectPayloadCoins` during live fee estimation as the user types an amount, so throwing there would break the fee row instead of letting the send form's own insufficient-balance validation surface the problem. Byte-parity is unaffected — the selections are identical whenever the send is funded. Happy to switch to throwing if reviewers prefer strict parity.

## Test plan

**Unit** — `SuiCoinSelectionTest`, 21 tests, green. Mirrors the SDK's `suiCoinSelection.test.ts` cases: covering selection, both tie-breaks, the 255 cap, normalization (long-form native, case-sensitive struct ids), and payload bounding for native and token sends. Full `:data:testDebugUnitTest` is 2202 tests, 0 failures.

**Mainnet, signed end-to-end on device** — vault `0x3a91…c65c`:

| Path | Transaction | What it exercises |
|---|---|---|
| Native SUI (`PaySui`) | [`FGSi1DUa…LcEoA`](https://suiscan.xyz/mainnet/tx/FGSi1DUasU6CkiDSSKwJbNpN4fHBM5Dve6oPGJGLcEoA) | `SplitCoins` from `GasCoin` → `TransferObjects`; bounded selection resolved to a **single** gas-payment object |
| Sui token (`Pay`) | [`7WD6TGJC…9EtL3`](https://suiscan.xyz/mainnet/tx/7WD6TGJCdtBjoYK64tJpeMz9kGBY9g8CER2eMq89EtL3) | ETH-on-Sui token object `0x7ec3…6ea0` split, gas paid from a **separate** native object — the branch the normalization change affects |

Both succeeded. The token send is the important one: it confirms the coin-type comparison still routes a token to `Pay` rather than falling through to `PaySui`.

**Not covered by these transactions, stated plainly:**

- The signing vault holds only 3 native SUI objects, so these txs do **not** exercise the scattered-balance case the size fix targets. That path is covered by unit tests (800-object dusty-wallet fixture) but not by an on-chain send.
- Cross-device byte parity is **not** demonstrated. It needs an iOS build carrying #4734, which is unmerged and unreleased, so no counterpart device exists to disagree with Android yet. Parity here rests on unit tests plus a line-by-line audit against the merged SDK.
- `SuiHelperInputDataTest` (8 byte-level `Sui.SigningInput` assertions) compiles but has not been run — it needs the WalletCore JNI on a device/emulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Sui payment and fee-simulation accuracy for fragmented balances by embedding only the required coins for transfers.
  - Deterministic native/token coin selection with native coin-type normalization, capped reference counts, and exclusion of look-alike coin types.
  - Added stricter handling for missing or underfunded token selections (fail fast instead of fallback).
  - Updated Sui coin fetching to cursor-based pagination to reliably retrieve all coins.

- **Tests**
  - Added extensive coverage for native/token coin selection, gas and payload selection rules, type matching, coin limits, and failure/rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->