### PR TITLE
fix: heal FCM re-registration and deliver pushes on the right channel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.work.testing)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,10 @@
             <meta-data
                 android:name="com.vultisig.wallet.app.startup.WorkManagerInitializer"
                 android:value="androidx.startup" />
+
+            <meta-data
+                android:name="com.vultisig.wallet.app.startup.PushNotificationInitializer"
+                android:value="androidx.startup" />
         </provider>
 
         <service
@@ -151,6 +155,15 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!--
+             A backgrounded message carrying a notification block is rendered by the FCM SDK itself,
+             so onMessageReceived never runs. Without this the SDK invents a "Miscellaneous" channel
+             at default importance and a keysign request arrives with no heads-up peek.
+        -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/keysign_notification_channel_id" />
 
     </application>
 

--- a/app/src/main/java/com/vultisig/wallet/app/startup/PushNotificationInitializer.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/startup/PushNotificationInitializer.kt
@@ -1,0 +1,31 @@
+package com.vultisig.wallet.app.startup
+
+import android.content.Context
+import androidx.startup.Initializer
+import com.vultisig.wallet.data.services.KeysignNotificationChannel
+import com.vultisig.wallet.data.services.PushRegistrationWorker
+
+/**
+ * Startup reconcile for push delivery.
+ *
+ * Creates the keysign channel before any push can arrive — a backgrounded message is rendered by
+ * the FCM SDK, which never reaches the app's own code, so a channel created lazily on first
+ * notification does not exist when it is needed.
+ *
+ * Then queues a re-registration. Nothing else re-registers after the initial opt-in, so a device
+ * whose token rotated while a registration failed kept a dead token on the server with no path back
+ * — pushes stopped permanently. Running this every launch is the healing path.
+ */
+internal class PushNotificationInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        val appContext = context.applicationContext
+        KeysignNotificationChannel.ensureCreated(appContext)
+        // KEEP: a run already in flight is registering the same token; restarting it would only
+        // reset its backoff.
+        PushRegistrationWorker.enqueue(appContext, replaceExisting = false)
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> =
+        listOf(WorkManagerInitializer::class.java)
+}

--- a/app/src/main/java/com/vultisig/wallet/data/di/DataModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/di/DataModule.kt
@@ -3,9 +3,14 @@ package com.vultisig.wallet.data.di
 import android.content.Context
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.vultisig.wallet.data.repositories.PrettyJson
+import com.vultisig.wallet.data.services.AndroidSystemNotificationStatus
+import com.vultisig.wallet.data.services.FcmTokenProvider
+import com.vultisig.wallet.data.services.FirebaseFcmTokenProvider
+import com.vultisig.wallet.data.services.SystemNotificationStatus
 import com.vultisig.wallet.data.utils.BigDecimalSerializer
 import com.vultisig.wallet.data.utils.BigIntegerSerializer
 import com.vultisig.wallet.data.utils.KeysignResponseSerializer
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,6 +28,14 @@ import tss.KeysignResponse
 @Module
 @InstallIn(SingletonComponent::class)
 internal interface DataModule {
+
+    @Binds @Singleton fun bindFcmTokenProvider(impl: FirebaseFcmTokenProvider): FcmTokenProvider
+
+    @Binds
+    @Singleton
+    fun bindSystemNotificationStatus(
+        impl: AndroidSystemNotificationStatus
+    ): SystemNotificationStatus
 
     companion object {
 

--- a/app/src/main/java/com/vultisig/wallet/data/services/FcmTokenProvider.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/FcmTokenProvider.kt
@@ -1,0 +1,20 @@
+package com.vultisig.wallet.data.services
+
+import com.google.firebase.messaging.FirebaseMessaging
+import javax.inject.Inject
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Fetches the device's current FCM registration token.
+ *
+ * Exists so token acquisition can be substituted in tests — [FirebaseMessaging.getInstance] reaches
+ * for a live Firebase app and cannot run on the JVM.
+ */
+interface FcmTokenProvider {
+    /** @throws Exception when the token cannot be minted (no Play Services, no network, …). */
+    suspend fun fetchToken(): String
+}
+
+internal class FirebaseFcmTokenProvider @Inject constructor() : FcmTokenProvider {
+    override suspend fun fetchToken(): String = FirebaseMessaging.getInstance().token.await()
+}

--- a/app/src/main/java/com/vultisig/wallet/data/services/KeysignNotificationChannel.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/KeysignNotificationChannel.kt
@@ -1,0 +1,69 @@
+package com.vultisig.wallet.data.services
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import com.vultisig.wallet.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * The high-importance channel keysign requests are delivered on.
+ *
+ * The id is duplicated in `AndroidManifest.xml` as
+ * `com.google.firebase.messaging.default_notification_channel_id`, both reading the same string
+ * resource. That meta-data is what makes a backgrounded push land here: when a message carries a
+ * `notification` block the FCM SDK renders the tray entry itself, `onMessageReceived` never runs,
+ * and without a declared default the SDK falls back to an auto-created "Miscellaneous" channel at
+ * default importance — no heads-up peek, trivially muted, for a time-critical signing request.
+ *
+ * The channel must therefore exist *before* any push arrives, which is why [ensureCreated] runs at
+ * app start rather than at first notification.
+ */
+internal object KeysignNotificationChannel {
+
+    fun id(context: Context): String = context.getString(R.string.keysign_notification_channel_id)
+
+    /** Idempotent — re-creating an existing channel is a no-op apart from name/description. */
+    fun ensureCreated(context: Context) {
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                id(context),
+                context.getString(R.string.keysign_notification_channel_name),
+                NotificationManager.IMPORTANCE_HIGH,
+            )
+        )
+    }
+
+    /**
+     * Whether a keysign push would actually surface: the app holds notification permission *and*
+     * the user has not blocked this specific channel. Either can be revoked in system settings long
+     * after opt-in, with no callback to the app — so the in-app toggle reads ON while every push is
+     * silently dropped.
+     */
+    fun areNotificationsEnabled(context: Context): Boolean {
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return false
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = notificationManager.getNotificationChannel(id(context)) ?: return true
+        return channel.importance != NotificationManager.IMPORTANCE_NONE
+    }
+}
+
+/**
+ * Injectable view of [KeysignNotificationChannel.areNotificationsEnabled], so callers can be
+ * exercised without a live `NotificationManager`.
+ */
+interface SystemNotificationStatus {
+    fun areNotificationsEnabled(): Boolean
+}
+
+internal class AndroidSystemNotificationStatus
+@Inject
+constructor(@ApplicationContext private val context: Context) : SystemNotificationStatus {
+    override fun areNotificationsEnabled(): Boolean =
+        KeysignNotificationChannel.areNotificationsEnabled(context)
+}

