### PR TITLE
fix(evm): throw on base-fee/priority-fee RPC error instead of signing a zeroed tx

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -459,8 +459,13 @@ class EvmApiImp(
     override suspend fun getMaxPriorityFeePerGas(): BigInteger {
         val rpcResp = fetch<RpcResponse>("eth_maxPriorityFeePerGas", buildJsonArray {})
         if (rpcResp.error != null) {
-            Timber.d("get max priority fee per gas , error: ${rpcResp.error.message}")
-            return BigInteger.ZERO
+            // A failed read must propagate, never collapse into ZERO: a zero priority fee can
+            // combine with a zeroed base fee (below) to sign an EIP-1559 tx priced under the real
+            // network fee, which broadcast then rejects as underpriced (#5400).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "max priority fee per gas rpc error: ${rpcResp.error.message}",
+            )
         }
 
         return rpcResp.result.convertToBigIntegerOrZero()
@@ -585,8 +590,11 @@ class EvmApiImp(
                     },
             )
         if (response.error != null) {
-            Timber.d("get base fee error: ${response.error.message}")
-            return BigInteger.ZERO
+            // Same rationale as getMaxPriorityFeePerGas above (#5400).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "base fee rpc error: ${response.error.message}",
+            )
         }
         return response.result?.baseFeePerGas.convertToBigIntegerOrZero()
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiFeeTest.kt
@@ -1,0 +1,85 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [EvmApiImp]'s EIP-1559 fee reads around the same failure-vs-zero
+ * distinction as [EvmApiBalanceTest] (issue #5400): an RPC error must propagate rather than
+ * collapse into a `0` that lets a signed transaction underprice itself below the real network fee.
+ */
+class EvmApiFeeTest {
+
+    @Test
+    fun `getBaseFee propagates an RPC failure instead of returning zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":{"code":-32000,"message":"rate limited"}}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        assertFailsWith<NetworkException> { api.getBaseFee() }
+    }
+
+    @Test
+    fun `getBaseFee returns parsed base fee on 200`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":{"baseFeePerGas":"0x3b9aca00"},"error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        assertEquals(BigInteger.valueOf(1_000_000_000), api.getBaseFee())
+    }
+
+    @Test
+    fun `getMaxPriorityFeePerGas propagates an RPC failure instead of returning zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":{"code":-32000,"message":"rate limited"}}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/avax/", Chain.Avalanche)
+
+        assertFailsWith<NetworkException> { api.getMaxPriorityFeePerGas() }
+    }
+
+    @Test
+    fun `getMaxPriorityFeePerGas returns parsed value on 200`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x77359400","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/avax/", Chain.Avalanche)
+
+        assertEquals(BigInteger.valueOf(2_000_000_000), api.getMaxPriorityFeePerGas())
+    }
+
+    // Avalanche is the one chain whose EIP-1559 calc (EthereumFeeService) reads BOTH getBaseFee()
+    // and getMaxPriorityFeePerGas() directly, so a shared RPC outage could previously zero both
+    // components at once and sign a tx priced near nothing. Both calls on the same failing
+    // endpoint must now fail closed instead of silently combining into an underpriced tx.
+    @Test
+    fun `Avalanche base fee and priority fee both fail closed on the same RPC outage`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body =
+                    """{"id":1,"result":null,"error":{"code":-32000,"message":"node unavailable"}}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/avax/", Chain.Avalanche)
+
+        assertFailsWith<NetworkException> { api.getBaseFee() }
+        assertFailsWith<NetworkException> { api.getMaxPriorityFeePerGas() }
+    }
+}


### PR DESCRIPTION
## Summary
- `EvmApi.getBaseFee()` and `getMaxPriorityFeePerGas()` silently returned `BigInteger.ZERO` on an `eth_getBlockByNumber`/`eth_maxPriorityFeePerGas` RPC error. `EthereumFeeService.calculateEip1559Fees()` built `maxFeePerGas` directly off `getBaseFee()` with no floor check, so a transient RPC error could sign a transaction priced near zero. Avalanche is hit twice, since its priority fee also comes straight from `getMaxPriorityFeePerGas()`.
- Both methods now throw `NetworkException` on `rpcResp.error != null`, matching the propagate-don't-swallow pattern already used by `getBalance`/`getBalances` (#5308/#5312) and iOS's throwing `RpcEvmService`. The happy-path parsing is untouched.

Overlap note: PR #5416 (https://github.com/vultisig/vultisig-android/pull/5416) also touches `EvmApi.kt`, for the sibling `getGasPrice()` RPC-error fix (issue #5399); low conflict risk since it edits `getGasPrice()`/`estimateGasForCallDataTransfer()`, non-adjacent to this diff's `getBaseFee()`/`getMaxPriorityFeePerGas()`.

Closes #5400

## Test plan
- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.EvmApiFeeTest"` — new tests: RPC error propagates for both methods, happy path still parses, and an Avalanche-chain instance fails closed on both calls for the same RPC outage
- `./gradlew :data:testDebugUnitTest` — full data module suite green
- `./gradlew :data:ktfmtCheck` — clean
- `./gradlew assembleDebug` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RPC failures while retrieving EIP-1559 fee data now surface as network errors instead of being treated as zero values.
  * Prevents transactions from being prepared with potentially invalid or underpriced fee components.

* **Tests**
  * Added coverage for successful fee parsing and error handling across supported EVM networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->