### PR TITLE
test(chains): golden vectors for TCY + the EVM chainId matrix

### DIFF
--- a/app/src/androidTest/assets/evm-chain-matrix.json
+++ b/app/src/androidTest/assets/evm-chain-matrix.json
@@ -1,0 +1,266 @@
+[
+    {
+        "name": "Send AVAX",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Avalanche",
+                "ticker": "AVAX",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "avax"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "8ec5af48e856ab7097310b6d735a48416d148a2149200ef8bcead1102a6e9ea7"
+        ]
+    },
+    {
+        "name": "Send Optimism ETH",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Optimism",
+                "ticker": "ETH",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "eth"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "f970f1a92f2a975629833039138e7c1632ee89bb4291531a9fe07b8db8610efc"
+        ]
+    },
+    {
+        "name": "Send Base ETH",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Base",
+                "ticker": "ETH",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "eth"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "6457cc2c6c7fdf7999ad4048fe2071945fc2008812ead29a442585d6512a85ec"
+        ]
+    },
+    {
+        "name": "Send Blast ETH",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Blast",
+                "ticker": "ETH",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "eth"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "da02a36a9246c5733b2e4850e6979f57fc72a74c68fb333a9532f807ac03ba70"
+        ]
+    },
+    {
+        "name": "Send CRO",
+        "keysign_payload": {
+            "coin": {
+                "chain": "CronosChain",
+                "ticker": "CRO",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "cro"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "5fd7121271694a87fc65e008596f4facdf6845dd2f218961192658ed7c3261c6"
+        ]
+    },
+    {
+        "name": "Send Zksync ETH",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Zksync",
+                "ticker": "ETH",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "zsync_era"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "02fb15a677a3ffb58c78f25191c6b284ec32050bfb65c534f71657ffbc55ddc7"
+        ]
+    },
+    {
+        "name": "Send Mantle MNT",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Mantle",
+                "ticker": "MNT",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "mantle"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "c20de51bca07bb677231de76a2445213a38860a7d5f00602f332b278a477481f"
+        ]
+    },
+    {
+        "name": "Send Hyperliquid HYPE",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Hyperliquid",
+                "ticker": "HYPE",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "hyperliquid"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "77b6a09109b679f49c1912222859339906386d61857b237c9017b433cfb52b7e"
+        ]
+    }
+]

