### PR TITLE
fix(evm): throw on eth_gasPrice RPC error instead of signing gasPrice = 0

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasSettingsViewModelTest.kt
@@ -253,6 +253,20 @@ internal class GasSettingsViewModelTest {
         assertEquals(true, vm.state.value.isLoadingEthFee)
     }
 
+    // Legacy-gas sibling of the test above (issue #5399): eth_gasPrice failing must hit the same
+    // isLoadingEthFee gate, not silently populate the BSC price field with a fake zero.
+    @Test
+    fun `legacy gas chain keeps isLoadingEthFee true when eth_gasPrice fails`() = runTest {
+        coEvery { evmApi.getGasPrice() } throws RuntimeException("network error")
+        val vm = viewModel()
+
+        vm.loadData(Chain.BscChain, ethSpec(priorityFeeWei = BigInteger("1000000000")))
+        advanceUntilIdle()
+
+        assertEquals(true, vm.state.value.isLoadingEthFee)
+        assertEquals("", vm.baseFeeState.text.toString())
+    }
+
     @Test
     fun `GasSettings Eth rejects a negative baseFee or priorityFee`() {
         assertThrows<IllegalArgumentException> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -360,11 +360,15 @@ class EvmApiImp(
     }
 
     override suspend fun getGasPrice(): BigInteger {
-
         val rpcResp = fetch<RpcResponse>("eth_gasPrice", buildJsonArray {})
         if (rpcResp.error != null) {
-            Timber.d("get gas price error: ${rpcResp.error.message}")
-            return BigInteger.ZERO
+            // A failed read must propagate, never collapse into ZERO: BSC (the only
+            // supportsLegacyGas chain) would otherwise sign a legacy transaction with
+            // gasPrice = 0 (#5399) instead of surfacing a retryable error.
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "get gas price rpc error: ${rpcResp.error.message}",
+            )
         }
         return rpcResp.result.convertToBigIntegerOrZero()
     }
