### PR TITLE
fix(keysign): guard startForegroundService against rejection

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/services/TransactionStatusServiceManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/TransactionStatusServiceManager.kt
@@ -49,8 +49,10 @@ constructor(@param:ApplicationContext private val context: Context) {
     /**
      * Starts the foreground status service for [txHash] on [chain] and binds to it.
      *
-     * @return `false` when the system rejected the binding: `onServiceConnected()` never fires in
-     *   that case, so [serviceReady] stays `false` and callers must not wait on it.
+     * @return `false` when the system rejected the start (e.g.
+     *   `ForegroundServiceStartNotAllowedException` on API 31+ with no foreground state) or the
+     *   binding: `onServiceConnected()` never fires in that case, so [serviceReady] stays `false`
+     *   and callers must not wait on it.
      */
     fun startPolling(txHash: String, chain: Chain): Boolean {
         val intent =
@@ -59,7 +61,11 @@ constructor(@param:ApplicationContext private val context: Context) {
                 putExtra(TransactionStatusService.EXTRA_TX_HASH, txHash)
                 putExtra(TransactionStatusService.EXTRA_CHAIN, chain.raw)
             }
-        context.startForegroundService(intent)
+        val started =
+            runCatching { context.startForegroundService(intent) }
+                .onFailure { Timber.w(it, "Failed to start transaction status service") }
+                .isSuccess
+        if (!started) return false
         if (isBound) return true
 
         // Marked bound on request, not on connect: a binding that has not connected yet still


### PR DESCRIPTION
## Summary
- `TransactionStatusServiceManager.startPolling()` called `context.startForegroundService(intent)` unguarded. On API 31+, this throws `ForegroundServiceStartNotAllowedException` when the app has no active foreground state (e.g. backgrounded right as a broadcast completes).
- The call runs inside `safeLaunch`, which swallows the exception, stranding the keysign done screen on the signing spinner with no error surfaced.
- Wrapped the call in `runCatching`, mirroring the existing `bindService` guard a few lines below, and return `false` on failure.
- No caller changes needed: `KeysignTxStatusPoller.pollStatusService` already treats `bound == false` as "emit `Pending`, return `null`" (added in #5394's fix for the equivalent teardown-side gap), so this closes the startup-side gap the same way.

## Issue
Closes #5407

## Test Plan
- [x] `./gradlew compileDebugKotlin`
- [x] `./gradlew lint`
- [ ] Manual: start a keysign for a chain with tx-status support, background the app right as the broadcast completes, confirm the done screen doesn't get stuck on the signing spinner

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction status polling reliability when background service startup is restricted.
  * Polling now fails gracefully instead of throwing an error when the service cannot start.
  * Callers receive a clear failure result and are no longer left waiting for an unavailable service connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->