### PR TITLE
fix(evm): point Ethereum POL at the real POL contract, not legacy MATIC's

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -61,7 +61,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             VaultNotificationSettingsEntity::class,
             TransactionHistoryEntity::class,
         ],
-    version = 36,
+    version = 37,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_32_33
 import com.vultisig.wallet.data.db.migrations.MIGRATION_33_34
 import com.vultisig.wallet.data.db.migrations.MIGRATION_34_35
 import com.vultisig.wallet.data.db.migrations.MIGRATION_35_36
+import com.vultisig.wallet.data.db.migrations.MIGRATION_36_37
 import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
@@ -108,6 +109,7 @@ internal interface DatabaseModule {
                     MIGRATION_33_34,
                     MIGRATION_34_35,
                     MIGRATION_35_36,
+                    MIGRATION_36_37,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -880,3 +880,25 @@ internal val MIGRATION_35_36 =
             )
         }
     }
+
+// Corrects the Ethereum POL contract address from the legacy MATIC contract it was mistakenly
+// sharing (#5404). The registry fix in Coins.kt only reaches newly enabled coins; coins are
+// persisted per-vault and reconstructed straight from the stored `contractAddress` column, so
+// vaults that already enabled POL keep resolving balances/transfers against the legacy MATIC
+// contract until the stored row itself is corrected. The cached balance in `tokenValue` is keyed
+// by contractAddress too, so it simply misses once and is re-fetched under the new address on the
+// next live read — no separate migration needed there.
+internal val MIGRATION_36_37 =
+    object : Migration(36, 37) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            UPDATE coin
+            SET contractAddress = '0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6'
+            WHERE chain = 'Ethereum' AND ticker = 'POL'
+              AND contractAddress = '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration36To37Test.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration36To37Test.kt
@@ -1,0 +1,32 @@
+package com.vultisig.wallet.data.db.migrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class Migration36To37Test {
+
+    @Test
+    fun `migrate corrects Ethereum POL rows still pointing at the legacy MATIC contract to the real POL contract`() {
+        val db = mockk<SupportSQLiteDatabase>(relaxed = true)
+        val sql = slot<String>()
+
+        MIGRATION_36_37.migrate(db)
+
+        verify { db.execSQL(capture(sql)) }
+        val statement = sql.captured
+        assertTrue(statement.contains("UPDATE coin"))
+        assertTrue(
+            statement.contains("SET contractAddress = '${Coins.Ethereum.POL.contractAddress}'")
+        )
+        assertTrue(statement.contains("WHERE chain = 'Ethereum'"))
+        assertTrue(statement.contains("ticker = 'POL'"))
+        assertTrue(
+            statement.contains("contractAddress = '${Coins.Ethereum.MATIC.contractAddress}'")
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -1214,7 +1214,7 @@ object Coins {
                 decimal = 18,
                 hexPublicKey = "",
                 priceProviderID = "polygon-ecosystem-token",
-                contractAddress = "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+                contractAddress = "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
                 isNativeToken = false,
             )
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinsPolContractAddressTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinsPolContractAddressTest.kt
@@ -1,0 +1,25 @@
+package com.vultisig.wallet.data.models
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Test
+
+internal class CoinsPolContractAddressTest {
+
+    @Test
+    fun `Ethereum POL points at the real POL contract, not the legacy MATIC contract`() {
+        assertEquals(
+            "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
+            Coins.Ethereum.POL.contractAddress,
+        )
+        assertNotEquals(Coins.Ethereum.MATIC.contractAddress, Coins.Ethereum.POL.contractAddress)
+    }
+
+    @Test
+    fun `Ethereum MATIC keeps its legacy contract address unchanged`() {
+        assertEquals(
+            "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+            Coins.Ethereum.MATIC.contractAddress,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`Coins.kt` defined `Ethereum.MATIC` and `Ethereum.POL` with the identical `contractAddress` (the legacy MATIC contract `0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0`). The real POL contract on Ethereum is a separate deployment (`0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6`); sharing the address meant enabling POL resolved balances and built transfers against MATIC's contract instead.

Coins are persisted per-vault and reconstructed straight from the stored columns, so the registry fix alone only reaches newly enabled coins. Added `MIGRATION_36_37` to correct the `contractAddress` for already-persisted `chain='Ethereum', ticker='POL'` rows still pointing at the legacy address. The `tokenValue` balance cache is keyed by contractAddress too, so it simply misses once for previously-cached POL balances and self-heals on the next live read (same pattern already established by `MIGRATION_34_35`).

`Ethereum.MATIC` and the unrelated native `Polygon.POL` (different chain, different object block) are untouched.

Closes #5404

## Tests

- `data/src/test/kotlin/.../CoinsPolContractAddressTest.kt` — pins `Ethereum.POL`'s contract address to the real value, asserts it's distinct from `Ethereum.MATIC`'s, and pins MATIC's address stays the legacy value.
- `app/src/test/java/.../Migration36To37Test.kt` — captures the exact SQL `MIGRATION_36_37` issues and asserts it targets `Coins.Ethereum.POL.contractAddress` (not a duplicated literal, so the migration and the registry can't silently drift apart) with the legacy-address filter matching `Coins.Ethereum.MATIC.contractAddress`.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — 2252 + 1615 tests, 0 failures
- [x] `./gradlew assembleDebug` — succeeds
- [x] `./gradlew :app:lintDebug :data:lintDebug` — clean, no new issues
- [x] `./gradlew :app:ktfmtCheckMain :app:ktfmtCheckTest :data:ktfmtCheckMain :data:ktfmtCheckTest` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Ethereum POL token to use its correct contract address.
  - Existing wallets are migrated automatically so stored POL entries reflect the corrected address.
  - Preserved the legacy MATIC contract address for MATIC tokens.

- **Tests**
  - Added coverage to verify the corrected POL address and database migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->