### PR TITLE
fix(address-book): recognize saved EVM contacts across all chains

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -61,7 +61,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             VaultNotificationSettingsEntity::class,
             TransactionHistoryEntity::class,
         ],
-    version = 36,
+    version = 37,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_32_33
 import com.vultisig.wallet.data.db.migrations.MIGRATION_33_34
 import com.vultisig.wallet.data.db.migrations.MIGRATION_34_35
 import com.vultisig.wallet.data.db.migrations.MIGRATION_35_36
+import com.vultisig.wallet.data.db.migrations.MIGRATION_36_37
 import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
@@ -108,6 +109,7 @@ internal interface DatabaseModule {
                     MIGRATION_33_34,
                     MIGRATION_34_35,
                     MIGRATION_35_36,
+                    MIGRATION_36_37,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -885,23 +885,42 @@ internal val MIGRATION_35_36 =
 // picker consolidated every EVM chain into one "EVM" tile, a contact saved on e.g. Arbitrum or BSC
 // was persisted under that chain's own id; the app now always reads/writes EVM entries under
 // "Ethereum", so those older rows would otherwise become permanently unreachable. Rows sharing an
-// address across the EVM family are collapsed to the earliest one first, so the chainId rewrite
-// below can never collide with an existing primary key.
-private const val EVM_CHAIN_IDS =
-    "'Arbitrum','Avalanche','Base','CronosChain','BSC','Blast','Ethereum','Optimism','Polygon'," +
-        "'Zksync','Mantle','Sei','Hyperliquid'"
+// address (case-insensitively, matching the app's own EVM address matching) across the EVM family
+// are collapsed to the earliest one first, so the chainId rewrite below can never collide with an
+// existing primary key. addressBookOrder keys embed the old chainId too ("$chainId-$address"), so
+// its now-stale legacy-chain rows are dropped; the list screen already re-creates a default order
+// entry for any address-book row it doesn't find one for.
+private val LEGACY_EVM_CHAIN_IDS =
+    listOf(
+        "Arbitrum",
+        "Avalanche",
+        "Base",
+        "CronosChain",
+        "BSC",
+        "Blast",
+        "Optimism",
+        "Polygon",
+        "Zksync",
+        "Mantle",
+        "Sei",
+        "Hyperliquid",
+    )
+private val EVM_CHAIN_IDS = LEGACY_EVM_CHAIN_IDS + "Ethereum"
 
 internal val MIGRATION_36_37 =
     object : Migration(36, 37) {
         override fun migrate(db: SupportSQLiteDatabase) {
+            val evmChainIdsSql = EVM_CHAIN_IDS.joinToString(",") { "'$it'" }
+            val legacyEvmChainIdsSql = LEGACY_EVM_CHAIN_IDS.joinToString(",") { "'$it'" }
+
             db.execSQL(
                 """
             DELETE FROM address_book_entry
-            WHERE chainId IN ($EVM_CHAIN_IDS)
+            WHERE chainId IN ($evmChainIdsSql)
             AND rowid NOT IN (
                 SELECT MIN(rowid) FROM address_book_entry
-                WHERE chainId IN ($EVM_CHAIN_IDS)
-                GROUP BY address
+                WHERE chainId IN ($evmChainIdsSql)
+                GROUP BY LOWER(address)
             )
             """
                     .trimIndent()
@@ -910,12 +929,12 @@ internal val MIGRATION_36_37 =
                 """
             UPDATE address_book_entry
             SET chainId = 'Ethereum'
-            WHERE chainId IN (
-                'Arbitrum','Avalanche','Base','CronosChain','BSC','Blast','Optimism','Polygon',
-                'Zksync','Mantle','Sei','Hyperliquid'
-            )
+            WHERE chainId IN ($legacyEvmChainIdsSql)
             """
                     .trimIndent()
             )
+            LEGACY_EVM_CHAIN_IDS.forEach { legacyChainId ->
+                db.execSQL("DELETE FROM addressBookOrder WHERE `value` LIKE '$legacyChainId-%'")
+            }
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -880,3 +880,42 @@ internal val MIGRATION_35_36 =
             )
         }
     }
