### PR TITLE
fix(keysign): gate personal_sign display decode on strict 0x prefix

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.api.swapAggregators.OneInchSwap
+import com.vultisig.wallet.data.common.isHexPrefixed
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
 import com.vultisig.wallet.data.common.toSha256ByteArray
@@ -50,8 +51,9 @@ object SigningHelper {
         // hex decoding on the `0x` prefix, so a plain-text message made only of hex characters
         // (e.g. "Vultisig") must be hashed as UTF-8 — otherwise the digest, and the md5 message-ID
         // derived from it, diverges and cross-platform co-signing can't locate the setup message.
+        // isHexPrefixed() is shared with normalizeMessageFormat (#5402) so display can't diverge.
         val processedBytes =
-            if (messagePayload.message.startsWith("0x")) {
+            if (messagePayload.message.isHexPrefixed()) {
                 messagePayload.message.toHexBytes()
             } else {
                 messagePayload.message.toByteArray()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/StringExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/StringExtensions.kt
@@ -31,6 +31,10 @@ fun String.toHexBytesInByteString(): ByteString {
     return ByteString.copyFrom(this.toHexBytes())
 }
 
+/**
+ * Lenient hex check (`0x` optional) for memo/calldata encoding in [toByteStringOrHex] only — do not
+ * use for personal_sign/message hex-vs-text gating, see [isHexPrefixed].
+ */
 fun String.isHex(): Boolean {
     return this.matches(Regex("^(0x)?[0-9A-Fa-f]+$"))
 }
@@ -43,11 +47,21 @@ fun String.toByteStringOrHex(): ByteString {
     }
 }
 
+/**
+ * True only for an explicit `0x` prefix — mirrors SigningHelper's signing-path check and iOS/
+ * Windows, so a personal_sign message can't display differently from what gets signed (#5402).
+ */
+fun String.isHexPrefixed(): Boolean = startsWith("0x")
+
 fun String.normalizeMessageFormat(): String {
     return try {
-        if (this.isHex()) {
+        if (this.isHexPrefixed()) {
             val hex = this.remove0x()
-            if (hex.length % 2 != 0) {
+            // A malformed remainder (odd length, or a non-hex character) must fall back to the
+            // raw string rather than decode: SigningHelper's hex-decode silently maps invalid
+            // digits to garbage bytes, so decoding here too could display a clean-looking (but
+            // wrong) string for content that doesn't actually represent well-formed hex.
+            if (hex.length % 2 != 0 || !hex.all { it.digitToIntOrNull(16) != null }) {
                 return this
             }
             val decoder =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/PersonalSignDisplayMatchesSignedMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/PersonalSignDisplayMatchesSignedMessageTest.kt
@@ -1,0 +1,46 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.common.normalizeMessageFormat
+import com.vultisig.wallet.data.common.toKeccak256ByteArray
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.CustomMessagePayload
+
+/**
+ * Cross-path invariant for issue #5402: for a well-formed personal_sign message — plain text, or
+ * `0x`-prefixed even-length hex — hashing the UTF-8 bytes of whatever [normalizeMessageFormat]
+ * displays must reproduce exactly what [SigningHelper] signs. (Malformed hex, e.g. odd length or a
+ * non-hex character, falls back to displaying the raw string on both sides of this gate; that
+ * fallback is intentionally excluded here since normalizeMessageFormat's odd-length/invalid-hex
+ * guards already cover it directly.)
+ */
+class PersonalSignDisplayMatchesSignedMessageTest {
+
+    @Test
+    fun `displayed message hashes to the same bytes SigningHelper signs`() {
+        val messages =
+            listOf(
+                "56756c7469736967", // hex-charset, no 0x prefix -> must be signed as UTF-8 text
+                "0x56756c7469736967", // 0x-prefixed hex -> decodes to "Vultisig" for display
+                "",
+            )
+
+        for (message in messages) {
+            val displayed = message.normalizeMessageFormat()
+            val expected = listOf(displayed.toByteArray().toKeccak256ByteArray().toHexString())
+
+            val actual =
+                SigningHelper.getKeysignMessages(
+                    CustomMessagePayload(
+                        method = "personal_sign",
+                        message = message,
+                        chain = "Ethereum",
+                    )
+                )
+
+            actual shouldBe expected
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/common/StringExtensionsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/common/StringExtensionsTest.kt
@@ -1,0 +1,47 @@
+package com.vultisig.wallet.data.common
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StringExtensionsTest {
+
+    @Test
+    fun `isHexPrefixed requires an explicit 0x prefix`() {
+        "0x56756c7469736967".isHexPrefixed() shouldBe true
+        "56756c7469736967".isHexPrefixed() shouldBe false
+        "0X56756c7469736967".isHexPrefixed() shouldBe false
+        "Hello Vultisig".isHexPrefixed() shouldBe false
+        "".isHexPrefixed() shouldBe false
+    }
+
+    @Test
+    fun `normalizeMessageFormat leaves a hex-charset message without 0x prefix untouched`() {
+        // #5402: must NOT decode to "Vultisig" — SigningHelper hashes this as raw UTF-8 text
+        // since it has no 0x prefix, so the Verify screen must display the same literal string.
+        val message = "56756c7469736967"
+
+        message.normalizeMessageFormat() shouldBe message
+    }
+
+    @Test
+    fun `normalizeMessageFormat decodes a proper 0x-prefixed hex message`() {
+        "0x56756c7469736967".normalizeMessageFormat() shouldBe "Vultisig"
+    }
+
+    @Test
+    fun `normalizeMessageFormat leaves odd-length 0x-prefixed hex untouched`() {
+        val message = "0xabc"
+
+        message.normalizeMessageFormat() shouldBe message
+    }
+
+    @Test
+    fun `normalizeMessageFormat leaves 0x-prefixed content with a non-hex character untouched`() {
+        // A non-hex character (e.g. "z") after the 0x prefix must not decode: SigningHelper's
+        // hex-decode maps invalid digits to garbage bytes rather than failing, so decoding here
+        // too could display a plausible-looking string for content that isn't well-formed hex.
+        val message = "0x008z41"
+
+        message.normalizeMessageFormat() shouldBe message
+    }
+}


### PR DESCRIPTION
## Summary

The Verify screen for a `personal_sign` custom-message keysign could display a hex-decoded interpretation of a message that has no `0x` prefix, while `SigningHelper.getKeysignMessages` only hex-decodes a strictly `0x`-prefixed message (fixed on the signing side in #4724/#4736). A bare hex-charset message (e.g. a nonce) displayed as decoded text on the Verify screen while the TSS signature was computed over the raw string bytes — the two paths could diverge.

## Changes

- Extracted `String.isHexPrefixed()` in `StringExtensions.kt` as the single `0x`-prefix gate now shared by `SigningHelper` (replacing its inline `startsWith("0x")`) and `normalizeMessageFormat()` (replacing the lenient `isHex()`, which makes the prefix optional and stays scoped to its other caller, EVM/Tron memo encoding).
- Added a hex-content validity check to `normalizeMessageFormat()`: a `0x`-prefixed remainder containing a non-hex character now falls back to displaying the raw string (same as the existing odd-length fallback), instead of silently decoding garbage bytes into a plausible-looking but wrong string.

## Testing

- `./gradlew :data:testDebugUnitTest` — full suite green, including the existing `SigningHelperCustomMessageTest` (unaffected) and two new test files: `StringExtensionsTest` (the display-path gate and its edge cases) and `PersonalSignDisplayMatchesSignedMessageTest` (cross-path invariant: hashing the UTF-8 bytes of what's displayed reproduces exactly what `SigningHelper` signs).
- `./gradlew :app:testDebugUnitTest` — green (unaffected by this change).
- `./gradlew :data:ktfmtCheckMain :data:ktfmtCheckTest` — clean.

Closes #5402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling to consistently distinguish hexadecimal content from plain text.
  * Prevented malformed or ambiguous hexadecimal messages from being incorrectly decoded.
  * Ensured displayed personal-sign messages match the content used for signing.

* **Tests**
  * Added coverage for prefixed, unprefixed, malformed, empty, and valid hexadecimal message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->