--- a/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/PushNotificationManager.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.data.services
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import com.google.firebase.messaging.FirebaseMessaging
 import com.vultisig.wallet.data.api.DeviceRegistrationRequest
 import com.vultisig.wallet.data.api.DeviceUnregisterRequest
 import com.vultisig.wallet.data.api.NotificationApi
@@ -17,7 +16,6 @@ import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 
 @SuppressLint(
@@ -31,27 +29,53 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val vaultNotificationSettingsDao: VaultNotificationSettingsDao,
     private val encryptedPrefs: SharedPreferences,
+    private val fcmTokenProvider: FcmTokenProvider,
 ) {
     fun getStoredToken(): String? = encryptedPrefs.getString(FCM_TOKEN_KEY, null)
 
-    suspend fun onNewToken(token: String) {
+    /**
+     * Persists a freshly minted token. Synchronous by design: `FirebaseMessagingService` stops
+     * itself once `onNewToken` returns, so a token handed to a coroutine can be lost when the
+     * service's scope is torn down mid-flight. The network half is re-registration, which
+     * [PushRegistrationWorker] owns.
+     */
+    fun storeToken(token: String) {
         encryptedPrefs.edit { putString(FCM_TOKEN_KEY, token) }
-        reRegisterAllOptedInVaults(token)
     }
 
     suspend fun refreshTokenIfNeeded() {
-        if (getStoredToken() != null) return
-        try {
-            val token = FirebaseMessaging.getInstance().token.await()
-            onNewToken(token)
+        currentToken()
+    }
+
+    /**
+     * The token to register with, minting and persisting one if none is stored yet.
+     *
+     * @return null when no token could be obtained; the caller should retry later rather than treat
+     *   this as a permanent state.
+     */
+    suspend fun currentToken(): String? {
+        getStoredToken()?.let {
+            return it
+        }
+        return try {
+            fcmTokenProvider.fetchToken().also { storeToken(it) }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.w(e, "Failed to fetch FCM token")
+            null
         }
     }
 
-    private suspend fun reRegisterAllOptedInVaults(token: String) {
+    /**
+     * Re-points every opted-in vault at [token] on the server.
+     *
+     * @return false when at least one vault failed, so the caller can reschedule. Registrations
+     *   that are never retried leave the server holding a dead token while the local toggle still
+     *   reads ON — pushes stop and never heal.
+     */
+    suspend fun reRegisterOptedInVaults(token: String): Boolean {
         val enabledSettings = vaultNotificationSettingsDao.getAllEnabled()
+        var allSucceeded = true
         enabledSettings.forEach { settings ->
             val vault =
                 vaultRepository.get(settings.vaultId)?.takeIf { it.isSecureVault() }
@@ -66,10 +90,15 @@ constructor(
                 )
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                Timber.w(e, "Failed to re-register vault ${vault.id} with new FCM token")
+                Timber.w(e, "Failed to re-register vault %s with new FCM token", vault.id)
+                allSucceeded = false
             }
         }
+        return allSucceeded
     }
+
+    suspend fun hasOptedInVaults(): Boolean =
+        vaultNotificationSettingsDao.getAllEnabled().isNotEmpty()
 
     private fun notificationVaultId(vault: Vault): String {
         val input = (vault.pubKeyECDSA + vault.hexChainCode).toByteArray()

--- a/app/src/main/java/com/vultisig/wallet/data/services/PushRegistrationWorker.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/PushRegistrationWorker.kt
@@ -1,0 +1,87 @@
+package com.vultisig.wallet.data.services
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+import timber.log.Timber
+
+/**
+ * Re-points the server at this device's current FCM token for every opted-in vault.
+ *
+ * Runs here rather than inline in `FirebaseMessagingService.onNewToken` because that service stops
+ * itself — and cancels its scope — as soon as the callback returns, so an in-flight HTTP
+ * re-registration raced teardown and a lost race left the server holding a dead token forever.
+ * WorkManager survives teardown, process death and reboot, and retries with backoff.
+ */
+@HiltWorker
+internal class PushRegistrationWorker
+@AssistedInject
+constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val pushNotificationManager: PushNotificationManager,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        // Nothing to keep alive on the server until at least one vault has opted in. Minting a
+        // token here would also prompt Firebase for one on devices that never asked for pushes.
+        if (!pushNotificationManager.hasOptedInVaults()) return Result.success()
+
+        val token = pushNotificationManager.currentToken() ?: return retryOrFail()
+
+        return if (pushNotificationManager.reRegisterOptedInVaults(token)) {
+            Result.success()
+        } else {
+            retryOrFail()
+        }
+    }
+
+    // WorkManager has no built-in attempt cap, so bound it here to stop rescheduling a failure
+    // that is never going to resolve.
+    private fun retryOrFail(): Result =
+        if (runAttemptCount < MAX_ATTEMPTS) {
+            Result.retry()
+        } else {
+            Timber.w("Giving up on FCM re-registration after %d attempts", runAttemptCount + 1)
+            Result.failure()
+        }
+
+    companion object {
+        const val MAX_ATTEMPTS = 5
+        private const val WORK_NAME = "push_registration"
+
+        /**
+         * Queues a re-registration.
+         *
+         * @param replaceExisting true when a *new* token has just arrived, so a run still queued
+         *   against the previous token is redundant and must not overwrite the newer one. False for
+         *   the startup reconcile, which must not restart an already-running attempt.
+         */
+        fun enqueue(context: Context, replaceExisting: Boolean) {
+            val request =
+                OneTimeWorkRequestBuilder<PushRegistrationWorker>()
+                    .setConstraints(
+                        Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+                    )
+                    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                    .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(
+                    WORK_NAME,
+                    if (replaceExisting) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP,
+                    request,
+                )
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/VultisigFirebaseMessagingService.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.data.services
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
@@ -14,21 +13,19 @@ import com.vultisig.wallet.app.activity.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
 class VultisigFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject lateinit var pushNotificationManager: PushNotificationManager
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onNewToken(token: String) {
-        serviceScope.launch { pushNotificationManager.onNewToken(token) }
+        // Both halves are synchronous so neither can be lost to service teardown: the token is
+        // persisted here and the HTTP re-registration is handed to WorkManager, which owns the
+        // retries. Callbacks arrive on a Firebase background thread, so the prefs write is safe.
+        pushNotificationManager.storeToken(token)
+        PushRegistrationWorker.enqueue(this, replaceExisting = true)
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
@@ -65,14 +62,6 @@ class VultisigFirebaseMessagingService : FirebaseMessagingService() {
     private fun showSystemNotification(qrCodeData: String) {
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
-        val channel =
-            NotificationChannel(
-                CHANNEL_ID,
-                getString(R.string.keysign_notification_channel_name),
-                NotificationManager.IMPORTANCE_HIGH,
-            )
-        notificationManager.createNotificationChannel(channel)
-
         val tapIntent =
             Intent(this, MainActivity::class.java).apply {
                 flags =
@@ -92,7 +81,7 @@ class VultisigFirebaseMessagingService : FirebaseMessagingService() {
             )
 
         val notification =
-            NotificationCompat.Builder(this, CHANNEL_ID)
+            NotificationCompat.Builder(this, KeysignNotificationChannel.id(this))
                 .setContentTitle(getString(R.string.keysign_notification_title))
                 .setContentText(getString(R.string.keysign_notification_body))
                 .setSmallIcon(R.drawable.ic_launcher_foreground)
@@ -104,15 +93,9 @@ class VultisigFirebaseMessagingService : FirebaseMessagingService() {
         notificationManager.notify(notificationId, notification)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        serviceScope.cancel()
-    }
-
     companion object {
         const val PUSH_NOTIFICATION_ACTION = "com.vultisig.wallet.PUSH_NOTIFICATION"
         const val QR_CODE_DATA = "message"
-        private const val CHANNEL_ID = "keysign_requests_channel"
         private val notificationIdCounter = AtomicInteger(1000)
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.isFastVault
 import com.vultisig.wallet.data.models.isSecureVault
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.services.PushNotificationManager
+import com.vultisig.wallet.data.services.SystemNotificationStatus
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
 import com.vultisig.wallet.ui.navigation.Destination
@@ -35,6 +36,12 @@ internal data class VaultNotificationUiModel(
 internal data class NotificationsSettingsUiState(
     val masterEnabled: Boolean = false,
     val vaults: List<VaultNotificationUiModel> = emptyList(),
+    /**
+     * Opted in in-app, but the OS will drop every push — permission revoked or the keysign channel
+     * muted after opt-in. Neither raises a callback, so without this the toggle reads ON while
+     * nothing is delivered.
+     */
+    val isBlockedBySystem: Boolean = false,
 )
 
 @HiltViewModel
@@ -44,6 +51,7 @@ constructor(
     private val navigator: Navigator<Destination>,
     private val vaultRepository: VaultRepository,
     private val pushNotificationManager: PushNotificationManager,
+    private val systemNotificationStatus: SystemNotificationStatus,
     private val snackbarFlow: SnackbarFlow,
 ) : ViewModel() {
     private val _state = MutableStateFlow(NotificationsSettingsUiState())
@@ -73,12 +81,13 @@ constructor(
                             )
                         }
 
-                    NotificationsSettingsUiState(
-                        masterEnabled = masterEnabled,
-                        vaults = vaultUiModels,
-                    )
+                    masterEnabled to vaultUiModels
                 }
-                .collect { newState -> _state.update { newState } }
+                .collect { (masterEnabled, vaultUiModels) ->
+                    // Preserve isBlockedBySystem: it comes from the OS on resume, not from this
+                    // flow, and replacing the whole state here would clear the warning.
+                    _state.update { it.copy(masterEnabled = masterEnabled, vaults = vaultUiModels) }
+                }
         }
     }
 
@@ -128,6 +137,16 @@ constructor(
                     pushNotificationManager.setVaultOptIn(pending.vaultId, enabled = true)
             }
         }
+    }
+
+    /**
+     * Re-reads the OS notification state. Called on every resume because the user can revoke
+     * permission or mute the channel from system settings while this screen sits in the background,
+     * and neither change notifies the app.
+     */
+    fun refreshSystemNotificationState() {
+        val blocked = !systemNotificationStatus.areNotificationsEnabled()
+        _state.update { it.copy(isBlockedBySystem = blocked) }
     }
 
     fun back() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
@@ -1,7 +1,11 @@
 package com.vultisig.wallet.ui.screens.settings
 
 import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -17,18 +21,26 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.VsSwitch
+import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.icons.VaultIcon
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.settings.NotificationsSettingsUiState
@@ -57,12 +69,41 @@ internal fun NotificationsSettingsScreen() {
         }
     }
 
+    // Re-checked on every resume: the user can revoke permission or mute the channel in system
+    // settings — including via the button below — and the OS raises no callback for either.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshSystemNotificationState()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val context = LocalContext.current
+
     NotificationsSettingsScreen(
         state = state,
         onMasterToggle = viewModel::onMasterToggle,
         onVaultToggle = viewModel::onVaultToggle,
+        onOpenSystemSettings = { context.openAppNotificationSettings() },
         onBackClick = viewModel::back,
     )
+}
+
+private fun Context.openAppNotificationSettings() {
+    val intent =
+        Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+            .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    runCatching { startActivity(intent) }
+        .onFailure {
+            startActivity(
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    .setData(Uri.fromParts("package", packageName, null))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
 }
 
 @Composable
@@ -70,11 +111,17 @@ private fun NotificationsSettingsScreen(
     state: NotificationsSettingsUiState,
     onMasterToggle: (Boolean) -> Unit,
     onVaultToggle: (String, Boolean) -> Unit,
+    onOpenSystemSettings: () -> Unit,
     onBackClick: () -> Unit,
 ) {
     V2Scaffold(title = stringResource(R.string.notifications), onBackClick = onBackClick) {
         Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
             MasterNotificationToggle(isChecked = state.masterEnabled, onToggle = onMasterToggle)
+
+            if (state.masterEnabled && state.isBlockedBySystem) {
+                UiSpacer(size = 16.dp)
+                SystemNotificationsBlockedWarning(onClick = onOpenSystemSettings)
+            }
 
             if (state.masterEnabled && state.vaults.isNotEmpty()) {
                 UiSpacer(size = 22.dp)
@@ -103,6 +150,35 @@ private fun NotificationsSettingsScreen(
 
             UiSpacer(size = 24.dp)
         }
+    }
+}
+
+@Composable
+private fun SystemNotificationsBlockedWarning(onClick: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(RoundedCornerShape(size = 12.dp))
+                .clickOnce(onClick = onClick)
+                .background(color = Theme.v2.colors.backgrounds.surface1)
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.alerts.warning,
+                    shape = RoundedCornerShape(size = 12.dp),
+                )
+                .padding(all = 16.dp),
+    ) {
+        UiIcon(
+            drawableResId = R.drawable.ic_triangle_alert,
+            tint = Theme.v2.colors.alerts.warning,
+            size = 16.dp,
+        )
+        Text(
+            text = stringResource(R.string.push_notifications_blocked_by_system),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.alerts.warning,
+        )
     }
 }
 
@@ -206,6 +282,32 @@ private fun NotificationsSettingsScreenPreview() {
             ),
         onMasterToggle = {},
         onVaultToggle = { _, _ -> },
+        onOpenSystemSettings = {},
+        onBackClick = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NotificationsSettingsScreenBlockedPreview() {
+    NotificationsSettingsScreen(
+        state =
+            NotificationsSettingsUiState(
+                masterEnabled = true,
+                isBlockedBySystem = true,
+                vaults =
+                    listOf(
+                        VaultNotificationUiModel(
+                            vaultId = "1",
+                            vaultName = "Secure Vault",
+                            isEnabled = true,
+                            isFastVault = false,
+                        )
+                    ),
+            ),
+        onMasterToggle = {},
+        onVaultToggle = { _, _ -> },
+        onOpenSystemSettings = {},
         onBackClick = {},
     )
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -391,6 +391,7 @@
     <string name="push_notifications_sent">Benachrichtigung erfolgreich gesendet!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Erhalten Sie eine Benachrichtigung, wenn Ihre Unterschrift erforderlich ist oder ein Gerät Zugriff anfordert.</string>
     <string name="keysign_notification_channel_name">Keysign-Anfragen</string>
+    <string name="push_notifications_blocked_by_system">Benachrichtigungen für Vultisig sind in den Systemeinstellungen deaktiviert. Sie erhalten keine Signierungsanfragen, bis Sie sie wieder aktivieren.</string>
     <string name="keysign_notification_title">Transaktion signieren</string>
     <string name="keysign_notification_body">Eine neue Signierungsanfrage wartet auf Sie</string>
     <string name="foreground_notification_banner_title">Transaktion beitreten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -391,6 +391,7 @@
     <string name="push_notifications_sent">¡Notificación enviada correctamente!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Recibe una notificación cuando se requiera tu firma o un dispositivo solicite acceso.</string>
     <string name="keysign_notification_channel_name">Solicitudes de firma</string>
+    <string name="push_notifications_blocked_by_system">Las notificaciones de Vultisig están desactivadas en la configuración del sistema. No recibirás solicitudes de firma hasta que vuelvas a activarlas.</string>
     <string name="keysign_notification_title">Firmar transacción</string>
     <string name="keysign_notification_body">Hay una nueva solicitud de firma esperándote</string>
     <string name="foreground_notification_banner_title">Unirse a la transacción</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -392,6 +392,7 @@
     <string name="push_notifications_sent">Obavijest je uspješno poslana!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Primite obavijest kada je potreban vaš potpis ili uređaj zatraži pristup.</string>
     <string name="keysign_notification_channel_name">Zahtjevi za potpisivanje</string>
+    <string name="push_notifications_blocked_by_system">Obavijesti za Vultisig isključene su u postavkama sustava. Nećete primati zahtjeve za potpisivanje dok ih ponovno ne uključite.</string>
     <string name="keysign_notification_title">Potpiši transakciju</string>
     <string name="keysign_notification_body">Čeka vas novi zahtjev za potpisivanje</string>
     <string name="foreground_notification_banner_title">Pridruži se transakciji</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -391,6 +391,7 @@
     <string name="push_notifications_sent">Notifica inviata con successo!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Ricevi una notifica quando è richiesta la tua firma o un dispositivo richiede l\'accesso.</string>
     <string name="keysign_notification_channel_name">Richieste di firma</string>
+    <string name="push_notifications_blocked_by_system">Le notifiche per Vultisig sono disattivate nelle impostazioni di sistema. Non riceverai richieste di firma finché non le riattivi.</string>
     <string name="keysign_notification_title">Firma transazione</string>
     <string name="keysign_notification_body">C\'è una nuova richiesta di firma in attesa</string>
     <string name="foreground_notification_banner_title">Partecipa alla transazione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -14,6 +14,7 @@
     <string name="push_notifications_sent">알림이 성공적으로 전송되었습니다!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">서명이 필요하거나 기기가 접근을 요청할 때 알림을 받으세요.</string>
     <string name="keysign_notification_channel_name">서명 요청</string>
+    <string name="push_notifications_blocked_by_system">시스템 설정에서 Vultisig의 알림이 꺼져 있습니다. 다시 켤 때까지 서명 요청을 받을 수 없습니다.</string>
     <string name="keysign_notification_title">거래 서명</string>
     <string name="keysign_notification_body">새로운 서명 요청이 대기 중입니다</string>
     <string name="foreground_notification_banner_title">거래 참여</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -390,6 +390,7 @@
     <string name="push_notifications_sent">Melding succesvol verzonden!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Ontvang een melding wanneer uw handtekening vereist is of een apparaat toegang aanvraagt.</string>
     <string name="keysign_notification_channel_name">Ondertekeningsverzoeken</string>
+    <string name="push_notifications_blocked_by_system">Meldingen voor Vultisig zijn uitgeschakeld in de systeeminstellingen. U ontvangt geen ondertekeningsverzoeken totdat u ze weer inschakelt.</string>
     <string name="keysign_notification_title">Transactie ondertekenen</string>
     <string name="keysign_notification_body">Er wacht een nieuw ondertekeningsverzoek op u</string>
     <string name="foreground_notification_banner_title">Doe mee aan transactie</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -391,6 +391,7 @@
     <string name="push_notifications_sent">Notificação enviada com sucesso!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Receba uma notificação quando a sua assinatura for necessária ou um dispositivo solicitar acesso.</string>
     <string name="keysign_notification_channel_name">Solicitações de assinatura</string>
+    <string name="push_notifications_blocked_by_system">As notificações da Vultisig estão desativadas nas definições do sistema. Não receberá solicitações de assinatura até as voltar a ativar.</string>
     <string name="keysign_notification_title">Assinar transação</string>
     <string name="keysign_notification_body">Há uma nova solicitação de assinatura aguardando você</string>
     <string name="foreground_notification_banner_title">Participar da transação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -392,6 +392,7 @@
     <string name="push_notifications_sent">Уведомление успешно отправлено!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Получайте уведомления, когда требуется ваша подпись или устройство запрашивает доступ.</string>
     <string name="keysign_notification_channel_name">Запросы на подписание</string>
+    <string name="push_notifications_blocked_by_system">Уведомления для Vultisig отключены в настройках системы. Вы не будете получать запросы на подписание, пока не включите их снова.</string>
     <string name="keysign_notification_title">Подписать транзакцию</string>
     <string name="keysign_notification_body">Новый запрос на подписание ожидает вас</string>
     <string name="foreground_notification_banner_title">Присоединиться к транзакции</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -14,6 +14,7 @@
     <string name="push_notifications_sent">通知发送成功！</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">当需要您的签名或设备请求访问时，您将收到通知。</string>
     <string name="keysign_notification_channel_name">签名请求</string>
+    <string name="push_notifications_blocked_by_system">系统设置中已关闭 Vultisig 的通知。在重新开启之前，您将不会收到签名请求。</string>
     <string name="keysign_notification_title">签署交易</string>
     <string name="keysign_notification_body">有一个新的签名请求等待您处理</string>
     <string name="foreground_notification_banner_title">加入交易</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,11 @@
     </plurals>
     <string name="push_notifications_sent">Notification sent successfully!</string>
     <string name="get_notified_when_your_signature_is_required_or_a_device_requests_access">Get notified when your signature is required or a device requests access.</string>
+    <!-- Channel id, not user-facing: shared by AndroidManifest's Firebase default-channel meta-data
+         and KeysignNotificationChannel so the two can never drift apart. -->
+    <string name="keysign_notification_channel_id" translatable="false">keysign_requests_channel</string>
     <string name="keysign_notification_channel_name">Keysign Requests</string>
+    <string name="push_notifications_blocked_by_system">Notifications are turned off for Vultisig in system settings. You will not receive signing requests until you turn them back on.</string>
     <string name="keysign_notification_title">Sign transaction</string>
     <string name="keysign_notification_body">A new signing request is waiting for you</string>
     <string name="foreground_notification_banner_title">Join transaction</string>

--- a/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationManagerTest.kt
@@ -24,9 +24,16 @@ internal class PushNotificationManagerTest {
     private val vaultRepository: VaultRepository = mockk(relaxed = true)
     private val settingsDao: VaultNotificationSettingsDao = mockk(relaxed = true)
     private val encryptedPrefs: SharedPreferences = mockk(relaxed = true)
+    private val fcmTokenProvider: FcmTokenProvider = mockk(relaxed = true)
 
     private val manager =
-        PushNotificationManager(notificationApi, vaultRepository, settingsDao, encryptedPrefs)
+        PushNotificationManager(
+            notificationApi,
+            vaultRepository,
+            settingsDao,
+            encryptedPrefs,
+            fcmTokenProvider,
+        )
 
     private val vault =
         Vault(

--- a/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationTokenTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/PushNotificationTokenTest.kt
@@ -1,0 +1,156 @@
+package com.vultisig.wallet.data.services
+
+import android.content.SharedPreferences
+import com.vultisig.wallet.data.api.DeviceRegistrationRequest
+import com.vultisig.wallet.data.api.NotificationApi
+import com.vultisig.wallet.data.db.dao.VaultNotificationSettingsDao
+import com.vultisig.wallet.data.db.models.VaultNotificationSettingsEntity
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Covers token acquisition and re-registration — the path #5439 left with no way to heal. */
+internal class PushNotificationTokenTest {
+
+    private val notificationApi: NotificationApi = mockk(relaxed = true)
+    private val vaultRepository: com.vultisig.wallet.data.repositories.VaultRepository =
+        mockk(relaxed = true)
+    private val settingsDao: VaultNotificationSettingsDao = mockk(relaxed = true)
+    private val encryptedPrefs: SharedPreferences = mockk(relaxed = true)
+    private val editor: SharedPreferences.Editor = mockk(relaxed = true)
+    private val fcmTokenProvider: FcmTokenProvider = mockk()
+
+    private lateinit var manager: PushNotificationManager
+
+    @BeforeEach
+    fun setUp() {
+        every { encryptedPrefs.edit() } returns editor
+        every { editor.putString(any(), any()) } returns editor
+        manager =
+            PushNotificationManager(
+                notificationApi,
+                vaultRepository,
+                settingsDao,
+                encryptedPrefs,
+                fcmTokenProvider,
+            )
+    }
+
+    private fun storedToken(token: String?) {
+        every { encryptedPrefs.getString(FCM_TOKEN_KEY, null) } returns token
+    }
+
+    private fun secureVault(id: String) =
+        Vault(
+            id = id,
+            name = id,
+            pubKeyECDSA = "02$id",
+            hexChainCode = "chaincode",
+            localPartyID = "party-$id",
+            signers = listOf("party-$id", "party-other"),
+            libType = SigningLibType.DKLS,
+        )
+
+    private fun optedIn(vararg vaultIds: String) {
+        coEvery { settingsDao.getAllEnabled() } returns
+            vaultIds.map {
+                VaultNotificationSettingsEntity(vaultId = it, notificationsEnabled = true)
+            }
+        vaultIds.forEach { id -> coEvery { vaultRepository.get(id) } returns secureVault(id) }
+    }
+
+    @Test
+    fun `storeToken persists synchronously so service teardown cannot lose it`() {
+        val stored = slot<String>()
+        every { editor.putString(FCM_TOKEN_KEY, capture(stored)) } returns editor
+
+        manager.storeToken("fresh-token")
+
+        stored.captured shouldBe "fresh-token"
+        verify { editor.putString(FCM_TOKEN_KEY, "fresh-token") }
+    }
+
+    @Test
+    fun `currentToken returns the stored token without minting a new one`() = runTest {
+        storedToken("stored-token")
+
+        manager.currentToken() shouldBe "stored-token"
+
+        coVerify(exactly = 0) { fcmTokenProvider.fetchToken() }
+    }
+
+    @Test
+    fun `currentToken mints and persists a token when none is stored`() = runTest {
+        storedToken(null)
+        coEvery { fcmTokenProvider.fetchToken() } returns "minted-token"
+
+        manager.currentToken() shouldBe "minted-token"
+
+        verify { editor.putString(FCM_TOKEN_KEY, "minted-token") }
+    }
+
+    /** Null, not an exception: the caller reschedules rather than treating this as permanent. */
+    @Test
+    fun `currentToken returns null when minting fails`() = runTest {
+        storedToken(null)
+        coEvery { fcmTokenProvider.fetchToken() } throws IOException("no play services")
+
+        manager.currentToken() shouldBe null
+    }
+
+    @Test
+    fun `reRegisterOptedInVaults registers every opted-in vault with the new token`() = runTest {
+        optedIn("vault-a", "vault-b")
+        val requests = mutableListOf<DeviceRegistrationRequest>()
+        coEvery { notificationApi.registerDevice(capture(requests)) } returns Unit
+
+        manager.reRegisterOptedInVaults("new-token") shouldBe true
+
+        requests.map { it.token } shouldBe listOf("new-token", "new-token")
+        requests.map { it.partyName } shouldBe listOf("party-vault-a", "party-vault-b")
+    }
+
+    @Test
+    fun `reRegisterOptedInVaults reports failure when a vault cannot be registered`() = runTest {
+        optedIn("vault-a", "vault-b")
+        coEvery { notificationApi.registerDevice(match { it.partyName == "party-vault-a" }) } throws
+            IOException("unreachable")
+
+        manager.reRegisterOptedInVaults("new-token") shouldBe false
+    }
+
+    /** One failure must not strand the vaults behind it — they still get the new token. */
+    @Test
+    fun `reRegisterOptedInVaults keeps going after a failure`() = runTest {
+        optedIn("vault-a", "vault-b")
+        coEvery { notificationApi.registerDevice(match { it.partyName == "party-vault-a" }) } throws
+            IOException("unreachable")
+
+        manager.reRegisterOptedInVaults("new-token")
+
+        coVerify(exactly = 1) {
+            notificationApi.registerDevice(match { it.partyName == "party-vault-b" })
+        }
+    }
+
+    @Test
+    fun `hasOptedInVaults is false when nothing is enabled`() = runTest {
+        coEvery { settingsDao.getAllEnabled() } returns emptyList()
+
+        manager.hasOptedInVaults() shouldBe false
+    }
+
+    private companion object {
+        const val FCM_TOKEN_KEY = "fcm_device_token"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/data/services/PushRegistrationWorkerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/PushRegistrationWorkerTest.kt
@@ -1,0 +1,104 @@
+package com.vultisig.wallet.data.services
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PushRegistrationWorkerTest {
+
+    private lateinit var pushNotificationManager: PushNotificationManager
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setUp() {
+        pushNotificationManager = mockk()
+        context = mockk(relaxed = true)
+    }
+
+    private fun buildWorker(runAttemptCount: Int = 0): PushRegistrationWorker =
+        TestListenableWorkerBuilder<PushRegistrationWorker>(context)
+            .setRunAttemptCount(runAttemptCount)
+            .setWorkerFactory(
+                object : WorkerFactory() {
+                    override fun createWorker(
+                        appContext: Context,
+                        workerClassName: String,
+                        workerParameters: WorkerParameters,
+                    ): ListenableWorker =
+                        PushRegistrationWorker(
+                            appContext,
+                            workerParameters,
+                            pushNotificationManager,
+                        )
+                }
+            )
+            .build()
+
+    @Test
+    fun `re-registers every opted-in vault against the current token`() = runTest {
+        coEvery { pushNotificationManager.hasOptedInVaults() } returns true
+        coEvery { pushNotificationManager.currentToken() } returns "fcm-token"
+        coEvery { pushNotificationManager.reRegisterOptedInVaults("fcm-token") } returns true
+
+        buildWorker().doWork() shouldBe ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) { pushNotificationManager.reRegisterOptedInVaults("fcm-token") }
+    }
+
+    /**
+     * The whole point of running in WorkManager: a registration that fails must come back, or the
+     * server keeps a dead token while the local toggle still reads ON and pushes stop for good.
+     */
+    @Test
+    fun `retries when a vault fails to re-register`() = runTest {
+        coEvery { pushNotificationManager.hasOptedInVaults() } returns true
+        coEvery { pushNotificationManager.currentToken() } returns "fcm-token"
+        coEvery { pushNotificationManager.reRegisterOptedInVaults(any()) } returns false
+
+        buildWorker().doWork() shouldBe ListenableWorker.Result.retry()
+    }
+
+    @Test
+    fun `retries when no token can be obtained`() = runTest {
+        coEvery { pushNotificationManager.hasOptedInVaults() } returns true
+        coEvery { pushNotificationManager.currentToken() } returns null
+
+        buildWorker().doWork() shouldBe ListenableWorker.Result.retry()
+
+        coVerify(exactly = 0) { pushNotificationManager.reRegisterOptedInVaults(any()) }
+    }
+
+    @Test
+    fun `gives up once the attempt cap is reached`() = runTest {
+        coEvery { pushNotificationManager.hasOptedInVaults() } returns true
+        coEvery { pushNotificationManager.currentToken() } returns "fcm-token"
+        coEvery { pushNotificationManager.reRegisterOptedInVaults(any()) } returns false
+
+        val worker = buildWorker(runAttemptCount = PushRegistrationWorker.MAX_ATTEMPTS)
+
+        worker.doWork() shouldBe ListenableWorker.Result.failure()
+    }
+
+    /**
+     * The startup reconcile runs on every launch, including for users who never enabled pushes.
+     * Minting a token for them would register a device nobody asked to register.
+     */
+    @Test
+    fun `does nothing when no vault has opted in`() = runTest {
+        coEvery { pushNotificationManager.hasOptedInVaults() } returns false
+
+        buildWorker().doWork() shouldBe ListenableWorker.Result.success()
+
+        coVerify(exactly = 0) { pushNotificationManager.currentToken() }
+        coVerify(exactly = 0) { pushNotificationManager.reRegisterOptedInVaults(any()) }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/settings/NotificationsSettingsViewModelTest.kt
@@ -1,0 +1,117 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.settings
+
+import com.vultisig.wallet.data.db.models.VaultNotificationSettingsEntity
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.services.PushNotificationManager
+import com.vultisig.wallet.data.services.SystemNotificationStatus
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.utils.SnackbarFlow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class NotificationsSettingsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+    private val vaultRepository: VaultRepository = mockk(relaxed = true)
+    private val pushNotificationManager: PushNotificationManager = mockk(relaxed = true)
+    private val systemNotificationStatus: SystemNotificationStatus = mockk()
+    private val snackbarFlow: SnackbarFlow = mockk(relaxed = true)
+
+    private val vault =
+        Vault(
+            id = "vault-a",
+            name = "Secure Vault",
+            signers = listOf("party-a", "party-b"),
+            libType = SigningLibType.DKLS,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { vaultRepository.getAllAsFlow() } returns flowOf(listOf(vault))
+        every { pushNotificationManager.observeAllSettings() } returns
+            flowOf(
+                listOf(
+                    VaultNotificationSettingsEntity(vaultId = vault.id, notificationsEnabled = true)
+                )
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() =
+        NotificationsSettingsViewModel(
+            navigator,
+            vaultRepository,
+            pushNotificationManager,
+            systemNotificationStatus,
+            snackbarFlow,
+        )
+
+    /**
+     * The in-app toggle stays ON after the OS revokes permission or the user mutes the channel —
+     * neither raises a callback — so the screen has to ask, or it claims pushes are on while every
+     * one is dropped (#5441).
+     */
+    @Test
+    fun `flags blocked notifications while the in-app toggle still reads on`() = runTest {
+        every { systemNotificationStatus.areNotificationsEnabled() } returns false
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.refreshSystemNotificationState()
+
+        with(viewModel.state.value) {
+            masterEnabled shouldBe true
+            isBlockedBySystem shouldBe true
+        }
+    }
+
+    @Test
+    fun `does not flag anything when the system allows notifications`() = runTest {
+        every { systemNotificationStatus.areNotificationsEnabled() } returns true
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.refreshSystemNotificationState()
+
+        viewModel.state.value.isBlockedBySystem shouldBe false
+    }
+
+    /** The settings flow re-emits often; a rebuild of the list must not clear the OS warning. */
+    @Test
+    fun `keeps the blocked flag when the settings flow re-emits`() = runTest {
+        every { systemNotificationStatus.areNotificationsEnabled() } returns false
+        val viewModel = viewModel()
+        viewModel.refreshSystemNotificationState()
+
+        advanceUntilIdle()
+
+        with(viewModel.state.value) {
+            vaults.map { it.vaultId } shouldBe listOf(vault.id)
+            isBlockedBySystem shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Closes #5439
Closes #5441

Two ends of the same failure: a push that is never re-registered, and a push that arrives but lands silently. They share one fix — a startup reconcile — so they ship together. One commit per issue.

## #5439 — re-registration raced service teardown

`onNewToken` launched the HTTP re-registration on the service's own `CoroutineScope`, which `onDestroy` cancels — and a `FirebaseMessagingService` stops itself as soon as the callback returns. Lose that race and the server keeps a dead token while the local toggle still reads ON.

Nothing healed it afterwards:

- `reRegisterAllOptedInVaults` swallowed every per-vault failure with a log line
- `refreshTokenIfNeeded` early-returned whenever *any* token was already stored
- nothing called it at app start

Classic "pushes worked, then stopped forever".

**Fix.** `onNewToken` is now fully synchronous — the token is persisted on the spot, the network half goes to `PushRegistrationWorker` — so neither half can be lost to teardown. The worker retries with exponential backoff behind a `CONNECTED` constraint, capped at 5 attempts so a permanent failure stops rescheduling. `reRegisterOptedInVaults` reports whether every vault landed instead of silently dropping the ones that didn't, and a failing vault no longer strands the vaults behind it.

`PushNotificationInitializer` enqueues the same worker on every launch — the path back for a device whose registration was already lost. It skips minting a token when no vault has opted in, so users who never asked for pushes are never registered.

Token acquisition moves behind `FcmTokenProvider` so the path is testable off-device.

## #5441 — pushes landed on "Miscellaneous"

Backend keysign messages carry a `notification` block, so a backgrounded or killed app never reaches `onMessageReceived` — the FCM SDK renders the tray entry itself. `keysign_requests_channel` (IMPORTANCE_HIGH) was created *inside* `showSystemNotification`, reachable only from `onMessageReceived`, so in exactly the case that matters it did not exist. With no `default_notification_channel_id` in the manifest either, the SDK fell back to an auto-created channel named "Miscellaneous" at default importance: no heads-up peek, trivially muted, easy to miss for a time-critical signing request.

**Fix.** The channel id is a string resource shared by the manifest meta-data and `KeysignNotificationChannel`, so the two can't drift. The channel is created by `PushNotificationInitializer` at app start — a push that starts the process runs ContentProviders before the messaging service, so the channel exists by the time the SDK renders.

**Second half:** nothing detected a revoked `POST_NOTIFICATIONS` or a muted channel after opt-in — `areNotificationsEnabled()` was never called anywhere. The server kept sending, the device dropped everything, the toggle read ON. The notifications screen now re-reads OS state on every resume (neither revocation raises a callback) and shows a warning that opens the app's system notification settings.

New string in all 10 locales, reusing each locale's existing wording for "system settings" (`notifications_vault_sheet_subtitle`) and "signing request" (`keysign_notification_body`). The channel id itself is `translatable="false"`.

## Test plan

`./gradlew :app:testDebugUnitTest` — **1739 tests, 0 failures**, including 16 new. `./gradlew :app:lintDebug` clean.

`PushRegistrationWorkerTest` (5) — re-registers against the current token; **retries when a vault fails**; retries when no token can be obtained; gives up at the attempt cap; does nothing when no vault has opted in.

`PushNotificationTokenTest` (8) — `storeToken` persists synchronously; `currentToken` prefers the stored token, mints and persists when absent, returns null (not throws) when minting fails; `reRegisterOptedInVaults` registers every vault with the new token, reports failure, and keeps going past a failure; `hasOptedInVaults`.

`NotificationsSettingsViewModelTest` (3) — flags blocked notifications while the in-app toggle still reads ON; stays quiet when the system allows them; keeps the flag when the settings flow re-emits.

### Manual

**#5441:** opt a Secure vault in, background the app, have a peer start a keysign. Expect a heads-up peek under **Keysign Requests** in the app's notification categories — not a silent entry under "Miscellaneous".

**#5441 second half:** with the toggle ON, revoke notifications in system settings, return to Settings → Notifications. Expect the warning; tapping it opens system notification settings; re-enabling and returning clears it.

**#5439:** hard to force by hand — it needs a token rotation whose re-registration fails. Closest approximation: opt in offline so registration fails, then restore network and relaunch; the startup worker should re-register (`adb shell dumpsys jobscheduler | grep push_registration`).

## Not verified on device

No `TRUSTWALLET_PAT` in this environment, so `assembleDebug` can't run and none of this is device-verified — unit tests and lint only, off the Gradle cache. The manual checks above are the ones that still need running, in particular the heads-up peek, which is the whole point of #5441.

## Note

The startup reconcile re-registers on **every** launch — one POST per opted-in vault, typically one or two. That's what #5439 asks for and registration is idempotent server-side, but say the word if you'd rather it were throttled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic push-notification initialization on app startup, including scheduled re-registration for opted-in vaults.
  * Introduced support for a high-priority signing notification channel.
  * Added an in-app settings warning when notifications are blocked by the system, with a one-tap shortcut to system notification settings.
* **Bug Fixes**
  * Improved FCM token handling and notification channel eligibility checks, with more reliable token re-registration and capped retry behavior.
* **Documentation**
  * Added translated “blocked by system” warning text across supported languages.
* **Tests**
  * Added/updated automated tests for token storage, registration retry behavior, and the system-blocked UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->