### PR TITLE
fix(swap): show the provider logo wherever a provider is named

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -53,6 +53,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.models.getProviderLogo
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.DAppMetadata
@@ -90,9 +91,11 @@ import com.vultisig.wallet.ui.models.TokenDetailUiModel
 import com.vultisig.wallet.ui.models.TokenSelectionUiModel
 import com.vultisig.wallet.ui.models.TokenUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
+import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryTab
 import com.vultisig.wallet.ui.models.TransactionHistoryUiState
 import com.vultisig.wallet.ui.models.TransactionScanStatus
+import com.vultisig.wallet.ui.models.TransactionStatusUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.models.VaultDetailUiModel
 import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
@@ -181,10 +184,12 @@ import com.vultisig.wallet.ui.screens.swap.preview.AdvancedGasLimitPreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedMenuConfiguredPreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedMenuPreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedSlippagePreview
+import com.vultisig.wallet.ui.screens.swap.preview.SwapFormProviderPreview
 import com.vultisig.wallet.ui.screens.swap.preview.SwapFormQuoteLoadingPreview
 import com.vultisig.wallet.ui.screens.swap.preview.SwapToolbarPreview
 import com.vultisig.wallet.ui.screens.transaction.SendTxOverviewScreen
 import com.vultisig.wallet.ui.screens.transaction.SwapTransactionOverviewScreen
