### PR TITLE
fix(folder): vertically center vault name in Edit Folder rows

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -55,6 +55,7 @@ import com.vultisig.wallet.data.usecases.GenerateQrBitmap
 import com.vultisig.wallet.data.usecases.MakeQrCodeBitmapShareFormat
 import com.vultisig.wallet.data.usecases.QrShareField
 import com.vultisig.wallet.data.usecases.QrShareInfo
+import com.vultisig.wallet.data.usecases.VaultAndBalance
 import com.vultisig.wallet.ui.components.SignMessageCard
 import com.vultisig.wallet.ui.components.SignTonDisplayView
 import com.vultisig.wallet.ui.components.UiIcon
@@ -88,6 +89,7 @@ import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorR
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
+import com.vultisig.wallet.ui.models.folder.CreateFolderUiModel
 import com.vultisig.wallet.ui.models.governance.GovernanceUiState
 import com.vultisig.wallet.ui.models.governance.ProposalStatus
 import com.vultisig.wallet.ui.models.governance.ProposalUi
@@ -122,6 +124,8 @@ import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingVerifyContent
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingPositionSkeleton
 import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
+import com.vultisig.wallet.ui.screens.folder.CreateFolderScreen
+import com.vultisig.wallet.ui.screens.folder.generateFakeVault
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
 import com.vultisig.wallet.ui.screens.keygen.SelectVaultTypeScreenPreview
