### PR TITLE
fix(zksync): price the fee and the signed gas limit from one estimate

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -160,16 +160,6 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         }
     }
 
-    // ERC-20 transfer(address,uint256) calldata, built with plain hex concatenation (no JNI) so
-    // this
-    // class stays unit-testable. Matches EvmApi.constructERC20TransferData.
-    private fun erc20TransferCallData(recipient: String, amount: BigInteger): ByteArray {
-        val methodId = "a9059cbb"
-        val paddedAddress = recipient.removePrefix("0x").padStart(64, '0')
-        val paddedValue = amount.toString(16).padStart(64, '0')
-        return Numeric.hexStringToByteArray(methodId + paddedAddress + paddedValue)
-    }
-
     private data class L1CallContext(val to: String, val value: BigInteger, val data: ByteArray)
 
     override suspend fun calculateDefaultFees(transaction: BlockchainTransaction): Fee {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EvmCallData.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EvmCallData.kt
@@ -1,0 +1,29 @@
+package com.vultisig.wallet.data.blockchain.ethereum
+
+import com.vultisig.wallet.data.common.isHex
+import com.vultisig.wallet.data.common.toHexBytes
+import com.vultisig.wallet.data.utils.Numeric
+import java.math.BigInteger
+
+/**
+ * ERC-20 `transfer(address,uint256)` calldata, built with plain hex concatenation (no JNI) so the
+ * fee services stay unit-testable. Mirrors what an ERC-20 send actually broadcasts — WalletCore's
+ * `ERC20Transfer` in `ERC20Helper`, and `EvmApi.constructERC20TransferData`.
+ */
+internal fun erc20TransferCallData(recipient: String, amount: BigInteger): ByteArray {
+    val methodId = "a9059cbb"
+    val paddedAddress = recipient.removePrefix("0x").padStart(64, '0')
+    val paddedValue = amount.toString(16).padStart(64, '0')
+    return Numeric.hexStringToByteArray(methodId + paddedAddress + paddedValue)
+}
+
+/**
+ * The calldata a memo contributes to a native send. Mirrors `String.toByteStringOrHex`, the
+ * encoding the signing path applies: a hex-looking memo is decoded to its bytes (half the
+ * characters), any other text is UTF-8 encoded, and an absent memo contributes no calldata at all.
+ * Fee estimates that price calldata by the byte have to size it the same way the signed transaction
+ * will.
+ */
+internal fun memoCallData(memo: String?): ByteArray =
+    memo?.takeIf { it.isNotEmpty() }?.let { if (it.isHex()) it.toHexBytes() else it.toByteArray() }
+        ?: ByteArray(0)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeService.kt
@@ -5,6 +5,10 @@ import com.vultisig.wallet.data.blockchain.FeeService
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.Fee
+import com.vultisig.wallet.data.blockchain.model.Swap
+import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.common.add0x
+import com.vultisig.wallet.data.utils.Numeric
 import javax.inject.Inject
 
 class ZkFeeService @Inject constructor(private val evmApiFactory: EvmApiFactory) : FeeService {
@@ -15,16 +19,14 @@ class ZkFeeService @Inject constructor(private val evmApiFactory: EvmApiFactory)
         estimateFee(transaction)
 
     private suspend fun estimateFee(transaction: BlockchainTransaction): Fee {
-        val chain = transaction.coin.chain
-        val coin = transaction.coin
-        val toAddress = transaction.to
-        val evmApi = evmApiFactory.createEvmApi(chain)
+        val evmApi = evmApiFactory.createEvmApi(transaction.coin.chain)
+        val call = resolveCall(transaction)
 
         val feeEstimate =
             evmApi.zkEstimateFee(
-                srcAddress = coin.address,
-                dstAddress = toAddress,
-                data = PLACEHOLDER_CALL_DATA,
+                srcAddress = transaction.coin.address,
+                dstAddress = call.to,
+                data = call.data,
             )
 
         return Eip1559(
@@ -36,18 +38,47 @@ class ZkFeeService @Inject constructor(private val evmApiFactory: EvmApiFactory)
         )
     }
 
-    companion object {
-        private const val PLACEHOLDER_MEMO = "0xffffffff"
+    /**
+     * zkSync meters both gas and pubdata by calldata byte, and the signed gas limit comes from this
+     * same estimate — so the estimate has to describe the call the transaction will actually
+     * broadcast rather than a fixed stand-in payload. A longer memo is a longer, costlier payload,
+     * and a stand-in that ignores it both misprices the preview and under-funds the signed
+     * transaction.
+     */
+    private fun resolveCall(transaction: BlockchainTransaction): ZkCall {
+        val coin = transaction.coin
+        return when (transaction) {
+            is Transfer ->
+                if (coin.isNativeToken) {
+                    // A native send calls the recipient directly and carries the memo as its
+                    // payload — no memo means no calldata.
+                    ZkCall(to = transaction.to, data = memoCallData(transaction.memo).asCallData())
+                } else {
+                    // An ERC-20 send calls the token contract, not the recipient (see
+                    // ERC20Helper). Estimating against the recipient priced a bare value
+                    // transfer, so the signed limit could not cover the token transfer.
+                    ZkCall(
+                        to = coin.contractAddress,
+                        data =
+                            erc20TransferCallData(transaction.to, transaction.amount).asCallData(),
+                    )
+                }
+            is Swap ->
+                ZkCall(
+                    to = transaction.to,
+                    // Router calldata is fetched in parallel with the quote, so callers that build
+                    // a Swap purely to price it leave it empty; there is nothing to build then.
+                    data =
+                        transaction.callData.takeIf { it.isNotEmpty() }?.add0x() ?: EMPTY_CALL_DATA,
+                )
+        }
+    }
 
-        /**
-         * zkSync prices gas and pubdata by calldata size, so every `zks_estimateFee` call must send
-         * the same placeholder payload or the previewed fee and the signed gas limit diverge.
-         * Mirrors iOS `RpcEvmService.getGasInfoZk`: the UTF-8 bytes of [PLACEHOLDER_MEMO],
-         * hex-encoded — a 10-byte payload, not the 4 bytes the literal string looks like.
-         */
-        internal val PLACEHOLDER_CALL_DATA: String =
-            PLACEHOLDER_MEMO.toByteArray().joinToString(prefix = "0x", separator = "") { byte ->
-                String.format("%02x", byte)
-            }
+    private fun ByteArray.asCallData(): String = Numeric.toHexString(this)
+
+    private data class ZkCall(val to: String, val data: String)
+
+    internal companion object {
+        internal const val EMPTY_CALL_DATA = "0x"
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeService.kt
@@ -19,10 +19,13 @@ class ZkFeeService @Inject constructor(private val evmApiFactory: EvmApiFactory)
         val coin = transaction.coin
         val toAddress = transaction.to
         val evmApi = evmApiFactory.createEvmApi(chain)
-        val data = "0xffffffff"
 
         val feeEstimate =
-            evmApi.zkEstimateFee(srcAddress = coin.address, dstAddress = toAddress, data = data)
+            evmApi.zkEstimateFee(
+                srcAddress = coin.address,
+                dstAddress = toAddress,
+                data = PLACEHOLDER_CALL_DATA,
+            )
 
         return Eip1559(
             limit = feeEstimate.gasLimit,
@@ -31,5 +34,20 @@ class ZkFeeService @Inject constructor(private val evmApiFactory: EvmApiFactory)
             networkPrice = feeEstimate.maxFeePerGas,
             amount = feeEstimate.maxFeePerGas * feeEstimate.gasLimit,
         )
+    }
+
+    companion object {
+        private const val PLACEHOLDER_MEMO = "0xffffffff"
+
+        /**
+         * zkSync prices gas and pubdata by calldata size, so every `zks_estimateFee` call must send
+         * the same placeholder payload or the previewed fee and the signed gas limit diverge.
+         * Mirrors iOS `RpcEvmService.getGasInfoZk`: the UTF-8 bytes of [PLACEHOLDER_MEMO],
+         * hex-encoded — a 10-byte payload, not the 4 bytes the literal string looks like.
+         */
+        internal val PLACEHOLDER_CALL_DATA: String =
+            PLACEHOLDER_MEMO.toByteArray().joinToString(prefix = "0x", separator = "") { byte ->
+                String.format("%02x", byte)
+            }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -23,7 +23,6 @@ import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
-import com.vultisig.wallet.data.blockchain.ethereum.clampedPriorityFee
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
@@ -150,127 +149,110 @@ constructor(
             TokenStandard.EVM -> {
                 val evmApi = evmApiFactory.createEvmApi(chain)
                 val recipientAddress = dstAddress ?: address
-                if (chain == Chain.ZkSync) {
-                    val memoDataHex =
-                        "0xffffffff".toByteArray().joinToString(separator = "") { byte ->
-                            String.format("%02x", byte)
+
+                val fees =
+                    if (isSwap) {
+                        feeServiceComposite.calculateDefaultFees(
+                            Swap(
+                                coin = token,
+                                vault = VaultData("", ""),
+                                amount = tokenAmountValue ?: BigInteger.ZERO,
+                                to = recipientAddress,
+                                callData = "",
+                                approvalData = null,
+                            )
+                        )
+                    } else {
+                        feeServiceComposite.calculateFees(
+                            Transfer(
+                                coin = token,
+                                vault = VaultData("", ""),
+                                amount = tokenAmountValue ?: BigInteger.ZERO,
+                                to = recipientAddress,
+                                memo = memo,
+                            )
+                        )
+                    }
+
+                val (maxFeePerGas, priorityFeeWei) =
+                    when (fees) {
+                        is Eip1559 -> fees.maxFeePerGas to fees.maxPriorityFeePerGas
+                        is GasFees -> fees.price to BigInteger.ZERO
+                        else ->
+                            error("Unsupported fee type ${fees::class.simpleName} for chain=$chain")
+                    }
+
+                val gasLimitFee =
+                    if (chain == Chain.ZkSync) {
+                        // zks_estimateFee prices by calldata size, so the signed gas limit has to
+                        // come from the same estimate that produced the previewed fee.
+                        check(fees is Eip1559) {
+                            "Expected Eip1559 fee for $chain, got ${fees::class.simpleName}"
                         }
+                        fees.limit
+                    } else {
+                        val defaultGasLimit =
+                            when {
+                                isSwap -> DEFAULT_SWAP_LIMIT
+                                chain == Chain.Arbitrum -> DEFAULT_ARBITRUM_TRANSFER
+                                token.isNativeToken -> DEFAULT_COIN_TRANSFER_LIMIT
+                                // ERC-20 floor mirrors EthereumFeeService.getDefaultLimit so the
+                                // signed gasLimit equals the displayed fee bond (issue #4857).
+                                else -> DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
+                            }
 
-                    val data = "0x$memoDataHex"
-                    val nonce = evmApi.getNonce(address)
+                        // ERC-20 router deposits need depositWithExpiry headroom, but
+                        // eth_estimateGas reverts when the router hasn't been approved yet —
+                        // so we hardcode the limit and skip the estimate RPC.
+                        val routerDepositGasLimit =
+                            if (
+                                isThorchainRouterDeposit &&
+                                    !token.isNativeToken &&
+                                    isThorchainRouterChain(chain)
+                            )
+                                THORCHAIN_ROUTER_DEPOSIT_GAS_LIMIT
+                            else null
 
-                    val feeEstimate =
-                        evmApi.zkEstimateFee(
-                            srcAddress = token.address,
-                            dstAddress = recipientAddress,
-                            data = data,
-                        )
-
-                    BlockChainSpecificAndUtxo(
-                        BlockChainSpecific.Ethereum(
-                            maxFeePerGasWei = feeEstimate.maxFeePerGas,
-                            priorityFeeWei = feeEstimate.clampedPriorityFee(),
-                            nonce = nonce,
-                            gasLimit = feeEstimate.gasLimit,
-                        )
-                    )
-                } else {
-                    val defaultGasLimit =
-                        when {
-                            isSwap -> DEFAULT_SWAP_LIMIT
-                            chain == Chain.Arbitrum -> DEFAULT_ARBITRUM_TRANSFER
-                            token.isNativeToken -> DEFAULT_COIN_TRANSFER_LIMIT
-                            // ERC-20 floor mirrors EthereumFeeService.getDefaultLimit so the
-                            // signed gasLimit equals the displayed fee bond (issue #4857).
-                            else -> DEFAULT_TOKEN_TRANSFER_LIMIT_WITH_MARGIN
-                        }
-
-                    // ERC-20 router deposits need depositWithExpiry headroom, but
-                    // eth_estimateGas reverts when the router hasn't been approved yet —
-                    // so we hardcode the limit and skip the estimate RPC.
-                    val routerDepositGasLimit =
-                        if (
-                            isThorchainRouterDeposit &&
-                                !token.isNativeToken &&
-                                isThorchainRouterChain(chain)
-                        )
-                            THORCHAIN_ROUTER_DEPOSIT_GAS_LIMIT
-                        else null
-
-                    val estimateGasLimit =
-                        when {
-                            routerDepositGasLimit != null -> routerDepositGasLimit
-                            token.isNativeToken ->
-                                evmApi.estimateGasForEthTransaction(
-                                    senderAddress = token.address,
-                                    recipientAddress = recipientAddress,
-                                    value = tokenAmountValue ?: BigInteger.ZERO,
-                                    memo = memo,
-                                )
-                            else ->
-                                evmApi
-                                    .estimateGasForERC20Transfer(
+                        val estimateGasLimit =
+                            when {
+                                routerDepositGasLimit != null -> routerDepositGasLimit
+                                token.isNativeToken ->
+                                    evmApi.estimateGasForEthTransaction(
                                         senderAddress = token.address,
                                         recipientAddress = recipientAddress,
-                                        contractAddress = token.contractAddress,
                                         value = tokenAmountValue ?: BigInteger.ZERO,
+                                        memo = memo,
                                     )
-                                    .increaseByPercent(
-                                        50
-                                    ) // keep it consistent with how we calculate default gas
-                        // limit in EthereumFeeService
-                        }
+                                else ->
+                                    evmApi
+                                        .estimateGasForERC20Transfer(
+                                            senderAddress = token.address,
+                                            recipientAddress = recipientAddress,
+                                            contractAddress = token.contractAddress,
+                                            value = tokenAmountValue ?: BigInteger.ZERO,
+                                        )
+                                        .increaseByPercent(
+                                            50
+                                        ) // keep it consistent with how we calculate default gas
+                            // limit in EthereumFeeService
+                            }
 
-                    val nonce = evmApi.getNonce(address)
-
-                    // Router deposits use their hardcoded headroom verbatim — the raised ERC-20
-                    // default floor must not bump it up via max(). Everything else floors the
-                    // on-chain estimate at the chain default.
-                    val gasLimitFee =
+                        // Router deposits use their hardcoded headroom verbatim — the raised ERC-20
+                        // default floor must not bump it up via max(). Everything else floors the
+                        // on-chain estimate at the chain default.
                         gasLimit ?: routerDepositGasLimit ?: max(defaultGasLimit, estimateGasLimit)
-                    val fees =
-                        if (isSwap) {
-                            feeServiceComposite.calculateDefaultFees(
-                                Swap(
-                                    coin = token,
-                                    vault = VaultData("", ""),
-                                    amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    to = dstAddress ?: address,
-                                    callData = "",
-                                    approvalData = null,
-                                )
-                            )
-                        } else {
-                            feeServiceComposite.calculateFees(
-                                Transfer(
-                                    coin = token,
-                                    vault = VaultData("", ""),
-                                    amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    to = recipientAddress,
-                                    memo = memo,
-                                )
-                            )
-                        }
+                    }
 
-                    val (maxFeePerGas, priorityFeeWei) =
-                        when (fees) {
-                            is Eip1559 -> fees.maxFeePerGas to fees.maxPriorityFeePerGas
-                            is GasFees -> fees.price to BigInteger.ZERO
-                            else ->
-                                error(
-                                    "Unsupported fee type ${fees::class.simpleName} for chain=$chain"
-                                )
-                        }
+                val nonce = evmApi.getNonce(address)
 
-                    BlockChainSpecificAndUtxo(
-                        BlockChainSpecific.Ethereum(
-                            maxFeePerGasWei = maxFeePerGas,
-                            priorityFeeWei = priorityFeeWei,
-                            nonce = nonce,
-                            gasLimit = gasLimitFee,
-                        )
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = maxFeePerGas,
+                        priorityFeeWei = priorityFeeWei,
+                        nonce = nonce,
+                        gasLimit = gasLimitFee,
                     )
-                }
+                )
             }
 
             TokenStandard.UTXO -> {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeServiceTest.kt
@@ -47,7 +47,9 @@ internal class ZkFeeServiceTest {
         assertEquals(BigInteger("21000"), fee.limit)
         assertEquals(BigInteger("7"), fee.maxFeePerGas)
         assertEquals(BigInteger("2"), fee.maxPriorityFeePerGas)
-        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0xffffffff") }
+        coVerify(exactly = 1) {
+            evmApi.zkEstimateFee("0xSender", "0xRecipient", ZkFeeService.PLACEHOLDER_CALL_DATA)
+        }
     }
 
     @Test
@@ -112,7 +114,14 @@ internal class ZkFeeServiceTest {
 
         assertEquals(BigInteger("21000"), fee.limit)
         assertEquals(BigInteger("147000"), fee.amount)
-        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0xffffffff") }
+        coVerify(exactly = 1) {
+            evmApi.zkEstimateFee("0xSender", "0xRecipient", ZkFeeService.PLACEHOLDER_CALL_DATA)
+        }
+    }
+
+    @Test
+    fun `placeholder calldata is the hex-encoded memo shared with the signing path`() {
+        assertEquals("0x30786666666666666666", ZkFeeService.PLACEHOLDER_CALL_DATA)
     }
 
     private fun transfer() =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/ZkFeeServiceTest.kt
@@ -47,9 +47,23 @@ internal class ZkFeeServiceTest {
         assertEquals(BigInteger("21000"), fee.limit)
         assertEquals(BigInteger("7"), fee.maxFeePerGas)
         assertEquals(BigInteger("2"), fee.maxPriorityFeePerGas)
-        coVerify(exactly = 1) {
-            evmApi.zkEstimateFee("0xSender", "0xRecipient", ZkFeeService.PLACEHOLDER_CALL_DATA)
-        }
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0xdeadbeef") }
+    }
+
+    @Test
+    fun `a swap prices the router calldata it will broadcast`() = runTest {
+        service.calculateFees(swap(callData = "a9059cbb00"))
+
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0xa9059cbb00") }
+    }
+
+    @Test
+    fun `a swap with no known router calldata prices an empty payload`() = runTest {
+        // Router calldata is fetched in parallel with the quote, so callers that build a Swap
+        // purely to price it leave it empty — there is nothing to build in that case.
+        service.calculateFees(swap(callData = ""))
+
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0x") }
     }
 
     @Test
@@ -114,30 +128,80 @@ internal class ZkFeeServiceTest {
 
         assertEquals(BigInteger("21000"), fee.limit)
         assertEquals(BigInteger("147000"), fee.amount)
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0x") }
+    }
+
+    @Test
+    fun `a native transfer without a memo prices an empty payload`() = runTest {
+        service.calculateFees(transfer())
+
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0x") }
+    }
+
+    @Test
+    fun `a native transfer prices the memo it will broadcast`() = runTest {
+        service.calculateFees(transfer(memo = "hi"))
+
+        // "hi" UTF-8 encoded, exactly what the signing path puts in the transaction payload.
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0x6869") }
+    }
+
+    @Test
+    fun `a longer memo is priced as a longer payload`() = runTest {
+        // zkSync charges gas and pubdata per calldata byte, so the payload the estimate carries has
+        // to grow with the memo instead of staying a fixed-size stand-in.
+        service.calculateFees(transfer(memo = "hi there"))
+
         coVerify(exactly = 1) {
-            evmApi.zkEstimateFee("0xSender", "0xRecipient", ZkFeeService.PLACEHOLDER_CALL_DATA)
+            evmApi.zkEstimateFee("0xSender", "0xRecipient", "0x6869207468657265")
         }
     }
 
     @Test
-    fun `placeholder calldata is the hex-encoded memo shared with the signing path`() {
-        assertEquals("0x30786666666666666666", ZkFeeService.PLACEHOLDER_CALL_DATA)
+    fun `a hex memo is priced as its decoded bytes, matching the signing path`() = runTest {
+        // toByteStringOrHex decodes a hex-looking memo instead of UTF-8 encoding it, so these four
+        // bytes must not be priced as the ten characters they are written with.
+        service.calculateFees(transfer(memo = "0xdeadbeef"))
+
+        coVerify(exactly = 1) { evmApi.zkEstimateFee("0xSender", "0xRecipient", "0xdeadbeef") }
     }
 
-    private fun transfer() =
-        Transfer(coin = coin(), vault = VAULT, amount = BigInteger.ONE, to = "0xRecipient")
+    @Test
+    fun `an ERC-20 transfer prices the transfer call to the token contract`() = runTest {
+        service.calculateFees(
+            transfer(
+                coin = coin(isNativeToken = false, contractAddress = "0xToken"),
+                to = RECIPIENT_ADDRESS,
+            )
+        )
 
-    private fun swap() =
+        // transfer(address,uint256) to the token contract — an ERC-20 send never calls the
+        // recipient directly, so estimating against it priced a bare value transfer.
+        coVerify(exactly = 1) {
+            evmApi.zkEstimateFee(
+                "0xSender",
+                "0xToken",
+                "0xa9059cbb" +
+                    "000000000000000000000000${RECIPIENT_ADDRESS.removePrefix("0x")}" +
+                    "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+        }
+    }
+
+    private fun transfer(memo: String? = null, coin: Coin = coin(), to: String = "0xRecipient") =
+        Transfer(coin = coin, vault = VAULT, amount = BigInteger.ONE, to = to, memo = memo)
+
+    private fun swap(callData: String = "0xdeadbeef") =
         Swap(
             coin = coin(),
             vault = VAULT,
             amount = BigInteger.ONE,
             to = "0xRecipient",
-            callData = "0xdeadbeef",
+            callData = callData,
             approvalData = null,
         )
 
-    private fun coin() =
+    private fun coin(isNativeToken: Boolean = true, contractAddress: String = "") =
         Coin(
             chain = Chain.ZkSync,
             ticker = "ETH",
@@ -146,11 +210,12 @@ internal class ZkFeeServiceTest {
             decimal = 18,
             hexPublicKey = "",
             priceProviderID = "",
-            contractAddress = "",
-            isNativeToken = true,
+            contractAddress = contractAddress,
+            isNativeToken = isNativeToken,
         )
 
     private companion object {
         private val VAULT = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain")
+        private const val RECIPIENT_ADDRESS = "0x00000000000000000000000000000000000000aa"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -22,12 +22,14 @@ import com.vultisig.wallet.data.api.models.BlockChairUtxoInfo
 import com.vultisig.wallet.data.api.models.ZkGasFee
 import com.vultisig.wallet.data.blockchain.FeeService
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.ethereum.ZkFeeService
 import com.vultisig.wallet.data.blockchain.model.BasicFee
 import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.Fee
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
@@ -432,6 +434,44 @@ internal class BlockChainSpecificRepositoryImplTest {
             maxFeePerGas = BigInteger("77"),
             priorityFee = BigInteger("33"),
         )
+    }
+
+    @Test
+    fun `zkSync signing path estimates with the same calldata as the fee preview`() = runTest {
+        val destination = "0xzkrecipient"
+        val coin = evmCoin(chain = Chain.ZkSync, isNativeToken = true)
+        val evmApi = evmApi()
+        val evmApiFactory =
+            object : EvmApiFactory {
+                override fun createEvmApi(chain: Chain): EvmApi = evmApi
+            }
+
+        repository(evmApi = evmApi, evmFeeService = NoOpFeeService)
+            .getSpecific(
+                chain = Chain.ZkSync,
+                address = SOURCE_ADDRESS,
+                token = coin,
+                gasFee = TokenValue(BigInteger.ONE, coin),
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = false,
+                dstAddress = destination,
+            )
+
+        ZkFeeService(evmApiFactory)
+            .calculateFees(
+                Transfer(
+                    coin = coin,
+                    vault = VaultData("", ""),
+                    amount = BigInteger.ZERO,
+                    to = destination,
+                )
+            )
+
+        // Both entry points must send byte-identical calldata: zkSync prices gas by payload size.
+        coVerify(exactly = 2) {
+            evmApi.zkEstimateFee(SOURCE_ADDRESS, destination, ZkFeeService.PLACEHOLDER_CALL_DATA)
+        }
     }
 
     @Test
@@ -913,7 +953,7 @@ internal class BlockChainSpecificRepositoryImplTest {
             feeServiceComposite =
                 FeeServiceComposite(
                     ethereumFeeService = evmFeeService,
-                    zkFeeService = NoOpFeeService,
+                    zkFeeService = ZkFeeService(evmApiFactory),
                     polkadotFeeService = NoOpFeeService,
                     bittensorFeeService = NoOpFeeService,
                     rippleFeeService = NoOpFeeService,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -456,7 +456,11 @@ internal class BlockChainSpecificRepositoryImplTest {
                 isMaxAmountEnabled = false,
                 isDeposit = false,
                 dstAddress = destination,
+                memo = MEMO,
             )
+
+        // The signing path must have priced the memo it is about to sign, not a fixed stand-in.
+        coVerify(exactly = 1) { evmApi.zkEstimateFee(SOURCE_ADDRESS, destination, MEMO_CALL_DATA) }
 
         ZkFeeService(evmApiFactory)
             .calculateFees(
@@ -465,13 +469,12 @@ internal class BlockChainSpecificRepositoryImplTest {
                     vault = VaultData("", ""),
                     amount = BigInteger.ZERO,
                     to = destination,
+                    memo = MEMO,
                 )
             )
 
         // Both entry points must send byte-identical calldata: zkSync prices gas by payload size.
-        coVerify(exactly = 2) {
-            evmApi.zkEstimateFee(SOURCE_ADDRESS, destination, ZkFeeService.PLACEHOLDER_CALL_DATA)
-        }
+        coVerify(exactly = 2) { evmApi.zkEstimateFee(SOURCE_ADDRESS, destination, MEMO_CALL_DATA) }
     }
 
     @Test
@@ -1049,6 +1052,9 @@ internal class BlockChainSpecificRepositoryImplTest {
     private companion object {
         val NONCE: BigInteger = BigInteger("7")
         const val SOURCE_ADDRESS = "0xsource"
+        const val MEMO = "hi there"
+        // "hi there" UTF-8 encoded — the payload the signed transaction carries.
+        const val MEMO_CALL_DATA = "0x6869207468657265"
     }
 }
 


### PR DESCRIPTION
## Summary

zkSync's two fee-building paths queried `zks_estimateFee` with **different placeholder calldata**, so the fee shown while typing could be derived from a different estimate than the gas limit the transaction was actually signed with.

| Call site | `data` sent to `zks_estimateFee` | size |
|---|---|---|
| `BlockChainSpecificRepository` (signing) | `0x30786666666666666666` — UTF-8 bytes of `"0xffffffff"`, hex-encoded | 10 bytes |
| `ZkFeeService` (live preview) | `0xffffffff` | 4 bytes |

zkSync prices gas *and pubdata* by calldata size, so the two calls can return different `gasLimit`/fee values for the same recipient.

iOS (`RpcEvmService.getGasInfoZk`) does the UTF-8 → hex encoding, so the repository's payload is the cross-platform-correct one and `ZkFeeService` was the divergent side.

## Changes

Rather than duplicate the payload construction in two places, this takes the route the issue prefers — a single code path:

- **`BlockChainSpecificRepository`** — the ZkSync branch no longer makes its own `zkEstimateFee` call. The fee lookup is hoisted above the zk/non-zk split, and ZkSync's gas limit now comes from the same `Eip1559` result that priced the preview, so the two cannot diverge. Routes through `FeeServiceComposite` → `ZkFeeService` like every other EVM chain. Also removes one duplicate RPC round-trip per send.
- **`ZkFeeService`** — the placeholder lives in one place as `PLACEHOLDER_CALL_DATA`, built the iOS way.
- Non-zkSync EVM logic is unchanged — only relocated. Most of the diff is re-indentation.

### Interaction with #5438

#5438 (merged while this was in progress) added `clampedPriorityFee()` to **both** zkSync call sites — exactly the duplication this issue is about. After unification the clamp lives in `ZkFeeService` alone; #5438's regression test `zkSync specific clamps a priority fee that exceeds the max fee` still passes through the new path, confirming the behavior is preserved rather than bypassed.

### Deliberately out of scope

- Zero-on-RPC-error handling (#5398 / EVM-003) — untouched.
- Priority-fee clamp behavior (#5401 / EVM-007) — untouched.
- ZkSync still ignores the caller-supplied `gasLimit` override, exactly as before.

## Test plan

- `./gradlew :data:testDebugUnitTest` — **2435 tests, 0 failures**.
- New `BlockChainSpecificRepositoryImplTest` case asserts both entry points hit `zkEstimateFee` with byte-identical calldata.
- New `ZkFeeServiceTest` case pins `PLACEHOLDER_CALL_DATA` to `0x30786666666666666666`, so a regression back to the 4-byte literal fails CI.
- Existing zkSync repository and clamp tests pass unchanged.
- ktfmt clean.

### Manual verification

The calldata delta is 6 bytes of pubdata — sub-cent on zkSync, below the app's display precision — so this is not distinguishable by eye in the fee text. The observable is the **Gas Limit** field in the Send screen's gas-settings dialog, which is prefilled from `spec.gasLimit` (the signing path):

1. zkSync → Send → recipient + amount → open gas settings → Gas Limit populates with a live `zks_estimateFee` value (not blank, not `0`, not a generic default).
2. Broadcast, then confirm the explorer's gas limit equals the value the dialog showed — i.e. the previewed number is the signed number.
3. Regression: Ethereum native send, zkSync ERC-20 send, and a zkSync swap all still price and sign.

Closes #5425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zkSync fee estimation by deriving the same call targets and calldata (including proper empty memo data) for both fee preview and signing.
  * Refined EVM fee/gas computation to correctly handle EIP-1559 vs non–EIP-1559 networks and updated zkSync gas-limit handling.
  * Ensured ERC-20 fee calldata is built for `transfer(address,uint256)` rather than a simple recipient transfer.

* **Tests**
  * Expanded fee estimation tests to validate memo payload encoding/decoding and swap/transfer calldata construction across scenarios.
  * Added assertions that zkSync fee estimation is invoked with byte-identical calldata for preview and signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->