### PR TITLE
Add Advanced Settings toggle to enable/disable Limit Swap

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/SecretViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/SecretViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 internal data class SecretUiModel(
     val isSwapKitEnabled: Boolean = true,
     val isCustomRpcEnabled: Boolean = false,
-    val isLimitSwapEnabled: Boolean = true,
+    val isLimitSwapEnabled: Boolean = false,
 )
 
 @HiltViewModel

--- a/app/src/main/java/com/vultisig/wallet/ui/models/SecretViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/SecretViewModel.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.data.repositories.CustomRpcConfig
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
 import com.vultisig.wallet.data.repositories.swap.SwapKitConfig
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
@@ -17,6 +18,7 @@ import kotlinx.coroutines.launch
 internal data class SecretUiModel(
     val isSwapKitEnabled: Boolean = true,
     val isCustomRpcEnabled: Boolean = false,
+    val isLimitSwapEnabled: Boolean = true,
 )
 
 @HiltViewModel
@@ -25,6 +27,7 @@ internal class SecretViewModel
 constructor(
     private val swapKitConfig: SwapKitConfig,
     private val customRpcConfig: CustomRpcConfig,
+    private val limitSwapConfig: LimitSwapConfig,
     private val navigator: Navigator<Destination>,
 ) : ViewModel() {
 
@@ -41,6 +44,11 @@ constructor(
                 state.update { it.copy(isCustomRpcEnabled = isCustomRpcEnabled) }
             }
         }
+        viewModelScope.launch {
+            limitSwapConfig.isFeatureEnabled.collect { isLimitSwapEnabled ->
+                state.update { it.copy(isLimitSwapEnabled = isLimitSwapEnabled) }
+            }
+        }
     }
 
     /** Persists the SwapKit aggregator feature flag from the hidden Vault Settings toggle. */
