### PR TITLE
fix(Sui): price auto-discovered tokens via CoinGecko contract lookup

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Chain.kt
@@ -457,6 +457,7 @@ fun Chain.coinGeckoAssetPlatformId(): String? =
         Chain.Robinhood -> "robinhood"
         Chain.Mantle -> "mantle"
         Chain.CronosChain -> "cronos"
+        Chain.Sui -> "sui"
         else -> null
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiContractPriceChainTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CoinGeckoApiContractPriceChainTest.kt
@@ -38,6 +38,27 @@ class CoinGeckoApiContractPriceChainTest {
     }
 
     @Test
+    fun `getContractsPrice resolves Sui to the sui CoinGecko platform id`() = runTest {
+        lateinit var requestedUrl: String
+        val engine = MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(content = "{}", status = HttpStatusCode.OK)
+        }
+        val api = CoinGeckoApiImpl(HttpClient(engine) { install(ContentNegotiation) { json() } })
+
+        api.getContractsPrice(
+            Chain.Sui,
+            listOf(
+                "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
+            ),
+            listOf("usd"),
+        )
+
+        assertContains(requestedUrl, "/token_price/sui")
+        assertContains(requestedUrl, "vs_currencies=usd")
+    }
+
+    @Test
     fun `getContractsPrice still degrades to an empty map for a chain without a mapping`() =
         runTest {
             var requestAttempted = false

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepositoryImplTest.kt
@@ -117,6 +117,40 @@ internal class TokenPriceRepositoryImplTest {
         assertEquals(BigDecimal("3400.0"), price)
     }
 
+    private val discoveredSuiToken =
+        Coin(
+            chain = Chain.Sui,
+            ticker = "HASUI",
+            logo = "",
+            address = "",
+            decimal = 9,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress =
+                "0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI",
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `auto-discovered Sui token with no priceProviderID is priced via its contract address`() =
+        runTest {
+            coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns emptyMap()
+            coEvery { coinGeckoApi.getContractsPrice(eq(Chain.Sui), any(), any()) } returns
+                mapOf(discoveredSuiToken.contractAddress to mapOf("usd" to BigDecimal("0.42")))
+
+            repository.refresh(listOf(discoveredSuiToken))
+
+            coVerify {
+                coinGeckoApi.getContractsPrice(
+                    Chain.Sui,
+                    match { it.contains(discoveredSuiToken.contractAddress) },
+                    any(),
+                )
+            }
+            val price = repository.getPrice(discoveredSuiToken, AppCurrency.USD).first()
+            assertEquals(BigDecimal("0.42"), price)
+        }
+
     @Test
     fun `does not call contract-address lookup when priceProviderID returns a price`() = runTest {
         coEvery { coinGeckoApi.getCryptoPrices(any(), any()) } returns


### PR DESCRIPTION
## Summary

Fixes #5508. Auto-discovered Sui tokens (`SuiTokenFinder`) carry an empty `priceProviderID` and only a contract address, so they depend entirely on `TokenPriceRepository`'s generic contract-price route. That route resolves its request through `coinGeckoAssetPlatformId()`, which had no entry for Sui — `CoinGeckoApiImpl` threw internally before any network call, degrading to an empty map, and the LI.FI fallback is EVM-only so it couldn't help either. The token was never priced and showed $0.00 indefinitely.

Adds the missing `"sui"` CoinGecko platform id — the same class of fix already shipped for Mantle in #5406. Verified against the live CoinGecko API that `"sui"` is the correct platform id (it's also the exact key CoinGecko uses in `usd-coin`'s own `platforms` map, matching our curated USDC contract address byte-for-byte).

The rest of the pipeline (`TokenPriceRepositoryImpl`, `CoinGeckoApiImpl`, `Coin.hasMarketDataSource`) is already chain-agnostic and needed no changes — the same code path already works for Solana.

Note: iOS additionally routes Sui through a Cetus on-chain router as its primary (not fallback) price source — a materially different, standalone integration with no existing footprint in this codebase. Out of scope here; this closes the reported gap for any token CoinGecko indexes.

## Before / After

Real device renders (chain page for a Sui vault holding a discovered token with no `priceProviderID`), fetched live through the actual `TokenPriceRepository`/`CoinGeckoApi` production code:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/8Q4iFiB.png) | ![after](https://i.imgur.com/GwIWRjw.png) |

## Testing

- `./gradlew :data:testDebugUnitTest` — full suite green, including two new tests: `CoinGeckoApiContractPriceChainTest` (pins the "sui" platform id resolution) and `TokenPriceRepositoryImplTest` (pins the dispatch of a discovered Sui token into the contract-price route).
- `./gradlew :data:ktfmtCheck` and `:data:lintDebug` — pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added support for retrieving Sui token prices through CoinGecko.
  - Sui tokens without a configured price-provider ID now fall back to contract-address pricing.
  - Corrected Sui platform mapping to ensure accurate USD price retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->