### PR TITLE
fix(keysign): done screen stuck on "Pending" when status tracking never reports

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -247,6 +247,10 @@ class PreviewActivity : ComponentActivity() {
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
+                    "send_tx_done_untracked_before" ->
+                        SendTxDonePreview(status = TransactionStatus.Pending)
+                    "send_tx_done_untracked_after" ->
+                        SendTxDonePreview(status = TransactionStatus.Broadcasted)
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1433,7 +1437,7 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
 }
 
 @Composable
-private fun SendTxDonePreview() {
+private fun SendTxDonePreview(status: TransactionStatus = TransactionStatus.Broadcasted) {
     val ethCoin = Coins.Ethereum.ETH
 
     SendTxOverviewScreen(
@@ -1441,14 +1445,14 @@ private fun SendTxDonePreview() {
         showSaveToAddressBook = true,
         transactionHash = "0x1a2b3c...d4e5f6",
         transactionLink = "https://etherscan.io/tx/0x1a2b3c",
-        transactionStatus = TransactionStatus.Broadcasted,
+        transactionStatus = status,
         onComplete = {},
         onBack = {},
         onAddToAddressBook = {},
         tx =
             UiTransactionInfo(
                 type = UiTransactionInfoType.Send,
-                token = ValuedToken(token = ethCoin, value = "1.5", fiatValue = "$3,847.50"),
+                token = ValuedToken(token = ethCoin, value = "0.05", fiatValue = "$128.25"),
                 from = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
                 to = "0x9876543210FeDcBa9876543210FeDcBa98765432",
                 memo = "",

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -247,10 +247,6 @@ class PreviewActivity : ComponentActivity() {
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
-                    "send_tx_done_untracked_before" ->
-                        SendTxDonePreview(status = TransactionStatus.Pending)
-                    "send_tx_done_untracked_after" ->
-                        SendTxDonePreview(status = TransactionStatus.Broadcasted)
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1437,7 +1433,7 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
 }
 
 @Composable
-private fun SendTxDonePreview(status: TransactionStatus = TransactionStatus.Broadcasted) {
+private fun SendTxDonePreview() {
     val ethCoin = Coins.Ethereum.ETH
 
     SendTxOverviewScreen(
@@ -1445,14 +1441,14 @@ private fun SendTxDonePreview(status: TransactionStatus = TransactionStatus.Broa
         showSaveToAddressBook = true,
         transactionHash = "0x1a2b3c...d4e5f6",
         transactionLink = "https://etherscan.io/tx/0x1a2b3c",
-        transactionStatus = status,
+        transactionStatus = TransactionStatus.Broadcasted,
         onComplete = {},
         onBack = {},
         onAddToAddressBook = {},
         tx =
             UiTransactionInfo(
                 type = UiTransactionInfoType.Send,
-                token = ValuedToken(token = ethCoin, value = "0.05", fiatValue = "$128.25"),
+                token = ValuedToken(token = ethCoin, value = "1.5", fiatValue = "$3,847.50"),
                 from = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
                 to = "0x9876543210FeDcBa9876543210FeDcBa98765432",
                 memo = "",

--- a/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
@@ -9,10 +9,10 @@ import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 /**
@@ -22,6 +22,19 @@ import timber.log.Timber
 private const val SWAPKIT_FOREGROUND_TIMEOUT_MS = 30 * 60 * 1000L
 
 /**
+ * How long to wait for the status service's binding to connect. The service runs in this process,
+ * so a binding that has not connected by now never will — the start was accepted and then dropped.
+ */
+private val SERVICE_BIND_TIMEOUT = 10.seconds
+
+/**
+ * Headroom over the chain's own `maxWaitSeconds` status-poll budget. The service emits
+ * [TransactionResult.TimedOut] once it reaches that budget, so this deadline expires only when the
+ * service is bound but never polled — never on a healthy poll it would otherwise tear down.
+ */
+private val STATUS_SERVICE_GRACE = 30.seconds
+
+/**
  * How a done-screen status poll ended. Every observed status already reached the caller through the
  * poll's `onStatus` callback; this says who owns the transaction's status from here on.
  */
@@ -29,7 +42,7 @@ enum class TxStatusPollOutcome {
     /** A terminal on-chain status was observed. */
     Terminal,
 
-    /** The status service never reported, and no further status can arrive. */
+    /** No status will arrive: the status service never reported, or stopped without settling. */
     NotTracked,
 
     /**
@@ -80,8 +93,9 @@ constructor(
     /**
      * Default status poll for the done screen — drives the foreground
      * [TransactionStatusServiceManager] for [txHash] on [chain], emitting each observed status via
-     * [onStatus] and persisting it. A rejected binding or a vanished binder yields
-     * [TxStatusPollOutcome.NotTracked]: no further status can arrive. Tears down the foreground
+     * [onStatus] and persisting it. Every way the service can fail to report — a rejected start, a
+     * binding that never connects, a vanished binder, or a bound service that never polls — yields
+     * [TxStatusPollOutcome.NotTracked] rather than waiting forever. Tears down the foreground
      * service on every exit path.
      */
     private suspend fun pollStatusService(
@@ -96,23 +110,27 @@ constructor(
                 return TxStatusPollOutcome.NotTracked
             }
             onStatus(TransactionResult.Pending)
-            transactionStatusServiceManager.serviceReady
-                .filter { it } // Wait until service is ready
-                .first()
+            withTimeoutOrNull(SERVICE_BIND_TIMEOUT) {
+                transactionStatusServiceManager.serviceReady.first { it }
+            } ?: return TxStatusPollOutcome.NotTracked
             val statusFlow =
                 transactionStatusServiceManager.getStatusFlow()
                     ?: return TxStatusPollOutcome.NotTracked
-            statusFlow
-                .onEach { statusResult ->
-                    persistStatus(
-                        txHash,
-                        chain,
-                        statusResult,
-                        "Failed to update tx history status for %s",
-                    )
-                    onStatus(statusResult)
-                }
-                .first { it.isTerminal() }
+            val budget =
+                txStatusConfigurationProvider.getConfigurationForChain(chain).maxWaitSeconds.seconds
+            withTimeoutOrNull(budget + STATUS_SERVICE_GRACE) {
+                statusFlow
+                    .onEach { statusResult ->
+                        persistStatus(
+                            txHash,
+                            chain,
+                            statusResult,
+                            "Failed to update tx history status for %s",
+                        )
+                        onStatus(statusResult)
+                    }
+                    .first { it.isTerminal() }
+            } ?: return TxStatusPollOutcome.NotTracked
             return TxStatusPollOutcome.Terminal
         } finally {
             // Tear down the foreground service on every exit path (terminal, early return, or

--- a/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
@@ -22,6 +22,24 @@ import timber.log.Timber
 private const val SWAPKIT_FOREGROUND_TIMEOUT_MS = 30 * 60 * 1000L
 
 /**
+ * How a done-screen status poll ended. Every observed status already reached the caller through the
+ * poll's `onStatus` callback; this says who owns the transaction's status from here on.
+ */
+enum class TxStatusPollOutcome {
+    /** A terminal on-chain status was observed. */
+    Terminal,
+
+    /** The status service never started: no status was observed and none ever will be. */
+    NotTracked,
+
+    /**
+     * Polling stopped with the transaction still in flight; the background tx-history poller
+     * settles it from here.
+     */
+    HandedOff,
+}
+
+/**
  * Drives transaction-status polling for the keysign done screen. Owns the foreground status service
  * lifecycle and the SwapKit settlement loop, and persists each observed status to tx history.
  *
@@ -40,9 +58,7 @@ constructor(
 
     /**
      * Polls [txHash] on [chain] for settlement, invoking [onStatus] with each observed
-     * [TransactionResult] (starting with [TransactionResult.Pending]) and persisting it to tx
-     * history. Returns the terminal result when one is reached, or `null` when polling ends without
-     * a terminal status (SwapKit foreground-timeout handoff to the background poller).
+     * [TransactionResult] and persisting it to tx history.
      *
      * A SwapKit-routed swap ([isSwapKitSwap]) settles on its destination leg, which the
      * source-chain status service can't see — gate Success on `/track` instead (parity with the
@@ -54,7 +70,7 @@ constructor(
         chain: Chain,
         isSwapKitSwap: Boolean,
         onStatus: suspend (TransactionResult) -> Unit,
-    ): TransactionResult? =
+    ): TxStatusPollOutcome =
         if (isSwapKitSwap && swapKitTrackingService.canTrack(chain)) {
             pollSwapKit(txHash, chain, onStatus)
         } else {
@@ -64,25 +80,29 @@ constructor(
     /**
      * Default status poll for the done screen — drives the foreground
      * [TransactionStatusServiceManager] for [txHash] on [chain], emitting each observed status via
-     * [onStatus] and persisting it. Returns the first terminal status, or `null` if the service
-     * binding was rejected or no status flow is available. Tears down the foreground service on
-     * every exit path.
+     * [onStatus] and persisting it. A rejected binding or a vanished binder yields
+     * [TxStatusPollOutcome.NotTracked]: no further status can arrive. Tears down the foreground
+     * service on every exit path.
      */
     private suspend fun pollStatusService(
         txHash: String,
         chain: Chain,
         onStatus: suspend (TransactionResult) -> Unit,
-    ): TransactionResult? {
+    ): TxStatusPollOutcome {
         try {
-            val bound = transactionStatusServiceManager.startPolling(txHash, chain)
+            // A rejected binding never connects, so serviceReady would suspend forever — and a
+            // status emitted here would be the last one the screen ever received.
+            if (!transactionStatusServiceManager.startPolling(txHash, chain)) {
+                return TxStatusPollOutcome.NotTracked
+            }
             onStatus(TransactionResult.Pending)
-            // A rejected binding never connects, so serviceReady would suspend forever.
-            if (!bound) return null
             transactionStatusServiceManager.serviceReady
                 .filter { it } // Wait until service is ready
                 .first()
-            val statusFlow = transactionStatusServiceManager.getStatusFlow() ?: return null
-            return statusFlow
+            val statusFlow =
+                transactionStatusServiceManager.getStatusFlow()
+                    ?: return TxStatusPollOutcome.NotTracked
+            statusFlow
                 .onEach { statusResult ->
                     persistStatus(
                         txHash,
@@ -93,9 +113,10 @@ constructor(
                     onStatus(statusResult)
                 }
                 .first { it.isTerminal() }
+            return TxStatusPollOutcome.Terminal
         } finally {
-            // Tear down the foreground service on every exit path (terminal, early null return,
-            // or cancellation) so it can't outlive the poll.
+            // Tear down the foreground service on every exit path (terminal, early return, or
+            // cancellation) so it can't outlive the poll.
             transactionStatusServiceManager.stopPolling()
         }
     }
@@ -105,14 +126,14 @@ constructor(
      * broadcast hash and gates Success on the destination-leg status. Runs in the caller's
      * coroutine (no foreground service): when the user leaves the screen the job is cancelled and
      * the tx-history poller ([com.vultisig.wallet.data.usecases.RefreshPendingTransactionsUseCase])
-     * takes over. On the timeout the row is left in-flight (handed off to that poller, returning
-     * `null`) rather than marked terminal.
+     * takes over. On the timeout the row is left in-flight ([TxStatusPollOutcome.HandedOff]) rather
+     * than marked terminal.
      */
     private suspend fun pollSwapKit(
         txHash: String,
         chain: Chain,
         onStatus: suspend (TransactionResult) -> Unit,
-    ): TransactionResult? {
+    ): TxStatusPollOutcome {
         onStatus(TransactionResult.Pending)
         val pollInterval =
             txStatusConfigurationProvider
@@ -124,7 +145,7 @@ constructor(
             if (System.currentTimeMillis() - startTime >= SWAPKIT_FOREGROUND_TIMEOUT_MS) {
                 // Hand off to the background tx-history poller; leave the row pending.
                 onStatus(TransactionResult.Pending)
-                return null
+                return TxStatusPollOutcome.HandedOff
             }
 
             val statusResult = swapKitTrackingService.checkSettlementStatus(txHash, chain)
@@ -138,12 +159,12 @@ constructor(
             when (statusResult) {
                 TransactionResult.Confirmed,
                 is TransactionResult.Failed,
-                is TransactionResult.Refunded -> return statusResult
+                is TransactionResult.Refunded -> return TxStatusPollOutcome.Terminal
 
                 else -> delay(pollInterval)
             }
         }
-        return null
+        return TxStatusPollOutcome.HandedOff
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/services/KeysignTxStatusPoller.kt
@@ -29,7 +29,7 @@ enum class TxStatusPollOutcome {
     /** A terminal on-chain status was observed. */
     Terminal,
 
-    /** The status service never started: no status was observed and none ever will be. */
+    /** The status service never reported, and no further status can arrive. */
     NotTracked,
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -41,6 +41,7 @@ import com.vultisig.wallet.data.repositories.PendingLimitOrderRepository
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.services.KeysignTxStatusPoller
+import com.vultisig.wallet.data.services.TxStatusPollOutcome
 import com.vultisig.wallet.data.swap.limit.LimitSwapCancelMemo
 import com.vultisig.wallet.data.swap.limit.LimitSwapMemo
 import com.vultisig.wallet.data.swap.limit.findOrderAddressedByCancelMemo
@@ -1039,7 +1040,7 @@ constructor(
         pollingTxStatusJob?.cancel()
         pollingTxStatusJob =
             viewModelScope.safeLaunch {
-                val terminal =
+                val outcome =
                     txStatusPoller.poll(txHash, chain, isSwapKitSwap = isSwapKitSwap()) { result ->
                         _state.update {
                             it.copy(
@@ -1050,7 +1051,21 @@ constructor(
                             )
                         }
                     }
-                if (terminal != null) tryUpdateEvmActualFee(txHash, chain)
+                when (outcome) {
+                    TxStatusPollOutcome.Terminal -> tryUpdateEvmActualFee(txHash, chain)
+                    // The done screen has no watcher left, so it must not keep advertising a
+                    // status that can never advance — land where a broadcast with nothing to poll
+                    // lands. The history row is still settled by the tx-history poller (#5510).
+                    TxStatusPollOutcome.NotTracked ->
+                        _state.update {
+                            it.copy(
+                                signingState =
+                                    KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+                            )
+                        }
+                    // Still settling: the last observed status is real and must stand.
+                    TxStatusPollOutcome.HandedOff -> Unit
+                }
             }
     }
 

--- a/app/src/test/java/com/vultisig/wallet/data/services/KeysignTxStatusPollerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/KeysignTxStatusPollerTest.kt
@@ -1,0 +1,145 @@
+package com.vultisig.wallet.data.services
+
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfiguration
+import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers how a done-screen poll ends (#5510): a transaction the status service never picked up must
+ * be reported as untracked, so the screen stops showing a status nothing will ever advance.
+ */
+internal class KeysignTxStatusPollerTest {
+
+    private val txHash = "0xhash"
+
+    private lateinit var serviceManager: TransactionStatusServiceManager
+    private lateinit var swapKitTrackingService: SwapKitTrackingService
+    private lateinit var configurationProvider: TxStatusConfigurationProvider
+    private lateinit var transactionHistoryRepository: TransactionHistoryRepository
+    private lateinit var poller: KeysignTxStatusPoller
+
+    @BeforeEach
+    fun setUp() {
+        serviceManager = mockk(relaxed = true)
+        swapKitTrackingService = mockk(relaxed = true)
+        configurationProvider = mockk(relaxed = true)
+        transactionHistoryRepository = mockk(relaxed = true)
+        every { serviceManager.serviceReady } returns MutableStateFlow(true)
+        every { configurationProvider.getConfigurationForChain(any()) } returns
+            TxStatusConfiguration(pollIntervalSeconds = 1L, maxWaitSeconds = 60L)
+        poller =
+            KeysignTxStatusPoller(
+                transactionStatusServiceManager = serviceManager,
+                swapKitTrackingService = swapKitTrackingService,
+                txStatusConfigurationProvider = configurationProvider,
+                transactionHistoryRepository = transactionHistoryRepository,
+            )
+    }
+
+    // A refused foreground-service start never connects, so waiting on the binding would suspend
+    // forever. Emitting a status here would leave the screen on a "Pending" nothing can advance.
+    @Test
+    fun `a rejected binding is untracked and emits no status`() = runTest {
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns false
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed)
+
+        outcome shouldBe TxStatusPollOutcome.NotTracked
+        observed shouldBe emptyList()
+        verify { serviceManager.stopPolling() }
+    }
+
+    // The binder can be gone by the time the service reports ready (disconnect, concurrent stop):
+    // same outcome, the transaction has no watcher.
+    @Test
+    fun `a vanished binder is untracked`() = runTest {
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns true
+        every { serviceManager.getStatusFlow() } returns null
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed)
+
+        outcome shouldBe TxStatusPollOutcome.NotTracked
+        observed shouldBe listOf(TransactionResult.Pending)
+    }
+
+    @Test
+    fun `a settled transaction is terminal and every status is emitted and persisted`() = runTest {
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns true
+        every { serviceManager.getStatusFlow() } returns
+            flowOf(TransactionResult.Pending, TransactionResult.Confirmed)
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed)
+
+        outcome shouldBe TxStatusPollOutcome.Terminal
+        observed shouldBe
+            listOf(
+                TransactionResult.Pending,
+                TransactionResult.Pending,
+                TransactionResult.Confirmed,
+            )
+        coVerify {
+            transactionHistoryRepository.updateTransactionStatus(
+                chain = Chain.Ethereum.raw,
+                txHash = txHash,
+                result = TransactionResult.Confirmed,
+            )
+        }
+        verify { serviceManager.stopPolling() }
+    }
+
+    // A SwapKit swap settles on its destination leg, tracked without the foreground service.
+    @Test
+    fun `a settled SwapKit swap is terminal`() = runTest {
+        every { swapKitTrackingService.canTrack(Chain.Ethereum) } returns true
+        coEvery { swapKitTrackingService.checkSettlementStatus(txHash, Chain.Ethereum) } returns
+            TransactionResult.Confirmed
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed, isSwapKitSwap = true)
+
+        outcome shouldBe TxStatusPollOutcome.Terminal
+        observed shouldBe listOf(TransactionResult.Pending, TransactionResult.Confirmed)
+        verify(exactly = 0) { serviceManager.startPolling(any(), any()) }
+    }
+
+    // Only SwapKit can see a SwapKit swap's destination leg; a chain it can't track falls back to
+    // the source-chain status service.
+    @Test
+    fun `a SwapKit swap on an untrackable chain falls back to the status service`() = runTest {
+        every { swapKitTrackingService.canTrack(Chain.Ethereum) } returns false
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns false
+
+        val outcome = poll(mutableListOf(), isSwapKitSwap = true)
+
+        outcome shouldBe TxStatusPollOutcome.NotTracked
+        verify { serviceManager.startPolling(txHash, Chain.Ethereum) }
+    }
+
+    private suspend fun poll(
+        observed: MutableList<TransactionResult>,
+        isSwapKitSwap: Boolean = false,
+    ) =
+        poller.poll(
+            txHash = txHash,
+            chain = Chain.Ethereum,
+            isSwapKitSwap = isSwapKitSwap,
+            onStatus = { observed += it },
+        )
+}

--- a/app/src/test/java/com/vultisig/wallet/data/services/KeysignTxStatusPollerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/services/KeysignTxStatusPollerTest.kt
@@ -64,6 +64,36 @@ internal class KeysignTxStatusPollerTest {
         verify { serviceManager.stopPolling() }
     }
 
+    // The system can accept the start and then drop it, so onServiceConnected never fires. Waiting
+    // on serviceReady would then hold the screen on "Pending" for the rest of the session.
+    @Test
+    fun `a binding that never connects is untracked`() = runTest {
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns true
+        every { serviceManager.serviceReady } returns MutableStateFlow(false)
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed)
+
+        outcome shouldBe TxStatusPollOutcome.NotTracked
+        observed shouldBe listOf(TransactionResult.Pending)
+        verify { serviceManager.stopPolling() }
+    }
+
+    // A service whose own startForeground threw never starts its poll job, so its status flow sits
+    // on its initial Pending forever — indistinguishable from a slow chain until the budget lapses.
+    @Test
+    fun `a bound service that never reports is untracked once the poll budget lapses`() = runTest {
+        every { serviceManager.startPolling(txHash, Chain.Ethereum) } returns true
+        every { serviceManager.getStatusFlow() } returns MutableStateFlow(TransactionResult.Pending)
+        val observed = mutableListOf<TransactionResult>()
+
+        val outcome = poll(observed)
+
+        outcome shouldBe TxStatusPollOutcome.NotTracked
+        observed shouldBe listOf(TransactionResult.Pending, TransactionResult.Pending)
+        verify { serviceManager.stopPolling() }
+    }
+
     // The binder can be gone by the time the service reports ready (disconnect, concurrent stop):
     // same outcome, the transaction has no watcher.
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -10,11 +10,15 @@ import com.vultisig.wallet.data.models.TssKeyType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.services.KeysignTxStatusPoller
+import com.vultisig.wallet.data.services.TxStatusPollOutcome
 import com.vultisig.wallet.data.usecases.KeysignBroadcastResult
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -50,6 +54,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
     private lateinit var txStatusConfigurationProvider: TxStatusConfigurationProvider
     private lateinit var transactionHistoryRepository: TransactionHistoryRepository
     private lateinit var explorerLinkRepository: ExplorerLinkRepository
+    private lateinit var txStatusPoller: KeysignTxStatusPoller
 
     @BeforeEach
     fun setUp() {
@@ -57,6 +62,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
         txStatusConfigurationProvider = mockk(relaxed = true)
         transactionHistoryRepository = mockk(relaxed = true)
         explorerLinkRepository = mockk(relaxed = true)
+        txStatusPoller = mockk(relaxed = true)
     }
 
     @AfterEach
@@ -149,6 +155,67 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             genericData.captured.explorerUrl shouldBe "https://etherscan.io/tx/0xhash2"
         }
 
+    // The status service can be refused (backgrounded app, API 31+), and nothing else will ever
+    // report on the transaction — so the done screen must not keep showing the "Pending" the poller
+    // emitted on its way out (issue #5510).
+    @Test
+    fun `a transaction nothing tracks reaches the terminal broadcasted state`() =
+        runTest(testDispatcher) {
+            val vm = createPollingViewModel { TxStatusPollOutcome.NotTracked }
+
+            vm.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            vm.state.value.signingState shouldBe
+                KeysignState.KeysignFinished(TransactionStatus.Broadcasted)
+        }
+
+    // "There is nothing to poll" and "the poller never started" are the same thing to the user — a
+    // clean broadcast with no watcher — so both must land on the same status.
+    @Test
+    fun `an untracked transaction lands where an unpollable one lands`() =
+        runTest(testDispatcher) {
+            val untracked = createPollingViewModel { TxStatusPollOutcome.NotTracked }
+            untracked.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            every { txStatusConfigurationProvider.supportTxStatus(any()) } returns false
+            val unpollable = createViewModel()
+            unpollable.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            untracked.state.value.signingState shouldBe unpollable.state.value.signingState
+        }
+
+    // A SwapKit swap whose foreground budget ran out is genuinely still settling; claiming
+    // "Transaction successful" would assert an outcome the app never observed.
+    @Test
+    fun `a handed-off transaction keeps the last observed status`() =
+        runTest(testDispatcher) {
+            val vm = createPollingViewModel { onStatus ->
+                onStatus(TransactionResult.Pending)
+                TxStatusPollOutcome.HandedOff
+            }
+
+            vm.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            vm.state.value.signingState shouldBe
+                KeysignState.KeysignFinished(TransactionStatus.Pending)
+        }
+
+    // The settled status the poller observed must survive: the untracked fallback may not overwrite
+    // a real on-chain result.
+    @Test
+    fun `a settled transaction keeps the observed terminal status`() =
+        runTest(testDispatcher) {
+            val vm = createPollingViewModel { onStatus ->
+                onStatus(TransactionResult.Confirmed)
+                TxStatusPollOutcome.Terminal
+            }
+
+            vm.applyBroadcastResult(broadcasted(txHash = "0xhash"))
+
+            vm.state.value.signingState shouldBe
+                KeysignState.KeysignFinished(TransactionStatus.Confirmed)
+        }
+
     private fun broadcasted(txHash: String?, additionalTxHashes: List<String> = emptyList()) =
         KeysignBroadcastResult.Broadcasted(
             chain = Chain.Ethereum,
@@ -159,6 +226,19 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             approveTxLink = "",
             additionalTxHashes = additionalTxHashes,
         )
+
+    /** A ViewModel on a status-polling chain whose poll body is [poll]. */
+    private fun createPollingViewModel(
+        poll: suspend (onStatus: suspend (TransactionResult) -> Unit) -> TxStatusPollOutcome
+    ): KeysignViewModel {
+        val onStatus = slot<suspend (TransactionResult) -> Unit>()
+        every { txStatusConfigurationProvider.supportTxStatus(any()) } returns true
+        coEvery { txStatusPoller.poll(any(), any(), any(), capture(onStatus)) } coAnswers
+            {
+                poll(onStatus.captured)
+            }
+        return createViewModel()
+    }
 
     private fun createViewModel(transactionHistoryData: TransactionHistoryData? = null) =
         KeysignViewModel(
@@ -185,7 +265,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             pullTssMessages = mockk(relaxed = true),
             addressBookRepository = mockk(relaxed = true),
             txStatusConfigurationProvider = txStatusConfigurationProvider,
-            txStatusPoller = mockk(relaxed = true),
+            txStatusPoller = txStatusPoller,
             vaultRepository = mockk(relaxed = true),
             chainAccountAddressRepository = mockk(relaxed = true),
             transactionHistoryRepository = transactionHistoryRepository,


### PR DESCRIPTION
## Summary

The keysign done screen could sit on "Transaction pending…" for the rest of the session — the transaction confirmed, the screen never said so.

Every chain has tx-status support, so `applyBroadcastResult` always takes the polling branch and the defensive `KeysignFinished(Broadcasted)` else-branch only ever covers a hashless broadcast. That left `pollStatusService` as the only thing that could finish the screen, and it had four ways to fail without doing so:

- `startForegroundService` is refused — API 31+ with the app backgrounded at the moment the broadcast lands. It emitted one `Pending`, returned, and nothing wrote the screen again. This is the route the ticket describes.
- The binding is accepted but `onServiceConnected` never fires, so the wait on `serviceReady` never resolves.
- The binder is gone by the time the service reports ready.
- The service binds but its own `startForeground` throws, so it stops before starting its poll job and its status flow sits on the initial `Pending` — the wait for a terminal status never resolves.

All four now land on `Broadcasted`, the same state a clean broadcast with nothing to poll already reaches. The middle two needed deadlines rather than a return value, because the coroutine never got far enough to return anything: the bind wait is short (the service runs in this process), and the status wait is the chain's own `maxWaitSeconds` plus headroom. That budget is what makes the deadline safe — the service starts its own clock in `onStartCommand` and emits `TimedOut` when it reaches it, so a healthy poll always settles first and is never torn down.

The rejected-start path also stops publishing the `Pending` it knows nothing can advance, so that case goes straight from the signing spinner to the done screen.

### Why `poll()` needed a new return type

Its nullable `TransactionResult` had a `null` that meant two contradictory things: the status service never reported, and the SwapKit foreground budget lapsed while the swap was still settling. Only the first should finish the screen — mapping `null` to `Broadcasted` would flip an unsettled cross-chain swap to "Transaction successful". They are now separate `TxStatusPollOutcome` cases, handled exhaustively:

- `Terminal` — refresh the actual EVM fee (unchanged).
- `NotTracked` — land on `Broadcasted`.
- `HandedOff` — leave the last observed status; the tx-history poller settles the row.

### Parity

iOS seeds its done-screen poller with `.broadcasted` and writes `.pending` only once an RPC actually answered (`ChainPoller.swift`, `TransactionStatusViewModel.swift`), so it cannot get stuck this way, and its SwapKit give-up (`failureGiveUpInterval = 30 * 60`) deliberately stays `.pending`. This lands Android on both. Windows degrades to `pending` forever when its status query fails — same bug class, still open there.

## Before / After

Send done screen after a successful broadcast the status service could not track. Same build, device and mock data; only the status differs.

| Before — stuck on "Transaction pending…" indefinitely | After — "Transaction successful" |
|--------|-------|
| ![before](https://i.imgur.com/9rzR23f.png) | ![after](https://i.imgur.com/WX0UJAL.png) |

## Testing

`./gradlew :app:ktfmtCheck :data:ktfmtCheck testDebugUnitTest lintDebug assembleDebug` — passing.

11 new tests. `KeysignTxStatusPollerTest` (new file) covers each of the four failure routes plus the settled and SwapKit paths. `KeysignViewModelApplyBroadcastResultTest` gains four, including one that drives both the "nothing to poll" and "the poller never started" paths and asserts they land on the same status, and one that pins the SwapKit handoff to `Pending` so the two outcomes cannot be collapsed. Three were confirmed to fail with the fix reverted; the two deadline tests hang without it.

Overlap note: PR #5513 (https://github.com/vultisig/vultisig-android/pull/5513) touches the transaction done screens; no shared files, low conflict risk.

Closes #5510
Closes #5516
