### PR TITLE
fix(transaction): collapse hero on scroll, fix bottom-bar nav padding

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -88,7 +88,7 @@ internal fun SendTxOverviewScreen(
                         text = stringResource(R.string.dapp_unverified_function_done_caution),
                         variant = BannerVariant.Warning,
                         modifier =
-                            Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 4.dp),
+                            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
                     )
                 }
                 VsButton(
@@ -96,7 +96,7 @@ internal fun SendTxOverviewScreen(
                     variant = VsButtonVariant.Primary,
                     size = VsButtonSize.Medium,
                     modifier =
-                        Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
+                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
                     onClick = onComplete,
                 )
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionOverviewScreen.kt
@@ -246,7 +246,7 @@ internal fun SwapTransactionOverviewScreen(
         bottomBarContent = {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
             ) {
                 if (!progressLink.isNullOrBlank()) {
                     val uriHandler = VsUriHandler()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
@@ -34,8 +35,10 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -126,6 +129,7 @@ internal fun TxDoneScaffold(
             }
             AnimatedVisibility(
                 visibleState = bottomBarVisibility,
+                modifier = Modifier.navigationBarsPadding(),
                 enter =
                     fadeIn(animationSpec = tween(durationMillis = 300, delayMillis = 120)) +
                         slideInVertically(
@@ -157,11 +161,22 @@ private fun SuccessTransaction(
     successTitle: String? = null,
 ) {
 
+    val scrollState = rememberScrollState()
+
+    // Scrolling the content collapses the pending hero, same as tapping "Transaction Details" —
+    // otherwise the fixed-height hero keeps hogging the top of the viewport while the user tries
+    // to read the rows below it (#5490).
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.value }
+            .collect { offset ->
+                if (offset > 0 && !isTransactionDetailVisible) {
+                    onTransactionDetailVisibleChange(true)
+                }
+            }
+    }
+
     Column(
-        modifier =
-            modifier
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier = modifier.verticalScroll(scrollState).padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         AnimatedVisibility(isTransactionDetailVisible.not()) {
             Column {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -66,7 +67,12 @@ import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asString
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+
+// Minimum scroll distance before the hero auto-collapses, so a stray touch or overscroll bounce
+// doesn't trigger it.
+private val SCROLL_COLLAPSE_THRESHOLD = 24.dp
 
 @Composable
 internal fun TxDoneScaffold(
@@ -162,17 +168,17 @@ private fun SuccessTransaction(
 ) {
 
     val scrollState = rememberScrollState()
+    val scrollCollapseThresholdPx =
+        with(LocalDensity.current) { SCROLL_COLLAPSE_THRESHOLD.roundToPx() }
 
     // Scrolling the content collapses the pending hero, same as tapping "Transaction Details" —
     // otherwise the fixed-height hero keeps hogging the top of the viewport while the user tries
-    // to read the rows below it (#5490).
-    LaunchedEffect(scrollState) {
-        snapshotFlow { scrollState.value }
-            .collect { offset ->
-                if (offset > 0 && !isTransactionDetailVisible) {
-                    onTransactionDetailVisibleChange(true)
-                }
-            }
+    // to read the rows below it (#5490). Wait for a deliberate scroll past the threshold, not the
+    // first pixel, so a stray touch/overscroll bounce doesn't collapse it; fire once and stop.
+    LaunchedEffect(scrollState, isTransactionDetailVisible) {
+        if (isTransactionDetailVisible) return@LaunchedEffect
+        snapshotFlow { scrollState.value }.first { it > scrollCollapseThresholdPx }
+        onTransactionDetailVisibleChange(true)
     }
 
     Column(


### PR DESCRIPTION
## Summary
- Scrolling the tx-done content (Send/Swap/QBTC done screens share `TxDoneScaffold`) now collapses the pending hero the same way tapping "Transaction Details" does, instead of leaving the fixed 300dp hero pinned at the top while the details get squeezed into the lower half of the screen.
- The shared Track/Done bottom bar now applies `navigationBarsPadding()` so the buttons clear the gesture-nav area under edge-to-edge instead of sitting ~12dp from the physical bottom edge.
- Bottom-bar horizontal padding aligned from 24dp to 16dp to match the rest of the screen content (Send + Swap done screens).

## Issue
Closes #5490

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [ ] Manual: open a pending swap tx overview, scroll down, confirm hero collapses and details get full viewport
- [ ] Manual: confirm Track/Done buttons sit above the gesture-nav bar with proper spacing on Send, Swap, and QBTC claim done screens

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Adjusted horizontal spacing for transaction completion banners, buttons, and action bars.
  * Added navigation-bar spacing to the transaction completion bottom bar.
  * Transaction details now expand automatically after scrolling, while still supporting manual expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->