### PR TITLE
fix(evm): propagate allowance RPC errors instead of a false zero

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -501,10 +501,9 @@ class EvmApiImp(
                 },
             )
         if (rpcResp.error != null) {
-            // A failed read must propagate, never collapse into ZERO: a zero allowance is
-            // indistinguishable from a real, already-sufficient one, so the swap layer would stage
-            // a needless approve — which hard-reverts on-chain for USDT-style tokens that reject
-            // raising a non-zero allowance (#5424).
+            // A failed read must propagate, never collapse into ZERO — indistinguishable from a
+            // real allowance, it would force a needless approve that hard-reverts on-chain for
+            // USDT-style tokens (#5424).
             throw NetworkException(
                 httpStatusCode = 0,
                 message =
@@ -512,7 +511,27 @@ class EvmApiImp(
                         "spender=$spender: ${rpcResp.error.message}",
             )
         }
-        return rpcResp.result.convertToBigIntegerOrZero()
+        // Same rationale for a null/malformed result with no explicit error: a healthy node
+        // returns "0x0" for a real zero, so this is still a failed read (#5424).
+        val cleaned = rpcResp.result?.removePrefix("0x")
+        if (cleaned.isNullOrEmpty()) {
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "get allowance null result, contract=$contractAddress owner=$owner " +
+                        "spender=$spender",
+            )
+        }
+        return try {
+            BigInteger(cleaned, 16)
+        } catch (e: NumberFormatException) {
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "get allowance malformed result, contract=$contractAddress owner=$owner " +
+                        "spender=$spender: ${rpcResp.result}",
+            )
+        }
     }
 
     override suspend fun sendTransaction(signedTransaction: String): String {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -501,10 +501,16 @@ class EvmApiImp(
                 },
             )
         if (rpcResp.error != null) {
-            Timber.d(
-                "get allowance,contract address: $contractAddress,owner: $owner,spender: $spender, error: ${rpcResp.error.message}"
+            // A failed read must propagate, never collapse into ZERO: a zero allowance is
+            // indistinguishable from a real, already-sufficient one, so the swap layer would stage
+            // a needless approve — which hard-reverts on-chain for USDT-style tokens that reject
+            // raising a non-zero allowance (#5424).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "get allowance rpc error, contract=$contractAddress owner=$owner " +
+                        "spender=$spender: ${rpcResp.error.message}",
             )
-            return BigInteger.ZERO
         }
         return rpcResp.result.convertToBigIntegerOrZero()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepository.kt
