### PR TITLE
fix(home): scroll-driven top bar transition, no duplicate balance

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -3419,9 +3419,18 @@ private fun TokenDetailSheetLoadingPreview() {
 }
 
 /**
- * Vault home (#5473) with the expandable top bar. Used to capture the bar mid-collapse: a slow `adb
- * shell input swipe` over the list drives `expandedFraction` through the transition so the frame
- * where both the expanded and collapsed balance are drawn can be recorded.
+ * Vault home (#5473) with the expandable top bar. Renders the bar mid-collapse so the handover can
+ * be checked: only one of the two balances may ever be legible.
+ *
+ * Scrolling the asset list — not dragging the bar — is what drives `expandedFraction`. `input
+ * swipe` releases on its own, so hold the gesture instead and stretch the fade wide enough to
+ * capture:
+ * ```
+ * adb shell settings put global animator_duration_scale 10
+ * adb shell "input motionevent DOWN 540 1600; input motionevent MOVE 540 1450; \
+ *            input motionevent MOVE 540 1150; screencap -p /sdcard/mid.png; \
+ *            input motionevent UP 540 1150"
+ * ```
  */
 @Composable
 private fun HomeTopBarPreview() {

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -91,6 +91,7 @@ import com.vultisig.wallet.ui.models.TokenSelectionUiModel
 import com.vultisig.wallet.ui.models.TokenUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.TransactionScanStatus
+import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.models.VaultDetailUiModel
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
@@ -146,6 +147,7 @@ import com.vultisig.wallet.ui.screens.deposit.BondFormContent
 import com.vultisig.wallet.ui.screens.deposit.VerifyDepositScreen
 import com.vultisig.wallet.ui.screens.folder.CreateFolderScreen
 import com.vultisig.wallet.ui.screens.folder.generateFakeVault
+import com.vultisig.wallet.ui.screens.home.VaultAccountsScreen
 import com.vultisig.wallet.ui.screens.keygen.FastVaultVerificationScreen
 import com.vultisig.wallet.ui.screens.keygen.ImportSeedphraseContent
 import com.vultisig.wallet.ui.screens.keygen.SelectVaultTypeScreenPreview
@@ -355,6 +357,7 @@ class PreviewActivity : ComponentActivity() {
                     "gas_settings_bsc_after" -> GasSettingsBscPreview(isLegacyGas = true)
                     "sui_token_selection_before" -> SuiTokenSelectionPreview(discovered = false)
                     "sui_token_selection_after" -> SuiTokenSelectionPreview(discovered = true)
+                    "home_topbar" -> HomeTopBarPreview()
                     else -> SwapConfirmPreview()
                 }
             }
@@ -3414,3 +3417,84 @@ private fun TokenDetailSheetLoadingPreview() {
 
     TokenDetailScreen(uiModel = uiModel)
 }
