### PR TITLE
fix(send): sum base + priority fee into the signed EVM gas price

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -48,6 +48,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.securityscanner.SecurityRiskLevel
 import com.vultisig.wallet.data.securityscanner.SecurityScannerResult
@@ -109,6 +110,7 @@ import com.vultisig.wallet.ui.models.peer.PeerDiscoveryUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimMaturingUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUtxoUiModel
+import com.vultisig.wallet.ui.models.send.GasSettingsUiModel
 import com.vultisig.wallet.ui.models.swap.SwapFormUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
@@ -139,6 +141,7 @@ import com.vultisig.wallet.ui.screens.referral.EmptyReferralBanner
 import com.vultisig.wallet.ui.screens.select.AssetUiModel
 import com.vultisig.wallet.ui.screens.select.SelectAssetScreen
 import com.vultisig.wallet.ui.screens.select.SelectAssetUiModel
+import com.vultisig.wallet.ui.screens.send.GasSettingsScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.settings.DiscountTiersScreenPreview
 import com.vultisig.wallet.ui.screens.settings.TierType
@@ -315,6 +318,8 @@ class PreviewActivity : ComponentActivity() {
                     "unbond_verify_before" -> UnbondVerifyPreview(after = false)
                     "unbond_verify_after" -> UnbondVerifyPreview(after = true)
                     "edit_folder" -> EditFolderPreview()
+                    "gas_settings_bsc_before" -> GasSettingsBscPreview(isLegacyGas = false)
+                    "gas_settings_bsc_after" -> GasSettingsBscPreview(isLegacyGas = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -464,6 +469,37 @@ private fun EditFolderPreview() {
             onMoveVaults = { _, _ -> },
             tryCheck = { checked, _ -> checked },
             onDeleteFolderClick = {},
+        )
+    }
+}
+
+/**
+ * Advanced Gas Settings for BSC (issue #5397). Before the fix, BSC rendered the same Base
+ * fee/Priority fee split as any EIP-1559 chain, with the base fee sourced from BSC's meaningless
+ * near-zero EIP-1559 base fee (BEP-226) — saving without editing signed a gasPrice of 0. After, BSC
+ * gets a single "Gas price" field sourced from eth_gasPrice and no priority-fee input.
+ */
+@Composable
+private fun GasSettingsBscPreview(isLegacyGas: Boolean) {
+    Box(modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary)) {
+        GasSettingsScreen(
+            isLegacyGas = isLegacyGas,
+            state =
+                GasSettingsUiModel(
+                    chainSpecific =
+                        BlockChainSpecific.Ethereum(
+                            maxFeePerGasWei = java.math.BigInteger.ZERO,
+                            priorityFeeWei = java.math.BigInteger.ZERO,
+                            nonce = java.math.BigInteger.ZERO,
+                            gasLimit = java.math.BigInteger.valueOf(21_000L),
+                        )
+                ),
+            gasLimitState = remember { TextFieldState("21000") },
+            baseFeeState = remember { TextFieldState(if (isLegacyGas) "3" else "0") },
+            priorityFeeState = remember { TextFieldState("1") },
+            byteFeeState = remember { TextFieldState() },
+            onCloseClick = {},
+            onSaveClick = {},
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeSelection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeSelection.kt
@@ -30,6 +30,6 @@ internal fun selectGasFeeForFeeEstimation(
                     )
             if (plan > 0) gasFee.copy(value = BigInteger.valueOf(plan)) else gasFee
         }
-        evmGasSettings != null -> gasFee.copy(value = evmGasSettings.baseFee)
+        evmGasSettings != null -> gasFee.copy(value = evmGasSettings.maxFeePerGasWei)
         else -> gasFee
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.blockchain.utxo.UtxoFeeService
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.supportsLegacyGas
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.usecases.ConvertGweiToWeiUseCase
 import com.vultisig.wallet.data.usecases.ConvertWeiToGweiUseCase
@@ -69,17 +70,32 @@ constructor(
 
     private fun loadEthData(chain: Chain, spec: BlockChainSpecific.Ethereum) {
         gasLimitState.setTextAndPlaceCursorAtEnd(spec.gasLimit.toString())
+        // This ViewModel is Hilt-scoped to the Send screen, not to one dialog open, so these
+        // fields survive a close-without-saving. Blank them synchronously (before the network
+        // fetch below) so a Save tapped for a newly opened chain, before that fetch resolves,
+        // can never sign a fee carried over from a previous chain's session.
+        baseFeeState.setTextAndPlaceCursorAtEnd("")
+        priorityFeeState.setTextAndPlaceCursorAtEnd("")
 
         viewModelScope.launch {
             val evmApi = evmApiFactory.createEvmApi(chain)
             try {
-                val baseFeeWei = evmApi.getBaseFee()
-                val baseFeeGwei = convertWeiToGwei(baseFeeWei)
-
-                baseFeeState.setTextAndPlaceCursorAtEnd(baseFeeGwei.toPlainString())
-                priorityFeeState.setTextAndPlaceCursorAtEnd(
-                    convertWeiToGwei(spec.priorityFeeWei).toPlainString()
-                )
+                if (chain.supportsLegacyGas) {
+                    // No EIP-1559 base fee exists on a legacy-gas chain (BSC's is pinned near
+                    // zero by BEP-226), so the single price the user edits here is the real
+                    // eth_gasPrice, carried in the same baseFee field; priority fee stays zero
+                    // and hidden so applyGasSettings' baseFee + priorityFee sum still lands on
+                    // exactly that price (issue #5397).
+                    val gasPriceGwei = convertWeiToGwei(evmApi.getGasPrice())
+                    baseFeeState.setTextAndPlaceCursorAtEnd(gasPriceGwei.toPlainString())
+                    priorityFeeState.setTextAndPlaceCursorAtEnd("0")
+                } else {
+                    val baseFeeGwei = convertWeiToGwei(evmApi.getBaseFee())
+                    baseFeeState.setTextAndPlaceCursorAtEnd(baseFeeGwei.toPlainString())
+                    priorityFeeState.setTextAndPlaceCursorAtEnd(
+                        convertWeiToGwei(spec.priorityFeeWei).toPlainString()
+                    )
+                }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 Timber.e(e)
@@ -103,12 +119,17 @@ constructor(
     fun save(): GasSettings {
         return when (state.value.chainSpecific) {
             is BlockChainSpecific.Ethereum -> {
+                // Neither field's format is restricted to non-negative (the keyboard still
+                // accepts a pasted "-"), so clamp here: this is what keeps maxFeePerGasWei
+                // (baseFee + priorityFee) from ever landing below priorityFee itself.
                 val baseFeeWei =
                     convertGweiToWei(baseFeeState.text.toString().toBigDecimalOrZero())
                         .toBigInteger()
+                        .coerceAtLeast(BigInteger.ZERO)
                 val priorityFeeWei =
                     convertGweiToWei(priorityFeeState.text.toString().toBigDecimalOrZero())
                         .toBigInteger()
+                        .coerceAtLeast(BigInteger.ZERO)
                 GasSettings.Eth(
                     baseFee = baseFeeWei,
                     priorityFee = priorityFeeWei,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModel.kt
@@ -24,6 +24,10 @@ import timber.log.Timber
 internal data class GasSettingsUiModel(
     val chainSpecific: BlockChainSpecific? = null,
     val byteFeeError: UiText? = null,
+    // True while loadEthData's fetch is in flight, and left true if it fails: Save must not be
+    // pressable while baseFee/priorityFee are blanked, or a slow/failed fetch would let the
+    // user save a zero fee (issue #5397).
+    val isLoadingEthFee: Boolean = false,
 )
 
 internal enum class PriorityFee {
@@ -76,6 +80,7 @@ constructor(
         // can never sign a fee carried over from a previous chain's session.
         baseFeeState.setTextAndPlaceCursorAtEnd("")
         priorityFeeState.setTextAndPlaceCursorAtEnd("")
+        state.update { it.copy(isLoadingEthFee = true) }
 
         viewModelScope.launch {
             val evmApi = evmApiFactory.createEvmApi(chain)
@@ -96,9 +101,12 @@ constructor(
                         convertWeiToGwei(spec.priorityFeeWei).toPlainString()
                     )
                 }
+                state.update { it.copy(isLoadingEthFee = false) }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 Timber.e(e)
+                // isLoadingEthFee stays true: the fields are still blank, so Save must stay
+                // disabled rather than let this failure save a zero fee.
             }
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
@@ -158,7 +158,14 @@ enum class AddressBookType {
 
 internal sealed class GasSettings {
     data class Eth(val baseFee: BigInteger, val priorityFee: BigInteger, val gasLimit: BigInteger) :
-        GasSettings()
+        GasSettings() {
+        // Single source of truth for the EIP-1559 fee cap: both the signed transaction
+        // (DefaultSendStrategy.applyGasSettings) and the displayed estimate
+        // (selectGasFeeForFeeEstimation) must derive maxFeePerGas from this, or the two can
+        // silently disagree (issue #5397).
+        val maxFeePerGasWei: BigInteger
+            get() = baseFee + priorityFee
+    }
 
     data class UTXO(val byteFee: BigInteger) : GasSettings()
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
@@ -159,6 +159,11 @@ enum class AddressBookType {
 internal sealed class GasSettings {
     data class Eth(val baseFee: BigInteger, val priorityFee: BigInteger, val gasLimit: BigInteger) :
         GasSettings() {
+        init {
+            require(baseFee >= BigInteger.ZERO) { "baseFee must be non-negative" }
+            require(priorityFee >= BigInteger.ZERO) { "priorityFee must be non-negative" }
+        }
+
         // Single source of truth for the EIP-1559 fee cap: both the signed transaction
         // (DefaultSendStrategy.applyGasSettings) and the displayed estimate
         // (selectGasFeeForFeeEstimation) must derive maxFeePerGas from this, or the two can

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -462,7 +462,7 @@ internal class DefaultSendStrategy(
                 it.copy(
                     blockChainSpecific =
                         spec.copy(
-                            maxFeePerGasWei = gs.baseFee,
+                            maxFeePerGasWei = gs.maxFeePerGasWei,
                             priorityFeeWei = gs.priorityFee,
                             gasLimit = gs.gasLimit,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.supportsLegacyGas
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -37,6 +38,7 @@ import com.vultisig.wallet.ui.models.send.GasSettings
 import com.vultisig.wallet.ui.models.send.GasSettingsUiModel
 import com.vultisig.wallet.ui.models.send.GasSettingsViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import java.math.BigInteger
 
 @Composable
 internal fun GasSettingsScreen(
@@ -52,6 +54,7 @@ internal fun GasSettingsScreen(
 
     BasicAlertDialog(onDismissRequest = onDismissGasSettings) {
         GasSettingsScreen(
+            isLegacyGas = chain.supportsLegacyGas,
             state = state,
             gasLimitState = model.gasLimitState,
             baseFeeState = model.baseFeeState,
@@ -67,7 +70,8 @@ internal fun GasSettingsScreen(
 }
 
 @Composable
-private fun GasSettingsScreen(
+internal fun GasSettingsScreen(
+    isLegacyGas: Boolean,
     state: GasSettingsUiModel,
     gasLimitState: TextFieldState,
     baseFeeState: TextFieldState,
@@ -111,6 +115,7 @@ private fun GasSettingsScreen(
         when (state.chainSpecific) {
             is BlockChainSpecific.Ethereum -> {
                 EthGasSettings(
+                    isLegacyGas = isLegacyGas,
                     state = state,
                     gasLimitState = gasLimitState,
                     baseFeeState = baseFeeState,
@@ -148,13 +153,18 @@ private fun UTXOSettings(state: GasSettingsUiModel, byteFeeState: TextFieldState
 
 @Composable
 private fun EthGasSettings(
+    isLegacyGas: Boolean,
     state: GasSettingsUiModel,
     gasLimitState: TextFieldState,
     baseFeeState: TextFieldState,
     priorityFeeState: TextFieldState,
 ) {
     Text(
-        text = stringResource(R.string.gas_settings_max_base_fee_gwei),
+        text =
+            stringResource(
+                if (isLegacyGas) R.string.gas_settings_gas_price_gwei
+                else R.string.gas_settings_max_base_fee_gwei
+            ),
         style = Theme.brockmann.body.s.medium,
         color = Theme.v2.colors.text.primary,
     )
@@ -165,17 +175,20 @@ private fun EthGasSettings(
 
     UiSpacer(14.dp)
 
-    Text(
-        text = stringResource(R.string.gas_settings_priority_fee_gwei),
-        style = Theme.brockmann.body.s.medium,
-        color = Theme.v2.colors.text.primary,
-    )
+    // Legacy-gas chains (BSC) have no priority fee: their gasPrice is the single field above.
+    if (!isLegacyGas) {
+        Text(
+            text = stringResource(R.string.gas_settings_priority_fee_gwei),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.primary,
+        )
 
-    UiSpacer(8.dp)
+        UiSpacer(8.dp)
 
-    VsTextInputField(textFieldState = priorityFeeState, keyboardType = KeyboardType.Number)
+        VsTextInputField(textFieldState = priorityFeeState, keyboardType = KeyboardType.Number)
 
-    UiSpacer(14.dp)
+        UiSpacer(14.dp)
+    }
 
     Text(
         text = stringResource(R.string.eth_gas_settings_gas_limit_title),
@@ -188,15 +201,39 @@ private fun EthGasSettings(
     VsTextInputField(textFieldState = gasLimitState, keyboardType = KeyboardType.Number)
 }
 
+private val previewEthSpec =
+    BlockChainSpecific.Ethereum(
+        maxFeePerGasWei = BigInteger.valueOf(3_000_000_000L),
+        priorityFeeWei = BigInteger.valueOf(1_000_000_000L),
+        nonce = BigInteger.ZERO,
+        gasLimit = BigInteger.valueOf(21_000L),
+    )
+
 @Preview
 @Composable
 private fun EthGasSettingsScreenPreview() {
     GasSettingsScreen(
-        state = GasSettingsUiModel(),
-        gasLimitState = TextFieldState(),
+        isLegacyGas = false,
+        state = GasSettingsUiModel(chainSpecific = previewEthSpec),
+        gasLimitState = TextFieldState("21000"),
         byteFeeState = TextFieldState(),
-        baseFeeState = TextFieldState(),
-        priorityFeeState = TextFieldState(),
+        baseFeeState = TextFieldState("3"),
+        priorityFeeState = TextFieldState("1"),
+        onSaveClick = {},
+        onCloseClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun LegacyGasSettingsScreenPreview() {
+    GasSettingsScreen(
+        isLegacyGas = true,
+        state = GasSettingsUiModel(chainSpecific = previewEthSpec),
+        gasLimitState = TextFieldState("21000"),
+        byteFeeState = TextFieldState(),
+        baseFeeState = TextFieldState("3"),
+        priorityFeeState = TextFieldState("0"),
         onSaveClick = {},
         onCloseClick = {},
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
@@ -135,6 +135,10 @@ internal fun GasSettingsScreen(
         VsButton(
             label = stringResource(R.string.add_vault_save),
             onClick = onSaveClick,
+            // Blocks saving while the eth_gasPrice/base fee fetch is in flight, and keeps
+            // blocking on failure too — the fields stay blank either way, and blank would
+            // otherwise save as a zero fee (issue #5397).
+            isLoading = state.isLoadingEthFee,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -814,6 +814,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Ihr Tresor wird generiert, sobald Sie die Einrichtung auf Ihrem Hauptgerät abgeschlossen haben.</string>
     <string name="join_key_sign_wrong_signing_library_type">Falscher Signaturbibliothekstyp</string>
     <string name="gas_settings_advanced_gas_fee">Gasvorschuss</string>
+    <string name="gas_settings_gas_price_gwei">Gas-Preis (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Maximale Grundgebühr (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Prioritätsgebühr (GWEI)</string>
     <string name="import_file_import_your_vault_share">Importieren Sie Ihre Vault-Freigabe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -812,6 +812,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Tu bóveda empezará a generarse en cuanto la configures en tu dispositivo principal</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo de biblioteca de firma incorrecto</string>
     <string name="gas_settings_advanced_gas_fee">Tarifa de gas anticipada</string>
+    <string name="gas_settings_gas_price_gwei">Precio del gas (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Tarifa base máxima (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Tarifa prioritaria (GWEI)</string>
     <string name="import_file_import_your_vault_share">Importar el recurso compartido de su bóveda</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -816,6 +816,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Vaš trezor će početi generirati od trenutka kada završite s postavljanjem trezora na glavnom uređaju</string>
     <string name="join_key_sign_wrong_signing_library_type">Pogrešna vrsta biblioteke za potpisivanje</string>
     <string name="gas_settings_advanced_gas_fee">Naknada za gorivo</string>
+    <string name="gas_settings_gas_price_gwei">Cijena gasa (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Maksimalna osnovna naknada (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Prioritetna naknada (GWEI)</string>
     <string name="import_file_import_your_vault_share">Uvezite svoj trezor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -812,6 +812,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Il vault inizierà a generare dati dal momento in cui finalizzi la configurazione del vault sul tuo dispositivo principale</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo di libreria di firma errato</string>
     <string name="gas_settings_advanced_gas_fee">Tariffa gas avanzata</string>
+    <string name="gas_settings_gas_price_gwei">Prezzo del gas (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Tariffa base massima (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Tariffa prioritaria (GWEI)</string>
     <string name="import_file_import_your_vault_share">Importa la tua condivisione Vault</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1047,6 +1047,7 @@
     <string name="fast_vault_invalid_password">유효하지 않은 비밀번호</string>
     <string name="folder">폴더</string>
     <string name="gas_settings_advanced_gas_fee">고급 가스 수수료</string>
+    <string name="gas_settings_gas_price_gwei">가스 가격 (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">최대 기본 수수료 (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">우선 수수료 (GWEI)</string>
     <string name="import_file_import_your_vault_share">볼트 공유 가져오기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -809,6 +809,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Je kluis wordt gegenereerd vanaf het moment dat je de kluis op je hoofdapparaat hebt ingesteld</string>
     <string name="join_key_sign_wrong_signing_library_type">Verkeerd type ondertekeningsbibliotheek</string>
     <string name="gas_settings_advanced_gas_fee">Geavanceerde gasvergoeding</string>
+    <string name="gas_settings_gas_price_gwei">Gasprijs (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Maximale basisvergoeding (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Prioriteitsvergoeding (GWEI)</string>
     <string name="import_file_import_your_vault_share">Importeer uw gedeelde kluis</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -811,6 +811,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">O seu cofre começará a ser gerado a partir do momento em que finalizar a configuração do cofre no seu dispositivo principal.</string>
     <string name="join_key_sign_wrong_signing_library_type">Tipo de biblioteca de assinatura incorreto.</string>
     <string name="gas_settings_advanced_gas_fee">Taxa de gás antecipada</string>
+    <string name="gas_settings_gas_price_gwei">Preço do gás (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Taxa básica máxima (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Taxa de prioridade (GWEI)</string>
     <string name="import_file_import_your_vault_share">Importe a sua partilha de cofre</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -815,6 +815,7 @@
     <string name="join_key_gen_your_vault_will_start_generating">Генерация вашего хранилища начнётся с момента завершения настройки хранилища на основном устройстве</string>
     <string name="join_key_sign_wrong_signing_library_type">Неверный тип библиотеки подписи</string>
     <string name="gas_settings_advanced_gas_fee">Расширенная комиссия за газ</string>
+    <string name="gas_settings_gas_price_gwei">Цена газа (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Максимальная базовая комиссия (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Приоритетная комиссия (GWEI)</string>
     <string name="import_file_import_your_vault_share">Импортируйте общий доступ к хранилищу</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -937,6 +937,7 @@
 
     <!-- Gas Settings -->
     <string name="gas_settings_advanced_gas_fee">高级燃料费</string>
+    <string name="gas_settings_gas_price_gwei">Gas 价格（GWEI）</string>
     <string name="gas_settings_max_base_fee_gwei">最大基础费用（GWEI）</string>
     <string name="gas_settings_priority_fee_gwei">优先费用（GWEI）</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1069,6 +1069,7 @@
     <string name="fast_vault_invalid_password">Invalid password</string>
     <string name="folder">folder</string>
     <string name="gas_settings_advanced_gas_fee">Advanced gas fee</string>
+    <string name="gas_settings_gas_price_gwei">Gas price (GWEI)</string>
     <string name="gas_settings_max_base_fee_gwei">Max base fee (GWEI)</string>
     <string name="gas_settings_priority_fee_gwei">Priority fee (GWEI)</string>
     <string name="import_file_import_your_vault_share">Import your vault share</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
@@ -129,4 +129,99 @@ internal class GasSettingsViewModelTest {
 
         assertEquals(BigInteger.ZERO, settings.priorityFee)
     }
+
+    @Test
+    fun `maxFeePerGasWei sums base and priority fee`() = runTest {
+        val vm = viewModel()
+        vm.loadData(
+            Chain.Ethereum,
+            ethSpec(priorityFeeWei = BigInteger("1500000000")), // 1.5 gwei
+        )
+        advanceUntilIdle()
+        // baseFee mocked to 3 gwei in setUp.
+
+        val settings = vm.save() as GasSettings.Eth
+
+        assertEquals(BigInteger("4500000000"), settings.maxFeePerGasWei)
+    }
+
+    @Test
+    fun `negative base fee input clamps to zero and no longer drags the sum below priority fee`() =
+        runTest {
+            val vm = viewModel()
+            vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+            advanceUntilIdle()
+
+            vm.baseFeeState.setTextAndPlaceCursorAtEnd("-5")
+            val settings = vm.save() as GasSettings.Eth
+
+            assertEquals(BigInteger.ZERO, settings.baseFee)
+            assertEquals(settings.priorityFee, settings.maxFeePerGasWei)
+        }
+
+    @Test
+    fun `negative priority fee input clamps to zero`() = runTest {
+        val vm = viewModel()
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        vm.priorityFeeState.setTextAndPlaceCursorAtEnd("-2")
+        val settings = vm.save() as GasSettings.Eth
+
+        assertEquals(BigInteger.ZERO, settings.priorityFee)
+        assertEquals(settings.baseFee, settings.maxFeePerGasWei)
+    }
+
+    @Test
+    fun `legacy gas chain sources its single price field from eth_gasPrice, not the base fee`() =
+        runTest {
+            coEvery { evmApi.getGasPrice() } returns BigInteger("5000000000") // 5 gwei
+            val vm = viewModel()
+
+            vm.loadData(Chain.BscChain, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+            advanceUntilIdle()
+
+            // Not the mocked 3 gwei getBaseFee() — BSC's base fee is meaningless (BEP-226).
+            assertEquals("5", vm.baseFeeState.text.toString())
+            assertEquals("0", vm.priorityFeeState.text.toString())
+        }
+
+    @Test
+    fun `legacy gas chain save sums to the entered gas price alone`() = runTest {
+        coEvery { evmApi.getGasPrice() } returns BigInteger("5000000000")
+        val vm = viewModel()
+        vm.loadData(Chain.BscChain, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        val settings = vm.save() as GasSettings.Eth
+
+        assertEquals(BigInteger("5000000000"), settings.maxFeePerGasWei)
+        assertEquals(BigInteger.ZERO, settings.priorityFee)
+    }
+
+    /**
+     * This ViewModel is Hilt-scoped to the Send screen, not to one dialog open, so a field left
+     * over from a prior chain's session survives a close-without-saving. Without clearing the
+     * fields up front, a Save tapped for the newly opened chain before this fetch resolves could
+     * sign a fee carried over from the previous chain (issue #5397 follow-up).
+     */
+    @Test
+    fun `switching chains blanks stale fields before the new chain's fetch resolves`() = runTest {
+        val vm = viewModel()
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+        // Left over from the prior (Ethereum) session; the dialog was closed without saving.
+        vm.priorityFeeState.setTextAndPlaceCursorAtEnd("9")
+
+        coEvery { evmApi.getGasPrice() } coAnswers
+            {
+                // By the time the new chain's fetch actually runs, both fields must already be
+                // blank — never still holding Ethereum's stale priority fee.
+                assertEquals("", vm.baseFeeState.text.toString())
+                assertEquals("", vm.priorityFeeState.text.toString())
+                BigInteger("5000000000")
+            }
+
+        vm.loadData(Chain.BscChain, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class GasSettingsViewModelTest {
 
@@ -223,5 +224,50 @@ internal class GasSettingsViewModelTest {
             }
 
         vm.loadData(Chain.BscChain, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+    }
+
+    @Test
+    fun `isLoadingEthFee clears once the fetch resolves`() = runTest {
+        val vm = viewModel()
+
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        assertEquals(false, vm.state.value.isLoadingEthFee)
+    }
+
+    /**
+     * CodeRabbit finding on this PR: blanking the fields on chain switch (above) closed the
+     * stale-value leak, but a slow or failed fetch left the fields blank with Save still pressable
+     * — save() would then read "" as zero, reproducing the original zero-fee bug via a different
+     * trigger. isLoadingEthFee must stay true (Save disabled) until a fetch actually succeeds.
+     */
+    @Test
+    fun `isLoadingEthFee stays true when the fetch fails, keeping Save disabled`() = runTest {
+        coEvery { evmApi.getBaseFee() } throws RuntimeException("network error")
+        val vm = viewModel()
+
+        vm.loadData(Chain.Ethereum, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        assertEquals(true, vm.state.value.isLoadingEthFee)
+    }
+
+    @Test
+    fun `GasSettings Eth rejects a negative baseFee or priorityFee`() {
+        assertThrows<IllegalArgumentException> {
+            GasSettings.Eth(
+                baseFee = BigInteger.valueOf(-1),
+                priorityFee = BigInteger.ZERO,
+                gasLimit = BigInteger("21000"),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            GasSettings.Eth(
+                baseFee = BigInteger.ZERO,
+                priorityFee = BigInteger.valueOf(-1),
+                gasLimit = BigInteger("21000"),
+            )
+        }
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SelectGasFeeForFeeEstimationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SelectGasFeeForFeeEstimationTest.kt
@@ -73,8 +73,9 @@ internal class SelectGasFeeForFeeEstimationTest {
     }
 
     @Test
-    fun `ethereum uses the base fee from evm gas settings`() {
+    fun `ethereum uses the base fee plus priority fee from evm gas settings`() {
         val baseFee = BigInteger.valueOf(42L)
+        val priorityFee = BigInteger.valueOf(2L)
         val result =
             selectGasFeeForFeeEstimation(
                 chain = Chain.Ethereum,
@@ -83,12 +84,12 @@ internal class SelectGasFeeForFeeEstimationTest {
                 evmGasSettings =
                     GasSettings.Eth(
                         baseFee = baseFee,
-                        priorityFee = BigInteger.valueOf(2L),
+                        priorityFee = priorityFee,
                         gasLimit = BigInteger.valueOf(21_000L),
                     ),
             )
 
-        assertEquals(baseFee, result.value)
+        assertEquals(BigInteger.valueOf(44L), result.value)
     }
 
     @Test
@@ -124,7 +125,7 @@ internal class SelectGasFeeForFeeEstimationTest {
     }
 
     @Test
-    fun `ethereum with zero base fee returns fee value of zero not the original gas fee`() {
+    fun `ethereum with zero base fee still returns the priority fee, not the original gas fee`() {
         val result =
             selectGasFeeForFeeEstimation(
                 chain = Chain.Ethereum,
@@ -138,7 +139,30 @@ internal class SelectGasFeeForFeeEstimationTest {
                     ),
             )
 
-        assertEquals(BigInteger.ZERO, result.value)
+        assertEquals(BigInteger.valueOf(2L), result.value)
         assertEquals(ethFee.unit, result.unit)
+    }
+
+    @Test
+    fun `ethereum estimate matches the same GasSettings' maxFeePerGasWei used at signing`() {
+        // The estimate shown on the Send form/confirmation and the value actually signed into
+        // BlockChainSpecific.Ethereum.maxFeePerGasWei (DefaultSendStrategy.applyGasSettings) must
+        // never diverge for the same GasSettings.Eth (issue #5397).
+        val gasSettings =
+            GasSettings.Eth(
+                baseFee = BigInteger.valueOf(30L),
+                priorityFee = BigInteger.valueOf(5L),
+                gasLimit = BigInteger.valueOf(21_000L),
+            )
+
+        val result =
+            selectGasFeeForFeeEstimation(
+                chain = Chain.Ethereum,
+                gasFee = ethFee,
+                planFee = null,
+                evmGasSettings = gasSettings,
+            )
+
+        assertEquals(gasSettings.maxFeePerGasWei, result.value)
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -29,10 +29,12 @@ import com.vultisig.wallet.ui.models.send.ChainValidationService
 import com.vultisig.wallet.ui.models.send.GasSettings
 import com.vultisig.wallet.ui.models.send.SendFocusField
 import com.vultisig.wallet.ui.models.send.SendSections
+import com.vultisig.wallet.ui.models.send.selectGasFeeForFeeEstimation
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -89,6 +91,7 @@ internal class DefaultSendStrategyTest {
     private var lastError: UiText? = null
     private var defiType: DeFiNavActions? = null
     private val accounts = MutableStateFlow<List<Account>>(emptyList())
+    private val gasSettings = MutableStateFlow<GasSettings?>(null)
 
     @BeforeEach
     fun setUp() {
@@ -135,64 +138,16 @@ internal class DefaultSendStrategyTest {
         mockkStatic(Dispatchers::class)
         every { Dispatchers.IO } returns mainDispatcher
         try {
-            val ethCoin = ethCoin()
-            val account =
-                Account(
-                    token = ethCoin,
-                    tokenValue =
-                        TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin),
-                    fiatValue = null,
-                    price = null,
-                )
-            vaultId = "vault-1"
-            selectedAccount = account
-            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
-            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
-            coEvery { accountValidator.validate() } returns
-                ValidatedAccount(
-                    vaultId = "vault-1",
-                    selectedAccount = account,
-                    chain = Chain.Ethereum,
-                    gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin),
-                    dstAddress = "0xdest",
-                )
-            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
-            coEvery {
-                blockChainSpecificRepository.getSpecific(
-                    chain = any(),
-                    address = any(),
-                    token = any(),
-                    gasFee = any(),
-                    isSwap = any(),
-                    isMaxAmountEnabled = any(),
-                    isDeposit = any(),
-                    dstAddress = any(),
-                    tokenAmountValue = any(),
-                    memo = any(),
-                    isThorchainRouterDeposit = any(),
-                )
-            } returns
-                BlockChainSpecificAndUtxo(
+            val captured =
+                arrangeSuccessfulEthSubmit(
+                    ethCoin(),
                     BlockChainSpecific.Ethereum(
                         maxFeePerGasWei = BigInteger.ONE,
                         priorityFeeWei = BigInteger.ONE,
                         nonce = BigInteger.ZERO,
                         gasLimit = BigInteger.valueOf(21000),
-                    )
+                    ),
                 )
-            every { amountManager.currentMaxAmount } returns BigDecimal.ONE
-            coEvery { getAvailableTokenBalance(any(), any()) } returns
-                TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin)
-            coEvery { gasFeeToEstimatedFee(any()) } returns
-                EstimatedGasFee(
-                    formattedFiatValue = "$0.10",
-                    formattedTokenValue = "0.0001 ETH",
-                    tokenValue = TokenValue(BigInteger.ONE, ethCoin),
-                    fiatValue = mockk(relaxed = true),
-                )
-
-            val captured = slot<Transaction>()
-            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
 
             build(this).submit()
             advanceUntilIdle()
@@ -207,6 +162,58 @@ internal class DefaultSendStrategyTest {
             unmockkStatic(Dispatchers::class)
         }
     }
+
+    /**
+     * Regression for #5397: the maxFeePerGasWei signed into BlockChainSpecific.Ethereum and the fee
+     * estimate shown to the user (GasFeeSelection.selectGasFeeForFeeEstimation, used by both the
+     * live Send-form estimate and this same submit path's totalGasAndFee) must derive from the same
+     * GasSettings.Eth sum. Previously the signed value dropped the priority fee entirely.
+     */
+    @Test
+    fun `submit sums base and priority fee into the signed maxFeePerGasWei, matching the fee estimate`() =
+        runTest {
+            mockkStatic(Dispatchers::class)
+            every { Dispatchers.IO } returns mainDispatcher
+            try {
+                val ethCoin = ethCoin()
+                val captured =
+                    arrangeSuccessfulEthSubmit(
+                        ethCoin,
+                        BlockChainSpecific.Ethereum(
+                            maxFeePerGasWei = BigInteger.ONE,
+                            priorityFeeWei = BigInteger.ONE,
+                            nonce = BigInteger.ZERO,
+                            gasLimit = BigInteger.valueOf(21000),
+                        ),
+                    )
+
+                val advancedGasSettings =
+                    GasSettings.Eth(
+                        baseFee = BigInteger.valueOf(30_000_000_000L),
+                        priorityFee = BigInteger.valueOf(2_000_000_000L),
+                        gasLimit = BigInteger.valueOf(21_000),
+                    )
+                gasSettings.value = advancedGasSettings
+
+                build(this).submit()
+                advanceUntilIdle()
+
+                assertNull(lastError, "Expected no error; got $lastError")
+                val signedSpec = captured.captured.blockChainSpecific as BlockChainSpecific.Ethereum
+                assertEquals(BigInteger.valueOf(32_000_000_000L), signedSpec.maxFeePerGasWei)
+
+                val displayedEstimateFee =
+                    selectGasFeeForFeeEstimation(
+                        chain = Chain.Ethereum,
+                        gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin),
+                        planFee = null,
+                        evmGasSettings = advancedGasSettings,
+                    )
+                assertEquals(signedSpec.maxFeePerGasWei, displayedEstimateFee.value)
+            } finally {
+                unmockkStatic(Dispatchers::class)
+            }
+        }
 
     /**
      * Production regression for #4152: when the user reaches the Send form via the THORChain LP
@@ -815,6 +822,66 @@ internal class DefaultSendStrategyTest {
         }
     }
 
+    /**
+     * Arranges a straightforward ETH native-token submit that reaches transactionRepository without
+     * error, returning the captured Transaction slot. [blockChainSpecific] is what getSpecific()
+     * returns before any gasSettings override is applied by the strategy itself.
+     */
+    private fun arrangeSuccessfulEthSubmit(
+        ethCoin: Coin,
+        blockChainSpecific: BlockChainSpecific.Ethereum,
+    ): CapturingSlot<Transaction> {
+        val account =
+            Account(
+                token = ethCoin,
+                tokenValue = TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin),
+                fiatValue = null,
+                price = null,
+            )
+        vaultId = "vault-1"
+        selectedAccount = account
+        addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount = account,
+                chain = Chain.Ethereum,
+                gasFee = TokenValue(BigInteger.valueOf(21_000), ethCoin),
+                dstAddress = "0xdest",
+            )
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                dstAddress = any(),
+                tokenAmountValue = any(),
+                memo = any(),
+                isThorchainRouterDeposit = any(),
+            )
+        } returns BlockChainSpecificAndUtxo(blockChainSpecific)
+        every { amountManager.currentMaxAmount } returns BigDecimal.ONE
+        coEvery { getAvailableTokenBalance(any(), any()) } returns
+            TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), ethCoin)
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.10",
+                formattedTokenValue = "0.0001 ETH",
+                tokenValue = TokenValue(BigInteger.ONE, ethCoin),
+                fiatValue = mockk(relaxed = true),
+            )
+
+        val captured = slot<Transaction>()
+        coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+        return captured
+    }
+
     private fun xrpCoin(): Coin =
         Coin(
             chain = Chain.Ripple,
@@ -872,7 +939,7 @@ internal class DefaultSendStrategyTest {
             chainValidationService = ChainValidationService(rippleApi = rippleApi),
             addressManager = addressManager,
             amountManager = amountManager,
-            gasSettings = MutableStateFlow<GasSettings?>(null),
+            gasSettings = gasSettings,
             planBtc = MutableStateFlow<Bitcoin.TransactionPlan?>(null),
             planFee = MutableStateFlow<Long?>(null),
             accounts = accounts,


### PR DESCRIPTION
## Summary

Advanced Gas Settings saved `maxFeePerGasWei` as the base fee alone, dropping the priority fee from what actually gets signed and broadcast on every EVM chain. On BSC this went further: its "Max base fee" field was populated from `eth_getBlockByNumber` (pinned near zero by BEP-226) instead of `eth_gasPrice`, so saving the dialog without changing anything signed a transaction with `gasPrice = 0`, rejected by BSC's mempool every time.

## What changed

- `GasSettings.Eth.maxFeePerGasWei` is now a computed `baseFee + priorityFee`, used both when signing (`DefaultSendStrategy.applyGasSettings`) and when estimating the fee shown to the user (`GasFeeSelection.selectGasFeeForFeeEstimation`) — one source of truth so the two can't disagree.
- Legacy-gas chains (currently BSC) get a single "Gas price" field sourced from `eth_gasPrice`, with the priority-fee input hidden entirely instead of showing a meaningless base-fee/priority-fee split.
- `save()` clamps both fields to non-negative, so a pasted negative value can never push the signed fee below the priority fee.
- Both fields are blanked before every chain's fetch, so a value left over from a previously-opened chain (the dialog's ViewModel is scoped to the Send screen, not to one dialog open) can't leak into a save for a different chain.

## Screenshots

BSC's Advanced Gas Settings dialog, same build, `isLegacyGas` toggled to show before/after:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/hwXGoXH.png) | ![after](https://i.imgur.com/D4qvIEx.png) |

Other EVM chains keep the existing two-field layout unchanged; only the underlying sum changed for them.

## Testing

- `./gradlew :app:testDebugUnitTest :data:testDebugUnitTest` — green
- `./gradlew :app:ktfmtCheckMain :app:ktfmtCheckTest :app:ktfmtCheckDebug :data:ktfmtCheck` — clean
- `./gradlew :app:lintDebug` — clean
- New/updated tests: `GasSettingsViewModelTest` (legacy-chain sourcing, negative-input clamping, stale-field-across-chain-switch regression), `SelectGasFeeForFeeEstimationTest` (sum instead of base-fee-alone), `DefaultSendStrategyTest` (signed `maxFeePerGasWei` matches the displayed estimate for the same `GasSettings.Eth`)

Closes #5397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy-gas handling in gas settings: shows a single gas price and hides priority-fee controls when applicable.
  * Updated the gas settings experience so loading state properly blocks saving during fee retrieval.
* **Localization**
  * Added translated “Gas price (GWEI)” labels across supported languages.
* **Bug Fixes**
  * Fixed Ethereum gas-fee math to consistently use the maximum fee (base + priority) for fee estimation and transaction signing.
  * Prevent negative fee inputs and avoid carrying over stale fee values when switching chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->