### PR TITLE
fix(sui): add a Sui branch to custom token search

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
     implementation(libs.wallet.core)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.coil)
+    implementation(libs.coil.svg)
     implementation(libs.play.update)
     implementation(libs.play.review)
     implementation(libs.androidx.work.ktx)

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -1,12 +1,15 @@
 package com.vultisig.wallet.app
 
 import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.decode.SvgDecoder
 import com.vultisig.wallet.BuildConfig
 import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
-internal open class VsBaseApplication : Application() {
+internal open class VsBaseApplication : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
         WalletCoreLoader
@@ -18,6 +21,11 @@ internal open class VsBaseApplication : Application() {
 
         initializeRive(this)
     }
+
+    // Coin logos (e.g. Sui on-chain metadata icons) are sometimes served as SVG, which the
+    // platform ImageDecoder rejects with "Failed to create image decoder ... unimplemented".
+    override fun newImageLoader(): ImageLoader =
+        ImageLoader.Builder(this).components { add(SvgDecoder.Factory()) }.build()
 }
 
 @HiltAndroidApp internal class VultisigApplication : VsBaseApplication()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -158,6 +158,10 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindSearchSuiTokenUseCase(impl: SearchSuiTokenUseCaseImpl): SearchSuiTokenUseCase
+
+    @Binds
+    @Singleton
     fun bindCreateVaultBackupFileNameUseCase(
         impl: CreateVaultBackupFileNameUseCaseImpl
     ): CreateVaultBackupFileNameUseCase

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.SuiCoinMetadata
 import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -8,6 +9,8 @@ import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import java.math.BigDecimal
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 
 internal interface SearchSuiTokenUseCase : suspend (String) -> CoinAndPrice?
 
@@ -24,7 +27,7 @@ constructor(private val suiApi: SuiApi, private val tokenPriceRepository: TokenP
             )
         }
 
-        val metadata = suiApi.getCoinMetadata(coinType) ?: return null
+        val metadata = fetchMetadata(coinType) ?: return null
         val coin =
             Coin(
                 chain = Chain.Sui,
@@ -39,6 +42,22 @@ constructor(private val suiApi: SuiApi, private val tokenPriceRepository: TokenP
             )
         return CoinAndPrice(coin, BigDecimal.ZERO)
     }
