### PR TITLE
fix(defi): drop the hardcoded "APY (approx.) 1%" from bonded headers

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -604,6 +604,7 @@ internal fun HeaderDeFiWidget(
     onClickAction: () -> Unit,
     totalAmount: String,
     totalPrice: String = "",
+    apy: String? = null,
     isLoading: Boolean = false,
     isBalanceVisible: Boolean = true,
     buttonState: VsButtonState = VsButtonState.Enabled,
@@ -666,9 +667,11 @@ internal fun HeaderDeFiWidget(
 
         UiSpacer(16.dp)
 
-        ApyApproxWithHint()
+        if (apy != null) {
+            ApyApproxWithHint(apy = apy)
 
-        UiSpacer(16.dp)
+            UiSpacer(16.dp)
+        }
 
         VsButton(
             label = buttonText,
@@ -681,8 +684,8 @@ internal fun HeaderDeFiWidget(
 
 @Composable
 private fun ApyApprox(
+    apy: String,
     modifier: Modifier = Modifier,
-    apy: String = "1%",
     onMoreInfoClick: (() -> Unit)? = null,
     onMoreInfoIconModifier: Modifier = Modifier,
 ) {
@@ -709,7 +712,7 @@ private fun ApyApprox(
 }
 
 @Composable
-private fun ApyApproxWithHint(modifier: Modifier = Modifier, apy: String = "1%") {
+private fun ApyApproxWithHint(apy: String, modifier: Modifier = Modifier) {
     var showHint by remember { mutableStateOf(false) }
     var iconPosition by remember { mutableStateOf(Offset.Zero) }
     var boxCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
@@ -755,6 +758,7 @@ internal fun HeaderDeFiWidget(
     onClickSecondAction: () -> Unit,
     totalAmount: String,
     totalPrice: String = "",
+    apy: String? = null,
     isLoading: Boolean = false,
     isBalanceVisible: Boolean = true,
     isSecondActionEnabled: Boolean = true,
@@ -817,9 +821,11 @@ internal fun HeaderDeFiWidget(
 
         UiSpacer(16.dp)
 
-        ApyApproxWithHint()
+        if (apy != null) {
+            ApyApproxWithHint(apy = apy)
 
-        UiSpacer(16.dp)
+            UiSpacer(16.dp)
+        }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -1012,6 +1018,7 @@ private fun HeaderDeFiWidgetTwoActionsPreview() {
             onClickFirstAction = {},
             onClickSecondAction = {},
             totalAmount = "0.7031 USDC",
+            apy = "1%",
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsScreen.kt
@@ -19,6 +19,12 @@ import com.vultisig.wallet.ui.screens.v2.defi.model.DefiUiModel
 import com.vultisig.wallet.ui.theme.Theme
 
 /**
+ * Circle publishes no APY feed, so the yield is a fixed product term rather than a fetched value —
+ * matching iOS `CircleYieldProvider.staticApyText`.
+ */
+private const val CIRCLE_STATIC_APY = "1%"
+
+/**
  * Entry point for the Circle USDC DeFi positions screen; wires ViewModel state and pull-to-refresh.
  */
 @Composable
@@ -109,6 +115,7 @@ private fun CircleContentDepositTab(
             onClickAction = onClickWithdraw,
             totalAmount = state.totalDeposit,
             totalPrice = state.totalDepositCurrency,
+            apy = CIRCLE_STATIC_APY,
             isLoading = state.isLoading,
             isBalanceVisible = isBalanceVisible,
         )
@@ -120,6 +127,7 @@ private fun CircleContentDepositTab(
             onClickAction = onCreateAccount,
             totalAmount = state.totalDeposit,
             totalPrice = state.totalDepositCurrency,
+            apy = CIRCLE_STATIC_APY,
             isLoading = state.isLoading,
             isBalanceVisible = isBalanceVisible,
             // New Circle deposits are disabled, so opening a new account is also gated off.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -40,7 +40,6 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
@@ -50,6 +49,7 @@ import com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsViewMod
 import com.vultisig.wallet.ui.screens.cosmosstaking.ValidatorAvatar
 import com.vultisig.wallet.ui.screens.v2.defi.ActionButton
 import com.vultisig.wallet.ui.screens.v2.defi.ApyInfoItem
+import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
@@ -124,12 +124,15 @@ internal fun SolanaStakingPositionsContent(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                SolanaTotalStakedCard(
+                HeaderDeFiWidget(
+                    title = stringResource(R.string.solana_staking_total_staked_sol),
+                    iconRes = R.drawable.solana,
+                    buttonText = stringResource(R.string.solana_delegate_new_validator),
+                    onClickAction = onStake,
                     totalAmount = state.totalStakedSolDisplay,
                     totalPrice = state.totalStakedFiatDisplay,
                     isLoading = state.isLoading,
                     isBalanceVisible = state.isBalanceVisible,
-                    onDelegate = onStake,
                 )
 
                 if (state.positions.isNotEmpty()) {
@@ -407,78 +410,6 @@ private fun SolanaHeaderBanner(totalValue: String, isLoading: Boolean, isBalance
                 )
             }
         }
-    }
-}
-
-/**
- * "Total Staked SOL" summary card + primary CTA. Mirrors the shared
- * [com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget] but omits its baked-in `APY (approx.)
- * 1%` row (there is no chain-wide APY for Solana native staking — APY is per stake account and
- * shown on each row), matching the iOS layout.
- */
-@Composable
-private fun SolanaTotalStakedCard(
-    totalAmount: String,
-    totalPrice: String,
-    isLoading: Boolean,
-    isBalanceVisible: Boolean,
-    onDelegate: () -> Unit,
-) {
-    Column(
-        modifier =
-            Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
-                .background(Theme.v2.colors.backgrounds.secondary)
-                .border(
-                    width = 1.dp,
-                    color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
-                )
-                .padding(16.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(R.drawable.solana),
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-            )
-            UiSpacer(12.dp)
-            Column {
-                Text(
-                    text = stringResource(R.string.solana_staking_total_staked_sol),
-                    style = Theme.brockmann.supplementary.footnote,
-                    color = Theme.v2.colors.text.tertiary,
-                )
-                UiSpacer(4.dp)
-                if (isLoading) {
-                    UiPlaceholderLoader(modifier = Modifier.size(width = 120.dp, height = 28.dp))
-                } else {
-                    Text(
-                        text = if (isBalanceVisible) totalAmount else HIDE_BALANCE_CHARS,
-                        style = Theme.brockmann.headings.title1,
-                        color = Theme.v2.colors.text.primary,
-                    )
-                    if (totalPrice.isNotEmpty()) {
-                        UiSpacer(4.dp)
-                        Text(
-                            text = if (isBalanceVisible) totalPrice else HIDE_BALANCE_CHARS,
-                            style = Theme.brockmann.supplementary.footnote,
-                            color = Theme.v2.colors.text.tertiary,
-                        )
-                    }
-                }
-            }
-        }
-
-        UiSpacer(16.dp)
-        UiHorizontalDivider(color = Theme.v2.colors.border.light)
-        UiSpacer(16.dp)
-
-        VsButton(
-            label = stringResource(R.string.solana_delegate_new_validator),
-            modifier = Modifier.fillMaxWidth(),
-            onClick = onDelegate,
-        )
     }
 }
 


### PR DESCRIPTION
Closes #5494

## Summary

The Bonded tab header on THORChain and Maya always rendered **"APY (approx.) 1%"**. No APY was ever fetched or passed for that row — the value came from a default parameter — and it sat directly above node cards showing the real computed APY (~20%), so the header contradicted the list beneath it. iOS shows no APY row in this header at all (`DefiChainBondedView.swift`), which is why the same screen reads correctly there.

## What changed

- **`DeFiComponents.kt`** — both `HeaderDeFiWidget` overloads take `apy: String? = null` and render `ApyApproxWithHint` (plus its trailing spacer) only when a caller supplies a value. The divider above the row is unaffected either way.
- Removed the `apy: String = "1%"` defaults from `ApyApprox` and `ApyApproxWithHint`. This is what stops the bug recurring — the value can now only originate at a call site, so a new screen cannot silently inherit a fabricated APY.
- **Bonded tab** passes nothing, so the row disappears for both THORChain and Maya (they share `BondedTabContent`).
- **Circle** is the one legitimate static-APY caller: it publishes no APY feed, and iOS carries the same fixed value as `CircleYieldProvider.staticApyText` (`circleStaticApy = "1%"`, identical across all iOS locales). It now passes `CIRCLE_STATIC_APY` explicitly at both call sites.
- **`SolanaTotalStakedCard` deleted.** It was a byte-for-byte copy of the single-action `HeaderDeFiWidget` minus the APY row, and its doc comment said it existed only to omit that "baked-in" row. With the row opt-in the clone is redundant, so the Solana screen uses the shared widget and ~65 lines of duplication go away.

## Test plan

- `:app:compileDebugKotlin` clean; `:app:lintDebug` BUILD SUCCESSFUL; existing DeFi unit tests pass; ktfmt applied.
- **THORChain** → DeFi toggle → THORChain card → Bonded tab (default): the "Total Bonded RUNE" header no longer shows an APY row; per-node APY on the cards below is unchanged.
- **Maya** → DeFi toggle → MayaChain card → Bonded tab: same.
- **Circle** → DeFi toggle → Circle card: header **still** shows "APY (approx.) 1%", in both the open-account and Open Account states.
- **Solana** → DeFi toggle → Solana card: the "Total Staked SOL" card renders exactly as before (no APY row); this is the screen to eyeball, since it swapped from the local clone to the shared widget.

No unit test added: the repo's only Compose test harness is `androidTest` (instrumented, emulator-required), so covering a render-gating change with no logic would mean standing up new test infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * APY information is now shown on DeFi headers when available.
  * Circle DeFi positions display a fixed 1% APY.
  * Solana staking now uses the shared DeFi header experience for staked totals and validator actions.
* **Improvements**
  * DeFi and staking screens provide a more consistent layout and interaction experience.
  * APY hints no longer appear when no APY value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->