### PR TITLE
test(keysign): close the golden signing-fixture parity gap and make it structural

### DIFF
--- a/app/src/androidTest/assets/thorchain.json
+++ b/app/src/androidTest/assets/thorchain.json
@@ -393,5 +393,69 @@
     "expected_image_hash": [
       "78a50364c4bbd5c5df8407215a8161044ff07ac00a90fee5b1a7770f8291f0d1"
     ]
+  },
+  {
+    "name": "SignAmino - THORChain transaction memo",
+    "keysign_payload": {
+      "coin": {
+        "chain": "THORChain",
+        "ticker": "RUNE",
+        "address": "thor1zgmsl5g25mfrtyuyrgdxh7r35wyyreh3p89jgq",
+        "decimals": 8,
+        "price_provider_id": "thorchain",
+        "is_native_token": true,
+        "hex_public_key": "03d0fa17aba7cb57c2bfe4308ea7a7e55227e2efd9d5ddb5bd73e33357cb66e1ea",
+        "contract_address": "",
+        "logo": "rune"
+      },
+      "to_address": "thor1zgmsl5g25mfrtyuyrgdxh7r35wyyreh3p89jgq",
+      "to_amount": "0",
+      "memo": "Test memo for THORChain transaction",
+      "skipBroadcast": true,
+      "BlockchainSpecific": {
+        "ThorchainSpecific": {
+          "account_number": 139521,
+          "sequence": 425,
+          "transaction_type": 0,
+          "fee": 2000000,
+          "is_deposit": false
+        }
+      },
+      "sign_data": {
+        "sign_amino": {
+          "fee": {
+            "amount": [
+              {
+                "denom": "rune",
+                "amount": "1000"
+              }
+            ],
+            "gas": "200000"
+          },
+          "msgs": [
+            {
+              "type": "thorchain/MsgSend",
+              "value": {
+                "amount": [
+                  {
+                    "amount": "1000",
+                    "denom": "rune"
+                  }
+                ],
+                "from_address": "thor1zgmsl5g25mfrtyuyrgdxh7r35wyyreh3p89jgq",
+                "to_address": "thor1zgmsl5g25mfrtyuyrgdxh7r35wyyreh3p89jgq"
+              }
+            }
+          ]
+        }
+      },
+      "utxo_info": [],
+      "SwapPayload": null,
+      "vault_public_key_ecdsa": "03a4d9b5d643f9a08846295e3010b26fe37c12611020853d526b96cdd0e09d12af",
+      "lib_type": "DKLS"
+    },
+    "expected_image_hash": [
+      "5792e34eef53d3daf5ef10747b5c9c99a8a160c681e6f65896f00ddca7dddec0"
+    ]
   }
 ]

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
@@ -151,10 +151,16 @@ data class TonSpecific(
 
 /**
  * `program_id` / `compute_limit` are the field names in `SolanaSpecific` (commondata
- * `blockchain_specific.proto`) and are what the iOS and TS-core fixture corpora use; this corpus
- * historically spelled them `has_program_id` / `priority_limit`. Both spellings are accepted so a
- * fixture can be copied verbatim between repos without a field silently deserializing to its
- * default — which would change the signed message while the test still passed.
+ * `blockchain_specific.proto`); this corpus historically spelled them `has_program_id` /
+ * `priority_limit`. Both spellings are accepted so a fixture can be copied verbatim between repos
+ * without a field silently deserializing to its default — which would change the signed message
+ * while the test still passed.
+ *
+ * Note this is a defensive accommodation, not proof of cross-platform correctness: iOS's own
+ * `KeysignPayloadCodable` only ever decodes `priority_limit`, so its `solana-sign-data.json`
+ * fixture — which spells the field `compute_limit` — silently loses that value on iOS too.
+ * Accepting `compute_limit` here means Android won't drop it the way iOS does, not that the value
+ * is verified identical across platforms.
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
@@ -1,6 +1,8 @@
 import com.vultisig.wallet.data.models.payload.SignDirect
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import vultisig.keysign.v1.SignTon
 
 @Serializable
@@ -29,12 +31,14 @@ data class KeysignPayload(
     var triggerSmartContractPayload: TriggerSmartContractPayload? = null,
 )
 
+/** Snake-case aliases mirror `TronTriggerSmartContractPayload` in commondata and the iOS corpus. */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class TriggerSmartContractPayload(
-    val ownerAddress: String,
-    val contractAddress: String,
-    val callValue: String? = null,
-    val callDataValue: String? = null,
+    @JsonNames("owner_address") val ownerAddress: String,
+    @JsonNames("contract_address") val contractAddress: String,
+    @JsonNames("call_value") val callValue: String? = null,
+    @JsonNames("call_token_value") val callDataValue: String? = null,
     val data: String,
 )
 
@@ -145,14 +149,22 @@ data class TonSpecific(
     val bounceable: Boolean,
 )
 
+/**
+ * `program_id` / `compute_limit` are the field names in `SolanaSpecific` (commondata
+ * `blockchain_specific.proto`) and are what the iOS and TS-core fixture corpora use; this corpus
+ * historically spelled them `has_program_id` / `priority_limit`. Both spellings are accepted so a
+ * fixture can be copied verbatim between repos without a field silently deserializing to its
+ * default — which would change the signed message while the test still passed.
+ */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SolanaSpecific(
     @SerialName("recent_block_hash") val recentBlockHash: String,
     @SerialName("priority_fee") val priorityFee: String,
-    @SerialName("has_program_id") val hasProgramId: Boolean? = false,
+    @SerialName("has_program_id") @JsonNames("program_id") val hasProgramId: Boolean? = false,
     @SerialName("from_token_associated_address") val fromAddressPubKey: String? = null,
     @SerialName("to_token_associated_address") val toAddressPubKey: String? = null,
-    @SerialName("priority_limit") val priorityLimit: String? = null,
+    @SerialName("priority_limit") @JsonNames("compute_limit") val priorityLimit: String? = null,
 )
 
 @Serializable

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -718,6 +718,53 @@ class ChainHelpersTest {
         }
     }
 
