### PR TITLE
fix(price): add Mantle to CoinGecko contract-price chain map

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
@@ -94,6 +94,7 @@ internal class CoinGeckoApiImpl @Inject constructor(private val http: HttpClient
                 Chain.BscChain -> "binance-smart-chain"
                 Chain.ZkSync -> "zksync"
                 Chain.Solana -> "solana"
+                Chain.Mantle -> "mantle"
 
                 else -> error("No CoinGecko asset id for chain $this")
             }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiContractPriceChainTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiContractPriceChainTest.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.assertContains
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for #5406: `coinGeckoAssetId` threw for Mantle before the request was ever sent,
+ * so `getContractsPrice` silently degraded to an empty map. Pins that Mantle now resolves to the
+ * "mantle" CoinGecko platform id (matching iOS's `coinGeckoPlatform`), and that a chain the map
+ * still doesn't cover keeps degrading gracefully instead of crashing.
+ */
+class CoinGeckoApiContractPriceChainTest {
+
+    @Test
+    fun `getContractsPrice resolves Mantle to the mantle CoinGecko platform id`() = runTest {
+        lateinit var requestedUrl: String
+        val engine = MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(content = "{}", status = HttpStatusCode.OK)
+        }
+        val api = CoinGeckoApiImpl(HttpClient(engine) { install(ContentNegotiation) { json() } })
+
+        api.getContractsPrice(Chain.Mantle, listOf("0xabc"), listOf("usd"))
+
+        assertContains(requestedUrl, "/token_price/mantle")
+        assertContains(requestedUrl, "contract_addresses=0xabc")
+        assertContains(requestedUrl, "vs_currencies=usd")
+    }
+
+    @Test
+    fun `getContractsPrice still degrades to an empty map for a chain without a mapping`() =
+        runTest {
+            var requestAttempted = false
+            val engine = MockEngine {
+                requestAttempted = true
+                respond(content = "{}", status = HttpStatusCode.OK)
+            }
+            val api =
+                CoinGeckoApiImpl(HttpClient(engine) { install(ContentNegotiation) { json() } })
+
+            val result = api.getContractsPrice(Chain.Sei, listOf("0xabc"), listOf("usd"))
+
+            assertFalse(requestAttempted, "an unmapped chain must not reach the network")
+            assertEquals(emptyMap<String, CurrencyToPrice>(), result)
+        }
+}


### PR DESCRIPTION
## Summary
`coinGeckoAssetId` had no entry for `Chain.Mantle`, so `getContractsPrice` hit the catch-all `else -> error(...)` before ever reaching the network and non-native Mantle tokens never resolved a USD price. iOS's `CryptoPriceService.coinGeckoPlatform` already maps Mantle to the same `"mantle"` platform id, so this adds the equivalent entry on Android.

Overlap note: PR #5390 (https://github.com/vultisig/vultisig-android/pull/5390) touches the same `when` block to add a Robinhood entry; low conflict risk since it's a one-line addition in an unrelated ~20-file feature PR (Robinhood chain support), not the same behavior.

## Test plan
- `./gradlew --no-daemon :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.*"` — passing, including a new regression test that fails with `UninitializedPropertyAccessException` when the fix is reverted (proving `coinGeckoAssetId` previously threw before any request was sent) and a sibling test confirming an unmapped chain still degrades to an empty map.
- `./gradlew --no-daemon :data:ktfmtFormat` — no diff
- `./gradlew --no-daemon :data:lintDebug` — clean

Closes #5406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added cryptocurrency price support for the Mantle network through CoinGecko.
  - Ensured contract price requests use the correct Mantle platform identifier.
  - Preserved graceful handling for networks without supported price mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->