### PR TITLE
fix(keysign): relay signTon, signSui and signBitcoin to co-signers

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -258,12 +258,13 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                 } else null,
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,
             // Every `sign_data` variant carries pre-built signing bytes a peer cannot reconstruct.
-            // Relaying one as null makes the peer rebuild a default input (bank send / plain
-            // transfer / Pay / OperationPayment) whose message hash diverges from the initiator's,
-            // so the DKLS setup message — keyed by md5(hash) — 404s and keysign never completes.
-            // `signBitcoin` also carries the only PSBT marker: drop it and the payload reaches the
-            // peer with no `blockchain_specific` member at all, which the inbound mapper rejects.
-            // The proto keeps the seven in a `oneof`, so at most one is ever set.
+            // Relaying one as null makes the peer fall back to rebuilding a default input (bank
+            // send / plain transfer / Pay / OperationPayment): at best its message hash diverges
+            // from the initiator's and the md5(hash)-keyed DKLS setup message 404s; at worst there
+            // is nothing to rebuild from and it throws — a `signSui` payload carries no toAddress,
+            // and `signBitcoin` carries the only PSBT marker, so without it the payload reaches the
+            // peer with no `blockchain_specific` member at all. The proto keeps the seven in a
+            // `oneof`, so at most one is ever set.
             signAmino = keysignPayload.signAmino,
             signDirect = keysignPayload.signDirect,
             signSolana = keysignPayload.signSolana,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -257,37 +257,19 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                     )
                 } else null,
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,
-            // Cosmos SignDoc artefacts MUST round-trip to peer devices. Without these, a relayed
-            // payload arrives with `signDirect`/`signAmino == null` on the peer, which then
-            // rebuilds
-            // a default (bank-send) signing input — its message hash diverges from the initiator's,
-            // so the DKLS setup message (keyed by md5(hash)) 404s and keysign never completes. The
-            // inbound [KeysignPayloadProtoMapper] already reads both fields; this makes the mapping
-            // symmetric. Required for the LUNA / LUNC staking flows (signDirect = MsgDelegate / …
-            // ).
+            // Every `sign_data` variant carries pre-built signing bytes a peer cannot reconstruct.
+            // Relaying one as null makes the peer rebuild a default input (bank send / plain
+            // transfer / Pay / OperationPayment) whose message hash diverges from the initiator's,
+            // so the DKLS setup message — keyed by md5(hash) — 404s and keysign never completes.
+            // `signBitcoin` also carries the only PSBT marker: drop it and the payload reaches the
+            // peer with no `blockchain_specific` member at all, which the inbound mapper rejects.
+            // The proto keeps the seven in a `oneof`, so at most one is ever set.
             signAmino = keysignPayload.signAmino,
             signDirect = keysignPayload.signDirect,
-            // Same round-trip requirement as signAmino/signDirect above: this carries the
-            // pre-built,
-            // byte-parity Solana native-staking raw transaction. Without relaying it, a co-signer
-            // receives signSolana == null and rebuilds a default (plain-transfer) signing input —
-            // its message hash diverges from the initiator's, so the DKLS setup message (keyed by
-            // md5(hash)) 404s and keysign never completes. The inbound [KeysignPayloadProtoMapper]
-            // already reads it; this makes the mapping symmetric. Required for multi-device (secure
-            // vault) Solana staking (delegate / unstake / move / finish-move / withdraw).
-            //
-            // NOTE: the inbound mapper also reads signTon / signSui / signBitcoin, which this
-            // outbound mapper still drops — so those chains retain the same latent multi-device
-            // relay gap. Fixing them is deliberately out of scope for this Solana PR (untested on
-            // those chains); tracked as a separate follow-up so any regression stays bisectable.
             signSolana = keysignPayload.signSolana,
