### PR TITLE
feat(sui): auto-discover held Sui tokens

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -87,6 +87,8 @@ import com.vultisig.wallet.ui.models.ChainTokensUiModel
 import com.vultisig.wallet.ui.models.ChainUiModel
 import com.vultisig.wallet.ui.models.DeviceMeta
 import com.vultisig.wallet.ui.models.TokenDetailUiModel
+import com.vultisig.wallet.ui.models.TokenSelectionUiModel
+import com.vultisig.wallet.ui.models.TokenUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
 import com.vultisig.wallet.ui.models.VaultDetailUiModel
@@ -134,6 +136,7 @@ import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
 import com.vultisig.wallet.ui.screens.ChainSelectionScreen
 import com.vultisig.wallet.ui.screens.TokenDetailScreen
+import com.vultisig.wallet.ui.screens.TokenSelectionScreen
 import com.vultisig.wallet.ui.screens.TransactionDoneView
 import com.vultisig.wallet.ui.screens.VaultDetailScreen
 import com.vultisig.wallet.ui.screens.cosmosstaking.CosmosStakingPositionsContent
@@ -350,6 +353,8 @@ class PreviewActivity : ComponentActivity() {
                     "edit_folder" -> EditFolderPreview()
                     "gas_settings_bsc_before" -> GasSettingsBscPreview(isLegacyGas = false)
                     "gas_settings_bsc_after" -> GasSettingsBscPreview(isLegacyGas = true)
+                    "sui_token_selection_before" -> SuiTokenSelectionPreview(discovered = false)
+                    "sui_token_selection_after" -> SuiTokenSelectionPreview(discovered = true)
                     else -> SwapConfirmPreview()
                 }
             }
@@ -385,6 +390,45 @@ private fun ChainSelectionClipPreview() {
         onBackClick = {},
     )
 }
