### PR TITLE
fix(ton): show GRAM instead of stale TON label in stake/unstake UI

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
@@ -53,9 +53,10 @@ import java.text.DecimalFormat
 @Composable
 internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
     val state by viewModel.state.collectAsState()
+    val ticker = state.ticker.ifEmpty { "GRAM" }
 
     V2Scaffold(
-        title = stringResource(R.string.ton_stake_title, state.ticker.ifEmpty { "TON" }),
+        title = stringResource(R.string.ton_stake_title, ticker),
         onBackClick = viewModel::back,
     ) {
         val amountText = viewModel.amountFieldState.text.toString()
@@ -69,7 +70,7 @@ internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 StakingAmountCard(
-                    ticker = state.ticker.ifEmpty { "TON" },
+                    ticker = ticker,
                     amountFieldState = viewModel.amountFieldState,
                     available = state.stakeableBalance,
                     percentageSelected = state.percentageSelected,
@@ -84,7 +85,7 @@ internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
                             stringResource(
                                 R.string.ton_stake_error_min_amount,
                                 state.requiredMinStake.stripTrailingZeros().toPlainString(),
-                                state.ticker.ifEmpty { "TON" },
+                                ticker,
                             ),
                         style = Theme.brockmann.supplementary.caption,
                         color = Theme.v2.colors.alerts.error,
@@ -120,6 +121,7 @@ internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
         if (state.isShowingPicker) {
             TonPoolPickerSheet(
                 state = state,
+                ticker = ticker,
                 searchTextFieldState = viewModel.searchTextFieldState,
                 onPoolSelected = viewModel::onPoolSelected,
                 onDismiss = viewModel::closePoolPicker,
@@ -183,6 +185,7 @@ private fun TonPoolPickerField(selected: TonPoolUiModel?, onClick: () -> Unit) {
 @Composable
 private fun TonPoolPickerSheet(
     state: TonStakeUiState,
+    ticker: String,
     searchTextFieldState: androidx.compose.foundation.text.input.TextFieldState,
     onPoolSelected: (TonPoolUiModel) -> Unit,
     onDismiss: () -> Unit,
@@ -274,6 +277,7 @@ private fun TonPoolPickerSheet(
                             items(state.pools, key = { it.address }) { pool ->
                                 TonPoolRow(
                                     pool = pool,
+                                    ticker = ticker,
                                     isSelected = pool.address == state.selectedPool?.address,
                                     onClick = { onPoolSelected(pool) },
                                 )
@@ -299,7 +303,12 @@ private fun CenteredMessage(text: String) {
 }
 
 @Composable
-private fun TonPoolRow(pool: TonPoolUiModel, isSelected: Boolean, onClick: () -> Unit) {
+private fun TonPoolRow(
+    pool: TonPoolUiModel,
+    ticker: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
     val shape = RoundedCornerShape(16.dp)
     Row(
         modifier =
@@ -338,7 +347,11 @@ private fun TonPoolRow(pool: TonPoolUiModel, isSelected: Boolean, onClick: () ->
             }
             Text(
                 text =
-                    stringResource(R.string.ton_staking_min_stake, formatMinStake(pool.minStake)),
+                    stringResource(
+                        R.string.ton_staking_min_stake,
+                        formatMinStake(pool.minStake),
+                        ticker,
+                    ),
                 style = Theme.brockmann.supplementary.caption,
                 color = Theme.v2.colors.text.secondary,
                 maxLines = 1,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
@@ -49,11 +49,14 @@ import com.vultisig.wallet.ui.utils.asString
 import java.math.BigDecimal
 import java.text.DecimalFormat
 
+/** Shown until [TonStakeViewModel]/[TonUnstakeViewModel] resolve the vault's native coin ticker. */
+internal const val TON_NATIVE_TICKER_FALLBACK = "GRAM"
+
 /** Dedicated TON nominator-pool stake screen. Mirrors iOS `TonStakeTransactionScreen`. */
 @Composable
 internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
     val state by viewModel.state.collectAsState()
-    val ticker = state.ticker.ifEmpty { "GRAM" }
+    val ticker = state.ticker.ifEmpty { TON_NATIVE_TICKER_FALLBACK }
 
     V2Scaffold(
         title = stringResource(R.string.ton_stake_title, ticker),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
@@ -36,7 +36,7 @@ import com.vultisig.wallet.ui.utils.asString
 @Composable
 internal fun TonUnstakeScreen(viewModel: TonUnstakeViewModel = hiltViewModel()) {
     val state by viewModel.state.collectAsState()
-    val ticker = state.ticker.ifEmpty { "TON" }
+    val ticker = state.ticker.ifEmpty { "GRAM" }
 
     V2Scaffold(
         title = stringResource(R.string.ton_unstake_title, ticker),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
@@ -36,7 +36,7 @@ import com.vultisig.wallet.ui.utils.asString
 @Composable
 internal fun TonUnstakeScreen(viewModel: TonUnstakeViewModel = hiltViewModel()) {
     val state by viewModel.state.collectAsState()
-    val ticker = state.ticker.ifEmpty { "GRAM" }
+    val ticker = state.ticker.ifEmpty { TON_NATIVE_TICKER_FALLBACK }
 
     V2Scaffold(
         title = stringResource(R.string.ton_unstake_title, ticker),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -927,7 +927,7 @@
     <string name="error_invalid_chain">Die Blockchain ist ungültig</string>
     <string name="ton_stake_error_unsupported_pool">Dieser Staking-Pool wird nicht unterstützt</string>
     <string name="ton_stake_error_min_amount">Mindest-Stake für diesen Pool beträgt %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON ist nicht in diesem Tresor</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM ist nicht in diesem Tresor</string>
     <string name="ton_defi_pending_withdrawal">Ausstehende Auszahlung</string>
     <string name="ton_defi_unlock_ready">Bereit zur Auszahlung</string>
     <string name="ton_defi_unlocks_in_days">Freigabe in %1$d T %2$d Std</string>
@@ -938,7 +938,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Keine Staking-Pools gefunden</string>
-    <string name="ton_staking_min_stake">Min. %1$s TON</string>
+    <string name="ton_staking_min_stake">Min. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Staken %1$s</string>
     <string name="ton_unstake_title">Unstaken %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -925,7 +925,7 @@
     <string name="error_invalid_chain">La cadena no es válida.</string>
     <string name="ton_stake_error_unsupported_pool">Este pool de staking no es compatible</string>
     <string name="ton_stake_error_min_amount">El stake mínimo para este pool es de %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON no está en esta bóveda</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM no está en esta bóveda</string>
     <string name="ton_defi_pending_withdrawal">Retiro pendiente</string>
     <string name="ton_defi_unlock_ready">Listo para retirar</string>
     <string name="ton_defi_unlocks_in_days">Se desbloquea en %1$d d %2$d h</string>
@@ -936,7 +936,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">No se encontraron pools de staking</string>
-    <string name="ton_staking_min_stake">Mín. %1$s TON</string>
+    <string name="ton_staking_min_stake">Mín. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Stakear %1$s</string>
     <string name="ton_unstake_title">Retirar stake de %1$s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -930,7 +930,7 @@
     <string name="error_invalid_chain">Lanac nije valjan</string>
     <string name="ton_stake_error_unsupported_pool">Ovaj staking pool nije podržan</string>
     <string name="ton_stake_error_min_amount">Minimalni ulog za ovaj pool je %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON nije u ovom trezoru</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM nije u ovom trezoru</string>
     <string name="ton_defi_pending_withdrawal">Isplata na čekanju</string>
     <string name="ton_defi_unlock_ready">Spremno za isplatu</string>
     <string name="ton_defi_unlocks_in_days">Otključava se za %1$d d %2$d h</string>
@@ -941,7 +941,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Nema pronađenih staking poolova</string>
-    <string name="ton_staking_min_stake">Min. %1$s TON</string>
+    <string name="ton_staking_min_stake">Min. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Stakiraj %1$s</string>
     <string name="ton_unstake_title">Povuci %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -925,7 +925,7 @@
     <string name="error_invalid_chain">La catena non è valida</string>
     <string name="ton_stake_error_unsupported_pool">Questo pool di staking non è supportato</string>
     <string name="ton_stake_error_min_amount">Lo stake minimo per questo pool è %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON non è in questa cassaforte</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM non è in questa cassaforte</string>
     <string name="ton_defi_pending_withdrawal">Prelievo in sospeso</string>
     <string name="ton_defi_unlock_ready">Pronto per il prelievo</string>
     <string name="ton_defi_unlocks_in_days">Si sblocca tra %1$d g %2$d h</string>
@@ -936,7 +936,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Nessun pool di staking trovato</string>
-    <string name="ton_staking_min_stake">Min %1$s TON</string>
+    <string name="ton_staking_min_stake">Min %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Stake %1$s</string>
     <string name="ton_unstake_title">Rimuovi lo stake di %1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -490,7 +490,7 @@
     <string name="error_invalid_chain">체인이 유효하지 않습니다</string>
     <string name="ton_stake_error_unsupported_pool">이 스테이킹 풀은 지원되지 않습니다</string>
     <string name="ton_stake_error_min_amount">이 풀의 최소 스테이킹 금액은 %1$s %2$s입니다</string>
-    <string name="ton_defi_error_ton_not_in_vault">이 볼트에 TON이 없습니다</string>
+    <string name="ton_defi_error_ton_not_in_vault">이 볼트에 GRAM이 없습니다</string>
     <string name="ton_defi_pending_withdrawal">대기 중인 출금</string>
     <string name="ton_defi_unlock_ready">출금 가능</string>
     <string name="ton_defi_unlocks_in_days">%1$d일 %2$d시간 후 잠금 해제</string>
@@ -501,7 +501,7 @@
     <string name="ton_staking_pool_header">풀</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">스테이킹 풀을 찾을 수 없습니다</string>
-    <string name="ton_staking_min_stake">최소 %1$s TON</string>
+    <string name="ton_staking_min_stake">최소 %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">%1$s 스테이킹</string>
     <string name="ton_unstake_title">%1$s 언스테이킹</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -922,7 +922,7 @@
     <string name="error_invalid_chain">Ketting is ongeldig</string>
     <string name="ton_stake_error_unsupported_pool">Deze staking-pool wordt niet ondersteund</string>
     <string name="ton_stake_error_min_amount">De minimale stake voor deze pool is %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON staat niet in deze kluis</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM staat niet in deze kluis</string>
     <string name="ton_defi_pending_withdrawal">Openstaande opname</string>
     <string name="ton_defi_unlock_ready">Klaar om op te nemen</string>
     <string name="ton_defi_unlocks_in_days">Ontgrendelt over %1$d d %2$d u</string>
@@ -933,7 +933,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Geen staking-pools gevonden</string>
-    <string name="ton_staking_min_stake">Min. %1$s TON</string>
+    <string name="ton_staking_min_stake">Min. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">%1$s staken</string>
     <string name="ton_unstake_title">%1$s unstaken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -924,7 +924,7 @@
     <string name="error_invalid_chain">A cadeia é inválida.</string>
     <string name="ton_stake_error_unsupported_pool">Este pool de staking não é suportado</string>
     <string name="ton_stake_error_min_amount">O stake mínimo para este pool é de %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON não está neste cofre</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM não está neste cofre</string>
     <string name="ton_defi_pending_withdrawal">Saque pendente</string>
     <string name="ton_defi_unlock_ready">Pronto para sacar</string>
     <string name="ton_defi_unlocks_in_days">Desbloqueia em %1$d d %2$d h</string>
@@ -935,7 +935,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Nenhum pool de staking encontrado</string>
-    <string name="ton_staking_min_stake">Mín. %1$s TON</string>
+    <string name="ton_staking_min_stake">Mín. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Fazer stake de %1$s</string>
     <string name="ton_unstake_title">Remover stake de %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -930,7 +930,7 @@
     <string name="error_invalid_chain">Сеть недействительна</string>
     <string name="ton_stake_error_unsupported_pool">Этот стейкинг-пул не поддерживается</string>
     <string name="ton_stake_error_min_amount">Минимальная сумма стейкинга для этого пула — %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON отсутствует в этом хранилище</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM отсутствует в этом хранилище</string>
     <string name="ton_defi_pending_withdrawal">Ожидающий вывод</string>
     <string name="ton_defi_unlock_ready">Готово к выводу</string>
     <string name="ton_defi_unlocks_in_days">Разблокировка через %1$d д %2$d ч</string>
@@ -941,7 +941,7 @@
     <string name="ton_staking_pool_header">Пул</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">Пулы стейкинга не найдены</string>
-    <string name="ton_staking_min_stake">Мин. %1$s TON</string>
+    <string name="ton_staking_min_stake">Мин. %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Стейкинг %1$s</string>
     <string name="ton_unstake_title">Вывести %1$s из стейкинга</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1256,7 +1256,7 @@
     <string name="error_invalid_chain">链无效</string>
     <string name="ton_stake_error_unsupported_pool">不支持此质押池</string>
     <string name="ton_stake_error_min_amount">此质押池的最低质押金额为 %1$s %2$s</string>
-    <string name="ton_defi_error_ton_not_in_vault">此保险库中没有 TON</string>
+    <string name="ton_defi_error_ton_not_in_vault">此保险库中没有 GRAM</string>
     <string name="ton_defi_pending_withdrawal">待提取</string>
     <string name="ton_defi_unlock_ready">可提取</string>
     <string name="ton_defi_unlocks_in_days">%1$d 天 %2$d 小时后解锁</string>
@@ -1267,7 +1267,7 @@
     <string name="ton_staking_pool_header">质押池</string>
     <string name="ton_staking_apy_header">年化收益率</string>
     <string name="ton_staking_no_pools_found">未找到质押池</string>
-    <string name="ton_staking_min_stake">最低 %1$s TON</string>
+    <string name="ton_staking_min_stake">最低 %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">质押 %1$s</string>
     <string name="ton_unstake_title">解除质押 %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,7 +503,7 @@
     <string name="ton_stake_error_unsupported_pool">This staking pool isn\'t supported</string>
     <string name="ton_stake_error_min_amount">Minimum stake for this pool is %1$s %2$s</string>
     <string name="ton" translatable="false">TON</string>
-    <string name="ton_defi_error_ton_not_in_vault">TON isn\'t in this vault</string>
+    <string name="ton_defi_error_ton_not_in_vault">GRAM isn\'t in this vault</string>
     <string name="ton_defi_pending_withdrawal">Pending withdrawal</string>
     <string name="ton_defi_unlock_ready">Ready to withdraw</string>
     <string name="ton_defi_unlocks_in_days">Unlocks in %1$dd %2$dh</string>
@@ -514,7 +514,7 @@
     <string name="ton_staking_pool_header">Pool</string>
     <string name="ton_staking_apy_header">APY</string>
     <string name="ton_staking_no_pools_found">No staking pools found</string>
-    <string name="ton_staking_min_stake">Min %1$s TON</string>
+    <string name="ton_staking_min_stake">Min %1$s %2$s</string>
     <string name="ton_staking_apy_value">%1$s%%</string>
     <string name="ton_stake_title">Stake %1$s</string>
     <string name="ton_unstake_title">Unstake %1$s</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonStakeViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonStakeViewModelTest.kt
@@ -160,6 +160,17 @@ internal class TonStakeViewModelTest {
     }
 
     @Test
+    fun `resolved ticker is the rebranded coin symbol, not the stale TON label`() = runTest {
+        stubSpendableBalance(nanoTon = 1_000_000_000L)
+        coEvery { depositGasFeeHelper.calculateGasFee(VAULT_ID, any(), any(), any()) } returns
+            TokenValue(value = BigInteger.valueOf(50_000_000L), unit = "GRAM", decimals = 9)
+
+        val vm = createViewModel()
+
+        vm.state.value.ticker shouldBe "GRAM"
+    }
+
+    @Test
     fun `stakeable balance reserves the deposit network fee, not the larger withdraw fee`() =
         runTest {
             // 1 TON spendable, 0.05 TON deposit network fee → 0.95 TON stakeable. Reserving the

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonUnstakeViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonUnstakeViewModelTest.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -105,6 +106,15 @@ internal class TonUnstakeViewModelTest {
         state.isLoading.shouldBeFalse()
         state.hasSufficientBalance.shouldBeFalse()
         state.errorMessage.shouldNotBeNull()
+    }
+
+    @Test
+    fun `resolved ticker is the rebranded coin symbol, not the stale TON label`() = runTest {
+        stubSpendableBalance(nanoTon = 1_000_000_000L)
+
+        val state = createViewModel().state.value
+
+        state.ticker shouldBe "GRAM"
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Toncoin → GRAM rebrand left three leftover "TON" leaks in the TON DeFi/staking UI. The chain-level "TON" labels (the network name, e.g. the DeFi banner header, `Chain.ticker()`, `feeUnit`) are correct as-is and untouched — the network is still TON, only the native coin's ticker changed to GRAM.

- `TonStakeScreen`/`TonUnstakeScreen`: the amount fields fell back to a hardcoded `"TON"` while `state.ticker` is still empty (before `loadCoin()` resolves the real native coin), so the label briefly showed the stale ticker on every open. Fallback is now `"GRAM"`, matching what it settles to.
- The stake pool list's minimum-stake hint (`ton_staking_min_stake`) had `"TON"` baked into the string with only one substitution arg for the amount. Added a second `%2$s` arg and threaded the real ticker through `TonPoolPickerSheet`/`TonPoolRow`.
- The coin-not-found error (`ton_defi_error_ton_not_in_vault`, shown by `TonStakeViewModel`/`TonUnstakeViewModel`/`TonDeFiPositionsViewModel` when the native coin can't be resolved from the vault) still named "TON"; changed to "GRAM" to match the sibling `solana_staking_error_sol_not_in_vault` pattern (hardcoded correct-for-chain ticker, no param).

All 9 other locale `strings.xml` files got the equivalent structural edit — same placeholder shape, word order/grammar preserved per locale, GRAM kept untranslated (matching how the existing `ton_forward_ton_amount` string already handles GRAM in every locale).

Closes #5499

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.defi.*"` — passing, including two new regression tests (`TonStakeViewModelTest`, `TonUnstakeViewModelTest`) asserting the resolved ticker is `"GRAM"`, not the stale `"TON"` label.
- `./gradlew :app:ktfmtCheck` — passing.
- `./gradlew :app:lintDebug` — passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - TON staking and unstaking screens now display **GRAM** when no ticker is provided.
  - Staking titles, amounts, minimum-stake messages, pool selection, and pool details consistently use the correct symbol.
  - Updated localized messages to reference GRAM and support dynamic asset symbols.

- **Bug Fixes**
  - Corrected outdated TON labels in staking and unstaking interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->