-            // Same round-trip requirement: the dApp's raw XRPL transaction must reach the peer
-            // co-signer verbatim. Without relaying it, a co-signer receives signRipple == null and
-            // rebuilds a native OperationPayment from toAddress/toAmount — its signing bytes
-            // diverge
-            // from the initiator's, the DKLS setup message (keyed by md5(hash)) 404s, and the
-            // co-sign never completes. The inbound [KeysignPayloadProtoMapper] already reads it;
-            // this makes the mapping symmetric. Required for Secure Vault XRPL dApp co-signing.
+            signTon = keysignPayload.signTon,
+            signBitcoin = keysignPayload.signBitcoin,
+            signSui = keysignPayload.signSui,
             signRipple = keysignPayload.signRipple,
             erc20ApprovePayload =
                 if (approvePayload is ERC20ApprovePayload) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignBitcoinTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignBitcoinTest.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.models.payload.KeysignPayload
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import vultisig.keysign.v1.BitcoinInput
 import vultisig.keysign.v1.BitcoinOutput
@@ -16,10 +17,13 @@ import vultisig.keysign.v1.SignBitcoin
  * Pins the `signBitcoin` (dApp PSBT) proto round-trip in both directions.
  *
  * `signBitcoin` is the only carrier of the PSBT marker: [BlockChainSpecific.BitcoinPSBT] is a
