### PR TITLE
fix(token detail): stop the sheet re-anchoring while its data loads

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -21,7 +21,11 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -82,6 +86,7 @@ import com.vultisig.wallet.ui.models.ChainTokenUiModel
 import com.vultisig.wallet.ui.models.ChainTokensUiModel
 import com.vultisig.wallet.ui.models.ChainUiModel
 import com.vultisig.wallet.ui.models.DeviceMeta
+import com.vultisig.wallet.ui.models.TokenDetailUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VaultDetailUiModel
@@ -128,6 +133,7 @@ import com.vultisig.wallet.ui.models.swap.VultTierGateUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
 import com.vultisig.wallet.ui.screens.ChainSelectionScreen
+import com.vultisig.wallet.ui.screens.TokenDetailScreen
 import com.vultisig.wallet.ui.screens.TransactionDoneView
 import com.vultisig.wallet.ui.screens.VaultDetailScreen
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsContent
@@ -190,6 +196,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.math.BigDecimal
+import kotlinx.coroutines.delay
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -219,6 +226,7 @@ class PreviewActivity : ComponentActivity() {
                             externalRecipient = "0x9876543210FeDcBa9876543210FeDcBa98765432"
                         )
                     "asset_action_button" -> AssetActionButtonPreview()
+                    "token_detail_sheet_loading" -> TokenDetailSheetLoadingPreview()
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
@@ -3233,4 +3241,38 @@ private fun LimitSwapFormPreview(expandedSection: LimitFormSection = LimitFormSe
             modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp),
         )
     }
