### PR TITLE
fix(swap): apply the 2x Kyber gas safety multiplier to Mantle

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJson.kt
@@ -37,7 +37,8 @@ fun KyberSwapQuoteJson.gasForChain(chain: Chain): Long {
             Chain.Base,
             Chain.Polygon,
             Chain.Avalanche,
-            Chain.BscChain -> 20L
+            Chain.BscChain,
+            Chain.Mantle -> 20L
             else -> 16L
         }
     return (baseGas * gasMultiplierTimes10) / 10

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJsonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/models/quotes/KyberSwapQuoteJsonTest.kt
@@ -1,0 +1,59 @@
+package com.vultisig.wallet.data.api.models.quotes
+
+import com.vultisig.wallet.data.models.Chain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KyberSwapQuoteJsonTest {
+
+    @Test
+    fun `gasForChain applies the 2x safety multiplier to Mantle like the other Kyber-eligible chains`() {
+        val quote = kyberQuote(gas = "600000")
+
+        val mantleGas = quote.gasForChain(Chain.Mantle)
+        val ethereumGas = quote.gasForChain(Chain.Ethereum)
+
+        assertEquals(1_200_000L, mantleGas)
+        assertEquals(ethereumGas, mantleGas)
+    }
+
+    @Test
+    fun `gasForChain keeps the 1_6x multiplier for chains outside the safety-margin set`() {
+        val quote = kyberQuote(gas = "600000")
+
+        assertEquals(960_000L, quote.gasForChain(Chain.ZkSync))
+    }
+
+    @Test
+    fun `gasForChain defaults base gas to 600000 when the quote omits gas`() {
+        val quote = kyberQuote(gas = null)
+
+        assertEquals(1_200_000L, quote.gasForChain(Chain.Mantle))
+    }
+
+    @Test
+    fun `gasForChain defaults base gas to 600000 when gas is not numeric`() {
+        val quote = kyberQuote(gas = "not-a-number")
+
+        assertEquals(1_200_000L, quote.gasForChain(Chain.Mantle))
+    }
+
+    private fun kyberQuote(gas: String?) =
+        KyberSwapQuoteJson(
+            code = 0,
+            message = "OK",
+            data =
+                KyberSwapQuoteData(
+                    amountIn = "1000000",
+                    amountInUsd = "1.0",
+                    amountOut = "990000",
+                    amountOutUsd = "0.99",
+                    gas = gas,
+                    gasUsd = "0.5",
+                    data = "0xkyberdata",
+                    routerAddress = "0xRouter",
+                    transactionValue = "0",
+                ),
+            requestId = "req-1",
+        )
+}


### PR DESCRIPTION
## Summary

`KyberSwapQuoteJson.gasForChain()` applies a 2.0x client-side gas safety multiplier to the seven Kyber-eligible EVM chains, falling back to 1.6x for every other chain. Mantle is Kyber-eligible per `SwapProviderTable` but was missing from the 2.0x branch, so it silently got the smaller 1.6x margin instead — the opposite of what Mantle needs, since #4898 already established Mantle requires more gas headroom than other EVM chains, not less.

Fixes #5426.

## Changes

- Added `Chain.Mantle` to the 2.0x branch of `gasForChain()`.

`gasForChain` is only reached by `KyberQuoteSource` for chains `SwapProviderTable` marks Kyber-eligible (Ethereum, Arbitrum, Optimism, Base, Polygon, Avalanche, BscChain, Mantle) — the pre-existing `when` branch already listed exactly the first seven, so Mantle was the only chain affected by the `else` fallback.

## Testing

- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.models.quotes.KyberSwapQuoteJsonTest"` — new tests covering Mantle's multiplier matching the other Kyber-eligible chains, the unaffected 1.6x fallback, and the null/non-numeric base-gas defaults
- `./gradlew :data:testDebugUnitTest` — full data module suite
- `./gradlew :data:lintDebug`
- `./gradlew assembleDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gas estimation for Mantle transactions to apply the appropriate safety multiplier.
  * Improved handling of quotes with missing or invalid gas values by using a reliable default.

* **Tests**
  * Added coverage for Mantle gas estimation, other supported chains, and fallback gas behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->