### PR TITLE
feat: Add price chart and market data to token detail screen

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
@@ -2,13 +2,14 @@ package com.vultisig.wallet.ui.components.chart
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,9 +21,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
@@ -79,15 +77,14 @@ private fun ChartRangeTab(
             modifier
                 .clip(RoundedCornerShape(percent = 50))
                 .background(backgroundColor)
-                .semantics {
-                    selected = isSelected
-                    role = Role.Tab
-                }
-                .clickable(
+                .selectable(
+                    selected = isSelected,
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
+                    role = Role.Tab,
                     onClick = onClick,
                 )
+                .heightIn(min = 48.dp)
                 .padding(vertical = 8.dp),
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
@@ -1,0 +1,111 @@
+package com.vultisig.wallet.ui.components.chart
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.ui.theme.Theme
+
+@Composable
+internal fun ChartRangePicker(
+    selectedRange: ChartRange,
+    onRangeSelected: (ChartRange) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(percent = 50))
+                .background(Theme.v2.colors.backgrounds.tertiary)
+                .padding(all = 4.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        ChartRange.entries.forEach { range ->
+            ChartRangeTab(
+                label = stringResource(range.labelRes()),
+                isSelected = range == selectedRange,
+                onClick = { onRangeSelected(range) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChartRangeTab(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor by
+        animateColorAsState(
+            targetValue = if (isSelected) Theme.v2.colors.buttons.primary else Color.Transparent,
+            label = "chartRangeBackground",
+        )
+    val textColor by
+        animateColorAsState(
+            targetValue =
+                if (isSelected) Theme.v2.colors.text.inverse else Theme.v2.colors.text.tertiary,
+            label = "chartRangeText",
+        )
+
+    Box(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(percent = 50))
+                .background(backgroundColor)
+                .semantics {
+                    selected = isSelected
+                    role = Role.Tab
+                }
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClick,
+                )
+                .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = label, style = Theme.brockmann.body.s.medium, color = textColor)
+    }
+}
+
+private fun ChartRange.labelRes(): Int =
+    when (this) {
+        ChartRange.ONE_DAY -> R.string.chart_range_1d
+        ChartRange.ONE_WEEK -> R.string.chart_range_1w
+        ChartRange.ONE_MONTH -> R.string.chart_range_1m
+        ChartRange.ONE_YEAR -> R.string.chart_range_1y
+        ChartRange.ALL -> R.string.chart_range_all
+    }
+
+@Preview
+@Composable
+private fun ChartRangePickerPreview() {
+    ChartRangePicker(selectedRange = ChartRange.ONE_DAY, onRangeSelected = {})
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/MarketStatsSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/MarketStatsSection.kt
@@ -62,7 +62,6 @@ internal fun MarketStatsSection(
         }
     if (rows.isEmpty()) return
 
-    UiSpacer(size = 24.dp)
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = stringResource(R.string.token_details_market_stats_title),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/MarketStatsSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/MarketStatsSection.kt
@@ -1,0 +1,84 @@
+package com.vultisig.wallet.ui.components.chart
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiHorizontalDivider
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
+import com.vultisig.wallet.ui.components.v2.tokenitem.TokenMetaRow
+import com.vultisig.wallet.ui.models.MarketStatsUiModel
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Market cap, rank, FDV, 24h volume and supply. While [isLoading] and [stats] is still null, shows
+ * a placeholder skeleton (fixed row set) so the sheet's layout doesn't jump once the fetch
+ * resolves; once loaded, only the fields CoinGecko actually returned are shown. Renders nothing
+ * once loaded if every field came back null.
+ */
+@Composable
+internal fun MarketStatsSection(
+    stats: MarketStatsUiModel?,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val rows: List<Pair<String, String?>> =
+        when {
+            stats != null ->
+                listOfNotNull(
+                    stats.marketCap?.let {
+                        stringResource(R.string.token_details_market_cap) to it
+                    },
+                    stats.marketCapRank?.let {
+                        stringResource(R.string.token_details_market_cap_rank) to it
+                    },
+                    stats.fullyDilutedValuation?.let {
+                        stringResource(R.string.token_details_fully_diluted_valuation) to it
+                    },
+                    stats.volume24h?.let {
+                        stringResource(R.string.token_details_volume_24h) to it
+                    },
+                    stats.circulatingSupply?.let {
+                        stringResource(R.string.token_details_circulating_supply) to it
+                    },
+                    stats.maxSupply?.let { stringResource(R.string.token_details_max_supply) to it },
+                )
+            isLoading ->
+                listOf(
+                    stringResource(R.string.token_details_market_cap) to null,
+                    stringResource(R.string.token_details_market_cap_rank) to null,
+                    stringResource(R.string.token_details_fully_diluted_valuation) to null,
+                    stringResource(R.string.token_details_volume_24h) to null,
+                    stringResource(R.string.token_details_circulating_supply) to null,
+                    stringResource(R.string.token_details_max_supply) to null,
+                )
+            else -> emptyList()
+        }
+    if (rows.isEmpty()) return
+
+    UiSpacer(size = 24.dp)
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.token_details_market_stats_title),
+            style = Theme.brockmann.body.m.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+        UiSpacer(size = 12.dp)
+        TopShineContainer(backgroundColor = Theme.v2.colors.backgrounds.surface1) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                rows.forEachIndexed { index, (key, value) ->
+                    TokenMetaRow(key = key, value = value)
+                    if (index != rows.lastIndex) {
+                        UiHorizontalDivider(modifier = Modifier.fillMaxWidth())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.components.chart
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -69,8 +71,10 @@ internal fun PriceChartSection(
             points = chart.points,
             isPositive = chart.isPositive,
             isLoading = chart.isLoading,
+            isStale = chart.isStale,
             changePercentText = chart.changePercentText,
             onScrub = { scrubbedPoint = it },
+            onRetry = { onRangeSelected(chart.selectedRange) },
         )
         UiSpacer(size = 16.dp)
         ChartRangePicker(selectedRange = chart.selectedRange, onRangeSelected = onRangeSelected)
@@ -162,8 +166,10 @@ private fun PriceChartCanvas(
     points: List<ChartPointUiModel>,
     isPositive: Boolean,
     isLoading: Boolean,
+    isStale: Boolean,
     changePercentText: String,
     onScrub: (ChartPointUiModel?) -> Unit,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val tint = if (isPositive) Theme.v2.colors.alerts.success else Theme.v2.colors.alerts.error
@@ -277,6 +283,27 @@ private fun PriceChartCanvas(
                             .clip(RoundedCornerShape(12.dp))
                             .background(placeholderColor)
                 )
+            }
+
+            // A range switch that fails before any data has ever loaded for it lands here
+            // (isStale=true, points cleared) — surface a retry affordance rather than a
+            // silent blank box, since nothing else on screen signals the fetch failed.
+            isStale -> {
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .height(CHART_HEIGHT)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(placeholderColor)
+                            .clickable(onClick = onRetry),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.price_chart_retry_hint),
+                        style = Theme.brockmann.body.s.medium,
+                        color = Theme.v2.colors.text.tertiary,
+                    )
+                }
             }
 
             else -> Unit

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
@@ -1,0 +1,320 @@
+package com.vultisig.wallet.ui.components.chart
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.models.ChartPointUiModel
+import com.vultisig.wallet.ui.models.ChartUiModel
+import com.vultisig.wallet.ui.theme.Theme
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import kotlin.math.roundToInt
+
+private val CHART_HEIGHT = 160.dp
+
+/**
+ * Price chart with a range picker and drag-to-scrub, tinted green/red by [ChartUiModel.isPositive].
+ */
+@Composable
+internal fun PriceChartSection(
+    chart: ChartUiModel,
+    onRangeSelected: (ChartRange) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var scrubbedPoint by remember(chart.points) { mutableStateOf<ChartPointUiModel?>(null) }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        ChartHeader(
+            isPositive = chart.isPositive,
+            changePercentText = chart.changePercentText,
+            scrubbedPoint = scrubbedPoint,
+        )
+        UiSpacer(size = 12.dp)
+        PriceChartCanvas(
+            points = chart.points,
+            isPositive = chart.isPositive,
+            isLoading = chart.isLoading,
+            changePercentText = chart.changePercentText,
+            onScrub = { scrubbedPoint = it },
+        )
+        UiSpacer(size = 16.dp)
+        ChartRangePicker(selectedRange = chart.selectedRange, onRangeSelected = onRangeSelected)
+    }
+}
+
+@Composable
+private fun ChartHeader(
+    isPositive: Boolean,
+    changePercentText: String,
+    scrubbedPoint: ChartPointUiModel?,
+) {
+    val tint = if (isPositive) Theme.v2.colors.alerts.success else Theme.v2.colors.alerts.error
+    Column {
+        if (scrubbedPoint != null) {
+            Text(
+                text = scrubbedPoint.priceText,
+                style = Theme.satoshi.price.title2,
+                color = Theme.v2.colors.text.primary,
+            )
+            Text(
+                text = scrubbedPoint.timestampMillis.toScrubDateText(),
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        } else {
+            Text(
+                text = changePercentText.ifEmpty { " " },
+                style = Theme.brockmann.body.s.medium,
+                color = tint,
+            )
+        }
+    }
+}
+
+/**
+ * Line/fill geometry for one (points, tint, canvas size) combination, rebuilt only when one of
+ * those actually changes rather than on every scrub-drag frame.
+ */
+private class ChartGeometry(
+    val stepX: Float,
+    val minPrice: Double,
+    val priceRange: Double,
+    val heightPx: Float,
+    val linePath: Path,
+    val fillPath: Path,
+    val fillBrush: Brush,
+) {
+    fun yFor(price: Double): Float =
+        heightPx - ((price - minPrice) / priceRange * heightPx).toFloat()
+}
+
+private fun buildChartGeometry(
+    points: List<ChartPointUiModel>,
+    tint: Color,
+    size: IntSize,
+): ChartGeometry? {
+    if (points.size < 2 || size.width == 0 || size.height == 0) return null
+    val minPrice = points.minOf { it.price }
+    val maxPrice = points.maxOf { it.price }
+    val priceRange = (maxPrice - minPrice).takeIf { it > 0.0 } ?: 1.0
+    val heightPx = size.height.toFloat()
+    val stepX = size.width / (points.size - 1).toFloat()
+
+    fun yFor(price: Double): Float =
+        heightPx - ((price - minPrice) / priceRange * heightPx).toFloat()
+
+    val linePath =
+        Path().apply {
+            points.forEachIndexed { index, point ->
+                val x = index * stepX
+                val y = yFor(point.price)
+                if (index == 0) moveTo(x, y) else lineTo(x, y)
+            }
+        }
+    val fillPath =
+        Path().apply {
+            addPath(linePath)
+            lineTo(size.width.toFloat(), heightPx)
+            lineTo(0f, heightPx)
+            close()
+        }
+    val fillBrush =
+        Brush.verticalGradient(colors = listOf(tint.copy(alpha = 0.28f), Color.Transparent))
+    return ChartGeometry(stepX, minPrice, priceRange, heightPx, linePath, fillPath, fillBrush)
+}
+
+@Composable
+private fun PriceChartCanvas(
+    points: List<ChartPointUiModel>,
+    isPositive: Boolean,
+    isLoading: Boolean,
+    changePercentText: String,
+    onScrub: (ChartPointUiModel?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tint = if (isPositive) Theme.v2.colors.alerts.success else Theme.v2.colors.alerts.error
+    val markerCenterColor = Theme.v2.colors.backgrounds.primary
+    val placeholderColor = Theme.v2.colors.backgrounds.tertiary_2
+    val chartDescription =
+        stringResource(R.string.price_chart_content_description, changePercentText.ifEmpty { "—" })
+
+    Box(modifier = modifier.fillMaxWidth().height(CHART_HEIGHT)) {
+        when {
+            points.size >= 2 -> {
+                var scrubX by remember(points) { mutableStateOf<Float?>(null) }
+                var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+                val latestPoints by rememberUpdatedState(points)
+
+                fun updateScrub(x: Float, width: Float) {
+                    val current = latestPoints
+                    scrubX = x
+                    onScrub(current[nearestPointIndex(x, width, current.size)])
+                }
+
+                val geometry =
+                    remember(points, tint, canvasSize) {
+                        buildChartGeometry(points, tint, canvasSize)
+                    }
+
+                Canvas(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .height(CHART_HEIGHT)
+                            .semantics { contentDescription = chartDescription }
+                            .onSizeChanged { canvasSize = it }
+                            // Keyed on Unit (not points) so a mid-scrub data refresh (e.g. a
+                            // currency switch) doesn't cancel the running drag gesture.
+                            .pointerInput(Unit) {
+                                detectDragGestures(
+                                    onDragStart = { offset ->
+                                        updateScrub(offset.x, size.width.toFloat())
+                                    },
+                                    onDrag = { change, _ ->
+                                        change.consume()
+                                        updateScrub(change.position.x, size.width.toFloat())
+                                    },
+                                    onDragEnd = {
+                                        scrubX = null
+                                        onScrub(null)
+                                    },
+                                    onDragCancel = {
+                                        scrubX = null
+                                        onScrub(null)
+                                    },
+                                )
+                            }
+                ) {
+                    val g = geometry ?: return@Canvas
+
+                    drawPath(path = g.fillPath, brush = g.fillBrush)
+                    drawPath(
+                        path = g.linePath,
+                        color = tint,
+                        style =
+                            Stroke(
+                                width = 2.dp.toPx(),
+                                cap = StrokeCap.Round,
+                                join = StrokeJoin.Round,
+                            ),
+                    )
+
+                    scrubX?.let { x ->
+                        val index = nearestPointIndex(x, size.width, points.size)
+                        val markerX = index * g.stepX
+                        val markerY = g.yFor(points[index].price)
+                        drawLine(
+                            color = tint.copy(alpha = 0.4f),
+                            start = Offset(markerX, 0f),
+                            end = Offset(markerX, size.height),
+                            strokeWidth = 1.dp.toPx(),
+                        )
+                        drawCircle(
+                            color = tint,
+                            radius = 5.dp.toPx(),
+                            center = Offset(markerX, markerY),
+                        )
+                        drawCircle(
+                            color = markerCenterColor,
+                            radius = 2.5.dp.toPx(),
+                            center = Offset(markerX, markerY),
+                        )
+                    }
+                }
+
+                // A range/currency-switch refetch keeps the previous series on screen while it
+                // resolves; dim it so isLoading still gives feedback instead of looking finished.
+                if (isLoading) {
+                    Box(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .height(CHART_HEIGHT)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(Theme.v2.colors.backgrounds.primary.copy(alpha = 0.4f))
+                    )
+                }
+            }
+
+            isLoading -> {
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .height(CHART_HEIGHT)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(placeholderColor)
+                )
+            }
+
+            else -> Unit
+        }
+    }
+}
+
+private fun nearestPointIndex(x: Float, width: Float, count: Int): Int {
+    if (count <= 1) return 0
+    val stepX = width / (count - 1)
+    return (x / stepX).roundToInt().coerceIn(0, count - 1)
+}
+
+private fun Long.toScrubDateText(): String =
+    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+        .withLocale(Locale.getDefault())
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.ofEpochMilli(this))
+
+@Preview
+@Composable
+private fun PriceChartSectionPreview() {
+    val points =
+        (0 until 48).map { i ->
+            ChartPointUiModel(
+                timestampMillis = i * 3_600_000L,
+                price = 100.0 + kotlin.math.sin(i / 4.0) * 10,
+                priceText = "$${100 + i}",
+            )
+        }
+    PriceChartSection(
+        chart =
+            ChartUiModel(
+                selectedRange = ChartRange.ONE_DAY,
+                points = points,
+                isPositive = true,
+                changePercentText = "+3.24%",
+            ),
+        onRangeSelected = {},
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
@@ -179,11 +179,12 @@ private fun PriceChartCanvas(
                 var scrubX by remember(points) { mutableStateOf<Float?>(null) }
                 var canvasSize by remember { mutableStateOf(IntSize.Zero) }
                 val latestPoints by rememberUpdatedState(points)
+                val latestOnScrub by rememberUpdatedState(onScrub)
 
                 fun updateScrub(x: Float, width: Float) {
                     val current = latestPoints
                     scrubX = x
-                    onScrub(current[nearestPointIndex(x, width, current.size)])
+                    latestOnScrub(current[nearestPointIndex(x, width, current.size)])
                 }
 
                 val geometry =
@@ -210,11 +211,11 @@ private fun PriceChartCanvas(
                                     },
                                     onDragEnd = {
                                         scrubX = null
-                                        onScrub(null)
+                                        latestOnScrub(null)
                                     },
                                     onDragCancel = {
                                         scrubX = null
-                                        onScrub(null)
+                                        latestOnScrub(null)
                                     },
                                 )
                             }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
@@ -119,9 +119,11 @@ private class ChartGeometry(
     val fillPath: Path,
     val fillBrush: Brush,
 ) {
-    fun yFor(price: Double): Float =
-        heightPx - ((price - minPrice) / priceRange * heightPx).toFloat()
+    fun yFor(price: Double): Float = yForPrice(price, minPrice, priceRange, heightPx)
 }
+
+private fun yForPrice(price: Double, minPrice: Double, priceRange: Double, heightPx: Float): Float =
+    heightPx - ((price - minPrice) / priceRange * heightPx).toFloat()
 
 private fun buildChartGeometry(
     points: List<ChartPointUiModel>,
@@ -135,14 +137,11 @@ private fun buildChartGeometry(
     val heightPx = size.height.toFloat()
     val stepX = size.width / (points.size - 1).toFloat()
 
-    fun yFor(price: Double): Float =
-        heightPx - ((price - minPrice) / priceRange * heightPx).toFloat()
-
     val linePath =
         Path().apply {
             points.forEachIndexed { index, point ->
                 val x = index * stepX
-                val y = yFor(point.price)
+                val y = yForPrice(point.price, minPrice, priceRange, heightPx)
                 if (index == 0) moveTo(x, y) else lineTo(x, y)
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceExtremesSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceExtremesSection.kt
@@ -53,7 +53,6 @@ internal fun PriceExtremesSection(
         }
     if (rows.isEmpty()) return
 
-    UiSpacer(size = 24.dp)
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = stringResource(R.string.token_details_price_extremes_title),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceExtremesSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceExtremesSection.kt
@@ -1,0 +1,77 @@
+package com.vultisig.wallet.ui.components.chart
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiHorizontalDivider
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
+import com.vultisig.wallet.ui.components.v2.tokenitem.TokenMetaRow
+import com.vultisig.wallet.ui.models.PriceExtremesUiModel
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * 24h low/high and all-time-high/low with their dates. While [isLoading] and [extremes] is still
+ * null, shows a placeholder skeleton so the sheet's layout doesn't jump once the fetch resolves;
+ * renders nothing once loaded if every field came back null.
+ */
+@Composable
+internal fun PriceExtremesSection(
+    extremes: PriceExtremesUiModel?,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val rows: List<Pair<String, String?>> =
+        when {
+            extremes != null ->
+                listOfNotNull(
+                    extremes.low24h?.let { stringResource(R.string.token_details_low_24h) to it },
+                    extremes.high24h?.let { stringResource(R.string.token_details_high_24h) to it },
+                    extremes.athPrice?.let {
+                        stringResource(R.string.token_details_all_time_high) to
+                            it.withDate(extremes.athDate)
+                    },
+                    extremes.atlPrice?.let {
+                        stringResource(R.string.token_details_all_time_low) to
+                            it.withDate(extremes.atlDate)
+                    },
+                )
+            isLoading ->
+                listOf(
+                    stringResource(R.string.token_details_low_24h) to null,
+                    stringResource(R.string.token_details_high_24h) to null,
+                    stringResource(R.string.token_details_all_time_high) to null,
+                    stringResource(R.string.token_details_all_time_low) to null,
+                )
+            else -> emptyList()
+        }
+    if (rows.isEmpty()) return
+
+    UiSpacer(size = 24.dp)
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.token_details_price_extremes_title),
+            style = Theme.brockmann.body.m.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+        UiSpacer(size = 12.dp)
+        TopShineContainer(backgroundColor = Theme.v2.colors.backgrounds.surface1) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                rows.forEachIndexed { index, (key, value) ->
+                    TokenMetaRow(key = key, value = value)
+                    if (index != rows.lastIndex) {
+                        UiHorizontalDivider(modifier = Modifier.fillMaxWidth())
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun String.withDate(date: String?): String = if (date != null) "$this · $date" else this

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/TokenInfoSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/TokenInfoSection.kt
@@ -1,0 +1,60 @@
+package com.vultisig.wallet.ui.components.chart
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiHorizontalDivider
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
+import com.vultisig.wallet.ui.components.v2.tokenitem.TokenMetaAddressRow
+import com.vultisig.wallet.ui.components.v2.tokenitem.TokenMetaRow
+import com.vultisig.wallet.ui.models.TokenInfoUiModel
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Contract address and decimals — always available from the already-loaded coin, independent of
+ * whether a CoinGecko chart/stats source exists. Network/explorer are shown elsewhere on this
+ * screen already. Contract address is absent on most non-EVM chains (Cosmos-SDK chains, etc.) that
+ * have no per-token contract concept — the row is simply omitted for those, same as any other null
+ * field here.
+ */
+@Composable
+internal fun TokenInfoSection(info: TokenInfoUiModel, modifier: Modifier = Modifier) {
+    val contractAddress = info.contractAddress
+    val decimals = info.decimals
+    if (contractAddress == null && decimals == null) return
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.token_details_token_info_title),
+            style = Theme.brockmann.body.m.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+        UiSpacer(size = 12.dp)
+        TopShineContainer(backgroundColor = Theme.v2.colors.backgrounds.surface1) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                if (contractAddress != null) {
+                    TokenMetaAddressRow(
+                        key = stringResource(R.string.token_details_contract_address),
+                        address = contractAddress,
+                    )
+                    if (decimals != null) {
+                        UiHorizontalDivider(modifier = Modifier.fillMaxWidth())
+                    }
+                }
+                if (decimals != null) {
+                    TokenMetaRow(
+                        key = stringResource(R.string.token_details_decimals),
+                        value = decimals,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
@@ -34,7 +34,8 @@ internal fun TokenMetaRow(
             modifier
                 .fillMaxWidth()
                 .background(Theme.v2.colors.backgrounds.primary)
-                .padding(all = 16.dp)
+                .padding(all = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         V2Container {
             Text(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
@@ -1,0 +1,102 @@
+package com.vultisig.wallet.ui.components.v2.tokenitem
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.components.CopyIcon
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.v2.containers.ContainerType
+import com.vultisig.wallet.ui.components.v2.containers.V2Container
+import com.vultisig.wallet.ui.components.v2.texts.LoadableValue
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * A key/value row: a label pill on the left, a value pill on the right. Used throughout the token
+ * detail screen for price/network/market-stats/token-info rows.
+ */
+@Composable
+internal fun TokenMetaRow(
+    key: String,
+    value: String?,
+    modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(Theme.v2.colors.backgrounds.primary)
+                .padding(all = 16.dp)
+    ) {
+        V2Container {
+            Text(
+                text = key,
+                color = Theme.v2.colors.text.primary,
+                style = Theme.brockmann.body.s.medium,
+                modifier = Modifier.padding(all = 4.dp),
+            )
+        }
+        UiSpacer(weight = 1f)
+        V2Container(type = ContainerType.TERTIARY) {
+            LoadableValue(
+                value = value,
+                color = Theme.v2.colors.text.primary,
+                style = Theme.satoshi.price.bodyS,
+                isVisible = isVisible,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Same key-pill layout as [TokenMetaRow], but the value is a long identifier (e.g. a contract
+ * address): middle-ellipsized to one line rather than wrapping, with a copy icon since it's meant
+ * to be copied, not read.
+ */
+@Composable
+internal fun TokenMetaAddressRow(key: String, address: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(Theme.v2.colors.backgrounds.primary)
+                .padding(all = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        V2Container {
+            Text(
+                text = key,
+                color = Theme.v2.colors.text.primary,
+                style = Theme.brockmann.body.s.medium,
+                modifier = Modifier.padding(all = 4.dp),
+            )
+        }
+        UiSpacer(weight = 1f)
+        V2Container(type = ContainerType.TERTIARY) {
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = address,
+                    color = Theme.v2.colors.text.primary,
+                    style = Theme.satoshi.price.bodyS,
+                    maxLines = 1,
+                    overflow = TextOverflow.MiddleEllipsis,
+                    modifier = Modifier.widthIn(max = 120.dp),
+                )
+                UiSpacer(size = 6.dp)
+                CopyIcon(textToCopy = address, size = 14.dp, tint = Theme.v2.colors.text.primary)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -106,7 +106,16 @@ internal data class MarketStatsUiModel(
     val volume24h: String? = null,
     val circulatingSupply: String? = null,
     val maxSupply: String? = null,
-)
+) {
+    /** CoinGecko can return a markets entry with every field absent (a stale/inactive coin). */
+    fun hasAnyValue(): Boolean =
+        marketCap != null ||
+            marketCapRank != null ||
+            fullyDilutedValuation != null ||
+            volume24h != null ||
+            circulatingSupply != null ||
+            maxSupply != null
+}
 
 @Immutable
 internal data class PriceExtremesUiModel(
@@ -116,7 +125,16 @@ internal data class PriceExtremesUiModel(
     val athDate: String? = null,
     val atlPrice: String? = null,
     val atlDate: String? = null,
-)
+) {
+    /** CoinGecko can return a markets entry with every field absent (a stale/inactive coin). */
+    fun hasAnyValue(): Boolean =
+        low24h != null ||
+            high24h != null ||
+            athPrice != null ||
+            athDate != null ||
+            atlPrice != null ||
+            atlDate != null
+}
 
 @Immutable
 internal data class TokenInfoUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -6,7 +6,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.CoinMarketStats
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.MarketChart
 import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.models.hasMarketDataSource
 import com.vultisig.wallet.data.models.isBuySupported
 import com.vultisig.wallet.data.models.isDepositSupported
 import com.vultisig.wallet.data.models.isLpToken
@@ -14,19 +20,31 @@ import com.vultisig.wallet.data.models.isReadOnlyAsset
 import com.vultisig.wallet.data.models.isSwapSupported
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.TokenPriceChartRepository
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigDecimal
+import java.text.NumberFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -47,6 +65,63 @@ internal data class TokenDetailUiModel(
     val canBuy: Boolean = false,
     val isBalanceVisible: Boolean = true,
     val explorerUrl: String = "",
+    // Null until the first load attempt resolves for the current coin: stays null forever for a
+    // pool-priced coin with no CoinGecko source, so the chart section never renders for it.
+    val chart: ChartUiModel? = null,
+    // True while the initial stats/extremes fetch for the current coin is in flight — the sections
+    // render a placeholder skeleton in this state rather than staying absent and then popping in,
+    // so the sheet's layout doesn't jump once the network call resolves.
+    val statsLoading: Boolean = false,
+    val marketStats: MarketStatsUiModel? = null,
+    val priceExtremes: PriceExtremesUiModel? = null,
+    val tokenInfo: TokenInfoUiModel? = null,
+)
+
+@Immutable
+internal data class ChartUiModel(
+    val selectedRange: ChartRange = ChartRange.ONE_DAY,
+    val points: List<ChartPointUiModel> = emptyList(),
+    val isPositive: Boolean = true,
+    val changePercentText: String = "",
+    val isLoading: Boolean = false,
+    // True when [points]/[changePercentText] don't actually belong to [selectedRange] and the
+    // current currency (a range/currency switch's fetch failed before any data for it ever loaded),
+    // so they're being shown only as a placeholder rather than fresh data. Lets a failed range be
+    // retapped to retry instead of being silently deduped as "already selected".
+    val isStale: Boolean = false,
+)
+
+@Immutable
+internal data class ChartPointUiModel(
+    val timestampMillis: Long,
+    val price: Double,
+    val priceText: String,
+)
+
+@Immutable
+internal data class MarketStatsUiModel(
+    val marketCap: String? = null,
+    val marketCapRank: String? = null,
+    val fullyDilutedValuation: String? = null,
+    val volume24h: String? = null,
+    val circulatingSupply: String? = null,
+    val maxSupply: String? = null,
+)
+
+@Immutable
+internal data class PriceExtremesUiModel(
+    val low24h: String? = null,
+    val high24h: String? = null,
+    val athPrice: String? = null,
+    val athDate: String? = null,
+    val atlPrice: String? = null,
+    val atlDate: String? = null,
+)
+
+@Immutable
+internal data class TokenInfoUiModel(
+    val contractAddress: String? = null,
+    val decimals: String? = null,
 )
 
 @HiltViewModel
@@ -60,6 +135,8 @@ constructor(
     private val accountsRepository: AccountsRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val explorerLinkRepository: ExplorerLinkRepository,
+    private val tokenPriceChartRepository: TokenPriceChartRepository,
+    private val appCurrencyRepository: AppCurrencyRepository,
 ) : ViewModel() {
 
     private val tokenDetail = savedStateHandle.toRoute<Route.TokenDetail>()
@@ -71,16 +148,51 @@ constructor(
     val uiState = MutableStateFlow(TokenDetailUiModel())
 
     private var loadDataJob: Job? = null
+    private var chartJob: Job? = null
+    private var statsJob: Job? = null
+
+    // The resolved Coin for the currently displayed token, used to fetch its chart/stats. Null
+    // until the first loadData() emission resolves an account for tokenId.
+    private var coin: Coin? = null
+
+    // (range, currencyTicker) of the chart data currently held in [uiState], updated only on a
+    // successful fetch. Lets a failed fetch tell "this exact view just failed to refresh" (safe to
+    // keep showing what's there) apart from "a different range/currency was requested and failed"
+    // (must not relabel that stale data as if it belonged to the new selection).
+    private var lastLoadedChartKey: Pair<ChartRange, String>? = null
 
     init {
-        viewModelScope.launch {
+        // Now a full-page destination (composable<TokenDetail>, not a dialog), so there's no
+        // ModalBottomSheet onExpand callback to trigger the first load from — kick it off directly.
+        loadData()
+        viewModelScope.safeLaunch {
             val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
             uiState.update { it.copy(isBalanceVisible = isBalanceVisible) }
         }
-        // Load here rather than when the sheet finishes opening: the sheet is measured and drawn
-        // before the animation settles, so a load started on expand guarantees a first frame with
-        // no values and no action buttons, and the sheet re-anchors once they arrive.
-        loadData()
+        // Re-fetch chart/stats in the new currency. drop(1) skips the flow's replay of the
+        // current currency on subscription — that initial load is already triggered by loadData()
+        // resolving the coin, so re-running it here would fire a redundant fetch on every screen
+        // open.
+        viewModelScope.safeLaunch {
+            appCurrencyRepository.currency.drop(1).collect {
+                val currentCoin = coin ?: return@collect
+                if (currentCoin.hasMarketDataSource) {
+                    loadChart(uiState.value.chart?.selectedRange ?: ChartRange.ONE_DAY)
+                }
+                if (currentCoin.priceProviderID.isNotEmpty()) {
+                    uiState.update { it.copy(statsLoading = true) }
+                    loadStats()
+                }
+            }
+        }
+    }
+
+    fun onChartRangeSelected(range: ChartRange) {
+        val chart = uiState.value.chart
+        // A stale chart's selectedRange was already set optimistically before its fetch failed, so
+        // re-tapping that same range must still retry rather than being deduped as a no-op.
+        if (chart?.selectedRange == range && !chart.isStale) return
+        loadChart(range)
     }
 
     fun send() {
@@ -114,10 +226,15 @@ constructor(
     private fun loadData() {
         loadDataJob?.cancel()
         loadDataJob =
-            viewModelScope.launch {
+            viewModelScope.safeLaunch(
+                onError = { e ->
+                    Timber.e(e, "Failed to load token detail for %s", tokenId)
+                    updateRefreshing(false)
+                }
+            ) {
                 updateRefreshing(true)
 
-                val chain = requireNotNull(Chain.fromRaw(chainRaw))
+                val chain = Chain.fromRaw(chainRaw)
 
                 accountsRepository
                     .loadAddress(vaultId = vaultId, chain = chain)
@@ -154,6 +271,9 @@ constructor(
                                 val explorerUrl =
                                     explorerLinkRepository.getAddressLink(chain, accountAddress)
 
+                                val isNewCoin = coin?.id != token.id
+                                coin = token
+
                                 uiState.update {
                                     it.copy(
                                         token = tokenUiModel,
@@ -171,7 +291,47 @@ constructor(
                                         canSend = !token.isReadOnlyAsset,
                                         canBuy = chain.isBuySupported,
                                         explorerUrl = explorerUrl,
+                                        tokenInfo =
+                                            TokenInfoUiModel(
+                                                contractAddress =
+                                                    token.contractAddress.takeIf {
+                                                        !token.isNativeToken && it.isNotEmpty()
+                                                    },
+                                                decimals = token.decimal.toString(),
+                                            ),
                                     )
+                                }
+
+                                if (isNewCoin) {
+                                    if (token.hasMarketDataSource) {
+                                        loadChart(ChartRange.ONE_DAY)
+                                    } else {
+                                        // Pool-priced token with no CoinGecko source at all: hide
+                                        // the chart entirely rather than showing a spinner for a
+                                        // fetch that will never resolve.
+                                        uiState.update { it.copy(chart = null) }
+                                    }
+                                    // Stats/extremes need a real CoinGecko id (the markets
+                                    // endpoint has no contract-address variant), a narrower gate
+                                    // than the chart's.
+                                    if (token.priceProviderID.isNotEmpty()) {
+                                        uiState.update {
+                                            it.copy(
+                                                statsLoading = true,
+                                                marketStats = null,
+                                                priceExtremes = null,
+                                            )
+                                        }
+                                        loadStats()
+                                    } else {
+                                        uiState.update {
+                                            it.copy(
+                                                statsLoading = false,
+                                                marketStats = null,
+                                                priceExtremes = null,
+                                            )
+                                        }
+                                    }
                                 }
                             } ?: run { updateRefreshing(false) }
                     }
@@ -180,7 +340,162 @@ constructor(
             }
     }
 
+    private fun loadChart(range: ChartRange) {
+        val coin = this.coin ?: return
+        chartJob?.cancel()
+        // Captured before the optimistic update below overwrites `chart` with a loading
+        // placeholder: true only when a fetch has ever actually succeeded for this coin, as
+        // opposed to the fresh, still-empty ChartUiModel the optimistic update is about to write.
+        val hadPriorPoints = uiState.value.chart?.points?.isNotEmpty() == true
+        chartJob =
+            viewModelScope.safeLaunch(
+                onError = { e ->
+                    Timber.e(e, "Failed to load chart for %s", coin.id)
+                    uiState.update {
+                        it.copy(
+                            chart =
+                                it.chart?.toFallback(range, hadPriorPoints, currencyTicker = null)
+                        )
+                    }
+                }
+            ) {
+                uiState.update {
+                    it.copy(
+                        chart =
+                            (it.chart ?: ChartUiModel()).copy(
+                                selectedRange = range,
+                                isLoading = true,
+                            )
+                    )
+                }
+                val currency = appCurrencyRepository.currency.first()
+                val chart = tokenPriceChartRepository.getChart(coin, range, currency)
+                if (chart != null) {
+                    lastLoadedChartKey = range to currency.ticker
+                }
+                val chartUiModel =
+                    chart?.let { c ->
+                        c.toUiModel(range, appCurrencyRepository.getCurrencyFormat())
+                    }
+                uiState.update {
+                    it.copy(
+                        chart =
+                            chartUiModel
+                                ?: it.chart?.toFallback(range, hadPriorPoints, currency.ticker)
+                    )
+                }
+            }
+    }
+
+    /**
+     * Builds the chart shown after a failed/empty fetch for [range]. Returns null (hiding the
+     * section) if this coin has never had a real series to fall back on; otherwise keeps the
+     * currently-held points only if they were last successfully loaded for this exact (range,
+     * currency) pair — a fetch for a different range/currency that just failed must not relabel
+     * older, mismatched data as if it belonged to the new selection.
+     */
+    private fun ChartUiModel.toFallback(
+        range: ChartRange,
+        hadPriorPoints: Boolean,
+        currencyTicker: String?,
+    ): ChartUiModel? {
+        if (!hadPriorPoints) return null
+        val matchesHeldData =
+            currencyTicker != null && lastLoadedChartKey == range to currencyTicker
+        return if (matchesHeldData) {
+            copy(isLoading = false, isStale = false)
+        } else {
+            copy(isLoading = false, isStale = true, points = emptyList(), changePercentText = "")
+        }
+    }
+
+    private fun loadStats() {
+        val coin = this.coin ?: return
+        statsJob?.cancel()
+        statsJob =
+            viewModelScope.safeLaunch(
+                onError = { e ->
+                    Timber.e(e, "Failed to load market stats for %s", coin.id)
+                    uiState.update { it.copy(statsLoading = false) }
+                }
+            ) {
+                val currency = appCurrencyRepository.currency.first()
+                val stats = tokenPriceChartRepository.getStats(coin, currency)
+                uiState.update {
+                    it.copy(
+                        statsLoading = false,
+                        marketStats =
+                            stats?.toMarketStatsUiModel(currency.ticker) ?: it.marketStats,
+                        priceExtremes =
+                            stats?.toPriceExtremesUiModel(currency.ticker) ?: it.priceExtremes,
+                    )
+                }
+            }
+    }
+
+    private fun MarketChart.toUiModel(range: ChartRange, priceFormat: NumberFormat): ChartUiModel =
+        ChartUiModel(
+            selectedRange = range,
+            points =
+                points.map {
+                    ChartPointUiModel(
+                        timestampMillis = it.timestampMillis,
+                        price = it.price.toDouble(),
+                        priceText = priceFormat.format(it.price),
+                    )
+                },
+            isPositive = isPositive,
+            changePercentText = changePercent.toChangePercentText(),
+            isLoading = false,
+        )
+
+    private suspend fun CoinMarketStats.toMarketStatsUiModel(
+        currencyTicker: String
+    ): MarketStatsUiModel =
+        MarketStatsUiModel(
+            marketCap = marketCap?.toFiatString(currencyTicker),
+            marketCapRank = marketCapRank?.let { "#$it" },
+            fullyDilutedValuation = fullyDilutedValuation?.toFiatString(currencyTicker),
+            volume24h = volume24h?.toFiatString(currencyTicker),
+            circulatingSupply = circulatingSupply?.let(::formatSupply),
+            maxSupply = maxSupply?.let(::formatSupply),
+        )
+
+    private suspend fun CoinMarketStats.toPriceExtremesUiModel(
+        currencyTicker: String
+    ): PriceExtremesUiModel =
+        PriceExtremesUiModel(
+            low24h = low24h?.toFiatString(currencyTicker),
+            high24h = high24h?.toFiatString(currencyTicker),
+            athPrice = athPrice?.toFiatString(currencyTicker, asPrice = true),
+            athDate = athDate?.toDisplayDate(),
+            atlPrice = atlPrice?.toFiatString(currencyTicker, asPrice = true),
+            atlDate = atlDate?.toDisplayDate(),
+        )
+
+    private suspend fun BigDecimal.toFiatString(
+        currencyTicker: String,
+        asPrice: Boolean = false,
+    ): String = fiatValueToStringMapper(FiatValue(this, currencyTicker), asPrice = asPrice)
+
     private fun updateRefreshing(isRefreshing: Boolean) {
         uiState.update { it.copy(isRefreshing = isRefreshing) }
     }
 }
+
+private fun Double.toChangePercentText(): String {
+    val sign = if (this >= 0) "+" else ""
+    return "$sign${"%.2f".format(Locale.getDefault(), this)}%"
+}
+
+private fun formatSupply(value: BigDecimal): String {
+    val format = NumberFormat.getNumberInstance(Locale.getDefault())
+    format.maximumFractionDigits = 0
+    return format.format(value)
+}
+
+private fun Instant.toDisplayDate(): String =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(Locale.getDefault())
+        .withZone(ZoneId.systemDefault())
+        .format(this)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -429,15 +429,15 @@ constructor(
                 // formatted for this exact currency — otherwise a currency switch would silently
                 // keep displaying amounts in the old currency with statsLoading already false.
                 val keepHeldOnFailure = lastLoadedStatsCurrency == currency.ticker
-                uiState.update {
-                    it.copy(
+                uiState.update { state ->
+                    state.copy(
                         statsLoading = false,
                         marketStats =
                             stats?.toMarketStatsUiModel(currency.ticker)
-                                ?: it.marketStats.takeIf { keepHeldOnFailure },
+                                ?: state.marketStats.takeIf { keepHeldOnFailure },
                         priceExtremes =
                             stats?.toPriceExtremesUiModel(currency.ticker)
-                                ?: it.priceExtremes.takeIf { keepHeldOnFailure },
+                                ?: state.priceExtremes.takeIf { keepHeldOnFailure },
                     )
                 }
                 if (stats != null) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenDetailViewModel.kt
@@ -161,6 +161,10 @@ constructor(
     // (must not relabel that stale data as if it belonged to the new selection).
     private var lastLoadedChartKey: Pair<ChartRange, String>? = null
 
+    // Currency the market stats/price extremes currently held in [uiState] were formatted for,
+    // updated only on a successful fetch — same purpose as [lastLoadedChartKey] for the chart.
+    private var lastLoadedStatsCurrency: String? = null
+
     init {
         // Now a full-page destination (composable<TokenDetail>, not a dialog), so there's no
         // ModalBottomSheet onExpand callback to trigger the first load from — kick it off directly.
@@ -421,14 +425,23 @@ constructor(
             ) {
                 val currency = appCurrencyRepository.currency.first()
                 val stats = tokenPriceChartRepository.getStats(coin, currency)
+                // A failed fetch may only fall back to previously-held stats if those were
+                // formatted for this exact currency — otherwise a currency switch would silently
+                // keep displaying amounts in the old currency with statsLoading already false.
+                val keepHeldOnFailure = lastLoadedStatsCurrency == currency.ticker
                 uiState.update {
                     it.copy(
                         statsLoading = false,
                         marketStats =
-                            stats?.toMarketStatsUiModel(currency.ticker) ?: it.marketStats,
+                            stats?.toMarketStatsUiModel(currency.ticker)
+                                ?: it.marketStats.takeIf { keepHeldOnFailure },
                         priceExtremes =
-                            stats?.toPriceExtremesUiModel(currency.ticker) ?: it.priceExtremes,
+                            stats?.toPriceExtremesUiModel(currency.ticker)
+                                ?: it.priceExtremes.takeIf { keepHeldOnFailure },
                     )
+                }
+                if (stats != null) {
+                    lastLoadedStatsCurrency = currency.ticker
                 }
             }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -174,7 +174,7 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
 
         composable<Route.AddVault> { StartScreen() }
 
-        dialog<TokenDetail> { TokenDetailScreen() }
+        composable<TokenDetail> { TokenDetailScreen() }
         dialog<Route.SelectTokens> { TokenSelectionScreen() }
 
         composable<Route.SignMessage> { entry ->

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -66,13 +66,13 @@ internal fun TokenDetailScreen(
 @Composable
 internal fun TokenDetailScreen(
     uiModel: TokenDetailUiModel,
-    onSend: () -> Unit,
-    onSwap: () -> Unit,
-    onDeposit: () -> Unit,
-    onBack: () -> Unit,
-    onBuy: () -> Unit,
-    onExplorer: () -> Unit,
-    onChartRangeSelected: (ChartRange) -> Unit,
+    onSend: () -> Unit = {},
+    onSwap: () -> Unit = {},
+    onDeposit: () -> Unit = {},
+    onBack: () -> Unit = {},
+    onBuy: () -> Unit = {},
+    onExplorer: () -> Unit = {},
+    onChartRangeSelected: (ChartRange) -> Unit = {},
 ) {
     V3Scaffold(
         title = uiModel.token.name,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -1,14 +1,13 @@
 package com.vultisig.wallet.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -20,20 +19,24 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.ChartRange
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.v2.bottomsheets.DottyBottomSheet
-import com.vultisig.wallet.ui.components.v2.buttons.DesignType
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
-import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
-import com.vultisig.wallet.ui.components.v2.containers.ContainerType
+import com.vultisig.wallet.ui.components.chart.MarketStatsSection
+import com.vultisig.wallet.ui.components.chart.PriceChartSection
+import com.vultisig.wallet.ui.components.chart.PriceExtremesSection
+import com.vultisig.wallet.ui.components.chart.TokenInfoSection
 import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
-import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.texts.LoadableValue
+import com.vultisig.wallet.ui.components.v2.tokenitem.TokenMetaRow
+import com.vultisig.wallet.ui.components.v3.V3Scaffold
 import com.vultisig.wallet.ui.models.ChainTokenUiModel
+import com.vultisig.wallet.ui.models.ChartUiModel
+import com.vultisig.wallet.ui.models.MarketStatsUiModel
+import com.vultisig.wallet.ui.models.PriceExtremesUiModel
 import com.vultisig.wallet.ui.models.TokenDetailUiModel
 import com.vultisig.wallet.ui.models.TokenDetailViewModel
+import com.vultisig.wallet.ui.models.TokenInfoUiModel
 import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainLogo
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
@@ -53,56 +56,54 @@ internal fun TokenDetailScreen(
         onSend = viewModel::send,
         onSwap = viewModel::swap,
         onDeposit = viewModel::deposit,
-        onDismiss = viewModel::back,
+        onBack = viewModel::back,
         onBuy = viewModel::buy,
         onExplorer = { uiModel.explorerUrl.takeIf { it.isNotEmpty() }?.let(uriHandler::openUri) },
+        onChartRangeSelected = viewModel::onChartRangeSelected,
     )
 }
 
 @Composable
 internal fun TokenDetailScreen(
     uiModel: TokenDetailUiModel,
-    onSend: () -> Unit = {},
-    onSwap: () -> Unit = {},
-    onDeposit: () -> Unit = {},
-    onDismiss: () -> Unit = {},
-    onBuy: () -> Unit = {},
-    onExplorer: () -> Unit = {},
+    onSend: () -> Unit,
+    onSwap: () -> Unit,
+    onDeposit: () -> Unit,
+    onBack: () -> Unit,
+    onBuy: () -> Unit,
+    onExplorer: () -> Unit,
+    onChartRangeSelected: (ChartRange) -> Unit,
 ) {
-    DottyBottomSheet(onDismiss = onDismiss) {
+    V3Scaffold(
+        title = uiModel.token.name,
+        onBackClick = onBack,
+        rightIcon = R.drawable.explor,
+        onRightIconClick = onExplorer,
+    ) {
         TokenDetailsContent(
             uiModel = uiModel,
             onSend = onSend,
             onSwap = onSwap,
             onDeposit = onDeposit,
             onBuy = onBuy,
-            onExplorer = onExplorer,
+            onChartRangeSelected = onChartRangeSelected,
         )
     }
 }
 
 @Composable
-private fun TokenDetailsContent(
+internal fun TokenDetailsContent(
     uiModel: TokenDetailUiModel,
     onSend: () -> Unit,
     onSwap: () -> Unit,
     onDeposit: () -> Unit,
     onBuy: () -> Unit,
-    onExplorer: () -> Unit,
+    onChartRangeSelected: (ChartRange) -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(all = 24.dp),
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        VsCircleButton(
-            onClick = onExplorer,
-            size = VsCircleButtonSize.Small,
-            icon = R.drawable.explor,
-            type = VsCircleButtonType.Secondary,
-            designType = DesignType.Shined,
-            modifier = Modifier.align(Alignment.End).offset(x = 8.dp, y = (-8).dp),
-        )
-
         Row(verticalAlignment = Alignment.CenterVertically) {
             ChainLogo(name = uiModel.token.name, logo = uiModel.token.tokenLogo)
             UiSpacer(size = 8.dp)
@@ -137,12 +138,9 @@ private fun TokenDetailsContent(
             horizontalArrangement =
                 Arrangement.spacedBy(space = 20.dp, alignment = Alignment.CenterHorizontally),
             // Every flag below starts false and only resolves once the account loads, so without a
-            // reserved height this row is zero-height on the first frame and the sheet re-anchors
-            // the moment the buttons appear.
-            modifier =
-                Modifier.fillMaxWidth()
-                    .heightIn(min = assetActionButtonHeight)
-                    .padding(horizontal = 24.dp),
+            // reserved height this row is zero-height on the first frame and the content jumps
+            // once the buttons appear.
+            modifier = Modifier.fillMaxWidth().heightIn(min = assetActionButtonHeight),
         ) {
             if (uiModel.canSwap) {
                 AssetActionButton(action = AssetAction.SWAP, isSelected = true, onClick = onSwap)
@@ -169,55 +167,48 @@ private fun TokenDetailsContent(
 
         TopShineContainer(backgroundColor = Theme.v2.colors.backgrounds.surface1) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                TokenMeta(
+                TokenMetaRow(
                     key = stringResource(R.string.token_details_bottom_sheet_price),
                     value = uiModel.token.price,
                 )
-                UiHorizontalDivider(modifier = Modifier.width(320.dp))
-                TokenMeta(
+                UiHorizontalDivider(modifier = Modifier.fillMaxWidth())
+                TokenMetaRow(
                     key = stringResource(R.string.token_details_bottom_sheet_network),
                     value = uiModel.token.network,
                 )
             }
         }
-    }
 
-    UiSpacer(size = 12.dp)
-}
-
-@Composable
-private fun TokenMeta(key: String, value: String?, isVisible: Boolean = true) {
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .background(Theme.v2.colors.backgrounds.primary)
-                .padding(all = 16.dp)
-    ) {
-        V2Container {
-            Text(
-                text = key,
-                color = Theme.v2.colors.text.primary,
-                style = Theme.brockmann.body.s.medium,
-                modifier = Modifier.padding(all = 4.dp),
+        uiModel.chart?.let { chart ->
+            UiSpacer(size = 24.dp)
+            PriceChartSection(
+                chart = chart,
+                onRangeSelected = onChartRangeSelected,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
-        UiSpacer(weight = 1f)
-        V2Container(type = ContainerType.TERTIARY) {
-            LoadableValue(
-                value = value,
-                color = Theme.v2.colors.text.primary,
-                style = Theme.satoshi.price.bodyS,
-                isVisible = isVisible,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-            )
+
+        if (uiModel.statsLoading || uiModel.marketStats != null) {
+            MarketStatsSection(stats = uiModel.marketStats, isLoading = uiModel.statsLoading)
         }
+
+        if (uiModel.statsLoading || uiModel.priceExtremes != null) {
+            PriceExtremesSection(extremes = uiModel.priceExtremes, isLoading = uiModel.statsLoading)
+        }
+
+        uiModel.tokenInfo?.let { info ->
+            UiSpacer(size = 24.dp)
+            TokenInfoSection(info = info)
+        }
+
+        UiSpacer(size = 12.dp)
     }
 }
 
 @Preview
 @Composable
 private fun TokenDetailsScreenPreview() {
-    TokenDetailsContent(
+    TokenDetailScreen(
         uiModel =
             TokenDetailUiModel(
                 token =
@@ -232,11 +223,17 @@ private fun TokenDetailsScreenPreview() {
                     ),
                 canSwap = true,
                 canDeposit = true,
+                chart = ChartUiModel(),
+                marketStats = MarketStatsUiModel(marketCap = "$1.2B", marketCapRank = "#42"),
+                priceExtremes = PriceExtremesUiModel(low24h = "$0.98", high24h = "$1.02"),
+                tokenInfo = TokenInfoUiModel(decimals = "6"),
             ),
         onSend = {},
         onSwap = {},
         onDeposit = {},
+        onBack = {},
         onBuy = {},
         onExplorer = {},
+        onChartRangeSelected = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -188,11 +188,13 @@ internal fun TokenDetailsContent(
             )
         }
 
-        if (uiModel.statsLoading || uiModel.marketStats != null) {
+        if (uiModel.statsLoading || uiModel.marketStats?.hasAnyValue() == true) {
+            UiSpacer(size = 24.dp)
             MarketStatsSection(stats = uiModel.marketStats, isLoading = uiModel.statsLoading)
         }
 
-        if (uiModel.statsLoading || uiModel.priceExtremes != null) {
+        if (uiModel.statsLoading || uiModel.priceExtremes?.hasAnyValue() == true) {
+            UiSpacer(size = 24.dp)
             PriceExtremesSection(extremes = uiModel.priceExtremes, isLoading = uiModel.statsLoading)
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -758,6 +758,23 @@
     <string name="vault_list_edit_vaults_header">Vaults bearbeiten</string>
     <string name="token_details_bottom_sheet_price">Preis</string>
     <string name="token_details_bottom_sheet_network">Netzwerk</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Preisdiagramm, Veränderung %1$s</string>
+    <string name="token_details_market_stats_title">Marktdaten</string>
+    <string name="token_details_price_extremes_title">Preisextreme</string>
+    <string name="token_details_token_info_title">Token-Info</string>
+    <string name="token_details_market_cap">Marktkapitalisierung</string>
+    <string name="token_details_market_cap_rank">Rang</string>
+    <string name="token_details_fully_diluted_valuation">Vollständig verwässerte Bewertung</string>
+    <string name="token_details_volume_24h">24-Std.-Volumen</string>
+    <string name="token_details_circulating_supply">Umlaufversorgung</string>
+    <string name="token_details_max_supply">Maximalversorgung</string>
+    <string name="token_details_low_24h">24-Std.-Tief</string>
+    <string name="token_details_high_24h">24-Std.-Hoch</string>
+    <string name="token_details_all_time_high">Allzeithoch</string>
+    <string name="token_details_all_time_low">Allzeittief</string>
+    <string name="token_details_contract_address">Vertragsadresse</string>
+    <string name="token_details_decimals">Dezimalstellen</string>
     <string name="send_tx_overview_add_to_address_book">Zum Adressbuch hinzufügen</string>
     <string name="invite_to_x_banner_title">Vultisig entwickelt mit Ihnen.</string>
     <string name="invite_to_x_banner_desc">Folgen Sie uns auf X</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -760,6 +760,7 @@
     <string name="token_details_bottom_sheet_network">Netzwerk</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Preisdiagramm, Veränderung %1$s</string>
+    <string name="price_chart_retry_hint">Diagramm konnte nicht geladen werden. Zum erneuten Versuch tippen.</string>
     <string name="token_details_market_stats_title">Marktdaten</string>
     <string name="token_details_price_extremes_title">Preisextreme</string>
     <string name="token_details_token_info_title">Token-Info</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -756,6 +756,23 @@
     <string name="vault_list_edit_vaults_header">Editar bóvedas</string>
     <string name="token_details_bottom_sheet_price">Precio</string>
     <string name="token_details_bottom_sheet_network">Red</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Gráfico de precios, variación de %1$s</string>
+    <string name="token_details_market_stats_title">Estadísticas del mercado</string>
+    <string name="token_details_price_extremes_title">Extremos de precio</string>
+    <string name="token_details_token_info_title">Información del token</string>
+    <string name="token_details_market_cap">Capitalización de mercado</string>
+    <string name="token_details_market_cap_rank">Clasificación</string>
+    <string name="token_details_fully_diluted_valuation">Valoración totalmente diluida</string>
+    <string name="token_details_volume_24h">Volumen de 24 h</string>
+    <string name="token_details_circulating_supply">Suministro circulante</string>
+    <string name="token_details_max_supply">Suministro máximo</string>
+    <string name="token_details_low_24h">Mínimo de 24 h</string>
+    <string name="token_details_high_24h">Máximo de 24 h</string>
+    <string name="token_details_all_time_high">Máximo histórico</string>
+    <string name="token_details_all_time_low">Mínimo histórico</string>
+    <string name="token_details_contract_address">Dirección del contrato</string>
+    <string name="token_details_decimals">Decimales</string>
     <string name="send_tx_overview_add_to_address_book">Agregar a la libreta de direcciones</string>
     <string name="invite_to_x_banner_title">Vultisig construye contigo.</string>
     <string name="invite_to_x_banner_desc">Síguenos en X</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -758,6 +758,7 @@
     <string name="token_details_bottom_sheet_network">Red</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Gráfico de precios, variación de %1$s</string>
+    <string name="price_chart_retry_hint">No se pudo cargar el gráfico. Toca para reintentar.</string>
     <string name="token_details_market_stats_title">Estadísticas del mercado</string>
     <string name="token_details_price_extremes_title">Extremos de precio</string>
     <string name="token_details_token_info_title">Información del token</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -759,6 +759,23 @@
     <string name="vault_list_edit_vaults_header">Uredi trezore</string>
     <string name="token_details_bottom_sheet_price">Cijena</string>
     <string name="token_details_bottom_sheet_network">Mreža</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Grafikon cijena, promjena %1$s</string>
+    <string name="token_details_market_stats_title">Tržišna statistika</string>
+    <string name="token_details_price_extremes_title">Ekstremi cijene</string>
+    <string name="token_details_token_info_title">Informacije o tokenu</string>
+    <string name="token_details_market_cap">Tržišna kapitalizacija</string>
+    <string name="token_details_market_cap_rank">Rang</string>
+    <string name="token_details_fully_diluted_valuation">Potpuno razrijeđena vrijednost</string>
+    <string name="token_details_volume_24h">24-satni volumen</string>
+    <string name="token_details_circulating_supply">Optjecajna ponuda</string>
+    <string name="token_details_max_supply">Maksimalna ponuda</string>
+    <string name="token_details_low_24h">24-satni minimum</string>
+    <string name="token_details_high_24h">24-satni maksimum</string>
+    <string name="token_details_all_time_high">Najviša cijena ikad</string>
+    <string name="token_details_all_time_low">Najniža cijena ikad</string>
+    <string name="token_details_contract_address">Adresa ugovora</string>
+    <string name="token_details_decimals">Decimale</string>
     <string name="send_tx_overview_add_to_address_book">Dodaj u adresar</string>
     <string name="invite_to_x_banner_title">Vultisig gradi s vama.</string>
     <string name="invite_to_x_banner_desc">Pratite nas na X</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -761,6 +761,7 @@
     <string name="token_details_bottom_sheet_network">Mreža</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Grafikon cijena, promjena %1$s</string>
+    <string name="price_chart_retry_hint">Nije moguće učitati grafikon. Dodirni za ponovni pokušaj.</string>
     <string name="token_details_market_stats_title">Tržišna statistika</string>
     <string name="token_details_price_extremes_title">Ekstremi cijene</string>
     <string name="token_details_token_info_title">Informacije o tokenu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -756,6 +756,23 @@
     <string name="vault_list_edit_vaults_header">Modifica Vault</string>
     <string name="token_details_bottom_sheet_price">Prezzo</string>
     <string name="token_details_bottom_sheet_network">Rete</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Grafico dei prezzi, variazione %1$s</string>
+    <string name="token_details_market_stats_title">Statistiche di mercato</string>
+    <string name="token_details_price_extremes_title">Estremi di prezzo</string>
+    <string name="token_details_token_info_title">Informazioni sul token</string>
+    <string name="token_details_market_cap">Capitalizzazione di mercato</string>
+    <string name="token_details_market_cap_rank">Posizione</string>
+    <string name="token_details_fully_diluted_valuation">Valutazione completamente diluita</string>
+    <string name="token_details_volume_24h">Volume nelle 24 ore</string>
+    <string name="token_details_circulating_supply">Offerta in circolazione</string>
+    <string name="token_details_max_supply">Offerta massima</string>
+    <string name="token_details_low_24h">Minimo nelle 24 ore</string>
+    <string name="token_details_high_24h">Massimo nelle 24 ore</string>
+    <string name="token_details_all_time_high">Massimo storico</string>
+    <string name="token_details_all_time_low">Minimo storico</string>
+    <string name="token_details_contract_address">Indirizzo del contratto</string>
+    <string name="token_details_decimals">Decimali</string>
     <string name="send_tx_overview_add_to_address_book">Aggiungi alla rubrica</string>
     <string name="invite_to_x_banner_title">Vultisig sta costruendo con te.</string>
     <string name="invite_to_x_banner_desc">Seguici su X</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -758,6 +758,7 @@
     <string name="token_details_bottom_sheet_network">Rete</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Grafico dei prezzi, variazione %1$s</string>
+    <string name="price_chart_retry_hint">Impossibile caricare il grafico. Tocca per riprovare.</string>
     <string name="token_details_market_stats_title">Statistiche di mercato</string>
     <string name="token_details_price_extremes_title">Estremi di prezzo</string>
     <string name="token_details_token_info_title">Informazioni sul token</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1052,6 +1052,23 @@
     <string name="vault_list_edit_vaults_header">볼트 수정</string>
     <string name="token_details_bottom_sheet_price">가격</string>
     <string name="token_details_bottom_sheet_network">네트워크</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">가격 차트, %1$s 변동</string>
+    <string name="token_details_market_stats_title">시장 통계</string>
+    <string name="token_details_price_extremes_title">가격 범위</string>
+    <string name="token_details_token_info_title">토큰 정보</string>
+    <string name="token_details_market_cap">시가총액</string>
+    <string name="token_details_market_cap_rank">순위</string>
+    <string name="token_details_fully_diluted_valuation">완전 희석 가치</string>
+    <string name="token_details_volume_24h">24시간 거래량</string>
+    <string name="token_details_circulating_supply">유통량</string>
+    <string name="token_details_max_supply">최대 공급량</string>
+    <string name="token_details_low_24h">24시간 최저가</string>
+    <string name="token_details_high_24h">24시간 최고가</string>
+    <string name="token_details_all_time_high">역대 최고가</string>
+    <string name="token_details_all_time_low">역대 최저가</string>
+    <string name="token_details_contract_address">컨트랙트 주소</string>
+    <string name="token_details_decimals">소수 자릿수</string>
     <string name="vault_ceil_active">활성</string>
     <string name="send_tx_overview_add_to_address_book">주소록에 추가</string>
     <string name="invite_to_x_banner_title">Vultisig는 여러분과 함께 성장합니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1054,6 +1054,7 @@
     <string name="token_details_bottom_sheet_network">네트워크</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">가격 차트, %1$s 변동</string>
+    <string name="price_chart_retry_hint">차트를 불러올 수 없습니다. 다시 시도하려면 탭하세요.</string>
     <string name="token_details_market_stats_title">시장 통계</string>
     <string name="token_details_price_extremes_title">가격 범위</string>
     <string name="token_details_token_info_title">토큰 정보</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -753,6 +753,23 @@
     <string name="vault_list_edit_vaults_header">Kluizen bewerken</string>
     <string name="token_details_bottom_sheet_price">Prijs</string>
     <string name="token_details_bottom_sheet_network">Netwerk</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Prijsgrafiek, verandering %1$s</string>
+    <string name="token_details_market_stats_title">Marktstatistieken</string>
+    <string name="token_details_price_extremes_title">Prijsuitersten</string>
+    <string name="token_details_token_info_title">Tokeninformatie</string>
+    <string name="token_details_market_cap">Marktkapitalisatie</string>
+    <string name="token_details_market_cap_rank">Rang</string>
+    <string name="token_details_fully_diluted_valuation">Volledig verwaterde waardering</string>
+    <string name="token_details_volume_24h">24-uursvolume</string>
+    <string name="token_details_circulating_supply">Circulerend aanbod</string>
+    <string name="token_details_max_supply">Maximaal aanbod</string>
+    <string name="token_details_low_24h">24-uurs laag</string>
+    <string name="token_details_high_24h">24-uurs hoog</string>
+    <string name="token_details_all_time_high">Hoogste ooit</string>
+    <string name="token_details_all_time_low">Laagste ooit</string>
+    <string name="token_details_contract_address">Contractadres</string>
+    <string name="token_details_decimals">Decimalen</string>
     <string name="send_tx_overview_add_to_address_book">Toevoegen aan adresboek</string>
     <string name="invite_to_x_banner_title">Vultisig bouwt met je mee.</string>
     <string name="invite_to_x_banner_desc">Volg ons op X</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -755,6 +755,7 @@
     <string name="token_details_bottom_sheet_network">Netwerk</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Prijsgrafiek, verandering %1$s</string>
+    <string name="price_chart_retry_hint">Grafiek kon niet worden geladen. Tik om opnieuw te proberen.</string>
     <string name="token_details_market_stats_title">Marktstatistieken</string>
     <string name="token_details_price_extremes_title">Prijsuitersten</string>
     <string name="token_details_token_info_title">Tokeninformatie</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -755,6 +755,23 @@
     <string name="vault_list_edit_vaults_header">Editar Cofres</string>
     <string name="token_details_bottom_sheet_price">Preço</string>
     <string name="token_details_bottom_sheet_network">Rede</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">Gráfico de preços, variação de %1$s</string>
+    <string name="token_details_market_stats_title">Estatísticas de mercado</string>
+    <string name="token_details_price_extremes_title">Extremos de preço</string>
+    <string name="token_details_token_info_title">Informações do token</string>
+    <string name="token_details_market_cap">Capitalização de mercado</string>
+    <string name="token_details_market_cap_rank">Classificação</string>
+    <string name="token_details_fully_diluted_valuation">Avaliação totalmente diluída</string>
+    <string name="token_details_volume_24h">Volume de 24h</string>
+    <string name="token_details_circulating_supply">Oferta em circulação</string>
+    <string name="token_details_max_supply">Oferta máxima</string>
+    <string name="token_details_low_24h">Mínima de 24h</string>
+    <string name="token_details_high_24h">Máxima de 24h</string>
+    <string name="token_details_all_time_high">Máxima histórica</string>
+    <string name="token_details_all_time_low">Mínima histórica</string>
+    <string name="token_details_contract_address">Endereço do contrato</string>
+    <string name="token_details_decimals">Casas decimais</string>
     <string name="send_tx_overview_add_to_address_book">Adicionar ao Catálogo de Endereços</string>
     <string name="invite_to_x_banner_title">A Vultisig está a construir consigo.</string>
     <string name="invite_to_x_banner_desc">Siga-nos no X</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -757,6 +757,7 @@
     <string name="token_details_bottom_sheet_network">Rede</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">Gráfico de preços, variação de %1$s</string>
+    <string name="price_chart_retry_hint">Não foi possível carregar o gráfico. Toque para tentar novamente.</string>
     <string name="token_details_market_stats_title">Estatísticas de mercado</string>
     <string name="token_details_price_extremes_title">Extremos de preço</string>
     <string name="token_details_token_info_title">Informações do token</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -759,6 +759,7 @@
     <string name="token_details_bottom_sheet_network">Сеть</string>
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">График цены, изменение %1$s</string>
+    <string name="price_chart_retry_hint">Не удалось загрузить график. Нажмите, чтобы повторить.</string>
     <string name="token_details_market_stats_title">Рыночная статистика</string>
     <string name="token_details_price_extremes_title">Экстремумы цены</string>
     <string name="token_details_token_info_title">Информация о токене</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -757,6 +757,23 @@
     <string name="vault_list_edit_vaults_header">Редактировать хранилища</string>
     <string name="token_details_bottom_sheet_price">Цена</string>
     <string name="token_details_bottom_sheet_network">Сеть</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">График цены, изменение %1$s</string>
+    <string name="token_details_market_stats_title">Рыночная статистика</string>
+    <string name="token_details_price_extremes_title">Экстремумы цены</string>
+    <string name="token_details_token_info_title">Информация о токене</string>
+    <string name="token_details_market_cap">Рыночная капитализация</string>
+    <string name="token_details_market_cap_rank">Рейтинг</string>
+    <string name="token_details_fully_diluted_valuation">Полностью разводненная оценка</string>
+    <string name="token_details_volume_24h">Объём за 24ч</string>
+    <string name="token_details_circulating_supply">Оборотное предложение</string>
+    <string name="token_details_max_supply">Максимальное предложение</string>
+    <string name="token_details_low_24h">Минимум за 24ч</string>
+    <string name="token_details_high_24h">Максимум за 24ч</string>
+    <string name="token_details_all_time_high">Исторический максимум</string>
+    <string name="token_details_all_time_low">Исторический минимум</string>
+    <string name="token_details_contract_address">Адрес контракта</string>
+    <string name="token_details_decimals">Знаков после запятой</string>
     <string name="send_tx_overview_add_to_address_book">Добавить в адресную книгу</string>
     <string name="invite_to_x_banner_title">Vultisig строит вместе с вами.</string>
     <string name="invite_to_x_banner_desc">Подпишитесь на нас в X</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1156,6 +1156,23 @@
     <string name="token_details_bottom_sheet_price">价格</string>
     <string name="token_details_bottom_sheet_network">网络</string>
 
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="price_chart_content_description">价格图表，变化 %1$s</string>
+    <string name="token_details_market_stats_title">市场数据</string>
+    <string name="token_details_price_extremes_title">价格区间</string>
+    <string name="token_details_token_info_title">代币信息</string>
+    <string name="token_details_market_cap">市值</string>
+    <string name="token_details_market_cap_rank">排名</string>
+    <string name="token_details_fully_diluted_valuation">完全稀释估值</string>
+    <string name="token_details_volume_24h">24小时交易量</string>
+    <string name="token_details_circulating_supply">流通供应量</string>
+    <string name="token_details_max_supply">最大供应量</string>
+    <string name="token_details_low_24h">24小时最低价</string>
+    <string name="token_details_high_24h">24小时最高价</string>
+    <string name="token_details_all_time_high">历史最高价</string>
+    <string name="token_details_all_time_low">历史最低价</string>
+    <string name="token_details_contract_address">合约地址</string>
+    <string name="token_details_decimals">小数位数</string>
 
     <!-- Invite to X Banner -->
     <string name="send_tx_overview_add_to_address_book">添加到地址簿</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1158,6 +1158,7 @@
 
     <!-- Price chart + market data — issue #5428 -->
     <string name="price_chart_content_description">价格图表，变化 %1$s</string>
+    <string name="price_chart_retry_hint">无法加载图表。点击重试。</string>
     <string name="token_details_market_stats_title">市场数据</string>
     <string name="token_details_price_extremes_title">价格区间</string>
     <string name="token_details_token_info_title">代币信息</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1074,6 +1074,28 @@
     <string name="vault_list_edit_vaults_header">Edit Vaults</string>
     <string name="token_details_bottom_sheet_price">Price</string>
     <string name="token_details_bottom_sheet_network">Network</string>
+    <!-- Price chart + market data — issue #5428 -->
+    <string name="chart_range_1d" translatable="false">1D</string>
+    <string name="chart_range_1w" translatable="false">1W</string>
+    <string name="chart_range_1m" translatable="false">1M</string>
+    <string name="chart_range_1y" translatable="false">1Y</string>
+    <string name="chart_range_all" translatable="false">ALL</string>
+    <string name="price_chart_content_description">Price chart, %1$s change</string>
+    <string name="token_details_market_stats_title">Market Stats</string>
+    <string name="token_details_price_extremes_title">Price Extremes</string>
+    <string name="token_details_token_info_title">Token Info</string>
+    <string name="token_details_market_cap">Market Cap</string>
+    <string name="token_details_market_cap_rank">Rank</string>
+    <string name="token_details_fully_diluted_valuation">Fully Diluted Valuation</string>
+    <string name="token_details_volume_24h">24h Volume</string>
+    <string name="token_details_circulating_supply">Circulating Supply</string>
+    <string name="token_details_max_supply">Max Supply</string>
+    <string name="token_details_low_24h">24h Low</string>
+    <string name="token_details_high_24h">24h High</string>
+    <string name="token_details_all_time_high">All-Time High</string>
+    <string name="token_details_all_time_low">All-Time Low</string>
+    <string name="token_details_contract_address">Contract Address</string>
+    <string name="token_details_decimals">Decimals</string>
     <string name="defi" translatable="false">DeFi</string>
     <string name="vault_ceil_active">Active</string>
     <string name="send_tx_overview_add_to_address_book">Add to Address Book</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1081,6 +1081,7 @@
     <string name="chart_range_1y" translatable="false">1Y</string>
     <string name="chart_range_all" translatable="false">ALL</string>
     <string name="price_chart_content_description">Price chart, %1$s change</string>
+    <string name="price_chart_retry_hint">Couldn\'t load chart. Tap to retry.</string>
     <string name="token_details_market_stats_title">Market Stats</string>
     <string name="token_details_price_extremes_title">Price Extremes</string>
     <string name="token_details_token_info_title">Token Info</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
@@ -343,4 +343,24 @@ internal class TokenDetailViewModelTest {
 
             vm.uiState.value.chart shouldBe null
         }
+
+    @Test
+    fun `MarketStatsUiModel hasAnyValue is false when every field is null`() {
+        MarketStatsUiModel().hasAnyValue() shouldBe false
+    }
+
+    @Test
+    fun `MarketStatsUiModel hasAnyValue is true when any single field is set`() {
+        MarketStatsUiModel(marketCap = "$1.2B").hasAnyValue() shouldBe true
+    }
+
+    @Test
+    fun `PriceExtremesUiModel hasAnyValue is false when every field is null`() {
+        PriceExtremesUiModel().hasAnyValue() shouldBe false
+    }
+
+    @Test
+    fun `PriceExtremesUiModel hasAnyValue is true when any single field is set`() {
+        PriceExtremesUiModel(low24h = "$0.98").hasAnyValue() shouldBe true
+    }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
@@ -1,0 +1,348 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.MarketChart
+import com.vultisig.wallet.data.models.MarketChartPoint
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.TokenPriceChartRepository
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.math.BigDecimal
+import java.text.NumberFormat
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class TokenDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var fiatValueToStringMapper: FiatValueToStringMapper
+    private lateinit var mapTokenValueToStringWithUnitMapper: TokenValueToStringWithUnitMapper
+    private lateinit var accountsRepository: AccountsRepository
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var explorerLinkRepository: ExplorerLinkRepository
+    private lateinit var tokenPriceChartRepository: TokenPriceChartRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var currencyFlow: MutableStateFlow<AppCurrency>
+
+    private val coin =
+        Coin(
+            chain = Chain.Bitcoin,
+            ticker = "BTC",
+            logo = "bitcoin",
+            address = "",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "bitcoin",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private lateinit var originalLocale: Locale
+
+    @BeforeEach
+    fun setUp() {
+        originalLocale = Locale.getDefault()
+        // Pins decimal-separator formatting in changePercentText assertions to "." regardless of
+        // the CI/dev machine's default locale.
+        Locale.setDefault(Locale.US)
+
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        every { any<SavedStateHandle>().toRoute<Route.TokenDetail>() } returns
+            Route.TokenDetail(
+                vaultId = "vault-1",
+                chainId = coin.chain.raw,
+                tokenId = coin.id,
+                mergeId = "",
+            )
+
+        navigator = mockk(relaxed = true)
+        fiatValueToStringMapper = mockk()
+        coEvery { fiatValueToStringMapper(any(), any(), any()) } returns "$100.00"
+        mapTokenValueToStringWithUnitMapper = mockk(relaxed = true)
+        accountsRepository = mockk()
+        balanceVisibilityRepository = mockk(relaxed = true)
+        explorerLinkRepository = mockk(relaxed = true)
+        tokenPriceChartRepository = mockk()
+        appCurrencyRepository = mockk()
+        currencyFlow = MutableStateFlow(AppCurrency.USD)
+        coEvery { appCurrencyRepository.currency } returns currencyFlow
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance()
+
+        coEvery { accountsRepository.loadAddress(any(), any()) } returns
+            flowOf(
+                Address(
+                    chain = Chain.Bitcoin,
+                    address = "bc1qxyz",
+                    accounts =
+                        listOf(
+                            Account(token = coin, tokenValue = null, fiatValue = null, price = null)
+                        ),
+                )
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+        Locale.setDefault(originalLocale)
+    }
+
+    private fun createViewModel() =
+        TokenDetailViewModel(
+            savedStateHandle = mockk(relaxed = true),
+            navigator = navigator,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToStringWithUnitMapper = mapTokenValueToStringWithUnitMapper,
+            accountsRepository = accountsRepository,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            explorerLinkRepository = explorerLinkRepository,
+            tokenPriceChartRepository = tokenPriceChartRepository,
+            appCurrencyRepository = appCurrencyRepository,
+        )
+
+    private fun chart(sign: Int) =
+        MarketChart(
+            points =
+                listOf(MarketChartPoint(1L, BigDecimal.TEN), MarketChartPoint(2L, BigDecimal.TEN)),
+            changePercent = sign.toDouble(),
+        )
+
+    @Test
+    fun `a coin with a CoinGecko source loads a chart defaulting to 1D`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns chart(sign = 1)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiState.value.chart?.selectedRange shouldBe ChartRange.ONE_DAY
+            vm.uiState.value.chart?.points?.size shouldBe 2
+            vm.uiState.value.chart?.isPositive shouldBe true
+        }
+
+    @Test
+    fun `a pool-priced coin with no CoinGecko source never shows a chart section`() =
+        runTest(testDispatcher) {
+            val poolCoin = coin.copy(priceProviderID = "", contractAddress = "")
+            coEvery { accountsRepository.loadAddress(any(), any()) } returns
+                flowOf(
+                    Address(
+                        chain = Chain.Bitcoin,
+                        address = "bc1qxyz",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = poolCoin,
+                                    tokenValue = null,
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiState.value.chart shouldBe null
+            vm.uiState.value.marketStats shouldBe null
+            vm.uiState.value.priceExtremes shouldBe null
+        }
+
+    @Test
+    fun `selecting a new range cancels the in-flight fetch for the previous range`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns chart(sign = 1)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+            // ONE_WEEK never resolves within this test's virtual time budget — it must be cancelled
+            // rather than eventually overwriting the ONE_MONTH result below.
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_WEEK, AppCurrency.USD)
+            } coAnswers
+                {
+                    delay(10_000)
+                    chart(sign = -1)
+                }
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_MONTH, AppCurrency.USD)
+            } returns chart(sign = 1).copy(changePercent = 42.0)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.onChartRangeSelected(ChartRange.ONE_WEEK)
+            vm.onChartRangeSelected(ChartRange.ONE_MONTH)
+            advanceUntilIdle()
+
+            vm.uiState.value.chart?.selectedRange shouldBe ChartRange.ONE_MONTH
+            vm.uiState.value.chart?.changePercentText shouldBe "+42.00%"
+        }
+
+    @Test
+    fun `range switch keeps the previous series visible while the new range loads`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns chart(sign = 1)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_WEEK, AppCurrency.USD)
+            } coAnswers
+                {
+                    delay(10_000)
+                    chart(sign = -1)
+                }
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            val pointsBeforeSwitch = vm.uiState.value.chart?.points
+
+            vm.onChartRangeSelected(ChartRange.ONE_WEEK)
+
+            // While ONE_WEEK's fetch is in flight, the 1D series must still be on screen.
+            vm.uiState.value.chart?.points shouldBe pointsBeforeSwitch
+            vm.uiState.value.chart?.isLoading shouldBe true
+        }
+
+    @Test
+    fun `switching the app currency re-fetches the chart and stats in the new currency`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns chart(sign = 1)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.EUR)
+            } returns chart(sign = 1).copy(changePercent = 7.0)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.EUR) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            currencyFlow.value = AppCurrency.EUR
+            advanceUntilIdle()
+
+            coVerify {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.EUR)
+            }
+            coVerify { tokenPriceChartRepository.getStats(coin, AppCurrency.EUR) }
+            vm.uiState.value.chart?.changePercentText shouldBe "+7.00%"
+        }
+
+    @Test
+    fun `a first-ever chart resolution with zero points hides the chart section entirely`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns null
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiState.value.chart shouldBe null
+        }
+
+    @Test
+    fun `a failed re-fetch on currency switch clears the section instead of relabeling the old currency's data as fresh`() =
+        runTest(testDispatcher) {
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.USD)
+            } returns chart(sign = 1)
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.USD) } returns null
+            coEvery {
+                tokenPriceChartRepository.getChart(coin, ChartRange.ONE_DAY, AppCurrency.EUR)
+            } returns null
+            coEvery { tokenPriceChartRepository.getStats(coin, AppCurrency.EUR) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.chart?.points?.size shouldBe 2
+
+            currencyFlow.value = AppCurrency.EUR
+            advanceUntilIdle()
+
+            // The USD series must not be shown as if it were EUR data: the section stays visible
+            // (the coin does have a data source) but with its points cleared and marked stale.
+            vm.uiState.value.chart?.points shouldBe emptyList()
+            vm.uiState.value.chart?.isStale shouldBe true
+            vm.uiState.value.chart?.isLoading shouldBe false
+        }
+
+    @Test
+    fun `ADVERSARIAL PROBE - pool-priced coin chart stays null after currency switch`() =
+        runTest(testDispatcher) {
+            val poolCoin = coin.copy(priceProviderID = "", contractAddress = "")
+            coEvery { accountsRepository.loadAddress(any(), any()) } returns
+                flowOf(
+                    Address(
+                        chain = Chain.Bitcoin,
+                        address = "bc1qxyz",
+                        accounts =
+                            listOf(
+                                Account(
+                                    token = poolCoin,
+                                    tokenValue = null,
+                                    fiatValue = null,
+                                    price = null,
+                                )
+                            ),
+                    )
+                )
+            coEvery { tokenPriceChartRepository.getChart(poolCoin, any(), any()) } returns null
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.chart shouldBe null
+
+            currencyFlow.value = AppCurrency.EUR
+            advanceUntilIdle()
+
+            vm.uiState.value.chart shouldBe null
+        }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/TokenDetailViewModelTest.kt
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class TokenDetailViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -315,7 +314,7 @@ internal class TokenDetailViewModelTest {
         }
 
     @Test
-    fun `ADVERSARIAL PROBE - pool-priced coin chart stays null after currency switch`() =
+    fun `a pool-priced coin chart stays null after a currency switch`() =
         runTest(testDispatcher) {
             val poolCoin = coin.copy(priceProviderID = "", contractAddress = "")
             coEvery { accountsRepository.loadAddress(any(), any()) } returns
@@ -334,7 +333,6 @@ internal class TokenDetailViewModelTest {
                             ),
                     )
                 )
-            coEvery { tokenPriceChartRepository.getChart(poolCoin, any(), any()) } returns null
 
             val vm = createViewModel()
             advanceUntilIdle()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
@@ -1,6 +1,10 @@
 package com.vultisig.wallet.data.api
 
+import com.vultisig.wallet.data.api.models.CoinMarketStatsJson
+import com.vultisig.wallet.data.api.models.MarketChartResponseJson
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.coinGeckoAssetPlatformId
+import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -24,6 +28,23 @@ interface CoinGeckoApi {
         contractAddresses: List<String>,
         currencies: List<String>,
     ): Map<String, CurrencyToPrice>
+
+    /**
+     * `/coins/{id}/market_chart` — id lookups are case-sensitive on CoinGecko, so [id] must be
+     * lowercased by the caller.
+     */
+    suspend fun getMarketChart(id: String, currency: String, days: String): MarketChartResponseJson
+
+    /** `/coins/{platform}/contract/{address}/market_chart`, for tokens with no CoinGecko id. */
+    suspend fun getContractMarketChart(
+        chain: Chain,
+        contractAddress: String,
+        currency: String,
+        days: String,
+    ): MarketChartResponseJson
+
+    /** `/coins/markets` — market cap, rank, FDV, volume, supply and price-extreme stats. */
+    suspend fun getMarketStats(id: String, currency: String): List<CoinMarketStatsJson>
 }
 
 internal class CoinGeckoApiImpl @Inject constructor(private val http: HttpClient) : CoinGeckoApi {
@@ -81,22 +102,48 @@ internal class CoinGeckoApiImpl @Inject constructor(private val http: HttpClient
             }
             .body()
 
-    private val Chain.coinGeckoAssetId: String
-        get() =
-            when (this) {
-                Chain.Ethereum -> "ethereum"
-                Chain.Avalanche -> "avalanche"
-                Chain.Base -> "base"
-                Chain.Blast -> "blast"
-                Chain.Arbitrum -> "arbitrum-one"
-                Chain.Polygon -> "polygon-pos"
-                Chain.Optimism -> "optimistic-ethereum"
-                Chain.BscChain -> "binance-smart-chain"
-                Chain.ZkSync -> "zksync"
-                Chain.Solana -> "solana"
-                Chain.Robinhood -> "robinhood"
-                Chain.Mantle -> "mantle"
-
-                else -> error("No CoinGecko asset id for chain $this")
+    override suspend fun getMarketChart(
+        id: String,
+        currency: String,
+        days: String,
+    ): MarketChartResponseJson =
+        http
+            .get(
+                "https://api.vultisig.com/coingeicko/api/v3/coins/${id.lowercase()}/market_chart"
+            ) {
+                parameter("vs_currency", currency)
+                parameter("days", days)
+                header("Content-Type", "application/json")
             }
+            .bodyOrThrow()
+
+    override suspend fun getContractMarketChart(
+        chain: Chain,
+        contractAddress: String,
+        currency: String,
+        days: String,
+    ): MarketChartResponseJson =
+        http
+            .get(
+                "https://api.vultisig.com/coingeicko/api/v3/coins/" +
+                    "${chain.coinGeckoAssetId}/contract/$contractAddress/market_chart"
+            ) {
+                parameter("vs_currency", currency)
+                parameter("days", days)
+                header("Content-Type", "application/json")
+            }
+            .bodyOrThrow()
+
+    override suspend fun getMarketStats(id: String, currency: String): List<CoinMarketStatsJson> =
+        http
+            .get("https://api.vultisig.com/coingeicko/api/v3/coins/markets") {
+                parameter("vs_currency", currency)
+                parameter("ids", id.lowercase())
+                parameter("price_change_percentage", "24h")
+                header("Content-Type", "application/json")
+            }
+            .bodyOrThrow()
+
+    private val Chain.coinGeckoAssetId: String
+        get() = coinGeckoAssetPlatformId() ?: error("No CoinGecko asset id for chain $this")
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
@@ -31,8 +31,8 @@ interface CoinGeckoApi {
     ): Map<String, CurrencyToPrice>
 
     /**
-     * `/coins/{id}/market_chart` — id lookups are case-sensitive on CoinGecko, so [id] must be
-     * lowercased by the caller.
+     * `/coins/{id}/market_chart` — id lookups are case-sensitive on CoinGecko; [id] is lowercased
+     * internally before the request, so callers don't need to normalize it themselves.
      */
     suspend fun getMarketChart(id: String, currency: String, days: String): MarketChartResponseJson
 
@@ -109,9 +109,13 @@ internal class CoinGeckoApiImpl @Inject constructor(private val http: HttpClient
         days: String,
     ): MarketChartResponseJson =
         http
-            .get(
-                "https://api.vultisig.com/coingeicko/api/v3/coins/${id.lowercase()}/market_chart"
-            ) {
+            .get("https://api.vultisig.com/coingeicko/api/v3/coins") {
+                // id can come from remote, untrusted data (e.g. a Solana token list's
+                // extensions.coingeckoId); encodeSlash = true stops a '/' in it from retargeting
+                // the request path, same as getContractMarketChart below.
+                url {
+                    appendPathSegments(listOf(id.lowercase(), "market_chart"), encodeSlash = true)
+                }
                 parameter("vs_currency", currency)
                 parameter("days", days)
                 header("Content-Type", "application/json")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CoinGeckoApi.kt
@@ -10,6 +10,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.http.appendPathSegments
 import java.math.BigDecimal
 import javax.inject.Inject
 import timber.log.Timber
@@ -124,10 +125,16 @@ internal class CoinGeckoApiImpl @Inject constructor(private val http: HttpClient
         days: String,
     ): MarketChartResponseJson =
         http
-            .get(
-                "https://api.vultisig.com/coingeicko/api/v3/coins/" +
-                    "${chain.coinGeckoAssetId}/contract/$contractAddress/market_chart"
-            ) {
+            .get("https://api.vultisig.com/coingeicko/api/v3/coins") {
+                url {
+                    // encodeSlash = true so a contractAddress containing '/' (defaults to false in
+                    // Ktor, which would let it split into extra path segments) can't retarget the
+                    // request path.
+                    appendPathSegments(
+                        listOf(chain.coinGeckoAssetId, "contract", contractAddress, "market_chart"),
+                        encodeSlash = true,
+                    )
+                }
                 parameter("vs_currency", currency)
                 parameter("days", days)
                 header("Content-Type", "application/json")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/CoinGeckoMarketJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/CoinGeckoMarketJson.kt
@@ -1,0 +1,40 @@
+package com.vultisig.wallet.data.api.models
+
+import java.math.BigDecimal
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * CoinGecko `market_chart` response (id and contract variants share this shape). `prices` is an
+ * array of `[msEpoch, price]` pairs — decoded as raw `Double` pairs (not `BigDecimal`) since the
+ * array-of-arrays shape isn't a natural fit for a per-field `@Contextual` serializer; values are
+ * converted to `BigDecimal` in
+ * [decodeMarketChartPoints][com.vultisig.wallet.data.utils.decodeMarketChartPoints].
+ */
+@Serializable data class MarketChartResponseJson(val prices: List<List<Double>> = emptyList())
+
+/**
+ * One entry of CoinGecko's `/coins/markets` response. Every numeric field is nullable — CoinGecko
+ * omits fields it doesn't have for a given asset (e.g. `max_supply` for an uncapped supply) rather
+ * than sending zero.
+ */
+@Serializable
+data class CoinMarketStatsJson(
+    @SerialName("market_cap") @Contextual val marketCap: BigDecimal? = null,
+    @SerialName("market_cap_rank") val marketCapRank: Int? = null,
+    @SerialName("fully_diluted_valuation")
+    @Contextual
+    val fullyDilutedValuation: BigDecimal? = null,
+    @SerialName("total_volume") @Contextual val totalVolume: BigDecimal? = null,
+    @SerialName("high_24h") @Contextual val high24h: BigDecimal? = null,
+    @SerialName("low_24h") @Contextual val low24h: BigDecimal? = null,
+    @SerialName("circulating_supply") @Contextual val circulatingSupply: BigDecimal? = null,
+    @SerialName("max_supply") @Contextual val maxSupply: BigDecimal? = null,
+    @SerialName("ath") @Contextual val ath: BigDecimal? = null,
+    @SerialName("ath_date") val athDate: String? = null,
+    @SerialName("ath_change_percentage") val athChangePercentage: Double? = null,
+    @SerialName("atl") @Contextual val atl: BigDecimal? = null,
+    @SerialName("atl_date") val atlDate: String? = null,
+    @SerialName("atl_change_percentage") val atlChangePercentage: Double? = null,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -433,6 +433,33 @@ fun Chain.swapAssetName(): String {
     }
 }
 
+/**
+ * CoinGecko's asset-platform id for the chains its contract-lookup endpoints
+ * (`/coins/{platform}/contract/{address}/...`) actually index, or null when unmapped. This is the
+ * single source of truth for both [com.vultisig.wallet.data.api.CoinGeckoApiImpl]'s contract-lookup
+ * URLs and [hasMarketDataSource]'s contract-address gate, so a chain can never be treated as
+ * chartable-by-contract-address without CoinGecko actually supporting the lookup. Sei and
+ * Hyperliquid are deliberately absent: their CoinGecko asset-platform ids are unverified, so they
+ * stay ungated rather than guessed.
+ */
+fun Chain.coinGeckoAssetPlatformId(): String? =
+    when (this) {
+        Chain.Ethereum -> "ethereum"
+        Chain.Avalanche -> "avalanche"
+        Chain.Base -> "base"
+        Chain.Blast -> "blast"
+        Chain.Arbitrum -> "arbitrum-one"
+        Chain.Polygon -> "polygon-pos"
+        Chain.Optimism -> "optimistic-ethereum"
+        Chain.BscChain -> "binance-smart-chain"
+        Chain.ZkSync -> "zksync"
+        Chain.Solana -> "solana"
+        Chain.Robinhood -> "robinhood"
+        Chain.Mantle -> "mantle"
+        Chain.CronosChain -> "cronos"
+        else -> null
+    }
+
 fun Chain.ticker(): String {
     return when (this) {
         Chain.ThorChain -> "RUNE"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/ChartRange.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/ChartRange.kt
@@ -1,0 +1,14 @@
+package com.vultisig.wallet.data.models
+
+/**
+ * Time ranges offered by the token detail price chart. [days] is CoinGecko's `market_chart` `days`
+ * query parameter; [cacheTtlMillis] is how long a fetched series for this range is considered fresh
+ * before a re-fetch is attempted (short for 1D, longer for 1Y/ALL, since older data changes less).
+ */
+enum class ChartRange(val label: String, val days: String, val cacheTtlMillis: Long) {
+    ONE_DAY(label = "1D", days = "1", cacheTtlMillis = 60_000L),
+    ONE_WEEK(label = "1W", days = "7", cacheTtlMillis = 600_000L),
+    ONE_MONTH(label = "1M", days = "30", cacheTtlMillis = 600_000L),
+    ONE_YEAR(label = "1Y", days = "365", cacheTtlMillis = 3_600_000L),
+    ALL(label = "ALL", days = "max", cacheTtlMillis = 3_600_000L),
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/ChartRange.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/ChartRange.kt
@@ -4,11 +4,12 @@ package com.vultisig.wallet.data.models
  * Time ranges offered by the token detail price chart. [days] is CoinGecko's `market_chart` `days`
  * query parameter; [cacheTtlMillis] is how long a fetched series for this range is considered fresh
  * before a re-fetch is attempted (short for 1D, longer for 1Y/ALL, since older data changes less).
+ * Display labels live in the `chart_range_*` string resources, not here.
  */
-enum class ChartRange(val label: String, val days: String, val cacheTtlMillis: Long) {
-    ONE_DAY(label = "1D", days = "1", cacheTtlMillis = 60_000L),
-    ONE_WEEK(label = "1W", days = "7", cacheTtlMillis = 600_000L),
-    ONE_MONTH(label = "1M", days = "30", cacheTtlMillis = 600_000L),
-    ONE_YEAR(label = "1Y", days = "365", cacheTtlMillis = 3_600_000L),
-    ALL(label = "ALL", days = "max", cacheTtlMillis = 3_600_000L),
+enum class ChartRange(val days: String, val cacheTtlMillis: Long) {
+    ONE_DAY(days = "1", cacheTtlMillis = 60_000L),
+    ONE_WEEK(days = "7", cacheTtlMillis = 600_000L),
+    ONE_MONTH(days = "30", cacheTtlMillis = 600_000L),
+    ONE_YEAR(days = "365", cacheTtlMillis = 3_600_000L),
+    ALL(days = "max", cacheTtlMillis = 3_600_000L),
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -56,6 +56,19 @@ data class Coin(
     }
 }
 
+/**
+ * True when this coin has a CoinGecko price-provider id, or a contract address on a chain
+ * [coinGeckoAssetPlatformId] actually supports for contract lookups. Pool-priced assets
+ * (THORChain/Maya/Solana pool tokens) have neither, and contract addresses on chains CoinGecko
+ * doesn't index by platform (e.g. Kujira's `factory/`/`ibc/` denoms, or Sei/Hyperliquid) would
+ * otherwise pass a bare non-empty check yet always fail the actual fetch — so this gates the token
+ * detail screen's price chart and market stats sections on a source that can genuinely resolve.
+ */
+val Coin.hasMarketDataSource: Boolean
+    get() =
+        priceProviderID.isNotEmpty() ||
+            (contractAddress.isNotEmpty() && chain.coinGeckoAssetPlatformId() != null)
+
 /** True if the coin represents a liquidity-pool position rather than a plain token. */
 val Coin.isLpToken: Boolean
     get() =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinMarketStats.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinMarketStats.kt
@@ -1,0 +1,27 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Market stats, price extremes and supply data for a coin, sourced from CoinGecko's
+ * `/coins/markets` endpoint. Every field is nullable because CoinGecko itself omits fields freely
+ * (e.g. `max_supply` for uncapped assets) — the UI hides a stat row rather than showing a
+ * placeholder when its field is null.
+ */
+data class CoinMarketStats(
+    val marketCap: BigDecimal?,
+    val marketCapRank: Int?,
+    val fullyDilutedValuation: BigDecimal?,
+    val volume24h: BigDecimal?,
+    val circulatingSupply: BigDecimal?,
+    val maxSupply: BigDecimal?,
+    val low24h: BigDecimal?,
+    val high24h: BigDecimal?,
+    val athPrice: BigDecimal?,
+    val athDate: Instant?,
+    val athChangePercent: Double?,
+    val atlPrice: BigDecimal?,
+    val atlDate: Instant?,
+    val atlChangePercent: Double?,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/MarketChart.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/MarketChart.kt
@@ -1,0 +1,15 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigDecimal
+
+/** A single price sample: milliseconds since epoch paired with the price at that time. */
+data class MarketChartPoint(val timestampMillis: Long, val price: BigDecimal)
+
+/**
+ * A downsampled price series for one [ChartRange], with the percent change from the first to the
+ * last point — used to tint the chart green/red and show the range's headline change.
+ */
+data class MarketChart(val points: List<MarketChartPoint>, val changePercent: Double) {
+    val isPositive: Boolean
+        get() = changePercent >= 0.0
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -96,6 +96,12 @@ internal interface RepositoriesModule {
 
     @Binds
     @Singleton
+    fun bindTokenPriceChartRepository(
+        impl: TokenPriceChartRepositoryImpl
+    ): TokenPriceChartRepository
+
+    @Binds
+    @Singleton
     fun bindAppLocaleRepository(impl: AppLocaleRepositoryImpl): AppLocaleRepository
 
     @Binds

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
@@ -1,0 +1,142 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.CoinGeckoApi
+import com.vultisig.wallet.data.api.models.CoinMarketStatsJson
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.CoinMarketStats
+import com.vultisig.wallet.data.models.MarketChart
+import com.vultisig.wallet.data.models.hasMarketDataSource
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.utils.DEFAULT_MAX_CHART_POINTS
+import com.vultisig.wallet.data.utils.TtlCache
+import com.vultisig.wallet.data.utils.changePercent
+import com.vultisig.wallet.data.utils.decodeMarketChartPoints
+import com.vultisig.wallet.data.utils.downsampleChartPoints
+import java.time.Instant
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+interface TokenPriceChartRepository {
+
+    /**
+     * Returns the price series for [coin] over [range] in [currency], or null when the coin has no
+     * CoinGecko source ([Coin.hasMarketDataSource] is false), CoinGecko has fewer than 2 points of
+     * history for it (too new/unindexed to plot a line), or the fetch failed with nothing cached to
+     * fall back on.
+     */
+    suspend fun getChart(coin: Coin, range: ChartRange, currency: AppCurrency): MarketChart?
+
+    /**
+     * Returns market stats/price-extremes for [coin] in [currency], or null when the coin has no
+     * CoinGecko price-provider id (CoinGecko's `/coins/markets` has no contract-address variant) or
+     * the fetch failed with nothing cached to fall back on.
+     */
+    suspend fun getStats(coin: Coin, currency: AppCurrency): CoinMarketStats?
+}
+
+private data class ChartCacheKey(val coinId: String, val range: ChartRange, val currency: String)
+
+private data class StatsCacheKey(val coinId: String, val currency: String)
+
+internal class TokenPriceChartRepositoryImpl
+@Inject
+constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository {
+
+    private val chartCache = TtlCache<ChartCacheKey, MarketChart>()
+    private val statsCache = TtlCache<StatsCacheKey, CoinMarketStats>()
+
+    override suspend fun getChart(
+        coin: Coin,
+        range: ChartRange,
+        currency: AppCurrency,
+    ): MarketChart? {
+        if (!coin.hasMarketDataSource) return null
+        val key = ChartCacheKey(coin.id, range, currency.ticker)
+        val result =
+            try {
+                chartCache.getOrPut(key, range.cacheTtlMillis) { fetchChart(coin, range, currency) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Timber.e(e, "Failed to fetch market chart for %s", coin.id)
+                // Fail open to the last-good series rather than a blank/error chart.
+                chartCache.peekStale(key)
+            }
+        // A brand-new or delisted coin can genuinely 200 with 0-1 price points; PriceChartCanvas
+        // needs at least 2 to draw a line, so treat that the same as "no data" rather than an
+        // empty-but-non-null chart.
+        return result?.takeIf { it.points.size >= 2 }
+    }
+
+    private suspend fun fetchChart(
+        coin: Coin,
+        range: ChartRange,
+        currency: AppCurrency,
+    ): MarketChart {
+        val currencyTicker = currency.ticker.lowercase()
+        val response =
+            if (coin.priceProviderID.isNotEmpty()) {
+                coinGeckoApi.getMarketChart(coin.priceProviderID, currencyTicker, range.days)
+            } else {
+                coinGeckoApi.getContractMarketChart(
+                    coin.chain,
+                    coin.contractAddress,
+                    currencyTicker,
+                    range.days,
+                )
+            }
+        val points =
+            downsampleChartPoints(
+                decodeMarketChartPoints(response.prices),
+                DEFAULT_MAX_CHART_POINTS,
+            )
+        return MarketChart(points = points, changePercent = changePercent(points))
+    }
+
+    override suspend fun getStats(coin: Coin, currency: AppCurrency): CoinMarketStats? {
+        if (coin.priceProviderID.isEmpty()) return null
+        val key = StatsCacheKey(coin.id, currency.ticker)
+        return try {
+            statsCache.getOrPut(key, STATS_CACHE_TTL_MILLIS) { fetchStats(coin, currency) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Timber.e(e, "Failed to fetch market stats for %s", coin.id)
+            statsCache.peekStale(key)
+        }
+    }
+
+    private suspend fun fetchStats(coin: Coin, currency: AppCurrency): CoinMarketStats {
+        val json =
+            coinGeckoApi
+                .getMarketStats(coin.priceProviderID, currency.ticker.lowercase())
+                .firstOrNull() ?: error("No market stats for ${coin.priceProviderID}")
+        return json.toDomain()
+    }
+
+    private companion object {
+        private const val STATS_CACHE_TTL_MILLIS = 60_000L
+    }
+}
+
+private fun CoinMarketStatsJson.toDomain(): CoinMarketStats =
+    CoinMarketStats(
+        marketCap = marketCap,
+        marketCapRank = marketCapRank,
+        fullyDilutedValuation = fullyDilutedValuation,
+        volume24h = totalVolume,
+        circulatingSupply = circulatingSupply,
+        maxSupply = maxSupply,
+        low24h = low24h,
+        high24h = high24h,
+        athPrice = ath,
+        athDate = athDate?.toInstantOrNull(),
+        athChangePercent = athChangePercentage,
+        atlPrice = atl,
+        atlDate = atlDate?.toInstantOrNull(),
+        atlChangePercent = atlChangePercentage,
+    )
+
+private fun String.toInstantOrNull(): Instant? = runCatching { Instant.parse(this) }.getOrNull()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.MarketChart
 import com.vultisig.wallet.data.models.hasMarketDataSource
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.utils.DEFAULT_MAX_CHART_POINTS
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.TtlCache
 import com.vultisig.wallet.data.utils.changePercent
 import com.vultisig.wallet.data.utils.decodeMarketChartPoints
@@ -59,7 +60,7 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
                 chartCache.getOrPut(key, range.cacheTtlMillis) { fetchChart(coin, range, currency) }
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Throwable) {
+            } catch (e: NetworkException) {
                 Timber.e(e, "Failed to fetch market chart for %s", coin.id)
                 // Fail open to the last-good series rather than a blank/error chart.
                 chartCache.peekStale(key)
@@ -102,9 +103,13 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
             statsCache.getOrPut(key, STATS_CACHE_TTL_MILLIS) { fetchStats(coin, currency) }
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
+        } catch (e: NetworkException) {
             Timber.e(e, "Failed to fetch market stats for %s", coin.id)
             statsCache.peekStale(key)
+        } catch (e: NoSuchElementException) {
+            // CoinGecko genuinely has no markets entry for this coin (e.g. delisted) — not a
+            // failure to fail open from, just no stats to show.
+            null
         }
     }
 
@@ -112,7 +117,8 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
         val json =
             coinGeckoApi
                 .getMarketStats(coin.priceProviderID, currency.ticker.lowercase())
-                .firstOrNull() ?: error("No market stats for ${coin.priceProviderID}")
+                .firstOrNull()
+                ?: throw NoSuchElementException("No market stats for ${coin.priceProviderID}")
         return json.toDomain()
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepository.kt
@@ -17,6 +17,8 @@ import com.vultisig.wallet.data.utils.downsampleChartPoints
 import java.time.Instant
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 interface TokenPriceChartRepository {
@@ -40,6 +42,13 @@ interface TokenPriceChartRepository {
 private data class ChartCacheKey(val coinId: String, val range: ChartRange, val currency: String)
 
 private data class StatsCacheKey(val coinId: String, val currency: String)
+
+/**
+ * Signals that CoinGecko's markets response for a coin was genuinely empty (e.g. a delisted coin) —
+ * a dedicated type rather than a generic [NoSuchElementException], so this catch can never
+ * accidentally swallow an unrelated bug that happens to throw the same standard-library exception.
+ */
+private class NoMarketStatsException(coinId: String) : Exception("No market stats for $coinId")
 
 internal class TokenPriceChartRepositoryImpl
 @Inject
@@ -88,12 +97,17 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
                     range.days,
                 )
             }
-        val points =
-            downsampleChartPoints(
-                decodeMarketChartPoints(response.prices),
-                DEFAULT_MAX_CHART_POINTS,
-            )
-        return MarketChart(points = points, changePercent = changePercent(points))
+        // CoinGecko can return thousands of raw points (e.g. the ALL range); decoding each into a
+        // BigDecimal and sorting the full series is real CPU work that must not run on the
+        // caller's dispatcher (viewModelScope defaults to Dispatchers.Main.immediate).
+        return withContext(Dispatchers.Default) {
+            val points =
+                downsampleChartPoints(
+                    decodeMarketChartPoints(response.prices),
+                    DEFAULT_MAX_CHART_POINTS,
+                )
+            MarketChart(points = points, changePercent = changePercent(points))
+        }
     }
 
     override suspend fun getStats(coin: Coin, currency: AppCurrency): CoinMarketStats? {
@@ -106,7 +120,7 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
         } catch (e: NetworkException) {
             Timber.e(e, "Failed to fetch market stats for %s", coin.id)
             statsCache.peekStale(key)
-        } catch (e: NoSuchElementException) {
+        } catch (_: NoMarketStatsException) {
             // CoinGecko genuinely has no markets entry for this coin (e.g. delisted) — not a
             // failure to fail open from, just no stats to show.
             null
@@ -117,8 +131,7 @@ constructor(private val coinGeckoApi: CoinGeckoApi) : TokenPriceChartRepository 
         val json =
             coinGeckoApi
                 .getMarketStats(coin.priceProviderID, currency.ticker.lowercase())
-                .firstOrNull()
-                ?: throw NoSuchElementException("No market stats for ${coin.priceProviderID}")
+                .firstOrNull() ?: throw NoMarketStatsException(coin.priceProviderID)
         return json.toDomain()
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/ChartDownsampler.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/ChartDownsampler.kt
@@ -4,18 +4,18 @@ package com.vultisig.wallet.data.utils
  * Downsamples [points] to at most [maxPoints] entries, always preserving the first and last point.
  * CoinGecko's free tier derives point density from the requested range (169 points for 1W, up to
  * ~4800 for ALL), so the chart/scrub UI needs a bounded, evenly-spaced series regardless of range.
+ *
+ * The generator expression below already lands exactly on index 0 for `i=0` and exactly on the last
+ * index for `i=maxPoints-1`: both products stay well within a Double's exact-integer range for any
+ * realistic point count, so IEEE-754 division introduces no rounding there — no separate first/last
+ * overwrite is needed.
  */
 fun <T> downsampleChartPoints(points: List<T>, maxPoints: Int = DEFAULT_MAX_CHART_POINTS): List<T> {
     require(maxPoints >= 2) { "maxPoints must be at least 2" }
     if (points.size <= maxPoints) return points
 
     val lastIndex = points.size - 1
-    val result =
-        List(maxPoints) { i -> points[(i * lastIndex.toDouble() / (maxPoints - 1)).toInt()] }
-            .toMutableList()
-    result[0] = points[0]
-    result[result.lastIndex] = points[lastIndex]
-    return result
+    return List(maxPoints) { i -> points[(i * lastIndex.toDouble() / (maxPoints - 1)).toInt()] }
 }
 
 const val DEFAULT_MAX_CHART_POINTS = 300

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/ChartDownsampler.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/ChartDownsampler.kt
@@ -1,0 +1,21 @@
+package com.vultisig.wallet.data.utils
+
+/**
+ * Downsamples [points] to at most [maxPoints] entries, always preserving the first and last point.
+ * CoinGecko's free tier derives point density from the requested range (169 points for 1W, up to
+ * ~4800 for ALL), so the chart/scrub UI needs a bounded, evenly-spaced series regardless of range.
+ */
+fun <T> downsampleChartPoints(points: List<T>, maxPoints: Int = DEFAULT_MAX_CHART_POINTS): List<T> {
+    require(maxPoints >= 2) { "maxPoints must be at least 2" }
+    if (points.size <= maxPoints) return points
+
+    val lastIndex = points.size - 1
+    val result =
+        List(maxPoints) { i -> points[(i * lastIndex.toDouble() / (maxPoints - 1)).toInt()] }
+            .toMutableList()
+    result[0] = points[0]
+    result[result.lastIndex] = points[lastIndex]
+    return result
+}
+
+const val DEFAULT_MAX_CHART_POINTS = 300

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoder.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.utils
 
 import com.vultisig.wallet.data.models.MarketChartPoint
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * Decodes CoinGecko's `market_chart` `prices` array (`[[msEpoch, price], ...]`) into
@@ -29,7 +30,7 @@ fun changePercent(points: List<MarketChartPoint>): Double {
     if (first.signum() == 0) return 0.0
     return last
         .subtract(first)
-        .divide(first, 10, java.math.RoundingMode.HALF_UP)
+        .divide(first, 10, RoundingMode.HALF_UP)
         .multiply(BigDecimal(100))
         .toDouble()
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoder.kt
@@ -1,0 +1,35 @@
+package com.vultisig.wallet.data.utils
+
+import com.vultisig.wallet.data.models.MarketChartPoint
+import java.math.BigDecimal
+
+/**
+ * Decodes CoinGecko's `market_chart` `prices` array (`[[msEpoch, price], ...]`) into
+ * [MarketChartPoint]s, sorted ascending by time. Sub-arrays with fewer than 2 elements are dropped
+ * rather than crashing — CoinGecko's free tier has been observed to return short/malformed entries.
+ */
+fun decodeMarketChartPoints(raw: List<List<Double>>): List<MarketChartPoint> =
+    raw.mapNotNull { pair ->
+            if (pair.size < 2) return@mapNotNull null
+            MarketChartPoint(
+                timestampMillis = pair[0].toLong(),
+                price = BigDecimal.valueOf(pair[1]),
+            )
+        }
+        .sortedBy { it.timestampMillis }
+
+/**
+ * The percent change from the first to the last point in [points], used to tint the chart and show
+ * the range's headline change. Zero when there are fewer than 2 points or the first price is zero
+ * (avoids a division by zero).
+ */
+fun changePercent(points: List<MarketChartPoint>): Double {
+    val first = points.firstOrNull()?.price ?: return 0.0
+    val last = points.lastOrNull()?.price ?: return 0.0
+    if (first.signum() == 0) return 0.0
+    return last
+        .subtract(first)
+        .divide(first, 10, java.math.RoundingMode.HALF_UP)
+        .multiply(BigDecimal(100))
+        .toDouble()
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.data.utils
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Generic in-memory TTL cache with per-key in-flight request coalescing: concurrent callers for the
+ * same key while a fetch is already running all await that same fetch instead of firing duplicate
+ * loads (e.g. a double-tap on a chart range).
+ */
+class TtlCache<K : Any, V> {
+    private class Entry<V>(val value: V, val expiresAt: Long)
+
+    /**
+     * A coalesced follower must never see the initiating caller's own [CancellationException] as if
+     * it were its own cancellation (that would make the follower's coroutine silently complete as
+     * Cancelled per structured-concurrency rules, even though it was never itself cancelled).
+     * Wrapping it in a plain [Exception] lets a follower's [CompletableDeferred.await] fail open
+     * instead.
+     */
+    private class CoalescedFetchCancelledException(cause: Throwable) :
+        Exception("A concurrent fetch for this key was cancelled before completing", cause)
+
+    private val mutex = Mutex()
+    private val entries = mutableMapOf<K, Entry<V>>()
+    private val inFlight = mutableMapOf<K, CompletableDeferred<V>>()
+
+    private sealed interface Lookup<out V> {
+        data class Hit<V>(val value: V) : Lookup<V>
+
+        data class Await<V>(val deferred: CompletableDeferred<V>) : Lookup<V>
+
+        data class Start<V>(val deferred: CompletableDeferred<V>) : Lookup<V>
+    }
+
+    /**
+     * Returns the cached value for [key] if it hasn't expired, otherwise runs [loader] (coalescing
+     * concurrent callers for the same key) and caches the result for [ttlMillis].
+     *
+     * [now] defaults to a monotonic clock (immune to wall-clock/NTP adjustments) rather than
+     * [System.currentTimeMillis], so TTL expiry tracks elapsed time, not wall-clock time.
+     */
+    suspend fun getOrPut(
+        key: K,
+        ttlMillis: Long,
+        now: Long = System.nanoTime() / 1_000_000,
+        loader: suspend () -> V,
+    ): V {
+        val lookup =
+            mutex.withLock {
+                val fresh = entries[key]?.takeIf { it.expiresAt > now }
+                when {
+                    fresh != null -> Lookup.Hit(fresh.value)
+                    inFlight[key] != null -> Lookup.Await(inFlight.getValue(key))
+                    else -> {
+                        val deferred = CompletableDeferred<V>()
+                        inFlight[key] = deferred
+                        Lookup.Start(deferred)
+                    }
+                }
+            }
+
+        return when (lookup) {
+            is Lookup.Hit -> lookup.value
+            is Lookup.Await -> lookup.deferred.await()
+            is Lookup.Start -> {
+                try {
+                    val value = loader()
+                    mutex.withLock {
+                        entries[key] = Entry(value, now + ttlMillis)
+                        inFlight.remove(key)
+                    }
+                    lookup.deferred.complete(value)
+                    value
+                } catch (e: CancellationException) {
+                    // Cleanup must run even if this coroutine is already cancelling, otherwise the
+                    // key is orphaned in inFlight forever and every future caller awaits a deferred
+                    // that will never complete.
+                    withContext(NonCancellable) { mutex.withLock { inFlight.remove(key) } }
+                    lookup.deferred.completeExceptionally(CoalescedFetchCancelledException(e))
+                    throw e
+                } catch (e: Throwable) {
+                    withContext(NonCancellable) { mutex.withLock { inFlight.remove(key) } }
+                    lookup.deferred.completeExceptionally(e)
+                    throw e
+                }
+            }
+        }
+    }
+
+    /** Returns the last cached value for [key] regardless of expiry, or null if never cached. */
+    suspend fun peekStale(key: K): V? = mutex.withLock { entries[key]?.value }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
@@ -68,7 +68,16 @@ class TtlCache<K : Any, V> {
 
         return when (lookup) {
             is Lookup.Hit -> lookup.value
-            is Lookup.Await -> lookup.deferred.await()
+            is Lookup.Await ->
+                try {
+                    lookup.deferred.await()
+                } catch (_: CoalescedFetchCancelledException) {
+                    // The fetch we were coalescing with was cancelled by whoever started it, not
+                    // by us — that isn't a real outcome to fail open on, so retry as a fresh
+                    // attempt instead of silently defeating the fail-open-to-stale contract for
+                    // every follower coalesced on it.
+                    getOrPut(key, ttlMillis, nowMillis, loader)
+                }
             is Lookup.Start -> {
                 try {
                     val value = loader()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/TtlCache.kt
@@ -41,18 +41,20 @@ class TtlCache<K : Any, V> {
      * Returns the cached value for [key] if it hasn't expired, otherwise runs [loader] (coalescing
      * concurrent callers for the same key) and caches the result for [ttlMillis].
      *
-     * [now] defaults to a monotonic clock (immune to wall-clock/NTP adjustments) rather than
-     * [System.currentTimeMillis], so TTL expiry tracks elapsed time, not wall-clock time.
+     * [nowMillis] defaults to a monotonic clock (immune to wall-clock/NTP adjustments) rather than
+     * [System.currentTimeMillis], so TTL expiry tracks elapsed time, not wall-clock time. Taken as
+     * a function (read again after [loader] completes) rather than a single snapshot, so a slow
+     * fetch doesn't shrink the entry's freshness window by its own latency.
      */
     suspend fun getOrPut(
         key: K,
         ttlMillis: Long,
-        now: Long = System.nanoTime() / 1_000_000,
+        nowMillis: () -> Long = { System.nanoTime() / 1_000_000 },
         loader: suspend () -> V,
     ): V {
         val lookup =
             mutex.withLock {
-                val fresh = entries[key]?.takeIf { it.expiresAt > now }
+                val fresh = entries[key]?.takeIf { it.expiresAt > nowMillis() }
                 when {
                     fresh != null -> Lookup.Hit(fresh.value)
                     inFlight[key] != null -> Lookup.Await(inFlight.getValue(key))
@@ -71,7 +73,7 @@ class TtlCache<K : Any, V> {
                 try {
                     val value = loader()
                     mutex.withLock {
-                        entries[key] = Entry(value, now + ttlMillis)
+                        entries[key] = Entry(value, nowMillis() + ttlMillis)
                         inFlight.remove(key)
                     }
                     lookup.deferred.complete(value)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
@@ -68,6 +68,17 @@ internal class CoinGeckoApiMarketChartTest {
     }
 
     @Test
+    fun `getMarketChart percent-encodes an id instead of letting it redirect the path`() = runTest {
+        val (api, url) = apiCapturingUrl("""{"prices":[]}""")
+
+        // priceProviderID can come from remote, untrusted data (e.g. a Solana token list's
+        // extensions.coingeckoId), not just a hardcoded table.
+        api.getMarketChart(id = "abc/../evil", currency = "usd", days = "1")
+
+        assertContains(url(), "/coins/abc%2F..%2Fevil/market_chart")
+    }
+
+    @Test
     fun `getContractMarketChart routes through the chain's CoinGecko platform id`() = runTest {
         val (api, url) = apiCapturingUrl("""{"prices":[]}""")
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
@@ -84,6 +84,21 @@ internal class CoinGeckoApiMarketChartTest {
     }
 
     @Test
+    fun `getContractMarketChart percent-encodes a contract address instead of letting it redirect the path`() =
+        runTest {
+            val (api, url) = apiCapturingUrl("""{"prices":[]}""")
+
+            api.getContractMarketChart(
+                chain = Chain.Base,
+                contractAddress = "0xabc/../evil",
+                currency = "usd",
+                days = "1",
+            )
+
+            assertContains(url(), "/coins/base/contract/0xabc%2F..%2Fevil/market_chart")
+        }
+
+    @Test
     fun `getMarketStats lowercases the id and queries the markets endpoint`() = runTest {
         val (api, url) = apiCapturingUrl("""[{"market_cap":1000000}]""")
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiMarketChartTest.kt
@@ -1,0 +1,138 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.utils.BigDecimalSerializerImpl
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import java.math.BigDecimal
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the market-chart/markets-stats endpoints added for issue #5428, following the
+ * URL-capturing pattern established in [CoinGeckoApiContractPriceChainTest].
+ */
+internal class CoinGeckoApiMarketChartTest {
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    // Mirrors production's Json (DataModule.provideJson): CoinMarketStatsJson has @Contextual
+    // BigDecimal fields, which need this registered to deserialize at all.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        serializersModule = SerializersModule {
+            contextual(BigDecimal::class, BigDecimalSerializerImpl())
+        }
+    }
+
+    private fun apiCapturingUrl(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): Pair<CoinGeckoApi, () -> String> {
+        var requestedUrl = ""
+        val engine = MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(content = body, status = status, headers = jsonHeaders)
+        }
+        val api =
+            CoinGeckoApiImpl(HttpClient(engine) { install(ContentNegotiation) { json(json) } })
+        return api to { requestedUrl }
+    }
+
+    @Test
+    fun `getMarketChart lowercases the id and forwards currency and days`() = runTest {
+        val (api, url) = apiCapturingUrl("""{"prices":[[1000,100.0],[2000,101.0]]}""")
+
+        val result = api.getMarketChart(id = "Bitcoin", currency = "usd", days = "1")
+
+        assertContains(url(), "/coins/bitcoin/market_chart")
+        assertContains(url(), "vs_currency=usd")
+        assertContains(url(), "days=1")
+        assertEquals(listOf(listOf(1000.0, 100.0), listOf(2000.0, 101.0)), result.prices)
+    }
+
+    @Test
+    fun `getContractMarketChart routes through the chain's CoinGecko platform id`() = runTest {
+        val (api, url) = apiCapturingUrl("""{"prices":[]}""")
+
+        api.getContractMarketChart(
+            chain = Chain.Base,
+            contractAddress = "0xabc123",
+            currency = "usd",
+            days = "max",
+        )
+
+        assertContains(url(), "/coins/base/contract/0xabc123/market_chart")
+        assertContains(url(), "vs_currency=usd")
+        assertContains(url(), "days=max")
+    }
+
+    @Test
+    fun `getMarketStats lowercases the id and queries the markets endpoint`() = runTest {
+        val (api, url) = apiCapturingUrl("""[{"market_cap":1000000}]""")
+
+        api.getMarketStats(id = "Bitcoin", currency = "eur")
+
+        assertContains(url(), "/coins/markets")
+        assertContains(url(), "ids=bitcoin")
+        assertContains(url(), "vs_currency=eur")
+    }
+
+    @Test
+    fun `getMarketChart throws NetworkException on a non-2xx response`() = runTest {
+        val (api, _) = apiCapturingUrl("""{"error":"coin not found"}""", HttpStatusCode.NotFound)
+
+        assertFailsWith<NetworkException> { api.getMarketChart("unknown-coin", "usd", "1") }
+    }
+
+    @Test
+    fun `getMarketStats decodes an empty array without throwing`() = runTest {
+        val (api, _) = apiCapturingUrl("""[]""")
+
+        val result = api.getMarketStats("bitcoin", "usd")
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `getContractMarketChart throws for a chain with no CoinGecko asset id, without reaching the network`() =
+        runTest {
+            var requestAttempted = false
+            val engine = MockEngine {
+                requestAttempted = true
+                respond(
+                    content = """{"prices":[]}""",
+                    status = HttpStatusCode.OK,
+                    headers = jsonHeaders,
+                )
+            }
+            val api =
+                CoinGeckoApiImpl(HttpClient(engine) { install(ContentNegotiation) { json(json) } })
+
+            assertFailsWith<IllegalStateException> {
+                api.getContractMarketChart(
+                    chain = Chain.Sei,
+                    contractAddress = "0xabc123",
+                    currency = "usd",
+                    days = "1",
+                )
+            }
+            assertFalse(requestAttempted, "an unmapped chain must not reach the network")
+        }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepositoryImplTest.kt
@@ -7,11 +7,13 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ChartRange
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.utils.NetworkException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigDecimal
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -99,12 +101,23 @@ internal class TokenPriceChartRepositoryImplTest {
         runTest {
             val token = coin(priceProviderId = "ethereum")
             coEvery { coinGeckoApi.getMarketChart(any(), any(), any()) } throws
-                RuntimeException("network down")
+                NetworkException(500, "network down")
 
             val chart = repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
 
             assertNull(chart)
         }
+
+    @Test
+    fun `getChart propagates a bug instead of silently failing open`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketChart(any(), any(), any()) } throws
+            IllegalStateException("a real bug, not a network failure")
+
+        assertFailsWith<IllegalStateException> {
+            repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+        }
+    }
 
     @Test
     fun `getChart returns null for a genuinely successful response with fewer than 2 points`() =
@@ -122,11 +135,20 @@ internal class TokenPriceChartRepositoryImplTest {
     fun `getStats returns null (no crash) when the network call fails`() = runTest {
         val token = coin(priceProviderId = "ethereum")
         coEvery { coinGeckoApi.getMarketStats(any(), any()) } throws
-            RuntimeException("network down")
+            NetworkException(500, "network down")
 
         val stats = repository.getStats(token, AppCurrency.USD)
 
         assertNull(stats)
+    }
+
+    @Test
+    fun `getStats propagates a bug instead of silently failing open`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketStats(any(), any()) } throws
+            IllegalStateException("a real bug, not a network failure")
+
+        assertFailsWith<IllegalStateException> { repository.getStats(token, AppCurrency.USD) }
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceChartRepositoryImplTest.kt
@@ -1,0 +1,185 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.CoinGeckoApi
+import com.vultisig.wallet.data.api.models.CoinMarketStatsJson
+import com.vultisig.wallet.data.api.models.MarketChartResponseJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.ChartRange
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TokenPriceChartRepositoryImplTest {
+
+    private lateinit var coinGeckoApi: CoinGeckoApi
+    private lateinit var repository: TokenPriceChartRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        coinGeckoApi = mockk()
+        repository = TokenPriceChartRepositoryImpl(coinGeckoApi)
+    }
+
+    private fun coin(priceProviderId: String = "", contractAddress: String = "") =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "TOK",
+            logo = "",
+            address = "",
+            decimal = 18,
+            hexPublicKey = "",
+            priceProviderID = priceProviderId,
+            contractAddress = contractAddress,
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `getChart returns null for a coin with no priceProviderId and no contractAddress`() =
+        runTest {
+            val poolToken = coin()
+
+            val chart = repository.getChart(poolToken, ChartRange.ONE_DAY, AppCurrency.USD)
+
+            assertNull(chart)
+            coVerify(exactly = 0) { coinGeckoApi.getMarketChart(any(), any(), any()) }
+            coVerify(exactly = 0) {
+                coinGeckoApi.getContractMarketChart(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `getChart routes by priceProviderId when present`() = runTest {
+        val token = coin(priceProviderId = "ethereum", contractAddress = "0xabc")
+        coEvery { coinGeckoApi.getMarketChart("ethereum", "usd", "1") } returns
+            MarketChartResponseJson(prices = listOf(listOf(1_000.0, 100.0), listOf(2_000.0, 110.0)))
+
+        val chart = repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+
+        requireNotNull(chart)
+        assertEquals(2, chart.points.size)
+        assertEquals(true, chart.isPositive)
+        coVerify(exactly = 0) { coinGeckoApi.getContractMarketChart(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `getChart routes by contract address when priceProviderId is empty`() = runTest {
+        val token = coin(priceProviderId = "", contractAddress = "0xabc")
+        coEvery { coinGeckoApi.getContractMarketChart(Chain.Ethereum, "0xabc", "usd", "1") } returns
+            MarketChartResponseJson(prices = listOf(listOf(1_000.0, 100.0), listOf(2_000.0, 90.0)))
+
+        val chart = repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+
+        requireNotNull(chart)
+        assertEquals(false, chart.isPositive)
+        coVerify(exactly = 0) { coinGeckoApi.getMarketChart(any(), any(), any()) }
+    }
+
+    @Test
+    fun `getChart caches within the range's TTL, avoiding a second network call`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketChart(any(), any(), any()) } returns
+            MarketChartResponseJson(prices = listOf(listOf(1_000.0, 100.0), listOf(2_000.0, 100.0)))
+
+        repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+        repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+
+        coVerify(exactly = 1) { coinGeckoApi.getMarketChart(any(), any(), any()) }
+    }
+
+    @Test
+    fun `getChart returns null (no crash) when the network call fails and nothing was cached yet`() =
+        runTest {
+            val token = coin(priceProviderId = "ethereum")
+            coEvery { coinGeckoApi.getMarketChart(any(), any(), any()) } throws
+                RuntimeException("network down")
+
+            val chart = repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+
+            assertNull(chart)
+        }
+
+    @Test
+    fun `getChart returns null for a genuinely successful response with fewer than 2 points`() =
+        runTest {
+            val token = coin(priceProviderId = "ethereum")
+            coEvery { coinGeckoApi.getMarketChart(any(), any(), any()) } returns
+                MarketChartResponseJson(prices = listOf(listOf(1_000.0, 100.0)))
+
+            val chart = repository.getChart(token, ChartRange.ONE_DAY, AppCurrency.USD)
+
+            assertNull(chart)
+        }
+
+    @Test
+    fun `getStats returns null (no crash) when the network call fails`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketStats(any(), any()) } throws
+            RuntimeException("network down")
+
+        val stats = repository.getStats(token, AppCurrency.USD)
+
+        assertNull(stats)
+    }
+
+    @Test
+    fun `getStats returns null when priceProviderId is empty`() = runTest {
+        val token = coin(priceProviderId = "", contractAddress = "0xabc")
+
+        val stats = repository.getStats(token, AppCurrency.USD)
+
+        assertNull(stats)
+        coVerify(exactly = 0) { coinGeckoApi.getMarketStats(any(), any()) }
+    }
+
+    @Test
+    fun `getStats maps the first markets entry into the domain model`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketStats("ethereum", "usd") } returns
+            listOf(
+                CoinMarketStatsJson(
+                    marketCap = BigDecimal("1000000"),
+                    marketCapRank = 2,
+                    circulatingSupply = BigDecimal("120000000"),
+                )
+            )
+
+        val stats = repository.getStats(token, AppCurrency.USD)
+
+        requireNotNull(stats)
+        assertEquals(BigDecimal("1000000"), stats.marketCap)
+        assertEquals(2, stats.marketCapRank)
+        assertEquals(BigDecimal("120000000"), stats.circulatingSupply)
+    }
+
+    @Test
+    fun `getStats returns null when the markets response is an empty array`() = runTest {
+        val token = coin(priceProviderId = "ethereum")
+        coEvery { coinGeckoApi.getMarketStats("ethereum", "usd") } returns emptyList()
+
+        val stats = repository.getStats(token, AppCurrency.USD)
+
+        assertNull(stats)
+    }
+
+    @Test
+    fun `getStats nulls a malformed ath_date without dropping the ath price or throwing`() =
+        runTest {
+            val token = coin(priceProviderId = "ethereum")
+            coEvery { coinGeckoApi.getMarketStats("ethereum", "usd") } returns
+                listOf(CoinMarketStatsJson(ath = BigDecimal("100"), athDate = "not-a-date"))
+
+            val stats = repository.getStats(token, AppCurrency.USD)
+
+            requireNotNull(stats)
+            assertEquals(BigDecimal("100"), stats.athPrice)
+            assertNull(stats.athDate)
+        }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/ChartDownsamplerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/ChartDownsamplerTest.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.data.utils
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ChartDownsamplerTest {
+
+    @Test
+    fun `returns the original list unchanged when already within bounds`() {
+        val points = (1..10).toList()
+
+        assertEquals(points, downsampleChartPoints(points, maxPoints = 300))
+    }
+
+    @Test
+    fun `caps the result at maxPoints`() {
+        val points = (1..5_000).toList()
+
+        val result = downsampleChartPoints(points, maxPoints = 300)
+
+        assertTrue(result.size <= 300)
+    }
+
+    @Test
+    fun `always preserves the first and last point`() {
+        val points = (1..5_000).toList()
+
+        val result = downsampleChartPoints(points, maxPoints = 300)
+
+        assertEquals(1, result.first())
+        assertEquals(5_000, result.last())
+    }
+
+    @Test
+    fun `handles the boundary where size equals maxPoints plus one`() {
+        val points = (1..301).toList()
+
+        val result = downsampleChartPoints(points, maxPoints = 300)
+
+        assertEquals(300, result.size)
+        assertEquals(1, result.first())
+        assertEquals(301, result.last())
+    }
+
+    @Test
+    fun `rejects a maxPoints below 2`() {
+        try {
+            downsampleChartPoints(listOf(1, 2, 3), maxPoints = 1)
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (_: IllegalArgumentException) {
+            // expected
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/ChartDownsamplerTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/ChartDownsamplerTest.kt
@@ -44,6 +44,31 @@ internal class ChartDownsamplerTest {
     }
 
     @Test
+    fun `always includes the exact first and last point for awkward (size, maxPoints) pairs`() {
+        // The generator's index formula for i=0 and i=maxPoints-1 relies on IEEE-754 division
+        // being exact for these products, not on an explicit overwrite — deliberately awkward
+        // (non-power-of-two, prime-ish, off-by-one) pairs pin that this holds in general, not just
+        // for the round numbers used elsewhere in this file.
+        val cases =
+            listOf(
+                997 to 37,
+                4_801 to 169, // CoinGecko's own documented raw/target sizes for ALL/1W
+                1_001 to 300,
+                2 to 2,
+                3 to 2,
+            )
+
+        for ((size, maxPoints) in cases) {
+            val points = (1..size).toList()
+
+            val result = downsampleChartPoints(points, maxPoints)
+
+            assertEquals(1, result.first(), "size=$size maxPoints=$maxPoints")
+            assertEquals(size, result.last(), "size=$size maxPoints=$maxPoints")
+        }
+    }
+
+    @Test
     fun `rejects a maxPoints below 2`() {
         try {
             downsampleChartPoints(listOf(1, 2, 3), maxPoints = 1)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/MarketChartDecoderTest.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.data.utils
+
+import com.vultisig.wallet.data.models.MarketChartPoint
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class MarketChartDecoderTest {
+
+    @Test
+    fun `decodes well-formed price pairs`() {
+        val raw = listOf(listOf(1_000.0, 100.5), listOf(2_000.0, 101.25))
+
+        val points = decodeMarketChartPoints(raw)
+
+        assertEquals(
+            listOf(
+                MarketChartPoint(1_000L, BigDecimal.valueOf(100.5)),
+                MarketChartPoint(2_000L, BigDecimal.valueOf(101.25)),
+            ),
+            points,
+        )
+    }
+
+    @Test
+    fun `returns empty list for an empty input`() {
+        assertTrue(decodeMarketChartPoints(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `drops short sub-arrays instead of crashing`() {
+        val raw = listOf(listOf(1_000.0), listOf(2_000.0, 101.25), emptyList())
+
+        val points = decodeMarketChartPoints(raw)
+
+        assertEquals(listOf(MarketChartPoint(2_000L, BigDecimal.valueOf(101.25))), points)
+    }
+
+    @Test
+    fun `sorts out-of-order pairs ascending by timestamp`() {
+        val raw = listOf(listOf(3_000.0, 103.0), listOf(1_000.0, 101.0), listOf(2_000.0, 102.0))
+
+        val points = decodeMarketChartPoints(raw)
+
+        assertEquals(listOf(1_000L, 2_000L, 3_000L), points.map { it.timestampMillis })
+    }
+
+    @Test
+    fun `changePercent is zero for fewer than two points`() {
+        assertEquals(0.0, changePercent(emptyList()))
+        assertEquals(0.0, changePercent(listOf(MarketChartPoint(1L, BigDecimal.TEN))))
+    }
+
+    @Test
+    fun `changePercent is zero when the first price is zero`() {
+        val points =
+            listOf(MarketChartPoint(1L, BigDecimal.ZERO), MarketChartPoint(2L, BigDecimal.TEN))
+
+        assertEquals(0.0, changePercent(points))
+    }
+
+    @Test
+    fun `changePercent reflects a positive move from first to last point`() {
+        val points =
+            listOf(
+                MarketChartPoint(1L, BigDecimal("100")),
+                MarketChartPoint(2L, BigDecimal("50")),
+                MarketChartPoint(3L, BigDecimal("110")),
+            )
+
+        assertEquals(10.0, changePercent(points))
+    }
+
+    @Test
+    fun `changePercent reflects a negative move from first to last point`() {
+        val points =
+            listOf(MarketChartPoint(1L, BigDecimal("100")), MarketChartPoint(2L, BigDecimal("90")))
+
+        assertEquals(-10.0, changePercent(points))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
@@ -5,8 +5,6 @@ package com.vultisig.wallet.data.utils
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -161,7 +159,7 @@ internal class TtlCacheTest {
         }
 
     @Test
-    fun `a follower observes a real failure instead of hanging when the coalesced leader is cancelled`() =
+    fun `a follower retries its own fetch instead of failing when the coalesced leader is cancelled`() =
         runTest {
             val cache = TtlCache<String, Int>()
             val leaderStarted = CompletableDeferred<Unit>()
@@ -176,16 +174,14 @@ internal class TtlCacheTest {
 
             leaderStarted.await()
 
-            val followerResult = async {
-                runCatching { cache.getOrPut("k", ttlMillis = 1_000) { 2 } }
-            }
+            val followerResult = async { cache.getOrPut("k", ttlMillis = 1_000) { 2 } }
             runCurrent() // let the follower reach Lookup.Await before the leader is cancelled
 
             leaderJob.cancel()
             leaderJob.join()
 
-            val result = followerResult.await()
-            assertTrue(result.isFailure)
-            assertTrue(result.exceptionOrNull() !is CancellationException)
+            // The leader's cancellation isn't a real outcome for the follower to fail open on —
+            // it retries its own fetch rather than silently defeating the fail-open contract.
+            assertEquals(2, followerResult.await())
         }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
@@ -25,12 +25,12 @@ internal class TtlCacheTest {
         val loadCount = AtomicInteger(0)
 
         val first =
-            cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+            cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 0L }) {
                 loadCount.incrementAndGet()
                 42
             }
         val second =
-            cache.getOrPut("k", ttlMillis = 1_000, now = 500L) {
+            cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 500L }) {
                 loadCount.incrementAndGet()
                 99
             }
@@ -45,12 +45,12 @@ internal class TtlCacheTest {
         val cache = TtlCache<String, Int>()
         val loadCount = AtomicInteger(0)
 
-        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+        cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 0L }) {
             loadCount.incrementAndGet()
             42
         }
         val afterExpiry =
-            cache.getOrPut("k", ttlMillis = 1_000, now = 1_001L) {
+            cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 1_001L }) {
                 loadCount.incrementAndGet()
                 99
             }
@@ -90,7 +90,7 @@ internal class TtlCacheTest {
     fun `peekStale returns the last cached value even after expiry`() = runTest {
         val cache = TtlCache<String, Int>()
 
-        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) { 42 }
+        cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 0L }) { 42 }
 
         assertEquals(42, cache.peekStale("k"))
     }
@@ -120,12 +120,12 @@ internal class TtlCacheTest {
         val cache = TtlCache<String, Int>()
         val loadCount = AtomicInteger(0)
 
-        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+        cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 0L }) {
             loadCount.incrementAndGet()
             42
         }
         val atExactExpiry =
-            cache.getOrPut("k", ttlMillis = 1_000, now = 1_000L) {
+            cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 1_000L }) {
                 loadCount.incrementAndGet()
                 99
             }
@@ -133,6 +133,32 @@ internal class TtlCacheTest {
         assertEquals(99, atExactExpiry)
         assertEquals(2, loadCount.get())
     }
+
+    @Test
+    fun `bases the entry's expiry on a clock reading taken after the loader completes, not before`() =
+        runTest {
+            val cache = TtlCache<String, Int>()
+            var currentTime = 0L
+
+            cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { currentTime }) {
+                currentTime = 500L // the loader itself takes 500ms of (real/wall) time to resolve
+                42
+            }
+
+            // A stale (call-start) reading would have set expiresAt to 0 + 1_000 = 1_000, making
+            // this lookup at now=1_200 see the entry as already expired. Reading the clock again
+            // after the loader completes sets expiresAt to 500 + 1_000 = 1_500, so it's still
+            // fresh.
+            val loadCount = AtomicInteger(0)
+            val cachedValue =
+                cache.getOrPut("k", ttlMillis = 1_000, nowMillis = { 1_200L }) {
+                    loadCount.incrementAndGet()
+                    99
+                }
+
+            assertEquals(42, cachedValue)
+            assertEquals(0, loadCount.get())
+        }
 
     @Test
     fun `a follower observes a real failure instead of hanging when the coalesced leader is cancelled`() =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/TtlCacheTest.kt
@@ -1,0 +1,165 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.utils
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class TtlCacheTest {
+
+    @Test
+    fun `caches a fresh value without re-invoking the loader`() = runTest {
+        val cache = TtlCache<String, Int>()
+        val loadCount = AtomicInteger(0)
+
+        val first =
+            cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+                loadCount.incrementAndGet()
+                42
+            }
+        val second =
+            cache.getOrPut("k", ttlMillis = 1_000, now = 500L) {
+                loadCount.incrementAndGet()
+                99
+            }
+
+        assertEquals(42, first)
+        assertEquals(42, second)
+        assertEquals(1, loadCount.get())
+    }
+
+    @Test
+    fun `re-invokes the loader once the entry has expired`() = runTest {
+        val cache = TtlCache<String, Int>()
+        val loadCount = AtomicInteger(0)
+
+        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+            loadCount.incrementAndGet()
+            42
+        }
+        val afterExpiry =
+            cache.getOrPut("k", ttlMillis = 1_000, now = 1_001L) {
+                loadCount.incrementAndGet()
+                99
+            }
+
+        assertEquals(99, afterExpiry)
+        assertEquals(2, loadCount.get())
+    }
+
+    @Test
+    fun `coalesces concurrent callers for the same key into a single load`() = runTest {
+        val cache = TtlCache<String, Int>()
+        val loadCount = AtomicInteger(0)
+
+        val result = coroutineScope {
+            val a = async {
+                cache.getOrPut("k", ttlMillis = 1_000) {
+                    loadCount.incrementAndGet()
+                    delay(100)
+                    7
+                }
+            }
+            val b = async {
+                cache.getOrPut("k", ttlMillis = 1_000) {
+                    loadCount.incrementAndGet()
+                    delay(100)
+                    8
+                }
+            }
+            listOf(a.await(), b.await())
+        }
+
+        assertEquals(listOf(7, 7), result)
+        assertEquals(1, loadCount.get())
+    }
+
+    @Test
+    fun `peekStale returns the last cached value even after expiry`() = runTest {
+        val cache = TtlCache<String, Int>()
+
+        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) { 42 }
+
+        assertEquals(42, cache.peekStale("k"))
+    }
+
+    @Test
+    fun `peekStale returns null when the key was never cached`() = runTest {
+        val cache = TtlCache<String, Int>()
+
+        assertEquals(null, cache.peekStale("missing"))
+    }
+
+    @Test
+    fun `a failing loader propagates to the caller and does not poison the cache`() = runTest {
+        val cache = TtlCache<String, Int>()
+
+        assertFailsWith<IllegalStateException> {
+            cache.getOrPut("k", ttlMillis = 1_000) { error("boom") }
+        }
+
+        // A subsequent call retries the loader rather than replaying the failure.
+        val value = cache.getOrPut("k", ttlMillis = 1_000) { 42 }
+        assertEquals(42, value)
+    }
+
+    @Test
+    fun `treats now equal to expiresAt as already expired`() = runTest {
+        val cache = TtlCache<String, Int>()
+        val loadCount = AtomicInteger(0)
+
+        cache.getOrPut("k", ttlMillis = 1_000, now = 0L) {
+            loadCount.incrementAndGet()
+            42
+        }
+        val atExactExpiry =
+            cache.getOrPut("k", ttlMillis = 1_000, now = 1_000L) {
+                loadCount.incrementAndGet()
+                99
+            }
+
+        assertEquals(99, atExactExpiry)
+        assertEquals(2, loadCount.get())
+    }
+
+    @Test
+    fun `a follower observes a real failure instead of hanging when the coalesced leader is cancelled`() =
+        runTest {
+            val cache = TtlCache<String, Int>()
+            val leaderStarted = CompletableDeferred<Unit>()
+
+            val leaderJob = launch {
+                cache.getOrPut("k", ttlMillis = 1_000) {
+                    leaderStarted.complete(Unit)
+                    delay(10_000)
+                    1
+                }
+            }
+
+            leaderStarted.await()
+
+            val followerResult = async {
+                runCatching { cache.getOrPut("k", ttlMillis = 1_000) { 2 } }
+            }
+            runCurrent() // let the follower reach Lookup.Await before the leader is cancelled
+
+            leaderJob.cancel()
+            leaderJob.join()
+
+            val result = followerResult.await()
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() !is CancellationException)
+        }
+}


### PR DESCRIPTION
## Summary

- Adds a CoinGecko-backed price chart (1D/1W/1M/1Y/ALL ranges, drag-to-scrub) to the token detail screen
- Adds market stats (market cap, rank, FDV, volume, supply) and price extremes (24h low/high, all-time high/low) sections
- Adds a token info section (contract address, decimals)
- Chart/stats sections are gated to coins with a genuine CoinGecko source (price-provider id, or a contract address on a chain CoinGecko's contract-lookup endpoint actually supports) — pool-priced and unsupported-chain tokens never show an empty/broken chart box
- Chart and stats fetches are cached per (coin, range, currency) with in-flight request coalescing, and fail open to the last-good series on a transient failure without ever relabeling stale data as belonging to a different range or currency
- A CoinGecko response with fewer than 2 price points (new/unindexed coins) is treated the same as no data

## Screenshots from testing

| ![Screenshot 1](https://github.com/user-attachments/assets/94576722-c6a4-4816-8906-a02fb4ee2fbe) | ![Screenshot 2](https://github.com/user-attachments/assets/2f721291-ad5b-415d-bd18-6a66913ac5bd) | ![Screenshot 3](https://github.com/user-attachments/assets/0c788f64-55c8-4202-9239-c157a31f437f) | ![Screenshot 4](https://github.com/user-attachments/assets/d523c50d-fb99-4357-b4fc-6a6504a54dd0) |
| :---: | :---: | :---: | :---: |
| ![Screenshot 5](https://github.com/user-attachments/assets/598377b7-1379-496b-8759-efe8076a7451) | ![Screenshot 6](https://github.com/user-attachments/assets/68b2e508-2597-43b4-8002-95e9e6aa1116) | ![Screenshot 7](https://github.com/user-attachments/assets/3a4615b2-bb48-4439-b574-4b2157400309) | ![Screenshot 8](https://github.com/user-attachments/assets/3365461b-147d-4d9d-9162-83fee55a1a27) |

## Test plan

- [ ] Open a token with a CoinGecko price-provider id or supported contract address — verify the chart loads, range switching works, and drag-to-scrub shows price/date
- [ ] Switch app currency, verify it re-fetches in the new currency
- [ ] Open a pool-priced token (e.g. a THORChain/Maya pool asset) — verify no chart/stats section appears
- [ ] Verify `:app:testDebugUnitTest` and `:data:testDebugUnitTest` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an interactive token price chart with selectable time ranges and drag-to-scrub.
  * Added token market data sections: market stats, 24h & all-time price extremes, and token info (including copyable contract address).
  * Migrated the token details screen to a new scaffold layout with updated sections and callbacks.
  * Added localized UI text for the chart/market data, limit-order flow, and send/notification messaging.

* **Bug Fixes**
  * Improved chart and market-stats loading resilience with stale-data fallback and better handling of missing/empty data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->