--- a/app/src/androidTest/assets/tcy.json
+++ b/app/src/androidTest/assets/tcy.json
@@ -1,0 +1,72 @@
+[
+    {
+        "name": "Send TCY",
+        "keysign_payload": {
+            "coin": {
+                "chain": "THORChain",
+                "ticker": "TCY",
+                "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+                "decimals": 8,
+                "price_provider_id": "",
+                "is_native_token": false,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "tcy",
+                "logo": "rune.png"
+            },
+            "to_address": "thor1tgxm5jw6hrlvslrd6lqpk4jwuu4g29dxytrean",
+            "to_amount": "100000000",
+            "memo": "",
+            "BlockchainSpecific": {
+                "ThorchainSpecific": {
+                    "account_number": 123456,
+                    "sequence": 1,
+                    "fee": 200000,
+                    "is_deposit": false,
+                    "transaction_type": 0
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "7124c5cdee5666615a0c0076697addbd8f1922983f8309ffde89ded55f42bb21"
+        ]
+    },
+    {
+        "name": "Swap TCY to RUNE",
+        "keysign_payload": {
+            "coin": {
+                "chain": "THORChain",
+                "ticker": "TCY",
+                "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+                "decimals": 8,
+                "price_provider_id": "",
+                "is_native_token": false,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "tcy",
+                "logo": "rune.png"
+            },
+            "to_address": "thor1tgxm5jw6hrlvslrd6lqpk4jwuu4g29dxytrean",
+            "to_amount": "100000000",
+            "memo": "=:THOR.RUNE:thor1tgxm5jw6hrlvslrd6lqpk4jwuu4g29dxytrean",
+            "BlockchainSpecific": {
+                "ThorchainSpecific": {
+                    "account_number": 123456,
+                    "sequence": 1,
+                    "fee": 200000,
+                    "is_deposit": true,
+                    "transaction_type": 0
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "209d7b5e196b6941d3161f310dda6521fca2f532ef1d07e31b46da4e73608f72"
+        ]
+    }
+]

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.crypto.ThorChainHelper
 import com.vultisig.wallet.data.crypto.TonHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.SwapPayload
 import java.math.BigInteger
@@ -119,6 +120,64 @@ class ChainHelpersTest {
                 }
             assertEquals(preImageHashes, transaction.expectedImageHash)
         }
+    }
+
+    /**
+     * One native-send vector per EVM chain not otherwise covered by [sendEVMTest]/[sendBSCTest]/
+     * [sendPOLTest]. Every case's payload is identical apart from `coin.chain` (and that chain's
+     * real native-asset ticker/logo, which the EVM signing input never reads), so the only thing
+     * that can separate their pre-image hashes is the EIP-155 chain ID — see
+     * [evmChainMatrixVectorsAreChainSpecific] for the guard that recomputes this directly. Mirrors
+     * iOS `ChainHelperTests.testEvmChainMatrixFixture`.
+     */
+    @Test
+    fun sendEvmChainMatrixTest() {
+        val transactions: List<TransactionData> = loadTransactionData(EVM_CHAIN_MATRIX_JSON_FILE)
+
+        transactions.forEach { transaction ->
+            val payload = transaction.keysignPayload.toInternalKeySignPayload()
+            val helper = EvmHelper(payload.coin.chain.coinType, HEX_PUBLIC_KEY, HEX_CHAIN_CODE)
+            val preImageHashes = helper.getPreSignedImageHash(payload)
+
+            assertEquals(preImageHashes, transaction.expectedImageHash)
+        }
+    }
+
+    /**
+     * Every EVM native send in the corpus must produce a different pre-image hash. The hashes are
+     * *recomputed* here from the payloads rather than read back out of the fixtures: since every
+     * matrix payload holds every pre-image-feeding field identical and varies only the chain, the
+     * only thing that can separate them is the EIP-155 chain ID. A chain that fell back to its
+     * WalletCore coin type's default chain ID — the hazard for chains sharing a coin type — would
+     * collapse onto another chain's hash while each vector still individually matched its own
+     * committed value; only the relationship between them exposes that. Mirrors iOS
+     * `testEvmChainMatrixVectorsAreChainSpecific`.
+     */
+    @Test
+    fun evmChainMatrixVectorsAreChainSpecific() {
+        val nativeSends =
+            (loadTransactionData(EVM_CHAIN_MATRIX_JSON_FILE) + loadTransactionData(EVM_JSON_FILE))
+                .filter { it.keysignPayload.coin.isNativeToken }
+
+        val hashesByCase =
+            nativeSends.associate { transaction ->
+                val payload = transaction.keysignPayload.toInternalKeySignPayload()
+                val helper = EvmHelper(payload.coin.chain.coinType, HEX_PUBLIC_KEY, HEX_CHAIN_CODE)
+                transaction.name to helper.getPreSignedImageHash(payload)
+            }
+
+        val allHashes = hashesByCase.values.flatten()
+        assertEquals(
+            "Every EVM native send should produce exactly one pre-image hash",
+            hashesByCase.size,
+            allHashes.size,
+        )
+        assertEquals(
+            "Two EVM native sends computed the same pre-image hash. Their payloads differ only " +
+                "by chain, so a chain has stopped contributing its own EIP-155 chain ID: $hashesByCase",
+            allHashes.size,
+            allHashes.toSet().size,
+        )
     }
 
     @Test
@@ -475,6 +534,23 @@ class ChainHelpersTest {
     @Test
     fun sendTHORchain() {
         val transactions: List<TransactionData> = loadTransactionData(THORCHAIN_JSON_FILE)
+        val helper = ThorChainHelper.thor(HEX_PUBLIC_KEY, HEX_CHAIN_CODE)
+        transactions.forEach { transaction ->
+            val preImageHashes =
+                helper.getPreSignedImageHash(transaction.keysignPayload.toInternalKeySignPayload())
+
+            assertEquals(preImageHashes, transaction.expectedImageHash)
+        }
+    }
+
+    /**
+     * TCY send + intra-chain TCY -> RUNE swap (`MsgDeposit` with a swap memo), the same
+     * non-RUNE-denom deposit shape `thorchain.json` already covers for RUJI/KUJI. Regression for
+     * vultisig-windows#4464. Mirrors iOS `ChainHelperTests.testTcyFixture`.
+     */
+    @Test
+    fun sendTCYTest() {
+        val transactions: List<TransactionData> = loadTransactionData(TCY_JSON_FILE)
         val helper = ThorChainHelper.thor(HEX_PUBLIC_KEY, HEX_CHAIN_CODE)
         transactions.forEach { transaction ->
             val preImageHashes =
@@ -856,6 +932,8 @@ class ChainHelpersTest {
 
         private const val BSC_JSON_FILE = "bsc.json"
         private const val EVM_JSON_FILE = "evm.json"
+        private const val EVM_CHAIN_MATRIX_JSON_FILE = "evm-chain-matrix.json"
+        private const val TCY_JSON_FILE = "tcy.json"
         private const val COSMOS_JSON_FILE = "cosmos.json"
         private const val XRP_JSON_FILE = "xrp.json"
         private const val TON_JSON_FILE = "ton.json"
@@ -888,6 +966,8 @@ class ChainHelpersTest {
             mapOf(
                 BSC_JSON_FILE to "sendBSCTest",
                 EVM_JSON_FILE to "sendEVMTest",
+                EVM_CHAIN_MATRIX_JSON_FILE to "sendEvmChainMatrixTest",
+                TCY_JSON_FILE to "sendTCYTest",
                 COSMOS_JSON_FILE to "sendCosmosTest",
                 XRP_JSON_FILE to "sendXRPTest",
                 TON_JSON_FILE to "sendTONTest",
@@ -908,7 +988,7 @@ class ChainHelpersTest {
                 ARB_SWAP_JSON_FILE to "oneInchArbitrumSwapTest",
             )
 
-        private const val EXPECTED_CASE_COUNT = 67
+        private const val EXPECTED_CASE_COUNT = 77
 
         private const val HEX_PUBLIC_KEY =
             "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"


### PR DESCRIPTION
## Summary
- Ports vultisig-ios#4999 (items 1 and 3 of #5421) to Android's golden signing-vector corpus.
- Adds `evm-chain-matrix.json` (8 native-send vectors: Avalanche, Optimism, Base, Blast, CronosChain, Zksync, Mantle, Hyperliquid) and `tcy.json` (TCY send + TCY → RUNE intra-chain swap via `MsgDeposit`).
- Fixture content (payloads and `expected_image_hash` values) is copied verbatim from the iOS PR so the iOS, Android and TS-core corpora stay identical, per #5421's rule that a hash needs agreement from at least two of the three real signers.
- Wires `sendEvmChainMatrixTest` (dispatches per-chain via `Chain.coinType`, mirroring `EVMHelper.getHelper` on iOS) and `sendTCYTest` (reuses `ThorChainHelper.thor`, the same helper already covering RUJI/KUJI non-RUNE-denom deposits in `thorchain.json`).
- Adds `evmChainMatrixVectorsAreChainSpecific`, which *recomputes* (not reads back) each EVM native send's pre-image hash and asserts they're pairwise distinct — a chain that fell back to its WalletCore coin type's default chain ID would collapse two hashes together even though each still matched its own committed value.
- Updates `FIXTURE_TESTS` and bumps `EXPECTED_CASE_COUNT` 67 → 77.

**SEI is deliberately excluded** — the iOS PR found Swift and the TS core disagree on SEI's fee envelope (legacy vs EIP-1559), so no vector was committed there either; that's tracked separately (vultisig-windows#4369).

## Issue
Tracks #5421 (items 1 and 3).

## Test plan
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — compiles clean
- [x] `./gradlew lint` — passes
- [ ] `./gradlew connectedDebugAndroidTest --tests "com.vultisig.wallet.data.blockchain.ChainHelpersTest"` on a device/emulator, to confirm the ported hashes actually verify against Android's real signers (not yet run — no emulator available in this session)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded transaction validation coverage across multiple EVM networks, including Avalanche, Optimism, Base, Blast, Cronos, zkSync, Mantle, and Hyperliquid.
  * Added coverage for TCY transfers and TCY-to-RUNE swaps.
  * Added checks to ensure transaction signing data remains unique and chain-specific.
  * Increased the number of validated transaction scenarios from 67 to 77, improving confidence in supported transaction flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->