### PR TITLE
fix(price): resolve LI.FI chain id for all EVM chains

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiQuestApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiQuestApi.kt
@@ -2,8 +2,7 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.LiQuestResponseJson
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.data.models.TokenStandard
-import com.vultisig.wallet.data.models.ticker
+import com.vultisig.wallet.data.models.evmChainId
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -31,9 +30,5 @@ internal class LiQuestApiImpl @Inject constructor(private val http: HttpClient) 
             .body()
 
     private val Chain.lifiChainId: String
-        get() =
-            when {
-                standard == TokenStandard.EVM -> ticker().lowercase()
-                else -> error("lifi chain id not found for chain $this")
-            }
+        get() = evmChainId() ?: error("lifi chain id not found for chain $this")
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiQuestApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiQuestApi.kt
@@ -2,6 +2,8 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.LiQuestResponseJson
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.ticker
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -30,8 +32,8 @@ internal class LiQuestApiImpl @Inject constructor(private val http: HttpClient) 
 
     private val Chain.lifiChainId: String
         get() =
-            when (this) {
-                Chain.Ethereum -> "eth"
+            when {
+                standard == TokenStandard.EVM -> ticker().lowercase()
                 else -> error("lifi chain id not found for chain $this")
             }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -369,6 +369,21 @@ fun Chain.oneInchChainId(): Long =
             throw SwapException.SwapRouteNotAvailable("Chain $this is not supported by 1inch API")
     }
 
