### PR TITLE
refactor(defi): share tab models and fiat conversion across Thorchain and Maya

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiFiatValueCalculator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiFiatValueCalculator.kt
@@ -1,0 +1,73 @@
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import java.math.BigDecimal
+import java.math.RoundingMode
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
+
+/**
+ * Prices DeFi position amounts in the user's currency.
+ *
+ * The Thorchain and Maya position screens each carried their own identical copy of this conversion;
+ * it lives here so both share one implementation. A price lookup that fails yields a zero value
+ * rather than propagating, so a position whose price is momentarily unavailable still renders its
+ * underlying token amount instead of collapsing the whole tab.
+ */
+internal class DefiFiatValueCalculator
+@Inject
+constructor(private val tokenPriceRepository: TokenPriceRepository) {
+
+    suspend fun createFiatValue(amount: BigDecimal, coin: Coin, currency: AppCurrency): FiatValue =
+        convert(amount, currency) {
+            tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
+                ?: tokenPriceRepository.getPriceByContactAddress(
+                    coin.chain.id,
+                    coin.contractAddress,
+                )
+        }
+
+    /**
+     * Prices a pool asset the vault does not hold as a [Coin], so there is no coin id to look up —
+     * the cache key is rebuilt from the pool's ticker and chain instead.
+     */
+    suspend fun createFiatValueFromPoolAsset(
+        amount: BigDecimal,
+        chain: Chain,
+        ticker: String,
+        contractAddress: String,
+        currency: AppCurrency,
+    ): FiatValue =
+        convert(amount, currency) {
+            tokenPriceRepository.getCachedPrice(
+                tokenId = "$ticker-${chain.id}",
+                appCurrency = currency,
+            ) ?: tokenPriceRepository.getPriceByContactAddress(chain.id, contractAddress)
+        }
+
+    private suspend fun convert(
+        amount: BigDecimal,
+        currency: AppCurrency,
+        price: suspend () -> BigDecimal,
+    ): FiatValue =
+        try {
+            // Scale-sensitive by design: only an exact BigDecimal.ZERO skips the price lookup.
+            if (amount == BigDecimal.ZERO) {
+                FiatValue(BigDecimal.ZERO, currency.ticker)
+            } else {
+                FiatValue(
+                    value = amount.multiply(price()).setScale(2, RoundingMode.DOWN),
+                    currency = currency.ticker,
+                )
+            }
+        } catch (t: Throwable) {
+            if (t is CancellationException) throw t
+            Timber.e(t)
+            FiatValue(value = BigDecimal.ZERO, currency = currency.ticker)
+        }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -1,0 +1,75 @@
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.coinType
+import com.vultisig.wallet.data.utils.symbol
+import com.vultisig.wallet.ui.screens.v2.defi.model.BondNodeState
+import com.vultisig.wallet.ui.utils.UiText
+import java.math.BigDecimal
+
+/**
+ * UI models for the Bonded / Staking / LP tabs, shared by every DeFi positions screen. They used to
+ * live inside ThorchainDefiPositionsViewModel.kt, which made them look Thorchain-specific even
+ * though the Maya screen renders the same tabs from the same types.
+ */
+internal data class BondedTabUiModel(
+    val isLoading: Boolean = false,
+    val totalBondedAmount: String = "0 ${Chain.ThorChain.coinType.symbol}",
+    val totalBondedPrice: String = "",
+    val nodes: List<BondedNodeUiModel> = emptyList(),
+)
+
+internal data class StakingTabUiModel(val positions: List<StakePositionUiModel> = emptyList())
+
+internal data class LpTabUiModel(
+    val isLoading: Boolean = false,
+    val positions: List<LpPositionUiModel> = emptyList(),
+)
+
+internal data class LpPositionUiModel(
+    val titleLp: String,
+    val totalPriceLp: String,
+    val icon: ImageModel,
+    val assetTicker: String,
+    val apr: String?,
+    val position: String,
+    val positionKey: String = "",
+    val canRemove: Boolean = true,
+    val chainLogo: Int? = null,
+)
+
+internal data class StakePositionUiModel(
+    val coin: Coin,
+    val stakeAssetHeader: UiText,
+    val stakeAmount: BigDecimal = BigDecimal.ZERO,
+    val stakedAmountDisplay: String,
+    val stakedFiatDisplay: String = "",
+    val apy: String?,
+    val isLoading: Boolean = false,
+    val supportsMint: Boolean = false,
+    val canWithdraw: Boolean = false,
+    val canTransfer: Boolean = false,
+    val canStake: Boolean = true,
+    val canUnstake: Boolean = false,
+    val rewards: String? = null,
+    val nextReward: String? = null,
+    val nextPayout: String? = null,
+    // Maya CACAO pool only: remaining time until the position becomes unstake-eligible.
+    // Drives the "Unlocks in N days, H hours" hint next to the disabled Unstake button.
+    val unstakeUnlocksInSeconds: Long? = null,
+    // Maya CACAO pool only: true when the maturity RPC returned UNKNOWN so the staking tab can
+    // surface "Couldn't verify position" instead of an unexplained disabled Unstake button.
+    val isUnstakeMaturityUnknown: Boolean = false,
+)
+
+internal data class BondedNodeUiModel(
+    val address: String,
+    val fullAddress: String,
+    val status: BondNodeState,
+    val apy: String,
+    val bondedAmount: String,
+    val nextAward: String,
+    val nextChurn: String,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.MayaMemberDetails
 import com.vultisig.wallet.data.api.MayaNodePool
 import com.vultisig.wallet.data.blockchain.maya.MayaCacaoStakingService
@@ -15,7 +16,6 @@ import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.lpAssetLogoRes
 import com.vultisig.wallet.data.models.monoToneLogo
-import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -47,7 +47,7 @@ import java.math.BigInteger
 import java.math.RoundingMode
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -134,6 +134,8 @@ constructor(
     private val appCurrencyRepository: AppCurrencyRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val defiPositionsRepository: DefiPositionsRepository,
+    private val fiatValueCalculator: DefiFiatValueCalculator,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private lateinit var vaultId: String
@@ -188,7 +190,7 @@ constructor(
     private fun loadBalanceVisibility() {
         viewModelScope.safeLaunch {
             val isVisible =
-                withContext(Dispatchers.IO) { balanceVisibilityRepository.getVisibility(vaultId) }
+                withContext(ioDispatcher) { balanceVisibilityRepository.getVisibility(vaultId) }
             updateModel { it.copy(isBalanceVisible = isVisible) }
         }
     }
@@ -219,8 +221,7 @@ constructor(
     private fun loadLpPositionsForDialog(): Job =
         viewModelScope.launch {
             try {
-                val pools =
-                    withContext(Dispatchers.IO) { mayachainBondRepository.getMayaNodePools() }
+                val pools = withContext(ioDispatcher) { mayachainBondRepository.getMayaNodePools() }
                 val lpPositions = pools.map { pool -> pool.toPositionDialogModel() }
                 updateModel { it.copy(lpPositionsDialog = lpPositions) }
                 reloadLpTab()
@@ -235,7 +236,7 @@ constructor(
         updateModel { it.copy(bonded = it.bonded.copy(isLoading = true)) }
 
         try {
-            val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+            val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
             val cacaoCoin =
                 vault?.coins?.find {
                     it.ticker == Coins.MayaChain.CACAO.ticker && it.chain == Chain.MayaChain
@@ -323,7 +324,7 @@ constructor(
         updateModel { it.copy(staking = StakingTabUiModel(positions = listOf(loadingPosition))) }
 
         try {
-            val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+            val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
             val cacaoCoin =
                 vault?.coins?.find {
                     it.ticker == Coins.MayaChain.CACAO.ticker && it.chain == Chain.MayaChain
@@ -394,9 +395,14 @@ constructor(
             try {
                 val currency = appCurrencyRepository.currency.first()
                 val totalInCacao = totalRaw.toValue(10)
-                val fiatValue = createFiatValue(totalInCacao, Coins.MayaChain.CACAO, currency)
+                val fiatValue =
+                    fiatValueCalculator.createFiatValue(
+                        totalInCacao,
+                        Coins.MayaChain.CACAO,
+                        currency,
+                    )
                 val currencyFormat =
-                    withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
                 updateModel {
                     it.copy(
                         totalAmountPrice = currencyFormat.format(fiatValue.value),
@@ -414,9 +420,10 @@ constructor(
     private suspend fun calculateStakingFiatPrice(amount: BigDecimal): String {
         return try {
             val currency = appCurrencyRepository.currency.first()
-            val fiatValue = createFiatValue(amount, Coins.MayaChain.CACAO, currency)
+            val fiatValue =
+                fiatValueCalculator.createFiatValue(amount, Coins.MayaChain.CACAO, currency)
             val currencyFormat =
-                withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
             currencyFormat.format(fiatValue.value)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -429,63 +436,15 @@ constructor(
         return try {
             val totalInCacao = totalBondedRaw.toValue(10)
             val currency = appCurrencyRepository.currency.first()
-            val fiatValue = createFiatValue(totalInCacao, Coins.MayaChain.CACAO, currency)
+            val fiatValue =
+                fiatValueCalculator.createFiatValue(totalInCacao, Coins.MayaChain.CACAO, currency)
             val currencyFormat =
-                withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
             currencyFormat.format(fiatValue.value)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Timber.e(e, "Failed to calculate Maya bonded fiat price")
             ""
-        }
-    }
-
-    private suspend fun createFiatValue(
-        amount: BigDecimal,
-        coin: com.vultisig.wallet.data.models.Coin,
-        currency: AppCurrency,
-    ): FiatValue {
-        return try {
-            if (amount == BigDecimal.ZERO) return FiatValue(BigDecimal.ZERO, currency.ticker)
-            val price =
-                tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
-                    ?: tokenPriceRepository.getPriceByContactAddress(
-                        coin.chain.id,
-                        coin.contractAddress,
-                    )
-            FiatValue(
-                value = amount.multiply(price).setScale(2, RoundingMode.DOWN),
-                currency = currency.ticker,
-            )
-        } catch (t: Throwable) {
-            if (t is CancellationException) throw t
-            Timber.e(t)
-            FiatValue(value = BigDecimal.ZERO, currency = currency.ticker)
-        }
-    }
-
-    private suspend fun createFiatValueFromPoolAsset(
-        amount: BigDecimal,
-        chain: Chain,
-        ticker: String,
-        contractAddress: String,
-        currency: AppCurrency,
-    ): FiatValue {
-        return try {
-            if (amount == BigDecimal.ZERO) return FiatValue(BigDecimal.ZERO, currency.ticker)
-            val price =
-                tokenPriceRepository.getCachedPrice(
-                    tokenId = "$ticker-${chain.id}",
-                    appCurrency = currency,
-                ) ?: tokenPriceRepository.getPriceByContactAddress(chain.id, contractAddress)
-            FiatValue(
-                value = amount.multiply(price).setScale(2, RoundingMode.DOWN),
-                currency = currency.ticker,
-            )
-        } catch (t: Throwable) {
-            if (t is CancellationException) throw t
-            Timber.e(t)
-            FiatValue(value = BigDecimal.ZERO, currency = currency.ticker)
         }
     }
 
@@ -534,7 +493,7 @@ constructor(
         loadLpJob?.cancel()
         loadLpJob =
             viewModelScope.safeLaunch {
-                val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+                val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
                 val cacaoCoin =
                     vault?.coins?.find {
                         it.ticker == Coins.MayaChain.CACAO.ticker && it.chain == Chain.MayaChain
@@ -561,7 +520,7 @@ constructor(
                 }
 
                 val (memberDetails, poolStats) =
-                    withContext(Dispatchers.IO) {
+                    withContext(ioDispatcher) {
                         coroutineScope {
                             val memberDeferred = async {
                                 try {
@@ -589,7 +548,7 @@ constructor(
                 val poolStatsMap = poolStats.associateBy { it.asset }
                 val currency = appCurrencyRepository.currency.first()
                 val currencyFormat =
-                    withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
 
                 val lpPositions =
                     selectedPools.map { pool ->
@@ -644,9 +603,13 @@ constructor(
 
                         val assetFiatValue =
                             if (assetCoin != null) {
-                                createFiatValue(assetAmount, assetCoin, currency)
+                                fiatValueCalculator.createFiatValue(
+                                    assetAmount,
+                                    assetCoin,
+                                    currency,
+                                )
                             } else if (assetChain != null) {
-                                createFiatValueFromPoolAsset(
+                                fiatValueCalculator.createFiatValueFromPoolAsset(
                                     assetAmount,
                                     assetChain,
                                     assetCoinTicker,
@@ -657,7 +620,11 @@ constructor(
                                 FiatValue(BigDecimal.ZERO, currency.ticker)
                             }
                         val cacaoFiatValue =
-                            createFiatValue(cacaoAmount, Coins.MayaChain.CACAO, currency)
+                            fiatValueCalculator.createFiatValue(
+                                cacaoAmount,
+                                Coins.MayaChain.CACAO,
+                                currency,
+                            )
                         val totalFiatValue =
                             FiatValue(
                                 value = assetFiatValue.value.add(cacaoFiatValue.value),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -21,7 +21,6 @@ import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DefiPositionsRepository
 import com.vultisig.wallet.data.repositories.MayachainBondRepository
-import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.MayachainBondUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -130,7 +129,6 @@ constructor(
     private val mayachainBondRepository: MayachainBondRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val mayaCacaoStakingService: MayaCacaoStakingService,
-    private val tokenPriceRepository: TokenPriceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val defiPositionsRepository: DefiPositionsRepository,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.defi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolStatsJson
 import com.vultisig.wallet.data.blockchain.model.BondedNodePosition
 import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
@@ -29,7 +30,6 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
 import com.vultisig.wallet.data.usecases.ThorchainBondUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
-import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.data.utils.toValue
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -47,7 +47,6 @@ import com.vultisig.wallet.ui.screens.v2.defi.formatToString
 import com.vultisig.wallet.ui.screens.v2.defi.getContractByDeFiAction
 import com.vultisig.wallet.ui.screens.v2.defi.hasBondPositions
 import com.vultisig.wallet.ui.screens.v2.defi.hasStakingPositions
-import com.vultisig.wallet.ui.screens.v2.defi.model.BondNodeState
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.screens.v2.defi.thorchainSupportStakingDeFi
@@ -59,7 +58,7 @@ import java.math.BigInteger
 import java.math.RoundingMode
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,66 +96,6 @@ internal data class ThorchainDefiPositionsUiModel(
     val tempSelectedPositions: List<String> = defaultSelectedPositionsDialog(),
 )
 
-internal data class BondedTabUiModel(
-    val isLoading: Boolean = false,
-    val totalBondedAmount: String = "0 ${Chain.ThorChain.coinType.symbol}",
-    val totalBondedPrice: String = "",
-    val nodes: List<BondedNodeUiModel> = emptyList(),
-)
-
-internal data class StakingTabUiModel(val positions: List<StakePositionUiModel> = emptyList())
-
-internal data class LpTabUiModel(
-    val isLoading: Boolean = false,
-    val positions: List<LpPositionUiModel> = emptyList(),
-)
-
-internal data class LpPositionUiModel(
-    val titleLp: String,
-    val totalPriceLp: String,
-    val icon: ImageModel,
-    val assetTicker: String,
-    val apr: String?,
-    val position: String,
-    val positionKey: String = "",
-    val canRemove: Boolean = true,
-    val chainLogo: Int? = null,
-)
-
-internal data class StakePositionUiModel(
-    val coin: Coin,
-    val stakeAssetHeader: UiText,
-    val stakeAmount: BigDecimal = BigDecimal.ZERO,
-    val stakedAmountDisplay: String,
-    val stakedFiatDisplay: String = "",
-    val apy: String?,
-    val isLoading: Boolean = false,
-    val supportsMint: Boolean = false,
-    val canWithdraw: Boolean = false,
-    val canTransfer: Boolean = false,
-    val canStake: Boolean = true,
-    val canUnstake: Boolean = false,
-    val rewards: String? = null,
-    val nextReward: String? = null,
-    val nextPayout: String? = null,
-    // Maya CACAO pool only: remaining time until the position becomes unstake-eligible.
-    // Drives the "Unlocks in N days, H hours" hint next to the disabled Unstake button.
-    val unstakeUnlocksInSeconds: Long? = null,
-    // Maya CACAO pool only: true when the maturity RPC returned UNKNOWN so the staking tab can
-    // surface "Couldn't verify position" instead of an unexplained disabled Unstake button.
-    val isUnstakeMaturityUnknown: Boolean = false,
-)
-
-internal data class BondedNodeUiModel(
-    val address: String,
-    val fullAddress: String,
-    val status: BondNodeState,
-    val apy: String,
-    val bondedAmount: String,
-    val nextAward: String,
-    val nextChurn: String,
-)
-
 data class TotalDefiValue(
     val bondAmount: BigInteger = BigInteger.ZERO,
     val defaultStakeValues: StakeDefaultValues = StakeDefaultValues(),
@@ -173,6 +112,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val bondUseCase: ThorchainBondUseCase,
     private val tokenPriceRepository: TokenPriceRepository,
+    private val fiatValueCalculator: DefiFiatValueCalculator,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val rujiStakingService: RujiStakingService,
     private val tcyStakingService: TCYStakingService,
@@ -180,6 +120,7 @@ constructor(
     private val defaultStakingPositionService: DefaultStakingPositionService,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private lateinit var vaultId: String
@@ -229,7 +170,7 @@ constructor(
         viewModelScope.launch {
             try {
                 val pools =
-                    withContext(Dispatchers.IO) {
+                    withContext(ioDispatcher) {
                         getThorChainLpPositionsUseCase.fetchAvailablePools()
                     }
                 availablePools.value = pools
@@ -259,7 +200,7 @@ constructor(
     private fun loadBalanceVisibility() {
         viewModelScope.launch {
             val isVisible =
-                withContext(Dispatchers.IO) { balanceVisibilityRepository.getVisibility(vaultId) }
+                withContext(ioDispatcher) { balanceVisibilityRepository.getVisibility(vaultId) }
             state.update { it.copy(isBalanceVisible = isVisible) }
         }
     }
@@ -298,14 +239,17 @@ constructor(
             try {
                 val currency = appCurrencyRepository.currency.first()
 
-                val runeFiatValue = createFiatValue(totalInRune, Coins.ThorChain.RUNE, currency)
-                val rujiFiatValue = createFiatValue(totalInRuji, Coins.ThorChain.RUJI, currency)
-                val tcyFiatValue = createFiatValue(totalInTCY, Coins.ThorChain.TCY, currency)
+                val runeFiatValue =
+                    fiatValueCalculator.createFiatValue(totalInRune, Coins.ThorChain.RUNE, currency)
+                val rujiFiatValue =
+                    fiatValueCalculator.createFiatValue(totalInRuji, Coins.ThorChain.RUJI, currency)
+                val tcyFiatValue =
+                    fiatValueCalculator.createFiatValue(totalInTCY, Coins.ThorChain.TCY, currency)
 
                 val defaultStakingFiatValues =
                     totalValue.defaultStakeValues.stakeElements.map { position ->
                         val decimalAmount = CoinType.THORCHAIN.toValue(position.amount)
-                        createFiatValue(decimalAmount, position.coin, currency)
+                        fiatValueCalculator.createFiatValue(decimalAmount, position.coin, currency)
                     }
 
                 val totalFiatValue =
@@ -316,7 +260,7 @@ constructor(
                         }
 
                 val currencyFormat =
-                    withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
 
                 state.update {
                     it.copy(
@@ -333,40 +277,11 @@ constructor(
         }
     }
 
-    private suspend fun createFiatValue(
-        amount: BigDecimal,
-        coin: Coin,
-        currency: AppCurrency,
-    ): FiatValue {
-        try {
-            if (amount == BigDecimal.ZERO) {
-                return FiatValue(BigDecimal.ZERO, currency.ticker)
-            }
-
-            val price =
-                tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
-                    ?: tokenPriceRepository.getPriceByContactAddress(
-                        coin.chain.id,
-                        coin.contractAddress,
-                    )
-
-            return FiatValue(
-                value = amount.multiply(price).setScale(2, RoundingMode.DOWN),
-                currency = currency.ticker,
-            )
-        } catch (t: Throwable) {
-            if (t is kotlinx.coroutines.CancellationException) throw t
-            Timber.e(t)
-
-            return FiatValue(value = BigDecimal.ZERO, currency = currency.ticker)
-        }
-    }
-
     private suspend fun calculateStakingFiatPrice(amount: BigDecimal, coin: Coin): String {
         return try {
             val currency = appCurrencyRepository.currency.first()
             val currencyFormat =
-                withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
             formatFiatString(amount, coin, currency, currencyFormat)
         } catch (e: java.io.IOException) {
             Timber.e(e, "Failed to calculate THORChain staking fiat price")
@@ -380,7 +295,7 @@ constructor(
         currency: AppCurrency,
         currencyFormat: java.text.NumberFormat,
     ): String {
-        val fiatValue = createFiatValue(amount, coin, currency)
+        val fiatValue = fiatValueCalculator.createFiatValue(amount, coin, currency)
         return currencyFormat.format(fiatValue.value)
     }
 
@@ -423,7 +338,7 @@ constructor(
 
                 // Load selected positions, if disabled then show nothing
                 try {
-                    val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+                    val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
                     // THORChain vaults hold several coins (RUNE, RUJI, TCY, …); match RUNE
                     // explicitly so we bond against the RUNE address, not the first THORChain coin.
                     val runeCoin =
@@ -496,9 +411,10 @@ constructor(
         return try {
             val totalInRune = CoinType.THORCHAIN.toValue(totalBondedRaw)
             val currency = appCurrencyRepository.currency.first()
-            val fiatValue = createFiatValue(totalInRune, Coins.ThorChain.RUNE, currency)
+            val fiatValue =
+                fiatValueCalculator.createFiatValue(totalInRune, Coins.ThorChain.RUNE, currency)
             val currencyFormat =
-                withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
             currencyFormat.format(fiatValue.value)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
@@ -532,7 +448,7 @@ constructor(
             }
 
             try {
-                val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+                val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
 
                 // THORChain hosts several coins (RUNE, RUJI, TCY…); staking is held against the
                 // RUNE account, so match the ticker explicitly rather than the first chain coin.
@@ -736,7 +652,7 @@ constructor(
                     // suspend functions, so fiat strings are pre-computed here.
                     val currency = appCurrencyRepository.currency.first()
                     val currencyFormat =
-                        withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                        withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
                     val stakedFiatByCoinId = mutableMapOf<String, String>()
                     for (defaultPosition in loadedPositions) {
                         val amount = Chain.ThorChain.coinType.toValue(defaultPosition.stakeAmount)
@@ -872,7 +788,7 @@ constructor(
         loadLpJob =
             viewModelScope.launch {
                 try {
-                    val vault = withContext(Dispatchers.IO) { vaultRepository.get(vaultId) }
+                    val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
                     // THORChain hosts several coins (RUNE, RUJI, TCY…); LP positions are held
                     // against the RUNE account, so match the ticker explicitly rather than the
                     // first chain coin.
@@ -902,7 +818,7 @@ constructor(
                             .toMap()
 
                     val allPositions =
-                        withContext(Dispatchers.IO) {
+                        withContext(ioDispatcher) {
                             getThorChainLpPositionsUseCase(
                                 runeAddress = runeCoin.address,
                                 assetAddressesByPool = assetAddressesByPool,
@@ -913,7 +829,7 @@ constructor(
 
                     val currency = appCurrencyRepository.currency.first()
                     val currencyFormat =
-                        withContext(Dispatchers.IO) { appCurrencyRepository.getCurrencyFormat() }
+                        withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
                     val runePrice = priceFor(Coins.ThorChain.RUNE, currency)
 
                     val merged =
@@ -1108,7 +1024,7 @@ constructor(
             val selectedPositions = state.value.tempSelectedPositions
 
             launch {
-                withContext(Dispatchers.IO) {
+                withContext(ioDispatcher) {
                     defiPositionsRepository.saveSelectedPositions(vaultId, selectedPositions)
                 }
             }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/DefiFiatValueCalculatorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/DefiFiatValueCalculatorTest.kt
@@ -1,0 +1,137 @@
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the fiat conversion the Thorchain and Maya position screens now share. Both used to hold
+ * their own copy; these tests pin the single implementation for both callers.
+ */
+internal class DefiFiatValueCalculatorTest {
+
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var calculator: DefiFiatValueCalculator
+
+    @BeforeEach
+    fun setUp() {
+        tokenPriceRepository = mockk(relaxed = true)
+        calculator = DefiFiatValueCalculator(tokenPriceRepository)
+    }
+
+    @Test
+    fun `prices an amount from the cached price`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(RUNE.id, AppCurrency.USD) } returns
+            BigDecimal("2.5")
+
+        val fiat = calculator.createFiatValue(BigDecimal("4"), RUNE, AppCurrency.USD)
+
+        assertEquals(BigDecimal("10.00"), fiat.value)
+        assertEquals("USD", fiat.currency)
+    }
+
+    @Test
+    fun `truncates fractional cents instead of rounding up`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(RUNE.id, AppCurrency.USD) } returns
+            BigDecimal("0.999")
+
+        val fiat = calculator.createFiatValue(BigDecimal("1"), RUNE, AppCurrency.USD)
+
+        assertEquals(BigDecimal("0.99"), fiat.value)
+    }
+
+    @Test
+    fun `an exact zero amount short-circuits before any price lookup`() = runTest {
+        val fiat = calculator.createFiatValue(BigDecimal.ZERO, RUNE, AppCurrency.USD)
+
+        assertEquals(BigDecimal.ZERO, fiat.value)
+        coVerify(exactly = 0) { tokenPriceRepository.getCachedPrice(any(), any()) }
+        coVerify(exactly = 0) { tokenPriceRepository.getPriceByContactAddress(any(), any()) }
+    }
+
+    @Test
+    fun `falls back to the contract address when nothing is cached`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(RUNE.id, AppCurrency.USD) } returns null
+        coEvery {
+            tokenPriceRepository.getPriceByContactAddress(RUNE.chain.id, RUNE.contractAddress)
+        } returns BigDecimal("3")
+
+        val fiat = calculator.createFiatValue(BigDecimal("2"), RUNE, AppCurrency.USD)
+
+        assertEquals(BigDecimal("6.00"), fiat.value)
+    }
+
+    @Test
+    fun `a failed price lookup yields zero rather than propagating`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } throws
+            RuntimeException("price service down")
+
+        val fiat = calculator.createFiatValue(BigDecimal("2"), RUNE, AppCurrency.USD)
+
+        assertEquals(BigDecimal.ZERO, fiat.value)
+        assertEquals("USD", fiat.currency)
+    }
+
+    @Test
+    fun `cancellation is never swallowed by the failure path`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } throws
+            CancellationException("scope closed")
+
+        assertFailsWith<CancellationException> {
+            calculator.createFiatValue(BigDecimal("2"), RUNE, AppCurrency.USD)
+        }
+    }
+
+    @Test
+    fun `a pool asset is keyed by ticker and chain id`() = runTest {
+        coEvery {
+            tokenPriceRepository.getCachedPrice("BTC-${Chain.Bitcoin.id}", AppCurrency.USD)
+        } returns BigDecimal("100")
+
+        val fiat =
+            calculator.createFiatValueFromPoolAsset(
+                amount = BigDecimal("0.5"),
+                chain = Chain.Bitcoin,
+                ticker = "BTC",
+                contractAddress = "",
+                currency = AppCurrency.USD,
+            )
+
+        assertEquals(BigDecimal("50.00"), fiat.value)
+    }
+
+    @Test
+    fun `an uncached pool asset falls back to its contract address`() = runTest {
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns null
+        coEvery {
+            tokenPriceRepository.getPriceByContactAddress(Chain.Ethereum.id, CONTRACT)
+        } returns BigDecimal("4")
+
+        val fiat =
+            calculator.createFiatValueFromPoolAsset(
+                amount = BigDecimal("3"),
+                chain = Chain.Ethereum,
+                ticker = "USDC",
+                contractAddress = CONTRACT,
+                currency = AppCurrency.USD,
+            )
+
+        assertEquals(BigDecimal("12.00"), fiat.value)
+    }
+
+    private companion object {
+        val RUNE = Coins.ThorChain.RUNE
+        const val CONTRACT = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -1,0 +1,474 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.data.api.MayaLpPoolStats
+import com.vultisig.wallet.data.api.MayaMemberDetails
+import com.vultisig.wallet.data.api.MayaMemberPool
+import com.vultisig.wallet.data.api.MayaNodePool
+import com.vultisig.wallet.data.blockchain.maya.MayaCacaoStakingDetails
+import com.vultisig.wallet.data.blockchain.maya.MayaCacaoStakingService
+import com.vultisig.wallet.data.blockchain.model.BondedNodePosition
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.monoToneLogo
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DefiPositionsRepository
+import com.vultisig.wallet.data.repositories.MayachainBondRepository
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.MayachainBondUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.MAYA_BOND_CACAO_KEY
+import com.vultisig.wallet.ui.screens.v2.defi.MAYA_STAKE_CACAO_KEY
+import com.vultisig.wallet.ui.screens.v2.defi.model.BondNodeState
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Characterization tests: they pin the behavior this ViewModel has today so the upcoming split into
+ * a shared Thorchain/Maya base can be verified as behavior-preserving. They describe what the code
+ * does, not necessarily what it ought to do.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class MayachainDefiPositionsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var bondUseCase: MayachainBondUseCase
+    private lateinit var mayachainBondRepository: MayachainBondRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var mayaCacaoStakingService: MayaCacaoStakingService
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var defiPositionsRepository: DefiPositionsRepository
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        navigator = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        bondUseCase = mockk(relaxed = true)
+        mayachainBondRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
+        mayaCacaoStakingService = mockk(relaxed = true)
+        tokenPriceRepository = mockk(relaxed = true)
+        appCurrencyRepository = mockk(relaxed = true)
+        balanceVisibilityRepository = mockk(relaxed = true)
+        defiPositionsRepository = mockk(relaxed = true)
+
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
+        coEvery { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance(Locale.US)
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns BigDecimal("2")
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+
+        selectPositions(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY)
+        coEvery { mayachainBondRepository.getMayaNodePools() } returns emptyList()
+        coEvery { mayachainBondRepository.getMemberDetails(any()) } returns MayaMemberDetails()
+        coEvery { mayachainBondRepository.getLpPoolStats() } returns emptyList()
+        coEvery { bondUseCase.getActiveNodes(any(), any()) } returns flowOf(emptyList())
+        coEvery { mayaCacaoStakingService.getStakingDetails(any()) } returns
+            flowOf(MayaCacaoStakingDetails(BigInteger.ZERO, apr = null, canUnstake = false))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `setData emits Success seeded with the default Maya bond and stake selection`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val data = successData(vm)
+        assertEquals(listOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY), data.selectedPositions)
+        assertTrue(data.isBalanceVisible)
+    }
+
+    @Test
+    fun `a saved selection holding no Maya key falls back to the Maya defaults`() = runTest {
+        // Selection persisted by the Thorchain screen: recognising it here would blank both tabs.
+        selectPositions("RUNE", "TCY")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(
+            listOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY),
+            successData(vm).selectedPositions,
+        )
+    }
+
+    @Test
+    fun `a saved selection holding a Maya key is used verbatim`() = runTest {
+        selectPositions(MAYA_BOND_CACAO_KEY)
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(listOf(MAYA_BOND_CACAO_KEY), successData(vm).selectedPositions)
+    }
+
+    @Test
+    fun `a dotted LP asset key counts as a Maya selection`() = runTest {
+        // "BTC.BTC" carries no Maya prefix; the dot is what marks it as an LP pool key.
+        selectPositions("BTC.BTC")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(listOf("BTC.BTC"), successData(vm).selectedPositions)
+    }
+
+    @Test
+    fun `bonded nodes are mapped with truncated address and formatted amounts`() = runTest {
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
+            flowOf(listOf(bondedNode(amount = HUNDRED_CACAO)))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val bonded = successData(vm).bonded
+        assertFalse(bonded.isLoading)
+        assertEquals("100.00000000 CACAO", bonded.totalBondedAmount)
+        assertEquals("$200.00", bonded.totalBondedPrice)
+
+        val node = bonded.nodes.single()
+        assertEquals("maya1qwer...fgh", node.address)
+        assertEquals(NODE_ADDRESS, node.fullAddress)
+        assertEquals(BondNodeState.ACTIVE, node.status)
+        assertEquals("15.25%", node.apy)
+        assertEquals("100.00000000 CACAO", node.bondedAmount)
+        assertEquals("1.2345 CACAO", node.nextAward)
+        assertEquals("N/A", node.nextChurn)
+    }
+
+    @Test
+    fun `a vault without a CACAO coin leaves the bonded tab empty and settled`() = runTest {
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT.copy(coins = emptyList())
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val bonded = successData(vm).bonded
+        assertFalse(bonded.isLoading)
+        assertTrue(bonded.nodes.isEmpty())
+    }
+
+    @Test
+    fun `the CACAO staking position carries its maturity hints through to the UI`() = runTest {
+        coEvery { mayaCacaoStakingService.getStakingDetails(CACAO_ADDRESS) } returns
+            flowOf(
+                MayaCacaoStakingDetails(
+                    stakeAmount = FIFTY_CACAO,
+                    apr = 0.0812,
+                    canUnstake = false,
+                    unstakeUnlocksInSeconds = 3_600L,
+                    isUnstakeMaturityUnknown = true,
+                )
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val position = successData(vm).staking.positions.single()
+        assertEquals("50.0000 CACAO", position.stakedAmountDisplay)
+        assertEquals("$100.00", position.stakedFiatDisplay)
+        assertEquals("8.12%", position.apy)
+        assertFalse(position.canUnstake)
+        assertEquals(3_600L, position.unstakeUnlocksInSeconds)
+        assertTrue(position.isUnstakeMaturityUnknown)
+    }
+
+    @Test
+    fun `deselecting the stake key clears the staking tab`() = runTest {
+        selectPositions(MAYA_BOND_CACAO_KEY)
+        coEvery { mayaCacaoStakingService.getStakingDetails(CACAO_ADDRESS) } returns
+            flowOf(MayaCacaoStakingDetails(FIFTY_CACAO, apr = 0.05, canUnstake = true))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertTrue(successData(vm).staking.positions.isEmpty())
+    }
+
+    @Test
+    fun `the header total sums the bonded and staked amounts`() = runTest {
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
+            flowOf(listOf(bondedNode(amount = HUNDRED_CACAO)))
+        coEvery { mayaCacaoStakingService.getStakingDetails(CACAO_ADDRESS) } returns
+            flowOf(MayaCacaoStakingDetails(FIFTY_CACAO, apr = null, canUnstake = false))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        // (100 bonded + 50 staked) CACAO at a price of 2.
+        val data = successData(vm)
+        assertEquals("$300.00", data.totalAmountPrice)
+        assertFalse(data.isTotalAmountLoading)
+    }
+
+    @Test
+    fun `an LP position is derived from the members share of the pool depths`() = runTest {
+        selectPositions(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY, BTC_POOL)
+        givenLpPool(liquidityUnits = "100", units = "1000")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val lp = successData(vm).lp
+        assertFalse(lp.isLoading)
+        val position = lp.positions.single()
+        assertEquals("CACAO/BTC Pool", position.titleLp)
+        assertEquals("BTC", position.assetTicker)
+        // 10% of a pool holding 1 BTC and 1 CACAO.
+        assertEquals("0.1 CACAO + 0.1 BTC", position.position)
+        assertEquals("$0.40", position.totalPriceLp)
+        assertEquals("25.00%", position.apr)
+        assertTrue(position.canRemove)
+        assertEquals(Chain.Bitcoin.monoToneLogo, position.chainLogo)
+    }
+
+    @Test
+    fun `a pool reporting zero units falls back to the raw added amounts`() = runTest {
+        selectPositions(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY, BTC_POOL)
+        givenLpPool(
+            liquidityUnits = "0",
+            units = "0",
+            assetAdded = "50000000",
+            cacaoAdded = "20000000000",
+        )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val position = successData(vm).lp.positions.single()
+        assertEquals("2 CACAO + 0.5 BTC", position.position)
+        assertEquals("$5.00", position.totalPriceLp)
+        // Nothing to withdraw without liquidity units.
+        assertFalse(position.canRemove)
+    }
+
+    @Test
+    fun `the LP tab stays empty while only the static Maya keys are selected`() = runTest {
+        givenLpPool(liquidityUnits = "100", units = "1000")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val lp = successData(vm).lp
+        assertFalse(lp.isLoading)
+        assertTrue(lp.positions.isEmpty())
+    }
+
+    @Test
+    fun `bond and unbond route to the deposit flow carrying the node address`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onClickBond(NODE_ADDRESS)
+        vm.onClickUnBond(NODE_ADDRESS)
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.MayaChain.id,
+                    depositType = DeFiNavActions.BOND.type,
+                    bondAddress = NODE_ADDRESS,
+                )
+            )
+        }
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.MayaChain.id,
+                    depositType = DeFiNavActions.UNBOND.type,
+                    bondAddress = NODE_ADDRESS,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `stake and LP actions route with their pool context`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onNavigateToStake(DeFiNavActions.STAKE_CACAO)
+        vm.onNavigateToLp(BTC_POOL, DeFiNavActions.ADD_LP)
+        vm.bondToNode()
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.MayaChain.id,
+                    depositType = DeFiNavActions.STAKE_CACAO.type,
+                )
+            )
+        }
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.MayaChain.id,
+                    depositType = DeFiNavActions.ADD_LP.type,
+                    poolId = BTC_POOL,
+                )
+            )
+        }
+        coVerify(exactly = 1) {
+            navigator.route(Route.BondForm(vaultId = VAULT_ID, chainId = Chain.MayaChain.id))
+        }
+    }
+
+    @Test
+    fun `opening the selection dialog rebases the draft on the committed selection`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onPositionSelectionChange(BTC_POOL, selected = true)
+        // Reopening must discard the abandoned draft.
+        vm.setPositionSelectionDialogVisibility(true)
+
+        val data = successData(vm)
+        assertTrue(data.showPositionSelectionDialog)
+        assertEquals(data.selectedPositions, data.tempSelectedPositions)
+    }
+
+    @Test
+    fun `confirming the dialog persists the draft and closes it`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.setPositionSelectionDialogVisibility(true)
+        vm.onPositionSelectionChange(BTC_POOL, selected = true)
+        vm.onPositionSelectionChange(MAYA_BOND_CACAO_KEY, selected = false)
+        vm.onPositionSelectionDone()
+
+        val expected = listOf(MAYA_STAKE_CACAO_KEY, BTC_POOL)
+        coVerify(exactly = 1) { defiPositionsRepository.saveSelectedPositions(VAULT_ID, expected) }
+        val data = successData(vm)
+        assertFalse(data.showPositionSelectionDialog)
+        assertEquals(expected, data.selectedPositions)
+    }
+
+    private fun selectPositions(vararg keys: String) {
+        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns
+            flowOf(keys.toSet())
+    }
+
+    private fun givenLpPool(
+        liquidityUnits: String,
+        units: String,
+        assetAdded: String = "0",
+        cacaoAdded: String = "0",
+    ) {
+        coEvery { mayachainBondRepository.getMayaNodePools() } returns
+            listOf(MayaNodePool(asset = BTC_POOL, status = "Available"))
+        coEvery { mayachainBondRepository.getMemberDetails(CACAO_ADDRESS) } returns
+            MayaMemberDetails(
+                pools =
+                    listOf(
+                        MayaMemberPool(
+                            pool = BTC_POOL,
+                            assetAdded = assetAdded,
+                            cacaoAdded = cacaoAdded,
+                            liquidityUnits = liquidityUnits,
+                        )
+                    )
+            )
+        coEvery { mayachainBondRepository.getLpPoolStats() } returns
+            listOf(
+                MayaLpPoolStats(
+                    asset = BTC_POOL,
+                    annualPercentageRate = "0.25",
+                    status = "Available",
+                    assetDepth = "100000000",
+                    cacaoDepth = "10000000000",
+                    units = units,
+                )
+            )
+    }
+
+    private fun bondedNode(amount: BigInteger) =
+        BondedNodePosition(
+            id = "cacao-node",
+            node = BondedNodePosition.BondedNode(address = NODE_ADDRESS, state = "active"),
+            amount = amount,
+            coin = CACAO_COIN,
+            apy = 0.1525,
+            nextReward = 12_345_678_901.0,
+            nextChurn = null,
+        )
+
+    private fun successData(vm: MayachainDefiPositionsViewModel): MayachainDefiPositionsUiModel {
+        val state = vm.state.value
+        assertTrue(state is MayachainDefiUiState.Success, "expected Success, was $state")
+        return (state as MayachainDefiUiState.Success).data
+    }
+
+    private fun createViewModel(): MayachainDefiPositionsViewModel =
+        MayachainDefiPositionsViewModel(
+            navigator = navigator,
+            vaultRepository = vaultRepository,
+            bondUseCase = bondUseCase,
+            mayachainBondRepository = mayachainBondRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            mayaCacaoStakingService = mayaCacaoStakingService,
+            tokenPriceRepository = tokenPriceRepository,
+            appCurrencyRepository = appCurrencyRepository,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            defiPositionsRepository = defiPositionsRepository,
+            // Real calculator over the mocked price repository: the fiat assertions below stay
+            // end-to-end rather than asserting against a stubbed conversion.
+            fiatValueCalculator = DefiFiatValueCalculator(tokenPriceRepository),
+            ioDispatcher = testDispatcher,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+        const val CACAO_ADDRESS = "maya1cacaoaddress"
+        const val NODE_ADDRESS = "maya1qwertyuiopasdfgh"
+        const val BTC_POOL = "BTC.BTC"
+
+        val HUNDRED_CACAO: BigInteger = BigInteger("1000000000000")
+        val FIFTY_CACAO: BigInteger = BigInteger("500000000000")
+
+        val CACAO_COIN = Coins.MayaChain.CACAO.copy(address = CACAO_ADDRESS)
+        val BTC_COIN = Coins.Bitcoin.BTC.copy(address = "bc1qbtcaddress")
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "Vultisig Wallet",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+                coins = listOf(CACAO_COIN, BTC_COIN),
+            )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -435,7 +435,6 @@ internal class MayachainDefiPositionsViewModelTest {
             mayachainBondRepository = mayachainBondRepository,
             chainAccountAddressRepository = chainAccountAddressRepository,
             mayaCacaoStakingService = mayaCacaoStakingService,
-            tokenPriceRepository = tokenPriceRepository,
             appCurrencyRepository = appCurrencyRepository,
             balanceVisibilityRepository = balanceVisibilityRepository,
             defiPositionsRepository = defiPositionsRepository,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -1,0 +1,652 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolStatsJson
+import com.vultisig.wallet.data.blockchain.model.BondedNodePosition
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
+import com.vultisig.wallet.data.blockchain.thorchain.RujiStakingService
+import com.vultisig.wallet.data.blockchain.thorchain.TCYStakingService
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.DefiPositionsRepository
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
+import com.vultisig.wallet.data.usecases.ThorchainBondUseCase
+import com.vultisig.wallet.data.utils.decimals
+import com.vultisig.wallet.data.utils.symbol
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wallet.core.jni.CoinType
+
+/**
+ * Characterization tests: they pin the behavior this ViewModel has today so the pending
+ * Thorchain/Maya deduplication can be verified as behavior-preserving. They describe what the code
+ * does, not necessarily what it ought to do.
+ *
+ * WalletCore's `CoinTypeConfiguration` is a JNI call with no host-JVM binary, so `coinType.symbol`
+ * and `coinType.decimals` are stubbed to THORChain's real values (RUNE, 8). Everything downstream —
+ * `toValue`, `formatAmount`, `formatRuneReward` — then runs its real arithmetic.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ThorchainDefiPositionsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var bondUseCase: ThorchainBondUseCase
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var rujiStakingService: RujiStakingService
+    private lateinit var tcyStakingService: TCYStakingService
+    private lateinit var defiPositionsRepository: DefiPositionsRepository
+    private lateinit var defaultStakingPositionService: DefaultStakingPositionService
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("com.vultisig.wallet.data.utils.CoinTypeKt")
+        every { any<CoinType>().symbol } returns "RUNE"
+        every { any<CoinType>().decimals } returns 8
+
+        navigator = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        bondUseCase = mockk(relaxed = true)
+        tokenPriceRepository = mockk(relaxed = true)
+        appCurrencyRepository = mockk(relaxed = true)
+        rujiStakingService = mockk(relaxed = true)
+        tcyStakingService = mockk(relaxed = true)
+        defiPositionsRepository = mockk(relaxed = true)
+        defaultStakingPositionService = mockk(relaxed = true)
+        balanceVisibilityRepository = mockk(relaxed = true)
+        getThorChainLpPositionsUseCase = mockk(relaxed = true)
+
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
+        coEvery { appCurrencyRepository.currency } returns flowOf(AppCurrencyUsd)
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance(Locale.US)
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns BigDecimal("2")
+
+        selectPositions()
+        coEvery { bondUseCase.getActiveNodes(any(), any()) } returns flowOf(emptyList())
+        coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns flowOf()
+        coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns flowOf()
+        coEvery { defaultStakingPositionService.getStakingDetails(any(), any()) } returns flowOf()
+        coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns emptyList()
+        coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } returns emptyList()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("com.vultisig.wallet.data.utils.CoinTypeKt")
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `the persisted selection replaces the defaults verbatim`() = runTest {
+        selectPositions("RUNE", "TCY")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(listOf("RUNE", "TCY"), vm.state.value.selectedPositions)
+        assertTrue(vm.state.value.isBalanceVisible)
+    }
+
+    @Test
+    fun `an empty persisted selection clears every tab rather than restoring defaults`() = runTest {
+        // Unlike the Maya screen, THORChain applies the stored set as-is with no fallback.
+        selectPositions()
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val state = vm.state.value
+        assertTrue(state.selectedPositions.isEmpty())
+        assertTrue(state.bonded.nodes.isEmpty())
+        assertTrue(state.staking.positions.isEmpty())
+        assertEquals(BigInteger.ZERO, vm.totalValueBond.value)
+    }
+
+    @Test
+    fun `bonding resolves the RUNE address even when another THORChain coin comes first`() =
+        runTest {
+            selectPositions("RUNE")
+
+            createViewModel().also { it.setData(VAULT_ID) }
+
+            // VAULT lists RUJI ahead of RUNE; picking the first THORChain coin would bond the
+            // wrong account.
+            coVerify { bondUseCase.getActiveNodes(VAULT_ID, RUNE_ADDRESS) }
+            coVerify(exactly = 0) { bondUseCase.getActiveNodes(VAULT_ID, RUJI_ADDRESS) }
+        }
+
+    @Test
+    fun `bonded nodes are mapped and totalled at RUNE precision`() = runTest {
+        selectPositions("RUNE")
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, RUNE_ADDRESS) } returns
+            flowOf(
+                listOf(bondedNode(BigInteger("1000000000")), bondedNode(BigInteger("250000000")))
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val bonded = vm.state.value.bonded
+        assertFalse(bonded.isLoading)
+        // (10 + 2.5) RUNE at 8 decimals.
+        assertEquals("12.50000000 RUNE", bonded.totalBondedAmount)
+        assertEquals("$25.00", bonded.totalBondedPrice)
+        assertEquals(2, bonded.nodes.size)
+        assertEquals(BigInteger("1250000000"), vm.totalValueBond.value)
+    }
+
+    @Test
+    fun `deselecting the bond position empties the bonded tab`() = runTest {
+        selectPositions("TCY")
+        coEvery { bondUseCase.getActiveNodes(any(), any()) } returns
+            flowOf(listOf(bondedNode(BigInteger("1000000000"))))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertTrue(vm.state.value.bonded.nodes.isEmpty())
+        assertEquals(BigInteger.ZERO, vm.totalValueBond.value)
+    }
+
+    @Test
+    fun `a vault without a RUNE coin settles the bonded tab instead of hanging`() = runTest {
+        selectPositions("RUNE")
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT.copy(coins = listOf(RUJI_COIN))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertFalse(vm.state.value.bonded.isLoading)
+        assertTrue(vm.state.value.bonded.nodes.isEmpty())
+    }
+
+    @Test
+    fun `the RUJI position exposes withdraw only while rewards are positive`() = runTest {
+        selectPositions("RUJI")
+        coEvery { rujiStakingService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(
+                stakingDetails(
+                    coin = Coins.ThorChain.RUJI,
+                    stakeAmount = BigInteger("500000000"),
+                    apr = 0.2,
+                    rewards = BigDecimal("1000000"),
+                    rewardsCoin = Coins.ThorChain.RUNE,
+                )
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val position = vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }
+        assertEquals("5 RUJI", position.stakedAmountDisplay)
+        assertEquals("$10.00", position.stakedFiatDisplay)
+        assertEquals("20.00%", position.apy)
+        assertTrue(position.canWithdraw)
+        assertTrue(position.canUnstake)
+        assertEquals(BigInteger("500000000"), vm.totalValueRujiStake.value)
+    }
+
+    @Test
+    fun `a RUJI position with no rewards cannot withdraw`() = runTest {
+        selectPositions("RUJI")
+        coEvery { rujiStakingService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(
+                stakingDetails(
+                    coin = Coins.ThorChain.RUJI,
+                    stakeAmount = BigInteger("500000000"),
+                    rewards = BigDecimal.ZERO,
+                )
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertFalse(vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }.canWithdraw)
+    }
+
+    @Test
+    fun `the TCY position is unstakeable but never withdrawable`() = runTest {
+        selectPositions("TCY")
+        coEvery { tcyStakingService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(
+                stakingDetails(coin = Coins.ThorChain.TCY, stakeAmount = BigInteger("300000000"))
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val tcy = vm.state.value.staking.positions.single { it.coin.id == TCY_ID }
+        assertFalse(tcy.canWithdraw)
+        assertTrue(tcy.canUnstake)
+        assertEquals("3 TCY", tcy.stakedAmountDisplay)
+        assertEquals(BigInteger("300000000"), vm.totalValueTCYStake.value)
+    }
+
+    @Test
+    fun `a non-RUJI position offering withdraw is corrected on the way into state`() = runTest {
+        selectPositions("TCY")
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        // Only RUJI pays claimable rewards. updateExistingPosition is the single choke point that
+        // enforces it, so a caller wrongly setting canWithdraw must still land as false.
+        vm.updateExistingPosition(
+            stakePositionUiModel(coin = Coins.ThorChain.TCY, canWithdraw = true)
+        )
+
+        assertFalse(vm.state.value.staking.positions.single { it.coin.id == TCY_ID }.canWithdraw)
+    }
+
+    @Test
+    fun `a RUJI position keeps the withdraw flag it was given`() = runTest {
+        selectPositions("RUJI")
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.updateExistingPosition(
+            stakePositionUiModel(coin = Coins.ThorChain.RUJI, canWithdraw = true)
+        )
+
+        assertTrue(vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }.canWithdraw)
+    }
+
+    @Test
+    fun `yRUNE is offered as mintable and sTCY as transferable`() = runTest {
+        selectPositions("yRUNE", "sTCY")
+        coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(
+                listOf(
+                    stakingDetails(Coins.ThorChain.yRUNE, BigInteger("100000000")),
+                    stakingDetails(Coins.ThorChain.sTCY, BigInteger("200000000")),
+                )
+            )
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val positions = vm.state.value.staking.positions
+        val yRune = positions.single { it.coin.id == Coins.ThorChain.yRUNE.id }
+        assertTrue(yRune.supportsMint)
+        assertFalse(yRune.canTransfer)
+
+        val sTcy = positions.single { it.coin.id == Coins.ThorChain.sTCY.id }
+        assertTrue(sTcy.canTransfer)
+        assertFalse(sTcy.supportsMint)
+    }
+
+    @Test
+    fun `a zero generic position cannot be unstaked`() = runTest {
+        selectPositions("yTCY")
+        coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(stakingDetails(Coins.ThorChain.yTCY, BigInteger.ZERO)))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertFalse(
+            vm.state.value.staking.positions
+                .single { it.coin.id == Coins.ThorChain.yTCY.id }
+                .canUnstake
+        )
+    }
+
+    @Test
+    fun `the LP tab stays loading until the available-pool fetch resolves`() = runTest {
+        selectPositions("RUNE")
+        coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } throws
+            RuntimeException("midgard down")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        // availablePools stays null so the tab must not flash an empty state.
+        assertTrue(vm.state.value.lp.isLoading)
+        assertFalse(vm.state.value.lpDialogLoaded)
+    }
+
+    @Test
+    fun `a selected pool with no liquidity still renders a placeholder card`() = runTest {
+        selectPositions(BTC_POOL)
+        coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns
+            listOf(poolStats(BTC_POOL))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val lp = vm.state.value.lp
+        assertFalse(lp.isLoading)
+        val position = lp.positions.single()
+        assertEquals("RUNE/BTC Pool", position.titleLp)
+        assertEquals("0 RUNE + 0 BTC", position.position)
+        assertEquals("$0.00", position.totalPriceLp)
+        // Nothing to withdraw from an empty position.
+        assertFalse(position.canRemove)
+        assertNull(position.apr)
+    }
+
+    @Test
+    fun `unbond carries the raw bonded amount resolved from the live node list`() = runTest {
+        selectPositions("RUNE")
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, RUNE_ADDRESS) } returns
+            flowOf(listOf(bondedNode(BigInteger("777000000"))))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.onClickUnBond(NODE_ADDRESS)
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Send(
+                    vaultId = VAULT_ID,
+                    type = DeFiNavActions.UNBOND.type,
+                    chainId = Chain.ThorChain.id,
+                    tokenId = Coins.ThorChain.RUNE.id,
+                    address = NODE_ADDRESS,
+                    bondedAmount = "777000000",
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `unbonding an unknown node sends no bonded amount`() = runTest {
+        selectPositions("RUNE")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.onClickUnBond("thor1unknownnode")
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Send(
+                    vaultId = VAULT_ID,
+                    type = DeFiNavActions.UNBOND.type,
+                    chainId = Chain.ThorChain.id,
+                    tokenId = Coins.ThorChain.RUNE.id,
+                    address = "thor1unknownnode",
+                    bondedAmount = null,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `bond routes to send against the RUNE token`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onClickBond(NODE_ADDRESS)
+        vm.bondToNode()
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Send(
+                    vaultId = VAULT_ID,
+                    type = DeFiNavActions.BOND.type,
+                    chainId = Chain.ThorChain.id,
+                    tokenId = Coins.ThorChain.RUNE.id,
+                    address = NODE_ADDRESS,
+                )
+            )
+        }
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Send(
+                    vaultId = VAULT_ID,
+                    type = DeFiNavActions.BOND.type,
+                    chainId = Chain.ThorChain.id,
+                    tokenId = Coins.ThorChain.RUNE.id,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `a vault without RUNE routes nowhere on bond`() = runTest {
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT.copy(coins = listOf(RUJI_COIN))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.onClickBond(NODE_ADDRESS)
+
+        coVerify(exactly = 0) { navigator.route(any<Route.Send>()) }
+    }
+
+    @Test
+    fun `staking actions carry the token the action operates on`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onNavigateToFunctions(DeFiNavActions.REDEEM_YRUNE)
+        vm.onNavigateToFunctions(DeFiNavActions.UNSTAKE_STCY)
+        vm.onNavigateToFunctions(DeFiNavActions.MINT_YRUNE)
+
+        // Redeem burns the yToken; minting spends the underlying. Swapping them would route the
+        // user into the wrong asset's balance.
+        coVerify { navigator.route(match<Route.Send> { it.tokenId == Coins.ThorChain.yRUNE.id }) }
+        coVerify { navigator.route(match<Route.Send> { it.tokenId == Coins.ThorChain.sTCY.id }) }
+        coVerify {
+            navigator.route(
+                match<Route.Send> {
+                    it.tokenId == Coins.ThorChain.RUNE.id &&
+                        it.type == DeFiNavActions.MINT_YRUNE.type
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `an action with no token mapping falls back to the deposit flow`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onNavigateToFunctions(DeFiNavActions.ADD_LP)
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.ThorChain.id,
+                    depositType = DeFiNavActions.ADD_LP.type,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `add and remove LP route with the pool id`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onClickAddLp(BTC_POOL)
+        vm.onClickRemoveLp(BTC_POOL)
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.ThorChain.id,
+                    depositType = DeFiNavActions.ADD_LP.type,
+                    poolId = BTC_POOL,
+                )
+            )
+        }
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.ThorChain.id,
+                    depositType = DeFiNavActions.REMOVE_LP.type,
+                    poolId = BTC_POOL,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `opening the selection dialog rebases the draft on the committed selection`() = runTest {
+        selectPositions("RUNE")
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.onPositionSelectionChange("TCY", isSelected = true)
+        vm.setPositionSelectionDialogVisibility(true)
+
+        val state = vm.state.value
+        assertTrue(state.showPositionSelectionDialog)
+        assertEquals(state.selectedPositions, state.tempSelectedPositions)
+    }
+
+    @Test
+    fun `confirming the dialog persists the draft and commits it`() = runTest {
+        selectPositions("RUNE")
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.setPositionSelectionDialogVisibility(true)
+        vm.onPositionSelectionChange("TCY", isSelected = true)
+        vm.onPositionSelectionChange("RUNE", isSelected = false)
+        vm.onPositionSelectionDone()
+
+        coVerify(exactly = 1) {
+            defiPositionsRepository.saveSelectedPositions(VAULT_ID, listOf("TCY"))
+        }
+        val state = vm.state.value
+        assertFalse(state.showPositionSelectionDialog)
+        assertEquals(listOf("TCY"), state.selectedPositions)
+    }
+
+    @Test
+    fun `switching tabs only changes the selected tab`() = runTest {
+        selectPositions("RUNE")
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val before = vm.state.value
+
+        vm.onTabSelected(com.vultisig.wallet.ui.screens.v2.defi.DeFiTab.LP)
+
+        val after = vm.state.value
+        assertEquals(
+            com.vultisig.wallet.ui.screens.v2.defi.DeFiTab.LP.displayNameRes,
+            after.selectedTab,
+        )
+        assertEquals(before.selectedPositions, after.selectedPositions)
+        assertEquals(before.bonded, after.bonded)
+    }
+
+    private fun selectPositions(vararg keys: String) {
+        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns
+            flowOf(keys.toSet())
+    }
+
+    private fun bondedNode(amount: BigInteger) =
+        BondedNodePosition(
+            id = "rune-node",
+            node = BondedNodePosition.BondedNode(address = NODE_ADDRESS, state = "active"),
+            amount = amount,
+            coin = RUNE_COIN,
+            apy = 0.1,
+            nextReward = 0.0,
+            nextChurn = null,
+        )
+
+    private fun stakingDetails(
+        coin: Coin,
+        stakeAmount: BigInteger,
+        apr: Double? = null,
+        rewards: BigDecimal? = null,
+        rewardsCoin: Coin? = null,
+    ) =
+        StakingDetails(
+            id = "${coin.id}-default",
+            coin = coin,
+            stakeAmount = stakeAmount,
+            apr = apr,
+            estimatedRewards = null,
+            nextPayoutDate = null,
+            rewards = rewards,
+            rewardsCoin = rewardsCoin,
+        )
+
+    private fun stakePositionUiModel(coin: Coin, canWithdraw: Boolean) =
+        StakePositionUiModel(
+            coin = coin,
+            stakeAssetHeader = UiText.StringResource(R.string.staked_tcy_header),
+            stakedAmountDisplay = "1 ${coin.ticker}",
+            apy = null,
+            canWithdraw = canWithdraw,
+        )
+
+    private fun poolStats(asset: String) =
+        ThorChainPoolStatsJson(asset = asset, status = "available")
+
+    private fun createViewModel(): ThorchainDefiPositionsViewModel =
+        ThorchainDefiPositionsViewModel(
+            navigator = navigator,
+            vaultRepository = vaultRepository,
+            bondUseCase = bondUseCase,
+            tokenPriceRepository = tokenPriceRepository,
+            // Real calculator over the mocked price repository, so fiat assertions stay end-to-end.
+            fiatValueCalculator = DefiFiatValueCalculator(tokenPriceRepository),
+            appCurrencyRepository = appCurrencyRepository,
+            rujiStakingService = rujiStakingService,
+            tcyStakingService = tcyStakingService,
+            defiPositionsRepository = defiPositionsRepository,
+            defaultStakingPositionService = defaultStakingPositionService,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            getThorChainLpPositionsUseCase = getThorChainLpPositionsUseCase,
+            ioDispatcher = testDispatcher,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+        const val RUNE_ADDRESS = "thor1runeaddress"
+        const val RUJI_ADDRESS = "thor1rujiaddress"
+        const val NODE_ADDRESS = "thor1nodeaddress"
+        const val BTC_POOL = "BTC.BTC"
+
+        val AppCurrencyUsd = com.vultisig.wallet.data.models.settings.AppCurrency.USD
+
+        val RUJI_ID = Coins.ThorChain.RUJI.id
+        val TCY_ID = Coins.ThorChain.TCY.id
+
+        val RUNE_COIN = Coins.ThorChain.RUNE.copy(address = RUNE_ADDRESS)
+        val RUJI_COIN = Coins.ThorChain.RUJI.copy(address = RUJI_ADDRESS)
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "Vultisig Wallet",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+                // RUJI deliberately first: the ViewModel must match RUNE by ticker, not position.
+                coins = listOf(RUJI_COIN, RUNE_COIN),
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Removes the duplication between the Thorchain and Maya DeFi position ViewModels, and puts a test net under both so the remaining deduplication can be done safely.

These two files were the largest untested ViewModels in the DeFi area (1343 and 811 lines) and are structural twins — roughly 17 of Maya's methods have an identically-named Thorchain counterpart, so a fix in one has to be repeated in the other.

**No user-visible change.** This is a refactor plus tests; the screens render exactly as before.

## What changed

**`DefiTabUiModels.kt` (new)** — the six shared tab models (`BondedTabUiModel`, `StakingTabUiModel`, `LpTabUiModel`, `LpPositionUiModel`, `StakePositionUiModel`, `BondedNodeUiModel`) moved out of `ThorchainDefiPositionsViewModel.kt`, where they only *looked* Thorchain-specific. Same package, so no import changes anywhere.

**`DefiFiatValueCalculator.kt` (new)** — `createFiatValue` was identical in both ViewModels, down to the `CancellationException` handling. It now exists once as an injected collaborator; `createFiatValueFromPoolAsset` moved alongside it.

**`@IoDispatcher` seam** — both ViewModels drop hardcoded `Dispatchers.IO` for the qualifier ten other ViewModels already use. Same dispatcher in production; it makes the load paths deterministic under test.

Net: **61 insertions, 178 deletions** in the two ViewModels.

| File | Before | After |
|---|---|---|
| `ThorchainDefiPositionsViewModel.kt` | 1343 | 1257 |
| `MayachainDefiPositionsViewModel.kt` | 811 | 778 |

## Deliberately not unified

`calculateStakingFiatPrice` looks like a twin but **Thorchain catches only `java.io.IOException` while Maya catches `Exception`** — merging them would silently change Thorchain's failure behavior. `calculateBondedFiatPrice` likewise differs by coin and decimal scale (RUNE/8 vs CACAO/10). Both belong in their own change, made deliberately.

## Tests

49 characterization tests. They pin the subtle behavior, not the obvious paths:

- Maya's saved-selection fallback, including the dotted LP key (`BTC.BTC`)
- Thorchain applying its stored selection **verbatim with no fallback** — an asymmetry with Maya that any future shared base must preserve
- RUNE-by-ticker resolution in all three places the vault is searched (the fixture lists RUJI first on purpose)
- The `updateExistingPosition` withdraw invariant
- Unbond resolving a node's raw bonded amount from the live list
- The `onNavigateToFunctions` token mapping (redeem burns the yToken, mint spends the underlying)
- LP pool-share math and the loading guards on both LP tabs

### Why Thorchain had no tests

Not neglect. Constructing its UI model reaches `wallet.core.jni.CoinTypeConfiguration`, which has no host-JVM binary:

```
java.lang.UnsatisfiedLinkError: 'java.lang.String
wallet.core.jni.CoinTypeConfiguration.getSymbol(wallet.core.jni.CoinType)'
```

The codebase already knew — `ChainValidationService.kt:37` hardcodes a constant to dodge the same call. Only the two JNI-backed extension properties are stubbed, pinned to THORChain's real values (`RUNE`, 8 decimals). `toValue`, `formatAmount` and `formatRuneReward` all run their genuine arithmetic.

### Mutation-checked

Every assertion was verified to actually constrain something: five defects seeded one at a time into the Thorchain ViewModel, three into Maya. Each was killed by the test naming that behavior.

One test failed that bar on the first pass — it asserted a constructor default rather than the invariant its name claimed, because `createTCYStakePosition` already hardcodes `canWithdraw = false`. It was split into two tests that call `updateExistingPosition` directly.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — **1663 tests, 0 failures** (up from 1638)
- [x] Mutation testing on all 8 seeded defects, run individually
- [x] `./gradlew :app:ktfmtCheckMain :app:ktfmtCheckTest` — clean
- [ ] Manual smoke: THORChain and MayaChain → **DeFi** toggle → Bonded / Staked / LP tabs, Manage Positions, and the bond/unbond/stake routes. Worth doing on a vault with real bonded nodes and an LP position — the fiat figures on both screens are the thing to watch, since they now flow through one shared calculator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared fiat-value conversion for DeFi token amounts and pool-asset legs.
  * Introduced reusable UI models for bonded, staking, and liquidity-pool tabs.
* **Bug Fixes**
  * Improved pricing fallback behavior and error handling (including safe zero-amount short-circuiting).
  * Enhanced DeFi loading/formatting and LP display fallback when pool stats are missing.
* **Tests**
  * Added and expanded characterization tests for DeFi position view models and fiat conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->