### PR TITLE
Passcode app-lock 2/5: encrypt vault keyshares at rest

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
@@ -42,6 +42,11 @@ interface VaultDao {
     @Query("SELECT coinId FROM disabledCoin WHERE vaultId = :vaultId")
     suspend fun loadDisabledCoinIds(vaultId: VaultId): List<String>
 
+    /**
+     * Every keyshare across every vault, used to re-key them when the passcode is set or removed.
+     */
+    @Query("SELECT * FROM keyShare") suspend fun loadAllKeyShares(): List<KeyShareEntity>
+
     @Query("SELECT COUNT(*) > 0 FROM vault") suspend fun hasVaults(): Boolean
 
     @Query("SELECT EXISTS(SELECT 1 FROM coin WHERE chain = :chainId)")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/KeyShareCipher.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/KeyShareCipher.kt
@@ -1,0 +1,77 @@
+package com.vultisig.wallet.data.passcode
+
+import java.security.GeneralSecurityException
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.inject.Inject
+import timber.log.Timber
+
+/**
+ * Encrypts individual vault keyshares under the passcode-derived data key.
+ *
+ * Ciphertext is tagged with [PREFIX] so plaintext and encrypted rows can coexist in the same table.
+ * That matters twice over: users who never set a passcode keep plaintext rows forever, and a bulk
+ * migration killed halfway through leaves a mix that the next launch still reads correctly.
+ *
+ * The key is passed per call rather than held, so this stays a pure function of its inputs and does
+ * not need to observe lock state.
+ */
+internal class KeyShareCipher @Inject constructor() {
+
+    // SecureRandom is thread-safe; Cipher is not, so it is created per call.
+    private val random = SecureRandom()
+
+    /** True when [stored] was written by [encrypt] rather than stored in the clear. */
+    fun isEncrypted(stored: String): Boolean = stored.startsWith(PREFIX)
+
+    /** Returns [plaintext] encrypted under [dataKey], tagged with [PREFIX]. */
+    fun encrypt(plaintext: String, dataKey: ByteArray): String {
+        val key = SecretKeySpec(dataKey, AES)
+        val iv = ByteArray(IV_LENGTH).also(random::nextBytes)
+        val cipher = Cipher.getInstance(AES_GCM_NO_PADDING)
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        return PREFIX + Base64.getEncoder().encodeToString(iv + ciphertext)
+    }
+
+    /**
+     * Returns the plaintext for [stored]: unchanged when it was never encrypted, decrypted under
+     * [dataKey] when it was, or null when it is encrypted and [dataKey] cannot open it.
+     */
+    fun decrypt(stored: String, dataKey: ByteArray?): String? {
+        if (!isEncrypted(stored)) return stored
+        if (dataKey == null) return null
+        return try {
+            val blob = Base64.getDecoder().decode(stored.removePrefix(PREFIX))
+            require(blob.size > IV_LENGTH) { "Encrypted keyshare is too short: ${blob.size}" }
+            val cipher = Cipher.getInstance(AES_GCM_NO_PADDING)
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(dataKey, AES),
+                GCMParameterSpec(GCM_TAG_BITS, blob, 0, IV_LENGTH),
+            )
+            String(cipher.doFinal(blob, IV_LENGTH, blob.size - IV_LENGTH), Charsets.UTF_8)
+        } catch (e: GeneralSecurityException) {
+            Timber.e(e, "Failed to decrypt keyshare")
+            null
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Malformed encrypted keyshare")
+            null
+        }
+    }
+
+    private companion object {
+        const val AES = "AES"
+        const val AES_GCM_NO_PADDING = "AES/GCM/NoPadding"
+        const val IV_LENGTH = 12
+        const val GCM_TAG_BITS = 128
+
+        /**
+         * Marks a keyshare as encrypted. Not valid base64url, so it cannot collide with a share.
+         */
+        const val PREFIX = "vlpc1:"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeModule.kt
@@ -19,4 +19,7 @@ internal interface PasscodeModule {
     @Binds fun bindPasscodeDataKeySource(impl: PasscodeRepositoryImpl): PasscodeDataKeySource
 
     @Binds fun bindAutoLockRepository(impl: AutoLockRepositoryImpl): AutoLockRepository
+
+    @Binds
+    fun bindVaultKeyShareProtection(impl: VaultKeyShareProtectionImpl): VaultKeyShareProtection
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -72,12 +72,16 @@ interface PasscodeRepository {
 internal interface PasscodeDataKeySource {
     /** The data-encryption key while unlocked, or null when locked or not configured. */
     fun dataKeyOrNull(): ByteArray?
+
+    /** True when a passcode is configured but has not been entered in this session. */
+    fun isLocked(): Boolean
 }
 
 @Singleton
 internal class PasscodeRepositoryImpl(
     private val cipher: PasscodeCipher,
     private val store: PasscodeStore,
+    private val keyShareProtection: VaultKeyShareProtection,
     private val dispatcher: CoroutineDispatcher,
     private val nowMillis: () -> Long,
 ) : PasscodeRepository, PasscodeDataKeySource {
@@ -86,8 +90,9 @@ internal class PasscodeRepositoryImpl(
     constructor(
         cipher: PasscodeCipher,
         store: PasscodeStore,
+        keyShareProtection: VaultKeyShareProtection,
         @DefaultDispatcher dispatcher: CoroutineDispatcher,
-    ) : this(cipher, store, dispatcher, System::currentTimeMillis)
+    ) : this(cipher, store, keyShareProtection, dispatcher, System::currentTimeMillis)
 
     private val _state = MutableStateFlow<PasscodeState>(PasscodeState.Unknown)
     override val state: StateFlow<PasscodeState> = _state.asStateFlow()
@@ -106,6 +111,8 @@ internal class PasscodeRepositoryImpl(
 
     override fun dataKeyOrNull(): ByteArray? = dataKey
 
+    override fun isLocked(): Boolean = _state.value == PasscodeState.Locked
+
     override suspend fun initialize() {
         mutex.withLock {
             if (_state.value != PasscodeState.Unknown) return
@@ -118,9 +125,12 @@ internal class PasscodeRepositoryImpl(
         requireValidPasscode(passcode)
         mutex.withLock {
             val key = withContext(dispatcher) { cipher.newDataKey() }
+            // Persist the wrapped key before encrypting anything with it. The reverse order would
+            // let a crash mid-encryption leave ciphertext whose key was never written down.
             persistWrappedKey(key, passcode)
             dataKey = key
-            store.writeLockout(PasscodeLockout.cleared())
+            withContext(dispatcher) { store.writeLockout(PasscodeLockout.cleared()) }
+            keyShareProtection.protectAll(key)
             _state.value = PasscodeState.Unlocked
         }
     }
@@ -132,6 +142,8 @@ internal class PasscodeRepositoryImpl(
         requireValidPasscode(newPasscode)
         return mutex.withLock {
             verifyLocked(currentPasscode) { key ->
+                // The data key is unchanged, so stored keyshares stay valid: only the wrap is
+                // rewritten. This is why changing the passcode is instant on a large vault set.
                 persistWrappedKey(key, newPasscode)
                 dataKey = key
                 _state.value = PasscodeState.Unlocked
@@ -141,7 +153,10 @@ internal class PasscodeRepositoryImpl(
 
     override suspend fun disablePasscode(passcode: String): PasscodeUnlockResult =
         mutex.withLock {
-            verifyLocked(passcode) {
+            verifyLocked(passcode) { key ->
+                // Decrypt first, drop the credentials second. A crash between the two leaves the
+                // passcode in place over a partly decrypted table, which still reads correctly.
+                keyShareProtection.unprotectAll(key)
                 withContext(dispatcher) { store.clearCredentials() }
                 dataKey = null
                 _state.value = PasscodeState.Disabled

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/VaultKeyShareProtection.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/VaultKeyShareProtection.kt
@@ -1,0 +1,72 @@
+package com.vultisig.wallet.data.passcode
+
+import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.db.dao.VaultDao
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Bulk-converts stored keyshares between plaintext and passcode-encrypted when the user turns the
+ * passcode on or off.
+ *
+ * Both directions are safe to interrupt. Rows carry their own "is encrypted" marker, so a process
+ * death mid-run leaves a readable mix rather than a corrupt table, and re-running finishes the job.
+ * The caller is responsible for ordering the credential write around these calls so that a partial
+ * run never produces ciphertext whose key has already been discarded — see
+ * [PasscodeRepositoryImpl].
+ */
+internal interface VaultKeyShareProtection {
+
+    /** Encrypts every plaintext keyshare under [dataKey]. */
+    suspend fun protectAll(dataKey: ByteArray)
+
+    /**
+     * Decrypts every encrypted keyshare with [dataKey] and stores it in the clear.
+     *
+     * @throws IllegalStateException if a keyshare cannot be decrypted, leaving the table untouched
+     *   rather than dropping shares the user would need to sign.
+     */
+    suspend fun unprotectAll(dataKey: ByteArray)
+}
+
+internal class VaultKeyShareProtectionImpl
+@Inject
+constructor(
+    private val vaultDao: VaultDao,
+    private val cipher: KeyShareCipher,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+) : VaultKeyShareProtection {
+
+    override suspend fun protectAll(dataKey: ByteArray) {
+        withContext(dispatcher) {
+            val plaintext =
+                vaultDao.loadAllKeyShares().filterNot { cipher.isEncrypted(it.keyShare) }
+            if (plaintext.isEmpty()) return@withContext
+            vaultDao.upsertKeyshares(
+                plaintext.map { it.copy(keyShare = cipher.encrypt(it.keyShare, dataKey)) }
+            )
+            Timber.i("Encrypted %d keyshare(s) at rest", plaintext.size)
+        }
+    }
+
+    override suspend fun unprotectAll(dataKey: ByteArray) {
+        withContext(dispatcher) {
+            val encrypted = vaultDao.loadAllKeyShares().filter { cipher.isEncrypted(it.keyShare) }
+            if (encrypted.isEmpty()) return@withContext
+            // Decrypt everything before writing anything: a share that will not open must abort the
+            // whole operation while the passcode is still in place to protect the rest.
+            val decrypted =
+                encrypted.map { entity ->
+                    val plaintext =
+                        checkNotNull(cipher.decrypt(entity.keyShare, dataKey)) {
+                            "Keyshare for vault ${entity.vaultId} failed to decrypt"
+                        }
+                    entity.copy(keyShare = plaintext)
+                }
+            vaultDao.upsertKeyshares(decrypted)
+            Timber.i("Decrypted %d keyshare(s) back to plaintext", decrypted.size)
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -13,6 +13,8 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.data.passcode.KeyShareCipher
+import com.vultisig.wallet.data.passcode.PasscodeDataKeySource
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -66,8 +68,12 @@ interface VaultRepository {
 
 internal class VaultRepositoryImpl
 @Inject
-constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRepository) :
-    VaultRepository {
+constructor(
+    private val vaultDao: VaultDao,
+    private val tokenRepository: TokenRepository,
+    private val keyShareCipher: KeyShareCipher,
+    private val passcodeDataKeySource: PasscodeDataKeySource,
+) : VaultRepository {
 
     override fun getEnabledTokens(vaultId: String): Flow<List<Coin>> =
         getAsFlow(vaultId).map { it?.coins.orEmpty() }
@@ -143,6 +149,41 @@ constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRe
         vaultDao.replaceToken(vaultId, oldToken.id, newToken.toCoinEntity(vaultId))
     }
 
+    /**
+     * Decrypts stored keyshares, dropping any that cannot be opened.
+     *
+     * They cannot be opened only when a passcode is set and the app is locked, which the lock
+     * screen keeps the user away from — but background work (notifications, balance sync) does
+     * still read vaults, and it only needs public keys and addresses. Returning the vault without
+     * its shares keeps that work alive; the write path refuses to persist a vault in that state, so
+     * a locked read can never be echoed back as data loss.
+     */
+    private fun List<KeyShareEntity>.toKeyShares(vaultId: VaultId): List<KeyShare> {
+        val dataKey = passcodeDataKeySource.dataKeyOrNull()
+        val shares = mapNotNull { entity ->
+            keyShareCipher.decrypt(entity.keyShare, dataKey)?.let { KeyShare(entity.pubKey, it) }
+        }
+        if (shares.size != size) {
+            Timber.w("Dropped %d locked keyshare(s) for vault %s", size - shares.size, vaultId)
+        }
+        return shares
+    }
+
+    /**
+     * Encrypts [keyShare] for storage when a passcode is active.
+     *
+     * Refuses to write while locked rather than silently storing a share in the clear, which would
+     * quietly undo the at-rest protection the user asked for.
+     */
+    private fun protect(keyShare: String): String {
+        val dataKey = passcodeDataKeySource.dataKeyOrNull()
+        if (dataKey != null) return keyShareCipher.encrypt(keyShare, dataKey)
+        check(!passcodeDataKeySource.isLocked()) {
+            "Refusing to persist a keyshare while the app is locked"
+        }
+        return keyShare
+    }
+
     private suspend fun VaultWithKeySharesAndTokens.toVault(): Vault {
         val vault = this
         return Vault(
@@ -155,7 +196,7 @@ constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRe
             localPartyID = vault.vault.localPartyID,
             signers = vault.signers.sortedBy { it.index }.map { it.title },
             resharePrefix = vault.vault.resharePrefix,
-            keyshares = vault.keyShares.map { KeyShare(it.pubKey, it.keyShare) },
+            keyshares = vault.keyShares.toKeyShares(vault.vault.id),
             coins =
                 vault.coins.mapNotNull { coinEntity ->
                     val chain =
@@ -225,7 +266,11 @@ constructor(private val vaultDao: VaultDao, private val tokenRepository: TokenRe
                 ),
             keyShares =
                 vault.keyshares.map {
-                    KeyShareEntity(vaultId = vaultId, pubKey = it.pubKey, keyShare = it.keyShare)
+                    KeyShareEntity(
+                        vaultId = vaultId,
+                        pubKey = it.pubKey,
+                        keyShare = protect(it.keyShare),
+                    )
                 },
             signers =
                 vault.signers.mapIndexed { index, signer ->

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/KeyShareCipherTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/KeyShareCipherTest.kt
@@ -1,0 +1,72 @@
+package com.vultisig.wallet.data.passcode
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class KeyShareCipherTest {
+
+    private val cipher = KeyShareCipher()
+    private val dataKey = ByteArray(32) { it.toByte() }
+    private val keyShare = "0402ab...a-realistic-looking-keyshare-blob"
+
+    @Test
+    fun `encrypt then decrypt round-trips`() {
+        val encrypted = cipher.encrypt(keyShare, dataKey)
+
+        assertEquals(keyShare, cipher.decrypt(encrypted, dataKey))
+    }
+
+    @Test
+    fun `ciphertext is tagged and does not leak the plaintext`() {
+        val encrypted = cipher.encrypt(keyShare, dataKey)
+
+        assertTrue(cipher.isEncrypted(encrypted))
+        assertFalse(encrypted.contains(keyShare))
+    }
+
+    @Test
+    fun `plaintext passes through untouched for users without a passcode`() {
+        assertFalse(cipher.isEncrypted(keyShare))
+        assertEquals(keyShare, cipher.decrypt(keyShare, dataKey))
+        assertEquals(keyShare, cipher.decrypt(keyShare, null))
+    }
+
+    @Test
+    fun `decrypt returns null when the app is locked`() {
+        val encrypted = cipher.encrypt(keyShare, dataKey)
+
+        assertNull(cipher.decrypt(encrypted, null))
+    }
+
+    @Test
+    fun `decrypt returns null for the wrong data key`() {
+        val encrypted = cipher.encrypt(keyShare, dataKey)
+
+        assertNull(cipher.decrypt(encrypted, ByteArray(32) { (it + 1).toByte() }))
+    }
+
+    @Test
+    fun `decrypt returns null for tampered or truncated ciphertext`() {
+        val encrypted = cipher.encrypt(keyShare, dataKey)
+
+        assertNull(cipher.decrypt(encrypted.dropLast(4), dataKey))
+        assertNull(cipher.decrypt("vlpc1:not-base64!!", dataKey))
+        assertNull(cipher.decrypt("vlpc1:", dataKey))
+    }
+
+    @Test
+    fun `each encryption uses a fresh IV`() {
+        assertNotEquals(cipher.encrypt(keyShare, dataKey), cipher.encrypt(keyShare, dataKey))
+    }
+
+    @Test
+    fun `empty keyshares round-trip`() {
+        val encrypted = cipher.encrypt("", dataKey)
+
+        assertEquals("", cipher.decrypt(encrypted, dataKey))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -19,11 +19,13 @@ import org.junit.jupiter.api.Test
 internal class PasscodeRepositoryImplTest {
 
     private lateinit var store: FakePasscodeStore
+    private lateinit var protection: RecordingKeyShareProtection
     private var now = 1_000_000L
 
     @BeforeEach
     fun setUp() {
         store = FakePasscodeStore()
+        protection = RecordingKeyShareProtection()
         now = 1_000_000L
     }
 
@@ -32,6 +34,7 @@ internal class PasscodeRepositoryImplTest {
         PasscodeRepositoryImpl(
             cipher = PasscodeCipher(),
             store = store,
+            keyShareProtection = protection,
             dispatcher = StandardTestDispatcher(testScheduler),
             nowMillis = { now },
         )
@@ -248,6 +251,80 @@ internal class PasscodeRepositoryImplTest {
         }
 
     @Test
+    fun `setPasscode encrypts stored keyshares with the new data key`() = runTest {
+        val repository = repository()
+
+        repository.setPasscode("12345")
+
+        assertEquals(listOf("protect"), protection.calls)
+        assertContentEquals(repository.dataKeyOrNull(), protection.protectedWith)
+    }
+
+    @Test
+    fun `setPasscode persists the wrapped key before encrypting anything with it`() = runTest {
+        // Reverse that order and a crash mid-encryption strands ciphertext with no recorded key.
+        val repository = repository()
+        protection.calls.clear()
+
+        repository.setPasscode("12345")
+
+        assertNotNull(store.readCredentials(), "credentials must exist by the time we encrypt")
+        assertEquals(listOf("protect"), protection.calls)
+    }
+
+    @Test
+    fun `disablePasscode decrypts keyshares before dropping the credentials`() = runTest {
+        val repository = repository()
+        repository.setPasscode("12345")
+        protection.calls.clear()
+
+        repository.disablePasscode("12345")
+
+        assertEquals(listOf("unprotect"), protection.calls)
+        assertNull(store.readCredentials())
+    }
+
+    @Test
+    fun `a failed decrypt leaves the passcode in place`() = runTest {
+        val repository = repository()
+        repository.setPasscode("12345")
+        protection.unprotectFailure = IllegalStateException("keyshare failed to decrypt")
+
+        assertFailsWith<IllegalStateException> { repository.disablePasscode("12345") }
+
+        assertNotNull(store.readCredentials(), "credentials must survive a failed decrypt")
+        assertEquals(PasscodeState.Unlocked, repository.state.value)
+        assertNotNull(repository.dataKeyOrNull())
+    }
+
+    @Test
+    fun `changePasscode does not re-encrypt keyshares`() = runTest {
+        val repository = repository()
+        repository.setPasscode("12345")
+        protection.calls.clear()
+
+        repository.changePasscode("12345", "54321")
+
+        assertEquals(emptyList(), protection.calls, "the data key is unchanged")
+    }
+
+    @Test
+    fun `isLocked is true only while a passcode is configured and not entered`() = runTest {
+        val repository = repository()
+        repository.initialize()
+        assertEquals(false, repository.isLocked())
+
+        repository.setPasscode("12345")
+        assertEquals(false, repository.isLocked())
+
+        repository.lock()
+        assertEquals(true, repository.isLocked())
+
+        repository.unlock("12345")
+        assertEquals(false, repository.isLocked())
+    }
+
+    @Test
     fun `concurrent wrong attempts are counted individually`() = runTest {
         // Runs on real threads: the mutex, not the test scheduler, has to serialise the
         // read-modify-write of the attempt counter.
@@ -255,6 +332,7 @@ internal class PasscodeRepositoryImplTest {
             PasscodeRepositoryImpl(
                 cipher = PasscodeCipher(),
                 store = store,
+                keyShareProtection = protection,
                 dispatcher = Dispatchers.Default,
                 nowMillis = { now },
             )
@@ -272,6 +350,23 @@ internal class PasscodeRepositoryImplTest {
             PasscodeLockout.ATTEMPTS_BEFORE_LOCKOUT - 1,
             store.readLockout().failedAttempts,
         )
+    }
+}
+
+/** Records how the repository drives the bulk keyshare re-keying, including its ordering. */
+internal class RecordingKeyShareProtection : VaultKeyShareProtection {
+    val calls = mutableListOf<String>()
+    var protectedWith: ByteArray? = null
+    var unprotectFailure: Throwable? = null
+
+    override suspend fun protectAll(dataKey: ByteArray) {
+        calls += "protect"
+        protectedWith = dataKey.copyOf()
+    }
+
+    override suspend fun unprotectAll(dataKey: ByteArray) {
+        calls += "unprotect"
+        unprotectFailure?.let { throw it }
     }
 }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/VaultKeyShareProtectionImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/VaultKeyShareProtectionImplTest.kt
@@ -1,0 +1,113 @@
+package com.vultisig.wallet.data.passcode
+
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.models.KeyShareEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class VaultKeyShareProtectionImplTest {
+
+    private val cipher = KeyShareCipher()
+    private val dataKey = ByteArray(32) { it.toByte() }
+    private lateinit var vaultDao: VaultDao
+    private lateinit var protection: VaultKeyShareProtectionImpl
+
+    @BeforeEach
+    fun setUp() {
+        vaultDao = mockk(relaxUnitFun = true)
+        protection =
+            VaultKeyShareProtectionImpl(vaultDao, cipher, UnconfinedTestDispatcher())
+    }
+
+    private fun share(vaultId: String, keyShare: String) =
+        KeyShareEntity(vaultId = vaultId, pubKey = "pub-$vaultId", keyShare = keyShare)
+
+    @Test
+    fun `protectAll encrypts every plaintext share`() = runTest {
+        coEvery { vaultDao.loadAllKeyShares() } returns
+            listOf(share("a", "share-a"), share("b", "share-b"))
+        val written = slot<List<KeyShareEntity>>()
+
+        protection.protectAll(dataKey)
+
+        coVerify { vaultDao.upsertKeyshares(capture(written)) }
+        assertEquals(2, written.captured.size)
+        assertTrue(written.captured.all { cipher.isEncrypted(it.keyShare) })
+        assertEquals(
+            listOf("share-a", "share-b"),
+            written.captured.map { cipher.decrypt(it.keyShare, dataKey) },
+        )
+    }
+
+    @Test
+    fun `protectAll skips shares that are already encrypted`() = runTest {
+        // The half-migrated table left by a process death must not be double-encrypted on retry.
+        coEvery { vaultDao.loadAllKeyShares() } returns
+            listOf(share("a", cipher.encrypt("share-a", dataKey)), share("b", "share-b"))
+        val written = slot<List<KeyShareEntity>>()
+
+        protection.protectAll(dataKey)
+
+        coVerify { vaultDao.upsertKeyshares(capture(written)) }
+        assertEquals(1, written.captured.size)
+        assertEquals("share-b", cipher.decrypt(written.captured.single().keyShare, dataKey))
+    }
+
+    @Test
+    fun `protectAll writes nothing when every share is already encrypted`() = runTest {
+        coEvery { vaultDao.loadAllKeyShares() } returns
+            listOf(share("a", cipher.encrypt("share-a", dataKey)))
+
+        protection.protectAll(dataKey)
+
+        coVerify(exactly = 0) { vaultDao.upsertKeyshares(any()) }
+    }
+
+    @Test
+    fun `unprotectAll restores plaintext`() = runTest {
+        coEvery { vaultDao.loadAllKeyShares() } returns
+            listOf(
+                share("a", cipher.encrypt("share-a", dataKey)),
+                share("b", "already-plaintext"),
+            )
+        val written = slot<List<KeyShareEntity>>()
+
+        protection.unprotectAll(dataKey)
+
+        coVerify { vaultDao.upsertKeyshares(capture(written)) }
+        assertEquals(listOf("share-a"), written.captured.map { it.keyShare })
+    }
+
+    @Test
+    fun `unprotectAll writes nothing when a share cannot be decrypted`() = runTest {
+        coEvery { vaultDao.loadAllKeyShares() } returns
+            listOf(
+                share("a", cipher.encrypt("share-a", dataKey)),
+                share("b", "vlpc1:Z2FyYmFnZQ=="),
+            )
+
+        assertFailsWith<IllegalStateException> { protection.unprotectAll(dataKey) }
+
+        // Partially decrypting would strand the good share in the clear while the bad one is lost.
+        coVerify(exactly = 0) { vaultDao.upsertKeyshares(any()) }
+    }
+
+    @Test
+    fun `an empty table is a no-op in both directions`() = runTest {
+        coEvery { vaultDao.loadAllKeyShares() } returns emptyList()
+
+        protection.protectAll(dataKey)
+        protection.unprotectAll(dataKey)
+
+        coVerify(exactly = 0) { vaultDao.upsertKeyshares(any()) }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -2,12 +2,16 @@ package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.db.dao.VaultDao
 import com.vultisig.wallet.data.db.models.CoinEntity
+import com.vultisig.wallet.data.db.models.KeyShareEntity
 import com.vultisig.wallet.data.db.models.VaultEntity
 import com.vultisig.wallet.data.db.models.VaultWithKeySharesAndTokens
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.passcode.KeyShareCipher
+import com.vultisig.wallet.data.passcode.PasscodeDataKeySource
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -15,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -28,13 +33,27 @@ internal class VaultRepositoryImplTest {
 
     private lateinit var vaultDao: VaultDao
     private lateinit var tokenRepository: TokenRepository
+    private lateinit var passcode: FakePasscodeDataKeySource
     private lateinit var repository: VaultRepositoryImpl
+
+    private val keyShareCipher = KeyShareCipher()
 
     @BeforeEach
     fun setUp() {
         vaultDao = mockk(relaxUnitFun = true)
         tokenRepository = mockk()
-        repository = VaultRepositoryImpl(vaultDao, tokenRepository)
+        passcode = FakePasscodeDataKeySource()
+        repository = VaultRepositoryImpl(vaultDao, tokenRepository, keyShareCipher, passcode)
+    }
+
+    /** Stands in for the passcode repository's in-memory key without pulling in its dependencies. */
+    private class FakePasscodeDataKeySource : PasscodeDataKeySource {
+        var dataKey: ByteArray? = null
+        var locked: Boolean = false
+
+        override fun dataKeyOrNull(): ByteArray? = dataKey
+
+        override fun isLocked(): Boolean = locked
     }
 
     /** Returns a minimal [VaultWithKeySharesAndTokens] suitable for DAO stub returns. */
@@ -422,4 +441,114 @@ internal class VaultRepositoryImplTest {
 
         assertEquals(listOf("ETH-Ethereum"), repository.getDisabledCoinIds("vault-1"))
     }
+
+    private val dataKey = ByteArray(32) { it.toByte() }
+
+    /** Returns a stored vault carrying [keyShare] verbatim in the keyshare column. */
+    private fun vaultWithStoredKeyShare(keyShare: String) =
+        makeVaultWithTokens()
+            .copy(
+                keyShares =
+                    listOf(
+                        KeyShareEntity(vaultId = "vault-1", pubKey = "pub-1", keyShare = keyShare)
+                    )
+            )
+
+    /** Verifies a vault stored before the passcode existed still loads unchanged. */
+    @Test
+    fun `get returns plaintext keyshares for vaults stored without a passcode`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns vaultWithStoredKeyShare("share-1")
+
+        assertEquals(listOf("share-1"), repository.get("vault-1")?.keyshares?.map { it.keyShare })
+    }
+
+    /** Verifies encrypted keyshares are decrypted while the app is unlocked. */
+    @Test
+    fun `get decrypts keyshares while unlocked`() = runTest {
+        passcode.dataKey = dataKey
+        coEvery { vaultDao.loadById("vault-1") } returns
+            vaultWithStoredKeyShare(keyShareCipher.encrypt("share-1", dataKey))
+
+        assertEquals(listOf("share-1"), repository.get("vault-1")?.keyshares?.map { it.keyShare })
+    }
+
+    /**
+     * Verifies a locked read yields the vault without its keyshares rather than throwing, so
+     * background work that only needs addresses keeps running behind the lock screen.
+     */
+    @Test
+    fun `get drops keyshares it cannot decrypt while locked`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns
+            vaultWithStoredKeyShare(keyShareCipher.encrypt("share-1", dataKey))
+        passcode.dataKey = null
+        passcode.locked = true
+
+        val vault = repository.get("vault-1")
+
+        assertNotNull(vault)
+        assertEquals(emptyList(), vault.keyshares)
+        assertEquals("ecdsa-vault-1", vault.pubKeyECDSA)
+    }
+
+    /** Verifies keyshares are encrypted on the way into the database while unlocked. */
+    @Test
+    fun `add encrypts keyshares while unlocked`() = runTest {
+        passcode.dataKey = dataKey
+        val stored = slot<VaultWithKeySharesAndTokens>()
+
+        repository.add(makeVault().copy(keyshares = listOf(KeyShare("pub-1", "share-1"))))
+
+        coVerify { vaultDao.insert(capture(stored)) }
+        val written = stored.captured.keyShares.single().keyShare
+        assertTrue(keyShareCipher.isEncrypted(written))
+        assertEquals("share-1", keyShareCipher.decrypt(written, dataKey))
+    }
+
+    /** Verifies users without a passcode keep storing keyshares in the clear. */
+    @Test
+    fun `add stores plaintext keyshares when no passcode is set`() = runTest {
+        val stored = slot<VaultWithKeySharesAndTokens>()
+
+        repository.add(makeVault().copy(keyshares = listOf(KeyShare("pub-1", "share-1"))))
+
+        coVerify { vaultDao.insert(capture(stored)) }
+        assertEquals("share-1", stored.captured.keyShares.single().keyShare)
+    }
+
+    /**
+     * Verifies a locked write fails loudly. Storing the share in the clear instead would silently
+     * undo the at-rest protection the user asked for.
+     */
+    @Test
+    fun `add refuses to persist keyshares while locked`() = runTest {
+        passcode.dataKey = null
+        passcode.locked = true
+
+        assertFailsWith<IllegalStateException> {
+            repository.add(makeVault().copy(keyshares = listOf(KeyShare("pub-1", "share-1"))))
+        }
+
+        coVerify(exactly = 0) { vaultDao.insert(any()) }
+    }
+
+    /** Verifies a locked write of a vault with no keyshares still goes through. */
+    @Test
+    fun `upsert of a keyshare-free vault is allowed while locked`() = runTest {
+        passcode.locked = true
+
+        repository.upsert(makeVault())
+
+        coVerify { vaultDao.upsert(any()) }
+    }
+
+    /** Returns a minimal domain [Vault]. */
+    private fun makeVault() =
+        Vault(
+            id = "vault-1",
+            name = "Test Vault",
+            pubKeyECDSA = "ecdsa-vault-1",
+            pubKeyEDDSA = "eddsa-vault-1",
+            hexChainCode = "chaincode",
+            localPartyID = "device-1",
+        )
 }


### PR DESCRIPTION
Part 2 of 5 for #5343. Stacked on #5528 — **review that one first**; this PR's diff is against it.

Keyshares are now stored encrypted under the passcode-derived data key. Still no UI: nothing enables a passcode yet, so every existing install keeps behaving exactly as before.

## What

Encryption happens at the two points where `VaultRepository` already converts between the domain vault and its rows, so the rest of the app is untouched.

Stored shares carry a `vlpc1:` tag, which lets plaintext and ciphertext coexist in one table. That is what makes the feature survivable: users who never set a passcode keep plaintext rows forever, and a bulk conversion killed halfway through leaves a mix the next launch still reads correctly, then finishes on retry.

## Ordering, which is the part that matters

Both directions are ordered so no interruption can strand a share:

- **Enabling** writes the wrapped key first and encrypts second, so ciphertext never exists without a recorded key.
- **Disabling** decrypts everything into memory and validates it before writing, and only then drops the credentials — so a share that will not open aborts the whole operation while the passcode is still protecting the rest.
- **Changing** the passcode rewraps the data key and touches no shares at all.

## Reads and writes while locked

Reads drop the shares and log rather than throwing. The lock screen keeps the user away from signing, but background work such as notifications and balance sync still reads vaults and needs only public keys and addresses. The write path refuses to persist a keyshare while locked, so a locked read can never be echoed back as data loss.

## Test plan

- `./gradlew :data:testDebugUnitTest` — 14 new tests plus 8 added to `VaultRepositoryImplTest`, covering the tagged round-trip, plaintext passthrough for passcode-less users, half-migrated tables, the abort-before-write path on an undecryptable share, and the locked read/write behaviour above.
- End-to-end signing is exercised in part 5, where a passcode can actually be set.