+
+    /**
+     * Mirrors [SuiTokenFinder]'s handling of the same call: a bad node response or transient
+     * network failure must surface as "not found" rather than crash the custom-token screen, the
+     * same contract [SearchTerraTokenUseCase] and [SearchKujiraTokenUseCase] give their own RPC
+     * reads.
+     */
+    private suspend fun fetchMetadata(coinType: String): SuiCoinMetadata? =
+        try {
+            suiApi.getCoinMetadata(coinType)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.d(e, "Sui coin metadata fetch failed for %s", coinType)
+            null
+        }
 
     /**
      * The curated [Coins] catalog entry for [coinType], matched through

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
@@ -1,17 +1,29 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import java.math.BigDecimal
 import javax.inject.Inject
 
 internal interface SearchSuiTokenUseCase : suspend (String) -> CoinAndPrice?
 
-internal class SearchSuiTokenUseCaseImpl @Inject constructor(private val suiApi: SuiApi) :
+internal class SearchSuiTokenUseCaseImpl
+@Inject
+constructor(private val suiApi: SuiApi, private val tokenPriceRepository: TokenPriceRepository) :
     SearchSuiTokenUseCase {
 
     override suspend operator fun invoke(coinType: String): CoinAndPrice? {
+        curatedCoin(coinType)?.let { coin ->
+            return CoinAndPrice(
+                coin,
+                tokenPriceRepository.getPriceByPriceProviderId(coin.priceProviderID),
+            )
+        }
+
         val metadata = suiApi.getCoinMetadata(coinType) ?: return null
         val coin =
             Coin(
@@ -27,4 +39,17 @@ internal class SearchSuiTokenUseCaseImpl @Inject constructor(private val suiApi:
             )
         return CoinAndPrice(coin, BigDecimal.ZERO)
     }
+
+    /**
+     * The curated [Coins] catalog entry for [coinType], matched through
+     * [SuiHelper.isSameSuiCoinType] rather than a raw string compare — a node may return a coin
+     * type's package address zero-padded where the catalog stores it short. Preferred over the
+     * on-chain [SuiApi.getCoinMetadata] read because the catalog carries a hand-verified logo and
+     * `priceProviderID`; on-chain metadata frequently omits `iconUrl`, which is what left custom-
+     * added catalog tokens like DEEP without an icon (vultisig-android#5507 follow-up).
+     */
+    private fun curatedCoin(coinType: String): Coin? =
+        Coins.coins[Chain.Sui]?.firstOrNull {
+            !it.isNativeToken && SuiHelper.isSameSuiCoinType(it.contractAddress, coinType)
+        }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
@@ -1,0 +1,30 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import java.math.BigDecimal
+import javax.inject.Inject
+
+internal interface SearchSuiTokenUseCase : suspend (String) -> CoinAndPrice?
+
+internal class SearchSuiTokenUseCaseImpl @Inject constructor(private val suiApi: SuiApi) :
+    SearchSuiTokenUseCase {
+
+    override suspend operator fun invoke(coinType: String): CoinAndPrice? {
+        val metadata = suiApi.getCoinMetadata(coinType) ?: return null
+        val coin =
+            Coin(
+                chain = Chain.Sui,
+                ticker = metadata.symbol.trim(),
+                logo = metadata.iconUrl.orEmpty(),
+                address = "",
+                decimal = metadata.decimals,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = coinType,
+                isNativeToken = false,
+            )
+        return CoinAndPrice(coin, BigDecimal.ZERO)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.usecases
 
+import com.vultisig.wallet.data.crypto.SuiHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
@@ -25,6 +26,7 @@ constructor(
     private val searchSolToken: SearchSolTokenUseCase,
     private val searchKujiToken: SearchKujiraTokenUseCase,
     private val searchTerraToken: SearchTerraTokenUseCase,
+    private val searchSuiToken: SearchSuiTokenUseCase,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
 ) : SearchTokenUseCase {
 
@@ -44,6 +46,7 @@ constructor(
             chain.standard == SOL -> searchSolToken(address)
             chain == Chain.Kujira -> searchKujiToken(address)
             chain == Chain.Terra || chain == Chain.TerraClassic -> searchTerraToken(chain, address)
+            chain == Chain.Sui -> searchSuiToken(address)
             else -> null
         }
 
@@ -56,6 +59,7 @@ constructor(
         when (chain) {
             Chain.Terra,
             Chain.TerraClassic -> isCw20ContractAddressShape()
+            Chain.Sui -> isSuiCoinTypeShape()
             else ->
                 isNotEmpty() &&
                     chainAccountAddressRepository.isValid(chain, canonicalizedFor(chain))
@@ -78,6 +82,20 @@ constructor(
         if (!startsWith(TERRA_CONTRACT_PREFIX)) return false
         val payload = removePrefix(TERRA_CONTRACT_PREFIX)
         return payload.length in 20..80 && payload.all { it in 'a'..'z' || it in '0'..'9' }
+    }
+
+    /**
+     * Struct-tag shape check for a Sui coin type (`address::module::struct`) — the on-chain
+     * `suix_getCoinMetadata` call rejects anything malformed, so this only screens obviously wrong
+     * input before spending a network round-trip. The native SUI type is excluded: it's already on
+     * the vault by default, never a "custom" token to add.
+     */
+    private fun String.isSuiCoinTypeShape(): Boolean {
+        val segments = split("::")
+        return segments.size == 3 &&
+            segments.all { it.isNotBlank() } &&
+            segments[0].startsWith("0x") &&
+            !SuiHelper.isNativeSuiCoinType(this)
     }
 
     private fun Coin.hasSaneMetadata(): Boolean = ticker.isNotBlank() && decimal in 0..MAX_DECIMALS

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
@@ -1,0 +1,61 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.SuiCoinMetadata
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class SearchSuiTokenUseCaseImplTest {
+
+    private val suiApi: SuiApi = mockk()
+    private val tokenPriceRepository: TokenPriceRepository = mockk()
+
+    private val useCase = SearchSuiTokenUseCaseImpl(suiApi, tokenPriceRepository)
+
+    @Test
+    fun `curated coin type resolves via catalog logo and price without an RPC call`() = runTest {
+        // Zero-padded form of the catalog's DEEP contract address.
+        val padded =
+            "0x0deeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP"
+        coEvery { tokenPriceRepository.getPriceByPriceProviderId("deep") } returns
+            BigDecimal("0.05")
+
+        val result = useCase(padded)
+
+        assertEquals("DEEP", result?.coin?.ticker)
+        assertEquals(
+            "https://s2.coinmarketcap.com/static/img/coins/64x64/33391.png",
+            result?.coin?.logo,
+        )
+        assertEquals(BigDecimal("0.05"), result?.price)
+        coVerify(exactly = 0) { suiApi.getCoinMetadata(any()) }
+    }
+
+    @Test
+    fun `uncatalogued coin type falls back to on-chain metadata with zero price`() = runTest {
+        val coinType = "0xabc::widget::WIDGET"
+        coEvery { suiApi.getCoinMetadata(coinType) } returns
+            SuiCoinMetadata(decimals = 9, symbol = "WIDGET", iconUrl = "https://example.com/w.png")
+
+        val result = useCase(coinType)
+
+        assertEquals("WIDGET", result?.coin?.ticker)
+        assertEquals("https://example.com/w.png", result?.coin?.logo)
+        assertEquals(BigDecimal.ZERO, result?.price)
+    }
+
+    @Test
+    fun `node with no metadata returns null`() = runTest {
+        val coinType = "0xabc::widget::WIDGET"
+        coEvery { suiApi.getCoinMetadata(coinType) } returns null
+
+        assertNull(useCase(coinType))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
@@ -58,4 +58,12 @@ internal class SearchSuiTokenUseCaseImplTest {
 
         assertNull(useCase(coinType))
     }
+
+    @Test
+    fun `RPC failure surfaces as null instead of propagating`() = runTest {
+        val coinType = "0xnothex::coin::COIN"
+        coEvery { suiApi.getCoinMetadata(coinType) } throws IllegalStateException("bad request")
+
+        assertNull(useCase(coinType))
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCaseImplTest.kt
@@ -24,6 +24,7 @@ internal class SearchTokenUseCaseImplTest {
     private val searchSolToken: SearchSolTokenUseCase = mockk()
     private val searchKujiToken: SearchKujiraTokenUseCase = mockk()
     private val searchTerraToken: SearchTerraTokenUseCase = mockk()
+    private val searchSuiToken: SearchSuiTokenUseCase = mockk()
     private val appCurrencyRepository: AppCurrencyRepository = mockk {
         every { currency } returns flowOf(AppCurrency.USD)
     }
@@ -35,6 +36,7 @@ internal class SearchTokenUseCaseImplTest {
             searchSolToken = searchSolToken,
             searchKujiToken = searchKujiToken,
             searchTerraToken = searchTerraToken,
+            searchSuiToken = searchSuiToken,
             chainAccountAddressRepository = addressRepository,
         )
 
@@ -283,6 +285,41 @@ internal class SearchTokenUseCaseImplTest {
     }
 
     @Test
+    fun `valid Sui coin type delegated to Sui searcher without WalletCore`() = runTest {
+        val coinType =
+            "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN"
+        coEvery { searchSuiToken(coinType) } returns
+            CoinAndPrice(suiCoin(contract = coinType), BigDecimal.ZERO)
+
+        val result = useCase(Chain.Sui.id, "  $coinType  ")
+
+        assertEquals(BigDecimal.ZERO, result?.fiatValue?.value)
+        coVerify(exactly = 1) { searchSuiToken(coinType) }
+        verify(exactly = 0) { addressRepository.isValid(any(), any()) }
+    }
+
+    @Test
+    fun `native Sui coin type rejected without hitting the searcher`() = runTest {
+        assertNull(useCase(Chain.Sui.id, "0x2::sui::SUI"))
+
+        coVerify(exactly = 0) { searchSuiToken(any()) }
+    }
+
+    @Test
+    fun `Sui coin type missing struct segment rejected`() = runTest {
+        assertNull(useCase(Chain.Sui.id, "0x2::sui"))
+
+        coVerify(exactly = 0) { searchSuiToken(any()) }
+    }
+
+    @Test
+    fun `Sui coin type with non-hex address rejected`() = runTest {
+        assertNull(useCase(Chain.Sui.id, "notanaddress::coin::COIN"))
+
+        coVerify(exactly = 0) { searchSuiToken(any()) }
+    }
+
+    @Test
     fun `unsupported chain returns null even for valid format`() = runTest {
         stubValid(Chain.Bitcoin, "bc1qanyaddress", valid = true)
 
@@ -336,6 +373,19 @@ internal class SearchTokenUseCaseImplTest {
     private fun kujiraCoin(ticker: String = "TOKEN", contract: String): Coin =
         Coin(
             chain = Chain.Kujira,
+            ticker = ticker,
+            logo = "",
+            address = "",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = contract,
+            isNativeToken = false,
+        )
+
+    private fun suiCoin(ticker: String = "COIN", contract: String): Coin =
+        Coin(
+            chain = Chain.Sui,
             ticker = ticker,
             logo = "",
             address = "",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,6 +114,7 @@ androidx-test-core-ktx = { group = "androidx.test", name = "core-ktx", version.r
 androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.7.0" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version = "1.7.0" }
 coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
 
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktorClientMock" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelComposeVersion" }


### PR DESCRIPTION
## Description

`SearchTokenUseCase` dispatched EVM/SOL/Kujira/Terra but had no Sui case, so the "+ Custom" tile (offered on every chain) always fell through to `CustomTokenViewModel.showError()` on Sui.

Added a `SearchSuiTokenUseCase` that resolves the pasted struct tag via `suix_getCoinMetadata` (existing `SuiApi` call), gated by a coin-type shape check (`address::module::struct`) that also excludes the native SUI type — it's already on the vault by default, never a "custom" token to add.

Fixes #5507

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

N/A — this only affects custom-token resolution (metadata read), not a send/swap transaction.

## Parity

- iOS: linked vultisig-ios#5026
- Windows + extension: n/a — issue notes Windows already has this working; used as the reference
- SDK: n/a — reuses existing `SuiHelper` coin-type normalization, no SDK change needed

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — data-layer fix, no UI change (the "+ Custom" tile already existed).

## Additional context

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5507
- **Confidence**: high
- **Needs human review for**: Sui coin-type shape validation regex/segments (no live Sui RPC hit in this environment; verified via unit tests only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for searching Sui tokens using valid Sui coin types.
  * Matching catalog tokens now include available provider pricing.
  * Uncatalogued tokens can be resolved using on-chain metadata with an initial zero price.
  * Invalid, malformed, native SUI, or unavailable token data is handled gracefully.
  * Added support for displaying SVG images throughout the app.

* **Tests**
  * Added coverage for valid searches, rejected coin types, catalog matching, metadata fallback, and unavailable token data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->