@@ -9,9 +9,8 @@ import javax.inject.Inject
 interface AllowanceRepository {
 
     /**
-     * Returns `null` when approval doesn't apply (native token or non-EVM chain) — never for a
-     * failed read. A failed RPC read throws instead, so callers can tell "no approval needed" apart
-     * from "couldn't check" rather than treating the latter as an allowance of zero (#5424).
+     * Returns `null` only when approval doesn't apply (native token / non-EVM chain); a failed RPC
+     * read throws instead, so "not needed" can't be confused with "couldn't check" (#5424).
      */
     suspend fun getAllowance(
         chain: Chain,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepository.kt
@@ -8,6 +8,11 @@ import javax.inject.Inject
 
 interface AllowanceRepository {
 
+    /**
+     * Returns `null` when approval doesn't apply (native token or non-EVM chain) — never for a
+     * failed read. A failed RPC read throws instead, so callers can tell "no approval needed" apart
+     * from "couldn't check" rather than treating the latter as an allowance of zero (#5424).
+     */
     suspend fun getAllowance(
         chain: Chain,
         contractAddress: String,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiAllowanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiAllowanceTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [EvmApiImp.getAllowance] around the failure vs. zero-allowance distinction
+ * (#5424): an in-band JSON-RPC error must propagate rather than collapse into a `0` that reads as
+ * "no allowance" and forces a needless — and for USDT-style tokens, on-chain-reverting — approve.
+ */
+class EvmApiAllowanceTest {
+
+    @Test
+    fun `getAllowance propagates an RPC-level error instead of swallowing it into zero`() =
+        runTest {
+            val client =
+                MockHttpClient.respondingWith(
+                    HttpStatusCode.OK,
+                    body =
+                        """{"id":1,"result":null,"error":{"code":-32000,"message":"rate limited"}}""",
+                )
+            val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+            assertFailsWith<NetworkException> { api.getAllowance(CONTRACT, OWNER, SPENDER) }
+        }
+
+    @Test
+    fun `getAllowance returns parsed amount on success`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x64","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        assertEquals(BigInteger.valueOf(100), api.getAllowance(CONTRACT, OWNER, SPENDER))
+    }
+
+    // A genuinely unapproved spender (healthy node returning 0x0) must still resolve to a real
+    // zero without throwing — the one legitimate zero, distinct from a failed read.
+    @Test
+    fun `getAllowance returns zero for a genuine on-chain zero without throwing`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x0","error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        assertEquals(BigInteger.ZERO, api.getAllowance(CONTRACT, OWNER, SPENDER))
+    }
+
+    private companion object {
+        const val CONTRACT = "0x2222222222222222222222222222222222222222"
+        const val OWNER = "0x1111111111111111111111111111111111111111"
+        const val SPENDER = "0x3333333333333333333333333333333333333333"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiAllowanceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiAllowanceTest.kt
@@ -57,6 +57,20 @@ class EvmApiAllowanceTest {
         assertEquals(BigInteger.ZERO, api.getAllowance(CONTRACT, OWNER, SPENDER))
     }
 
+    // A null result with no explicit `error` is still a failed read, not a zero — a healthy node
+    // always returns "0x0" for a real one.
+    @Test
+    fun `getAllowance propagates a null result instead of swallowing it into zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+        assertFailsWith<NetworkException> { api.getAllowance(CONTRACT, OWNER, SPENDER) }
+    }
+
     private companion object {
         const val CONTRACT = "0x2222222222222222222222222222222222222222"
         const val OWNER = "0x1111111111111111111111111111111111111111"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AllowanceRepositoryTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.EvmApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.utils.NetworkException
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * [AllowanceRepositoryImpl] must not turn a failed read into the same `null` it returns for a
+ * genuinely not-applicable approval (native token / non-EVM chain) — see the contract documented on
+ * [AllowanceRepository.getAllowance] (#5424).
+ */
+internal class AllowanceRepositoryTest {
+
+    private val evmApi: EvmApi = mockk()
+    private val evmApiFactory: EvmApiFactory = mockk {
+        every { createEvmApi(any()) } returns evmApi
+    }
+    private val repository = AllowanceRepositoryImpl(evmApiFactory)
+
+    @Test
+    fun `getAllowance propagates an EvmApi failure instead of swallowing it into null`() = runTest {
+        coEvery { evmApi.getAllowance(any(), any(), any()) } throws
+            NetworkException(httpStatusCode = 0, message = "rpc error")
+
+        assertFailsWith<NetworkException> {
+            repository.getAllowance(Chain.Ethereum, CONTRACT, OWNER, SPENDER)
+        }
+    }
+
+    @Test
+    fun `getAllowance returns null for an empty contract address without calling the API`() =
+        runTest {
+            assertNull(repository.getAllowance(Chain.Ethereum, "", OWNER, SPENDER))
+        }
+
+    @Test
+    fun `getAllowance returns null for a non-EVM chain without calling the API`() = runTest {
+        assertNull(repository.getAllowance(Chain.Solana, CONTRACT, OWNER, SPENDER))
+    }
+
+    @Test
+    fun `getAllowance returns the parsed value on success`() = runTest {
+        coEvery { evmApi.getAllowance(any(), any(), any()) } returns BigInteger.TEN
+
+        val allowance = repository.getAllowance(Chain.Ethereum, CONTRACT, OWNER, SPENDER)
+
+        assertEquals(BigInteger.TEN, allowance)
+    }
+
+    private companion object {
+        const val CONTRACT = "0x2222222222222222222222222222222222222222"
+        const val OWNER = "0x1111111111111111111111111111111111111111"
+        const val SPENDER = "0x3333333333333333333333333333333333333333"
+    }
+}


### PR DESCRIPTION
## Summary

`EvmApiImp.getAllowance()` swallowed a JSON-RPC-level error into `BigInteger.ZERO`, only logging it via `Timber.d`. A zero allowance is indistinguishable from a real "nothing approved yet" state, so `SwapTransactionBuilder`'s `isApprovalRequired = allowance != null && allowance < srcTokenValue.value` check would force a needless `approve()` on a transient RPC hiccup — which hard-reverts on-chain for USDT-style tokens that reject raising an already-nonzero allowance.

`getAllowance()` now throws on an RPC error instead, exactly mirroring the pattern already applied to the sibling balance/gas-price reads for the identical bug class (#5308, #5399, #5400). `AllowanceRepositoryImpl.getAllowance()` already had no try/catch around the call, so the failure now propagates naturally to `SwapFormViewModel.swap()`'s existing `safeLaunch` error handler, which shows a retryable error instead of silently staging a bad approve. Added a short KDoc on the `AllowanceRepository` interface documenting the null (not applicable) vs. throw (failed read) contract the three `SwapTransactionBuilder` call sites depend on.

Happy-path allowance parsing and the approve-transaction building logic are unchanged.

Closes #5424

## Testing

- `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.EvmApiAllowanceTest" --tests "com.vultisig.wallet.data.repositories.AllowanceRepositoryTest"`
- `./gradlew :data:testDebugUnitTest` (full module)
- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "*SwapTransactionBuilder*" --tests "*SwapFormViewModel*"`
- `./gradlew :data:ktfmtCheckTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Allowance reads now surface JSON-RPC failures as network errors instead of defaulting to zero.
  * Malformed or null/empty RPC results are treated as failed reads and now throw network errors.
  * Genuine on-chain zero allowances still return `0` without throwing.
  * Allowance checks remain unavailable for native tokens and non-EVM chains.
* **Documentation**
  * Clarified `getAllowance` nullability semantics in repository docs.
* **Tests**
  * Added/expanded unit coverage for RPC error cases, success parsing, on-chain zero, and null-result failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->