@@ -408,7 +412,14 @@ class EvmApiImp(
         callData: String,
     ): BigInteger {
         val nonce = getNonce(senderAddress)
-        val gasPrice = getGasPrice()
+        // Only sizes this eth_estimateGas call, never a signed price (iOS's equivalent doesn't
+        // send gasPrice at all) — a gas-price RPC failure must not block gas-limit estimation.
+        val gasPrice =
+            try {
+                getGasPrice()
+            } catch (_: NetworkException) {
+                BigInteger.ZERO
+            }
         val rpcResp =
             fetch<RpcResponse>(
                 "eth_estimateGas",

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiGasPriceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiGasPriceTest.kt
@@ -1,0 +1,71 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [EvmApiImp.getGasPrice] around the RPC-error-swallow fix (issue #5399): a
+ * failed `eth_gasPrice` read must propagate instead of collapsing into a fake `0`, which would let
+ * BSC's legacy-gas signing path (the only [com.vultisig.wallet.data.models.supportsLegacyGas]
+ * chain) sign a transaction with `gasPrice = 0`.
+ */
+class EvmApiGasPriceTest {
+
+    private fun api(client: io.ktor.client.HttpClient) =
+        EvmApiImp(client, "https://api.vultisig.com/bsc/", Chain.BscChain)
+
+    @Test
+    fun `getGasPrice propagates an RPC failure instead of swallowing it into zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":{"code":-32005,"message":"rate limited"}}""",
+            )
+
+        assertFailsWith<NetworkException> { api(client).getGasPrice() }
+    }
+
+    @Test
+    fun `getGasPrice returns the parsed price on success`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x3b9aca00","error":null}""",
+            )
+
+        assertEquals(BigInteger.valueOf(1_000_000_000L), api(client).getGasPrice())
+    }
+
+    // The eth_estimateGas call's gasPrice field only sizes the estimate, never a signed value
+    // (iOS's equivalent doesn't send it at all) — a gas-price RPC failure here must not block
+    // gas-limit estimation for ERC-20 transfers on every EVM chain.
+    @Test
+    fun `estimateGasForERC20Transfer still estimates the limit when the gas price RPC fails`() =
+        runTest {
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{"id":1,"result":"0x1","error":null}""", // nonce
+                    HttpStatusCode.OK to
+                        """{"id":1,"result":null,"error":{"code":-32005,"message":"boom"}}""", // gas price
+                    HttpStatusCode.OK to """{"id":1,"result":"0x5208","error":null}""", // estimate
+                )
+
+            val limit =
+                api(client)
+                    .estimateGasForERC20Transfer(
+                        senderAddress = "0x1111111111111111111111111111111111111111",
+                        contractAddress = "0x2222222222222222222222222222222222222222",
+                        recipientAddress = "0x3333333333333333333333333333333333333333",
+                        value = BigInteger.TEN,
+                    )
+
+            assertEquals(BigInteger.valueOf(21_000L), limit)
+        }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiGasPriceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiGasPriceTest.kt
@@ -3,10 +3,21 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.appendIfNameAbsent
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -45,17 +56,39 @@ class EvmApiGasPriceTest {
 
     // The eth_estimateGas call's gasPrice field only sizes the estimate, never a signed value
     // (iOS's equivalent doesn't send it at all) — a gas-price RPC failure here must not block
-    // gas-limit estimation for ERC-20 transfers on every EVM chain.
+    // gas-limit estimation for ERC-20 transfers on every EVM chain, and must fall back to the
+    // zero gasPrice the estimate call previously always saw.
     @Test
-    fun `estimateGasForERC20Transfer still estimates the limit when the gas price RPC fails`() =
+    fun `estimateGasForERC20Transfer sends a zero gasPrice fallback when the RPC call fails`() =
         runTest {
-            val client =
-                MockHttpClient.respondingWithSequence(
-                    HttpStatusCode.OK to """{"id":1,"result":"0x1","error":null}""", // nonce
-                    HttpStatusCode.OK to
-                        """{"id":1,"result":null,"error":{"code":-32005,"message":"boom"}}""", // gas price
-                    HttpStatusCode.OK to """{"id":1,"result":"0x5208","error":null}""", // estimate
+            val responses =
+                listOf(
+                    """{"id":1,"result":"0x1","error":null}""", // nonce
+                    """{"id":1,"result":null,"error":{"code":-32005,"message":"boom"}}""", // gas
+                    // price
+                    """{"id":1,"result":"0x5208","error":null}""", // estimate
                 )
+            val requestBodies = mutableListOf<String>()
+            var callIndex = 0
+            val client =
+                HttpClient(
+                    MockEngine { request ->
+                        requestBodies.add(request.body.toByteArray().decodeToString())
+                        respond(
+                            content = responses[callIndex++],
+                            status = HttpStatusCode.OK,
+                            headers = MockHttpClient.JSON_HEADERS,
+                        )
+                    }
+                ) {
+                    install(ContentNegotiation) { json() }
+                    install(DefaultRequest) {
+                        headers.appendIfNameAbsent(
+                            HttpHeaders.ContentType,
+                            ContentType.Application.Json.toString(),
+                        )
+                    }
+                }
 
             val limit =
                 api(client)
@@ -67,5 +100,9 @@ class EvmApiGasPriceTest {
                     )
 
             assertEquals(BigInteger.valueOf(21_000L), limit)
+            assertTrue(
+                requestBodies[2].contains(""""gasPrice":"0x0""""),
+                "expected the estimate request to fall back to gasPrice 0x0, got ${requestBodies[2]}",
+            )
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -16,6 +16,7 @@ import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.utils.NetworkException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -23,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -296,6 +298,14 @@ internal class EthereumFeeServiceTest {
         assertTrue(fee is GasFees)
         assertEquals(gwei(3), fee.price)
         assertEquals(fee.price.multiply(fee.limit), fee.amount)
+    }
+
+    // #5399: a gas-price RPC failure must propagate, not be signed as gasPrice = 0.
+    @Test
+    fun `BSC legacy gas signing propagates a gas price RPC failure`() = runTest {
+        coEvery { evmApi.getGasPrice() } throws NetworkException(0, "rate limited")
+
+        assertFailsWith<NetworkException> { service.calculateDefaultFees(transfer(Chain.BscChain)) }
     }
 
     // ---------- Default limits ----------


### PR DESCRIPTION
## Summary
- `EvmApi.getGasPrice()` silently returned `BigInteger.ZERO` on an `eth_gasPrice` RPC error. BSC is the only chain with `supportsLegacyGas`, so it's the only chain reaching `EthereumFeeService.calculateLegacyGasFees()`, which used that value with no floor check before signing — a transient RPC failure could sign and broadcast a BSC transaction with `gasPrice = 0`.
- `getGasPrice()` now throws `NetworkException` on an RPC error, matching the propagate-don't-swallow pattern already used by `getBalance`/`getBalances` (#5308/#5312) and iOS's throwing `fetchGasPrice()`.
- `getGasPrice()` has one internal caller besides the signing path: `estimateGasForCallDataTransfer` (used by `estimateGasForERC20Transfer`, which every EVM chain's ERC-20 gas-*limit* estimate goes through, not just BSC). That call only sizes the `eth_estimateGas` request's `gasPrice` parameter — never a signed value, and iOS's equivalent doesn't even send that field — so it keeps its old degrade-to-zero behavior via a local `try/catch`, avoiding a regression to gas-limit estimation on every chain from a transient price-fetch hiccup.

## Issue
Closes #5399

## Test plan
- `./gradlew :data:testDebugUnitTest --tests EvmApiGasPriceTest` — new tests: RPC error propagates, success still parses, gas-limit estimation survives a gas-price RPC failure
- `./gradlew :data:testDebugUnitTest --tests EthereumFeeServiceTest` — new test proving `calculateDefaultFees` propagates the failure for BSC instead of signing a zero price (48/48 passing)
- `./gradlew :app:testDebugUnitTest --tests GasSettingsViewModelTest` — new test covering the BSC gas-settings dialog's sibling failure path (the existing `isLoadingEthFee` safety net, previously untested and unreachable since `getGasPrice()` never threw)
- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` (full targeted run across both modules) — all green
- `./gradlew :data:ktfmtCheck :app:ktfmtCheck` — clean
- `./gradlew :data:lintDebug :app:lintDebug` — clean

Note: this diff doesn't touch `FeeServiceComposite`, but it does change its runtime behavior slightly — `calculateFees`'s existing `catch (e: Exception) { calculateDefaultFees(transaction) }` fallback will now also catch a BSC gas-price RPC error (previously never thrown) and retry once through `calculateDefaultFees`, which calls `getGasPrice()` again. If the failure isn't transient, the second call fails identically and the error still propagates normally — so end behavior is correct, just a double RPC round-trip during a gas-price outage. Flagging as an FYI, not a functional issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gas price retrieval errors are now surfaced instead of being silently treated as zero.
  - Legacy gas fee signing no longer proceeds with an invalid zero gas price when requests fail.
  - Gas-limit estimation can still continue when gas-price retrieval fails.
  - Loading and fee states remain accurate during gas-setting failures.

- **Tests**
  - Added coverage for successful gas-price retrieval, network failures, and legacy gas fee behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->