### PR TITLE
fix(zksync): propagate zk fee estimate RPC errors instead of zeroing

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -672,19 +672,21 @@ class EvmApiImp(
                 },
             )
         return if (response.error != null) {
-            Timber.d(
-                "zk estimate fee, srcAddress: $srcAddress,dstAddress: $dstAddress," +
-                    "data: $data error: ${response.error.message}"
+            // A failed estimate must propagate, never collapse into ZERO: a zeroed gasLimit/
+            // maxFeePerGas signs a tx that broadcast then rejects as intrinsic-gas-too-low,
+            // after the ceremony already ran (#5398).
+            throw NetworkException(
+                httpStatusCode = 0,
+                message =
+                    "zk estimate fee rpc error, srcAddress: $srcAddress,dstAddress: $dstAddress," +
+                        "data: $data error: ${response.error.message}",
             )
-            ZkGasFee(BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO)
         } else {
             val resultJson =
                 response.result
-                    ?: return ZkGasFee(
-                        BigInteger.ZERO,
-                        BigInteger.ZERO,
-                        BigInteger.ZERO,
-                        BigInteger.ZERO,
+                    ?: throw NetworkException(
+                        httpStatusCode = 0,
+                        message = "zk estimate fee rpc returned no result",
                     )
             ZkGasFee(
                 gasLimit = resultJson.gasLimit.convertToBigIntegerOrZero(),

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiFeeTest.kt
@@ -65,6 +65,54 @@ class EvmApiFeeTest {
         assertEquals(BigInteger.valueOf(2_000_000_000), api.getMaxPriorityFeePerGas())
     }
 
+    @Test
+    fun `zkEstimateFee propagates an RPC failure instead of returning zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body =
+                    """{"id":1,"result":null,"error":{"code":-32601,"message":"method not found"}}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
+
+        assertFailsWith<NetworkException> {
+            api.zkEstimateFee(srcAddress = "0xSender", dstAddress = "0xRecipient", data = "0x")
+        }
+    }
+
+    @Test
+    fun `zkEstimateFee propagates a missing result instead of returning zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
+
+        assertFailsWith<NetworkException> {
+            api.zkEstimateFee(srcAddress = "0xSender", dstAddress = "0xRecipient", data = "0x")
+        }
+    }
+
+    @Test
+    fun `zkEstimateFee returns parsed fee on 200`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body =
+                    """{"id":1,"result":{"gas_limit":"0x30d40","gas_per_pubdata_limit":"0x14",""" +
+                        """"max_fee_per_gas":"0x77359400","max_priority_fee_per_gas":"0x0"},""" +
+                        """"error":null}""",
+            )
+        val api = EvmApiImp(client, "https://api.vultisig.com/zksync/", Chain.ZkSync)
+
+        val fee =
+            api.zkEstimateFee(srcAddress = "0xSender", dstAddress = "0xRecipient", data = "0x")
+
+        assertEquals(BigInteger.valueOf(200_000), fee.gasLimit)
+        assertEquals(BigInteger.valueOf(2_000_000_000), fee.maxFeePerGas)
+    }
+
     // Avalanche is the one chain whose EIP-1559 calc (EthereumFeeService) reads BOTH getBaseFee()
     // and getMaxPriorityFeePerGas() directly, so a shared RPC outage could previously zero both
     // components at once and sign a tx priced near nothing. Both calls on the same failing


### PR DESCRIPTION
## Summary
- `EvmApi.zkEstimateFee()` collapsed a JSON-RPC error (or a null `result`) into an all-zero `ZkGasFee`, and neither consumer (`ZkFeeService`, the ZkSync branch in `BlockChainSpecificRepository`) applied a floor — so a transient/unsupported-RPC error on `zks_estimateFee` produced a normal-looking $0.00 fee preview and a `gasLimit=0` signed transaction.
- Broadcast then rejects the zero-fee tx as intrinsic-gas-too-low, after the full multi-device MPC signing ceremony already ran.
- Fixed by making `zkEstimateFee()` throw `NetworkException` on RPC error / missing result, matching the existing `getBaseFee()`/`getMaxPriorityFeePerGas()` convention (#5400) — `FeeServiceComposite.calculateFees` already catches and retries via `calculateDefaultFees`, and a repeated failure now surfaces as a visible error instead of silently signing a zero-fee tx.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest --tests "com.vultisig.wallet.data.api.EvmApiFeeTest" --tests "com.vultisig.wallet.data.blockchain.ethereum.ZkFeeServiceTest" --tests "com.vultisig.wallet.data.repositories.BlockChainSpecificRepositoryImplTest"` — pass
- [x] Added tests covering `zkEstimateFee`'s RPC-error path, missing-result path, and happy path

Fixes #5398

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ZkSync fee estimation error handling.
  - RPC failures and missing fee results now report a network error instead of returning an invalid zero fee.
  - Successful responses continue to provide the expected gas limit and fee details.

- **Tests**
  - Added coverage for failed, incomplete, and successful fee estimation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->