### PR TITLE
fix: notify vault devices without a local FCM token

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
@@ -187,12 +187,15 @@ constructor(
         setVaultsOptIn(allVaults.map { it.id to enabled })
     }
 
+    /**
+     * Asks the server to push the keysign QR to this vault's registered devices.
+     *
+     * Deliberately independent of the local device's own push state: [NotifyRequest] carries no
+     * token, and the server picks the recipients from the devices registered under `vaultId`. An
+     * initiator that never opted in — or whose token write was lost — must still be able to notify
+     * peers that did. Failures propagate so the caller can report them rather than claim success.
+     */
     suspend fun notifyVaultDevices(vault: Vault, qrCodeData: String) {
-        val token = getStoredToken()
-        if (token == null) {
-            Timber.d("No FCM token available, skipping notification")
-            return
-        }
         notificationApi.notify(
             NotifyRequest(
                 vaultId = notificationVaultId(vault),

--- a/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationManagerTest.kt
@@ -1,0 +1,104 @@
+package com.vultisig.wallet.data.services
+
+import android.content.SharedPreferences
+import com.vultisig.wallet.data.api.NotificationApi
+import com.vultisig.wallet.data.api.NotifyRequest
+import com.vultisig.wallet.data.db.dao.VaultNotificationSettingsDao
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.io.IOException
+import java.security.MessageDigest
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PushNotificationManagerTest {
+
+    private val notificationApi: NotificationApi = mockk(relaxed = true)
+    private val vaultRepository: VaultRepository = mockk(relaxed = true)
+    private val settingsDao: VaultNotificationSettingsDao = mockk(relaxed = true)
+    private val encryptedPrefs: SharedPreferences = mockk(relaxed = true)
+
+    private val manager =
+        PushNotificationManager(notificationApi, vaultRepository, settingsDao, encryptedPrefs)
+
+    private val vault =
+        Vault(
+            id = "vault-id",
+            name = "My Vault",
+            pubKeyECDSA = "02abcdef",
+            hexChainCode = "chaincode",
+            localPartyID = "iPhone-A1B2",
+        )
+
+    private fun storedToken(token: String?) {
+        every { encryptedPrefs.getString(FCM_TOKEN_KEY, null) } returns token
+    }
+
+    /**
+     * The initiator's own token is irrelevant to /notify — the server picks recipients from the
+     * devices registered under `vaultId`. Skipping the call here stranded peers that had opted in,
+     * while the caller was told the push went out (#5440).
+     */
+    @Test
+    fun `notifies vault devices when the local device has no stored token`() = runTest {
+        storedToken(null)
+
+        manager.notifyVaultDevices(vault, QR_CODE_DATA)
+
+        coVerify(exactly = 1) { notificationApi.notify(any()) }
+    }
+
+    @Test
+    fun `notifies vault devices when the local device has a stored token`() = runTest {
+        storedToken("fcm-token")
+
+        manager.notifyVaultDevices(vault, QR_CODE_DATA)
+
+        coVerify(exactly = 1) { notificationApi.notify(any()) }
+    }
+
+    @Test
+    fun `sends the vault identity and qr payload, never the local token`() = runTest {
+        storedToken(null)
+        val request = slot<NotifyRequest>()
+        coEvery { notificationApi.notify(capture(request)) } returns Unit
+
+        manager.notifyVaultDevices(vault, QR_CODE_DATA)
+
+        with(request.captured) {
+            vaultId shouldBe sha256Hex(vault.pubKeyECDSA + vault.hexChainCode)
+            vaultName shouldBe vault.name
+            localPartyId shouldBe vault.localPartyID
+            qrCodeData shouldBe QR_CODE_DATA
+        }
+    }
+
+    /**
+     * The caller reports success off a normal return, so a failed notify must not return normally —
+     * otherwise the user sees "sent" and is locked out by the resend cooldown.
+     */
+    @Test
+    fun `propagates notify failures to the caller`() = runTest {
+        storedToken("fcm-token")
+        coEvery { notificationApi.notify(any()) } throws IOException("unreachable")
+
+        assertThrows<IOException> { manager.notifyVaultDevices(vault, QR_CODE_DATA) }
+    }
+
+    private fun sha256Hex(input: String): String =
+        MessageDigest.getInstance("SHA-256").digest(input.toByteArray()).joinToString("") {
+            "%02x".format(it)
+        }
+
+    private companion object {
+        const val FCM_TOKEN_KEY = "fcm_device_token"
+        const val QR_CODE_DATA = "https://vultisig.com?type=SignTransaction"
+    }
+}


### PR DESCRIPTION
Closes #5440

## Problem

`PushNotificationManager.notifyVaultDevices` early-returned when the **initiating** device had no stored FCM token, so a keysign started from that device never reached `/notify` — and peers that *had* opted in were never pushed.

The guard checked a value the request never uses. `NotifyRequest` carries only `vault_id`, `vault_name`, `local_party_id` and `qr_code_data`; the server selects recipients from the devices registered under `vault_id`. The initiator's own token has no bearing on the call.

This is the same gate #3302 already removed from this function for the sender's opt-in flag — the token check was its surviving sibling, both introduced together in #3271.

Because the skip was a plain `return`, `KeysignFlowViewModel.sendNotification` carried on as if it had succeeded: it recorded the QR as notified, showed **"Notification sent successfully!"**, and started the 30s resend cooldown. The user was told the push went out *and* was locked out of retrying, while nothing had been sent.

## Fix

Remove the guard.

That also fixes the reporting half on its own — `notificationApi.notify` throws via `throwIfUnsuccessful()`, so with the silent return gone a real failure reaches `sendNotification`'s `safeLaunch(onError = …)`, which shows **"Push notification failed"** and leaves both `lastNotifiedQrData` and the cooldown untouched, so the resend button stays live. `safeLaunch` rethrows `CancellationException`, so navigating away isn't misreported as a push failure.

## How the no-token state is reachable

`getStoredToken()` / `refreshTokenIfNeeded()` have no callers outside `PushNotificationManager`. The token is written only by:

1. `VultisigFirebaseMessagingService.onNewToken` → `serviceScope.launch { … }`, a scope `onDestroy` cancels (#5439) — the write can be lost
2. `refreshTokenIfNeeded()`, reached only from `setVaultOptIn` / `setVaultsOptIn` **when enabling**

So a user who never opted in, or who lost the #5439 race, has no token — and then every keysign silently skipped the notify while claiming success. #5439 and #5440 compound each other.

## Cross-platform

iOS `PushNotificationManager.swift:248` has no token gate, so this brings Android to parity.

Worth noting separately: iOS swallows the error (`catch { logger.error(…) }`) and `KeysignDiscoveryView.swift:313` sets the success banner unconditionally, so iOS has the false-success half of this bug. Not addressed here — needs a sibling iOS issue.

## Test plan

New `PushNotificationManagerTest` — 4/4 green via `./gradlew :app:testDebugUnitTest`:

- notify fires when there is **no** stored token (the regression — fails on the old code, where `notify` was never called)
- notify fires when there is a stored token
- the request carries the SHA-256 vault id, vault name, local party id and QR data, and no token
- a throwing `notify` propagates rather than returning normally, so the caller can't report success

### Manual

Two Secure-vault devices, A = initiator, B = peer. B has push notifications on for the vault; A has no FCM token (fresh install first launched offline, and Settings → Notifications never opened, since that screen back-fills the token).

A → Send → Sign, landing on peer discovery:

| | Before | After |
|---|---|---|
| Phone A | "Notification sent successfully!" + 30s cooldown | same |
| **Phone B** | nothing, ever | **"Sign transaction — A new signing request is waiting for you"** |

Failure surfacing: on A's peer-discovery screen, enable airplane mode and tap **Resend notification** → "Push notification failed", button stays tappable with no cooldown lockout.

Regression: A with notifications **on** → B still receives the push, A still shows success + cooldown. Unchanged.

No UI changes in this PR — no visual diff to show.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault device notifications are now sent regardless of whether a local push token is available.
  * Notification failures are properly reported instead of being treated as successful when local token data is missing.

* **Tests**
  * Added coverage for notification delivery with and without a local push token.
  * Added verification of notification payload details and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->