@@ -51,6 +59,11 @@ constructor(
     /** Persists the Custom RPC feature flag (#4787) from the hidden Vault Settings toggle. */
     fun toggleCustomRpc(state: Boolean) {
         viewModelScope.safeLaunch { customRpcConfig.setFeatureEnabled(state) }
+    }
+
+    /** Persists the Limit Swap feature flag from the hidden Vault Settings toggle. */
+    fun toggleLimitSwap(state: Boolean) {
+        viewModelScope.safeLaunch { limitSwapConfig.setFeatureEnabled(state) }
     }
 
     fun back() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -22,6 +22,7 @@ import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.FeatureFlagRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.SwapTransactionRepository
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
 import com.vultisig.wallet.data.swap.limit.LimitSwapMarketPriceRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
@@ -72,6 +73,7 @@ constructor(
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val getDiscountBpsUseCase: GetDiscountBpsUseCase,
     private val featureFlagRepository: FeatureFlagRepository,
+    private val limitSwapConfig: LimitSwapConfig,
     private val limitMarketPriceRepository: LimitSwapMarketPriceRepository,
     private val buildLimitSwapTransactionUseCase: BuildLimitSwapTransactionUseCase,
     private val appCurrencyRepository: AppCurrencyRepository,
@@ -243,7 +245,10 @@ constructor(
      */
     private fun observeLimitForm() {
         viewModelScope.safeLaunch {
-            isLimitFlagEnabled.value = featureFlagRepository.getFeatureFlags().isLimitSwapEnabled
+            val isRemoteEnabled = featureFlagRepository.getFeatureFlags().isLimitSwapEnabled
+            limitSwapConfig.isFeatureEnabled.collect { isLocallyEnabled ->
+                isLimitFlagEnabled.value = isRemoteEnabled && isLocallyEnabled
+            }
         }
         // Fetch a fresh reference price whenever the Limit tab is shown with a routable pair. The
         // flag is part of the source set so a late-resolving remote flag re-fires the fetch, and so

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/SecretScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/SecretScreen.kt
@@ -28,6 +28,7 @@ internal fun SecretScreen(model: SecretViewModel = hiltViewModel()) {
         onBackClick = model::back,
         onToggleSwapKit = model::toggleSwapKit,
         onToggleCustomRpc = model::toggleCustomRpc,
+        onToggleLimitSwap = model::toggleLimitSwap,
     )
 }
 
@@ -37,6 +38,7 @@ private fun SecretScreen(
     onBackClick: () -> Unit,
     onToggleSwapKit: (Boolean) -> Unit,
     onToggleCustomRpc: (Boolean) -> Unit,
+    onToggleLimitSwap: (Boolean) -> Unit,
 ) {
 
     V2Scaffold(title = stringResource(R.string.vault_settings_title), onBackClick = onBackClick) {
@@ -54,6 +56,11 @@ private fun SecretScreen(
                 isChecked = state.isCustomRpcEnabled,
                 onCheckedChange = onToggleCustomRpc,
             )
+            SelectionItem(
+                title = stringResource(R.string.settings_advanced_limit_swap_toggle),
+                isChecked = state.isLimitSwapEnabled,
+                onCheckedChange = onToggleLimitSwap,
+            )
         }
     }
 }
@@ -66,5 +73,6 @@ private fun SecretScreenPreview() {
         onBackClick = {},
         onToggleSwapKit = {},
         onToggleCustomRpc = {},
+        onToggleLimitSwap = {},
     )
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -596,6 +596,7 @@
     <string name="vault_settings_advanced_title">Fortschrittlich</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit Aggregator</string>
     <string name="settings_advanced_custom_rpc_toggle">Benutzerdefinierter RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">Limit-Orders</string>
     <string name="custom_rpc_title">Benutzerdefinierter RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Nutze eigene Nodes pro Blockchain</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -598,6 +598,7 @@
     <string name="vault_settings_advanced_title">Avanzado</string>
     <string name="settings_advanced_swapkit_toggle">Agregador SwapKit</string>
     <string name="settings_advanced_custom_rpc_toggle">RPC personalizado</string>
+    <string name="settings_advanced_limit_swap_toggle">Órdenes límite</string>
     <string name="custom_rpc_title">RPC personalizado</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Usa tus propios nodos por cadena</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -597,6 +597,7 @@
     <string name="vault_settings_advanced_title">Napredno</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit agregator</string>
     <string name="settings_advanced_custom_rpc_toggle">Prilagođeni RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">Limit nalozi</string>
     <string name="custom_rpc_title">Prilagođeni RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Koristite vlastite čvorove po lancu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -596,6 +596,7 @@
     <string name="vault_settings_advanced_title">Avanzato</string>
     <string name="settings_advanced_swapkit_toggle">Aggregatore SwapKit</string>
     <string name="settings_advanced_custom_rpc_toggle">RPC personalizzato</string>
+    <string name="settings_advanced_limit_swap_toggle">Ordini limite</string>
     <string name="custom_rpc_title">RPC personalizzato</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Usa i tuoi nodi per ogni catena</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -897,6 +897,7 @@
     <string name="vault_settings_advanced_title">고급</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit 어그리게이터</string>
     <string name="settings_advanced_custom_rpc_toggle">사용자 지정 RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">지정가 주문</string>
     <string name="custom_rpc_title">사용자 지정 RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">체인별로 자체 노드를 사용하세요</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -593,6 +593,7 @@
     <string name="vault_settings_advanced_title">Geavanceerd</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit-aggregator</string>
     <string name="settings_advanced_custom_rpc_toggle">Aangepaste RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">Limietorders</string>
     <string name="custom_rpc_title">Aangepaste RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Gebruik je eigen nodes per blockchain</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -594,6 +594,7 @@
     <string name="vault_settings_advanced_title">Avançadas</string>
     <string name="settings_advanced_swapkit_toggle">Agregador SwapKit</string>
     <string name="settings_advanced_custom_rpc_toggle">RPC personalizado</string>
+    <string name="settings_advanced_limit_swap_toggle">Ordens limite</string>
     <string name="custom_rpc_title">RPC personalizado</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Use os seus próprios nós por cadeia</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -597,6 +597,7 @@
     <string name="vault_settings_advanced_title">Дополнительно</string>
     <string name="settings_advanced_swapkit_toggle">Агрегатор SwapKit</string>
     <string name="settings_advanced_custom_rpc_toggle">Пользовательский RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">Лимитные ордера</string>
     <string name="custom_rpc_title">Пользовательский RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Используйте собственные узлы для каждой сети</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -846,6 +846,7 @@
     <string name="vault_settings_advanced_title">高级</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit 聚合器</string>
     <string name="settings_advanced_custom_rpc_toggle">自定义 RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">限价订单</string>
     <string name="custom_rpc_title">自定义 RPC</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">为每条链使用您自己的节点</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -907,6 +907,7 @@
     <string name="vault_settings_advanced_title">Advanced</string>
     <string name="settings_advanced_swapkit_toggle">SwapKit aggregator</string>
     <string name="settings_advanced_custom_rpc_toggle">Custom RPC</string>
+    <string name="settings_advanced_limit_swap_toggle">Limit Orders</string>
     <string name="custom_rpc_title">Custom RPCs</string>
     <string name="custom_rpc_tier_badge">VULT TIER</string>
     <string name="custom_rpc_advanced_subtitle">Use your own nodes per chain</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/SecretViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/SecretViewModelTest.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.ui.models
 
 import com.vultisig.wallet.data.repositories.CustomRpcConfig
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
 import com.vultisig.wallet.data.repositories.swap.SwapKitConfig
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -29,6 +30,7 @@ internal class SecretViewModelTest {
 
     private lateinit var swapKitConfig: SwapKitConfig
     private lateinit var customRpcConfig: CustomRpcConfig
+    private lateinit var limitSwapConfig: LimitSwapConfig
     private lateinit var navigator: Navigator<Destination>
 
     /** Sets up mocks and test dispatcher before each test. */
@@ -37,6 +39,7 @@ internal class SecretViewModelTest {
         Dispatchers.setMain(testDispatcher)
         swapKitConfig = mockk(relaxed = true) { every { isFeatureEnabled } returns flowOf(false) }
         customRpcConfig = mockk(relaxed = true) { every { isFeatureEnabled } returns flowOf(false) }
+        limitSwapConfig = mockk(relaxed = true) { every { isFeatureEnabled } returns flowOf(false) }
         navigator = mockk(relaxed = true)
     }
 
@@ -50,6 +53,7 @@ internal class SecretViewModelTest {
         SecretViewModel(
             swapKitConfig = swapKitConfig,
             customRpcConfig = customRpcConfig,
+            limitSwapConfig = limitSwapConfig,
             navigator = navigator,
         )
 
@@ -97,5 +101,28 @@ internal class SecretViewModelTest {
             val vm = createViewModel()
 
             vm.state.value.isCustomRpcEnabled.shouldBeTrue()
+        }
+
+    /** Verifies toggleLimitSwap persists the new feature flag value. */
+    @Test
+    fun `toggleLimitSwap persists the new flag value`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+
+            vm.toggleLimitSwap(true)
+            coVerify { limitSwapConfig.setFeatureEnabled(true) }
+
+            vm.toggleLimitSwap(false)
+            coVerify { limitSwapConfig.setFeatureEnabled(false) }
+        }
+
+    /** Verifies a `true` emission from limitSwapConfig.isFeatureEnabled reflects into the state. */
+    @Test
+    fun `limit swap feature emissions reflect into state`() =
+        runTest(testDispatcher) {
+            every { limitSwapConfig.isFeatureEnabled } returns flowOf(true)
+            val vm = createViewModel()
+
+            vm.state.value.isLimitSwapEnabled.shouldBeTrue()
         }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.SwapTransactionRepository
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
 import com.vultisig.wallet.data.swap.limit.LimitSwapMarketPriceRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
@@ -118,6 +119,7 @@ internal class SwapFormViewModelTest {
     private lateinit var tokenBalanceMapper: AccountToTokenBalanceUiModelMapper
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var featureFlagRepository: FeatureFlagRepository
+    private lateinit var limitSwapConfig: LimitSwapConfig
     private lateinit var limitMarketPriceRepository: LimitSwapMarketPriceRepository
     private lateinit var buildLimitSwapTransactionUseCase: BuildLimitSwapTransactionUseCase
 
@@ -168,6 +170,9 @@ internal class SwapFormViewModelTest {
         featureFlagRepository = mockk(relaxed = true)
         coEvery { featureFlagRepository.getFeatureFlags() } returns
             FeatureFlagJson(isLimitSwapEnabled = false)
+        // Local Advanced Settings toggle defaults to enabled, so the remote flag above stays the
+        // single source of "off" for tests that don't opt into the limit form.
+        limitSwapConfig = mockk(relaxed = true) { every { isFeatureEnabled } returns flowOf(true) }
         limitMarketPriceRepository = mockk(relaxed = true)
         buildLimitSwapTransactionUseCase = mockk(relaxed = true)
 
@@ -267,6 +272,7 @@ internal class SwapFormViewModelTest {
                 chainAccountAddressRepository = chainAccountAddressRepository,
                 getDiscountBpsUseCase = getDiscountBpsUseCase,
                 featureFlagRepository = featureFlagRepository,
+                limitSwapConfig = limitSwapConfig,
                 limitMarketPriceRepository = limitMarketPriceRepository,
                 buildLimitSwapTransactionUseCase = buildLimitSwapTransactionUseCase,
                 appCurrencyRepository = mockk(relaxed = true),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -13,6 +13,8 @@ import com.vultisig.wallet.data.repositories.order.VaultOrderRepository
 import com.vultisig.wallet.data.repositories.swap.JupiterQuoteSource
 import com.vultisig.wallet.data.repositories.swap.KyberQuoteSource
 import com.vultisig.wallet.data.repositories.swap.LiFiQuoteSource
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
+import com.vultisig.wallet.data.repositories.swap.LimitSwapConfigImpl
 import com.vultisig.wallet.data.repositories.swap.MayaQuoteSource
 import com.vultisig.wallet.data.repositories.swap.OneInchQuoteSource
 import com.vultisig.wallet.data.repositories.swap.SwapKitConfig
@@ -371,6 +373,8 @@ internal interface RepositoriesModule {
     @Binds @Singleton fun bindCustomRpcConfig(impl: CustomRpcConfigImpl): CustomRpcConfig
 
     @Binds @Singleton fun bindSwapKitConfig(impl: SwapKitConfigImpl): SwapKitConfig
+
+    @Binds @Singleton fun bindLimitSwapConfig(impl: LimitSwapConfigImpl): LimitSwapConfig
 
     // Phase 2 scaffolding. The cache is fully implemented and bound, but is intentionally NOT yet
     // injected into SwapKitQuoteSource: Phase 1 deliberately drops the client-side provider gate

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
@@ -1,0 +1,36 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import com.vultisig.wallet.data.sources.AppDataStore
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DataStore-backed feature flag for the THORChain Limit Swap ("Place Limit Order") flow. Default is
+ * `true`, mirroring [SwapKitConfig] and [com.vultisig.wallet.data.repositories.CustomRpcConfig] —
+ * the feature ships out of the box and users can opt out via Settings → Advanced → Limit Swap.
+ * Combined (AND) with the remote `limit-swap` kill switch in `SwapFormViewModel`.
+ */
+interface LimitSwapConfig {
+    /** Live flow of the user's Advanced Settings → Limit Swap toggle. Defaults to `true`. */
+    val isFeatureEnabled: Flow<Boolean>
+
+    /** Persists the user's new toggle value. */
+    suspend fun setFeatureEnabled(enabled: Boolean)
+}
+
+/** [LimitSwapConfig] backed by the shared [AppDataStore] preferences store. */
+internal class LimitSwapConfigImpl @Inject constructor(private val dataStore: AppDataStore) :
+    LimitSwapConfig {
+
+    override val isFeatureEnabled: Flow<Boolean>
+        get() = dataStore.readData(LIMIT_SWAP_ENABLED_KEY, true)
+
+    override suspend fun setFeatureEnabled(enabled: Boolean) {
+        dataStore.set(LIMIT_SWAP_ENABLED_KEY, enabled)
+    }
+
+    private companion object {
+        val LIMIT_SWAP_ENABLED_KEY = booleanPreferencesKey("limit_swap_enabled")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
@@ -7,12 +7,11 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * DataStore-backed feature flag for the THORChain Limit Swap ("Place Limit Order") flow. Default is
- * `true`, mirroring [SwapKitConfig] and [com.vultisig.wallet.data.repositories.CustomRpcConfig] —
- * the feature ships out of the box and users can opt out via Settings → Advanced → Limit Swap.
- * Combined (AND) with the remote `limit-swap` kill switch in `SwapFormViewModel`.
+ * `false` — the feature is opt-in via Settings → Advanced → Limit Orders. Combined (AND) with the
+ * remote `limit-swap` kill switch in `SwapFormViewModel`.
  */
 interface LimitSwapConfig {
-    /** Live flow of the user's Advanced Settings → Limit Swap toggle. Defaults to `true`. */
+    /** Live flow of the user's Advanced Settings → Limit Swap toggle. Defaults to `false`. */
     val isFeatureEnabled: Flow<Boolean>
 
     /** Persists the user's new toggle value. */
@@ -24,7 +23,7 @@ internal class LimitSwapConfigImpl @Inject constructor(private val dataStore: Ap
     LimitSwapConfig {
 
     override val isFeatureEnabled: Flow<Boolean>
-        get() = dataStore.readData(LIMIT_SWAP_ENABLED_KEY, true)
+        get() = dataStore.readData(LIMIT_SWAP_ENABLED_KEY, false)
 
     override suspend fun setFeatureEnabled(enabled: Boolean) {
         dataStore.set(LIMIT_SWAP_ENABLED_KEY, enabled)


### PR DESCRIPTION
## Summary
- Adds a `LimitSwapConfig` DataStore feature flag (mirrors `SwapKitConfig`/`CustomRpcConfig`), defaulting to enabled
- Adds a "Limit Orders" toggle to the Advanced Settings screen (same screen as the "Custom RPC" toggle)
- `SwapFormViewModel` now gates the Limit tab on `remote flag AND local toggle`, so disabling it locally hides the tab even when the remote `limit-swap` flag is on
- Added the toggle string to all 10 locales, reusing each locale's existing "limit order" terminology

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :data:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest --tests SecretViewModelTest --tests SwapFormViewModelTest`
- [ ] Manual: toggle off "Limit Orders" in Advanced Settings, confirm the Limit tab disappears from the Swap screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Limit Orders** toggle under Advanced Settings.
  * Limit Orders availability now reflects both app configuration and the user’s local preference.
  * The selected setting is saved and restored across sessions.

* **Localization**
  * Added Limit Orders labels for English, German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese.

* **Tests**
  * Added coverage for enabling, disabling, saving, and restoring the Limit Orders setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->