### PR TITLE
fix(qr): raise error correction so the address QR logo doesn't break decoding

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GenerateAccountQrUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GenerateAccountQrUseCase.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Path
 import android.util.TypedValue
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
@@ -53,7 +54,7 @@ constructor(
                         Path.Direction.CCW,
                     )
                     canvas.clipPath(path)
-                    canvas.drawColor(V2.colors.neutrals.n50.toArgb())
+                    canvas.drawColor(V2.colors.backgrounds.secondary.toArgb())
                     drawable.setBounds(0, 0, canvas.width, canvas.height)
                     drawable.draw(canvas)
                     bitmap
@@ -64,11 +65,8 @@ constructor(
 
     private suspend fun generateQr(address: String, logo: Bitmap?): QrBitmapData {
         val qrBitmap =
-            // Dark modules on a light, opaque background — not just app-internal contrast.
-            // Third-party scanners (notably iOS's Camera/Vision QR reader) frequently fail to
-            // decode color-inverted (light-on-dark) QR codes that our own in-app scanner tolerates.
             withContext(Dispatchers.IO) {
-                generateQrBitmap(address, colors.neutrals.n900, colors.neutrals.n50, logo)
+                generateQrBitmap(address, colors.neutrals.n50, Color.Transparent, logo)
             }
 
         val bitmapPainter =

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/GenerateAccountQrUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/GenerateAccountQrUseCase.kt
@@ -6,7 +6,6 @@ import android.graphics.Canvas
 import android.graphics.Path
 import android.util.TypedValue
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
@@ -54,7 +53,7 @@ constructor(
                         Path.Direction.CCW,
                     )
                     canvas.clipPath(path)
-                    canvas.drawColor(V2.colors.backgrounds.secondary.toArgb())
+                    canvas.drawColor(V2.colors.neutrals.n50.toArgb())
                     drawable.setBounds(0, 0, canvas.width, canvas.height)
                     drawable.draw(canvas)
                     bitmap
@@ -65,8 +64,11 @@ constructor(
 
     private suspend fun generateQr(address: String, logo: Bitmap?): QrBitmapData {
         val qrBitmap =
+            // Dark modules on a light, opaque background — not just app-internal contrast.
+            // Third-party scanners (notably iOS's Camera/Vision QR reader) frequently fail to
+            // decode color-inverted (light-on-dark) QR codes that our own in-app scanner tolerates.
             withContext(Dispatchers.IO) {
-                generateQrBitmap(address, colors.neutrals.n50, Color.Transparent, logo)
+                generateQrBitmap(address, colors.neutrals.n900, colors.neutrals.n50, logo)
             }
 
         val bitmapPainter =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GenerateQrBitmap.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GenerateQrBitmap.kt
@@ -7,6 +7,7 @@ import androidx.core.graphics.scale
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import javax.inject.Inject
 
 private const val QR_CODE_SCALE_FACTOR = 8
@@ -27,7 +28,16 @@ internal class GenerateQrBitmapImpl @Inject constructor() : GenerateQrBitmap {
         backgroundColor: Color,
         logo: Bitmap?,
     ): Bitmap {
-        val hintMap = mapOf(EncodeHintType.MARGIN to QR_CODE_QUIET_ZONE)
+        // Logos overwrite modules in the center, so bump error correction well past the ZXing
+        // default (L, ~7%) to leave enough recovery budget for the overwritten area — otherwise
+        // stricter third-party decoders (e.g. iOS's AVFoundation/Vision scanner) fail to decode.
+        val hintMap =
+            mapOf(EncodeHintType.MARGIN to QR_CODE_QUIET_ZONE) +
+                if (logo != null) {
+                    mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.H)
+                } else {
+                    emptyMap()
+                }
 
         val qrCodeWriter = QRCodeWriter()
         val bitmapMatrix = qrCodeWriter.encode(qrCodeContent, BarcodeFormat.QR_CODE, 0, 0, hintMap)


### PR DESCRIPTION
## Summary
- Receive-address QR codes embed a chain logo over the center of the code, but generation never raised error correction above ZXing's default (`L`, ~7% recovery budget) — leaving too little headroom for the modules the logo overwrites.
- Stricter third-party decoders (notably iOS's AVFoundation/Vision-based scanner) failed to decode the result. Android's own ZXing-based scanner is far more tolerant, which is why this only surfaced on iOS.
- Keygen/keysign/QBTC pairing QR codes are unaffected — they never embed a logo, so this path was never exercised for them; confirmed manually those already scan fine.
- Fixed `GenerateQrBitmap` to set `EncodeHintType.ERROR_CORRECTION = H` whenever a logo is present (address QR only); no change for the logo-less QR flows.
- An earlier attempt in this PR swapped the QR's colors to standard dark-on-light polarity. That was reverted — manual testing showed it did not fix the iOS scanning issue, confirming color polarity wasn't the actual cause.

## Test Plan
- [x] `./gradlew :app:compileDebugKotlin` succeeds
- [x] `./gradlew lint` passes
- [x] Manually verified: receive-address QR now scans successfully with an iOS device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code readability when a logo is overlaid by applying stronger error correction.
  * QR codes without logos continue to use the standard generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->