+
+/**
+ * Vault home (#5473) with the expandable top bar. Used to capture the bar mid-collapse: a slow `adb
+ * shell input swipe` over the list drives `expandedFraction` through the transition so the frame
+ * where both the expanded and collapsed balance are drawn can be recorded.
+ */
+@Composable
+private fun HomeTopBarPreview() {
+    VaultAccountsScreen(
+        state =
+            VaultAccountsUiModel(
+                vaultName = "Main Vault",
+                totalFiatValue = "$12,345.67",
+                isBalanceValueVisible = true,
+                accounts =
+                    listOf(
+                        homeAccount(
+                            Chain.Ethereum,
+                            "Ethereum",
+                            R.drawable.ethereum,
+                            "0xAbCd1234",
+                            "0.5 ETH",
+                            "$1,234.56",
+                            "ETH",
+                            3,
+                        ),
+                        homeAccount(
+                            Chain.Bitcoin,
+                            "Bitcoin",
+                            R.drawable.bitcoin,
+                            "bc1qxyz",
+                            "0.1 BTC",
+                            "$6,500.00",
+                            "BTC",
+                            1,
+                        ),
+                        homeAccount(
+                            Chain.ThorChain,
+                            "THORChain",
+                            R.drawable.rune,
+                            "thor1abc",
+                            "100 RUNE",
+                            "$400.00",
+                            "RUNE",
+                            1,
+                        ),
+                        homeAccount(
+                            Chain.Solana,
+                            "Solana",
+                            R.drawable.solana,
+                            "So1anaAddr",
+                            "12 SOL",
+                            "$2,210.11",
+                            "SOL",
+                            2,
+                        ),
+                    ),
+            )
+    )
+}
+
+private fun homeAccount(
+    chain: Chain,
+    chainName: String,
+    logo: Int,
+    address: String,
+    nativeTokenAmount: String,
+    fiatAmount: String,
+    ticker: String,
+    assetsSize: Int,
+) =
+    AccountUiModel(
+        model = Address(chain = chain, address = address, accounts = emptyList()),
+        chainName = chainName,
+        logo = logo,
+        address = address,
+        nativeTokenAmount = nativeTokenAmount,
+        fiatAmount = fiatAmount,
+        assetsSize = assetsSize,
+        nativeTokenTicker = ticker,
+    )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ExpandableTopBar.kt
@@ -2,7 +2,6 @@
 
 package com.vultisig.wallet.ui.components.v2.scaffold
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
@@ -30,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -206,15 +206,29 @@ fun VsExpandableTopBar(
             tonalElevation = 0.dp,
             color = backgroundColor,
         ) {
-            Crossfade(
-                targetState = expandedFraction > 0.5f,
-                animationSpec = tween(durationMillis = 150),
-                label = "content_transition",
-            ) { isExpanded ->
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    content = if (isExpanded) expandedContent else collapsedContent,
-                )
+            // Both contents carry the portfolio balance, so a Crossfade — which overlaps its two
+            // children by design — drew the amount twice mid-transition (#5473). Drive the alphas
+            // off expandedFraction over non-overlapping halves of the range instead: the expanded
+            // content only fades in above 0.5, the collapsed content only below it, so they hand
+            // over cleanly and follow the drag in both directions rather than snapping on a
+            // threshold. Each is skipped entirely at zero alpha so an invisible content never
+            // holds a click target.
+            val expandedAlpha = ((expandedFraction - 0.5f) * 2f).coerceIn(0f, 1f)
+            val collapsedAlpha = ((0.5f - expandedFraction) * 2f).coerceIn(0f, 1f)
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                if (expandedAlpha > 0f) {
+                    Box(
+                        modifier = Modifier.fillMaxSize().graphicsLayer { alpha = expandedAlpha },
+                        content = expandedContent,
+                    )
+                }
+                if (collapsedAlpha > 0f) {
+                    Box(
+                        modifier = Modifier.fillMaxSize().graphicsLayer { alpha = collapsedAlpha },
+                        content = collapsedContent,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

`VsExpandableTopBar` swapped its expanded and collapsed content with a `Crossfade`. A `Crossfade` overlaps both children by design, and both of them carry the portfolio balance — collapsed in `VaultAccountsScreen`, expanded via `WalletExpandedTopbarContent` → `BalanceBanner`. Mid-collapse the amount was therefore drawn twice at partial alpha, reading as a duplicate rather than a transition. The fixed 150ms tween on a `expandedFraction > 0.5f` threshold also made the swap snap at the midpoint instead of tracking the drag.

Both alphas are now derived from `expandedFraction` over non-overlapping halves of the range:

```kotlin
val expandedAlpha = ((expandedFraction - 0.5f) * 2f).coerceIn(0f, 1f)
val collapsedAlpha = ((0.5f - expandedFraction) * 2f).coerceIn(0f, 1f)
```

The expanded content is only visible above 0.5, the collapsed content only below it, so the two can never be legible at the same time and the handover follows the gesture in both directions. Each side is skipped entirely at zero alpha, preserving the `Crossfade` property that invisible content holds no click target.

`VsExpandableTopBar` is shared through `ScaffoldWithExpandableTopBar`, so `ChainTokensScreen` gets the same behaviour.

Fixes #5473

## Before / After

Captured on an emulator at the same drag position, held mid-transition with `input motionevent` while `animator_duration_scale=10` stretched the fade enough to screenshot. Before, both the collapsed *"Portfolio Balance $12,345.67"* and the expanded *"$12,345.67"* are on screen, with the collapsed text bleeding over the history and settings icons.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/QFVW3E0.png) | ![after](https://i.imgur.com/ArQKozw.png) |

Five consecutive frames through the same transition — before, the amount is doubled in the middle frames; after, only one balance is ever drawn:

| Before | After |
|--------|-------|
| ![before burst](https://i.imgur.com/1g7NrI9.png) | ![after burst](https://i.imgur.com/09WudBl.png) |

End states at normal animation speed — expanded, fully collapsed, and expanded again after reversing the drag:

![end states](https://i.imgur.com/1RszfY6.png)

## Test plan

- [x] Vault home: collapse and expand by scrolling the asset list — never two balances legible at once.
- [x] Transition follows the drag and reverses cleanly; the `onDragStopped` settle is unchanged.
- [x] End states render correctly expanded and fully collapsed.
- [x] `./gradlew lintDebug` passes.
- [ ] `ChainTokensScreen` shares the component and is covered by the same change, but was not screenshot-verified.

Adds a `home_topbar` entry to the debug-only `PreviewActivity` so the transition can be captured without a real vault.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the top bar’s expanded and collapsed transition for smoother visual changes.
  - Prevented hidden top bar content from remaining interactive during transitions.
  - Reduced visual overlap and improved interaction reliability while expanding or collapsing the top bar.

- **Developer Experience**
  - Added a preview of the home screen top bar with representative account data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->