### PR TITLE
fix(sui): intent-wrap the custom-message digest so co-signing converges

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelper.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.common.toKeccak256ByteArray
 import com.vultisig.wallet.data.common.toSha256ByteArray
 import com.vultisig.wallet.data.common.toSha512ByteArray
+import com.vultisig.wallet.data.common.toSuiPersonalMessageDigest
 import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.crypto.TonHelper
@@ -70,12 +71,16 @@ object SigningHelper {
         //  - Ripple (XRPL GemWallet signMessage / ripple-keypairs) signs SHA-512-half — the
         //    first 32 bytes of SHA-512 — of the message bytes. keccak256 here diverges from
         //    the extension initiator's digest and cross-platform co-signing 404s.
+        //  - Sui is EdDSA but is *not* a raw passthrough: the Wallet Standard
+        //    signPersonalMessage/signMessage digest is intent-wrapped and BCS-length-prefixed,
+        //    so it must be carved out ahead of the EdDSA branch below.
         //  - Everything else (EVM, Tron) signs the keccak256.
         val bytes =
             when {
                 chain?.standard == TokenStandard.COSMOS ||
                     chain?.standard == TokenStandard.THORCHAIN -> processedBytes.toSha256ByteArray()
                 chain == Chain.Ripple -> processedBytes.toSha512ByteArray().copyOf(32)
+                chain == Chain.Sui -> processedBytes.toSuiPersonalMessageDigest()
                 chain?.TssKeysignType == TssKeyType.EDDSA -> processedBytes
                 else -> processedBytes.toKeccak256ByteArray()
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/common/ByteArrayExtensions.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.common
 import com.google.protobuf.ByteString
 import com.vultisig.wallet.data.utils.Numeric
 import java.security.MessageDigest
+import org.bouncycastle.crypto.digests.Blake2bDigest
 import org.bouncycastle.jcajce.provider.digest.Keccak
 
 fun ByteArray.toKeccak256(): String {
@@ -21,6 +22,44 @@ fun ByteArray.toSha256ByteArray(): ByteArray {
 fun ByteArray.toSha512ByteArray(): ByteArray {
     return MessageDigest.getInstance("SHA-512").digest(this)
 }
+
+/**
+ * Sui Wallet Standard `signPersonalMessage` / `signMessage` digest: `blake2b_256(intent ||
+ * bcs(message))`.
+ *
+ * The intent prefix is `[scope, version, appId]` = `[PersonalMessage(3), V0(0), Sui(0)]`, and the
+ * message is BCS-encoded as `vector<u8>` — a ULEB128 length prefix followed by the raw bytes.
+ * Mirrors `@mysten/sui`'s `signPersonalMessage` (`messageWithIntent('PersonalMessage',
+ * bcs.byteVector().serialize(bytes))` then `blake2b(_, dkLen = 32)`) and the vultisig-windows
+ * initiator's `getSuiPersonalMessageDigest`. Signing the raw bytes instead — which every other
+ * EdDSA chain correctly does — diverges from the initiator's digest, so the MPC round never
+ * converges.
+ *
+ * Note this is a different intent scope from a built Sui transaction (PTB), which uses
+ * `TransactionData(0)` and no BCS wrap; see `SwapKitSuiSigner.digest`.
+ */
+fun ByteArray.toSuiPersonalMessageDigest(): ByteArray {
+    val intentMessage = SUI_PERSONAL_MESSAGE_INTENT + ulebEncode(size) + this
+    val blake = Blake2bDigest(SUI_DIGEST_SIZE_BITS)
+    blake.update(intentMessage, 0, intentMessage.size)
+    return ByteArray(blake.digestSize).also { blake.doFinal(it, 0) }
+}
+
+/** BCS ULEB128 length prefix — 7 payload bits per byte, high bit set while more bytes follow. */
+private fun ulebEncode(value: Int): ByteArray {
+    val out = ArrayList<Byte>()
+    var remaining = value
+    while (remaining >= 0x80) {
+        out.add(((remaining and 0x7F) or 0x80).toByte())
+        remaining = remaining ushr 7
+    }
+    out.add((remaining and 0x7F).toByte())
+    return out.toByteArray()
+}
+
+private val SUI_PERSONAL_MESSAGE_INTENT = byteArrayOf(0x03, 0x00, 0x00)
+
+private const val SUI_DIGEST_SIZE_BITS = 256
 
 fun ByteArray.toByteString(): ByteString {
     return ByteString.copyFrom(this)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SigningHelperCustomMessageTest.kt
@@ -124,6 +124,68 @@ class SigningHelperCustomMessageTest {
     }
 
     @Test
+    fun `Sui digest is byte-identical to the vultisig-windows extension contract`() {
+        // Pinned reference vectors produced by the canonical initiator implementation
+        // (@vultisig/core-chain `getSuiPersonalMessageDigest`, which getCustomMessageHex.ts's
+        // `sui` branch calls): blake2b_256([0x03,0x00,0x00] || uleb128(len) || message).
+        val utf8Payload =
+            CustomMessagePayload(
+                method = "sui_signPersonalMessage",
+                message = "Hello Vultisig",
+                chain = "Sui",
+            )
+        SigningHelper.getKeysignMessages(utf8Payload) shouldBe
+            listOf("4a140032aaf9e5699dc678b2caf2687349a2a6ac1103cdba6a2d3f462ca21182")
+
+        // "0x56756c7469736967" decodes to the ASCII bytes of "Vultisig" before wrapping.
+        val hexPayload =
+            CustomMessagePayload(
+                method = "sui_signPersonalMessage",
+                message = "0x56756c7469736967",
+                chain = "Sui",
+            )
+        SigningHelper.getKeysignMessages(hexPayload) shouldBe
+            listOf("245f3ecbbcca443e43d26989bab5ba55cf03c6db0f9b28a4e12d072b894e83d6")
+    }
+
+    @Test
+    fun `Sui message longer than 127 bytes uses a multi-byte uleb128 length prefix`() {
+        // 200 bytes forces the BCS length prefix to spill to two bytes (0xC8 0x01). A single-byte
+        // encoding would silently truncate the length and diverge from the initiator on exactly
+        // the messages most likely to be real — dApp login challenges are routinely > 127 bytes.
+        val payload =
+            CustomMessagePayload(
+                method = "sui_signPersonalMessage",
+                message = "0x" + "41".repeat(200),
+                chain = "Sui",
+            )
+
+        SigningHelper.getKeysignMessages(payload) shouldBe
+            listOf("a90b2a8fe4149193029c26b2e2000730da6e64f6dee07ccf939142d02ef7ceb6")
+    }
+
+    @Test
+    fun `Sui does not fall through to the raw EdDSA passthrough`() {
+        // Sui's TssKeysignType is EdDSA, so without an explicit carve-out it would sign the raw
+        // message bytes and never converge with the Windows initiator (#5442).
+        val message = "Hello Vultisig"
+        val payload =
+            CustomMessagePayload(
+                method = "sui_signPersonalMessage",
+                message = message,
+                chain = "Sui",
+            )
+
+        val messages = SigningHelper.getKeysignMessages(payload)
+
+        messages shouldNotBe listOf(message.toByteArray().toHexString())
+        messages shouldNotBe
+            SigningHelper.getKeysignMessages(
+                CustomMessagePayload(method = "sign", message = message, chain = "Solana")
+            )
+    }
+
+    @Test
     fun `ECDSA and EdDSA produce different keysign messages for the same hex input`() {
         val hexMessage = "0xabcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
 


### PR DESCRIPTION
Closes #5442

## Problem

Sui is an EdDSA chain, so `SigningHelper.getKeysignMessages(CustomMessagePayload)` matched the generic `chain?.TssKeysignType == TssKeyType.EDDSA -> processedBytes` branch and signed the **raw message bytes**.

The Sui Wallet Standard `signPersonalMessage` / `signMessage` digest is not the raw bytes. It is:

```
blake2b_256( [PersonalMessage(3), V0(0), Sui(0)] || uleb128(len) || message )
```

So when a Sui dApp signs through the Windows extension against a Secure Vault, the initiator derives the intent-wrapped digest while the joining Android device derives the raw bytes. The two parties never agree on what to sign — the MPC threshold round cannot converge, and the session hangs with no diagnostic pointing at the real cause.

This is the same bug shape already fixed for Cosmos (#5240) and Ripple (#5349) in this exact `when`-expression. Sui was simply the next chain not yet carved out.

## Fix

- `SigningHelper.kt` — add `chain == Chain.Sui -> processedBytes.toSuiPersonalMessageDigest()` ahead of the EdDSA branch, mirroring the Ripple line directly above it.
- `ByteArrayExtensions.kt` — new `toSuiPersonalMessageDigest()` implementing the intent prefix, BCS `vector<u8>` ULEB128 length prefix, and blake2b-256.

The helper lives in `ByteArrayExtensions` alongside the other hashes this dispatch already uses (`toSha256ByteArray`, `toSha512ByteArray`, `toKeccak256ByteArray`) rather than in `SuiHelper` — that object initializes `CoinType.SUI` at class load, which would drag WalletCore JNI into the unit tests and make them unrunnable on the JVM.

The `signSui` / PTB co-signing path is untouched. It uses the `TransactionData(0)` intent scope with no BCS wrap and was already correct; see `SwapKitSuiSigner.digest`.

## Cross-platform contract

The intent encoding was confirmed from `@mysten/sui`'s BCS definitions, not from memory:

| Field | Value |
|---|---|
| `IntentScope` | `TransactionData=0, TransactionEffects=1, CheckpointSummary=2, PersonalMessage=3` |
| `IntentVersion` | `V0 = 0` |
| `AppId` | `Sui = 0` |

giving the `[0x03, 0x00, 0x00]` prefix, matching `@vultisig/core-chain`'s `suiPersonalMessageIntent`.

The extension sends the message as `0x`-prefixed hex (`clients/extension/src/inpage/providers/sui/sign.ts`), so it lands on the existing hex-decode branch — deliberately, to avoid UTF-8 round-tripping corrupting binary payloads. Both the hex and UTF-8 branches are covered.

## Testing

**Test vectors are pinned against the canonical initiator implementation** — `@vultisig/core-chain`'s `getSuiPersonalMessageDigest`, the exact function the extension's `getCustomMessageHex.ts` `sui` branch calls — rather than derived from this code, so the test can't agree with a bug it shares.

| Input | Expected digest |
|---|---|
| `"Hello Vultisig"` (UTF-8) | `4a140032aaf9e5699dc678b2caf2687349a2a6ac1103cdba6a2d3f462ca21182` |
| `0x56756c7469736967` (hex) | `245f3ecbbcca443e43d26989bab5ba55cf03c6db0f9b28a4e12d072b894e83d6` |
| 200 x `0x41` | `a90b2a8fe4149193029c26b2e2000730da6e64f6dee07ccf939142d02ef7ceb6` |

The 200-byte case forces the BCS length prefix to spill to two bytes (`0xC8 0x01`). A naive single-byte encoder passes every short vector and silently diverges on exactly the messages most likely to be real — dApp login challenges routinely exceed 127 bytes.

A third test asserts Sui no longer produces the raw-passthrough result, pinning the regression itself.

- All 3 new tests **fail with the branch removed and pass with it** — verified explicitly, not assumed.
- Full `:data` suite: **2470 tests, 0 failures**.
- `./gradlew assembleDebug` succeeds.
- ktfmt clean.

## Not covered

The live multi-device ceremony is **not** verified. That needs a Sui dApp driving the Windows extension as initiator against a Secure Vault with an Android co-signer. The digest now matches the canonical implementation byte-for-byte, but convergence of the real MPC round is untested here.

Note there is no Android-only way to exercise this: the in-app Sign-custom-message screen (`SignMessageFormViewModel`) never sets `chain`, so it always falls to the keccak256 default and cannot reach the Sui branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sui personal message signing by applying the correct Wallet Standard digest format.
  * Added support for UTF-8, hexadecimal, and longer messages during Sui signing.

* **Tests**
  * Added coverage for Sui digest reference values, extended message lengths, and separation from raw EdDSA behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->