+/**
+ * The chain's real numeric EVM chain id, string-encoded, for external services keyed by the
+ * standard chain id rather than 1inch's routing-restricted [oneInchChainId] (which also carries a
+ * non-EVM pseudo-id for [Chain.Solana], so non-EVM standard is checked first rather than trusting
+ * [oneInchChainId] to fail for every non-EVM chain). [Chain.Sei] is the one EVM chain those
+ * services index that 1inch doesn't route (adding it to [oneInchChainId] would wrongly signal swap
+ * support), so it stays the sole documented exception; every other EVM chain tracks the shared map.
+ */
+fun Chain.evmChainId(): String? =
+    when {
+        standard != EVM -> null
+        this == Chain.Sei -> "1329"
+        else -> runCatching { oneInchChainId().toString() }.getOrNull()
+    }
+
 fun Chain.swapAssetName(): String {
     return when (this) {
         Chain.ThorChain -> "THOR"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ContractAbiRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ContractAbiRepository.kt
@@ -5,7 +5,7 @@ import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.SourcifyApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.TokenStandard
-import com.vultisig.wallet.data.models.oneInchChainId
+import com.vultisig.wallet.data.models.evmChainId
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration
@@ -94,7 +94,7 @@ constructor(
         signature: String,
     ): List<AbiParam>? {
         if (chain.standard != TokenStandard.EVM) return null
-        val chainId = evmChainId(chain) ?: return null
+        val chainId = chain.evmChainId() ?: return null
         val address = contractAddress.trim().takeIf { it.isNotEmpty() } ?: return null
         val canonical = canonicalSignature(signature) ?: return null
 
@@ -187,20 +187,6 @@ constructor(
         val components = (obj["components"] as? JsonArray)?.mapNotNull(::toAbiParam)
         return AbiParam(name = name, type = type, components = components)
     }
-
-    /**
-     * Maps an EVM [Chain] to its decimal chain id for Sourcify's path by reusing the shared
-     * [oneInchChainId] source, so this can no longer drift from it. [Chain.Sei] is the one EVM
-     * chain Sourcify indexes that 1inch doesn't route (adding it to [oneInchChainId] would wrongly
-     * signal swap support), so it stays the sole documented exception; every other chain tracks the
-     * shared map. Unsupported chains return null (not queried) and an id Sourcify doesn't index
-     * just yields a graceful 404.
-     */
-    private fun evmChainId(chain: Chain): String? =
-        when (chain) {
-            Chain.Sei -> "1329"
-            else -> runCatching { chain.oneInchChainId().toString() }.getOrNull()
-        }
 
     private data class CacheEntry(val abi: Map<String, List<AbiParam>>, val fetchedAt: Long)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -271,7 +271,7 @@ constructor(
             BigDecimal(liQuestApi.getLifiContractPriceUsd(chain, contract).priceUsd)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e(e, "Failed to fetch Lifi price for $chain contract: $contract")
+            Timber.e(e, "Failed to fetch Lifi price for %s contract: %s", chain, contract)
             null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -271,6 +271,7 @@ constructor(
             BigDecimal(liQuestApi.getLifiContractPriceUsd(chain, contract).priceUsd)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
+            Timber.e(e, "Failed to fetch Lifi price for $chain contract: $contract")
             null
         }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiQuestApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiQuestApiImplTest.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the `chain` query param LI.FI's price-fallback endpoint receives for every EVM chain,
+ * matching iOS's `chain.ticker.lowercased()`. Every non-Ethereum EVM chain used to throw instead of
+ * resolving a real identifier.
+ */
+class LiQuestApiImplTest {
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun apiCapturing(onRequest: (HttpRequestData) -> Unit): LiQuestApi =
+        LiQuestApiImpl(
+            HttpClient(
+                MockEngine { request ->
+                    onRequest(request)
+                    respond(
+                        content = """{"priceUSD":"1.23"}""",
+                        status = HttpStatusCode.OK,
+                        headers = jsonHeaders,
+                    )
+                }
+            ) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            }
+        )
+
+    @Test
+    fun `every EVM chain resolves a lifi chain id matching iOS ticker lowercased`() = runTest {
+        val evmChainToLifiId =
+            mapOf(
+                Chain.Ethereum to "eth",
+                Chain.Avalanche to "avax",
+                Chain.Base to "base",
+                Chain.Blast to "blast",
+                Chain.Arbitrum to "arb",
+                Chain.Polygon to "pol",
+                Chain.Optimism to "op",
+                Chain.BscChain to "bnb",
+                Chain.CronosChain to "cro",
+                Chain.ZkSync to "zk",
+                Chain.Mantle to "mnt",
+                Chain.Sei to "sei",
+                Chain.Hyperliquid to "hype",
+            )
+
+        for ((chain, expectedChainParam) in evmChainToLifiId) {
+            var chainParam: String? = null
+            val api = apiCapturing { chainParam = it.url.parameters["chain"] }
+
+            val result = api.getLifiContractPriceUsd(chain, "0xcontract")
+
+            assertEquals(expectedChainParam, chainParam, "unexpected lifi chain id for $chain")
+            assertEquals("1.23", result.priceUsd)
+        }
+    }
+
+    @Test
+    fun `non-EVM chain still throws instead of silently sending a wrong identifier`() = runTest {
+        val api = apiCapturing {}
+
+        assertFailsWith<IllegalStateException> { api.getLifiContractPriceUsd(Chain.Solana, "mint") }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiQuestApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiQuestApiImplTest.kt
@@ -18,9 +18,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**
- * Pins the `chain` query param LI.FI's price-fallback endpoint receives for every EVM chain,
- * matching iOS's `chain.ticker.lowercased()`. Every non-Ethereum EVM chain used to throw instead of
- * resolving a real identifier.
+ * Pins the `chain` query param LI.FI's price-fallback endpoint receives for every EVM chain: the
+ * chain's real numeric EVM chain id, matching iOS's `chain.chainID` and reusing this repo's own
+ * [com.vultisig.wallet.data.models.evmChainId]. Every non-Ethereum EVM chain used to throw instead
+ * of resolving an identifier; a ticker-based identifier (e.g. "avax", "bnb") was tried first but
+ * verified against the live li.quest API to 400 for 7 of the 13 chains, so the numeric id is what's
+ * asserted here.
  */
 class LiQuestApiImplTest {
 
@@ -44,22 +47,22 @@ class LiQuestApiImplTest {
         )
 
     @Test
-    fun `every EVM chain resolves a lifi chain id matching iOS ticker lowercased`() = runTest {
+    fun `every EVM chain resolves its numeric lifi chain id`() = runTest {
         val evmChainToLifiId =
             mapOf(
-                Chain.Ethereum to "eth",
-                Chain.Avalanche to "avax",
-                Chain.Base to "base",
-                Chain.Blast to "blast",
-                Chain.Arbitrum to "arb",
-                Chain.Polygon to "pol",
-                Chain.Optimism to "op",
-                Chain.BscChain to "bnb",
-                Chain.CronosChain to "cro",
-                Chain.ZkSync to "zk",
-                Chain.Mantle to "mnt",
-                Chain.Sei to "sei",
-                Chain.Hyperliquid to "hype",
+                Chain.Ethereum to "1",
+                Chain.Avalanche to "43114",
+                Chain.Base to "8453",
+                Chain.Blast to "81457",
+                Chain.Arbitrum to "42161",
+                Chain.Polygon to "137",
+                Chain.Optimism to "10",
+                Chain.BscChain to "56",
+                Chain.CronosChain to "25",
+                Chain.ZkSync to "324",
+                Chain.Mantle to "5000",
+                Chain.Sei to "1329",
+                Chain.Hyperliquid to "999",
             )
 
         for ((chain, expectedChainParam) in evmChainToLifiId) {


### PR DESCRIPTION
## Summary
`LiQuestApi`'s `Chain.lifiChainId` resolver only mapped `Chain.Ethereum -> "eth"` and threw for every other chain, so the LI.FI price-fallback call (used when CoinGecko has no contract price) failed for all 12 other EVM chains. The failure was also swallowed silently in `TokenPriceRepository` with no log, so an affected token just showed a $0 valuation with no trace.

- `lifiChainId` now resolves the chain's real numeric EVM chain id via a new `Chain.evmChainId()` extension, matching iOS's `fetchLifiTokenPrice`, which sends `String(chain.chainID)`. Verified against the live `li.quest` API directly: 7 of the 13 EVM chains reject a ticker-style value (`avax`, `base`, `blast`, `op`, `bnb`, `zk`, `hype`) with HTTP 400, while every chain accepts its numeric id.
- `evmChainId()` reuses the existing `oneInchChainId()` table (gated on `TokenStandard.EVM` so non-EVM chains correctly return null despite `oneInchChainId()` also carrying a non-EVM Solana pseudo-id) plus the same `Sei -> "1329"` override `ContractAbiRepository` already used for Sourcify lookups. That repository's private copy of this exact table is now replaced with a call to the shared extension instead of carrying two near-identical private tables.
- Added the missing `Timber.e` log (using `%s` format args) in `TokenPriceRepository.getLifiContractPriceInUsd`'s catch block.
- Non-EVM chains still throw (unchanged), since this fallback is EVM-only; the CoinGecko price path and the separate LI.FI swap-quote chain-id resolver are untouched.

Closes #5405

## Test plan
- `./gradlew --no-daemon :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.LiQuestApiImplTest" --tests "com.vultisig.wallet.data.repositories.TokenPriceRepositoryImplTest" --tests "com.vultisig.wallet.data.repositories.ContractAbiRepositoryTest"` — passing, including a new test asserting all 13 EVM chains resolve the correct numeric chain id without throwing, and that non-EVM chains still throw
- `./gradlew --no-daemon :data:ktfmtCheck` — clean
- `./gradlew --no-daemon :data:lintDebug` — clean
- Verified all 13 numeric chain ids return HTTP 200 from the live `li.quest/v1/token` endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Li.Fi token price requests by deriving the correct LiQuest network identifier for EVM networks.
  * Added detailed error logging when token price lookups fail, including the relevant chain and contract info.
  * Ensured non-EVM networks fail clearly instead of sending an incorrect identifier.
* **Tests**
  * Added tests verifying EVM network identifier resolution and that non-EVM requests throw an exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->