+}
+
+/**
+ * Reproduces the real open of the token detail sheet: it is composed with an empty model, and the
+ * account lands a few hundred milliseconds later. Record this to see whether the sheet settles once
+ * or slides a second time when the values and action buttons arrive.
+ */
+@Composable
+private fun TokenDetailSheetLoadingPreview() {
+    var uiModel by remember { mutableStateOf(TokenDetailUiModel()) }
+
+    LaunchedEffect(Unit) {
+        delay(700)
+        uiModel =
+            TokenDetailUiModel(
+                token =
+                    ChainTokenUiModel(
+                        name = "SOL",
+                        balance = "0.07010079 SOL",
+                        fiatBalance = "$5.15",
+                        tokenLogo = getCoinLogo(Coins.Solana.SOL.logo),
+                        chainLogo = Chain.Solana.logo,
+                        price = "$73.51",
+                        network = Chain.Solana.raw,
+                    ),
+                canSwap = true,
+                canSend = true,
+                canBuy = true,
+            )
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary))
+
+    TokenDetailScreen(uiModel = uiModel)
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/DottyBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/DottyBottomSheet.kt
@@ -35,9 +35,10 @@ internal fun DottyBottomSheet(
     content: @Composable ColumnScope.() -> Unit,
 ) {
 
+    // Nothing drives expand() here on purpose: ModalBottomSheet already animates to Expanded on
+    // first composition, and skipPartiallyExpanded leaves nowhere else to settle. Expanding on the
+    // same frame short-circuits that animation and the sheet lands at its target without sliding.
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    LaunchedEffect(Unit) { sheetState.expand() }
 
     LaunchedEffect(sheetState.currentValue) {
         if (sheetState.currentValue != SheetValue.Hidden) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/texts/LoadableValue.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/texts/LoadableValue.kt
@@ -1,6 +1,9 @@
 package com.vultisig.wallet.ui.components.v2.texts
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -8,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -42,7 +46,22 @@ internal fun LoadableValue(
     minLines: Int = 1,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
-    AnimatedContent(modifier = modifier, targetState = value) { v ->
+    // The placeholder has to stand as tall as the line it replaces, otherwise the layout around it
+    // shifts the moment the value lands.
+    val placeholderMinHeight =
+        with(LocalDensity.current) {
+            val loadedLineHeight = if (lineHeight.isSp) lineHeight else style.lineHeight
+            if (loadedLineHeight.isSp) loadedLineHeight.toDp() else PlaceholderMinHeight
+        }
+
+    AnimatedContent(
+        modifier = modifier,
+        targetState = value,
+        // Cross-fade only. The default transition carries a SizeTransform, so the box keeps
+        // re-measuring for the length of the animation after the value arrives, and anything sized
+        // by its content around it re-anchors while that runs.
+        transitionSpec = { fadeIn() togetherWith fadeOut() using null },
+    ) { v ->
         ToggleVisibilityText(
             text = v ?: "",
             isVisible = isVisible,
@@ -53,7 +72,10 @@ internal fun LoadableValue(
                 modifier
                     .clip(RoundedCornerShape(2.dp))
                     .background(Theme.v2.colors.backgrounds.tertiary_2)
-                    .defaultMinSize(minWidth = 20.dp, minHeight = 16.dp)
+                    .defaultMinSize(
+                        minWidth = PlaceholderMinWidth,
+                        minHeight = placeholderMinHeight,
+                    )
                     .takeIf { v == null } ?: modifier,
             fontSize = fontSize,
             fontStyle = fontStyle,
@@ -70,3 +92,6 @@ internal fun LoadableValue(
         )
     }
 }
+
+private val PlaceholderMinWidth = 20.dp
+private val PlaceholderMinHeight = 16.dp

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -77,9 +77,9 @@ constructor(
             val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
             uiState.update { it.copy(isBalanceVisible = isBalanceVisible) }
         }
-    }
-
-    fun refresh() {
+        // Load here rather than when the sheet finishes opening: the sheet is measured and drawn
+        // before the animation settles, so a load started on expand guarantees a first frame with
+        // no values and no action buttons, and the sheet re-anchors once they arrive.
         loadData()
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -36,6 +37,7 @@ import com.vultisig.wallet.ui.models.TokenDetailViewModel
 import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainLogo
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
+import com.vultisig.wallet.ui.screens.v2.home.components.assetActionButtonHeight
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
 
@@ -48,7 +50,6 @@ internal fun TokenDetailScreen(
 
     TokenDetailScreen(
         uiModel = uiModel,
-        onBottomSheetExpanded = viewModel::refresh,
         onSend = viewModel::send,
         onSwap = viewModel::swap,
         onDeposit = viewModel::deposit,
@@ -59,17 +60,16 @@ internal fun TokenDetailScreen(
 }
 
 @Composable
-private fun TokenDetailScreen(
+internal fun TokenDetailScreen(
     uiModel: TokenDetailUiModel,
-    onBottomSheetExpanded: () -> Unit,
-    onSend: () -> Unit,
-    onSwap: () -> Unit,
-    onDeposit: () -> Unit,
-    onDismiss: () -> Unit,
-    onBuy: () -> Unit,
-    onExplorer: () -> Unit,
+    onSend: () -> Unit = {},
+    onSwap: () -> Unit = {},
+    onDeposit: () -> Unit = {},
+    onDismiss: () -> Unit = {},
+    onBuy: () -> Unit = {},
+    onExplorer: () -> Unit = {},
 ) {
-    DottyBottomSheet(onExpand = onBottomSheetExpanded, onDismiss = onDismiss) {
+    DottyBottomSheet(onDismiss = onDismiss) {
         TokenDetailsContent(
             uiModel = uiModel,
             onSend = onSend,
@@ -136,7 +136,13 @@ private fun TokenDetailsContent(
         Row(
             horizontalArrangement =
                 Arrangement.spacedBy(space = 20.dp, alignment = Alignment.CenterHorizontally),
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+            // Every flag below starts false and only resolves once the account loads, so without a
+            // reserved height this row is zero-height on the first frame and the sheet re-anchors
+            // the moment the buttons appear.
+            modifier =
+                Modifier.fillMaxWidth()
+                    .heightIn(min = assetActionButtonHeight)
+                    .padding(horizontal = 24.dp),
         ) {
             if (uiModel.canSwap) {
                 AssetActionButton(action = AssetAction.SWAP, isSelected = true, onClick = onSwap)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
@@ -27,6 +29,21 @@ enum class AssetAction {
     RECEIVE,
     FUNCTIONS,
 }
+
+/**
+ * Height of a single [AssetActionButton]. Rows built from flags that resolve asynchronously should
+ * reserve this, so the row is not zero-height on the first frame — a container sized by its content
+ * (a bottom sheet, above all) re-anchors when the buttons appear.
+ */
+internal val assetActionButtonHeight: Dp
+    @Composable
+    get() =
+        IconBoxSize +
+            IconLabelSpacing +
+            with(LocalDensity.current) { Theme.brockmann.supplementary.caption.lineHeight.toDp() }
+
+private val IconBoxSize = 52.dp
+private val IconLabelSpacing = 8.dp
 
 @Composable
 fun AssetActionButton(
@@ -60,7 +77,7 @@ fun AssetActionButton(
     ) {
         Box(
             modifier =
-                Modifier.size(size = 52.dp)
+                Modifier.size(size = IconBoxSize)
                     .clip(shape = RoundedCornerShape(16.dp))
                     .border(
                         width = 1.dp,
@@ -73,7 +90,7 @@ fun AssetActionButton(
             UiIcon(drawableResId = logo, size = 20.dp, tint = Theme.v2.colors.text.primary)
         }
 
-        UiSpacer(8.dp)
+        UiSpacer(IconLabelSpacing)
 
         Text(
             text = stringResource(title),


### PR DESCRIPTION
## Description

Reported via a screen recording: opening a token from a chain screen makes the detail sheet appear, sit noticeably too low with empty skeletons, and then lurch upward once the balance arrives.

Frame-by-frame on the original recording (91 frames, 1080x2400): the sheet appeared fully placed in a single frame with no slide-in, held ~73dp below its resting place for ~600 ms with the Network row clipped under the gesture bar, then snapped upward. It reached rest **880 ms after it first appeared**.

Three things combine to cause it:

- **The load only started after the open animation settled.** `TokenDetailScreen` wired `onExpand` to `refresh()`, and `DottyBottomSheet` fires `onExpand` only once `sheetState.currentValue` settles — so the sheet was always composed, measured and drawn before any data existed.
- **The action row measured 0 dp on the first frame.** `canSwap` / `canSend` / `canBuy` / `canDeposit` all default to `false` and only resolve once the account loads, so the row went from 0 dp to ~76 dp in one recomposition. That was the single biggest height jump.
- **`LoadableValue` kept re-measuring after the values landed.** Its `AnimatedContent` used the default `transitionSpec`, which carries a `SizeTransform`; four of them in one sheet meant the content height was still changing for hundreds of ms, and `ModalBottomSheet` re-derives its anchors on every size change. The skeleton's flat `defaultMinSize(20.dp, 16.dp)` also didn't reserve the loaded line's height.

Fixes:

- `TokenDetailViewModel` loads in `init` instead of on expand, so the fetch is in flight while the sheet animates in.
- The action row reserves `heightIn(min = assetActionButtonHeight)`. That value is exported from `AssetActionButton` and derived from the same `52.dp` icon box, `8.dp` gap and caption line height the button itself uses, so it can't drift from the real thing.
- `LoadableValue` cross-fades only (`fadeIn() togetherWith fadeOut() using null`) and sizes its placeholder from the passed style's line height, so skeleton and loaded text occupy identical space.
- Dropped `LaunchedEffect(Unit) { sheetState.expand() }` in `DottyBottomSheet`. `ModalBottomSheet` already animates to Expanded on first composition and `skipPartiallyExpanded` leaves nowhere else to settle; expanding on the same frame short-circuited that animation, which is why the sheet had no slide-in at all.

### Original report

The recording the bug was reported with, on a real device. The sheet pops in with empty skeletons, holds too low with the Network row clipped under the gesture bar, then lurches up once the balance lands. The wallet address is blurred.

![reported bug](https://i.imgur.com/JH6mLu5.gif)

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

None of the above — presentation only. No keysign, broadcast or fee path is touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

No unit test: the defect is layout timing inside `ModalBottomSheet`'s anchor calculation, which a JVM test can't observe. Verified instead by recording the same launch on both builds and measuring the sheet position per frame (numbers below). A debug preview is included so the check is repeatable.

## Screenshots

Captured on `emulator-5554` (1080x2400, animation scales at 1.0) via a new debug preview, `PreviewActivity -e screen token_detail_sheet_loading`, which composes the sheet with an empty model and lands the account 700 ms later — the real sequence. Both clips are trimmed to the same window around the sheet opening.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/vdvwFRm.gif) | ![after](https://i.imgur.com/fDVFFIk.gif) |

The loading frame is where it shows clearest — same moment in both builds, sheet at two different heights:

| Before (loading) | After (loading) |
|--------|-------|
| ![before loading](https://i.imgur.com/5GS7jyx.png) | ![after loading](https://i.imgur.com/pfxJg4Z.png) |

| Before (loaded) | After (loaded) |
|--------|-------|
| ![before loaded](https://i.imgur.com/mNG4xu7.png) | ![after loaded](https://i.imgur.com/CD6DRwx.png) |

Drag-handle y tracked frame by frame across both recordings:

| | Before | After |
|---|---|---|
| enter animation | none — fully placed in one frame | slides in over ~215 ms (469 → 268) |
| position while loading | y=320, ~73 dp below its resting place | y=268, already final |
| when the data lands | single-frame snap 320 → 270 | stays at 268, no movement |
| time to settle | ~615 ms after appearing | settles once and stays |

## Additional context

- `assetActionButtonHeight` is new public-in-module API on `AssetActionButton`. Any other row built from asynchronously-resolved capability flags can reserve it the same way.
- The inner `TokenDetailScreen(uiModel, …)` composable went from `private` to `internal` with defaulted callbacks so the debug preview can drive it directly. Happy to keep it private and duplicate the content in the preview instead if that's preferred.
- `LoadableValue` is shared with `VaultAccountsScreen`, `BalanceBanner`, `AccountItem`, `ChainAccount`, `ChainTokensScreen` and `VaultListScreen`. The change makes every one of them size-stable across a load; no call site needed edits.
- `TokenAddressQrBottomSheet` has the identical late-load pattern (`onExpand = viewModel::loadData`). Left alone to keep this diff focused — worth a follow-up.
- The equivalent sheet on iOS is a separate implementation and wasn't inspected; if it shows the same jump it needs its own ticket.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none — reported by screen recording
- **Confidence**: high
- **Needs human review for**: the `private` → `internal` widening of `TokenDetailScreen`, and whether the `LoadableValue` cross-fade (no size animation) is wanted everywhere it's used
