### PR TITLE
feat(swap): screen the external recipient on non-EVM-source swaps

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
@@ -17,6 +18,7 @@ import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.securityscanner.BLOCKAID_PROVIDER
 import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
+import com.vultisig.wallet.data.securityscanner.SecurityScannerSupport
 import com.vultisig.wallet.data.securityscanner.isChainSupported
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -32,7 +34,7 @@ import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.handleSigningFlowCommon
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -144,6 +146,7 @@ constructor(
     private val securityScannerService: SecurityScannerContract,
     private val vaultRepository: VaultRepository,
     private val inboundHaltPreflight: SwapInboundHaltPreflight,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     val state = MutableStateFlow(VerifySwapUiModel())
@@ -292,15 +295,18 @@ constructor(
                     transaction.payload is SwapPayload.ThorChain ||
                         transaction.payload is SwapPayload.MayaChain
 
+                if (!securityScannerService.isSecurityServiceEnabled()) return@launch
+
+                val supportedChains = securityScannerService.getSupportedChainsByFeature()
                 val isSupported =
                     !isThorchainOrMaya &&
                         chain.standard == TokenStandard.EVM &&
-                        securityScannerService
-                            .getSupportedChainsByFeature()
-                            .isChainSupported(chain) &&
-                        securityScannerService.isSecurityServiceEnabled()
+                        supportedChains.isChainSupported(chain)
 
-                if (!isSupported) return@launch
+                if (!isSupported) {
+                    scanExternalRecipient(transaction, supportedChains)
+                    return@launch
+                }
 
                 state.update { it.copy(txScanStatus = TransactionScanStatus.Scanning) }
 
@@ -308,7 +314,7 @@ constructor(
                     securityScannerService.createSecurityScannerTransaction(transaction)
 
                 val result =
-                    withContext(Dispatchers.IO) {
+                    withContext(ioDispatcher) {
                         securityScannerService.scanTransaction(securityScannerTransaction)
                     }
 
@@ -330,6 +336,44 @@ constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Fallback screening for swaps whose source chain can't be scanned as a full transaction (e.g.
+     * a Solana-source swap): the funds still leave the vault to an external recipient, so that
+     * address is screened on its own on the destination chain (#5348).
+     *
+     * Silently skipped when there is no external recipient — a swap back into the vault's own
+     * address needs no address screening — or when the destination chain isn't an EVM chain the
+     * provider covers, which is the only address-shaped scan Blockaid offers. Provider-side AML
+     * screening remains the backstop there.
+     */
+    private suspend fun scanExternalRecipient(
+        transaction: SwapTransaction,
+        supportedChains: List<SecurityScannerSupport>,
+    ) {
+        val hasExternalRecipient =
+            (transaction as? SwapTransaction.RegularSwapTransaction)
+                ?.externalRecipient
+                ?.isNotBlank() == true
+        if (!hasExternalRecipient) return
+
+        val dstChain = transaction.dstToken.chain
+        if (dstChain.standard != TokenStandard.EVM || !supportedChains.isChainSupported(dstChain)) {
+            return
+        }
+
+        state.update { it.copy(txScanStatus = TransactionScanStatus.Scanning) }
+
+        val recipientScannerTransaction =
+            securityScannerService.createRecipientSecurityScannerTransaction(transaction)
+
+        val result =
+            withContext(ioDispatcher) {
+                securityScannerService.scanTransaction(recipientScannerTransaction)
+            }
+
+        state.update { it.copy(txScanStatus = TransactionScanStatus.Scanned(result)) }
     }
 
     fun onDismissSecurityScanner() {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/VerifySwapViewModelTest.kt
@@ -13,7 +13,12 @@ import com.vultisig.wallet.data.repositories.SwapTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.securityscanner.SecurityScannerContract
+import com.vultisig.wallet.data.securityscanner.SecurityScannerFeaturesType
+import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
+import com.vultisig.wallet.data.securityscanner.SecurityScannerSupport
+import com.vultisig.wallet.data.securityscanner.SecurityScannerTransaction
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.mappers.SwapTransactionToUiModelMapper
 import com.vultisig.wallet.ui.navigation.Destination
@@ -106,6 +111,7 @@ internal class VerifySwapViewModelTest {
             securityScannerService = securityScannerService,
             vaultRepository = vaultRepository,
             inboundHaltPreflight = inboundHaltPreflight,
+            ioDispatcher = testDispatcher,
         )
 
     /**
@@ -268,8 +274,91 @@ internal class VerifySwapViewModelTest {
             coVerify(exactly = 0) { launchKeysign(any(), any(), any(), any(), any()) }
         }
 
+    /**
+     * Solana-source swaps can't be scanned as a full transaction, so before #5348 they were skipped
+     * entirely — the external recipient the funds land on was never screened. The fallback screens
+     * that address on its own on the destination chain and publishes the verdict through the same
+     * scan status the EVM path uses.
+     */
+    @Test
+    fun `a non-scannable source swap still screens its external recipient`() =
+        runTest(testDispatcher) {
+            val result = mockk<SecurityScannerResult>(relaxed = true)
+            val recipientScan = mockk<SecurityScannerTransaction>(relaxed = true)
+            givenNonEvmSourceSwap(dstChain = Chain.Ethereum, externalRecipient = RECIPIENT)
+            every {
+                securityScannerService.createRecipientSecurityScannerTransaction(any())
+            } returns recipientScan
+            coEvery { securityScannerService.scanTransaction(recipientScan) } returns result
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.state.value.txScanStatus shouldBe TransactionScanStatus.Scanned(result)
+        }
+
+    /** A swap that lands back in the vault's own address has no external address to screen. */
+    @Test
+    fun `a non-scannable source swap without an external recipient stays unscanned`() =
+        runTest(testDispatcher) {
+            givenNonEvmSourceSwap(dstChain = Chain.Ethereum, externalRecipient = null)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.state.value.txScanStatus shouldBe TransactionScanStatus.NotStarted
+            coVerify(exactly = 0) { securityScannerService.scanTransaction(any()) }
+        }
+
+    /** Non-EVM destinations have no address-shaped scan, so the fallback skips them silently. */
+    @Test
+    fun `a non-scannable source swap to a non-EVM destination stays unscanned`() =
+        runTest(testDispatcher) {
+            givenNonEvmSourceSwap(dstChain = Chain.Solana, externalRecipient = RECIPIENT)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.state.value.txScanStatus shouldBe TransactionScanStatus.NotStarted
+            coVerify(exactly = 0) { securityScannerService.scanTransaction(any()) }
+        }
+
+    /**
+     * Drives `init` with a Solana-source swap: the source chain is Blockaid-supported but isn't
+     * EVM, so the full-transaction path is skipped and only the recipient fallback can run.
+     */
+    private fun givenNonEvmSourceSwap(dstChain: Chain, externalRecipient: String?) {
+        val tx =
+            mockk<SwapTransaction.RegularSwapTransaction>(relaxed = true) {
+                every { isApprovalRequired } returns false
+                every { memo } returns null
+                every { srcToken } returns
+                    mockk<Coin>(relaxed = true).apply { every { chain } returns Chain.Solana }
+                every { dstToken } returns
+                    mockk<Coin>(relaxed = true).apply { every { chain } returns dstChain }
+                every { this@mockk.externalRecipient } returns externalRecipient
+            }
+        coEvery { swapTransactionRepository.getTransaction(TX_ID) } returns tx
+        coEvery { mapTransactionToUiModel(tx) } returns SwapTransactionUiModel()
+        coEvery { securityScannerService.isSecurityServiceEnabled() } returns true
+        every { securityScannerService.getSupportedChainsByFeature() } returns
+            listOf(
+                SecurityScannerSupport(
+                    provider = "blockaid",
+                    feature =
+                        listOf(
+                            SecurityScannerSupport.Feature(
+                                chains = listOf(Chain.Solana, Chain.Ethereum),
+                                featureType = SecurityScannerFeaturesType.SCAN_TRANSACTION,
+                            )
+                        ),
+                )
+            )
+    }
+
     private companion object {
         const val VAULT_ID = "vault-1"
         const val TX_ID = "tx-1"
+        const val RECIPIENT = "0x9876543210FeDcBa9876543210FeDcBa98765432"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerContract.kt
@@ -16,6 +16,14 @@ interface SecurityScannerContract {
         transaction: SwapTransaction
     ): SecurityScannerTransaction
 
+    /**
+     * Screens a swap's external recipient on the destination chain, independently of whether the
+     * source-chain swap transaction itself can be scanned.
+     */
+    fun createRecipientSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ): SecurityScannerTransaction
+
     fun getDisabledProviders(): List<String>
 
     fun getEnabledProviders(): List<String>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerService.kt
@@ -42,6 +42,12 @@ class SecurityScannerService(
         return factory.createSecurityScannerTransaction(transaction)
     }
 
+    override fun createRecipientSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ): SecurityScannerTransaction {
+        return factory.createRecipientSecurityScannerTransaction(transaction)
+    }
+
     override fun getDisabledProviders(): List<String> {
         return disabledProvidersNames.toList()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactory.kt
@@ -57,6 +57,45 @@ class SecurityScannerTransactionFactory(
         }
     }
 
+    /**
+     * Builds a recipient-only scan for a swap: a native transfer to the swap's external recipient
+     * on the DESTINATION chain, so Blockaid screens the address the funds land on even when the
+     * source-chain swap transaction can't be scanned (e.g. a Solana-source swap, #5348).
+     *
+     * Only EVM destinations are modelled — they are the one address-shaped scan the provider takes;
+     * the Bitcoin/Solana/Sui endpoints need a serialized transaction, which doesn't exist for an
+     * outbound leg the vault never signs. Throws for anything else so the caller can skip silently.
+     */
+    override fun createRecipientSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ): SecurityScannerTransaction {
+        val recipient =
+            (transaction as? SwapTransaction.RegularSwapTransaction)?.externalRecipient?.takeIf {
+                it.isNotBlank()
+            } ?: throw SecurityScannerException("Security Scanner: Swap has no external recipient")
+
+        val dstToken = transaction.dstToken
+        val chain = dstToken.chain
+        if (chain.standard != TokenStandard.EVM) {
+            throw SecurityScannerException(
+                "Security Scanner: Recipient scan not supported on ${chain.name}",
+                chain = chain,
+            )
+        }
+        require(dstToken.address.isNotBlank()) {
+            "Security Scanner: Missing vault address on ${chain.name}"
+        }
+
+        return SecurityScannerTransaction(
+            chain = chain,
+            type = SecurityTransactionType.COIN_TRANSFER,
+            from = dstToken.address,
+            to = recipient,
+            amount = BigInteger.ZERO,
+            data = "0x",
+        )
+    }
+
     private fun createEVMSecurityScannerTransaction(
         transaction: SwapTransaction
     ): SecurityScannerTransaction {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerTransactionFactoryContract.kt
@@ -11,4 +11,12 @@ interface SecurityScannerTransactionFactoryContract {
     suspend fun createSecurityScannerTransaction(
         transaction: SwapTransaction
     ): SecurityScannerTransaction
+
+    /**
+     * Screens a swap's external recipient on the destination chain, independently of whether the
+     * source-chain swap transaction itself can be scanned.
+     */
+    fun createRecipientSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ): SecurityScannerTransaction
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerRecipientTransactionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/SecurityScannerRecipientTransactionTest.kt
@@ -1,0 +1,147 @@
+package com.vultisig.wallet.data.securityscanner
+
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [SecurityScannerTransactionFactory.createRecipientSecurityScannerTransaction] — the
+ * recipient-only fallback that screens a swap's external recipient on the destination chain when
+ * the source-chain swap transaction itself can't be scanned (#5348).
+ */
+class SecurityScannerRecipientTransactionTest {
+
+    private val factory = SecurityScannerTransactionFactory(mockk<SolanaApi>(), mockk<SuiApi>())
+
+    private val solana =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "sol",
+            address = "8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj",
+            decimal = 9,
+            hexPublicKey = "",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val ethereum =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "eth",
+            address = VAULT_ETH_ADDRESS,
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun swap(dstToken: Coin, externalRecipient: String?) =
+        SwapTransaction.RegularSwapTransaction(
+            id = "tx-1",
+            vaultId = "vault-1",
+            srcToken = solana,
+            srcTokenValue = TokenValue(value = BigInteger.ONE, token = solana),
+            dstToken = dstToken,
+            dstAddress = "router-address",
+            expectedDstTokenValue = TokenValue(value = BigInteger.ONE, token = dstToken),
+            blockChainSpecific = mockk<BlockChainSpecificAndUtxo>(),
+            estimatedFees = TokenValue(value = BigInteger.ZERO, token = dstToken),
+            gasFees = TokenValue(value = BigInteger.ZERO, token = solana),
+            memo = null,
+            payload = mockk<SwapPayload>(),
+            isApprovalRequired = false,
+            gasFeeFiatValue = FiatValue(value = BigDecimal.ZERO, currency = "USD"),
+            externalRecipient = externalRecipient,
+        )
+
+    @Test
+    fun `EVM destination screens the external recipient as a native transfer from the vault`() {
+        val transaction = swap(dstToken = ethereum, externalRecipient = EXTERNAL_RECIPIENT)
+
+        val scan = factory.createRecipientSecurityScannerTransaction(transaction)
+
+        assertEquals(
+            SecurityScannerTransaction(
+                chain = Chain.Ethereum,
+                type = SecurityTransactionType.COIN_TRANSFER,
+                from = VAULT_ETH_ADDRESS,
+                to = EXTERNAL_RECIPIENT,
+                amount = BigInteger.ZERO,
+                data = "0x",
+            ),
+            scan,
+        )
+    }
+
+    @Test
+    fun `a swap back into the vault has no recipient to screen`() {
+        val transaction = swap(dstToken = ethereum, externalRecipient = null)
+
+        val exception =
+            runCatching { factory.createRecipientSecurityScannerTransaction(transaction) }
+                .exceptionOrNull()
+
+        assertTrue(exception is SecurityScannerException)
+    }
+
+    @Test
+    fun `blank recipient is treated as absent rather than scanned`() {
+        val transaction = swap(dstToken = ethereum, externalRecipient = "   ")
+
+        val exception =
+            runCatching { factory.createRecipientSecurityScannerTransaction(transaction) }
+                .exceptionOrNull()
+
+        assertTrue(exception is SecurityScannerException)
+    }
+
+    /**
+     * Non-EVM destinations have no address-shaped scan at the provider — their endpoints take a
+     * serialized transaction, which doesn't exist for an outbound leg the vault never signs.
+     */
+    @Test
+    fun `non-EVM destination is rejected so the caller skips the fallback`() {
+        val transaction = swap(dstToken = solana, externalRecipient = EXTERNAL_RECIPIENT)
+
+        val exception =
+            runCatching { factory.createRecipientSecurityScannerTransaction(transaction) }
+                .exceptionOrNull()
+
+        assertTrue(exception is SecurityScannerException)
+        assertEquals(Chain.Solana, (exception as SecurityScannerException).chain)
+    }
+
+    /** Blockaid scans an address pair; a missing vault address would send an empty `from`. */
+    @Test
+    fun `missing vault address on the destination chain is rejected`() {
+        val transaction =
+            swap(dstToken = ethereum.copy(address = ""), externalRecipient = EXTERNAL_RECIPIENT)
+
+        val exception =
+            runCatching { factory.createRecipientSecurityScannerTransaction(transaction) }
+                .exceptionOrNull()
+
+        assertTrue(exception is IllegalArgumentException)
+    }
+
+    private companion object {
+        const val VAULT_ETH_ADDRESS = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12"
+        const val EXTERNAL_RECIPIENT = "0x9876543210FeDcBa9876543210FeDcBa98765432"
+    }
+}


### PR DESCRIPTION
Closes #5348

## Problem

When a swap's source chain can't be scanned as a full transaction, the verify screen skipped security screening entirely — not even the destination address was checked. A Solana-source swap sending its output to an external recipient reached the sign step with **zero** malicious/sanctioned-address screening, unlike the equivalent EVM-source swap.

## Solution

Add a recipient-only fallback that screens the swap's external recipient on the **destination** chain, independently of whether the source-chain transaction can be scanned:

- `SecurityScannerTransactionFactory.createRecipientSecurityScannerTransaction()` models the recipient as a native transfer on the destination chain (`from` = the vault's destination-chain address, `to` = the external recipient, amount 0, data `0x`).
- `VerifySwapViewModel` falls through to it when the existing source-chain gate fails, publishing the verdict through the same `TransactionScanStatus.Scanned` the EVM path uses — so the existing Blockaid badge and the pre-sign warning sheet pick it up with no UI changes.

Only EVM destinations are modelled: that is the one address-shaped scan Blockaid takes. The Bitcoin/Solana/Sui endpoints need a serialized transaction, which doesn't exist for an outbound leg the vault never signs — those are skipped silently, with provider-side AML screening remaining the backstop. The fallback is also skipped when the swap lands back in the vault's own address, since there is no external address to screen.

Mirrors the iOS implementation (`SecurityScannerTransactionFactory.createRecipientSecurityScanner` / `SecurityScannerViewModel.scanRecipientOnly`).

**The EVM-source full-transaction path is unchanged**, as is verdict-handling and blocking behaviour — the fallback only adds a signal where there was none.

Incidental: the IO dispatcher is now injected rather than hardcoded, matching the send-side `VerifyTransactionViewModel`, so the scan hop runs on the test scheduler and the resulting state is assertable.

## Device verification

Mainnet SwapKit **SOL → ETH** swap with an external recipient (`0x0bd4…eF3Fe6`). The **"Transaction scanned by Blockaid"** badge only renders on `TransactionScanStatus.Scanned`, and a Solana source can never reach the full-transaction path — so the verdict comes from the new recipient-only scan on the Ethereum side. On `main` this same screen shows no scan row at all.

![after](https://i.imgur.com/5LhSqNt.png)

## Test plan

- [x] `./gradlew assembleDebug`
- [x] `./gradlew :app:lintDebug :data:lintDebug`
- [x] `SecurityScannerRecipientTransactionTest` (5 cases): EVM destination builds the expected scan; missing/blank recipient rejected; non-EVM destination rejected and carries the chain; missing vault address on the destination chain rejected
- [x] `VerifySwapViewModelTest` (9 cases, 3 new): Solana-source + external EVM recipient → `Scanned`; no external recipient → `NotStarted`, no scan call; non-EVM destination → `NotStarted`, no scan call
- [x] Device: Solana → Ethereum swap with an external recipient shows the Blockaid badge (screenshot above)

## Known limitation

Solana → Bitcoin / Sui / Cosmos destinations remain unscanned — there is no address-shaped scan for those chains at the provider. Extending coverage to them is out of scope here, matching the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipient-only security scanning for swaps when full source-chain transaction scanning isn’t supported.
  * Supported EVM destination checks using the swap’s external recipient.
  * Security scanning now skips unsupported chains, missing recipients, and unsupported destinations safely.

* **Bug Fixes**
  * Improved security-scan handling for swaps originating on non-EVM chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->