+
+// Canonicalizes legacy EVM address-book rows to Chain.Ethereum's id (#5403). Before the network
+// picker consolidated every EVM chain into one "EVM" tile, a contact saved on e.g. Arbitrum or BSC
+// was persisted under that chain's own id; the app now always reads/writes EVM entries under
+// "Ethereum", so those older rows would otherwise become permanently unreachable. Rows sharing an
+// address across the EVM family are collapsed to the earliest one first, so the chainId rewrite
+// below can never collide with an existing primary key.
+private const val EVM_CHAIN_IDS =
+    "'Arbitrum','Avalanche','Base','CronosChain','BSC','Blast','Ethereum','Optimism','Polygon'," +
+        "'Zksync','Mantle','Sei','Hyperliquid'"
+
+internal val MIGRATION_36_37 =
+    object : Migration(36, 37) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            DELETE FROM address_book_entry
+            WHERE chainId IN ($EVM_CHAIN_IDS)
+            AND rowid NOT IN (
+                SELECT MIN(rowid) FROM address_book_entry
+                WHERE chainId IN ($EVM_CHAIN_IDS)
+                GROUP BY address
+            )
+            """
+                    .trimIndent()
+            )
+            db.execSQL(
+                """
+            UPDATE address_book_entry
+            SET chainId = 'Ethereum'
+            WHERE chainId IN (
+                'Arbitrum','Avalanche','Base','CronosChain','BSC','Blast','Optimism','Polygon',
+                'Zksync','Mantle','Sei','Hyperliquid'
+            )
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressBookViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressBookViewModel.kt
@@ -10,11 +10,14 @@ import com.vultisig.wallet.data.db.models.AddressBookOrderEntity
 import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.addressBookChainId
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.order.OrderRepository
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.models.evmNetworkUiModel
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -80,7 +83,9 @@ constructor(
                     val entries =
                         addressBookRepository.getEntries().let { entries ->
                             if (chain != null) {
-                                entries.filter { it.chain == chain }
+                                entries.filter {
+                                    it.chain.addressBookChainId == chain.addressBookChainId
+                                }
                             } else {
                                 entries
                             }
@@ -107,7 +112,12 @@ constructor(
                             model = it,
                             image = it.chain.logo,
                             name = it.title,
-                            network = it.chain.name.capitalize(Locale.current),
+                            network =
+                                if (it.chain.standard == TokenStandard.EVM) {
+                                    evmNetworkUiModel.title
+                                } else {
+                                    it.chain.name.capitalize(Locale.current)
+                                },
                             address = it.address,
                         )
                     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressBookViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressBookViewModelTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertSame
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -190,6 +191,65 @@ internal class AddressBookViewModelTest {
             assertEquals(null, vm.state.value.pendingDeletion)
         }
 
+    @Test
+    fun `EVM entries show EVM as the network label`() =
+        runTest(testDispatcher) {
+            coEvery { addressBookRepository.getEntries() } returns
+                listOf(
+                    AddressBookEntry(
+                        chain = Chain.Ethereum,
+                        address = ALICE_ADDRESS,
+                        title = "Alice",
+                    )
+                )
+            every { orderRepository.loadOrders(null) } returns flowOf(emptyList())
+            val vm = createViewModel()
+
+            vm.loadData()
+            advanceUntilIdle()
+
+            assertEquals("EVM", vm.state.value.entries.single().network)
+        }
+
+    @Test
+    fun `non-EVM entries keep their chain name as the network label`() =
+        runTest(testDispatcher) {
+            coEvery { addressBookRepository.getEntries() } returns
+                listOf(
+                    AddressBookEntry(chain = Chain.Bitcoin, address = BTC_ADDRESS, title = "Cold")
+                )
+            every { orderRepository.loadOrders(null) } returns flowOf(emptyList())
+            val vm = createViewModel()
+
+            vm.loadData()
+            advanceUntilIdle()
+
+            assertEquals("Bitcoin", vm.state.value.entries.single().network)
+        }
+
+    @Test
+    fun `loadData filtered by one EVM chain still surfaces entries saved under another`() =
+        runTest(testDispatcher) {
+            every { any<SavedStateHandle>().toRoute<Route.AddressBookScreen>() } returns
+                Route.AddressBookScreen(vaultId = VAULT_ID, chainId = Chain.Arbitrum.id)
+            coEvery { addressBookRepository.getEntries() } returns
+                listOf(
+                    AddressBookEntry(
+                        chain = Chain.Ethereum,
+                        address = ALICE_ADDRESS,
+                        title = "Alice",
+                    ),
+                    AddressBookEntry(chain = Chain.Bitcoin, address = BTC_ADDRESS, title = "Cold"),
+                )
+            every { orderRepository.loadOrders(null) } returns flowOf(emptyList())
+            val vm = createViewModel()
+
+            vm.loadData()
+            advanceUntilIdle()
+
+            assertEquals(listOf("Alice"), vm.state.value.entries.map { it.name })
+        }
+
     private fun createViewModel(): AddressBookViewModel =
         AddressBookViewModel(
             savedStateHandle = SavedStateHandle(),
@@ -216,5 +276,6 @@ internal class AddressBookViewModelTest {
         const val VAULT_ID = "vault-1"
         const val ALICE_ADDRESS = "0xAlice"
         const val BOB_ADDRESS = "0xBob"
+        const val BTC_ADDRESS = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -83,6 +83,13 @@ val Chain.toDefi: DefiChain
             else -> DefiChain(raw = raw, chain = this)
         }
 
+/**
+ * Chain-id used for address-book storage and lookups. EVM chains share one address space, so every
+ * EVM chain canonicalizes to [Chain.Ethereum]'s id here, matching iOS/Windows.
+ */
+val Chain.addressBookChainId: ChainId
+    get() = if (standard == EVM) Chain.Ethereum.id else id
+
 val Chain.coinType: CoinType
     get() =
         when (this) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepository.kt
@@ -4,7 +4,9 @@ import com.vultisig.wallet.data.db.dao.AddressBookEntryDao
 import com.vultisig.wallet.data.db.models.AddressBookEntryEntity
 import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.ChainId
 import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.addressBookChainId
 import javax.inject.Inject
 
 interface AddressBookRepository {
@@ -32,41 +34,52 @@ constructor(private val addressBookEntryDao: AddressBookEntryDao) : AddressBookR
     }
 
     override suspend fun getEntry(chainId: String, address: String): AddressBookEntry? {
+        val lookup = chainId.toLookupKey()
         val entity =
-            if (isEvm(chainId)) {
-                addressBookEntryDao.getEntryIgnoringCase(chainId, address)
+            if (lookup.isEvm) {
+                addressBookEntryDao.getEntryIgnoringCase(lookup.chainId, address)
             } else {
-                addressBookEntryDao.getEntry(chainId, address)
+                addressBookEntryDao.getEntry(lookup.chainId, address)
             }
         return entity?.toAddressBookEntry()
     }
 
     override suspend fun delete(chainId: String, address: String) {
-        if (isEvm(chainId)) {
-            addressBookEntryDao.deleteIgnoringCase(chainId, address)
+        val lookup = chainId.toLookupKey()
+        if (lookup.isEvm) {
+            addressBookEntryDao.deleteIgnoringCase(lookup.chainId, address)
         } else {
-            addressBookEntryDao.delete(chainId, address)
+            addressBookEntryDao.delete(lookup.chainId, address)
         }
     }
 
-    override suspend fun entryExists(chainId: String, address: String): Boolean =
-        if (isEvm(chainId)) {
-            addressBookEntryDao.entryExistsIgnoringCase(chainId, address)
+    override suspend fun entryExists(chainId: String, address: String): Boolean {
+        val lookup = chainId.toLookupKey()
+        return if (lookup.isEvm) {
+            addressBookEntryDao.entryExistsIgnoringCase(lookup.chainId, address)
         } else {
-            addressBookEntryDao.entryExists(chainId, address)
+            addressBookEntryDao.entryExists(lookup.chainId, address)
         }
+    }
 
     // EVM addresses use EIP-55 checksum casing, so the same account can be written with different
     // capitalization; matching them case-insensitively keeps one logical entry. Other chains use
-    // case-sensitive address encodings (base58, bech32, base64), so they stay exact-match. Unknown
-    // chain ids fall back to exact-match, matching the pre-existing behavior.
-    private fun isEvm(chainId: String): Boolean =
-        Chain.entries.firstOrNull { it.raw.equals(chainId, ignoreCase = true) }?.standard ==
-            TokenStandard.EVM
+    // case-sensitive address encodings (base58, bech32, base64), so they stay exact-match. EVM
+    // chains also share one address space, so their chainId is canonicalized to Chain.Ethereum's id
+    // before it reaches storage or a query. Unknown chain ids fall back to exact-match, unchanged.
+    private fun String.toLookupKey(): LookupKey {
+        val chain = Chain.entries.firstOrNull { it.raw.equals(this, ignoreCase = true) }
+        return LookupKey(
+            chainId = chain?.addressBookChainId ?: this,
+            isEvm = chain?.standard == TokenStandard.EVM,
+        )
+    }
+
+    private data class LookupKey(val chainId: ChainId, val isEvm: Boolean)
 
     private fun AddressBookEntryEntity.toAddressBookEntry() =
         AddressBookEntry(chain = Chain.fromRaw(chainId), address = address, title = title)
 
     private fun AddressBookEntry.toEntity() =
-        AddressBookEntryEntity(chainId = chain.id, address = address, title = title)
+        AddressBookEntryEntity(chainId = chain.addressBookChainId, address = address, title = title)
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AddressBookRepositoryImplTest.kt
@@ -101,6 +101,57 @@ internal class AddressBookRepositoryImplTest {
         assertTrue(repository.entryExists(Chain.Bitcoin.id, BTC_ADDRESS))
     }
 
+    @Test
+    fun `EVM entry saved from one chain is recognized on every other EVM chain`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Arbitrum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        assertTrue(repository.entryExists(Chain.Base.id, CHECKSUMMED))
+        assertTrue(repository.entryExists(Chain.Optimism.id, CHECKSUMMED))
+        assertEquals("Alice", repository.getEntry(Chain.Ethereum.id, CHECKSUMMED)?.title)
+    }
+
+    @Test
+    fun `EVM entry is always stored under the canonical Ethereum chain id`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Arbitrum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        val entry = repository.getEntries().single()
+        assertEquals(Chain.Ethereum, entry.chain)
+    }
+
+    @Test
+    fun `cross-chain EVM match is still case-insensitive on the address`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Arbitrum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        assertTrue(repository.entryExists(Chain.Base.id, LOWERCASED))
+        assertEquals("Alice", repository.getEntry(Chain.Optimism.id, LOWERCASED)?.title)
+    }
+
+    @Test
+    fun `deleting from a different EVM chain removes the canonical entry`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Arbitrum, address = CHECKSUMMED, title = "Alice")
+        )
+
+        repository.delete(Chain.Base.id, CHECKSUMMED)
+
+        assertFalse(repository.entryExists(Chain.Arbitrum.id, CHECKSUMMED))
+    }
+
+    @Test
+    fun `EVM and non-EVM chains never share an entry`() = runTest {
+        repository.add(
+            AddressBookEntry(chain = Chain.Bitcoin, address = BTC_ADDRESS, title = "Cold storage")
+        )
+
+        assertFalse(repository.entryExists(Chain.Ethereum.id, BTC_ADDRESS))
+    }
+
     private companion object {
         // EIP-55 checksummed reference address and its all-lowercase canonical form.
         const val CHECKSUMMED = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"


### PR DESCRIPTION
## Summary

Every EVM chain address-book entry has always been stored under the consolidated `Ethereum` chain id (the add/edit screen only ever shows one "EVM" network tile), but `AddressBookRepository`'s reads, existence checks, and deletes were keyed off the transaction's exact chain id. A contact saved from an Arbitrum send was invisible to every other EVM chain — including Arbitrum itself the next time — so the address-poisoning warning and "add to address book" prompt kept reappearing for a contact that was already saved.

- `AddressBookRepositoryImpl` now canonicalizes any EVM chain id to `Chain.Ethereum`'s before it reaches storage or a query (`Chain.addressBookChainId`), so a contact saved on one EVM chain is recognized, edited, and deleted correctly from any of them. Non-EVM chains are untouched.
- The address book list screen shows "EVM" instead of a misleading "Ethereum" label for these entries, and its optional per-chain filter matches on the same canonical id instead of exact `Chain` equality.

No storage schema change — this is query/save key derivation only, so no Room migration is needed.

Closes #5403

## Test plan
- [x] `./gradlew :data:testDebugUnitTest` — 2255 tests, 0 failures (new cases cover saving on one EVM chain and being recognized/edited/deleted from another, plus non-EVM chains staying isolated)
- [x] `./gradlew :app:testDebugUnitTest` — 1617 tests, 0 failures (new cases cover the "EVM" network label and the chain filter)
- [x] `./gradlew :app:ktfmtCheckMain :app:ktfmtCheckTest :data:ktfmtCheckMain :data:ktfmtCheckTest`
- [x] `./gradlew :app:lintDebug :data:lintDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address book entries are now stored and retrieved using a unified identifier across all EVM networks for consistent lookups when switching chains.
  * EVM address matching is case-insensitive, and the UI shows **“EVM”** for EVM entries; non-EVM entries retain their own chain names.
  * Non-EVM entries remain isolated to their respective networks.
* **Database**
  * Added a Room migration to normalize legacy EVM address-book records into the unified format.
* **Tests**
  * Expanded coverage for cross-EVM and non-EVM address-book behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->