### PR TITLE
Start screen: primary CTA reads "Create new Vault", not "Get started"

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
@@ -171,7 +171,7 @@ private fun StartScreen(
                 UiSpacer(size = 16.dp)
 
                 VsButton(
-                    label = stringResource(R.string.referral_onboarding_get_started),
+                    label = stringResource(R.string.start_screen_create_new_vault),
                     modifier =
                         Modifier.startScreenAnimations(delay = 100)
                             .fillMaxWidth()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -293,6 +293,7 @@
     <string name="keysign_sign_transaction">Transaktion unterschreiben</string>
     <string name="sign_transaction">Transaktion signieren</string>
     <string name="keysign_password_title">Passwort</string>
+    <string name="start_screen_create_new_vault">Neuen Tresor erstellen</string>
     <string name="start_screen_new">NEU</string>
     <string name="start_screen_import_seedphrase">Seed-Phrase importieren</string>
     <string name="start_screen_import_seedphrase_desc">Geben Sie sie ein, erstellen Sie einen Tresor, schauen Sie nie zurück.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -293,6 +293,7 @@
     <string name="keysign_sign_transaction">Firmar transacción</string>
     <string name="sign_transaction">Firmar transacción</string>
     <string name="keysign_password_title">Contraseña</string>
+    <string name="start_screen_create_new_vault">Crear nueva bóveda</string>
     <string name="start_screen_new">NUEVO</string>
     <string name="start_screen_import_seedphrase">Importar frase semilla</string>
     <string name="start_screen_import_seedphrase_desc">Ingrésala, crea una bóveda, no mires atrás.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -293,6 +293,7 @@
     <string name="keysign_sign_transaction">Potpiši transakciju</string>
     <string name="sign_transaction">Potpiši transakciju</string>
     <string name="keysign_password_title">Lozinka</string>
+    <string name="start_screen_create_new_vault">Stvori novi trezor</string>
     <string name="start_screen_new">NOVO</string>
     <string name="start_screen_import_seedphrase">Uvezi seed-frazu</string>
     <string name="start_screen_import_seedphrase_desc">Unesi je, stvori trezor, ne osvrći se.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -293,6 +293,7 @@
     <string name="keysign_sign_transaction">Firma transazione</string>
     <string name="sign_transaction">Firma transazione</string>
     <string name="keysign_password_title">Password</string>
+    <string name="start_screen_create_new_vault">Crea nuovo vault</string>
     <string name="start_screen_new">NUOVO</string>
     <string name="start_screen_import_seedphrase">Importa seedphrase</string>
     <string name="start_screen_import_seedphrase_desc">Inseriscila, crea un vault, non guardare indietro.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -382,6 +382,7 @@
     <string name="keysign_sign_transaction">거래 서명</string>
     <string name="sign_transaction">거래 서명</string>
     <string name="keysign_password_title">비밀번호</string>
+    <string name="start_screen_create_new_vault">새 볼트 생성</string>
     <string name="start_screen_new">새로운</string>
     <string name="start_screen_import_seedphrase">시드 구문 가져오기</string>
     <string name="start_screen_import_seedphrase_desc">입력하고, 볼트를 생성하고, 다시는 돌아보지 마세요.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -292,6 +292,7 @@
     <string name="keysign_sign_transaction">Transactie ondertekenen</string>
     <string name="sign_transaction">Transactie ondertekenen</string>
     <string name="keysign_password_title">Wachtwoord</string>
+    <string name="start_screen_create_new_vault">Nieuwe kluis aanmaken</string>
     <string name="start_screen_new">NIEUW</string>
     <string name="start_screen_import_seedphrase">Seedphrase importeren</string>
     <string name="start_screen_import_seedphrase_desc">Voer het in, maak een kluis aan, kijk nooit meer om.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -293,6 +293,7 @@
     <string name="keysign_sign_transaction">Assinar transação</string>
     <string name="sign_transaction">Assinar transação</string>
     <string name="keysign_password_title">Palavra-passe</string>
+    <string name="start_screen_create_new_vault">Criar novo cofre</string>
     <string name="start_screen_new">NOVO</string>
     <string name="start_screen_import_seedphrase">Importar frase-semente</string>
     <string name="start_screen_import_seedphrase_desc">Introduza-a, crie um cofre, nunca mais olhe para trás.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -292,6 +292,7 @@
     <string name="keysign_sign_transaction">Подписать транзакцию</string>
     <string name="sign_transaction">Подписать транзакцию</string>
     <string name="keysign_password_title">Пароль</string>
+    <string name="start_screen_create_new_vault">Создать новое хранилище</string>
     <string name="start_screen_new">НОВОЕ</string>
     <string name="start_screen_import_seedphrase">Импортировать сид-фразу</string>
     <string name="start_screen_import_seedphrase_desc">Введите её, создайте хранилище, не оглядывайтесь назад.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -536,6 +536,7 @@
     <string name="keysign_password_title">密码</string>
 
     <!-- Home Screen -->
+    <string name="start_screen_create_new_vault">创建新保险库</string>
     <string name="start_screen_new">新功能</string>
     <string name="start_screen_import_seedphrase">导入助记词</string>
     <string name="start_screen_import_seedphrase_desc">输入它，创建保险库，永不回头。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,7 @@
     <string name="keysign_sign_transaction">Sign transaction</string>
     <string name="sign_transaction">Sign Transaction</string>
     <string name="keysign_password_title">Password</string>
+    <string name="start_screen_create_new_vault">Create new Vault</string>
     <string name="start_screen_new">NEW</string>
     <string name="start_screen_import_seedphrase">Import seedphrase</string>
     <string name="start_screen_import_seedphrase_desc">Enter it, create a vault, never look back.</string>


### PR DESCRIPTION
Closes #5489

## Summary

The Start screen's primary button read **"Get started"**. The two secondary buttons above it name their actions ("Scan QR", "Import"); the one that actually creates a vault did not. [Figma node 67139-90504](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=67139-90504) names it **"Create new Vault"** — lowercase `new`, capital `V`. The rest of the screen already matches the design; only the label differed.

## What changed

- `StartScreen.kt:174` — now uses a new `start_screen_create_new_vault` key
- The new key added to all 10 locale files, placed in the existing `start_screen_*` block

The button had been borrowing `referral_onboarding_get_started`. That key is **not** repurposed or reworded here, because it still renders two other CTAs — `ReferralOnboardingScreen.kt:73` and `ChooseDeviceCountScreen.kt:94` — and editing it in place would have silently retitled both.

| Locale | Value |
|---|---|
| en | Create new Vault |
| de | Neuen Tresor erstellen |
| es | Crear nueva bóveda |
| hr | Stvori novi trezor |
| it | Crea nuovo vault |
| ko | 새 볼트 생성 |
| nl | Nieuwe kluis aanmaken |
| pt | Criar novo cofre |
| ru | Создать новое хранилище |
| zh-rCN | 创建新保险库 |

Each translation reuses the vault noun that locale already uses (de `Tresor`, es `bóveda`, hr `trezor`, it `vault`, ko `볼트`, nl `kluis`, pt `cofre`, ru `хранилище`, zh `保险库`) and the verb phrasing from `onboarding_summary_button` ("Create your vault"), so the string reads like the rest of the app rather than a literal rendering of the English.

## Cross-platform

The same label is landing on iOS (vultisig/vultisig-ios#5018) and desktop/extension (vultisig/vultisig-windows#4542). Note for desktop: its existing `create_new_vault` value is `"Create New Vault"` with a capital **N** — Figma is lowercase, so that one needs a recase, not just key reuse.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:ktfmtCheckMain` — green
- [x] All 10 `strings.xml` files parse
- [x] Verified `referral_onboarding_get_started` still resolves for its two remaining call sites
- [ ] Launch with no vaults → Start screen primary button reads "Create new Vault" and still routes to vault creation (testTag `StartScreen.createNewVault` unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the start screen’s create-vault button to display the correct “Create new vault” label instead of an unrelated onboarding message.

- **Localization**
  - Added the create-vault label in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, Simplified Chinese, and English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->