### PR TITLE
chore: bump version to 1.0.115

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 36
-        versionCode = 114
-        versionName = "1.0.114"
+        versionCode = 115
+        versionName = "1.0.115"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ android.nonTransitiveRClass=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.daemon=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Bump versionCode to 115 / versionName to 1.0.115 for release v1.0.115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the app version to 1.0.115.
* **Performance**
  * Improved Gradle build tooling configuration for faster, more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->