- * sibling of `UTXO`, not a subtype, so it deliberately maps to no `blockchain_specific` member. The
- * outbound mapper used to drop `signBitcoin`, which left the relayed payload with neither a
- * `sign_bitcoin` block nor a chain-specific one — and the inbound mapper rejects that outright
- * rather than merely signing different bytes.
+ * sibling of `UTXO`, not a subtype, so it maps to no `blockchain_specific` member. The outbound
+ * mapper dropped `signBitcoin`, which left anything it relayed with neither a `sign_bitcoin` block
+ * nor a chain-specific one — and the inbound mapper rejects that outright rather than merely
+ * signing different bytes, which the second test pins.
+ *
+ * Only the extension originates `signBitcoin` today, and Android never re-serializes a payload it
+ * joined, so the gap was latent rather than a shipped regression.
  */
 class KeysignPayloadProtoMapperSignBitcoinTest {
 
@@ -28,7 +32,43 @@ class KeysignPayloadProtoMapperSignBitcoinTest {
 
     @Test
     fun `signBitcoin survives the KeysignPayload to proto round-trip`() {
-        val signBitcoin =
+        val proto = requireNotNull(outbound(psbtPayload()))
+        // The outbound mapper must carry signBitcoin onto the wire. `BitcoinPSBT` holds no data,
+        // so Android re-emits no chain-specific block and signBitcoin is the peer's only handle.
+        assertEquals(PSBT, proto.signBitcoin)
+        assertNull(proto.utxoSpecific)
+
+        // …and the inbound mapper must restore both the PSBT and its marker on the peer device.
+        val restored = inbound(proto)
+        assertEquals(PSBT, restored.signBitcoin)
+        assertEquals(PSBT.inputs, restored.signBitcoin?.inputs)
+        assertEquals(PSBT.outputs, restored.signBitcoin?.outputs)
+        assertEquals(BlockChainSpecific.BitcoinPSBT, restored.blockChainSpecific)
+    }
+
+    @Test
+    fun `a PSBT payload stripped of signBitcoin leaves the peer nothing to resolve`() {
+        val proto = requireNotNull(outbound(psbtPayload())).copy(signBitcoin = null)
+
+        assertThrows(IllegalStateException::class.java) { inbound(proto) }
+    }
+
+    private fun psbtPayload() =
+        KeysignPayload(
+            coin = BTC,
+            toAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            toAmount = BigInteger("200000"),
+            blockChainSpecific = BlockChainSpecific.BitcoinPSBT,
+            memo = null,
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+            signBitcoin = PSBT,
+        )
+
+    private companion object {
+        val PSBT =
             SignBitcoin(
                 version = 2u,
                 locktime = 0u,
@@ -55,35 +95,6 @@ class KeysignPayloadProtoMapperSignBitcoinTest {
                     ),
             )
 
-        val payload =
-            KeysignPayload(
-                coin = BTC,
-                toAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
-                toAmount = BigInteger("200000"),
-                blockChainSpecific = BlockChainSpecific.BitcoinPSBT,
-                memo = null,
-                vaultPublicKeyECDSA = "pub",
-                vaultLocalPartyID = "local",
-                libType = null,
-                wasmExecuteContractPayload = null,
-                signBitcoin = signBitcoin,
-            )
-
-        val proto = requireNotNull(outbound(payload))
-        // The outbound mapper must carry signBitcoin onto the wire; a PSBT payload has no
-        // chain-specific block, so this is the peer's only handle on the transaction.
-        assertEquals(signBitcoin, proto.signBitcoin)
-        assertNull(proto.utxoSpecific)
-
-        // …and the inbound mapper must restore both the PSBT and its marker on the peer device.
-        val restored = inbound(proto)
-        assertEquals(signBitcoin, restored.signBitcoin)
-        assertEquals(signBitcoin.inputs, restored.signBitcoin?.inputs)
-        assertEquals(signBitcoin.outputs, restored.signBitcoin?.outputs)
-        assertEquals(BlockChainSpecific.BitcoinPSBT, restored.blockChainSpecific)
-    }
-
-    private companion object {
         val BTC =
             Coin(
                 chain = Chain.Bitcoin,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignBitcoinTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignBitcoinTest.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.BitcoinInput
+import vultisig.keysign.v1.BitcoinOutput
+import vultisig.keysign.v1.SignBitcoin
+
+/**
+ * Pins the `signBitcoin` (dApp PSBT) proto round-trip in both directions.
+ *
+ * `signBitcoin` is the only carrier of the PSBT marker: [BlockChainSpecific.BitcoinPSBT] is a
+ * sibling of `UTXO`, not a subtype, so it deliberately maps to no `blockchain_specific` member. The
+ * outbound mapper used to drop `signBitcoin`, which left the relayed payload with neither a
+ * `sign_bitcoin` block nor a chain-specific one — and the inbound mapper rejects that outright
+ * rather than merely signing different bytes.
+ */
+class KeysignPayloadProtoMapperSignBitcoinTest {
+
+    private val outbound = PayloadToProtoMapperImpl()
+    private val inbound = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `signBitcoin survives the KeysignPayload to proto round-trip`() {
+        val signBitcoin =
+            SignBitcoin(
+                version = 2u,
+                locktime = 0u,
+                inputs =
+                    listOf(
+                        BitcoinInput(
+                            hash =
+                                "9f2c1b0e7a5d3c8b6e4f2a1d0c9b8a7f6e5d4c3b2a1908070605040302010000",
+                            index = 1u,
+                            amount = 250_000L,
+                            scriptPubKey = "0014a1b2c3d4e5f60708090a0b0c0d0e0f1011121314",
+                            scriptType = "p2wpkh",
+                            isOurs = true,
+                        )
+                    ),
+                outputs =
+                    listOf(
+                        BitcoinOutput(
+                            amount = 200_000L,
+                            address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                            scriptPubKey = "0014312e63d4c2b1a0f9e8d7c6b5a4938271605f4e3d",
+                            isChange = false,
+                        )
+                    ),
+            )
+
+        val payload =
+            KeysignPayload(
+                coin = BTC,
+                toAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                toAmount = BigInteger("200000"),
+                blockChainSpecific = BlockChainSpecific.BitcoinPSBT,
+                memo = null,
+                vaultPublicKeyECDSA = "pub",
+                vaultLocalPartyID = "local",
+                libType = null,
+                wasmExecuteContractPayload = null,
+                signBitcoin = signBitcoin,
+            )
+
+        val proto = requireNotNull(outbound(payload))
+        // The outbound mapper must carry signBitcoin onto the wire; a PSBT payload has no
+        // chain-specific block, so this is the peer's only handle on the transaction.
+        assertEquals(signBitcoin, proto.signBitcoin)
+        assertNull(proto.utxoSpecific)
+
+        // …and the inbound mapper must restore both the PSBT and its marker on the peer device.
+        val restored = inbound(proto)
+        assertEquals(signBitcoin, restored.signBitcoin)
+        assertEquals(signBitcoin.inputs, restored.signBitcoin?.inputs)
+        assertEquals(signBitcoin.outputs, restored.signBitcoin?.outputs)
+        assertEquals(BlockChainSpecific.BitcoinPSBT, restored.blockChainSpecific)
+    }
+
+    private companion object {
+        val BTC =
+            Coin(
+                chain = Chain.Bitcoin,
+                ticker = "BTC",
+                logo = "bitcoin",
+                address = "bc1q9d4ywgfnd8h43da5tpcxcn6ajv590cg6d3tg6a",
+                decimal = 8,
+                hexPublicKey = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+                priceProviderID = "bitcoin",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
@@ -11,7 +11,7 @@ import vultisig.keysign.v1.SignSui
 import vultisig.keysign.v1.SuiSpecific
 
 /**
- * Pins the inbound mapping of a dApp-supplied Sui PTB (`signSui`).
+ * Pins the mapping of a dApp-supplied Sui PTB (`signSui`) in both directions.
  *
  * A `SignSui` payload is signed verbatim from its base64 `TransactionData` BCS bytes via
  * WalletCore's SignDirect path, so the initiator omits the SUI RPC-derived `suicheSpecific` (coins
@@ -19,9 +19,15 @@ import vultisig.keysign.v1.SuiSpecific
  * takes the SignDirect branch, and (2) stand in an empty [BlockChainSpecific.Sui] placeholder so
  * the helper — which casts `blockChainSpecific` to `Sui` — has a value to read. This mirrors how
  * `signBitcoin` short-circuits to [BlockChainSpecific.BitcoinPSBT].
+ *
+ * The outbound mapper must put `signSui` back on the wire: a peer that receives it as null skips
+ * the SignDirect branch and rebuilds a `Pay`/`PaySui` from the placeholder's empty coin list and
+ * the PTB's empty `toAddress`, so it signs different bytes — or dies constructing the address —
+ * instead of the PTB the dApp asked for.
  */
 class KeysignPayloadProtoMapperSignSuiTest {
 
+    private val outbound = PayloadToProtoMapperImpl()
     private val inbound = KeysignPayloadProtoMapperImpl()
 
     @Test
@@ -80,6 +86,23 @@ class KeysignPayloadProtoMapperSignSuiTest {
         check(specific is BlockChainSpecific.Sui)
         assertEquals(BigInteger("750"), specific.referenceGasPrice)
         assertEquals(BigInteger("3000000"), specific.gasBudget)
+    }
+
+    @Test
+    fun `signSui survives the proto to KeysignPayload round-trip`() {
+        val signSui = SignSui(unsignedTxMsg = "AAACAAgA4fUFAAAAAA==")
+
+        val relayed = requireNotNull(outbound(inbound(basePayload(signSui = signSui))))
+
+        assertEquals(signSui, relayed.signSui)
+        // The placeholder re-serializes into a zeroed `suicheSpecific`, which is harmless: the
+        // inbound `signSui` branch runs first, so a peer still takes the SignDirect path and the
+        // payload settles after one pass.
+        assertEquals(
+            SuiSpecific(referenceGasPrice = "0", gasBudget = "0", coins = emptyList()),
+            relayed.suicheSpecific,
+        )
+        assertEquals(relayed, outbound(inbound(relayed)))
     }
 
     private fun basePayload(signSui: SignSui? = null, suicheSpecific: SuiSpecific? = null) =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignSuiTest.kt
@@ -46,8 +46,9 @@ class KeysignPayloadProtoMapperSignSuiTest {
 
     @Test
     fun `signSui takes precedence over a present suicheSpecific`() {
-        // Defensive: even if an initiator wrongly attaches both, the SignDirect bytes win so the
-        // helper never rebuilds a Pay/PaySui from RPC coins it shouldn't use.
+        // Initiators do attach both — iOS and the extension send a zeroed `suicheSpecific`, and so
+        // does this app's own outbound mapper. The SignDirect bytes win either way, so the helper
+        // never rebuilds a Pay/PaySui from RPC coins it shouldn't use.
         val payload =
             inbound(
                 basePayload(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignTonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignTonTest.kt
@@ -13,12 +13,15 @@ import vultisig.keysign.v1.TonMessage
 /**
  * Pins the `signTon` (TON Connect messages) proto round-trip in both directions.
  *
- * The outbound mapper used to drop `signTon`, so a relayed payload reached the peer with `signTon
- * == null`. [TonHelper] then took its native-send fallback and built a single plain transfer to
- * `toAddress`/`toAmount` with the memo as a text comment — discarding messages 2..N and message 1's
- * `payload`/`stateInit` BOC. The resulting signing input hashes differently from the initiator's,
- * so the DKLS setup message (keyed by `md5(hash)`) 404s and keysign never completes. TON Connect
- * requests routinely carry more than one message, so the fallback is not a near-miss.
+ * The outbound mapper dropped `signTon`, so any payload it relayed would reach the peer with
+ * `signTon == null`. [TonHelper] then takes its native-send fallback and builds a single plain
+ * transfer to `toAddress`/`toAmount` with the memo as a text comment — discarding messages 2..N and
+ * message 1's `payload`/`stateInit` BOC. That signing input hashes differently from the
+ * initiator's, so the DKLS setup message (keyed by `md5(hash)`) 404s and keysign never completes.
+ * TON Connect requests routinely carry more than one message, so the fallback is not a near-miss.
+ *
+ * Only the extension originates `signTon` today, and Android never re-serializes a payload it
+ * joined, so the gap was latent rather than a shipped regression.
  */
 class KeysignPayloadProtoMapperSignTonTest {
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignTonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSignTonTest.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignTon
+import vultisig.keysign.v1.TonMessage
+
+/**
+ * Pins the `signTon` (TON Connect messages) proto round-trip in both directions.
+ *
+ * The outbound mapper used to drop `signTon`, so a relayed payload reached the peer with `signTon
+ * == null`. [TonHelper] then took its native-send fallback and built a single plain transfer to
+ * `toAddress`/`toAmount` with the memo as a text comment — discarding messages 2..N and message 1's
+ * `payload`/`stateInit` BOC. The resulting signing input hashes differently from the initiator's,
+ * so the DKLS setup message (keyed by `md5(hash)`) 404s and keysign never completes. TON Connect
+ * requests routinely carry more than one message, so the fallback is not a near-miss.
+ */
+class KeysignPayloadProtoMapperSignTonTest {
+
+    private val outbound = PayloadToProtoMapperImpl()
+    private val inbound = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `signTon survives the KeysignPayload to proto round-trip`() {
+        val signTon =
+            SignTon(
+                tonMessages =
+                    listOf(
+                        TonMessage(
+                            to = "UQAX2SbFUCkNC6BLKBnrf7ilNfBTMKgLNqmXHrBAqi9Xm000",
+                            amount = "100000000",
+                            payload = "te6ccgEBAQEADgAAGAAAAABoZWxsbwAAAA==", // opaque BOC
+                        ),
+                        // A second message is what the native-send fallback silently drops.
+                        TonMessage(
+                            to = "UQD1a2Zt0hMLnRoSY9jLbnJHRoLKrpUuoRSZzvsYUAAAAAAA",
+                            amount = "250000000",
+                            stateInit = "te6ccgEBAQEAAgAAAA==",
+                        ),
+                    )
+            )
+
+        val payload =
+            KeysignPayload(
+                coin = TON,
+                toAddress = "UQAX2SbFUCkNC6BLKBnrf7ilNfBTMKgLNqmXHrBAqi9Xm000",
+                toAmount = BigInteger("100000000"),
+                blockChainSpecific =
+                    BlockChainSpecific.Ton(
+                        sequenceNumber = 12uL,
+                        expireAt = 1_775_000_000uL,
+                        bounceable = false,
+                        sendMaxAmount = false,
+                        jettonAddress = "",
+                        isActiveDestination = true,
+                    ),
+                memo = null,
+                vaultPublicKeyECDSA = "pub",
+                vaultLocalPartyID = "local",
+                libType = null,
+                wasmExecuteContractPayload = null,
+                signTon = signTon,
+            )
+
+        val proto = requireNotNull(outbound(payload))
+        // The outbound mapper must carry signTon onto the wire.
+        assertEquals(signTon, proto.signTon)
+
+        // …and the inbound mapper must restore every message on the peer device.
+        val restored = inbound(proto)
+        assertEquals(signTon, restored.signTon)
+        assertEquals(signTon.tonMessages, restored.signTon?.tonMessages)
+    }
+
+    private companion object {
+        val TON =
+            Coin(
+                chain = Chain.Ton,
+                ticker = "TON",
+                logo = "ton",
+                address = "UQD1a2Zt0hMLnRoSY9jLbnJHRoLKrpUuoRSZzvsYUAAAAAAA",
+                decimal = 9,
+                hexPublicKey = "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+                priceProviderID = "the-open-network",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

`PayloadToProtoMapper` (domain → proto, used by the keysign initiator in `BuildKeysignMessageUseCase`) wrote only four of the seven `sign_data` oneof members. A relayed payload therefore reached peer devices with `signTon`, `signSui` and `signBitcoin` stripped, even though the inbound `KeysignPayloadProtoMapper` has always read all seven.

A peer that loses one of these rebuilds a default signing input instead — a single plain TON transfer rather than the TON Connect messages (`TonHelper.kt:69-77`), a `Pay`/`PaySui` rather than the dApp's PTB (`SuiHelper.kt:81`) — so its message hash stops matching the initiator's and the `md5(hash)`-keyed DKLS setup message 404s. `signBitcoin` fails harder: it carries the only PSBT marker, since `BlockChainSpecific.BitcoinPSBT` is a sibling of `UTXO` and deliberately maps to no chain-specific block. Dropping it leaves nothing for the inbound mapper to resolve and it hits its terminal `error(...)`.

iOS models `sign_data` as one enum and switches over it exhaustively (`Cosmos+ProtoMappable.swift:38-55`); the extension builds the protobuf oneof directly (`keysignPayload/build.ts:529-547`). Both emit all seven. Android flattened the oneof into seven independent nullable fields that the mapper lists by hand, which is how three came to be missed.

No shipped flow changes behaviour: Android does not originate a `signTon`/`signSui`/`signBitcoin` keysign today, so the gap is latent until such a payload is re-serialized. `signSolana` (named in the issue) and `signRipple` were already covered by #5239 and #5303.

Also folds the three near-duplicate comment blocks in that region into one and drops the stale note that still listed these three as a deferred follow-up.

Closes #5445

## Notes

- No `BitcoinPSBT` branch is added to the outbound chain-specific chain, deliberately: the variant has no fields, and the inbound mapper resolves it from `signBitcoin` before it looks at any `*Specific` block. Fabricating a `utxo_specific` would reintroduce exactly the stale `byteFee`/`sendMaxAmount` the inbound mapper documents discarding.
- `signBitcoin` is the one member whose round-trip is still not wire-compatible with iOS: `KeysignPayloadProtoMapper.kt:136` collapses the wire's `utxoSpecific` into the dataless `BitcoinPSBT` marker, so an Android-relayed PSBT payload carries no `blockchain_specific` and iOS rejects it at `KeysignMessage+ProtoMappable.swift:80`. That is unchanged by this PR — before it, the same payload failed on iOS *and* on Android — and unreachable today. Fixing it means giving `BitcoinPSBT` a `byteFee`/`sendMaxAmount`, which touches the inbound mapper this ticket scopes out; worth a follow-up.
- A re-serialized `signSui` payload emits a zeroed `suicheSpecific` from the inbound placeholder. That is inert — the inbound `signSui` branch runs ahead of `suicheSpecific` on every platform — and the test pins that a second pass is a fixed point.

## Testing

- `./gradlew :data:testDebugUnitTest` — 2517 tests, 0 failures
- `./gradlew :data:ktfmtCheck :data:lintDebug`
- `./gradlew :app:compileDebugKotlin`

The three new round-trip tests were confirmed to fail against the unpatched mapper (`signBitcoin`, `signSui`, `signTon` all red; the pre-existing tests in those files stayed green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing payload handling for Bitcoin, Sui, and TON transactions.
  * Preserved transaction details, messages, BOC fields, and chain-specific markers during data conversion.

* **Tests**
  * Added coverage confirming Bitcoin, Sui, and TON signing payloads remain intact through conversion round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
