### PR TITLE
fix(keysign): stop a stuck relay message from stranding a co-signer

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -293,9 +293,8 @@ class DKLSKeygen(
         return false
     }
 
-    @Throws(Exception::class)
     private suspend fun deleteMessageFromServer(hash: String) {
-        sessionApi.deleteTssMessage(
+        sessionApi.deleteTssMessageQuietly(
             mediatorURL,
             sessionID,
             this.localPartyId,

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -32,8 +32,6 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import timber.log.Timber
 import tss.KeysignResponse
 
 /**
@@ -72,12 +70,20 @@ class DKLSKeysign(
             isEncryptionGCM = true,
         )
     private val cache = mutableMapOf<String, Any>()
+    private val redeletedHashes = mutableSetOf<String>()
 
     /** Collects signatures keyed by the signed message hex string. */
     val signatures = mutableMapOf<String, KeysignResponse>()
-    private val heardFromThisAttempt = mutableSetOf<String>()
-    private val heardFromEver = mutableSetOf<String>()
-    private var waitingNotified = false
+    private val poller =
+        KeysignMessagePoller(
+            sessionApi = sessionApi,
+            mediatorURL = mediatorURL,
+            sessionID = sessionID,
+            localPartyID = localPartyID,
+            keysignCommittee = keysignCommittee,
+            onWaitingForPeers = onWaitingForPeers,
+            onPeersResumed = onPeersResumed,
+        )
 
     private fun getKeyshareString(): String? {
         for (ks in vault.keyshares) {
@@ -225,59 +231,6 @@ class DKLSKeysign(
         }
     }
 
-    private suspend fun pullInboundMessages(handle: Handle, messageID: String): Boolean {
-        Timber.d("start pulling inbound messages")
-
-        heardFromThisAttempt.clear()
-        var lastMessageNano = System.nanoTime()
-        while (true) {
-            try {
-                val msgs =
-                    sessionApi.getTssMessages(mediatorURL, sessionID, localPartyID, messageID)
-
-                if (msgs.isNotEmpty()) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                    lastMessageNano = System.nanoTime()
-                    heardFromThisAttempt.clear()
-                    if (processInboundMessage(handle, msgs, messageID)) {
-                        return true
-                    }
-                } else {
-                    delay(100)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to get messages")
-            }
-
-            val silenceSecs = (System.nanoTime() - lastMessageNano) / 1_000_000_000.0
-            if (!waitingNotified && silenceSecs > 10) {
-                waitingNotified = true
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                if (missingPeers.isNotEmpty()) {
-                    onWaitingForPeers?.invoke(missingPeers)
-                }
-            }
-
-            if (silenceSecs > 60) {
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                val msg =
-                    if (missingPeers.isEmpty()) {
-                        "keysign timed out: all peers responded but protocol did not complete within 60s"
-                    } else {
-                        "no messages from ${missingPeers.joinToString()} in 60s"
-                    }
-                error(msg)
-            }
-        }
-    }
-
     private suspend fun processInboundMessage(
         handle: Handle,
         msgs: List<Message>,
@@ -288,11 +241,16 @@ class DKLSKeysign(
             val key = "$sessionID-$localPartyID-$messageID-${msg.hash}"
             if (cache[key] != null) {
                 println("message with key: $key has been applied before")
+                // The relay is still serving a message we applied, so our delete never took. Retry
+                // it once per attempt: repeating it on every poll would park the loop behind the
+                // relay client's own delete backoff without changing the outcome.
+                if (redeletedHashes.add(msg.hash)) {
+                    deleteMessageFromServer(msg.hash, messageID)
+                }
                 continue
             }
             println("Got message from: ${msg.from}, to: ${msg.to}, key: $key")
-            heardFromThisAttempt.add(msg.from)
-            heardFromEver.add(msg.from)
+            poller.recordPeerHeard(msg.from)
             val decryptedBody =
                 encryption.decrypt(
                     Base64.decode(msg.body),
@@ -316,15 +274,15 @@ class DKLSKeysign(
     }
 
     private suspend fun deleteMessageFromServer(hash: String, messageID: String) {
-        sessionApi.deleteTssMessage(mediatorURL, sessionID, localPartyID, hash, messageID)
+        sessionApi.deleteTssMessageQuietly(mediatorURL, sessionID, localPartyID, hash, messageID)
     }
 
     private suspend fun keysignOneMessageWithRetry(attempt: Int, messageToSign: String) {
         if (attempt == 0) {
-            heardFromEver.clear()
-            waitingNotified = false
+            poller.resetForNewMessage()
         }
         cache.clear()
+        redeletedHashes.clear()
         val msgHash = messageToSign.md5()
         val localMessenger =
             TssMessenger(
@@ -395,7 +353,8 @@ class DKLSKeysign(
                 error("fail to create sign session from setup message, error: $sessionResult")
             }
             processDKLSOutboundMessage(handler)
-            val isFinished = pullInboundMessages(handler, msgHash)
+            val isFinished =
+                poller.poll(msgHash) { msgs -> processInboundMessage(handler, msgs, msgHash) }
             if (isFinished) {
                 val sig = dklsSignSessionFinish(handler)
                 val resp = KeysignResponse()
@@ -422,16 +381,12 @@ class DKLSKeysign(
                     msgHash = msgHash,
                     messageToSign = messageToSign,
                     signatures = signatures,
-                ) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                }
+                    onRecovered = poller::clearWaitingForPeers,
+                )
             if (recovered) {
                 return
             }
-            val maxRetries = if (heardFromEver.isEmpty()) 1 else 3
+            val maxRetries = if (poller.hasHeardFromAnyPeer) 3 else 1
             if (attempt < maxRetries) {
                 keysignOneMessageWithRetry(attempt + 1, messageToSign)
             } else {

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -241,12 +241,9 @@ class DKLSKeysign(
             val key = "$sessionID-$localPartyID-$messageID-${msg.hash}"
             if (cache[key] != null) {
                 println("message with key: $key has been applied before")
-                // The relay is still serving a message we applied, so our delete never took. Retry
-                // it once per attempt: repeating it on every poll would park the loop behind the
-                // relay client's own delete backoff without changing the outcome.
-                if (redeletedHashes.add(msg.hash)) {
-                    deleteMessageFromServer(msg.hash, messageID)
-                }
+                // Once per attempt: repeating a delete the relay is ignoring only parks the poll
+                // loop behind the relay client's own backoff.
+                if (redeletedHashes.add(msg.hash)) deleteMessageFromServer(msg.hash, messageID)
                 continue
             }
             println("Got message from: ${msg.from}, to: ${msg.to}, key: $key")
@@ -353,8 +350,7 @@ class DKLSKeysign(
                 error("fail to create sign session from setup message, error: $sessionResult")
             }
             processDKLSOutboundMessage(handler)
-            val isFinished =
-                poller.poll(msgHash) { msgs -> processInboundMessage(handler, msgs, msgHash) }
+            val isFinished = poller.poll(msgHash) { processInboundMessage(handler, it, msgHash) }
             if (isFinished) {
                 val sig = dklsSignSessionFinish(handler)
                 val resp = KeysignResponse()

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
@@ -1,0 +1,138 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.mediator.Message
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import timber.log.Timber
+
+/**
+ * Polls the relay for one signing attempt's inbound messages and hands each batch to the caller,
+ * which applies it to its own native session. Shared by the DKLS, Schnorr and ML-DSA keysign
+ * helpers, whose loops are otherwise identical.
+ *
+ * @param onWaitingForPeers Invoked when no inbound messages have arrived for ~10 s; receives the
+ *   silent peer IDs.
+ * @param onPeersResumed Invoked when messages resume after [onWaitingForPeers] was called.
+ * @param nanoTime Monotonic clock, injectable so the deadlines are testable.
+ */
+internal class KeysignMessagePoller(
+    private val sessionApi: SessionApi,
+    private val mediatorURL: String,
+    private val sessionID: String,
+    private val localPartyID: String,
+    private val keysignCommittee: List<String>,
+    private val onWaitingForPeers: ((List<String>) -> Unit)?,
+    private val onPeersResumed: (() -> Unit)?,
+    private val nanoTime: () -> Long = System::nanoTime,
+) {
+    private val heardFromThisWindow = mutableSetOf<String>()
+    private val heardFromEver = mutableSetOf<String>()
+    private var waitingNotified = false
+
+    /** Whether any peer has answered since [resetForNewMessage]; the retry budget depends on it. */
+    val hasHeardFromAnyPeer: Boolean
+        get() = heardFromEver.isNotEmpty()
+
+    /**
+     * Drops the state that spans one message's retries, including a silent-peer hint the previous
+     * message left raised. Call before a message's first attempt.
+     */
+    fun resetForNewMessage() {
+        heardFromEver.clear()
+        clearWaitingForPeers()
+    }
+
+    /** Records that [from] sent a message this device applied to its session. */
+    fun recordPeerHeard(from: String) {
+        heardFromThisWindow += from
+        heardFromEver += from
+    }
+
+    /** Lowers the silent-peer flag, reporting the resumption if the flag had been raised. */
+    fun clearWaitingForPeers() {
+        if (waitingNotified) {
+            waitingNotified = false
+            onPeersResumed?.invoke()
+        }
+    }
+
+    /**
+     * Polls until [applyMessages] reports the protocol complete, or until the attempt's deadline.
+     *
+     * That deadline is absolute. A message this device cannot clear — one whose relay delete
+     * failed, or whose body will not decrypt — is re-served by every poll, so extending the
+     * deadline whenever a batch arrives would keep a doomed attempt alive until the relay expires
+     * the message, stranding the user on the signing screen (#5488). Only the silent-peer hint
+     * reads the resettable clock.
+     */
+    suspend fun poll(
+        messageID: String,
+        applyMessages: suspend (List<Message>) -> Boolean,
+    ): Boolean {
+        Timber.d("start pulling inbound messages")
+
+        heardFromThisWindow.clear()
+        val deadlineStart = nanoTime()
+        var lastBatchNano = deadlineStart
+        while (true) {
+            try {
+                val msgs =
+                    sessionApi.getTssMessages(mediatorURL, sessionID, localPartyID, messageID)
+                if (msgs.isNotEmpty()) {
+                    clearWaitingForPeers()
+                    lastBatchNano = nanoTime()
+                    heardFromThisWindow.clear()
+                    if (applyMessages(msgs)) {
+                        return true
+                    }
+                } else {
+                    delay(POLL_INTERVAL_MS)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to get messages")
+                delay(POLL_INTERVAL_MS)
+            }
+
+            if (!waitingNotified && secondsSince(lastBatchNano) > PEER_SILENCE_HINT_SECONDS) {
+                waitingNotified = true
+                val silent = peersOutside(heardFromThisWindow)
+                if (silent.isNotEmpty()) {
+                    onWaitingForPeers?.invoke(silent)
+                }
+            }
+            if (secondsSince(deadlineStart) > TIMEOUT_SECONDS) {
+                error(timeoutMessage())
+            }
+        }
+    }
+
+    private fun secondsSince(nanos: Long): Double = (nanoTime() - nanos) / NANOS_PER_SECOND
+
+    private fun peersOutside(heard: Set<String>): List<String> =
+        keysignCommittee.filter { it != localPartyID && it !in heard }
+
+    /**
+     * Reads [heardFromEver] rather than the silence window, which holds only the most recent batch:
+     * the deadline can now expire while peers are still answering, and naming one of them as absent
+     * would send support down the wrong path.
+     */
+    private fun timeoutMessage(): String {
+        val absent = peersOutside(heardFromEver)
+        return if (absent.isEmpty()) {
+            "keysign timed out after ${TIMEOUT_SECONDS}s: " +
+                "all peers responded but the protocol did not complete"
+        } else {
+            "keysign timed out after ${TIMEOUT_SECONDS}s: no messages from ${absent.joinToString()}"
+        }
+    }
+
+    private companion object {
+        const val POLL_INTERVAL_MS = 100L
+        const val PEER_SILENCE_HINT_SECONDS = 10
+        const val TIMEOUT_SECONDS = 60
+        const val NANOS_PER_SECOND = 1_000_000_000.0
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
@@ -2,6 +2,10 @@ package com.vultisig.wallet.data.keygen
 
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import timber.log.Timber
@@ -73,45 +77,39 @@ internal class KeysignMessagePoller(
         Timber.d("start pulling inbound messages")
 
         heardFromThisWindow.clear()
-        val deadlineStart = nanoTime()
-        var lastBatchNano = deadlineStart
+        val startedAt = nanoTime()
+        var lastBatchAt = startedAt
         while (true) {
             try {
                 val msgs =
                     sessionApi.getTssMessages(mediatorURL, sessionID, localPartyID, messageID)
                 if (msgs.isNotEmpty()) {
                     clearWaitingForPeers()
-                    lastBatchNano = nanoTime()
+                    lastBatchAt = nanoTime()
                     heardFromThisWindow.clear()
-                    if (applyMessages(msgs)) {
-                        return true
-                    }
+                    if (applyMessages(msgs)) return true
                 } else {
-                    delay(POLL_INTERVAL_MS)
+                    delay(POLL_INTERVAL)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get messages")
-                delay(POLL_INTERVAL_MS)
+                delay(POLL_INTERVAL)
             }
 
-            if (!waitingNotified && secondsSince(lastBatchNano) > PEER_SILENCE_HINT_SECONDS) {
+            if (!waitingNotified && elapsedSince(lastBatchAt) > PEER_SILENCE_HINT) {
                 waitingNotified = true
-                val silent = peersOutside(heardFromThisWindow)
-                if (silent.isNotEmpty()) {
-                    onWaitingForPeers?.invoke(silent)
-                }
+                val silent = peersNotIn(heardFromThisWindow)
+                if (silent.isNotEmpty()) onWaitingForPeers?.invoke(silent)
             }
-            if (secondsSince(deadlineStart) > TIMEOUT_SECONDS) {
-                error(timeoutMessage())
-            }
+            if (elapsedSince(startedAt) > ATTEMPT_TIMEOUT) error(timeoutMessage())
         }
     }
 
-    private fun secondsSince(nanos: Long): Double = (nanoTime() - nanos) / NANOS_PER_SECOND
+    private fun elapsedSince(nanos: Long): Duration = (nanoTime() - nanos).nanoseconds
 
-    private fun peersOutside(heard: Set<String>): List<String> =
+    private fun peersNotIn(heard: Set<String>): List<String> =
         keysignCommittee.filter { it != localPartyID && it !in heard }
 
     /**
@@ -120,19 +118,16 @@ internal class KeysignMessagePoller(
      * would send support down the wrong path.
      */
     private fun timeoutMessage(): String {
-        val absent = peersOutside(heardFromEver)
-        return if (absent.isEmpty()) {
-            "keysign timed out after ${TIMEOUT_SECONDS}s: " +
-                "all peers responded but the protocol did not complete"
-        } else {
-            "keysign timed out after ${TIMEOUT_SECONDS}s: no messages from ${absent.joinToString()}"
-        }
+        val absent = peersNotIn(heardFromEver)
+        val reason =
+            if (absent.isEmpty()) "all peers responded but the protocol did not complete"
+            else "no messages from ${absent.joinToString()}"
+        return "keysign timed out after ${ATTEMPT_TIMEOUT.inWholeSeconds}s: $reason"
     }
 
     private companion object {
-        const val POLL_INTERVAL_MS = 100L
-        const val PEER_SILENCE_HINT_SECONDS = 10
-        const val TIMEOUT_SECONDS = 60
-        const val NANOS_PER_SECOND = 1_000_000_000.0
+        val POLL_INTERVAL = 100.milliseconds
+        val PEER_SILENCE_HINT = 10.seconds
+        val ATTEMPT_TIMEOUT = 60.seconds
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
@@ -209,9 +209,14 @@ class MldsaKeygen(
         return false
     }
 
-    @Throws(Exception::class)
     private suspend fun deleteMessageFromServer(hash: String) {
-        sessionApi.deleteTssMessage(mediatorURL, sessionID, localPartyId, hash, activeMessageId)
+        sessionApi.deleteTssMessageQuietly(
+            mediatorURL,
+            sessionID,
+            localPartyId,
+            hash,
+            activeMessageId,
+        )
     }
 
     @Throws(Exception::class)

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
@@ -228,7 +228,7 @@ class MldsaKeysign(
                 .check("create sign session")
 
             drainOutbound(session)
-            if (poller.poll(msgHash) { msgs -> applyInboundMessages(session, msgs, msgHash) }) {
+            if (poller.poll(msgHash) { applyInboundMessages(session, it, msgHash) }) {
                 drainOutbound(session)
                 // finish can fail transiently (LIB_ABORT_PROTOCOL_PARTY_*) — retry is inside
                 val sig = finishSignSession(session)
@@ -304,12 +304,9 @@ class MldsaKeysign(
         for (msg in msgs.sortedBy { it.sequenceNo }) {
             val cacheKey = "$sessionID-$localPartyID-$messageID-${msg.hash}"
             if (cacheKey in appliedMessages) {
-                // The relay is still serving a message we applied, so our delete never took. Retry
-                // it once per attempt: repeating it on every poll would park the loop behind the
-                // relay client's own delete backoff without changing the outcome.
-                if (redeletedHashes.add(msg.hash)) {
-                    deleteMessageFromServer(msg.hash, messageID)
-                }
+                // Once per attempt: repeating a delete the relay is ignoring only parks the poll
+                // loop behind the relay client's own backoff.
+                if (redeletedHashes.add(msg.hash)) deleteMessageFromServer(msg.hash, messageID)
                 continue
             }
 

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
@@ -34,7 +34,6 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import timber.log.Timber
 import tss.KeysignResponse
 
@@ -64,9 +63,17 @@ class MldsaKeysign(
     private var messenger: TssMessenger? = null
     /** Deduplicates already-applied inbound messages by composite key. */
     private val appliedMessages = mutableSetOf<String>()
-    private val heardFromThisAttempt = mutableSetOf<String>()
-    private val heardFromEver = mutableSetOf<String>()
-    private var waitingNotified = false
+    private val redeletedHashes = mutableSetOf<String>()
+    private val poller =
+        KeysignMessagePoller(
+            sessionApi = sessionApi,
+            mediatorURL = mediatorURL,
+            sessionID = sessionID,
+            localPartyID = localPartyID,
+            keysignCommittee = keysignCommittee,
+            onWaitingForPeers = onWaitingForPeers,
+            onPeersResumed = onPeersResumed,
+        )
 
     /** Collects signatures keyed by the signed message hex string. */
     val signatures = mutableMapOf<String, KeysignResponse>()
@@ -85,10 +92,10 @@ class MldsaKeysign(
      */
     private suspend fun keysignOneMessage(attempt: Int, messageToSign: String) {
         if (attempt == 0) {
-            heardFromEver.clear()
-            waitingNotified = false
+            poller.resetForNewMessage()
         }
         appliedMessages.clear()
+        redeletedHashes.clear()
         val msgHash = messageToSign.md5()
 
         messenger =
@@ -130,16 +137,12 @@ class MldsaKeysign(
                     msgHash = msgHash,
                     messageToSign = messageToSign,
                     signatures = signatures,
-                ) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                }
+                    onRecovered = poller::clearWaitingForPeers,
+                )
             if (recovered) {
                 return
             }
-            val maxRetries = if (heardFromEver.isEmpty()) 1 else MAX_PROTOCOL_RETRIES
+            val maxRetries = if (poller.hasHeardFromAnyPeer) MAX_PROTOCOL_RETRIES else 1
             if (attempt < maxRetries) {
                 keysignOneMessage(attempt + 1, messageToSign)
             } else {
@@ -225,7 +228,7 @@ class MldsaKeysign(
                 .check("create sign session")
 
             drainOutbound(session)
-            if (pollInbound(session, msgHash)) {
+            if (poller.poll(msgHash) { msgs -> applyInboundMessages(session, msgs, msgHash) }) {
                 drainOutbound(session)
                 // finish can fail transiently (LIB_ABORT_PROTOCOL_PARTY_*) — retry is inside
                 val sig = finishSignSession(session)
@@ -289,62 +292,6 @@ class MldsaKeysign(
     }
 
     /**
-     * Polls the mediator for inbound messages until the protocol completes or 60 s of silence
-     * elapses. Notifies [onWaitingForPeers] after 10 s of silence and [onPeersResumed] when
-     * messages resume.
-     *
-     * @return `true` when the signing protocol has finished successfully.
-     */
-    private suspend fun pollInbound(handle: Handle, messageID: String): Boolean {
-        heardFromThisAttempt.clear()
-        var lastMessageNano = System.nanoTime()
-
-        while (true) {
-            try {
-                val msgs =
-                    sessionApi.getTssMessages(mediatorURL, sessionID, localPartyID, messageID)
-                if (msgs.isNotEmpty()) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                    lastMessageNano = System.nanoTime()
-                    heardFromThisAttempt.clear()
-                    if (applyInboundMessages(handle, msgs, messageID)) return true
-                } else {
-                    delay(POLL_INTERVAL_MS)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to get messages")
-                delay(POLL_INTERVAL_MS)
-            }
-
-            val silenceSecs = (System.nanoTime() - lastMessageNano) / 1_000_000_000.0
-            if (!waitingNotified && silenceSecs > 10) {
-                waitingNotified = true
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                if (missingPeers.isNotEmpty()) {
-                    onWaitingForPeers?.invoke(missingPeers)
-                }
-            }
-            if (silenceSecs > 60) {
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                val msg =
-                    if (missingPeers.isEmpty()) {
-                        "keysign timed out: all peers responded but protocol did not complete within 60s"
-                    } else {
-                        "no messages from ${missingPeers.joinToString()} in 60s"
-                    }
-                error(msg)
-            }
-        }
-    }
-
-    /**
      * Decrypts and applies each inbound message to the session.
      *
      * @return `true` when the native library signals that signing is complete.
@@ -356,11 +303,18 @@ class MldsaKeysign(
     ): Boolean {
         for (msg in msgs.sortedBy { it.sequenceNo }) {
             val cacheKey = "$sessionID-$localPartyID-$messageID-${msg.hash}"
-            if (!appliedMessages.add(cacheKey)) continue
+            if (cacheKey in appliedMessages) {
+                // The relay is still serving a message we applied, so our delete never took. Retry
+                // it once per attempt: repeating it on every poll would park the loop behind the
+                // relay client's own delete backoff without changing the outcome.
+                if (redeletedHashes.add(msg.hash)) {
+                    deleteMessageFromServer(msg.hash, messageID)
+                }
+                continue
+            }
 
             Timber.d("Got message from: %s, to: %s, key: %s", msg.from, msg.to, cacheKey)
-            heardFromThisAttempt.add(msg.from)
-            heardFromEver.add(msg.from)
+            poller.recordPeerHeard(msg.from)
 
             val decrypted =
                 encryption.decrypt(
@@ -377,6 +331,7 @@ class MldsaKeysign(
                 )
                 .check("apply inbound message")
 
+            appliedMessages += cacheKey
             deleteMessageFromServer(msg.hash, messageID)
             drainOutbound(handle)
 
@@ -386,7 +341,7 @@ class MldsaKeysign(
     }
 
     private suspend fun deleteMessageFromServer(hash: String, messageID: String) {
-        sessionApi.deleteTssMessage(mediatorURL, sessionID, localPartyID, hash, messageID)
+        sessionApi.deleteTssMessageQuietly(mediatorURL, sessionID, localPartyID, hash, messageID)
     }
 
     /** Finds the MLDSA keyshare matching [publicKeyMldsa] in the vault. */
@@ -472,6 +427,5 @@ class MldsaKeysign(
         internal const val FINISH_RETRY_DELAY_MS = 1000L
 
         private const val MAX_PROTOCOL_RETRIES = 3
-        private const val POLL_INTERVAL_MS = 100L
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/RelayMessageCleanup.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/RelayMessageCleanup.kt
@@ -1,0 +1,29 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.api.SessionApi
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+/**
+ * Removes an already-applied message from this device's relay inbox.
+ *
+ * Deleting is cleanup, not a protocol step: the local dedup cache already skips the message, so a
+ * failed delete costs at most a re-served batch. Letting it throw would abort the round that
+ * applied the message and discard the completion flag the caller has not read yet, leaving a device
+ * that has finished signing unable to produce its signature (#5488).
+ */
+internal suspend fun SessionApi.deleteTssMessageQuietly(
+    serverUrl: String,
+    sessionId: String,
+    localPartyId: String,
+    msgHash: String,
+    messageId: String?,
+) {
+    try {
+        deleteTssMessage(serverUrl, sessionId, localPartyId, msgHash, messageId)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.w(e, "Failed to delete relay message %s", msgHash)
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -225,7 +225,13 @@ class SchnorrKeygen(
     }
 
     private suspend fun deleteMessageFromServer(hash: String) {
-        sessionApi.deleteTssMessage(mediatorURL, sessionID, localPartyId, hash, activeMessageId)
+        sessionApi.deleteTssMessageQuietly(
+            mediatorURL,
+            sessionID,
+            localPartyId,
+            hash,
+            activeMessageId,
+        )
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -231,12 +231,9 @@ class SchnorrKeysign(
             val key = "$sessionID-$localPartyID-$messageID-${msg.hash}"
             if (cache.containsKey(key)) {
                 println("message with key: $key has been applied before")
-                // The relay is still serving a message we applied, so our delete never took. Retry
-                // it once per attempt: repeating it on every poll would park the loop behind the
-                // relay client's own delete backoff without changing the outcome.
-                if (redeletedHashes.add(msg.hash)) {
-                    deleteMessageFromServer(msg.hash, messageID)
-                }
+                // Once per attempt: repeating a delete the relay is ignoring only parks the poll
+                // loop behind the relay client's own backoff.
+                if (redeletedHashes.add(msg.hash)) deleteMessageFromServer(msg.hash, messageID)
                 continue
             }
             println("Got message from: ${msg.from}, to: ${msg.to}, key: $key")
@@ -351,8 +348,7 @@ class SchnorrKeysign(
                 )
             }
             processSchnorrOutboundMessage(handler)
-            val isFinished =
-                poller.poll(msgHash) { msgs -> processInboundMessage(handler, msgs, msgHash) }
+            val isFinished = poller.poll(msgHash) { processInboundMessage(handler, it, msgHash) }
             if (isFinished) {
                 val sig = signSessionFinish(handler)
                 val resp = KeysignResponse()

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -31,7 +31,6 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import timber.log.Timber
 import tss.KeysignResponse
 
@@ -64,13 +63,21 @@ class SchnorrKeysign(
     var messenger: TssMessenger? = null
     /** Deduplicates already-applied inbound messages by composite key. */
     val cache = mutableMapOf<String, Any>()
+    private val redeletedHashes = mutableSetOf<String>()
     /** Collects signatures keyed by the signed message hex string. */
     val signatures = mutableMapOf<String, KeysignResponse>()
     /** Holds the raw keyshare bytes loaded for the current signing session. */
     var keyshare: ByteArray = byteArrayOf()
-    private val heardFromThisAttempt = mutableSetOf<String>()
-    private val heardFromEver = mutableSetOf<String>()
-    private var waitingNotified = false
+    private val poller =
+        KeysignMessagePoller(
+            sessionApi = sessionApi,
+            mediatorURL = mediatorURL,
+            sessionID = sessionID,
+            localPartyID = localPartyID,
+            keysignCommittee = keysignCommittee,
+            onWaitingForPeers = onWaitingForPeers,
+            onPeersResumed = onPeersResumed,
+        )
 
     /**
      * Returns the raw keyshare string for [publicKeyEdDSA] from the vault, or null if not found.
@@ -210,66 +217,6 @@ class SchnorrKeysign(
     }
 
     /**
-     * Polls the mediator for inbound messages until the protocol completes or 60 s of silence
-     * elapses. Notifies [onWaitingForPeers] after 10 s of silence and [onPeersResumed] when
-     * messages resume.
-     *
-     * @return `true` when the signing protocol has finished successfully.
-     */
-    suspend fun pullInboundMessages(handle: Handle, messageID: String): Boolean {
-        Timber.d("start pulling inbound messages")
-
-        heardFromThisAttempt.clear()
-        var lastMessageNano = System.nanoTime()
-        while (true) {
-            try {
-                val msgs =
-                    sessionApi.getTssMessages(mediatorURL, sessionID, localPartyID, messageID)
-
-                if (msgs.isNotEmpty()) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                    lastMessageNano = System.nanoTime()
-                    heardFromThisAttempt.clear()
-                    if (processInboundMessage(handle, msgs, messageID)) {
-                        return true
-                    }
-                } else {
-                    delay(100)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to get messages")
-                delay(100)
-            }
-
-            val silenceSecs = (System.nanoTime() - lastMessageNano) / 1_000_000_000.0
-            if (!waitingNotified && silenceSecs > 10) {
-                waitingNotified = true
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                if (missingPeers.isNotEmpty()) {
-                    onWaitingForPeers?.invoke(missingPeers)
-                }
-            }
-            if (silenceSecs > 60) {
-                val missingPeers =
-                    keysignCommittee.filter { it != localPartyID && it !in heardFromThisAttempt }
-                val msg =
-                    if (missingPeers.isEmpty()) {
-                        "keysign timed out: all peers responded but protocol did not complete within 60s"
-                    } else {
-                        "no messages from ${missingPeers.joinToString()} in 60s"
-                    }
-                error(msg)
-            }
-        }
-    }
-
-    /**
      * Decrypts and applies each inbound message to the session.
      *
      * @return `true` when the native library signals that signing is complete.
@@ -284,11 +231,16 @@ class SchnorrKeysign(
             val key = "$sessionID-$localPartyID-$messageID-${msg.hash}"
             if (cache.containsKey(key)) {
                 println("message with key: $key has been applied before")
+                // The relay is still serving a message we applied, so our delete never took. Retry
+                // it once per attempt: repeating it on every poll would park the loop behind the
+                // relay client's own delete backoff without changing the outcome.
+                if (redeletedHashes.add(msg.hash)) {
+                    deleteMessageFromServer(msg.hash, messageID)
+                }
                 continue
             }
             println("Got message from: ${msg.from}, to: ${msg.to}, key: $key")
-            heardFromThisAttempt.add(msg.from)
-            heardFromEver.add(msg.from)
+            poller.recordPeerHeard(msg.from)
             val decryptedBody =
                 encryption.decrypt(
                     Base64.decode(msg.body),
@@ -312,7 +264,7 @@ class SchnorrKeysign(
     }
 
     private suspend fun deleteMessageFromServer(hash: String, messageID: String) {
-        sessionApi.deleteTssMessage(mediatorURL, sessionID, localPartyID, hash, messageID)
+        sessionApi.deleteTssMessageQuietly(mediatorURL, sessionID, localPartyID, hash, messageID)
     }
 
     /**
@@ -323,10 +275,10 @@ class SchnorrKeysign(
      */
     suspend fun keysignOneMessageWithRetry(attempt: Int, messageToSign: String) {
         if (attempt == 0) {
-            heardFromEver.clear()
-            waitingNotified = false
+            poller.resetForNewMessage()
         }
         cache.clear()
+        redeletedHashes.clear()
         val msgHash = messageToSign.md5()
         val localMessenger =
             TssMessenger(
@@ -399,7 +351,8 @@ class SchnorrKeysign(
                 )
             }
             processSchnorrOutboundMessage(handler)
-            val isFinished = pullInboundMessages(handler, msgHash)
+            val isFinished =
+                poller.poll(msgHash) { msgs -> processInboundMessage(handler, msgs, msgHash) }
             if (isFinished) {
                 val sig = signSessionFinish(handler)
                 val resp = KeysignResponse()
@@ -425,16 +378,12 @@ class SchnorrKeysign(
                     msgHash = msgHash,
                     messageToSign = messageToSign,
                     signatures = signatures,
-                ) {
-                    if (waitingNotified) {
-                        waitingNotified = false
-                        onPeersResumed?.invoke()
-                    }
-                }
+                    onRecovered = poller::clearWaitingForPeers,
+                )
             if (recovered) {
                 return
             }
-            val maxRetries = if (heardFromEver.isEmpty()) 1 else 3
+            val maxRetries = if (poller.hasHeardFromAnyPeer) 3 else 1
             if (attempt < maxRetries) {
                 keysignOneMessageWithRetry(attempt + 1, messageToSign)
             } else {

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/FakeRelaySessionApi.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/FakeRelaySessionApi.kt
@@ -1,0 +1,101 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.api.SessionApi
+import com.vultisig.wallet.data.mediator.Message
+
+/**
+ * A [SessionApi] whose relay message endpoints are supplied per test; every other endpoint fails
+ * the test if it is reached.
+ *
+ * Hand-written rather than a mockk because mockk eagerly resolves the native `tss.KeysignResponse`
+ * return types and crashes with `UnsatisfiedLinkError` on the host JVM.
+ *
+ * @param onPoll Serves one `getTssMessages` response, given the 1-based poll number.
+ * @param onDelete Handles one `deleteTssMessage` call, given the message hash.
+ */
+internal class FakeRelaySessionApi(
+    private val onPoll: (Int) -> List<Message> = { unexpected("getTssMessages") },
+    private val onDelete: (String) -> Unit = {},
+) : SessionApi {
+    var polls = 0
+        private set
+
+    val deletedHashes = mutableListOf<String>()
+
+    override suspend fun getTssMessages(
+        serverUrl: String,
+        sessionId: String,
+        localPartyId: String,
+        messageId: String?,
+    ): List<Message> {
+        polls++
+        return onPoll(polls)
+    }
+
+    override suspend fun deleteTssMessage(
+        serverUrl: String,
+        sessionId: String,
+        localPartyId: String,
+        msgHash: String,
+        messageId: String?,
+    ) {
+        deletedHashes += msgHash
+        onDelete(msgHash)
+    }
+
+    override suspend fun checkCommittee(serverUrl: String, sessionId: String): List<String> =
+        unexpected("checkCommittee")
+
+    override suspend fun startSession(
+        serverUrl: String,
+        sessionId: String,
+        localPartyId: List<String>,
+    ) = unexpected("startSession")
+
+    override suspend fun startWithCommittee(
+        serverUrl: String,
+        sessionId: String,
+        committee: List<String>,
+    ) = unexpected("startWithCommittee")
+
+    override suspend fun markLocalPartyComplete(
+        serverUrl: String,
+        sessionId: String,
+        localPartyId: List<String>,
+    ) = unexpected("markLocalPartyComplete")
+
+    override suspend fun getCompletedParties(serverUrl: String, sessionId: String): List<String> =
+        unexpected("getCompletedParties")
+
+    override suspend fun getParticipants(serverUrl: String, sessionId: String): List<String> =
+        unexpected("getParticipants")
+
+    override suspend fun sendTssMessage(serverUrl: String, messageId: String?, message: Message) =
+        unexpected("sendTssMessage")
+
+    override suspend fun markLocalPartyKeysignComplete(
+        serverUrl: String,
+        messageId: String,
+        sig: tss.KeysignResponse,
+    ) = unexpected("markLocalPartyKeysignComplete")
+
+    override suspend fun checkKeysignComplete(
+        serverUrl: String,
+        messageId: String,
+    ): tss.KeysignResponse = unexpected("checkKeysignComplete")
+
+    override suspend fun getSetupMessage(
+        serverUrl: String,
+        sessionId: String,
+        messageId: String?,
+    ): String = unexpected("getSetupMessage")
+
+    override suspend fun uploadSetupMessage(
+        serverUrl: String,
+        sessionId: String,
+        message: String,
+        messageId: String?,
+    ) = unexpected("uploadSetupMessage")
+}
+
+private fun unexpected(name: String): Nothing = error("Unexpected SessionApi call in test: $name")

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
@@ -6,6 +6,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.currentTime
@@ -26,14 +29,14 @@ class KeysignMessagePollerTest {
 
     /** Monotonic clock the fake relay advances by one poll interval per poll. */
     private class TestClock {
-        var nanos = 0L
+        var elapsed: Duration = Duration.ZERO
             private set
 
-        val elapsedMillis: Long
-            get() = nanos / 1_000_000
+        val nanos: Long
+            get() = elapsed.inWholeNanoseconds
 
         fun tick() {
-            nanos += POLL_INTERVAL_MS * 1_000_000
+            elapsed += POLL_INTERVAL
         }
     }
 
@@ -58,7 +61,7 @@ class KeysignMessagePollerTest {
                 clock.tick()
                 // An Error, not an Exception: the poll loop tolerates exceptions by design, so a
                 // broken deadline would swallow this guard and hang the suite instead of failing.
-                if (clock.elapsedMillis > RUNAWAY_LOOP_MILLIS) {
+                if (clock.elapsed > RUNAWAY_LOOP_LIMIT) {
                     throw AssertionError("poll loop did not terminate")
                 }
                 onPoll(poll)
@@ -77,7 +80,7 @@ class KeysignMessagePollerTest {
                 }
 
             failure.message shouldContain "keysign timed out after 60s"
-            clock.elapsedMillis shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+            clock.elapsed shouldBe ATTEMPT_TIMEOUT + POLL_INTERVAL
         }
 
     @Test
@@ -91,7 +94,7 @@ class KeysignMessagePollerTest {
             }
 
         failure.message shouldContain "keysign timed out after 60s"
-        clock.elapsedMillis shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+        clock.elapsed shouldBe ATTEMPT_TIMEOUT + POLL_INTERVAL
     }
 
     @Test
@@ -106,7 +109,7 @@ class KeysignMessagePollerTest {
                 }
 
             failure.message shouldContain "keysign timed out after 60s"
-            currentTime shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+            currentTime shouldBe (ATTEMPT_TIMEOUT + POLL_INTERVAL).inWholeMilliseconds
         }
 
     @Test
@@ -141,7 +144,7 @@ class KeysignMessagePollerTest {
             val clock = TestClock()
             val sessionApi =
                 relay(clock) {
-                    if (clock.elapsedMillis < 11_000) emptyList() else listOf(peerMessage())
+                    if (clock.elapsed < SILENCE_HINT_PASSED) emptyList() else listOf(peerMessage())
                 }
 
             poller(sessionApi, clock).poll(MESSAGE_ID) { true } shouldBe true
@@ -218,10 +221,13 @@ class KeysignMessagePollerTest {
         const val LOCAL_PARTY = "deviceA"
         const val PEER = "deviceB"
         const val MESSAGE_ID = "message-1"
-        const val POLL_INTERVAL_MS = 100L
-        const val TIMEOUT_MS = 60_000L
+        val POLL_INTERVAL = 100.milliseconds
+        val ATTEMPT_TIMEOUT = 60.seconds
+
+        /** Comfortably past the 10 s silent-peer hint, so the hint has certainly fired. */
+        val SILENCE_HINT_PASSED = 11.seconds
 
         /** Fails a poll loop that never terminates instead of letting the suite hang. */
-        const val RUNAWAY_LOOP_MILLIS = 10 * TIMEOUT_MS
+        val RUNAWAY_LOOP_LIMIT = ATTEMPT_TIMEOUT * 10
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
@@ -1,0 +1,227 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.mediator.Message
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #5488: a co-signing device sat on the signing screen for minutes while
+ * the transaction landed on-chain, because the keysign poll loop pushed its 60 s abort deadline
+ * forward on every non-empty relay response. A message the device can never clear — one whose relay
+ * delete failed, or whose body will not decrypt — is re-served by every poll, so the deadline was
+ * extended indefinitely and the error that hands over to relay recovery never fired.
+ *
+ * The deadline now runs from the start of the attempt, matching iOS and Windows.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class KeysignMessagePollerTest {
+
+    /** Monotonic clock the fake relay advances by one poll interval per poll. */
+    private class TestClock {
+        var nanos = 0L
+            private set
+
+        val elapsedMillis: Long
+            get() = nanos / 1_000_000
+
+        fun tick() {
+            nanos += POLL_INTERVAL_MS * 1_000_000
+        }
+    }
+
+    private val waitingForPeers = mutableListOf<List<String>>()
+    private var resumedCount = 0
+
+    private fun poller(sessionApi: FakeRelaySessionApi, clock: TestClock) =
+        KeysignMessagePoller(
+            sessionApi = sessionApi,
+            mediatorURL = "http://relay.example",
+            sessionID = "session-1",
+            localPartyID = LOCAL_PARTY,
+            keysignCommittee = listOf(LOCAL_PARTY, PEER),
+            onWaitingForPeers = { waitingForPeers += it },
+            onPeersResumed = { resumedCount++ },
+            nanoTime = { clock.nanos },
+        )
+
+    private fun relay(clock: TestClock, onPoll: (Int) -> List<Message>) =
+        FakeRelaySessionApi(
+            onPoll = { poll ->
+                clock.tick()
+                // An Error, not an Exception: the poll loop tolerates exceptions by design, so a
+                // broken deadline would swallow this guard and hang the suite instead of failing.
+                if (clock.elapsedMillis > RUNAWAY_LOOP_MILLIS) {
+                    throw AssertionError("poll loop did not terminate")
+                }
+                onPoll(poll)
+            }
+        )
+
+    @Test
+    fun `aborts at the deadline while the relay keeps re-serving a message that is never applied`() =
+        runTest {
+            val clock = TestClock()
+            val sessionApi = relay(clock) { listOf(peerMessage()) }
+
+            val failure =
+                shouldThrow<IllegalStateException> {
+                    poller(sessionApi, clock).poll(MESSAGE_ID) { false }
+                }
+
+            failure.message shouldContain "keysign timed out after 60s"
+            clock.elapsedMillis shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+        }
+
+    @Test
+    fun `aborts at the deadline when every batch fails to apply`() = runTest {
+        val clock = TestClock()
+        val sessionApi = relay(clock) { listOf(peerMessage()) }
+
+        val failure =
+            shouldThrow<IllegalStateException> {
+                poller(sessionApi, clock).poll(MESSAGE_ID) { error("fail to decrypt message body") }
+            }
+
+        failure.message shouldContain "keysign timed out after 60s"
+        clock.elapsedMillis shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+    }
+
+    @Test
+    fun `backs off between failing polls instead of hot-looping, and still aborts at the deadline`() =
+        runTest {
+            val clock = TestClock()
+            val sessionApi = relay(clock) { error("relay unreachable") }
+
+            val failure =
+                shouldThrow<IllegalStateException> {
+                    poller(sessionApi, clock).poll(MESSAGE_ID) { true }
+                }
+
+            failure.message shouldContain "keysign timed out after 60s"
+            currentTime shouldBe TIMEOUT_MS + POLL_INTERVAL_MS
+        }
+
+    @Test
+    fun `names the peers it has not heard from, or reports that all of them answered`() = runTest {
+        val clock = TestClock()
+        val silentRelay = relay(clock) { listOf(peerMessage()) }
+
+        val silent =
+            shouldThrow<IllegalStateException> {
+                poller(silentRelay, clock).poll(MESSAGE_ID) { false }
+            }
+        silent.message shouldContain "no messages from $PEER"
+
+        val answeringClock = TestClock()
+        val answeringRelay = relay(answeringClock) { listOf(peerMessage()) }
+        val answering = poller(answeringRelay, answeringClock)
+
+        val allHeard =
+            shouldThrow<IllegalStateException> {
+                answering.poll(MESSAGE_ID) {
+                    answering.recordPeerHeard(PEER)
+                    false
+                }
+            }
+
+        allHeard.message shouldContain "all peers responded but the protocol did not complete"
+    }
+
+    @Test
+    fun `reports silent peers after ten seconds and reports the resumption when messages return`() =
+        runTest {
+            val clock = TestClock()
+            val sessionApi =
+                relay(clock) {
+                    if (clock.elapsedMillis < 11_000) emptyList() else listOf(peerMessage())
+                }
+
+            poller(sessionApi, clock).poll(MESSAGE_ID) { true } shouldBe true
+
+            waitingForPeers shouldContainExactly listOf(listOf(PEER))
+            resumedCount shouldBe 1
+        }
+
+    @Test
+    fun `stays quiet about silent peers while batches keep arriving`() = runTest {
+        val clock = TestClock()
+        val sessionApi = relay(clock) { listOf(peerMessage()) }
+        val subject = poller(sessionApi, clock)
+
+        shouldThrow<IllegalStateException> {
+            subject.poll(MESSAGE_ID) {
+                subject.recordPeerHeard(PEER)
+                false
+            }
+        }
+
+        waitingForPeers.shouldBeEmpty()
+        resumedCount shouldBe 0
+    }
+
+    @Test
+    fun `starting the next message clears a silent-peer hint the previous one left raised`() =
+        runTest {
+            val clock = TestClock()
+            val subject = poller(relay(clock) { emptyList() }, clock)
+
+            shouldThrow<IllegalStateException> { subject.poll(MESSAGE_ID) { true } }
+            waitingForPeers shouldContainExactly listOf(listOf(PEER))
+            resumedCount shouldBe 0
+
+            subject.resetForNewMessage()
+
+            resumedCount shouldBe 1
+        }
+
+    @Test
+    fun `propagates cancellation instead of retrying the poll`() = runTest {
+        val clock = TestClock()
+        val sessionApi = relay(clock) { throw CancellationException("keysign cancelled") }
+
+        shouldThrow<CancellationException> { poller(sessionApi, clock).poll(MESSAGE_ID) { true } }
+    }
+
+    @Test
+    fun `tracks whether any peer answered until the next message resets it`() {
+        val clock = TestClock()
+        val subject = poller(relay(clock) { emptyList() }, clock)
+
+        subject.hasHeardFromAnyPeer shouldBe false
+
+        subject.recordPeerHeard(PEER)
+        subject.hasHeardFromAnyPeer shouldBe true
+
+        subject.resetForNewMessage()
+        subject.hasHeardFromAnyPeer shouldBe false
+    }
+
+    private fun peerMessage() =
+        Message(
+            sessionID = "session-1",
+            from = PEER,
+            to = listOf(LOCAL_PARTY),
+            body = "body",
+            hash = "hash-1",
+            sequenceNo = 0,
+        )
+
+    private companion object {
+        const val LOCAL_PARTY = "deviceA"
+        const val PEER = "deviceB"
+        const val MESSAGE_ID = "message-1"
+        const val POLL_INTERVAL_MS = 100L
+        const val TIMEOUT_MS = 60_000L
+
+        /** Fails a poll loop that never terminates instead of letting the suite hang. */
+        const val RUNAWAY_LOOP_MILLIS = 10 * TIMEOUT_MS
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/RelayMessageCleanupTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/RelayMessageCleanupTest.kt
@@ -1,0 +1,49 @@
+package com.vultisig.wallet.data.keygen
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #5488: the relay delete of an applied message used to be able to throw
+ * out of the round that applied it, skipping the outbound drain and the completion check that
+ * follow. A device that had already finished signing therefore discarded its own completion flag
+ * and could never produce its signature — which is how the reporting user's transaction broadcast
+ * fine while their second device stayed on the signing screen.
+ */
+class RelayMessageCleanupTest {
+
+    @Test
+    fun `a failed relay delete does not propagate to the round that applied the message`() =
+        runTest {
+            val sessionApi = FakeRelaySessionApi(onDelete = { error("relay rejected the delete") })
+
+            sessionApi.deleteTssMessageQuietly(
+                serverUrl = "http://relay.example",
+                sessionId = "session-1",
+                localPartyId = "deviceA",
+                msgHash = "hash-1",
+                messageId = "message-1",
+            )
+
+            sessionApi.deletedHashes shouldContainExactly listOf("hash-1")
+        }
+
+    @Test
+    fun `cancellation still propagates`() = runTest {
+        val sessionApi =
+            FakeRelaySessionApi(onDelete = { throw CancellationException("keysign cancelled") })
+
+        shouldThrow<CancellationException> {
+            sessionApi.deleteTssMessageQuietly(
+                serverUrl = "http://relay.example",
+                sessionId = "session-1",
+                localPartyId = "deviceA",
+                msgHash = "hash-1",
+                messageId = "message-1",
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignStaleMessageTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignStaleMessageTest.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.data.keygen
+
+import com.silencelaboratories.goschnorr.Handle
+import com.vultisig.wallet.data.mediator.Message
+import com.vultisig.wallet.data.models.KeyShare
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.Encryption
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for issue #5488: a message the relay keeps serving after this device already
+ * applied it used to be skipped without re-issuing its delete, so a single delete failure left the
+ * message in the inbox for the rest of the session. Re-issuing the (best-effort) delete clears it
+ * at the source instead of waiting for the relay to expire it — but only once per attempt, because
+ * the relay client backs off between its own delete retries and the poll loop waits on that.
+ *
+ * Only the dedup branch is exercised — it returns before the goschnorr JNI rounds, which are
+ * unavailable on the host JVM, so the session handle is never dereferenced.
+ */
+class SchnorrKeysignStaleMessageTest {
+
+    @Test
+    fun `an already-applied message is deleted from the relay again, once, not on every poll`() =
+        runTest {
+            val sessionApi = FakeRelaySessionApi()
+            val keysign =
+                SchnorrKeysign(
+                    keysignCommittee = listOf(LOCAL_PARTY, PEER),
+                    mediatorURL = "http://relay.example",
+                    sessionID = SESSION_ID,
+                    messageToSign = listOf("abc123deadbeef"),
+                    vault = vault(),
+                    encryptionKeyHex = "00".repeat(32),
+                    isInitiateDevice = false,
+                    sessionApi = sessionApi,
+                    encryption = mockk<Encryption>(relaxed = true),
+                )
+            val staleMessage =
+                Message(
+                    sessionID = SESSION_ID,
+                    from = PEER,
+                    to = listOf(LOCAL_PARTY),
+                    body = "body",
+                    hash = "hash-1",
+                    sequenceNo = 0,
+                )
+            keysign.cache["$SESSION_ID-$LOCAL_PARTY-$MESSAGE_ID-${staleMessage.hash}"] = Any()
+
+            val handle = mockk<Handle>(relaxed = true)
+            repeat(3) {
+                keysign.processInboundMessage(
+                    handle = handle,
+                    msgs = listOf(staleMessage),
+                    messageID = MESSAGE_ID,
+                ) shouldBe false
+            }
+
+            sessionApi.deletedHashes shouldContainExactly listOf(staleMessage.hash)
+        }
+
+    private fun vault() =
+        Vault(
+            id = "vault-id",
+            name = "test-vault",
+            pubKeyECDSA = "pub-ecdsa",
+            pubKeyEDDSA = "pub-eddsa",
+            pubKeyMLDSA = "pub-mldsa",
+            localPartyID = LOCAL_PARTY,
+            keyshares = listOf(KeyShare("pub-eddsa", "share")),
+        )
+
+    private companion object {
+        const val SESSION_ID = "session-1"
+        const val MESSAGE_ID = "message-1"
+        const val LOCAL_PARTY = "deviceA"
+        const val PEER = "deviceB"
+    }
+}


### PR DESCRIPTION
## Summary

A co-signing device could sit on the signing screen for minutes while the transaction landed on-chain. Two independent defects in the keysign message loop:

- **The 60s abort deadline was reset on every non-empty relay response.** The relay GET is non-destructive, so one message the device can never clear — a delete that failed, a body that will not decrypt, a peer re-posting a body we already deleted — is re-served by every poll and pushes the deadline forward indefinitely. The `error()` that hands over to `recoverKeysignFromRelay` never fires. The deadline now runs from the start of the attempt; the resettable clock only drives the 10s silent-peer hint.
- **The relay delete of an applied message sat between the dedup-cache write and the `isFinished` check**, so a delete failure threw out of the round that had just applied the message, skipping the outbound drain and discarding an already-set completion flag. That is how the initiator can broadcast fine while the co-signer hangs. The delete is now best-effort.

An absolute deadline is what iOS (`DKLSKeysign.swift:226`) and Windows (`@vultisig/core-mpc`, 3-min `AbortController`) use, and what this repo's three keygen helpers still use. Keysign lost it in #4339; ML-DSA keysign had it from #3240 until then.

Also in here:

- The three keysign poll loops were identical copies and are now one `KeysignMessagePoller`. That is also what makes the loop unit-testable — it no longer needs a native session handle.
- The same failed-delete-drops-`isFinished` shape exists in `DklsKeygen`/`SchnorrKeygen`/`MldsaKeygen`, so they route through the same best-effort helper.
- A message the relay keeps re-serving now gets one more delete per attempt instead of never being retried. Once per attempt, not per poll: `deleteTssMessage` retries with backoff and the poll loop waits on it.
- ML-DSA marked a message applied *before* applying it, so a body that failed to decrypt was recorded as applied. Moved after the apply, matching DKLS and Schnorr.
- The DKLS loop had no back-off in its exception handler, unlike its two siblings.
- The timeout message now names peers never heard from during the attempt rather than peers absent from the last batch — with an absolute deadline the loop can time out while peers are still answering, and that string is user-reachable via "Show exact error".

## Testing

`./gradlew ktfmtCheck testDebugUnitTest lintDebug assembleDebug` — passing.

12 new tests across `KeysignMessagePollerTest`, `RelayMessageCleanupTest` and `SchnorrKeysignStaleMessageTest`. Each regression test was confirmed to fail with its fix reverted: the deadline tests hang past the guard rail with the resettable clock restored, the stale-message test records three deletes without the per-attempt bound, and the hint test never reports a resumption without the reset.

No UI surface changed.

Closes #5488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key signing message polling and retry handling.
  * Added clearer timeout and silent-peer notifications.
  * Prevented repeated processing of duplicate relay messages.
  * Relay cleanup failures no longer interrupt key generation or signing, while cancellations remain responsive.

* **Tests**
  * Added coverage for polling timeouts, retries, cancellation, peer tracking, and stale-message cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->