### PR TITLE
fix(tron): apply 30% energy safety margin to TRC20 fee_limit

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -685,7 +685,7 @@ constructor(
                                 )
 
                             val totalEnergy = triggerResult.energyUsed + triggerResult.energyPenalty
-                            totalEnergy * energyPrice
+                            contractFeeLimit(totalEnergy, energyPrice)
                         }
 
                 BlockChainSpecificAndUtxo(
@@ -736,5 +736,15 @@ constructor(
         private const val ENERGY_TO_SUN_FACTOR = 280
 
         private val THORCHAIN_ROUTER_DEPOSIT_GAS_LIMIT = BigInteger.valueOf(200_000)
+
+        // 30% headroom on top of simulated energy, covering a contract's per-call dynamic
+        // energy_factor surge between simulation and broadcast. Matches iOS's
+        // TronService.contractFeeLimit (ENERGY_SAFETY_NUMERATOR/DENOMINATOR = 13/10).
+        // https://developers.tron.network/docs/resource-model#dynamic-energy-model
+        private const val ENERGY_SAFETY_NUMERATOR = 13L
+        private const val ENERGY_SAFETY_DENOMINATOR = 10L
+
+        internal fun contractFeeLimit(totalEnergyUsed: Long, energyPrice: Long): Long =
+            (totalEnergyUsed * ENERGY_SAFETY_NUMERATOR / ENERGY_SAFETY_DENOMINATOR) * energyPrice
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -739,6 +739,30 @@ internal class BlockChainSpecificRepositoryImplTest {
         }
     }
 
+    @Test
+    fun `Tron TRC20 fee_limit applies iOS's 30 percent energy safety multiplier`() {
+        // 65,000 energy x 1.3 x 420 sun/energy = 35,490,000 sun — pins the same value as iOS's
+        // TronServiceFeeLimitTests.testContractFeeLimit_appliesSafetyMultiplierToEnergyAtChainPrice.
+        assertEquals(
+            35_490_000L,
+            BlockChainSpecificRepositoryImpl.contractFeeLimit(
+                totalEnergyUsed = 65_000L,
+                energyPrice = 420L,
+            ),
+        )
+    }
+
+    @Test
+    fun `Tron TRC20 fee_limit safety multiplier survives truncation for energy not divisible by 10`() {
+        val bare = 65_001L * 420L
+        val withSafety =
+            BlockChainSpecificRepositoryImpl.contractFeeLimit(
+                totalEnergyUsed = 65_001L,
+                energyPrice = 420L,
+            )
+        assertTrue(withSafety > bare)
+    }
+
     private fun suiApi(referenceGasPrice: BigInteger, coins: List<SuiCoin> = emptyList()): SuiApi =
         mockk {
             coEvery { getReferenceGasPrice() } returns referenceGasPrice

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -754,13 +754,16 @@ internal class BlockChainSpecificRepositoryImplTest {
 
     @Test
     fun `Tron TRC20 fee_limit safety multiplier survives truncation for energy not divisible by 10`() {
-        val bare = 65_001L * 420L
-        val withSafety =
+        // 65,001 x 13 / 10 = 84,501.3 truncated to 84,501, x 420 = 35,490,420 — the
+        // multiply-before-
+        // divide order must be preserved or this pins a different (smaller) value.
+        assertEquals(
+            35_490_420L,
             BlockChainSpecificRepositoryImpl.contractFeeLimit(
                 totalEnergyUsed = 65_001L,
                 energyPrice = 420L,
-            )
-        assertTrue(withSafety > bare)
+            ),
+        )
     }
 
     private fun suiApi(referenceGasPrice: BigInteger, coins: List<SuiCoin> = emptyList()): SuiApi =


### PR DESCRIPTION
Closes #5480

## Summary

TRC20 `fee_limit` on Android was set straight from the simulated `energy_used + energy_penalty`, with no margin for the contract's dynamic `energy_factor` congestion surge between simulation and broadcast. iOS applies a documented 1.3x multiplier for exactly this reason (`TronService.contractFeeLimit`, added in iOS PR #4131 after a real OUT_OF_ENERGY bug). This adds the same 30% headroom to Android's `BlockChainSpecificRepository` TRC20 branch.

The multiplier is pulled into a small pure function, `BlockChainSpecificRepositoryImpl.contractFeeLimit(totalEnergyUsed, energyPrice)`, mirroring iOS's own static `contractFeeLimit(energyUsed:energyPrice:)` — same operation order (multiply by 13 before dividing by 10) so integer truncation can't erode the margin.

## Why this covers both display and the signed transaction

`gasFeeEstimation` computed here becomes both what's shown to the user and, directly, the wire `fee_limit` (`TronHelper.setFeeLimit(tronSpecific.gasFeeEstimation.toLong())`). The joiner in a keysign ceremony doesn't recompute this — it builds from the same `KeysignPayload.blockChainSpecific` the initiator already sent — so fixing this one function keeps every consumer (display, initiator signing, joiner signing) on the identical multiplied value.

## Scope

Only the TRC20 contract-simulation branch is touched. The native TRX path (fixed `TRON_DEFAULT_ESTIMATION_FEE`) and `TronFeeService`'s separate display-only congestion-factor calculation are untouched, matching the ticket's scope.

## Testing

- `./gradlew :data:testDebugUnitTest --tests "*BlockChainSpecificRepositoryImplTest*" --tests "*TronFeeServiceTest*"` — 25 tests, all passing
- `./gradlew :data:ktfmtFormat` — no diff beyond the intended changes

New tests pin the ticket's exact example (65,000 energy x 1.3 x 420 sun/energy = 35,490,000 sun, matching iOS's `TronServiceFeeLimitTests`) and confirm the multiplier survives integer-division truncation for energy not divisible by 10.

No screenshots: this is a pure fee-calculation change with no UI, layout, or string diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tron TRC20 transaction fee-limit estimation by adding a 30% safety margin to simulated energy usage.
  * Helps reduce the risk of underestimating fees, including when calculations involve rounded values.

* **Tests**
  * Added coverage for standard and rounded energy-usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->