### PR TITLE
fix(solana): fall back to cached rent-exempt reserve on RPC failure

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -66,6 +66,13 @@ import wallet.core.jni.SolanaAddress
 interface SolanaApi {
     suspend fun getBalance(address: String): BigInteger
 
+    /**
+     * Live rent-exempt reserve for a new 165-byte SPL Associated Token Account. The last
+     * successfully-fetched value is cached and reused as the fallback when the underlying RPC read
+     * fails, so a transient error never silently drops the fee to zero. Before any call has
+     * succeeded this session, falls back to the standard 165-byte rent-exempt minimum (2,039,280
+     * lamports).
+     */
     suspend fun getMinimumBalanceForRentExemption(): BigInteger
 
     suspend fun getRecentBlockHash(): String
@@ -101,9 +108,10 @@ interface SolanaApi {
     suspend fun checkStatus(txHash: String): SolanaRpcResponseJson<SolanaSignatureStatusesResult>?
 
     /**
-     * Minimum lamports for rent exemption of an account of the given byte length. The no-arg
-     * overload targets SPL token accounts (165 bytes); staking passes the 200-byte stake-account
-     * size. Returns [BigInteger.ZERO] on RPC failure.
+     * Minimum lamports for rent exemption of an account of [dataLength] bytes (e.g. the 200-byte
+     * stake-account size used by staking). Returns [BigInteger.ZERO] on RPC failure; callers that
+     * need a non-zero fallback supply their own (see the no-arg [getMinimumBalanceForRentExemption]
+     * for the SPL-account overload that caches one internally).
      */
     suspend fun getMinimumBalanceForRentExemption(dataLength: Int): BigInteger
 
@@ -145,6 +153,14 @@ internal class SolanaApiImp(
     private val splTokensInfoEndpoint2 = "$JUPITER_URL/tokens/v2/search"
     private val jupiterTokensUrl = "$JUPITER_URL/tokens/v2/tag"
 
+    // Last successfully-fetched 165-byte SPL Associated Token Account rent-exempt reserve, reused
+    // as the fallback on a subsequent RPC failure instead of a hardcoded literal so it tracks the
+    // live network value once a fetch has succeeded this session. A single @Volatile reference
+    // makes the read/publish atomic; concurrent refreshes are harmless (idempotent fetch).
+    @Volatile
+    private var cachedSplAtaRentExemptionLamports: BigInteger =
+        SPL_TOKEN_ACCOUNT_RENT_EXEMPT_LAMPORTS_BOOTSTRAP.toBigInteger()
+
     override suspend fun getBalance(address: String): BigInteger {
         return try {
             val payload =
@@ -171,19 +187,9 @@ internal class SolanaApiImp(
     }
 
     override suspend fun getMinimumBalanceForRentExemption(): BigInteger =
-        try {
-            httpClient
-                .postRpc<SolanaMinimumBalanceForRentExemptionJson>(
-                    rpcEndpoint,
-                    "getMinimumBalanceForRentExemption",
-                    params = buildJsonArray { add(DATA_LENGTH_MINIMUM_BALANCE_FOR_RENT_EXEMPTION) },
-                )
-                .result
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e("Error getting minimum balance for rent exemption: ${e.message}")
-            BigInteger.ZERO
-        }
+        getMinimumBalanceForRentExemption(DATA_LENGTH_MINIMUM_BALANCE_FOR_RENT_EXEMPTION)
+            .takeIf { it.signum() > 0 }
+            ?.also { cachedSplAtaRentExemptionLamports = it } ?: cachedSplAtaRentExemptionLamports
 
     override suspend fun getRecentBlockHash(): String {
         val payload =
@@ -678,6 +684,11 @@ internal class SolanaApiImp(
         private const val TOKEN_PROGRAM_ID_2022 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         private const val ENCODING_SPL_REQUEST_PARAM = "jsonParsed"
         private const val DATA_LENGTH_MINIMUM_BALANCE_FOR_RENT_EXEMPTION = 165
+        // Rent formula for a 165-byte SPL Token Account: (128-byte account overhead + 165-byte
+        // token data) x 3,480 lamports/byte-year x 2-year exemption threshold. Matches iOS's
+        // SolanaHelper.ataRentLamports, which uses this value as its only source (no live RPC
+        // call).
+        private const val SPL_TOKEN_ACCOUNT_RENT_EXEMPT_LAMPORTS_BOOTSTRAP = 2_039_280L
         // 100x the floor — caps priority fee at ~0.01 SOL per tx to prevent overpayment
         // during congestion spikes or compromised RPC proxy
         private const val MAX_PRIORITY_FEE_PRICE = 100_000_000L

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaRentExemptionCacheTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SolanaRentExemptionCacheTest.kt
@@ -1,0 +1,81 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
+import com.vultisig.wallet.data.utils.SplTokenResponseJsonSerializerImpl
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [SolanaApiImp.getMinimumBalanceForRentExemption] (the no-arg, 165-byte SPL Associated
+ * Token Account overload): a transient RPC failure must fall back to the last successfully-fetched
+ * value instead of zero, and a cold-start failure (no prior success this session) must fall back to
+ * the standard 165-byte rent-exempt minimum (issue #5345).
+ */
+class SolanaRentExemptionCacheTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        serializersModule = SerializersModule { contextual(BigIntegerSerializerImpl()) }
+    }
+
+    private fun apiRespondingWith(vararg responses: Pair<HttpStatusCode, String>): SolanaApi =
+        SolanaApiImp(
+            json = json,
+            httpClient = MockHttpClient.respondingWithSequence(*responses, jsonFormat = json),
+            splTokenSerializer = SplTokenResponseJsonSerializerImpl(json),
+        )
+
+    @Test
+    fun `returns the live value on a successful fetch`() = runTest {
+        val api = apiRespondingWith(HttpStatusCode.OK to rentExemption(2_500_000))
+
+        val result = api.getMinimumBalanceForRentExemption()
+
+        assertEquals(2_500_000.toBigInteger(), result)
+    }
+
+    @Test
+    fun `falls back to the cached value when a later fetch fails`() = runTest {
+        val api =
+            apiRespondingWith(
+                HttpStatusCode.OK to rentExemption(2_500_000),
+                HttpStatusCode.OK to RPC_ERROR,
+            )
+
+        val first = api.getMinimumBalanceForRentExemption()
+        val second = api.getMinimumBalanceForRentExemption()
+
+        assertEquals(2_500_000.toBigInteger(), first)
+        assertEquals(2_500_000.toBigInteger(), second)
+    }
+
+    @Test
+    fun `falls back to the SPL rent bootstrap constant on a cold-start failure`() = runTest {
+        val api = apiRespondingWith(HttpStatusCode.OK to RPC_ERROR)
+
+        val result = api.getMinimumBalanceForRentExemption()
+
+        assertEquals(2_039_280.toBigInteger(), result)
+    }
+
+    private fun rentExemption(lamports: Long): String =
+        """
+        { "result": $lamports }
+        """
+            .trimIndent()
+
+    private companion object {
+        val RPC_ERROR =
+            """
+            { "error": { "code": -32602, "message": "boom" }, "result": null }
+            """
+                .trimIndent()
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -107,8 +107,14 @@ object MockHttpClient {
      * Builds a client that steps through [responses] in order, pinning the last entry once the
      * sequence is exhausted. Each entry is a [Pair] of (status, body). The MockEngine block runs
      * sequentially within a single coroutine, so a plain mutable [Int] is sufficient.
+     *
+     * Pass a custom [jsonFormat] when a response model contains `@Contextual` fields, same as
+     * [respondingWith].
      */
-    fun respondingWithSequence(vararg responses: Pair<HttpStatusCode, String>): HttpClient {
+    fun respondingWithSequence(
+        vararg responses: Pair<HttpStatusCode, String>,
+        jsonFormat: Json = json,
+    ): HttpClient {
         require(responses.isNotEmpty()) { "respondingWithSequence requires at least one response" }
         var index = 0
         return HttpClient(
@@ -118,7 +124,7 @@ object MockHttpClient {
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
         ) {
-            installDefaults()
+            installDefaults(jsonFormat)
         }
     }
 


### PR DESCRIPTION
## Summary
`getMinimumBalanceForRentExemption()` caught any RPC failure and returned zero, which fed directly into both the displayed fee estimate and the pre-send balance check for an SPL send that needs to create a new associated token account — a transient RPC hiccup could understate the real fee needed.

- The no-arg overload now delegates to the existing byte-length overload and treats a non-positive result the same way `SolanaDelegateViewModel.fetchRentReserve` already treats its own rent-exempt read: fall back instead of trusting a zero.
- The fallback is the last successfully-fetched value this session, cached in a `@Volatile` field (same pattern as `CosmosFeeService`/`TronFeeService`), so it tracks the live network value once a read has succeeded.
- Before any call has succeeded (cold start), it falls back to the standard 165-byte SPL Token Account rent-exempt minimum (2,039,280 lamports) — the same constant iOS's `SolanaHelper.ataRentLamports` uses as its only source, with no live RPC call at all.
- The 200-byte staking overload (`getMinimumBalanceForRentExemption(dataLength)`) is unchanged; it still returns zero on failure and its one caller already supplies its own fallback constant.

Closes #5345

## Test plan
- `./gradlew --no-daemon :data:testDebugUnitTest` — passing, including new tests asserting the live value is returned on success, the cached value is used when a later fetch fails, and the bootstrap constant is used on a cold-start failure
- `./gradlew --no-daemon :data:ktfmtCheck` — clean
- `./gradlew --no-daemon :data:lintDebug` — clean
- `./gradlew --no-daemon assembleDebug` — successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Solana rent-exemption estimates now use the latest available network value.
  * If the network is temporarily unavailable, the app retains the last successful value or uses a standard fallback for the initial request.

* **Tests**
  * Added coverage for successful lookups, temporary RPC failures, and first-use fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->