### PR TITLE
fix(keysign): select imported chain share for custom messages

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -104,6 +104,15 @@ import vultisig.keysign.v1.CustomMessagePayload
 
 private const val DEFAULT_ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'/0/0"
 
+internal fun resolveKeysignChain(
+    keysignPayload: KeysignPayload?,
+    customMessagePayload: CustomMessagePayload?,
+): Chain? =
+    keysignPayload?.coin?.chain
+        ?: customMessagePayload?.chain?.let { raw ->
+            runCatching { Chain.fromRaw(raw) }.getOrNull()
+        }
+
 /** UI state for an in-progress or completed keysign session. */
 internal sealed class KeysignState {
     /** Initial state while the native signing instance is being constructed. */
@@ -527,7 +536,7 @@ constructor(
      * signing (chainPath = "").
      */
     private suspend fun startKeysignKeyImport() {
-        val chain = keysignPayload?.coin?.chain
+        val chain = resolveKeysignChain(keysignPayload, customMessagePayload)
         startKeysignCore(
             ecdsaPublicKeyOverride =
                 if (chain != null) vault.getEcdsaSigningKey(chain).publicKey else vault.pubKeyECDSA,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveKeysignChainTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/ResolveKeysignChainTest.kt
@@ -1,0 +1,18 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import vultisig.keysign.v1.CustomMessagePayload
+
+class ResolveKeysignChainTest {
+    @Test
+    fun `custom message resolves its chain for KeyImport share selection`() {
+        val customMessage = CustomMessagePayload(chain = Chain.Ethereum.raw)
+
+        assertEquals(
+            Chain.Ethereum,
+            resolveKeysignChain(keysignPayload = null, customMessagePayload = customMessage),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

KeyImport custom-message signing fell back to the vault root keyshare because `startKeysignKeyImport()` selected its chain only from `KeysignPayload`. Custom-message sessions have no transaction payload; their chain is carried by `CustomMessagePayload.chain`.

Other signing participants selected the chain-specific imported keyshare, so Android entered the DKLS ceremony with a different share and failed with `Invalid final_session_id` / `Vault Share Mismatch`. Normal transaction signing was unaffected because `KeysignPayload.coin.chain` was present.

Resolve the KeyImport signing chain from the transaction payload first, then from the custom-message payload. This preserves transaction behavior while selecting the matching per-chain ECDSA/EdDSA keys for message signing.

## Scope

- Changes only KeyImport keyshare selection for custom messages.
- Does not change FCM, notifications, APK packaging, or extension behavior.
- Keeps the existing root-key fallback when neither payload provides a recognized chain.

## Test plan

- [x] Added `ResolveKeysignChainTest` covering custom-message chain resolution when `KeysignPayload` is absent.
- [x] `./gradlew --init-script /tmp/opencode/use-local-wallet-core.init.gradle :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.keysign.ResolveKeysignChainTest"`
- [x] `./gradlew ktfmtCheck`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-message signing to select the correct blockchain-specific signing key.
  * Added safer handling when determining the signing chain from available message data.

* **Tests**
  * Added coverage for resolving the Ethereum chain from a custom-message signing request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->