@@ -310,6 +314,7 @@ class PreviewActivity : ComponentActivity() {
                     "verify_send_empty_memo" -> VerifySendEmptyMemoPreview()
                     "unbond_verify_before" -> UnbondVerifyPreview(after = false)
                     "unbond_verify_after" -> UnbondVerifyPreview(after = true)
+                    "edit_folder" -> EditFolderPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -412,6 +417,53 @@ private fun SwapAdvancedLockedPreview() {
                 ),
             onGetVult = {},
             onDismiss = {},
+        )
+    }
+}
+
+/**
+ * Edit Folder bottom sheet (#folder-row-centering). The active-vault rows are built without a
+ * balance, which is exactly the case that exposed the vertical-centering bug in [VaultCeil]: the
+ * empty subtitle line pushed the vault name above the row's center. The "Available" row keeps its
+ * balance ("US$3.14") so both the fixed and unfixed states are visible in one screen.
+ */
+@Composable
+private fun EditFolderPreview() {
+    val secureSigners = listOf("iPhone-A1B", "iPhone-C2D")
+    val fastSigners = listOf("Server-206", "iPhone-C2D")
+
+    fun vaultAndBalance(name: String, signers: List<String>, balance: String?) =
+        VaultAndBalance(
+            vault = generateFakeVault().copy(name = name, signers = signers),
+            balance = balance,
+            balanceFiatValue = null,
+        )
+
+    val activeVaults =
+        listOf(
+            vaultAndBalance("Secure Vault #1", secureSigners, balance = null),
+            vaultAndBalance("Ahmad-Ehsan", secureSigners, balance = null),
+            vaultAndBalance("sss", secureSigners, balance = null),
+            vaultAndBalance("Fast-DKLS", fastSigners, balance = null),
+        )
+    val availableVaults =
+        listOf(vaultAndBalance("Fast-QBTC-Claim", fastSigners, balance = "US$3.14"))
+
+    Box(modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+        CreateFolderScreen(
+            state =
+                CreateFolderUiModel(
+                    currentName = "test",
+                    vaults = activeVaults,
+                    availableVaults = availableVaults,
+                ),
+            textFieldState = remember { TextFieldState("test") },
+            onAddVaultClick = {},
+            onCheckVault = { _, _ -> },
+            isEditMode = true,
+            onMoveVaults = { _, _ -> },
+            tryCheck = { checked, _ -> checked },
+            onDeleteFolderClick = {},
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
@@ -108,6 +108,9 @@ internal fun VaultCeil(
 
                 UiSpacer(size = 12.dp)
 
+                val hasSubtitle =
+                    activeVaultName != null || model.isFolder || !model.balance.isNullOrEmpty()
+
                 Column {
                     Text(
                         text = model.name,
@@ -117,54 +120,57 @@ internal fun VaultCeil(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.widthIn(max = 140.dp),
                     )
-                    UiSpacer(size = 2.dp)
-                    Row(verticalAlignment = Alignment.Bottom) {
-                        if (model.isFolder && isSelected && activeVaultName != null) {
-                            UiIcon(
-                                drawableResId = R.drawable.ic_check,
-                                tint = Theme.v2.colors.alerts.info,
-                                size = 16.dp,
-                            )
-                            UiSpacer(size = 4.dp)
-                        }
-
-                        if (activeVaultName != null) {
-                            Row {
-                                ActiveVaultName(
-                                    isSelected = isSelected,
-                                    isFolder = model.isFolder,
-                                    content = "'",
+                    if (hasSubtitle) {
+                        UiSpacer(size = 2.dp)
+                        Row(verticalAlignment = Alignment.Bottom) {
+                            if (model.isFolder && isSelected && activeVaultName != null) {
+                                UiIcon(
+                                    drawableResId = R.drawable.ic_check,
+                                    tint = Theme.v2.colors.alerts.info,
+                                    size = 16.dp,
                                 )
-                                ActiveVaultName(
-                                    isSelected = isSelected,
-                                    isFolder = model.isFolder,
-                                    content = activeVaultName,
-                                )
-                                ActiveVaultName(
-                                    isSelected = isSelected,
-                                    isFolder = model.isFolder,
-                                    content = "'",
-                                )
-
                                 UiSpacer(size = 4.dp)
+                            }
 
-                                ActiveVaultName(
-                                    isSelected = isSelected,
-                                    isFolder = model.isFolder,
-                                    content = stringResource(R.string.vault_ceil_active),
+                            if (activeVaultName != null) {
+                                Row {
+                                    ActiveVaultName(
+                                        isSelected = isSelected,
+                                        isFolder = model.isFolder,
+                                        content = "'",
+                                    )
+                                    ActiveVaultName(
+                                        isSelected = isSelected,
+                                        isFolder = model.isFolder,
+                                        content = activeVaultName,
+                                    )
+                                    ActiveVaultName(
+                                        isSelected = isSelected,
+                                        isFolder = model.isFolder,
+                                        content = "'",
+                                    )
+
+                                    UiSpacer(size = 4.dp)
+
+                                    ActiveVaultName(
+                                        isSelected = isSelected,
+                                        isFolder = model.isFolder,
+                                        content = stringResource(R.string.vault_ceil_active),
+                                    )
+                                }
+                            } else {
+                                Text(
+                                    text =
+                                        if (model.isFolder)
+                                            "$vaultCounts Vault${if (vaultCounts != 1) "s" else ""}"
+                                        else model.balance ?: "",
+                                    style = Theme.brockmann.supplementary.footnote,
+                                    color =
+                                        if (model.isFolder && isSelected)
+                                            Theme.v2.colors.alerts.info
+                                        else Theme.v2.colors.text.tertiary,
                                 )
                             }
-                        } else {
-                            Text(
-                                text =
-                                    if (model.isFolder)
-                                        "$vaultCounts Vault${if (vaultCounts != 1) "s" else ""}"
-                                    else model.balance ?: "",
-                                style = Theme.brockmann.supplementary.footnote,
-                                color =
-                                    if (model.isFolder && isSelected) Theme.v2.colors.alerts.info
-                                    else Theme.v2.colors.text.tertiary,
-                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/folder/CreateFolderScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/folder/CreateFolderScreen.kt
@@ -98,7 +98,7 @@ internal fun CreateFolderScreen(
 }
 
 @Composable
-private fun CreateFolderScreen(
+internal fun CreateFolderScreen(
     state: CreateFolderUiModel,
     textFieldState: TextFieldState,
     onAddVaultClick: () -> Unit,


### PR DESCRIPTION
## Summary

On the **Edit Folder** screen, the vault **name** in each **Active Vaults** row was not vertically centered — it sat above the row's center, misaligned with the vault icon and toggle.

### Root cause
The active-vault rows build a `VaultCeilUiModel` **without** a `balance`. `VaultCeil` still rendered the subtitle as `Text(text = model.balance ?: "")` — an empty, invisible line that reserved a full footnote line-height plus a 2.dp spacer. Because the row is laid out `CenterVertically`, it centered the whole `Column` (name + invisible subtitle), pushing the visible name above the icon's center. The **Available** row has a real balance, so it looked balanced — which is why only the active rows appeared off.

### Fix
Only render the subtitle line (and its spacer) when there is something to show — an active-vault name, a folder count, or a non-empty balance. Balance-less rows now collapse to just the name and center correctly. Folder rows and vaults with a balance are unchanged (`hasSubtitle` stays true).

### Also
- Exposed the inner `CreateFolderScreen` overload as `internal` and added an `edit_folder` debug preview in `PreviewActivity` to render the screen with mock data for before/after capture.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/YBLtFs7.png) | ![after](https://i.imgur.com/kbKfxtT.png) |

## Test plan
- Open a folder → tap edit (pencil) → verify each **Active Vaults** row's name is vertically centered with the icon and toggle.
- Verify the **Available** row (with a balance) and folder rows are unchanged.

Closes #5388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault row layout so subtitle areas are shown only when relevant information is available.
  * Improved vertical centering for vault rows without balances.

* **Preview**
  * Added an edit-folder preview showcasing vault rows with and without balances for easier visual verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->