### PR TITLE
fix(limit order): cosigner's confirmation reads as a plain swap

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -217,6 +217,12 @@ class PreviewActivity : ComponentActivity() {
                     "limit_swap_form_assets" ->
                         LimitSwapFormPreview(expandedSection = LimitFormSection.Asset)
                     "limit_order_confirm" -> LimitOrderConfirmPreview()
+                    "limit_order_fees_before" -> LimitOrderFeesPreview(carriesRouteFees = false)
+                    "limit_order_fees_after" -> LimitOrderFeesPreview(carriesRouteFees = true)
+                    "join_limit_order_confirm_before" ->
+                        JoinLimitOrderConfirmPreview(recognizesLimitOrder = false)
+                    "join_limit_order_confirm_after" ->
+                        JoinLimitOrderConfirmPreview(recognizesLimitOrder = true)
                     "limit_order_done" -> LimitOrderDonePreview()
                     "swap_confirm" -> SwapConfirmPreview()
                     "swap_confirm_chain" -> SwapChainIndicatorPreview()
@@ -867,6 +873,94 @@ private fun LimitOrderConfirmPreview() {
             ),
         hasToolbar = true,
         confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
+    )
+}
+
+/**
+ * The *placing* device's confirmation for the same limit order. [carriesRouteFees] false reproduces
+ * the fee rows before the route's breakdown was carried: the swap fee is the source-chain gas fee
+ * read as a destination-token amount, there is no outbound fee, and the total counts the network
+ * fee twice over.
+ */
+@Composable
+private fun LimitOrderFeesPreview(carriesRouteFees: Boolean) {
+    val btcCoin = Coins.Bitcoin.BTC
+    val ethCoin = Coins.Ethereum.ETH
+
+    val tx =
+        SwapTransactionUiModel(
+            src = ValuedToken(token = btcCoin, value = "0.00010981", fiatValue = "$7.08"),
+            dst = ValuedToken(token = ethCoin, value = "0.003849", fiatValue = "$7.08"),
+            networkFee = ValuedToken(token = btcCoin, value = "0.00000705", fiatValue = "$0.45"),
+            providerFee =
+                ValuedToken(
+                    token = ethCoin,
+                    value = if (carriesRouteFees) "0.0000002" else "0.00000705",
+                    fiatValue = if (carriesRouteFees) "$0.04" else "$0.01",
+                ),
+            outboundFee = "$0.25".takeIf { carriesRouteFees },
+            totalFee = if (carriesRouteFees) "$0.74" else "$0.47",
+            networkFeeFormatted = "0.00000705 BTC",
+            provider = "THORChain",
+            providerLabel = "THORChain",
+            isLimitOrder = true,
+            limitTargetPriceLabel = "1 ETH = $1,838.58",
+            limitExpiryLabel = UiText.StringResource(R.string.limit_swap_expiry_12h),
+        )
+
+    VerifySwapScreen(
+        state =
+            VerifySwapUiModel(
+                tx = tx,
+                consentAmount = true,
+                consentReceiveAmount = true,
+                vaultName = "AE_QBTC_IOS",
+            ),
+        hasToolbar = true,
+        confirmTitle = "Sign transaction",
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
+    )
+}
+
+/**
+ * The same limit order as seen on the *joining* device (#4154): no consent checkboxes, no fast sign
+ * — just the overview it signs. [recognizesLimitOrder] false reproduces the cosigner reading the
+ * order as an ordinary swap, before the target price and lifetime were recovered from the memo.
+ */
+@Composable
+private fun JoinLimitOrderConfirmPreview(recognizesLimitOrder: Boolean) {
+    val btcCoin = Coins.Bitcoin.BTC
+    val ethCoin = Coins.Ethereum.ETH
+
+    val tx =
+        SwapTransactionUiModel(
+            src = ValuedToken(token = btcCoin, value = "0.00010981", fiatValue = "$7.36"),
+            dst = ValuedToken(token = ethCoin, value = "0.003849", fiatValue = "$7.36"),
+            networkFee = ValuedToken(token = btcCoin, value = "0.00001125", fiatValue = "$0.73"),
+            providerFee = ValuedToken(token = ethCoin, value = "0.0000002", fiatValue = "$0.04"),
+            outboundFee = "$0.25",
+            totalFee = "$1.01",
+            networkFeeFormatted = "0.00001125 BTC",
+            provider = "THORChain",
+            providerLabel = "THORChain",
+            isLimitOrder = recognizesLimitOrder,
+            limitTargetPriceLabel = "1 ETH = $1,838.58".takeIf { recognizesLimitOrder },
+            limitExpiryLabel =
+                UiText.StringResource(R.string.limit_swap_expiry_12h).takeIf {
+                    recognizesLimitOrder
+                },
+        )
+
+    VerifySwapScreen(
+        state = VerifySwapUiModel(tx = tx, vaultName = "AE_QBTC_SAM"),
+        hasToolbar = true,
+        confirmTitle = "Sign transaction",
+        isConsentsEnabled = false,
         onFastSignClick = {},
         onConfirm = {},
         onBackClick = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -29,11 +29,15 @@ import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
 import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
+import com.vultisig.wallet.data.swap.limit.LimitSwapMemo
+import com.vultisig.wallet.data.swap.limit.toThorchainFixedPoint
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
+import com.vultisig.wallet.ui.models.swap.LimitOrderLabels
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
@@ -63,6 +67,7 @@ constructor(
     private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper,
     private val swapQuoteRepository: SwapQuoteRepository,
     private val mapSwapTransactionToHistoryData: SwapTransactionToHistoryDataMapper,
+    private val formatLimitOrderLabels: FormatLimitOrderLabelsUseCase,
 ) {
 
     /**
@@ -367,6 +372,14 @@ constructor(
                         externalRecipient = externalRecipient,
                         swapFee = rawFees?.let { dstToken.convertToTokenValue(it.affiliate) },
                         outboundFee = rawFees?.let { dstToken.convertToTokenValue(it.outbound) },
+                        limitOrderLabels =
+                            resolveLimitOrderLabels(
+                                memo = payload.memo,
+                                srcToken = srcToken,
+                                srcTokenValue = srcTokenValue,
+                                dstToken = dstToken,
+                                currency = currency,
+                            ),
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -524,6 +537,9 @@ constructor(
         // Hides the Swap Fee row and drops it from the total for a SwapKit UTXO deposit whose cost
         // is already the Network Fee — matching the initiator's verify screen and the form (#5358).
         swapFeeHidden: Boolean = false,
+        // Non-null only for a THORChain `=<` limit order, recovered from the signed memo. Drives
+        // the limit-order title and the Target Price / expiry row (#4154).
+        limitOrderLabels: LimitOrderLabels? = null,
     ): SwapTransactionUiModel {
         val estimatedFee = convertTokenValueToFiat(providerFeeToken, providerFee, currency)
 
@@ -586,6 +602,42 @@ constructor(
             providerLabel = providerLabel,
             externalRecipient = externalRecipient,
             swapFeeHidden = swapFeeHidden,
+            isLimitOrder = limitOrderLabels != null,
+            limitTargetPriceLabel = limitOrderLabels?.targetPriceLabel,
+            limitExpiryLabel = limitOrderLabels?.expiryLabel,
+        )
+    }
+
+    /**
+     * Recovers the limit order a cosigner would otherwise sign as an ordinary swap (#4154).
+     *
+     * A `=<` order reaches the joining device as a plain THORChain swap payload plus its memo, so
+     * without this it reads "You're swapping" with no target price and no expiry — the two terms
+     * that make the order an order. The memo is the order, so both are recoverable from it: the LIM
+     * against the sold amount gives the target price, the interval blocks give the lifetime. Null
+     * for a market swap or a memo this app can't read back, which leaves the screen exactly as it
+     * was.
+     */
+    private suspend fun resolveLimitOrderLabels(
+        memo: String?,
+        srcToken: Coin,
+        srcTokenValue: TokenValue,
+        dstToken: Coin,
+        currency: AppCurrency,
+    ): LimitOrderLabels? {
+        val parsed = memo?.let { LimitSwapMemo.parse(it) } ?: return null
+        val targetPrice =
+            LimitSwapMemo.targetPrice(
+                limit = parsed.limit,
+                sourceAmount = toThorchainFixedPoint(srcTokenValue.value, srcToken.decimal),
+            ) ?: return null
+        val expiryHours = LimitSwapMemo.expiryHours(parsed.expiryBlocks) ?: return null
+        return formatLimitOrderLabels(
+            srcToken = srcToken,
+            dstToken = dstToken,
+            targetPrice = targetPrice,
+            expiryHours = expiryHours,
+            currency = currency,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -1,35 +1,23 @@
 package com.vultisig.wallet.ui.models.mappers
 
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
-import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapTransaction
 import com.vultisig.wallet.data.models.TokenStandard
-import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.models.payload.SwapPayload
-import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.swap.limit.LimitSwapMemo
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
-import com.vultisig.wallet.ui.models.swap.LimitExpiryOption
-import com.vultisig.wallet.ui.models.swap.LimitOrderPricing
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.clampDstFiatToSrcFiat
 import com.vultisig.wallet.ui.models.swap.formatPriceImpact
 import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
-import com.vultisig.wallet.ui.utils.UiText
-import java.math.BigDecimal
-import java.math.BigInteger
-import java.math.RoundingMode
-import java.text.DecimalFormat
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
-import timber.log.Timber
 
 internal interface SwapTransactionToUiModelMapper :
     SuspendMapperFunc<SwapTransaction, SwapTransactionUiModel>
@@ -42,6 +30,7 @@ constructor(
     private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val tokenRepository: TokenRepository,
+    private val formatLimitOrderLabels: FormatLimitOrderLabelsUseCase,
 ) : SwapTransactionToUiModelMapper {
     override suspend fun invoke(from: SwapTransaction): SwapTransactionUiModel {
         val currency = appCurrencyRepository.currency.first()
@@ -146,27 +135,24 @@ constructor(
 
         // Limit-order confirmation labels, present only for a `=<` order built with them. Both are
         // formatted here rather than at build time so the price lands in the user's currency and
-        // the expiry reuses the same string resources as the form's pills.
+        // the expiry reuses the same string resources as the form's pills. The cosigner formats the
+        // same pair through the same use case, from the memo it is asked to sign.
         val isLimitMemo = from.memo?.startsWith(LimitSwapMemo.PREFIX) == true
         val regular = from as? SwapTransaction.RegularSwapTransaction
         val limitTargetPrice = regular?.limitOrderTargetPrice?.takeIf { isLimitMemo }
-        val limitTargetPriceLabel =
-            limitTargetPrice?.let { targetPrice ->
-                limitTargetPriceLabel(
+        val limitExpiryHours = regular?.limitOrderExpiryHours?.takeIf { isLimitMemo }
+        val limitLabels =
+            if (limitTargetPrice != null && limitExpiryHours != null) {
+                formatLimitOrderLabels(
                     srcToken = from.srcToken,
                     dstToken = from.dstToken,
-                    targetPrice = targetPrice,
+                    targetPrice = limitTargetPrice,
+                    expiryHours = limitExpiryHours,
                     currency = currency,
                 )
+            } else {
+                null
             }
-        val limitExpiryLabel =
-            regular
-                ?.limitOrderExpiryHours
-                ?.takeIf { isLimitMemo }
-                ?.let { hours ->
-                    LimitExpiryOption.entries.firstOrNull { it.hours == hours }?.labelRes
-                }
-                ?.let { UiText.StringResource(it) }
 
         return SwapTransactionUiModel(
             src =
@@ -224,62 +210,11 @@ constructor(
             referralBpsDiscountFiatValue = from.referralBpsDiscountFiatValue,
             priceImpactPercent = priceImpactDisplay?.percent,
             priceImpactLevel = priceImpactDisplay?.level,
-            // Classify as a limit order only when BOTH the `=<` memo and the confirmation labels
-            // are
-            // present, so the limit title can never render without its Target Price / expiry row.
-            isLimitOrder = limitTargetPriceLabel != null && limitExpiryLabel != null,
-            limitTargetPriceLabel = limitTargetPriceLabel,
-            limitExpiryLabel = limitExpiryLabel,
+            // Classify as a limit order only when the `=<` memo yielded both labels, so the limit
+            // title can never render without its Target Price / expiry row.
+            isLimitOrder = limitLabels != null,
+            limitTargetPriceLabel = limitLabels?.targetPriceLabel,
+            limitExpiryLabel = limitLabels?.expiryLabel,
         )
-    }
-
-    /**
-     * "1 <buy> = $65,800.13" — the target price expressed per whole buy unit, in the app currency
-     * (never a hardcoded `$`), matching how the limit form prices the same order. Falls back to
-     * sell-asset units when the sell asset has no price.
-     */
-    private suspend fun limitTargetPriceLabel(
-        srcToken: Coin,
-        dstToken: Coin,
-        targetPrice: BigDecimal,
-        currency: AppCurrency,
-    ): String {
-        val sellUnitFiat =
-            try {
-                convertTokenValueToFiat(
-                    srcToken,
-                    TokenValue(
-                        BigInteger.TEN.pow(srcToken.decimal),
-                        srcToken.ticker,
-                        srcToken.decimal,
-                    ),
-                    currency,
-                )
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to price the limit order's sell asset")
-                null
-            }
-        val fiat = LimitOrderPricing.fiatPricePerBuyUnit(targetPrice, sellUnitFiat?.value)
-        if (fiat != null) {
-            val formatted =
-                fiatValueToStringMapper(FiatValue(fiat, currency.ticker), asPrice = true)
-            return "1 ${dstToken.ticker} = $formatted"
-        }
-        val sellPerBuy =
-            if (targetPrice.signum() > 0) {
-                BigDecimal.ONE.divide(targetPrice, ASSET_PRICE_SCALE, RoundingMode.HALF_UP)
-            } else {
-                BigDecimal.ZERO
-            }
-        // DecimalFormat is not thread-safe, and this mapper is a singleton called from several
-        // screens' scopes, so the formatter is built per call rather than shared.
-        val assetFormat = DecimalFormat("#,##0.########")
-        return "1 ${dstToken.ticker} = ${assetFormat.format(sellPerBuy)} ${srcToken.ticker}"
-    }
-
-    private companion object {
-        const val ASSET_PRICE_SCALE = 8
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCase.kt
@@ -1,29 +1,34 @@
 package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.data.api.ThorChainApi
-import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapTransaction.RegularSwapTransaction
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.SwapPayload
-import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.data.repositories.AllowanceRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.ThorMimirRepository
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteRequest
+import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import com.vultisig.wallet.data.swap.limit.LimitSwapMemo
 import com.vultisig.wallet.data.swap.limit.buildLimitSwapMemoForCoins
 import com.vultisig.wallet.data.swap.limit.fromThorchainFixedPoint
 import com.vultisig.wallet.data.swap.limit.thorchainMemoAssetChainPrefix
 import com.vultisig.wallet.data.swap.limit.toThorchainFixedPoint
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 
 /**
@@ -32,8 +37,8 @@ import timber.log.Timber
  * Mirrors the Vultisig SDK's `buildLimitSwapKeysignPayload`, reusing the market swap's keysign
  * pipeline (`SwapPayload.ThorChain` + memo → verify → keysign). The only substitution is a
  * locally-built `=<` memo in place of the server quote's memo; the route itself is an ordinary
- * THORChain swap, so the inbound vault and the ERC20 router are resolved exactly as the market path
- * resolves them.
+ * THORChain swap, so the inbound vault, the ERC20 router, and the affiliate / outbound fee
+ * breakdown are all resolved exactly as the market path resolves them.
  *
  * How the memo reaches the chain depends on the source asset, exactly like the market path:
  * - **native RUNE** → `MsgDeposit` on THORChain (no inbound vault; the deposit target is the
@@ -55,6 +60,7 @@ constructor(
     private val thorMimirRepository: ThorMimirRepository,
     private val swapGasCalculator: SwapGasCalculator,
     private val allowanceRepository: AllowanceRepository,
+    private val swapQuoteRepository: SwapQuoteRepository,
 ) {
 
     data class Params(
@@ -118,14 +124,20 @@ constructor(
                 } ?: error("No live THORChain inbound for ${srcToken.chain}")
             }
 
+        // A limit order settles on the ordinary THORChain swap route, so its route details come
+        // from the ordinary swap quote — the ERC20 router here, and the affiliate / outbound fee
+        // breakdown below. One quote serves both. The cosigner fetches this same quote when it
+        // rebuilds the confirmation screen from the payload, which is what keeps the two devices'
+        // fee rows in agreement instead of each showing its own number.
+        val quote = fetchSwapQuote(params)
+
         // An EVM ERC20 must deposit through the router's depositWithExpiry (which carries the
         // memo). With no router it would fall back to a plain transfer that drops the memo and
         // strands the tokens on the inbound vault — never a protected limit order — so fail closed
-        // instead. A limit order settles on the ordinary THORChain swap route, so the router comes
-        // from the ordinary swap quote, exactly as the market path resolves it.
+        // instead.
         val router =
             if (isEvmToken) {
-                fetchSwapRouter(params)
+                quote?.router?.takeIf { it.isNotBlank() }
                     ?: error(
                         "THORChain has no router for ${srcToken.chain}; cannot place an ERC20 " +
                             "limit order"
@@ -178,6 +190,22 @@ constructor(
 
         val externalRecipient = params.destinationAddress.takeIf { it != dstToken.address }
 
+        // THORChain charges a resting order the same affiliate and outbound fees as a market swap
+        // on the same route, so the confirmation screen shows the quote's breakdown rather than the
+        // gas fee it used to pass here — which, read as a destination-token amount by the verify
+        // mapper, priced a BTC gas fee as ETH and then added it on top of the Network Fee. Quoted
+        // at the market rate while the order fills at its target price, so these are estimates; the
+        // cosigner derives its rows from the same quote, so both devices agree.
+        val quoteFees = quote?.fees
+        val swapFee = quoteFees?.let { dstToken.convertToTokenValue(it.affiliate) }
+        val outboundFee = quoteFees?.let { dstToken.convertToTokenValue(it.outbound) }
+        // A quote failure is not worth blocking a placement whose memo is already fully determined,
+        // so the breakdown degrades to none rather than failing closed. Zero in the destination
+        // token, never the gas fee: the fee rows read this as a destination-token amount.
+        val estimatedFees =
+            quoteFees?.let { dstToken.convertToTokenValue(it.total) }
+                ?: TokenValue(value = BigInteger.ZERO, token = dstToken)
+
         return RegularSwapTransaction(
             limitOrderTargetPrice = params.targetPrice,
             limitOrderExpiryHours = params.expiryHours,
@@ -189,7 +217,9 @@ constructor(
             dstAddress = dstAddress,
             expectedDstTokenValue = expectedDstTokenValue,
             blockChainSpecific = specificAndUtxo,
-            estimatedFees = params.estimatedNetworkFeeTokenValue ?: params.gasFee,
+            estimatedFees = estimatedFees,
+            swapFee = swapFee,
+            outboundFee = outboundFee,
             gasFees = params.estimatedNetworkFeeTokenValue ?: params.gasFee,
             memo = memo,
             isApprovalRequired = isApprovalRequired,
@@ -219,34 +249,42 @@ constructor(
     }
 
     /**
-     * The chain's router contract for this swap, read off an ordinary THORChain swap quote — the
-     * node sets it whenever the inbound asset is an ERC20. Null when the node returns no router, or
-     * when the quote itself fails; the caller fails closed on either, since a router-less ERC20
-     * deposit would strand the tokens.
+     * The ordinary THORChain swap quote for this pair and amount, or null when it fails.
+     *
+     * Supplies the two things a `=<` deposit can't derive on its own: the chain's router contract
+     * (set by the node whenever the inbound asset is an ERC20) and the affiliate / outbound fee
+     * breakdown. Deliberately requests no referral code and no bps discount, matching what the
+     * cosigner can ask for — a discount only the placing device knows about would put the two
+     * confirmation screens back out of agreement.
+     *
+     * A null return fails the ERC20 placement closed (a router-less deposit would strand the
+     * tokens) but only costs the fee breakdown on every other route.
      */
-    private suspend fun fetchSwapRouter(params: Params): String? {
-        val quote =
-            thorChainApi.getSwapQuotes(
-                ThorChainSwapQuoteRequest(
-                    address = params.destinationAddress,
-                    fromAsset = params.srcToken.swapAssetName(),
-                    toAsset = params.dstToken.swapAssetName(),
-                    amount =
-                        toThorchainFixedPoint(params.srcTokenValue.value, params.srcToken.decimal)
-                            .toString(),
-                    interval = "1",
-                    referralCode = "",
-                    bpsDiscount = 0,
-                    streamingQuantity = 0,
-                )
-            )
-        return when (quote) {
-            is THORChainSwapQuoteDeserialized.Result ->
-                quote.data.router?.takeIf { it.isNotBlank() }
-            is THORChainSwapQuoteDeserialized.Error -> {
-                Timber.w("THORChain router quote failed: %s", quote.error.message)
-                null
-            }
+    private suspend fun fetchSwapQuote(params: Params): THORChainSwapQuote? =
+        try {
+            val quote =
+                swapQuoteRepository
+                    .getQuote(
+                        SwapProvider.THORCHAIN,
+                        SwapQuoteRequest(
+                            srcToken = params.srcToken,
+                            dstToken = params.dstToken,
+                            tokenValue = params.srcTokenValue,
+                            // The vault's own destination address, not a custom recipient: this is
+                            // the request the cosigner reconstructs from the payload, and only an
+                            // identical request yields identical fees.
+                            dstAddress = params.dstToken.address,
+                        ),
+                    )
+                    .expectNative(SwapProvider.THORCHAIN)
+            (quote as? SwapQuote.ThorChain)?.data
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // The quote used to be fetched only for ERC20 placements, where a failure fails closed
+            // on the missing router. Every route asks for it now, so a failure has to degrade to a
+            // missing fee breakdown rather than block a placement whose memo is fully determined.
+            Timber.w(e, "THORChain limit-order quote failed")
+            null
         }
-    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/FormatLimitOrderLabelsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/FormatLimitOrderLabelsUseCase.kt
@@ -1,0 +1,111 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.utils.UiText
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+/** The confirmation-screen labels of a limit order — always produced as a pair or not at all. */
+internal data class LimitOrderLabels(val targetPriceLabel: String, val expiryLabel: UiText)
+
+/**
+ * Formats the Target Price / expiry labels shown on a limit order's confirmation screen.
+ *
+ * Shared by both signing devices: the initiator formats them from the order it built, the cosigner
+ * from the price and lifetime it recovers out of the `=<` memo it is asked to sign (#4154). Keeping
+ * one formatter is what makes the two screens read identically — the co-signer must be able to see
+ * that it is approving a limit order at a given price, not an ordinary swap.
+ */
+internal class FormatLimitOrderLabelsUseCase
+@Inject
+constructor(
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase,
+    private val fiatValueToStringMapper: FiatValueToStringMapper,
+) {
+
+    /**
+     * Returns null for a lifetime this app has no pill for, so a caller can never end up rendering
+     * the limit-order title with half its detail row.
+     */
+    suspend operator fun invoke(
+        srcToken: Coin,
+        dstToken: Coin,
+        targetPrice: BigDecimal,
+        expiryHours: Int,
+        currency: AppCurrency,
+    ): LimitOrderLabels? {
+        val expiry =
+            LimitExpiryOption.entries.firstOrNull { it.hours == expiryHours } ?: return null
+        return LimitOrderLabels(
+            targetPriceLabel =
+                targetPriceLabel(
+                    srcToken = srcToken,
+                    dstToken = dstToken,
+                    targetPrice = targetPrice,
+                    currency = currency,
+                ),
+            expiryLabel = UiText.StringResource(expiry.labelRes),
+        )
+    }
+
+    /**
+     * "1 <buy> = $65,800.13" — the target price expressed per whole buy unit, in the app currency
+     * (never a hardcoded `$`), matching how the limit form prices the same order. Falls back to
+     * sell-asset units when the sell asset has no price.
+     */
+    private suspend fun targetPriceLabel(
+        srcToken: Coin,
+        dstToken: Coin,
+        targetPrice: BigDecimal,
+        currency: AppCurrency,
+    ): String {
+        val sellUnitFiat =
+            try {
+                convertTokenValueToFiat(
+                    srcToken,
+                    TokenValue(
+                        BigInteger.TEN.pow(srcToken.decimal),
+                        srcToken.ticker,
+                        srcToken.decimal,
+                    ),
+                    currency,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to price the limit order's sell asset")
+                null
+            }
+        val fiat = LimitOrderPricing.fiatPricePerBuyUnit(targetPrice, sellUnitFiat?.value)
+        if (fiat != null) {
+            val formatted =
+                fiatValueToStringMapper(FiatValue(fiat, currency.ticker), asPrice = true)
+            return "1 ${dstToken.ticker} = $formatted"
+        }
+        val sellPerBuy =
+            if (targetPrice.signum() > 0) {
+                BigDecimal.ONE.divide(targetPrice, ASSET_PRICE_SCALE, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+        // DecimalFormat is not thread-safe, and this use case is injected into singleton-scoped
+        // callers reached from several screens' scopes, so the formatter is built per call rather
+        // than shared.
+        val assetFormat = DecimalFormat("#,##0.########")
+        return "1 ${dstToken.ticker} = ${assetFormat.format(sellPerBuy)} ${srcToken.ticker}"
+    }
+
+    private companion object {
+        const val ASSET_PRICE_SCALE = 8
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFeeBreakdownTest.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -54,6 +55,11 @@ internal class SwapTransactionToUiModelMapperFeeBreakdownTest {
             convertTokenValueToFiat = convertTokenValueToFiat,
             appCurrencyRepository = appCurrencyRepository,
             tokenRepository = tokenRepository,
+            formatLimitOrderLabels =
+                FormatLimitOrderLabelsUseCase(
+                    convertTokenValueToFiat = convertTokenValueToFiat,
+                    fiatValueToStringMapper = fiatValueToStringMapper,
+                ),
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFiatClampTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperFiatClampTest.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -47,6 +48,11 @@ internal class SwapTransactionToUiModelMapperFiatClampTest {
             convertTokenValueToFiat = convertTokenValueToFiat,
             appCurrencyRepository = appCurrencyRepository,
             tokenRepository = tokenRepository,
+            formatLimitOrderLabels =
+                FormatLimitOrderLabelsUseCase(
+                    convertTokenValueToFiat = convertTokenValueToFiat,
+                    fiatValueToStringMapper = fiatValueToStringMapper,
+                ),
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperSwapKitProviderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapperSwapKitProviderTest.kt
@@ -16,6 +16,7 @@ import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -51,6 +52,11 @@ internal class SwapTransactionToUiModelMapperSwapKitProviderTest {
             convertTokenValueToFiat = convertTokenValueToFiat,
             appCurrencyRepository = appCurrencyRepository,
             tokenRepository = tokenRepository,
+            formatLimitOrderLabels =
+                FormatLimitOrderLabelsUseCase(
+                    convertTokenValueToFiat = convertTokenValueToFiat,
+                    fiatValueToStringMapper = fiatValueToStringMapper,
+                ),
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCaseTest.kt
@@ -1,23 +1,27 @@
 package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
-import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
-import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteError
 import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import com.vultisig.wallet.data.repositories.AllowanceRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.ThorMimirRepository
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -29,6 +33,7 @@ internal class BuildLimitSwapTransactionUseCaseTest {
     private val thorMimirRepository = mockk<ThorMimirRepository>()
     private val swapGasCalculator = mockk<SwapGasCalculator>()
     private val allowanceRepository = mockk<AllowanceRepository>()
+    private val swapQuoteRepository = mockk<SwapQuoteRepository>()
 
     private val useCase =
         BuildLimitSwapTransactionUseCase(
@@ -36,6 +41,7 @@ internal class BuildLimitSwapTransactionUseCaseTest {
             thorMimirRepository = thorMimirRepository,
             swapGasCalculator = swapGasCalculator,
             allowanceRepository = allowanceRepository,
+            swapQuoteRepository = swapQuoteRepository,
         )
 
     private val btcInbound = "bc1qasgardinboundvaultxxxxxxxxxxxxxxxxxx0wlh"
@@ -75,6 +81,7 @@ internal class BuildLimitSwapTransactionUseCaseTest {
         coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
         coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
             listOf(inbound("BTC", btcInbound))
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns quote()
         coEvery {
             swapGasCalculator.getSpecificAndUtxo(any(), any(), any(), any(), any(), any(), any())
         } returns mockk(relaxed = true)
@@ -103,6 +110,7 @@ internal class BuildLimitSwapTransactionUseCaseTest {
                 true,
             )
         coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns quote()
         coEvery {
             swapGasCalculator.getSpecificAndUtxo(any(), any(), any(), any(), any(), any(), any())
         } returns mockk(relaxed = true)
@@ -127,7 +135,8 @@ internal class BuildLimitSwapTransactionUseCaseTest {
         coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
         coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
             listOf(inbound("ETH", "0xInboundVault"))
-        coEvery { thorChainApi.getSwapQuotes(any()) } returns quote(router = thorRouter)
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns
+            quote(router = thorRouter)
         coEvery {
             swapGasCalculator.getSpecificAndUtxo(any(), any(), any(), any(), any(), any(), any())
         } returns mockk(relaxed = true)
@@ -149,7 +158,8 @@ internal class BuildLimitSwapTransactionUseCaseTest {
             listOf(inbound("ETH", "0xInboundVault"))
         // Quote carries no router — a plain transfer would drop the memo and strand the tokens
         // instead of placing a protected order, so build() must reject the route.
-        coEvery { thorChainApi.getSwapQuotes(any()) } returns quote(router = null)
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns
+            quote(router = null)
         coEvery {
             swapGasCalculator.getSpecificAndUtxo(any(), any(), any(), any(), any(), any(), any())
         } returns mockk(relaxed = true)
@@ -165,8 +175,8 @@ internal class BuildLimitSwapTransactionUseCaseTest {
         coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
         coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
             listOf(inbound("ETH", "0xInboundVault"))
-        coEvery { thorChainApi.getSwapQuotes(any()) } returns
-            THORChainSwapQuoteDeserialized.Error(THORChainSwapQuoteError("thornode unavailable"))
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+            IllegalStateException("thornode unavailable")
         coEvery {
             swapGasCalculator.getSpecificAndUtxo(any(), any(), any(), any(), any(), any(), any())
         } returns mockk(relaxed = true)
@@ -176,6 +186,72 @@ internal class BuildLimitSwapTransactionUseCaseTest {
         assertTrue(error is IllegalStateException)
         assertTrue(error?.message.orEmpty().contains("router"))
     }
+
+    @Test
+    fun `carries the quote's affiliate and outbound fees, denominated in the bought asset`() =
+        runTest {
+            coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
+            coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
+                listOf(inbound("BTC", btcInbound))
+            // THORChain reports fees in its 1e8 fixed point: 0.005 / 0.02 / 0.025 ETH.
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } returns
+                quote(affiliate = "500000", outbound = "2000000", total = "2500000")
+            coEvery {
+                swapGasCalculator.getSpecificAndUtxo(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns mockk(relaxed = true)
+            coEvery { allowanceRepository.getAllowance(any(), any(), any(), any()) } returns null
+
+            val tx = useCase.build(params())
+
+            // Rescaled from 1e8 into ETH's 18 decimals, and denominated in the bought asset — the
+            // gas fee used to land here and be read as an ETH amount by the verify screen.
+            assertEquals(eth.ticker, tx.swapFee?.unit)
+            assertEquals(BigInteger("5000000000000000"), tx.swapFee?.value)
+            assertEquals(BigInteger("20000000000000000"), tx.outboundFee?.value)
+            assertEquals(BigInteger("25000000000000000"), tx.estimatedFees.value)
+            // The network fee stays in the sold asset and is unaffected by the breakdown.
+            assertEquals(btc.ticker, tx.gasFees.unit)
+        }
+
+    @Test
+    fun `a failed quote drops the fee breakdown instead of blocking a native placement`() =
+        runTest {
+            coEvery { thorMimirRepository.isAdvancedSwapQueueEnabled() } returns true
+            coEvery { thorChainApi.getTHORChainInboundAddresses() } returns
+                listOf(inbound("BTC", btcInbound))
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                IllegalStateException("thornode unavailable")
+            coEvery {
+                swapGasCalculator.getSpecificAndUtxo(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns mockk(relaxed = true)
+            coEvery { allowanceRepository.getAllowance(any(), any(), any(), any()) } returns null
+
+            val tx = useCase.build(params())
+
+            // The memo is fully determined without the quote, so the order is still placeable —
+            // it just shows no fee breakdown, and never the gas fee mispriced as the bought asset.
+            assertEquals("=<:ETH.ETH:$ethAddress:1600000000/14400/0:va:50", tx.memo)
+            assertEquals(null, tx.swapFee)
+            assertEquals(null, tx.outboundFee)
+            assertEquals(BigInteger.ZERO, tx.estimatedFees.value)
+            assertEquals(eth.ticker, tx.estimatedFees.unit)
+        }
 
     @Test
     fun `rejects a trading-paused inbound at placement`() = runTest {
@@ -213,10 +289,31 @@ internal class BuildLimitSwapTransactionUseCaseTest {
                 srcTokenValue = TokenValue(BigInteger("1000000"), token = usdc),
             )
 
-    /** A swap quote carrying only the field the router lookup reads. */
-    private fun quote(router: String?) =
-        THORChainSwapQuoteDeserialized.Result(
-            mockk<THORChainSwapQuote>(relaxed = true) { every { this@mockk.router } returns router }
+    /** A THORChain quote carrying only the fields the placement reads: router and fee breakdown. */
+    private fun quote(
+        router: String? = null,
+        affiliate: String = "0",
+        outbound: String = "0",
+        total: String = "0",
+    ) =
+        SwapQuoteResult.Native(
+            SwapQuote.ThorChain(
+                expectedDstValue = TokenValue(BigInteger.ZERO, eth),
+                fees = TokenValue(BigInteger.ZERO, eth),
+                recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
+                expiredAt = Instant.DISTANT_FUTURE,
+                data =
+                    mockk<THORChainSwapQuote>(relaxed = true) {
+                        every { this@mockk.router } returns router
+                        every { fees } returns
+                            Fees(
+                                affiliate = affiliate,
+                                asset = "0",
+                                outbound = outbound,
+                                total = total,
+                            )
+                    },
+            )
         )
 
     private fun inbound(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/swap/limit/LimitSwapMemo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/swap/limit/LimitSwapMemo.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenStandard
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.math.RoundingMode
 
 /** Allowed limit-order lifetimes, in hours. Anything else is rejected. */
 val limitSwapExpiryHours: List<Int> = listOf(12, 24, 72)
@@ -33,10 +34,16 @@ object LimitSwapMemo {
     const val UTXO_BYTE_LIMIT = 80
     const val OTHER_BYTE_LIMIT = 250
 
-    private val PRICE_SCALE: BigInteger = BigInteger.TEN.pow(8)
+    /** Fractional digits a target price can carry — the grid both the memo and its inverse use. */
+    private const val PRICE_DECIMALS = 8
+
+    private val PRICE_SCALE: BigInteger = BigInteger.TEN.pow(PRICE_DECIMALS)
 
     private val expiryHoursToIntervalBlocks: Map<Int, Int> =
         mapOf(12 to 7_200, 24 to 14_400, 72 to 43_200)
+
+    private val intervalBlocksToExpiryHours: Map<Int, Int> =
+        expiryHoursToIntervalBlocks.entries.associate { (hours, blocks) -> blocks to hours }
 
     private val PRICE_PATTERN = Regex("^(\\d+)(?:\\.(\\d{1,8})?)?$")
 
@@ -48,6 +55,29 @@ object LimitSwapMemo {
         requireNotNull(expiryHoursToIntervalBlocks[expiryHours]) {
             "expiry_hours must be one of ${limitSwapExpiryHours.joinToString(", ")}, got $expiryHours"
         }
+
+    /**
+     * Reverse of [intervalBlocks]: the order's lifetime in hours, or null when the memo carries a
+     * block count outside [limitSwapExpiryHours] — a memo built by another client, which has no
+     * expiry pill to render.
+     */
+    fun expiryHours(intervalBlocks: Int): Int? = intervalBlocksToExpiryHours[intervalBlocks]
+
+    /**
+     * The order's target price recovered from a memo's LIM — for a cosigner, whose only record of
+     * the order is the memo it is asked to sign.
+     *
+     * Inverts [getLimitAmount]: `LIM = floor(sourceAmount * targetPrice)`, so this can land up to
+     * one LIM unit below the price the placing device entered. Display-only (the confirmation
+     * screen's Target Price row); the signed bytes are the memo itself and are never derived from
+     * this. Both amounts are in THORChain's 1e8 fixed point.
+     */
+    fun targetPrice(limit: BigInteger, sourceAmount: BigInteger): BigDecimal? {
+        if (limit.signum() <= 0 || sourceAmount.signum() <= 0) return null
+        return BigDecimal(limit)
+            .divide(BigDecimal(sourceAmount), PRICE_DECIMALS, RoundingMode.HALF_UP)
+            .takeIf { it.signum() > 0 }
+    }
 
     /**
      * The order's guaranteed minimum output (LIM), in the target's 1e8 fixed point.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/swap/limit/LimitSwapMemoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/swap/limit/LimitSwapMemoTest.kt
@@ -348,6 +348,57 @@ class LimitSwapMemoTest {
         )
     }
 
+    @Test
+    fun `targetPrice inverts the LIM math a cosigner only has the memo for`() {
+        // 1 ETH sold at 0.04 BTC/ETH — the fixture memo's LIM, read back from the wire.
+        val sourceAmount = toThorchainFixedPoint(BigInteger.TEN.pow(18), 18)
+        assertEquals(
+            BigDecimal("0.04000000"),
+            LimitSwapMemo.targetPrice(BigInteger.valueOf(4_000_000L), sourceAmount),
+        )
+    }
+
+    @Test
+    fun `targetPrice returns null for a zero LIM or zero source amount`() {
+        assertEquals(null, LimitSwapMemo.targetPrice(BigInteger.ZERO, BigInteger.TEN))
+        assertEquals(null, LimitSwapMemo.targetPrice(BigInteger.TEN, BigInteger.ZERO))
+        // Floors below the memo's 8-decimal grid rather than reporting a price of zero.
+        assertEquals(null, LimitSwapMemo.targetPrice(BigInteger.ONE, BigInteger.TEN.pow(9)))
+    }
+
+    @Test
+    fun `expiryHours reverses intervalBlocks and rejects a foreign lifetime`() {
+        limitSwapExpiryHours.forEach { hours ->
+            assertEquals(hours, LimitSwapMemo.expiryHours(LimitSwapMemo.intervalBlocks(hours)))
+        }
+        assertEquals(null, LimitSwapMemo.expiryHours(1_234))
+    }
+
+    @Test
+    fun `a built memo round-trips back into its target price and lifetime`() {
+        val sourceAmount = BigInteger.valueOf(10_981L) // 0.00010981 BTC
+        val memo =
+            buildLimitSwapMemoForCoins(
+                fromCoin = nativeCoin(Chain.Bitcoin, "BTC", 8),
+                toCoin = nativeCoin(Chain.Ethereum, "ETH", 18),
+                amount = sourceAmount,
+                targetPrice = BigDecimal("35.05144"),
+                expiryHours = 12,
+                destinationAddress = "0x0cb1D4a24292bB89862f599Ac5B10F42b6DE07e4",
+            )
+        val parsed = checkNotNull(LimitSwapMemo.parse(memo)) { "failed to parse limit memo: $memo" }
+        assertEquals(12, LimitSwapMemo.expiryHours(parsed.expiryBlocks))
+        // Recovered within one floored LIM unit of the placing device's price (#4154).
+        val recovered =
+            checkNotNull(
+                LimitSwapMemo.targetPrice(parsed.limit, toThorchainFixedPoint(sourceAmount, 8))
+            )
+        assertTrue(
+            (BigDecimal("35.05144") - recovered).abs() < BigDecimal("0.0001"),
+            "recovered target price was $recovered",
+        )
+    }
+
     private fun nativeCoin(chain: Chain, ticker: String, decimals: Int) =
         Coin(
             chain = chain,


### PR DESCRIPTION
## Summary

Follow-up to #4154 (THORChain limit swap — Place flow).

### Transaction hash
https://mempool.space/tx/9b8973d49f50033d5436996ec5b69bb8e43b9b345f93abcf924f32e5808264b5

A `=<` limit order reaches the joining device as an ordinary THORChain swap payload plus its memo. The target price and the lifetime only ever existed as form state on the placing device, so the cosigner was asked to approve **"You're swapping"** — no price floor, no expiry, nothing distinguishing it from a market swap.

- Recover both from the memo, which *is* the order: LIM against the sold amount gives the target price, the interval blocks give the lifetime (`LimitSwapMemo.targetPrice` / `expiryHours`).
- Format them through the same use case the placing device uses, extracted for the purpose — one formatter is what makes the two screens read identically.
- Fix the fee rows, which disagreed for a separate reason (see below).

## Fee parity

The limit builder passed the source-chain **gas fee** as `estimatedFees`, a field the verify mapper reads as a *destination-token* amount for THORChain — a BTC gas fee priced as ETH, shown as the Swap Fee and then added on top of the Network Fee in the total. It also never asked for the affiliate and outbound fees a resting order actually pays, while the cosigner did.

Both devices now read one THORChain quote, through the same repository call with the same request shape (vault's own destination address, no referral code, no bps discount). The discount is omitted deliberately: it's known only to the placing device, so including it would put the two screens back out of agreement.

Every route fetches that quote now, not just ERC20 placements, so a quote failure degrades to no fee breakdown rather than blocking an order whose memo is already fully determined. ERC20 still fails closed on a missing router.

## Before / After

Joined device — the reported bug:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/mulfRpy.png) | ![after](https://i.imgur.com/pp9YbTa.png) |

Placing device — fee rows:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/CssksKS.png) | ![after](https://i.imgur.com/l86zxcv.png) |

Real Android renders (PreviewActivity on an emulator), not design mockups. The placing device's existing confirmation screen is the reference for the joined one — this is a behavioral gap, not a visual mismatch, so there is no separate Figma node.

## Changes

| | Before (cosigner) | After (cosigner) |
|---|---|---|
| Title | "You're swapping" | "You're placing a limit order" |
| Target Price / expiry row | absent | `1 ETH = $1,838.58` · `12h` |

| | Before (placing device) | After (placing device) |
|---|---|---|
| Swap Fee | $0.01 — gas fee read as the bought asset | $0.04 — quote's affiliate fee |
| Outbound Fee | absent | $0.25 |
| Max. Total Fee | $0.47 — network fee counted twice | $0.74 |

Known remaining difference: the two devices still show a different **Network Fee** (the placing device shows the swap form's projection, the cosigner recomputes the UTXO transaction plan from the payload). That is generic join-path behavior for every UTXO swap, not limit-specific, so it is out of scope here.

## Test plan

- [x] `:app` and `:data` unit tests pass (1729 tests, 0 failures)
- [x] New coverage: memo → target price / lifetime round-trip and its null cases; fee breakdown rescaled from THORChain's 1e8 into the bought asset's decimals; degraded path when the quote fails
- [x] `ktfmtCheck` clean, `assembleDebug` succeeds
- [x] Joined-device and placing-device confirmations captured on emulator
- [ ] End-to-end: place a BTC→ETH limit order on a 2-of-2 vault and confirm both devices show the same title, target price, expiry, and fee rows
- [ ] Market swaps unaffected on both devices (no limit memo → unchanged screen)
- [ ] ERC20 limit order still fails closed when THORChain reports no router

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added limit-order details to join-device and transaction confirmation screens, including target price and expiry.
  - Added clearer fee breakdowns for limit-order confirmations, including provider, outbound, and total fees.
  - Improved limit-order price and expiry display across supported swap flows.
  - Enhanced transaction construction with route-aware fee information when available.

- **Bug Fixes**
  - Improved handling when quote data or limit-order metadata is unavailable, allowing transactions to continue with appropriate fallback values.

- **Tests**
  - Added coverage for limit-order metadata, pricing, expiry conversion, fee calculations, and memo round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->