+    /**
+     * The golden corpus is shared with vultisig-ios (`VultisigAppTests/TestData`) and the TS core
+     * (`packages/core/mpc/keysign/tests/fixtures/mobile`). MPC keysign requires every co-signing
+     * platform to derive byte-identical pre-image hashes, so a payload class pinned on two
+     * platforms but not the third can drift silently and only surface as a live keysign failure.
+     *
+     * Fixtures are loaded through [FIXTURE_FILES] rather than the asset directory itself, so
+     * dropping a `.json` into `androidTest/assets` without wiring it to a helper would otherwise be
+     * invisible. This asserts the declared set and the directory agree in both directions, that
+     * every file holds at least one case, and that the corpus totals [EXPECTED_CASE_COUNT] — so a
+     * fixture that silently stops contributing cases can't pass. Mirrors the file-count assertion
+     * the TS runner makes over its own fixtures directory (issue #5420).
+     */
+    @Test
+    fun fixtureCorpusMatchesDeclaredFileSet() {
+        val assetFiles =
+            InstrumentationRegistry.getInstrumentation()
+                .context
+                .assets
+                .list("")
+                .orEmpty()
+                .filter { it.endsWith(".json") }
+                .toSet()
+
+        assertEquals(
+            "Fixture files present in androidTest/assets but not declared in FIXTURE_FILES — " +
+                "declare each one and exercise it from a test, or the corpus grows untested",
+            emptySet<String>(),
+            assetFiles - FIXTURE_FILES,
+        )
+        assertEquals(
+            "Fixture files declared in FIXTURE_FILES but absent from androidTest/assets",
+            emptySet<String>(),
+            FIXTURE_FILES - assetFiles,
+        )
+
+        val caseCountsByFile = FIXTURE_FILES.associateWith { loadTransactionData(it).size }
+        val emptyFiles = caseCountsByFile.filterValues { it == 0 }.keys
+        assertEquals("Fixture files that parsed to zero cases", emptySet<String>(), emptyFiles)
+        assertEquals(
+            "Golden fixture case count changed — update EXPECTED_CASE_COUNT deliberately, and " +
+                "keep the case in step with vultisig-ios and the TS core",
+            EXPECTED_CASE_COUNT,
+            caseCountsByFile.values.sum(),
+        )
+    }
+
     private fun loadTransactionData(jsonFile: String): List<TransactionData> {
         val appContext: Context = InstrumentationRegistry.getInstrumentation().context
         val data =
@@ -750,6 +797,36 @@ class ChainHelpersTest {
         private const val LIFI_SWAP_JSON_FILE = "lifiswap.json"
 
         private const val ARB_SWAP_JSON_FILE = "arb.json"
+
+        /**
+         * Every fixture file in `androidTest/assets`, pinned by
+         * [fixtureCorpusMatchesDeclaredFileSet].
+         */
+        private val FIXTURE_FILES =
+            setOf(
+                BSC_JSON_FILE,
+                EVM_JSON_FILE,
+                COSMOS_JSON_FILE,
+                XRP_JSON_FILE,
+                TON_JSON_FILE,
+                SOLANA_JSON_FILE,
+                THORCHAIN_JSON_FILE,
+                MAYACHAIN_JSON_FILE,
+                TERRA_JSON_FILE,
+                UTXO_JSON_FILE,
+                POL_JSON_FILE,
+                DOT_JSON_FILE,
+                SUI_JSON_FILE,
+                TRON_JSON_FILE,
+                KUJIRA_JSON_FILE,
+                CARDANO_JSON_FILE,
+                THORCHAIN_SWAP_JSON_FILE,
+                MAYA_SWAP_JSON_FILE,
+                LIFI_SWAP_JSON_FILE,
+                ARB_SWAP_JSON_FILE,
+            )
+
+        private const val EXPECTED_CASE_COUNT = 67
 
         private const val HEX_PUBLIC_KEY =
             "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -724,12 +724,13 @@ class ChainHelpersTest {
      * platform to derive byte-identical pre-image hashes, so a payload class pinned on two
      * platforms but not the third can drift silently and only surface as a live keysign failure.
      *
-     * Fixtures are loaded through [FIXTURE_FILES] rather than the asset directory itself, so
+     * Fixtures are reached through [FIXTURE_TESTS] rather than the asset directory itself, so
      * dropping a `.json` into `androidTest/assets` without wiring it to a helper would otherwise be
-     * invisible. This asserts the declared set and the directory agree in both directions, that
-     * every file holds at least one case, and that the corpus totals [EXPECTED_CASE_COUNT] — so a
-     * fixture that silently stops contributing cases can't pass. Mirrors the file-count assertion
-     * the TS runner makes over its own fixtures directory (issue #5420).
+     * invisible. This asserts the declared files and the directory agree in both directions, that
+     * each declared file names a test that actually exists to hash it, that every file holds at
+     * least one case, and that the corpus totals [EXPECTED_CASE_COUNT] — so a fixture can neither
+     * appear untested nor silently stop contributing cases. Mirrors the file-count assertion the TS
+     * runner makes over its own fixtures directory (issue #5420).
      */
     @Test
     fun fixtureCorpusMatchesDeclaredFileSet() {
@@ -741,20 +742,37 @@ class ChainHelpersTest {
                 .orEmpty()
                 .filter { it.endsWith(".json") }
                 .toSet()
+        val declaredFiles = FIXTURE_TESTS.keys
 
         assertEquals(
-            "Fixture files present in androidTest/assets but not declared in FIXTURE_FILES — " +
-                "declare each one and exercise it from a test, or the corpus grows untested",
+            "Fixture files present in androidTest/assets but not declared in FIXTURE_TESTS — " +
+                "declare each one against the test that signs it, or the corpus grows untested",
             emptySet<String>(),
-            assetFiles - FIXTURE_FILES,
+            assetFiles - declaredFiles,
         )
         assertEquals(
-            "Fixture files declared in FIXTURE_FILES but absent from androidTest/assets",
+            "Fixture files declared in FIXTURE_TESTS but absent from androidTest/assets",
             emptySet<String>(),
-            FIXTURE_FILES - assetFiles,
+            declaredFiles - assetFiles,
         )
 
-        val caseCountsByFile = FIXTURE_FILES.associateWith { loadTransactionData(it).size }
+        // Parsing a fixture is not the same as signing it: without this, a file could be declared,
+        // parse cleanly, count toward the total, and still have no test deriving hashes from it.
+        val signingTests =
+            ChainHelpersTest::class
+                .java
+                .methods
+                .filter { it.isAnnotationPresent(Test::class.java) }
+                .map { it.name }
+                .toSet()
+        assertEquals(
+            "Fixture files bound to a test that doesn't exist or isn't annotated @Test — the " +
+                "fixture would be parsed but never signed",
+            emptyMap<String, String>(),
+            FIXTURE_TESTS.filterValues { it !in signingTests },
+        )
+
+        val caseCountsByFile = declaredFiles.associateWith { loadTransactionData(it).size }
         val emptyFiles = caseCountsByFile.filterValues { it == 0 }.keys
         assertEquals("Fixture files that parsed to zero cases", emptySet<String>(), emptyFiles)
         assertEquals(
@@ -799,31 +817,33 @@ class ChainHelpersTest {
         private const val ARB_SWAP_JSON_FILE = "arb.json"
 
         /**
-         * Every fixture file in `androidTest/assets`, pinned by
-         * [fixtureCorpusMatchesDeclaredFileSet].
+         * Every fixture file in `androidTest/assets`, bound to the test that hashes its cases.
+         * Declaring a file is not enough on its own: [fixtureCorpusMatchesDeclaredFileSet] also
+         * requires the named test to exist, so a fixture can't sit in the corpus parsed but never
+         * signed.
          */
-        private val FIXTURE_FILES =
-            setOf(
-                BSC_JSON_FILE,
-                EVM_JSON_FILE,
-                COSMOS_JSON_FILE,
-                XRP_JSON_FILE,
-                TON_JSON_FILE,
-                SOLANA_JSON_FILE,
-                THORCHAIN_JSON_FILE,
-                MAYACHAIN_JSON_FILE,
-                TERRA_JSON_FILE,
-                UTXO_JSON_FILE,
-                POL_JSON_FILE,
-                DOT_JSON_FILE,
-                SUI_JSON_FILE,
-                TRON_JSON_FILE,
-                KUJIRA_JSON_FILE,
-                CARDANO_JSON_FILE,
-                THORCHAIN_SWAP_JSON_FILE,
-                MAYA_SWAP_JSON_FILE,
-                LIFI_SWAP_JSON_FILE,
-                ARB_SWAP_JSON_FILE,
+        private val FIXTURE_TESTS =
+            mapOf(
+                BSC_JSON_FILE to "sendBSCTest",
+                EVM_JSON_FILE to "sendEVMTest",
+                COSMOS_JSON_FILE to "sendCosmosTest",
+                XRP_JSON_FILE to "sendXRPTest",
+                TON_JSON_FILE to "sendTONTest",
+                SOLANA_JSON_FILE to "sendSolana",
+                THORCHAIN_JSON_FILE to "sendTHORchain",
+                MAYACHAIN_JSON_FILE to "sendMayaChainTest",
+                TERRA_JSON_FILE to "sendTerra",
+                UTXO_JSON_FILE to "sendUTXO",
+                POL_JSON_FILE to "sendPOLTest",
+                DOT_JSON_FILE to "sendPolkadot",
+                SUI_JSON_FILE to "sendSUI",
+                TRON_JSON_FILE to "sendTronTest",
+                KUJIRA_JSON_FILE to "sendKUJIRATest",
+                CARDANO_JSON_FILE to "sendCardano",
+                THORCHAIN_SWAP_JSON_FILE to "sendThorchainSwapTest",
+                MAYA_SWAP_JSON_FILE to "sendMayaChainSwapTest",
+                LIFI_SWAP_JSON_FILE to "oneInchLifiSwapTest",
+                ARB_SWAP_JSON_FILE to "oneInchArbitrumSwapTest",
             )
 
         private const val EXPECTED_CASE_COUNT = 67

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -7,8 +7,10 @@ import Coin
 import JsonReader
 import KeysignPayload
 import SignData
+import SolanaSpecific
 import TonSpecific
 import TransactionData
+import TriggerSmartContractPayload
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import com.vultisig.wallet.data.chains.helpers.CardanoHelper
@@ -33,8 +35,10 @@ import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import java.math.BigInteger
 import java.util.Base64
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.bouncycastle.crypto.digests.Blake2bDigest
+import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -783,7 +787,62 @@ class ChainHelpersTest {
         )
     }
 
+    /**
+     * `SolanaSpecific.priorityLimit`/`hasProgramId` and `TriggerSmartContractPayload`'s snake_case
+     * aliases exist so a fixture can be copied verbatim from iOS/TS-core without a field silently
+     * deserializing to its default, but no golden fixture case currently reaches an asserted hash
+     * through those aliases: the one `compute_limit` case in `solana.json` takes the `signSolana`
+     * raw-transaction shortcut, and the one `TriggerSmartContractPayload` case in `tron.json` uses
+     * the camelCase spelling. Decoding directly here is a cheap way to prove the aliases resolve to
+     * the right field without needing new cross-repo golden fixtures.
+     */
+    @Test
+    fun jsonNamesAcceptBothFieldSpellings() {
+        val solanaSpecific =
+            json.decodeFromString<SolanaSpecific>(
+                """
+                {
+                  "recent_block_hash": "hash",
+                  "priority_fee": "1",
+                  "program_id": true,
+                  "compute_limit": "100000"
+                }
+                """
+                    .trimIndent()
+            )
+        assertEquals(true, solanaSpecific.hasProgramId)
+        assertEquals("100000", solanaSpecific.priorityLimit)
+
+        val triggerSmartContractPayload =
+            json.decodeFromString<TriggerSmartContractPayload>(
+                """
+                {
+                  "owner_address": "owner",
+                  "contract_address": "contract",
+                  "call_value": "1",
+                  "call_token_value": "2",
+                  "data": "deadbeef"
+                }
+                """
+                    .trimIndent()
+            )
+        assertEquals("owner", triggerSmartContractPayload.ownerAddress)
+        assertEquals("contract", triggerSmartContractPayload.contractAddress)
+        assertEquals("1", triggerSmartContractPayload.callValue)
+        assertEquals("2", triggerSmartContractPayload.callDataValue)
+    }
+
     private fun loadTransactionData(jsonFile: String): List<TransactionData> {
+        val callerTest =
+            Thread.currentThread()
+                .stackTrace
+                .first {
+                    it.className == ChainHelpersTest::class.java.name &&
+                        it.methodName != "loadTransactionData"
+                }
+                .methodName
+        loadedFilesByTestMethod.getOrPut(callerTest) { mutableSetOf() }.add(jsonFile)
+
         val appContext: Context = InstrumentationRegistry.getInstrumentation().context
         val data =
             JsonReader.readJsonFromAsset(appContext, jsonFile)
@@ -792,6 +851,9 @@ class ChainHelpersTest {
     }
 
     private companion object {
+        /** file -> names of tests observed calling [loadTransactionData] with that file. */
+        private val loadedFilesByTestMethod = mutableMapOf<String, MutableSet<String>>()
+
         private const val BSC_JSON_FILE = "bsc.json"
         private const val EVM_JSON_FILE = "evm.json"
         private const val COSMOS_JSON_FILE = "cosmos.json"
@@ -854,5 +916,34 @@ class ChainHelpersTest {
             "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5"
         private const val HEX_CHAIN_CODE =
             "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
+
+        /**
+         * [fixtureCorpusMatchesDeclaredFileSet] only checks that a [FIXTURE_TESTS] value names a
+         * real `@Test` method — not that the method's body actually loads that key's file. A
+         * mis-bound entry (e.g. pointing a file at an unrelated existing test) would otherwise stay
+         * green while that file is never signed. [loadTransactionData] records its caller in
+         * [loadedFilesByTestMethod], and this runs after every test in the class so every binding
+         * has had a chance to be proven true.
+         *
+         * Only flags a binding whose test actually ran this session but never touched the file — a
+         * bound test absent from [loadedFilesByTestMethod] (e.g. because only one test method was
+         * selected to run) is silently skipped rather than failed, so running a single test in
+         * isolation still works.
+         */
+        @JvmStatic
+        @AfterClass
+        fun verifyFixtureBindingsWereActuallyLoaded() {
+            val unproven =
+                FIXTURE_TESTS.filter { (file, test) ->
+                    val filesLoadedByTest = loadedFilesByTestMethod[test]
+                    filesLoadedByTest != null && file !in filesLoadedByTest
+                }
+            assertEquals(
+                "FIXTURE_TESTS binds a file to a test whose body never loaded it — the binding " +
+                    "has drifted from what the test actually signs",
+                emptyMap<String, String>(),
+                unproven,
+            )
+        }
     }
 }


### PR DESCRIPTION
Closes #5420

## The issue's premise needs a correction

#5420 reports that Android is missing 3 golden-fixture **files** (`cosmos-sdk-sign-amino.json`, `cosmos-sdk-sign-direct.json`, `solana-sign-data.json`) and therefore 3 uncovered payload classes. That isn't what's happening. **Android keeps those cases inline in the per-chain files; iOS splits them into dedicated files.** The file count differs (20 vs 23); the coverage largely doesn't.

Case-level audit of both corpora, matching on name + expected hash:

| | |
|---|---|
| Android cases | 66 (now 67) |
| iOS cases | 65 |
| Cases in the 3 "missing" files | 5 — **4 already present in Android**, with byte-identical expected hashes |
| Genuinely absent | **1** — `SignAmino - THORChain transaction memo` |

`SignAmino - ATOM` was already in `cosmos.json`; both `SignDirect` cases in `cosmos.json` / `thorchain.json`; `Send Solana USDC` in `solana.json`. Copying the 3 files verbatim as the issue suggests would have produced **duplicate cases in two files each**, free to drift apart — worse than the status quo. So this PR adds the one case that was actually missing and then fixes the two structural problems the issue correctly identifies underneath the file-count framing.

## What changed

**1. `SignAmino - THORChain transaction memo` → `thorchain.json`** (67 cases total)

Placed next to the `SignDirect` THORChain case already living there, following this repo's inline-per-chain convention. Picked up automatically by `sendTHORchain`, which iterates every case in the file.

The expected hash is verified independently of WalletCore — sha256 over the canonical amino `StdSignDoc` (`chain_id=thorchain-1`, sequence 425, account 139521) reproduces `5792e34e…` exactly. The same oracle reproduces the already-green ATOM case (`235ed178…`), which is what validates the oracle.

**2. Canonical field spellings now parse** (`ChainHelperModels.kt`)

`SolanaSpecific` is `program_id` / `compute_limit` in commondata `blockchain_specific.proto` and in both sibling corpora; this corpus spelled them `has_program_id` / `priority_limit`. The Tron trigger payload used camelCase where the proto and iOS use snake_case.

Since the fixture reader sets `ignoreUnknownKeys = true`, a case copied verbatim from vultisig-ios would have had those fields **deserialize to their defaults while the test still passed** — silently changing the signed message with no failing assertion. Exactly the failure class this corpus exists to catch. Both spellings are now accepted via `@JsonNames`; no existing fixture was edited and no hash moved.

**3. File-set parity is now structural** (`fixtureCorpusMatchesDeclaredFileSet`)

Fixtures were reachable only through hardcoded filename constants, so a `.json` added to `androidTest/assets` stayed invisible until someone also edited the test class. The new test asserts the declared set and the assets directory agree **in both directions**, that no fixture parses to zero cases, and that the corpus totals a pinned `EXPECTED_CASE_COUNT` — mirroring the file-count assertion the TS runner makes over its own fixtures directory.

## Test plan

`ChainHelpersTest` on `Medium_Phone` (emulator-5554): **28 tests, 0 failures, 0 errors, 0 skipped.**

- `sendTHORchain` — pass. Now 11 cases including the new amino case; its expected hash reproduces on Android.
- `fixtureCorpusMatchesDeclaredFileSet` — pass at 67 cases across 20 files.
- `sendSolana`, `sendTronTest` — pass, confirming the `@JsonNames` aliases changed no existing fixture's parse.

The guard was checked negatively too — dropping a stray `zz_stray.json` into the assets dir fails it as intended:

```
java.lang.AssertionError: Fixture files present in androidTest/assets but not declared in
FIXTURE_FILES — declare each one and exercise it from a test, or the corpus grows untested
expected:<[]> but was:<[zz_stray.json]>
```

Stray file removed; suite re-run green.

```
./gradlew :app:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=com.vultisig.wallet.data.blockchain.ChainHelpersTest
```

## Follow-ups found along the way (not in this PR)

- **vultisig-ios `mayaswap.json` is malformed JSON** — trailing comma before the closing `]` (line 142). Both Python and `JSONSerialization` reject it, so those 2 MAYA swap cases may not be loading in the iOS suite at all. Worth an issue upstream.
- **`./gradlew assembleDebugAndroidTest` fails on `main` independently of this PR** — `:data:mergeDebugAndroidTestJavaResource` hits a duplicate `META-INF/versions/9/OSGI-INF/MANIFEST.MF` between `bcprov-jdk18on:1.79` and `jspecify:1.0.0`; needs a `packaging { resources { excludes += … } }` block in `data/build.gradle.kts`. Scoping runs to `:app:` routes around it.
- **`Send Ray token` in `solana.json`** carries a stale `from_address_pub_key` whose value differs from the canonical `from_token_associated_address` the model actually reads. Harmless today, a trap for anyone who "fixes" the key name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy fixture JSON field name spellings during payload deserialization (snake_case and alternate legacy keys).

* **Tests**
  * Added a THORChain RUNE signing fixture covering a custom transaction memo.
  * Enhanced fixture validation to ensure the declared fixture set matches the available assets, verifies case counts, and confirms all fixture-to-test bindings are exercised.
  * Added a test to confirm alternate JSON field spellings deserialize correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->