+import com.vultisig.wallet.ui.screens.transaction.TransactionDetailBottomSheet
 import com.vultisig.wallet.ui.screens.transaction.TransactionHistoryEmptyState
 import com.vultisig.wallet.ui.screens.transaction.TransactionHistoryScreen
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfo
@@ -276,6 +281,10 @@ class PreviewActivity : ComponentActivity() {
                     "swap_error_before" -> SwapErrorBeforePreview()
                     "swap_error" -> SwapErrorPreview()
                     "swap_quote_loading" -> SwapFormQuoteLoadingPreview()
+                    "provider_swap_form" -> SwapFormProviderPreview()
+                    "provider_tx_done" -> SwapProviderTxDonePreview()
+                    "provider_detail_sheet" -> SwapProviderDetailSheetPreview()
+                    "provider_verify" -> SwapProviderVerifyPreview()
                     "swap_toolbar" -> SwapToolbarPreview()
                     "swap_advanced_locked" -> SwapAdvancedLockedPreview()
                     "custom_rpc_gate" -> CustomRpcGatePreview()
@@ -1875,6 +1884,90 @@ private fun BlockaidHeroDoneSwapPreview() {
         onBack = {},
         onUriClick = {},
         transactionTypeUiModel = TransactionTypeUiModel.Send(blockaidHeroSwapDetails()),
+    )
+}
+
+// The three surfaces that named a swap provider as plain text, plus verify as the control. Each
+// uses a provider whose logo getProviderLogo can resolve, so a missing icon means the surface is
+// not wired up rather than that the provider has no drawable.
+@Composable
+private fun swapProviderDoneTx() =
+    SwapTransactionUiModel(
+        src = ValuedToken(token = Coins.Ethereum.ETH, value = "1.5", fiatValue = "$3,847.50"),
+        dst = ValuedToken(token = Coins.Bitcoin.BTC, value = "0.0589", fiatValue = "$3,820.00"),
+        networkFee = ValuedToken(token = Coins.Ethereum.ETH, value = "0.0024", fiatValue = "$6.15"),
+        providerFee =
+            ValuedToken(token = Coins.Ethereum.ETH, value = "0.0045", fiatValue = "$11.52"),
+        totalFee = "$17.67",
+        networkFeeFormatted = "0.0024 ETH ($6.15)",
+        providerFeeFormatted = "0.0045 ETH ($11.52)",
+        provider = "SwapKit",
+        providerLabel = "SwapKit (CHAINFLIP)",
+    )
+
+@Composable
+private fun SwapProviderTxDonePreview() {
+    TransactionDoneView(
+        showToolbar = true,
+        transactionHash = "0xabc123def456...",
+        approveTransactionHash = "",
+        transactionLink = "https://etherscan.io/tx/0xabc123",
+        approveTransactionLink = "",
+        onComplete = {},
+        onBack = {},
+        onUriClick = {},
+        transactionTypeUiModel = TransactionTypeUiModel.Swap(swapProviderDoneTx()),
+    )
+}
+
+@Composable
+private fun SwapProviderDetailSheetPreview() {
+    TransactionDetailBottomSheet(
+        item =
+            TransactionHistoryItemUiModel.Swap(
+                id = "2",
+                txHash = "0xdef456",
+                chain = "Ethereum",
+                status = TransactionStatusUiModel.Confirmed,
+                explorerUrl = "https://etherscan.io/tx/0xdef456",
+                timestamp = 1_754_400_000_000,
+                fromToken = "RUNE",
+                fromAmount = "1,000.12",
+                fromChain = "THORChain",
+                fromTokenLogo = R.drawable.rune,
+                toToken = "WBTC",
+                toAmount = "0.1251",
+                toChain = "Ethereum",
+                toTokenLogo = R.drawable.wbtc,
+                provider = "THORChain",
+                providerLogo = getProviderLogo("THORChain"),
+                fiatValue = "$1,116.28",
+                fromAddress = "0xF43jf9840fkfjn38fk0dk9Ac5",
+                toAddress = "0xF43jf9840fkfjn38fk0dk9Ac5",
+                feeEstimate = "0.2 ETH",
+            ),
+        onDismiss = {},
+        onViewExplorer = {},
+    )
+}
+
+@Composable
+private fun SwapProviderVerifyPreview() {
+    VerifySwapScreen(
+        state =
+            VerifySwapUiModel(
+                tx = swapProviderDoneTx(),
+                consentAmount = true,
+                consentReceiveAmount = true,
+                consentAllowance = false,
+                hasFastSign = true,
+                vaultName = "Main Vault",
+            ),
+        hasToolbar = true,
+        confirmTitle = "Sign",
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/data/models/CoinLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/models/CoinLogo.kt
@@ -2,20 +2,24 @@ package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.R
 
+/**
+ * Drawable for a swap provider's logo, resolved from the label the UI shows for it.
+ *
+ * Keyed off [SwapProvider] rather than the raw display string, so adding a provider to the swap
+ * layer is a compile error here instead of a silently missing icon. Route hints appended by
+ * `formatSwapKitProviderLabel` (`SwapKit (CHAINFLIP)`) are stripped before the lookup, so a hinted
+ * label resolves the same logo as the bare provider — for every provider, not just SwapKit.
+ */
 internal fun getProviderLogo(providerName: String): ImageModel? {
-    val name = providerName.lowercase()
-    if (name.startsWith("swapkit")) return R.drawable.swapkit
-    return when (name) {
-        "thorchain" -> R.drawable.rune
-        "maya",
-        "mayachain" -> R.drawable.maya
-        "jupiter" -> R.drawable.jup
-        "uni" -> R.drawable.uni
-        "1inch" -> R.drawable.oneinch
-        "kyber",
-        "kyberswap" -> R.drawable.kyberswap
-        "li.fi" -> R.drawable.lifi
-        else -> null
+    val provider = swapProviderFromWireId(providerName.substringBefore(" (")) ?: return null
+    return when (provider) {
+        SwapProvider.THORCHAIN -> R.drawable.rune
+        SwapProvider.MAYA -> R.drawable.maya
+        SwapProvider.JUPITER -> R.drawable.jup
+        SwapProvider.ONEINCH -> R.drawable.oneinch
+        SwapProvider.KYBER -> R.drawable.kyberswap
+        SwapProvider.LIFI -> R.drawable.lifi
+        SwapProvider.SWAPKIT -> R.drawable.swapkit
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SwapProviderLabel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SwapProviderLabel.kt
@@ -1,0 +1,49 @@
+package com.vultisig.wallet.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.getProviderLogo
+import com.vultisig.wallet.ui.screens.transaction.components.TokenCircle
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * A swap provider's logo followed by its name — the shape Figma specifies for every surface that
+ * names a provider (swap form, verify, transaction done, history card, detail sheet), so the same
+ * swap reads identically wherever it appears.
+ *
+ * The 16dp logo matches the caption/body line height the callers use, keeping the row the same
+ * height as a plain-text value. Providers [getProviderLogo] has no drawable for degrade to the bare
+ * name.
+ *
+ * @param logo pre-resolved logo for callers whose UI model already carries one; resolved from
+ *   [provider] when absent.
+ */
+@Composable
+internal fun SwapProviderLabel(
+    provider: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = Theme.brockmann.body.s.medium,
+    color: Color = Theme.v2.colors.text.primary,
+    logo: ImageModel? = null,
+) {
+    val providerLogo = logo ?: remember(provider) { getProviderLogo(provider) }
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        if (providerLogo != null) {
+            TokenCircle(logo = providerLogo, ticker = provider, size = 16)
+        }
+        Text(text = provider, style = style, color = color, maxLines = 1)
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.SignMessageCard
+import com.vultisig.wallet.ui.components.SwapProviderLabel
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -274,10 +275,11 @@ private fun SwapTransactionDetail(swapTransaction: SwapTransactionUiModel) {
     )
 
     if (swapTransaction.provider.isNotEmpty()) {
-        OtherField(
-            title = stringResource(R.string.swap_screen_provider_title),
-            value = swapTransaction.providerLabel.ifBlank { swapTransaction.provider },
-        )
+        OtherField(title = stringResource(R.string.swap_screen_provider_title)) {
+            SwapProviderLabel(
+                provider = swapTransaction.providerLabel.ifBlank { swapTransaction.provider }
+            )
+        }
     }
 
     // Mirror the verify screen (#5358): hide the Swap Fee row for a SwapKit UTXO deposit whose cost
@@ -429,6 +431,18 @@ private fun AddressField(title: String, address: String, divider: Boolean = true
 
 @Composable
 private fun OtherField(title: String, value: String, divider: Boolean = true) {
+    OtherField(title = title, divider = divider) {
+        Text(
+            text = value,
+            textAlign = TextAlign.End,
+            color = Theme.v2.colors.text.primary,
+            style = Theme.brockmann.body.s.medium,
+        )
+    }
+}
+
+@Composable
+private fun OtherField(title: String, divider: Boolean = true, value: @Composable () -> Unit) {
     Column {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -443,12 +457,7 @@ private fun OtherField(title: String, value: String, divider: Boolean = true) {
             UiSpacer(weight = 1f)
             UiSpacer(size = 8.dp)
 
-            Text(
-                text = value,
-                textAlign = TextAlign.End,
-                color = Theme.v2.colors.text.primary,
-                style = Theme.brockmann.body.s.medium,
-            )
+            value()
         }
 
         if (divider) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -44,11 +44,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.getCoinLogo
-import com.vultisig.wallet.data.models.getProviderLogo
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.data.usecases.getTierType
+import com.vultisig.wallet.ui.components.SwapProviderLabel
 import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -707,7 +707,6 @@ internal fun VerifyExternalRecipientRow(address: String, modifier: Modifier = Mo
 
 @Composable
 internal fun VerifyProviderRow(provider: String, modifier: Modifier = Modifier) {
-    val logo = remember(provider) { getProviderLogo(provider) }
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier.fillMaxWidth().padding(vertical = 12.dp),
@@ -722,31 +721,7 @@ internal fun VerifyProviderRow(provider: String, modifier: Modifier = Modifier) 
 
         UiSpacer(weight = 1f)
 
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (logo != null) {
-                TokenLogo(
-                    logo = logo,
-                    title = provider,
-                    errorLogoModifier = Modifier.size(16.dp).clip(CircleShape),
-                    modifier =
-                        Modifier.size(16.dp)
-                            .border(
-                                width = 1.dp,
-                                color = Theme.v2.colors.border.light,
-                                shape = CircleShape,
-                            ),
-                )
-            }
-            Text(
-                text = provider,
-                style = Theme.brockmann.body.s.medium,
-                color = Theme.v2.colors.text.primary,
-                maxLines = 1,
-            )
-        }
+        SwapProviderLabel(provider = provider)
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/SwapFeeBreakdown.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.SwapProviderLabel
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.library.form.FormDetails2
@@ -75,11 +76,17 @@ internal fun SwapFeeBreakdown(
         ) {
             FormDetails2(
                 title = stringResource(R.string.swap_screen_provider_title),
-                value = quoteDisplay.provider.asString(),
-                placeholder =
+                valueComposable = {
                     if (isLoading) {
-                        { loadingPlaceholder() }
-                    } else null,
+                        loadingPlaceholder()
+                    } else {
+                        SwapProviderLabel(
+                            provider = quoteDisplay.provider.asString(),
+                            style = Theme.brockmann.supplementary.caption,
+                            color = Theme.v2.colors.text.secondary,
+                        )
+                    }
+                },
             )
 
             FormDetails2(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/SwapPreviewData.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/SwapPreviewData.kt
@@ -168,6 +168,38 @@ internal fun SwapFormQuoteLoadingPreview() {
     )
 }
 
+// Resolved-quote snapshot used to check the fee panel's Provider row: the provider name must be
+// preceded by its logo, and the row must stay the same height as while the quote was loading.
+@Preview
+@Composable
+internal fun SwapFormProviderPreview() {
+    SwapScreen(
+        state =
+            SwapFormUiModel(
+                selectedSrcToken = longTokenInput,
+                selectedDstToken = tokenInput,
+                srcFiatValue = "5.25",
+                quoteDisplay =
+                    QuoteDisplay(
+                        provider = UiText.DynamicString("THORChain"),
+                        estimatedDstTokenValue = "12.80",
+                        estimatedDstFiatValue = "$5.24",
+                        hasQuote = true,
+                        expiredAt = Clock.System.now().plus(36.seconds),
+                    ),
+                feeBreakdown =
+                    FeeBreakdown(
+                        networkFee = "0.02 RUNE",
+                        networkFeeFiat = "$0.004",
+                        totalFee = "$0.024",
+                        fee = "0.02 RUNE",
+                    ),
+                isSwapDisabled = false,
+            ),
+        srcAmountTextFieldState = TextFieldState("2.5"),
+    )
+}
+
 // Full Swap screen with the quote countdown running, used to verify the top toolbar (back / title /
 // advanced-settings sliders button / timer) and the bottom CTA together (#4858).
 @Preview

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
@@ -262,6 +262,7 @@ private fun SwapDetailContent(item: TransactionHistoryItemUiModel.Swap) {
         feeEstimate = item.feeEstimate,
         network = item.chain,
         provider = item.provider.takeIf { it.isNotEmpty() },
+        providerLogo = item.providerLogo,
     )
 }
 
@@ -305,6 +306,7 @@ private fun DetailInfoRows(
     feeEstimate: String?,
     network: String,
     provider: String?,
+    providerLogo: ImageModel? = null,
 ) {
     Column(
         modifier =
@@ -376,7 +378,7 @@ private fun DetailInfoRows(
             HorizontalDivider(color = Theme.v2.colors.border.light, thickness = 1.dp)
             DetailRow(
                 label = stringResource(R.string.transaction_history_detail_provider),
-                value = { DetailValuePill(text = provider) },
+                value = { DetailValuePill(text = provider, logo = providerLogo) },
             )
         }
         if (!feeEstimate.isNullOrEmpty()) {
@@ -437,11 +439,10 @@ private fun DetailRow(label: String, value: @Composable () -> Unit) {
 }
 
 @Composable
-private fun DetailValuePill(text: String, modifier: Modifier = Modifier) {
-    Text(
-        text = text,
-        style = Theme.brockmann.supplementary.caption,
-        color = Theme.v2.colors.text.primary,
+private fun DetailValuePill(text: String, modifier: Modifier = Modifier, logo: ImageModel? = null) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
         modifier =
             modifier
                 .background(
@@ -449,7 +450,16 @@ private fun DetailValuePill(text: String, modifier: Modifier = Modifier) {
                     shape = RoundedCornerShape(8.dp),
                 )
                 .padding(horizontal = 8.dp, vertical = 3.dp),
-    )
+    ) {
+        if (logo != null) {
+            TokenCircle(logo = logo, ticker = text, size = 16)
+        }
+        Text(
+            text = text,
+            style = Theme.brockmann.supplementary.caption,
+            color = Theme.v2.colors.text.primary,
+        )
+    }
 }
 
 @Composable

--- a/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/models/CoinLogoTest.kt
@@ -3,6 +3,8 @@ package com.vultisig.wallet.data.models
 import com.vultisig.wallet.R
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -138,5 +140,63 @@ internal class CoinLogoTest {
     fun `tokenLogoRes resolves hyperliquid aliases`() {
         assertEquals(R.drawable.hyperliquid, coin(logo = "hype").tokenLogoRes())
         assertEquals(R.drawable.hyperliquid, coin(logo = "whype").tokenLogoRes())
+    }
+
+    // The five surfaces that name a swap provider all render through getProviderLogo, so one it
+    // cannot resolve shows a bare name on every one of them. The `when` over SwapProvider turns a
+    // newly added provider into a compile error; these tests pin the string -> enum step in front
+    // of it, which no compiler can check.
+    @Test
+    fun `getProviderLogo resolves every provider's display label`() {
+        SwapProvider.entries.forEach { provider ->
+            val label = provider.getSwapProviderId()
+            assertNotNull(
+                getProviderLogo(label),
+                "Expected a logo for $provider, whose UI label is \"$label\"",
+            )
+        }
+    }
+
+    @Test
+    fun `getProviderLogo resolves display labels to their drawable`() {
+        assertEquals(R.drawable.rune, getProviderLogo("THORChain"))
+        assertEquals(R.drawable.maya, getProviderLogo("MayaChain"))
+        assertEquals(R.drawable.jup, getProviderLogo("Jupiter"))
+        assertEquals(R.drawable.oneinch, getProviderLogo("1Inch"))
+        assertEquals(R.drawable.kyberswap, getProviderLogo("KyberSwap"))
+        assertEquals(R.drawable.lifi, getProviderLogo("LI.FI"))
+        assertEquals(R.drawable.swapkit, getProviderLogo("SwapKit"))
+    }
+
+    @Test
+    fun `getProviderLogo is case-insensitive`() {
+        assertEquals(R.drawable.rune, getProviderLogo("thorchain"))
+        assertEquals(R.drawable.rune, getProviderLogo("THORCHAIN"))
+    }
+
+    @Test
+    fun `getProviderLogo resolves wire aliases the history layer stores`() {
+        assertEquals(R.drawable.maya, getProviderLogo("maya"))
+        assertEquals(R.drawable.maya, getProviderLogo("mayachain"))
+        assertEquals(R.drawable.kyberswap, getProviderLogo("kyber"))
+        assertEquals(R.drawable.kyberswap, getProviderLogo("kyberswap"))
+    }
+
+    // formatSwapKitProviderLabel appends the route as `SwapKit (CHAINFLIP)`. Stripping the hint is
+    // a
+    // general rule now rather than a startsWith("swapkit") special case, so it must hold for a
+    // provider that has never carried a hint too.
+    @Test
+    fun `getProviderLogo strips the route hint before matching`() {
+        assertEquals(R.drawable.swapkit, getProviderLogo("SwapKit (CHAINFLIP)"))
+        assertEquals(R.drawable.swapkit, getProviderLogo("SwapKit (NEAR)"))
+        assertEquals(R.drawable.swapkit, getProviderLogo("SwapKit (GARDEN)"))
+        assertEquals(R.drawable.rune, getProviderLogo("THORChain (SOMEROUTE)"))
+    }
+
+    @Test
+    fun `getProviderLogo returns null for an unknown provider`() {
+        assertNull(getProviderLogo("NotAProvider"))
+        assertNull(getProviderLogo(""))
     }
 }


### PR DESCRIPTION
## Summary

Per [Figma node 45201-39285](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=45201-39285), every surface that names a swap **provider** shows its **logo** next to the name. Three of the five did not — so the same swap showed a logo on its history **card** and none in the detail **sheet** opened from that card.

The detail sheet was the starkest case: its UI model already carried `providerLogo`, and the value was dropped one line above the row that needed it.

Android side of [vultisig-windows#4572](https://github.com/vultisig/vultisig-windows/pull/4572).

## Changes

All five surfaces now route through a single `SwapProviderLabel` composable (16dp logo + 4dp gap + name, per Figma) instead of four near-copies that could drift apart again.

| Surface | File | Change |
|---|---|---|
| Swap form | `SwapFeeBreakdown.kt` | plain text → logo + name (`valueComposable` overload) |
| Transaction done | `TransactionDoneScreen.kt` | plain text → logo + name (new composable-value `OtherField` overload) |
| Detail sheet | `TransactionDetailBottomSheet.kt` | now passes the `providerLogo` the model already carried |
| Verify | `VerifySwapScreen.kt` | inline logo code replaced by the shared component |
| History card | `SwapTransactionCard.kt` | unchanged — already correct |

`getProviderLogo` is now keyed off the `SwapProvider` enum through the existing `swapProviderFromWireId`, so **a provider added to the swap layer is a compile error here** rather than a silently missing icon. The route hint is stripped once up front, generalising what `startsWith("swapkit")` did for one provider — `SwapKit (CHAINFLIP)` and any future hinted label resolve by the same rule.

## Before / After

Real Android renders (emulator, `PreviewActivity` + `adb screencap`). Identical preview code in both builds; only the fix differs.

**Swap form** — `Provider` row in the fee panel

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/tjWDoQz.png) | ![after](https://i.imgur.com/vyaHfI5.png) |

**Transaction done** — also shows the route hint resolving: the label reads `SwapKit (CHAINFLIP)` and still finds the SwapKit drawable

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/O4WwTpY.png) | ![after](https://i.imgur.com/6KURKSa.png) |

**Detail sheet** — the pill that disagreed with its own history card

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/FFETfRJ.png) | ![after](https://i.imgur.com/VPOWCaP.png) |

**Verify** — the control. Included because this PR refactors it; before/after are identical, so the shared component introduced no regression on the surface that was already right.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/FrotzSM.png) | ![after](https://i.imgur.com/xapKgRD.png) |

The swap-form `Provider` row sits at the same Y in both shots — the 16dp logo matches the caption line height and the loading skeleton, so nothing shifts as a quote resolves.

## Three deliberate deviations from the issue checklist

1. **CowSwap is not added.** It is not a provider on Android at all — absent from the `SwapProvider` enum and from `swapProviderFromWireId`; the only reference in the repo is a settlement-contract address in `KnownEvmContracts.kt`. A drawable plus mapping would be unreachable code. Supporting CowSwap as a provider is worth its own issue.
2. **`"uni" -> R.drawable.uni` removed as dead.** No swap provider named Uni exists — the Uniswap hits in the repo are EVM *router contract labels*, unrelated. `uni.webp` stays; `getCoinLogo` still uses it.
3. **`VerifyProviderRow` lost its 1dp logo border.** Figma shows no border on the provider logo and the history card's `ViaBadge` never had one. Acceptance criterion #1 asks all five surfaces to match, so this unifies rather than preserving the odd one out. This is the only change to a surface the issue called already-correct — see the Verify comparison above.

## Test plan

- `CoinLogoTest` — 6 new tests: every `SwapProvider` display label resolves a logo (the check no compiler can do for the string → enum step), display labels → drawable, case-insensitivity, wire aliases the history layer stores, route-hint stripping including on a non-SwapKit provider, unknown → null. 23/23 green.
- Full `:app:testDebugUnitTest` suite green.
- `:app:lintDebug` green.
- Four `PreviewActivity` cases added for manual re-checks: `provider_swap_form`, `provider_tx_done`, `provider_detail_sheet`, `provider_verify`.

Closes #5524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider logos and names throughout swap verification, fee breakdowns, completed transactions, and transaction details.
  - Provider details now support optional logos with graceful text-only fallback.
  - Added previews for provider-based swap and transaction states.

- **Bug Fixes**
  - Improved provider recognition across display names, aliases, capitalization differences, and route hints.
  - Unsupported providers continue to display without an incorrect logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->