+
+/**
+ * Sui "Select tokens" list (#5443). `discovered = false` is the catalog-only list Sui offered
+ * before held-token discovery; `true` adds the coin types the address actually holds. Discovered
+ * coins carry their icon as a URL rather than a bundled drawable, so they fall back to a letter
+ * tile.
+ */
+@Composable
+private fun SuiTokenSelectionPreview(discovered: Boolean) {
+    val held =
+        listOf(
+            suiToken("HASUI", "0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d"),
+            suiToken("BUCK", "0xce7ff77a83ea0cb6fd39bd8748e2ec89a3f41e8efdc3f4eb123e0ca37b184db2"),
+            suiToken("SCA", "0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6"),
+        )
+    val tokens =
+        Coins.Sui.all.filterNot { it.isNativeToken } + if (discovered) held else emptyList()
+    TokenSelectionScreen(
+        searchTextFieldState = remember { TextFieldState() },
+        state =
+            TokenSelectionUiModel(
+                tokens = tokens.map { TokenUiModel(isEnabled = false, coin = it) }
+            ),
+        hasCustomToken = true,
+    )
+}
+
+private fun suiToken(ticker: String, packageAddress: String) =
+    Coin(
+        chain = Chain.Sui,
+        ticker = ticker,
+        logo = "",
+        address = "",
+        decimal = 9,
+        hexPublicKey = "",
+        priceProviderID = "",
+        contractAddress = "$packageAddress::${ticker.lowercase()}::$ticker",
+        isNativeToken = false,
+    )
 
 @Composable
 private fun ErrorScreenAfterPreview() {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -34,6 +34,9 @@ interface SuiApi {
 
     suspend fun getAllCoins(address: String): List<SuiCoin>
 
+    /** The on-chain [SuiCoinMetadata] for [coinType], or `null` when the coin publishes none. */
+    suspend fun getCoinMetadata(coinType: String): SuiCoinMetadata?
+
     suspend fun executeTransactionBlock(unsignedTransaction: String, signature: String): String
 
     suspend fun dryRunTransaction(transactionBytes: String): SuiDryRunResponse
@@ -121,6 +124,21 @@ constructor(private val http: HttpClient, private val json: Json) : SuiApi {
         } while (cursor != null)
 
         return allCoins
+    }
+
+    override suspend fun getCoinMetadata(coinType: String): SuiCoinMetadata? {
+        val response =
+            http.postRpc<EvmRpcResponseJson<SuiCoinMetadata>>(
+                url = rpcUrl,
+                method = "suix_getCoinMetadata",
+                params = buildJsonArray { add(coinType) },
+            )
+        // A null result is the node's answer for a coin that publishes no metadata object, and is
+        // distinct from an RPC failure — only the latter may abort, so a transient outage is never
+        // read as "this coin has no metadata".
+        val error = response.error
+        if (error != null) error(error.describe("Failed to fetch sui coin metadata"))
+        return response.result
     }
 
     override suspend fun executeTransactionBlock(
@@ -218,6 +236,18 @@ private fun RpcError?.describe(fallback: String): String =
  */
 internal class SuiRpcException(val rpcError: RpcError) :
     Exception("Sui RPC error ${rpcError.code}: ${rpcError.message}")
+
+/**
+ * A Sui coin's on-chain `CoinMetadata` object. [decimals] and [symbol] are required: a coin the
+ * node cannot describe must be dropped rather than shown at a guessed magnitude or under a
+ * placeholder ticker.
+ */
+@Serializable
+data class SuiCoinMetadata(
+    @SerialName("decimals") val decimals: Int,
+    @SerialName("symbol") val symbol: String,
+    @SerialName("iconUrl") val iconUrl: String? = null,
+)
 
 @Serializable
 data class SuiDryRunResponse(@SerialName("effects") val effects: SuiTransactionEffects)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -53,7 +53,10 @@ object SuiHelper {
         return "0x" + hex.ifEmpty { "0" }
     }
 
-    private fun SuiCoin.isNativeSui(): Boolean = isSameSuiCoinType(coinType, suiContractAddress)
+    internal fun isNativeSuiCoinType(coinType: String): Boolean =
+        isSameSuiCoinType(coinType, suiContractAddress)
+
+    private fun SuiCoin.isNativeSui(): Boolean = isNativeSuiCoinType(coinType)
 
     /**
      * Upper bound on the coin objects a single send may reference. Sui rejects a transaction whose

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -186,6 +186,8 @@ internal interface DataUsecasesModule {
 
     @Binds @Singleton fun bindRippleTokenFinder(impl: RippleTokenFinderImpl): RippleTokenFinder
 
+    @Binds @Singleton fun bindSuiTokenFinder(impl: SuiTokenFinderImpl): SuiTokenFinder
+
     @Binds
     @Singleton
     fun bindGetChainTokenUseCase(impl: GetChainTokensUseCaseImpl): GetChainTokensUseCase

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
@@ -1,0 +1,149 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.SuiCoinMetadata
+import com.vultisig.wallet.data.crypto.SuiHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.utils.NetworkException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import timber.log.Timber
+
+/**
+ * Auto-discovers the Sui coin types an address actually holds.
+ *
+ * Companion to [EvmCoinFinder], [CosmosBankCoinFinder] and [RippleTokenFinder], but reached from
+ * `GetChainTokensUseCase` rather than `TokenRepository.getTokensWithBalance`: that path feeds the
+ * background refresh worker, which enables everything it returns straight into the vault. Anyone
+ * can mint a Sui coin and airdrop it, so a held coin type is offered in the token picker for the
+ * user to enable — the same treatment Solana's SPL holdings already get on Android. iOS instead
+ * adds every discovered Sui coin to the vault unprompted, behind a spam heuristic Android has no
+ * equivalent of.
+ *
+ * Unlike iOS, which walks `suix_getOwnedObjects` and fetches each object individually, this reads
+ * the already-paginated `suix_getAllCoins`: it returns coin objects only (no NFTs), so nothing is
+ * lost to a first-page cutoff. Held types the curated [Coins] catalog already lists resolve to the
+ * catalog entry, which carries the hand-verified ticker, logo and `priceProviderID`; the rest are
+ * described by their on-chain `CoinMetadata`, and are dropped when that metadata is missing or
+ * unusable rather than shown under a placeholder ticker at a guessed magnitude.
+ *
+ * Network failures are logged and yield an empty list, matching the sibling finders: a transient
+ * blip must not wipe tokens the vault already holds, and the next refresh retries.
+ *
+ * Tracks vultisig/vultisig-android#5443.
+ */
+interface SuiTokenFinder {
+    suspend fun find(address: String): List<Coin>
+}
+
+internal class SuiTokenFinderImpl @Inject constructor(private val suiApi: SuiApi) : SuiTokenFinder {
+
+    override suspend fun find(address: String): List<Coin> {
+        val heldCoinTypes = fetchHeldCoinTypes(address)
+        if (heldCoinTypes.isEmpty()) return emptyList()
+
+        // Cap in-flight metadata reads so a heavily airdropped address doesn't burst the shared
+        // public Sui endpoint into throttling — a throttled read drops the coin it describes.
+        val gate = Semaphore(MAX_CONCURRENT_METADATA_REQUESTS)
+        return coroutineScope {
+            heldCoinTypes
+                .map { coinType ->
+                    async { curatedCoin(coinType) ?: gate.withPermit { discoveredCoin(coinType) } }
+                }
+                .awaitAll()
+                .filterNotNull()
+        }
+    }
+
+    private suspend fun fetchHeldCoinTypes(address: String): List<String> {
+        val coins =
+            try {
+                suiApi.getAllCoins(address)
+            } catch (e: SocketTimeoutException) {
+                Timber.e(e, "Sui getAllCoins timed out")
+                return emptyList()
+            } catch (e: NetworkException) {
+                Timber.e(e, "Sui getAllCoins failed: status=%d", e.httpStatusCode)
+                return emptyList()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Sui getAllCoins failed")
+                return emptyList()
+            }
+
+        return coins
+            .asSequence()
+            .map { it.coinType }
+            .filterNot { it.isBlank() || SuiHelper.isNativeSuiCoinType(it) }
+            // An address holds one coin object per payment received, so a single coin type comes
+            // back as many objects.
+            .distinctBy { SuiHelper.normalizeSuiCoinType(it) }
+            // Two coin types are free to publish the same symbol, and a Sui Coin.id is its ticker
+            // alone — so the token list can only keep one of them. Ordering by coin type rather
+            // than by the node's object order makes that always the same one.
+            .sortedBy { SuiHelper.normalizeSuiCoinType(it) }
+            .toList()
+    }
+
+    /**
+     * The curated [Coins] catalog entry for [coinType], or `null` when the catalog does not list
+     * it. Matched through [SuiHelper.isSameSuiCoinType] because a node may return a coin type's
+     * package address zero-padded where the catalog stores it short: a raw string compare would
+     * miss, and republish a known token under its on-chain symbol with no price source.
+     */
+    private fun curatedCoin(coinType: String): Coin? =
+        Coins.coins[Chain.Sui]?.firstOrNull {
+            !it.isNativeToken && SuiHelper.isSameSuiCoinType(it.contractAddress, coinType)
+        }
+
+    private suspend fun discoveredCoin(coinType: String): Coin? {
+        val metadata = fetchMetadata(coinType) ?: return null
+
+        val ticker = metadata.symbol.trim()
+        // Decimals scale every amount the user reads and approves before signing, so a coin the
+        // node cannot describe is dropped rather than surfaced at the wrong magnitude. On-chain the
+        // field is a u8, so anything outside that range is a malformed response, not a real coin.
+        if (ticker.isEmpty() || metadata.decimals !in VALID_DECIMALS) {
+            Timber.d("Dropping sui coin %s: unusable metadata", coinType)
+            return null
+        }
+
+        return Coin(
+            chain = Chain.Sui,
+            ticker = ticker,
+            logo = metadata.iconUrl.orEmpty(),
+            address = "",
+            decimal = metadata.decimals,
+            hexPublicKey = "",
+            priceProviderID = "",
+            // Kept in the form the node reported: every coin-type comparison normalizes both
+            // sides, so canonicalizing it here would only hide which form the chain answered with.
+            contractAddress = coinType,
+            isNativeToken = false,
+        )
+    }
+
+    private suspend fun fetchMetadata(coinType: String): SuiCoinMetadata? =
+        try {
+            suiApi.getCoinMetadata(coinType)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.d(e, "Sui coin metadata fetch failed for %s", coinType)
+            null
+        }
+
+    private companion object {
+        const val MAX_CONCURRENT_METADATA_REQUESTS = 8
+        val VALID_DECIMALS = 0..UByte.MAX_VALUE.toInt()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCase.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.repositories.SplTokenRepository
 import com.vultisig.wallet.data.repositories.ThorChainSecuredAssetRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
 import com.vultisig.wallet.data.usecases.OneInchToCoinsUseCase
+import com.vultisig.wallet.data.usecases.SuiTokenFinder
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -25,6 +26,7 @@ constructor(
     private val oneInchApi: OneInchApi,
     private val oneInchToCoins: OneInchToCoinsUseCase,
     private val securedAssetRepository: ThorChainSecuredAssetRepository,
+    private val suiTokenFinder: SuiTokenFinder,
 ) : GetChainTokensUseCase {
 
     override fun invoke(chain: Chain, vault: Vault): Flow<List<Coin>> = flow {
@@ -47,6 +49,9 @@ constructor(
             }
             chain.standard == TokenStandard.SOL -> {
                 emitSolTokens(vault, chain, refreshedTokens, builtInTokens)
+            }
+            chain.standard == TokenStandard.SUI -> {
+                emitSuiTokens(vault, chain, refreshedTokens, builtInTokens)
             }
             else -> Unit
         }
@@ -86,6 +91,21 @@ constructor(
         val jupiterTokens =
             runCatching { splTokenRepository.getJupiterTokens() }.getOrElse { emptyList() }
         emitUniqueTokens(refreshedTokens, builtInTokens, tokens, jupiterTokens)
+    }
+
+    private suspend fun FlowCollector<List<Coin>>.emitSuiTokens(
+        vault: Vault,
+        chain: Chain,
+        refreshedTokens: List<Coin>,
+        builtInTokens: List<Coin>,
+    ) {
+        val address =
+            vault.coins.firstOrNull { it.chain == chain }?.address
+                ?: run {
+                    emitUniqueTokens(refreshedTokens, builtInTokens)
+                    return
+                }
+        emitUniqueTokens(refreshedTokens, builtInTokens, suiTokenFinder.find(address))
     }
 
     private suspend fun FlowCollector<List<Coin>>.emitUniqueTokens(vararg items: List<Coin>) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
@@ -86,6 +86,63 @@ class SuiApiTest {
     }
 
     @Test
+    fun `getCoinMetadata throws with the real RPC error message and code`() = runTest {
+        val api =
+            api("""{"id":1,"result":null,"error":{"code":-32602,"message":"bad coin type"}}""")
+
+        val e = assertFailsWith<IllegalStateException> { api.getCoinMetadata(COIN_TYPE) }
+        assert(e.message!!.contains("bad coin type")) { "message was: ${e.message}" }
+        assert(e.message!!.contains("-32602")) { "message was: ${e.message}" }
+    }
+
+    @Test
+    fun `getCoinMetadata returns null when the coin publishes no metadata`() = runTest {
+        val api = api("""{"id":1,"result":null,"error":null}""")
+
+        assertNull(api.getCoinMetadata(COIN_TYPE))
+    }
+
+    @Test
+    fun `getCoinMetadata returns the parsed metadata on success`() = runTest {
+        val api =
+            api(
+                """{"id":1,"result":{"decimals":6,"name":"Gold","symbol":"GOLD","description":"","iconUrl":"https://example.test/gold.png","id":"0x9"},"error":null}"""
+            )
+
+        val metadata = api.getCoinMetadata(COIN_TYPE)
+
+        assertEquals(6, metadata?.decimals)
+        assertEquals("GOLD", metadata?.symbol)
+        assertEquals("https://example.test/gold.png", metadata?.iconUrl)
+    }
+
+    @Test
+    fun `getCoinMetadata leaves an absent iconUrl null`() = runTest {
+        val api = api("""{"id":1,"result":{"decimals":9,"symbol":"SILVER"},"error":null}""")
+
+        assertNull(api.getCoinMetadata(COIN_TYPE)?.iconUrl)
+    }
+
+    @Test
+    fun `getCoinMetadata asks the node for the requested coin type`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            SuiApiImpl(
+                MockHttpClient.capturingRequest(
+                    HttpStatusCode.OK,
+                    """{"id":1,"result":{"decimals":6,"symbol":"GOLD"},"error":null}""",
+                    capture,
+                ),
+                json,
+            )
+
+        api.getCoinMetadata(COIN_TYPE)
+
+        assert(capture.lastBody.contains("suix_getCoinMetadata")) { capture.lastBody }
+        assert(capture.lastBody.contains(COIN_TYPE)) { capture.lastBody }
+    }
+
+    @Test
     fun `checkStatus returns null for the not-found RPC code`() = runTest {
         val api =
             api(
@@ -110,5 +167,10 @@ class SuiApiTest {
         val api = api("""{"id":1,"result":{"digest":"abc","checkpoint":10},"error":null}""")
 
         assertEquals("abc", api.checkStatus("digest")?.digest)
+    }
+
+    private companion object {
+        const val COIN_TYPE =
+            "0x0a2b3c4d5e6f7809000000000000000000000000000000000000000000000001::gold::GOLD"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinderTest.kt
@@ -1,0 +1,261 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.SuiCoinMetadata
+import com.vultisig.wallet.data.crypto.SuiHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import vultisig.keysign.v1.SuiCoin
+
+/**
+ * Covers Sui held-token auto-discovery (issue #5443): a coin type outside the curated
+ * `Coins.Sui.all` catalog used to be unreachable in the UI however it was acquired.
+ */
+internal class SuiTokenFinderTest {
+
+    private val suiApi: SuiApi = mockk()
+
+    private val finder = SuiTokenFinderImpl(suiApi)
+
+    @Test
+    fun `discovers a held coin type the curated catalog does not list`() = runTest {
+        stubHeld(heldObject(GOLD_TYPE))
+        coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } returns
+            SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = GOLD_ICON)
+
+        val discovered = finder.find(ADDRESS).single()
+
+        assertEquals(Chain.Sui, discovered.chain)
+        assertEquals("GOLD", discovered.ticker)
+        assertEquals(6, discovered.decimal)
+        assertEquals(GOLD_TYPE, discovered.contractAddress)
+        assertEquals(GOLD_ICON, discovered.logo)
+        assertFalse(discovered.isNativeToken)
+        // The address is stamped on later, by whoever enables the token into a vault.
+        assertEquals("", discovered.address)
+    }
+
+    @Test
+    fun `resolves a held coin type to its curated entry when the node reports it short-form`() =
+        runTest {
+            // The catalog stores CETUS's package address zero-padded and a node may answer with it
+            // stripped. A raw string compare would miss and republish a known token under its
+            // on-chain symbol with no price source.
+            val cetus = Coins.Sui.CETUS
+            val shortForm = withShortPackageAddress(cetus.contractAddress)
+            assertNotEquals(cetus.contractAddress, shortForm)
+            stubHeld(heldObject(shortForm))
+
+            val discovered = finder.find(ADDRESS)
+
+            assertEquals(listOf(cetus), discovered)
+            coVerify(exactly = 0) { suiApi.getCoinMetadata(any()) }
+        }
+
+    @Test
+    fun `skips native sui in both the short and the zero-padded address form`() = runTest {
+        stubHeld(heldObject(NATIVE_TYPE, "0x1"), heldObject(PADDED_NATIVE_TYPE, "0x2"))
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+        coVerify(exactly = 0) { suiApi.getCoinMetadata(any()) }
+    }
+
+    @Test
+    fun `collapses every coin object of one type into a single token`() = runTest {
+        stubHeld(
+            heldObject(GOLD_TYPE, "0x1"),
+            heldObject(GOLD_TYPE, "0x2"),
+            heldObject(withShortPackageAddress(GOLD_TYPE), "0x3"),
+        )
+        coEvery { suiApi.getCoinMetadata(any()) } returns
+            SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = null)
+
+        assertEquals(1, finder.find(ADDRESS).size)
+        coVerify(exactly = 1) { suiApi.getCoinMetadata(any()) }
+    }
+
+    @Test
+    fun `a failed metadata read drops only its own coin`() = runTest {
+        stubHeld(heldObject(GOLD_TYPE, "0x1"), heldObject(SILVER_TYPE, "0x2"))
+        coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } throws
+            IllegalStateException("node overloaded")
+        coEvery { suiApi.getCoinMetadata(SILVER_TYPE) } returns
+            SuiCoinMetadata(decimals = 9, symbol = "SILVER", iconUrl = null)
+
+        assertEquals(listOf("SILVER"), finder.find(ADDRESS).map { it.ticker })
+    }
+
+    @Test
+    fun `drops a coin the node publishes no metadata for`() = runTest {
+        stubHeld(heldObject(GOLD_TYPE))
+        coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } returns null
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+    }
+
+    @Test
+    fun `drops a coin whose metadata carries a blank symbol`() = runTest {
+        stubHeld(heldObject(GOLD_TYPE))
+        coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } returns
+            SuiCoinMetadata(decimals = 6, symbol = "   ", iconUrl = null)
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+    }
+
+    @Test
+    fun `drops a coin whose metadata reports decimals outside the on-chain u8 range`() = runTest {
+        // Negative decimals shift every displayed balance the wrong way, inflating it; an
+        // out-of-range positive one blows up the BigDecimal scaling that renders the balance.
+        stubHeld(heldObject(GOLD_TYPE, "0x1"), heldObject(SILVER_TYPE, "0x2"))
+        coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } returns
+            SuiCoinMetadata(decimals = -6, symbol = "GOLD", iconUrl = null)
+        coEvery { suiApi.getCoinMetadata(SILVER_TYPE) } returns
+            SuiCoinMetadata(decimals = 1_000_000_000, symbol = "SILVER", iconUrl = null)
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+    }
+
+    @Test
+    fun `ignores a coin object reported without a coin type`() = runTest {
+        stubHeld(heldObject(coinType = ""))
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+        coVerify(exactly = 0) { suiApi.getCoinMetadata(any()) }
+    }
+
+    @Test
+    fun `returns empty when the held-coin read fails`() = runTest {
+        coEvery { suiApi.getAllCoins(ADDRESS) } throws IllegalStateException("invalid address")
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+    }
+
+    @Test
+    fun `propagates cancellation instead of reporting an empty wallet`() = runTest {
+        coEvery { suiApi.getAllCoins(ADDRESS) } throws CancellationException("navigated away")
+
+        assertThrows<CancellationException> { finder.find(ADDRESS) }
+    }
+
+    @Test
+    fun `returns empty for an address holding nothing`() = runTest {
+        stubHeld()
+
+        assertEquals(emptyList<Coin>(), finder.find(ADDRESS))
+        coVerify(exactly = 0) { suiApi.getCoinMetadata(any()) }
+    }
+
+    @Test
+    fun `a discovered token selects its own objects when the node later pads the coin type`() =
+        runTest {
+            // Discovery stores whichever form the node answered with. The send that follows
+            // re-reads the coin objects, and a node — or a custom RPC — may then pad the package
+            // address. Both ends have to resolve to the same coin type, or the send embeds no
+            // token objects and fails at signing.
+            val shortForm = withShortPackageAddress(GOLD_TYPE)
+            assertNotEquals(GOLD_TYPE, shortForm)
+            stubHeld(heldObject(shortForm, "0xt1", "500"))
+            coEvery { suiApi.getCoinMetadata(shortForm) } returns
+                SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = null)
+
+            val discovered = finder.find(ADDRESS).single()
+            assertEquals(shortForm, discovered.contractAddress)
+
+            val reReadLater =
+                listOf(heldObject(GOLD_TYPE, "0xt1", "500"), heldObject(NATIVE_TYPE, "0xg1", GAS))
+            assertTrue(selectedObjectIds(reReadLater, discovered.contractAddress).contains("0xt1"))
+        }
+
+    @Test
+    fun `orders tokens by coin type, not by the order the node listed the objects`() = runTest {
+        // Two coin types may publish the same symbol, and a Sui Coin.id is its ticker alone, so the
+        // token list keeps only the first of them. Node object order would make that an arbitrary
+        // pick that flips between refreshes, silently changing what the row stands for.
+        val gold = heldObject(GOLD_TYPE, "0x1")
+        val impostor = heldObject(SILVER_TYPE, "0x2")
+        coEvery { suiApi.getCoinMetadata(any()) } returns
+            SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = null)
+
+        stubHeld(gold, impostor)
+        val oneOrder = finder.find(ADDRESS)
+        stubHeld(impostor, gold)
+        val otherOrder = finder.find(ADDRESS)
+
+        assertEquals(oneOrder, otherOrder)
+        assertEquals(GOLD_TYPE, oneOrder.first().contractAddress)
+    }
+
+    @Test
+    fun `a curated token discovered short-form still selects its own objects at signing`() =
+        runTest {
+            // Same invariant across the catalog path, where the contract address the coin carries
+            // is the catalog's zero-padded form rather than the string the node answered with.
+            val shortForm = withShortPackageAddress(Coins.Sui.CETUS.contractAddress)
+            val held =
+                listOf(heldObject(shortForm, "0xt1", "500"), heldObject(NATIVE_TYPE, "0xg1", GAS))
+            coEvery { suiApi.getAllCoins(ADDRESS) } returns held
+
+            val discovered = finder.find(ADDRESS).single()
+
+            assertEquals(Coins.Sui.CETUS.contractAddress, discovered.contractAddress)
+            assertTrue(selectedObjectIds(held, discovered.contractAddress).contains("0xt1"))
+        }
+
+    /** The coin objects a token send of [contractAddress] would embed in its keysign payload. */
+    private fun selectedObjectIds(held: List<SuiCoin>, contractAddress: String): List<String> =
+        SuiHelper.selectPayloadCoins(
+                coins = held,
+                isNativeToken = false,
+                contractAddress = contractAddress,
+                amount = BigInteger.valueOf(500),
+                gasBudget = BigInteger.valueOf(3_000_000),
+            )
+            .map { it.coinObjectId }
+
+    private fun stubHeld(vararg objects: SuiCoin) {
+        coEvery { suiApi.getAllCoins(ADDRESS) } returns objects.toList()
+    }
+
+    private fun heldObject(coinType: String, objectId: String = "0x1", balance: String = "10") =
+        SuiCoin(
+            coinType = coinType,
+            coinObjectId = objectId,
+            version = "1",
+            digest = "digest-$objectId",
+            balance = balance,
+            previousTransaction = "",
+        )
+
+    /** [coinType] with its package address stripped of leading zeros, as a node may report it. */
+    private fun withShortPackageAddress(coinType: String): String {
+        val separator = coinType.indexOf("::")
+        val address = coinType.substring(0, separator).removePrefix("0x").trimStart('0')
+        return "0x$address${coinType.substring(separator)}"
+    }
+
+    private companion object {
+        const val ADDRESS = "0xf00d"
+        const val GAS = "1000000000"
+        const val NATIVE_TYPE = "0x2::sui::SUI"
+        const val PADDED_NATIVE_TYPE =
+            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+        const val GOLD_TYPE =
+            "0x0a2b3c4d5e6f7809000000000000000000000000000000000000000000000001::gold::GOLD"
+        const val SILVER_TYPE =
+            "0x0a2b3c4d5e6f7809000000000000000000000000000000000000000000000002::silver::SILVER"
+        const val GOLD_ICON = "https://example.test/gold.png"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/chaintokens/GetChainTokensUseCaseTest.kt
@@ -4,10 +4,13 @@ package com.vultisig.wallet.data.usecases.chaintokens
 
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ThorChainSecuredAssetRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.usecases.SuiTokenFinder
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
@@ -21,6 +24,7 @@ internal class GetChainTokensUseCaseTest {
 
     private val tokenRepository: TokenRepository = mockk()
     private val securedAssetRepository: ThorChainSecuredAssetRepository = mockk()
+    private val suiTokenFinder: SuiTokenFinder = mockk()
     private val vault: Vault = mockk()
 
     private val useCase =
@@ -30,6 +34,7 @@ internal class GetChainTokensUseCaseTest {
             oneInchApi = mockk(relaxed = true),
             oneInchToCoins = mockk(relaxed = true),
             securedAssetRepository = securedAssetRepository,
+            suiTokenFinder = suiTokenFinder,
         )
 
     @Test
@@ -121,6 +126,53 @@ internal class GetChainTokensUseCaseTest {
         assertEquals(listOf(heldBtcSecured), emitted)
     }
 
+    @Test
+    fun `surfaces a discovered sui token alongside the curated catalog`() = runTest {
+        val curated = Coins.Sui.USDC
+        val discovered = coin(Chain.Sui, ticker = "GOLD", contractAddress = "0xa::gold::GOLD")
+        stubSuiVault()
+        every { tokenRepository.builtInTokens } returns flowOf(listOf(curated))
+        coEvery { suiTokenFinder.find(SUI_ADDRESS) } returns listOf(discovered)
+
+        val emitted = useCase(Chain.Sui, vault).toList().last()
+
+        assertEquals(setOf(curated, discovered), emitted.toSet())
+    }
+
+    @Test
+    fun `a discovered sui token never displaces the curated entry sharing its ticker`() = runTest {
+        // Anyone can mint a Sui coin whose symbol is USDC. Coin.id is ticker-chainId on Sui, so
+        // the two collide on the list key — the hand-verified catalog entry has to be the survivor,
+        // not a spoof carrying its own decimals and no price source.
+        val curated = Coins.Sui.USDC
+        val spoof = coin(Chain.Sui, ticker = "USDC", contractAddress = "0xbad::usdc::USDC", 2)
+        stubSuiVault()
+        every { tokenRepository.builtInTokens } returns flowOf(listOf(curated))
+        coEvery { suiTokenFinder.find(SUI_ADDRESS) } returns listOf(spoof)
+
+        val emitted = useCase(Chain.Sui, vault).toList().last()
+
+        assertEquals(listOf(curated), emitted)
+    }
+
+    @Test
+    fun `skips sui discovery when the vault holds no sui address`() = runTest {
+        val curated = Coins.Sui.USDC
+        every { vault.coins } returns emptyList()
+        every { tokenRepository.builtInTokens } returns flowOf(listOf(curated))
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } returns emptyList()
+
+        val emitted = useCase(Chain.Sui, vault).toList().last()
+
+        assertEquals(listOf(curated), emitted)
+        coVerify(exactly = 0) { suiTokenFinder.find(any()) }
+    }
+
+    private fun stubSuiVault() {
+        every { vault.coins } returns listOf(Coins.Sui.SUI.copy(address = SUI_ADDRESS))
+        coEvery { tokenRepository.getRefreshTokens(any(), any()) } returns emptyList()
+    }
+
     private fun coin(chain: Chain, ticker: String, contractAddress: String, decimal: Int = 18) =
         Coin(
             chain = chain,
@@ -133,4 +185,8 @@ internal class GetChainTokensUseCaseTest {
             contractAddress = contractAddress,
             isNativeToken = false,
         )
+
+    private companion object {
+        const val SUI_ADDRESS = "0xf00d"
+    }
 }


### PR DESCRIPTION
## Summary

A Sui coin type outside the curated ~11 entries in `Coins.kt` had no way into the UI. `GetChainTokensUseCaseImpl` attempted no discovery for Sui (`else -> Unit`), and the custom-token search doesn't cover the chain either — so a token acquired by airdrop, swap payout or transfer stayed invisible however it arrived.

`SuiTokenFinder` reads the already-paginated `suix_getAllCoins` for the vault's Sui address, collapses the coin objects to distinct coin types, and resolves each one:

- a held type the curated catalog lists resolves to the catalog entry, so its hand-verified ticker, logo and `priceProviderID` come along. Matched through `SuiHelper.isSameSuiCoinType`, since a node may return a package address zero-padded where the catalog stores it short (CETUS is one) and a raw string compare would miss;
- anything else is described by its on-chain `CoinMetadata` via the new `suix_getCoinMetadata`. A type the node can't describe is dropped rather than shown under a placeholder ticker at a guessed magnitude — decimals scale every amount the user reads and approves before signing.

Discovered types are offered in the token picker for the user to enable, the same treatment Solana's SPL holdings already get here. iOS instead adds every discovered Sui coin to the vault unprompted, behind a spam heuristic this app has no equivalent of, and anyone can mint a Sui coin and airdrop it — hence the deliberate difference. Windows has no Sui discovery at all.

Two smaller notes on the finder:

- iOS walks `suix_getOwnedObjects` and then fetches each object individually, unpaginated, so a wallet with more than a page of owned objects (NFTs included) loses tokens. `suix_getAllCoins` returns coin objects only and is already paginated here, so nothing is lost to a first-page cutoff.
- Coin types are ordered by type rather than by the node's object order. Two types are free to publish the same symbol and a Sui `Coin.id` is its ticker alone, so the list can keep only one of them — ordering makes that always the same one instead of flipping between refreshes.

## Screenshots

Sui "Select tokens", rendered on the emulator via `PreviewActivity`. Same device and mock data in both; the after adds HASUI, BUCK and SCA — three coin types the address holds that aren't in the catalog. They fall back to a letter tile because a discovered coin carries its icon as a URL rather than a bundled drawable.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/hUgeuGj.png) | ![after](https://i.imgur.com/7bg6Gwq.png) |

## Testing

- `./gradlew :data:testDebugUnitTest` — pass. 15 new `SuiTokenFinderTest` cases (curated short-form match, native exclusion in both address forms, object collapsing, per-coin metadata failure isolation, null/blank-symbol/out-of-range-decimals drops, cancellation propagation) and 5 new `SuiApiTest` cases for `getCoinMetadata`.
- Two of those drive the finder's output back into `SuiHelper.selectPayloadCoins`, pinning that a discovered token still selects its own coin objects at signing time when the node later reports the coin type in the other address form.
- `./gradlew :app:assembleDebug`, `:app:lintDebug`, `:data:lintDebug`, `ktfmtCheck` — pass.

Fixes #5443

Overlap note: PR #5464 also touches `app/src/debug/.../PreviewActivity.kt` for its limit-order previews; low conflict risk since both only append a `when` entry and a preview function in different regions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of Sui tokens held in a wallet.
  * Added metadata retrieval for newly discovered Sui tokens, including symbols, decimals, and optional icons.
  * Preserved curated token information and excluded the native SUI token from discovery.
  * Added preview support for selecting Sui tokens.

* **Bug Fixes**
  * Improved handling of duplicate, invalid, unavailable, and inconsistently formatted Sui token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->