### PR TITLE
Passcode app-lock 3/5: the App Locked entry screen

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -143,6 +143,9 @@ import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.swap.VultTierGateUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
 import com.vultisig.wallet.ui.models.v3.ReviewVaultDevicesUiState
+import com.vultisig.wallet.ui.models.passcode.PasscodeLockError
+import com.vultisig.wallet.ui.models.passcode.PasscodeLockUiModel
+import com.vultisig.wallet.ui.screens.passcode.PasscodeLockScreen
 import com.vultisig.wallet.ui.screens.ChainSelectionScreen
 import com.vultisig.wallet.ui.screens.TokenDetailScreen
 import com.vultisig.wallet.ui.screens.TokenSelectionScreen
@@ -229,6 +232,24 @@ class PreviewActivity : ComponentActivity() {
         setContent {
             OnBoardingComposeTheme {
                 when (screen) {
+                    "passcode_lock" ->
+                        PasscodeLockScreen(
+                            state = PasscodeLockUiModel(),
+                            textFieldState = TextFieldState(),
+                        )
+                    "passcode_lock_filled" ->
+                        PasscodeLockScreen(
+                            state = PasscodeLockUiModel(),
+                            textFieldState = TextFieldState("12"),
+                        )
+                    "passcode_lock_error" ->
+                        PasscodeLockScreen(
+                            state =
+                                PasscodeLockUiModel(
+                                    error = PasscodeLockError.Wrong(remainingAttempts = 2)
+                                ),
+                            textFieldState = TextFieldState(),
+                        )
                     "limit_swap_form" -> LimitSwapFormPreview()
                     "limit_swap_form_assets" ->
                         LimitSwapFormPreview(expandedSection = LimitFormSection.Asset)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/PasscodeInputField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/PasscodeInputField.kt
@@ -1,0 +1,176 @@
+package com.vultisig.wallet.ui.components.inputs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.data.passcode.PASSCODE_LENGTH
+import com.vultisig.wallet.ui.theme.Theme
+
+/** Whether the field is showing a plain entry or flagging a rejected passcode. */
+internal enum class PasscodeInputFieldState {
+    Default,
+    Error,
+}
+
+/**
+ * Five-cell passcode entry.
+ *
+ * Follows the same mechanic as [VsCodeInputField] — a 1dp invisible [BasicTextField] owns the input
+ * and keyboard while the visible cells are drawn from its text — but masks what it renders. This is
+ * a passcode over the user's vaults, so the digits are never shown, not even transiently.
+ */
+@Composable
+internal fun PasscodeInputField(
+    textFieldState: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    state: PasscodeInputFieldState = PasscodeInputFieldState.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(enabled) { if (enabled) focusRequester.requestFocus() }
+
+    Box(modifier = modifier) {
+        BasicTextField(
+            state = textFieldState,
+            enabled = enabled,
+            keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = KeyboardType.NumberPassword,
+                    imeAction = ImeAction.Go,
+                ),
+            inputTransformation = InputTransformation.maxLength(PASSCODE_LENGTH),
+            onKeyboardAction = onKeyboardAction,
+            modifier =
+                Modifier.size(1.dp)
+                    .alpha(0.01f)
+                    .onFocusChanged { isFocused = it.isFocused }
+                    .focusRequester(focusRequester)
+                    .testTag(PASSCODE_INPUT_FIELD_TAG),
+            // Belt and braces with the masking below: even the off-screen field renders nothing.
+            textStyle = TextStyle.Default.copy(color = Color.Transparent),
+        )
+
+        val entered = textFieldState.text.length
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            modifier =
+                Modifier.height(PASSCODE_CELL_HEIGHT).clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    enabled = enabled,
+                ) {
+                    focusRequester.requestFocus()
+                    keyboard?.show()
+                },
+        ) {
+            repeat(PASSCODE_LENGTH) { index ->
+                val isActive = enabled && isFocused && index == entered
+                val isFilled = index < entered
+
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier =
+                        Modifier.weight(1f)
+                            .height(PASSCODE_CELL_HEIGHT)
+                            .background(
+                                color = Theme.v2.colors.backgrounds.surface1,
+                                shape = PasscodeCellShape,
+                            )
+                            .border(
+                                width = 1.dp,
+                                color =
+                                    when {
+                                        state == PasscodeInputFieldState.Error ->
+                                            Theme.v2.colors.alerts.error
+                                        isActive -> Theme.v2.colors.border.light
+                                        else -> PasscodeCellBorder
+                                    },
+                                shape = PasscodeCellShape,
+                            ),
+                ) {
+                    when {
+                        isFilled ->
+                            Text(
+                                text = FILLED_MARK,
+                                color = Theme.v2.colors.text.primary,
+                                style = Theme.brockmann.body.m.medium,
+                            )
+                        isActive ->
+                            Text(
+                                text = CARET_MARK,
+                                color = Theme.v2.colors.primary.accent4,
+                                style = Theme.brockmann.body.m.medium,
+                            )
+                    }
+                }
+            }
+        }
+
+        // One description for the whole row: announcing five identical cells adds nothing, whereas
+        // how many digits are in so far is the part a screen-reader user cannot see.
+        Box(
+            modifier =
+                Modifier.size(1.dp).semantics {
+                    contentDescription = "$entered of $PASSCODE_LENGTH digits entered"
+                }
+        )
+    }
+}
+
+private val PASSCODE_CELL_HEIGHT = 51.dp
+private val PasscodeCellShape = RoundedCornerShape(12.dp)
+
+/** Figma uses a flat 10% white hairline on the idle cells rather than a theme border token. */
+private val PasscodeCellBorder = Color.White.copy(alpha = 0.1f)
+
+private const val FILLED_MARK = "•"
+private const val CARET_MARK = "|"
+
+internal const val PASSCODE_INPUT_FIELD_TAG = "passcodeInputField"
+
+@Preview
+@Composable
+private fun PasscodeInputFieldPreview() {
+    PasscodeInputField(textFieldState = remember { TextFieldState("12") })
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModel.kt
@@ -1,0 +1,114 @@
+package com.vultisig.wallet.ui.models.passcode
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vultisig.wallet.data.passcode.PASSCODE_LENGTH
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeUnlockResult
+import com.vultisig.wallet.ui.utils.textAsFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** Why the last passcode entry was rejected, if it was. */
+@Immutable
+internal sealed interface PasscodeLockError {
+    /** The passcode was wrong; [remainingAttempts] tries remain before entry is throttled. */
+    data class Wrong(val remainingAttempts: Int) : PasscodeLockError
+
+    /** Entry is throttled for another [remainingSeconds]. */
+    data class LockedOut(val remainingSeconds: Long) : PasscodeLockError
+}
+
+@Immutable
+internal data class PasscodeLockUiModel(
+    val isVerifying: Boolean = false,
+    val error: PasscodeLockError? = null,
+) {
+    val isInputEnabled: Boolean
+        get() = !isVerifying && error !is PasscodeLockError.LockedOut
+}
+
+/**
+ * Drives the App Locked screen: collects five digits, verifies them, and counts down the throttle
+ * when too many were wrong.
+ */
+@HiltViewModel
+internal class PasscodeLockViewModel
+@Inject
+constructor(private val passcodeRepository: PasscodeRepository) : ViewModel() {
+
+    val textFieldState = TextFieldState()
+
+    val state = MutableStateFlow(PasscodeLockUiModel())
+
+    private var verifyJob: Job? = null
+    private var countdownJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            textFieldState.textAsFlow().collect { text ->
+                // Clear a stale error as soon as the user starts over, so the screen does not keep
+                // accusing them while they type the next attempt.
+                if (state.value.error is PasscodeLockError.Wrong) {
+                    state.update { it.copy(error = null) }
+                }
+                if (text.length == PASSCODE_LENGTH) {
+                    verify(text.toString())
+                }
+            }
+        }
+    }
+
+    private fun verify(passcode: String) {
+        // Restarting rather than ignoring: the field cannot reach full length again until the
+        // in-flight attempt has cleared it, so a queued second attempt would be the same passcode.
+        verifyJob?.cancel()
+        verifyJob =
+            viewModelScope.launch {
+                state.update { it.copy(isVerifying = true) }
+                val result = passcodeRepository.unlock(passcode)
+                state.update { it.copy(isVerifying = false) }
+                when (result) {
+                    // The repository's state flow flips to Unlocked and the guard swaps the screen
+                    // out; there is nothing left for this view model to do.
+                    is PasscodeUnlockResult.Success -> Unit
+                    is PasscodeUnlockResult.Wrong -> {
+                        textFieldState.clearText()
+                        state.update {
+                            it.copy(error = PasscodeLockError.Wrong(result.remainingAttempts))
+                        }
+                    }
+                    is PasscodeUnlockResult.LockedOut -> {
+                        textFieldState.clearText()
+                        startCountdown(result.retryAfterMillis)
+                    }
+                }
+            }
+    }
+
+    private fun startCountdown(retryAfterMillis: Long) {
+        countdownJob?.cancel()
+        countdownJob =
+            viewModelScope.launch {
+                var remaining = retryAfterMillis.milliseconds
+                while (remaining > 0.seconds) {
+                    state.update {
+                        it.copy(error = PasscodeLockError.LockedOut(remaining.inWholeSeconds))
+                    }
+                    delay(1.seconds)
+                    remaining -= 1.seconds
+                }
+                state.update { it.copy(error = null) }
+            }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.data.passcode.PASSCODE_LENGTH
 import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
 import com.vultisig.wallet.data.passcode.PasscodeUnlockResult
 import com.vultisig.wallet.ui.utils.textAsFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -58,8 +59,10 @@ constructor(private val passcodeRepository: PasscodeRepository) : ViewModel() {
         viewModelScope.launch {
             textFieldState.textAsFlow().collect { text ->
                 // Clear a stale error as soon as the user starts over, so the screen does not keep
-                // accusing them while they type the next attempt.
-                if (state.value.error is PasscodeLockError.Wrong) {
+                // accusing them while they type the next attempt. Only a non-empty field counts as
+                // starting over: emptying it is how this view model reacts to a wrong passcode, and
+                // treating that as a fresh start would wipe the error in the frame it appears.
+                if (text.isNotEmpty() && state.value.error is PasscodeLockError.Wrong) {
                     state.update { it.copy(error = null) }
                 }
                 if (text.length == PASSCODE_LENGTH) {
@@ -67,6 +70,28 @@ constructor(private val passcodeRepository: PasscodeRepository) : ViewModel() {
                 }
             }
         }
+
+        // This view model outlives any single lock, because the guard hosts it outside the nav
+        // graph and it is therefore scoped to the activity. Without this, a half-typed or rejected
+        // attempt is still sitting in the field the next time the app locks, so the user returns to
+        // pre-filled cells and a stale error rather than a clean prompt.
+        viewModelScope.launch {
+            passcodeRepository.state.collect { passcodeState ->
+                if (passcodeState == PasscodeState.Locked) {
+                    reset()
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the prompt to its blank state, abandoning anything left over from a previous lock.
+     */
+    private fun reset() {
+        verifyJob?.cancel()
+        countdownJob?.cancel()
+        textFieldState.clearText()
+        state.value = PasscodeLockUiModel()
     }
 
     private fun verify(passcode: String) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
@@ -1,0 +1,182 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.inputs.PasscodeInputField
+import com.vultisig.wallet.ui.components.inputs.PasscodeInputFieldState
+import com.vultisig.wallet.ui.models.passcode.PasscodeLockError
+import com.vultisig.wallet.ui.models.passcode.PasscodeLockUiModel
+import com.vultisig.wallet.ui.models.passcode.PasscodeLockViewModel
+import com.vultisig.wallet.ui.theme.Theme
+import kotlin.math.ceil
+
+/** Full-screen gate shown whenever the app is locked behind a passcode. */
+@Composable
+internal fun PasscodeLockScreen(model: PasscodeLockViewModel = hiltViewModel()) {
+    val state by model.state.collectAsStateWithLifecycle()
+
+    PasscodeLockScreen(state = state, textFieldState = model.textFieldState)
+}
+
+@Composable
+internal fun PasscodeLockScreen(state: PasscodeLockUiModel, textFieldState: TextFieldState) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary).glow(),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+                Modifier.widthIn(max = CONTENT_MAX_WIDTH)
+                    .padding(horizontal = 16.dp)
+                    // The design sits the block slightly above true centre so the keyboard does not
+                    // crowd it once it opens.
+                    .padding(bottom = 56.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.passcode_lock_title),
+                color = Theme.v2.colors.text.primary,
+                style = Theme.brockmann.headings.largeTitle,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Text(
+                text = stringResource(R.string.passcode_lock_subtitle),
+                color = Theme.v2.colors.text.tertiary,
+                style = Theme.brockmann.supplementary.footnote,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+            )
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = 36.dp)
+                        .background(color = CardBackground, shape = CardShape)
+                        .border(width = 1.dp, color = CardBorder, shape = CardShape)
+                        .padding(26.dp),
+            ) {
+                PasscodeInputField(
+                    textFieldState = textFieldState,
+                    enabled = state.isInputEnabled,
+                    state =
+                        if (state.error != null) PasscodeInputFieldState.Error
+                        else PasscodeInputFieldState.Default,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            state.error?.let { error ->
+                Text(
+                    text = error.message(),
+                    color = Theme.v2.colors.alerts.error,
+                    style = Theme.brockmann.supplementary.footnote,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasscodeLockError.message(): String =
+    when (this) {
+        is PasscodeLockError.Wrong ->
+            if (remainingAttempts == 1) stringResource(R.string.passcode_lock_last_attempt)
+            else stringResource(R.string.passcode_lock_wrong_passcode)
+        is PasscodeLockError.LockedOut ->
+            if (remainingSeconds >= SECONDS_PER_MINUTE) {
+                stringResource(
+                    R.string.passcode_lock_too_many_attempts_minutes,
+                    ceil(remainingSeconds / SECONDS_PER_MINUTE.toFloat()).toInt(),
+                )
+            } else {
+                stringResource(
+                    R.string.passcode_lock_too_many_attempts_seconds,
+                    remainingSeconds.toInt(),
+                )
+            }
+    }
+
+/**
+ * The design's backdrop: a wide, soft radial wash with a barely-there ring at its edge, centred
+ * above the content rather than on it.
+ */
+private fun Modifier.glow(): Modifier = drawWithCache {
+    val radius = size.width * GLOW_RADIUS_TO_WIDTH
+    val center = Offset(x = size.width / 2f, y = size.height * GLOW_CENTER_TO_HEIGHT)
+    val wash =
+        Brush.radialGradient(
+            colors = listOf(GlowInner, GlowOuter),
+            center = center,
+            radius = radius,
+        )
+    onDrawBehind {
+        drawCircle(brush = wash, radius = radius, center = center)
+        drawCircle(
+            color = GlowRing,
+            radius = radius * GLOW_RING_TO_RADIUS,
+            center = center,
+            style = Stroke(width = 1f),
+        )
+    }
+}
+
+private val CONTENT_MAX_WIDTH = 360.dp
+private val CardShape = RoundedCornerShape(12.dp)
+
+/** Figma tints the card with 10% of the normal border blue; there is no background token for it. */
+private val CardBackground = Color(0xFF1B3F73).copy(alpha = 0.1f)
+private val CardBorder = Color.White.copy(alpha = 0.1f)
+
+private val GlowInner = Color(0xFF0439C7).copy(alpha = 0.29f)
+private val GlowOuter = Color(0xFF02122A).copy(alpha = 0f)
+private val GlowRing = Color(0xFF33E6BF).copy(alpha = 0.05f)
+
+private const val GLOW_RADIUS_TO_WIDTH = 0.9f
+private const val GLOW_CENTER_TO_HEIGHT = 0.577f
+private const val GLOW_RING_TO_RADIUS = 0.911f
+private const val SECONDS_PER_MINUTE = 60
+
+@Preview
+@Composable
+private fun PasscodeLockScreenPreview() {
+    PasscodeLockScreen(state = PasscodeLockUiModel(), textFieldState = TextFieldState("12"))
+}
+
+@Preview
+@Composable
+private fun PasscodeLockScreenErrorPreview() {
+    PasscodeLockScreen(
+        state = PasscodeLockUiModel(error = PasscodeLockError.Wrong(remainingAttempts = 2)),
+        textFieldState = TextFieldState(),
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,16 +48,24 @@ internal fun PasscodeLockScreen(model: PasscodeLockViewModel = hiltViewModel()) 
 internal fun PasscodeLockScreen(state: PasscodeLockUiModel, textFieldState: TextFieldState) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary).glow(),
+        modifier =
+            Modifier.fillMaxSize()
+                .background(Theme.v2.colors.backgrounds.primary)
+                .glow()
+                // The numeric keypad opens the moment this screen appears and covers roughly a
+                // third of the display. Insetting by it shrinks the centring box to what is
+                // actually visible, so the prompt re-centres above the keyboard instead of staying
+                // put and being half-covered.
+                .imePadding(),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier =
                 Modifier.widthIn(max = CONTENT_MAX_WIDTH)
                     .padding(horizontal = 16.dp)
-                    // The design sits the block slightly above true centre so the keyboard does not
-                    // crowd it once it opens.
-                    .padding(bottom = 56.dp),
+                    // Figma centres the block 28dp above the frame's midpoint; doubling that as
+                    // bottom padding shifts the centred content up by exactly that much.
+                    .padding(bottom = FIGMA_CENTRE_OFFSET * 2),
         ) {
             Text(
                 text = stringResource(R.string.passcode_lock_title),
@@ -151,6 +160,9 @@ private fun Modifier.glow(): Modifier = drawWithCache {
 }
 
 private val CONTENT_MAX_WIDTH = 360.dp
+
+/** Figma seats the content block this far above the frame's vertical midpoint. */
+private val FIGMA_CENTRE_OFFSET = 28.dp
 private val CardShape = RoundedCornerShape(12.dp)
 
 /** Figma tints the card with 10% of the normal border blue; there is no background token for it. */

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -162,6 +162,14 @@
     <string name="send_error_no_gas_fee">Keine Gasgebühren</string>
     <string name="send_screen_max">MAX</string>
     <string name="biometry_auth_login_button">Login mit Biometrie</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">App gesperrt</string>
+    <string name="passcode_lock_subtitle">Geben Sie Ihren Passcode ein, um fortzufahren.</string>
+    <string name="passcode_lock_wrong_passcode">Falscher Passcode, bitte versuchen Sie es erneut.</string>
+    <string name="passcode_lock_last_attempt">Falscher Passcode. Noch ein Versuch übrig.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Zu viele Versuche. Erneut versuchen in %1$d Sek.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Zu viele Versuche. Erneut versuchen in %1$d Min.</string>
     <string name="feature_item_learn_more">Erfahren Sie mehr</string>
     <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Keygen fehlgeschlagen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -163,6 +163,14 @@
     <string name="faq_settings_a5">Vultisig es gratuito. Solo se aplican las tarifas de red estándar para el envío. Y para los intercambios y puentes, hay una tarifa del 0,5 % (50 puntos básicos).</string>
     <string name="faq_settings_a6">Vultisig admite las principales criptomonedas y tokens, con más de 30 cadenas y sus tokens disponibles actualmente.</string>
     <string name="biometry_auth_login_button">Iniciar sesión con biometría</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">Aplicación bloqueada</string>
+    <string name="passcode_lock_subtitle">Introduzca su código de acceso para continuar.</string>
+    <string name="passcode_lock_wrong_passcode">Código de acceso incorrecto, inténtelo de nuevo.</string>
+    <string name="passcode_lock_last_attempt">Código de acceso incorrecto. Queda un intento.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Demasiados intentos. Inténtelo de nuevo en %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Demasiados intentos. Inténtelo de nuevo en %1$d min.</string>
     <string name="swap_form_from_title">De</string>
     <string name="swap_form_estimated_fees_title">Tarifa de intercambio</string>
     <string name="swap_form_estimated_fees_with_percent_title">Tarifa de intercambio (%1$s)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -162,6 +162,14 @@
     <string name="send_error_no_gas_fee">Nema naknade za plin</string>
     <string name="send_screen_max">MAKS</string>
     <string name="biometry_auth_login_button">Prijavite se biometrijom</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">Aplikacija je zaključana</string>
+    <string name="passcode_lock_subtitle">Unesite svoj pristupni kod za nastavak.</string>
+    <string name="passcode_lock_wrong_passcode">Netočan pristupni kod, pokušajte ponovno.</string>
+    <string name="passcode_lock_last_attempt">Netočan pristupni kod. Preostao je jedan pokušaj.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Previše pokušaja. Pokušajte ponovno za %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Previše pokušaja. Pokušajte ponovno za %1$d min.</string>
     <string name="feature_item_learn_more">Saznajte više</string>
     <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Keygen nije uspio</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -162,6 +162,14 @@
     <string name="send_error_no_gas_fee">Nessuna commissione per il gas</string>
     <string name="send_screen_max">Massimo</string>
     <string name="biometry_auth_login_button">Accedi con la biometria</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">App bloccata</string>
+    <string name="passcode_lock_subtitle">Inserisci il tuo codice di accesso per continuare.</string>
+    <string name="passcode_lock_wrong_passcode">Codice di accesso errato, riprova.</string>
+    <string name="passcode_lock_last_attempt">Codice di accesso errato. Resta un tentativo.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Troppi tentativi. Riprova tra %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Troppi tentativi. Riprova tra %1$d min.</string>
     <string name="feature_item_learn_more">Saperne di più</string>
     <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Keygen non riuscito</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -249,6 +249,14 @@
     <string name="faq_settings_a5">Vultisig는 무료로 사용할 수 있습니다. 보내기에는 표준 네트워크 수수료만 적용됩니다. 스왑과 브릿지에는 0.5% (50 bps) 수수료가 있습니다.</string>
     <string name="faq_settings_a6">Vultisig는 주요 암호화폐와 토큰을 지원하며, 현재 30개 이상의 체인과 해당 토큰을 사용할 수 있습니다.</string>
     <string name="biometry_auth_login_button">생체 인증으로 로그인</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">앱 잠김</string>
+    <string name="passcode_lock_subtitle">계속하려면 패스코드를 입력하세요.</string>
+    <string name="passcode_lock_wrong_passcode">패스코드가 틀렸습니다. 다시 시도해 주세요.</string>
+    <string name="passcode_lock_last_attempt">패스코드가 틀렸습니다. 1회 남았습니다.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">시도 횟수를 초과했습니다. %1$d초 후에 다시 시도하세요.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">시도 횟수를 초과했습니다. %1$d분 후에 다시 시도하세요.</string>
     <string name="swap_form_from_title">보내는 토큰</string>
     <string name="swap_form_estimated_fees_title">스왑 수수료</string>
     <string name="swap_form_estimated_fees_with_percent_title">스왑 수수료 (%1$s)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -173,6 +173,14 @@
     <string name="faq_settings_a5">Vultisig is gratis te gebruiken. Alleen de standaard netwerkkosten zijn van toepassing op verzenden. Voor ruilen en bridgen geldt een tarief van 0,5% (50 bps).</string>
     <string name="faq_settings_a6">Vultisig ondersteunt de belangrijkste cryptovaluta en tokens, met ondersteuning voor vele blockchains en hun tokens.</string>
     <string name="biometry_auth_login_button">Inloggen met biometrie</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">App vergrendeld</string>
+    <string name="passcode_lock_subtitle">Voer je toegangscode in om door te gaan.</string>
+    <string name="passcode_lock_wrong_passcode">Onjuiste toegangscode, probeer het opnieuw.</string>
+    <string name="passcode_lock_last_attempt">Onjuiste toegangscode. Nog één poging over.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Te veel pogingen. Probeer het opnieuw over %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Te veel pogingen. Probeer het opnieuw over %1$d min.</string>
     <string name="swap_form_from_title">Van</string>
     <string name="swap_form_estimated_fees_title">Wisselkosten</string>
     <string name="swap_form_estimated_fees_with_percent_title">Wisselkosten (%1$s)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -162,6 +162,14 @@
     <string name="send_error_no_gas_fee">Sem taxas de gás</string>
     <string name="send_screen_max">MÁXIMA</string>
     <string name="biometry_auth_login_button">Login com biometria</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">Aplicação bloqueada</string>
+    <string name="passcode_lock_subtitle">Introduza o seu código de acesso para continuar.</string>
+    <string name="passcode_lock_wrong_passcode">Código de acesso incorreto, tente novamente.</string>
+    <string name="passcode_lock_last_attempt">Código de acesso incorreto. Resta uma tentativa.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Demasiadas tentativas. Tente novamente em %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Demasiadas tentativas. Tente novamente em %1$d min.</string>
     <string name="feature_item_learn_more">Saber mais</string>
     <string name="keysign">Keysign</string>
     <string name="generating_key_screen_keygen_failed">Falha na geração de chaves</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -173,6 +173,14 @@
     <string name="faq_settings_a5">Vultisig предоставляется бесплатно. За отправку взимается только стандартная комиссия сети. За обмены и мосты взимается комиссия в размере 0,5% (50 б.с.).</string>
     <string name="faq_settings_a6">Vultisig поддерживает основные криптовалюты и токены, в настоящее время доступно более 30 сетей и их токенов.</string>
     <string name="biometry_auth_login_button">Вход с использованием биометрии</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">Приложение заблокировано</string>
+    <string name="passcode_lock_subtitle">Введите код-пароль, чтобы продолжить.</string>
+    <string name="passcode_lock_wrong_passcode">Неверный код-пароль, попробуйте еще раз.</string>
+    <string name="passcode_lock_last_attempt">Неверный код-пароль. Осталась одна попытка.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Слишком много попыток. Повторите через %1$d с.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Слишком много попыток. Повторите через %1$d мин.</string>
     <string name="swap_form_from_title">Из</string>
     <string name="swap_form_estimated_fees_title">Комиссия за обмен</string>
     <string name="swap_form_estimated_fees_with_percent_title">Комиссия за обмен (%1$s)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -309,6 +309,14 @@
     <!-- Biometry Auth -->
     <string name="biometry_auth_login_button">使用生物识别登录</string>
 
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">应用已锁定</string>
+    <string name="passcode_lock_subtitle">输入密码以继续。</string>
+    <string name="passcode_lock_wrong_passcode">密码错误，请重试。</string>
+    <string name="passcode_lock_last_attempt">密码错误，还剩 1 次机会。</string>
+    <string name="passcode_lock_too_many_attempts_seconds">尝试次数过多，请在 %1$d 秒后重试。</string>
+    <string name="passcode_lock_too_many_attempts_minutes">尝试次数过多，请在 %1$d 分钟后重试。</string>
+
     <!-- Swap Form -->
     <string name="swap_form_from_title">从</string>
     <string name="swap_form_estimated_fees_title">交换费用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,14 @@
     <string name="faq_settings_a5">Vultisig is free to use. Only standard network fees apply to sending. And for swaps and bridges, there\'s a 0.5% (50 bps) fee.</string>
     <string name="faq_settings_a6">Vultisig supports major cryptocurrencies and tokens, with over 30 chains and their tokens, currently available.</string>
     <string name="biometry_auth_login_button">Login with biometry</string>
+
+    <!-- Passcode App Lock -->
+    <string name="passcode_lock_title">App Locked</string>
+    <string name="passcode_lock_subtitle">Enter your passcode to continue.</string>
+    <string name="passcode_lock_wrong_passcode">Wrong passcode. Try again.</string>
+    <string name="passcode_lock_last_attempt">Wrong passcode. One attempt left.</string>
+    <string name="passcode_lock_too_many_attempts_seconds">Too many attempts. Try again in %1$d s.</string>
+    <string name="passcode_lock_too_many_attempts_minutes">Too many attempts. Try again in %1$d min.</string>
     <string name="swap_form_from_title">From</string>
     <string name="swap_form_estimated_fees_title">Swap Fee</string>
     <string name="swap_form_estimated_fees_with_percent_title">Swap Fee (%1$s)</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModelTest.kt
@@ -1,0 +1,146 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.passcode
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeUnlockResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Unit tests for [PasscodeLockViewModel]. */
+internal class PasscodeLockViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var passcodeRepository: PasscodeRepository
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        passcodeRepository = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() = PasscodeLockViewModel(passcodeRepository)
+
+    /**
+     * Types [text] into the field the way the UI would. The view model observes the field through
+     * `snapshotFlow`, which only re-emits once snapshot changes are published — without this the
+     * second and later edits in a test are silently invisible to it.
+     */
+    private fun TextFieldState.type(text: String) {
+        setTextAndPlaceCursorAtEnd(text)
+        Snapshot.sendApplyNotifications()
+    }
+
+    @Test
+    fun `does not verify until all five digits are entered`() = runTest {
+        val model = viewModel()
+
+        model.textFieldState.type("1234")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { passcodeRepository.unlock(any()) }
+    }
+
+    @Test
+    fun `verifies as soon as the fifth digit lands`() = runTest {
+        coEvery { passcodeRepository.unlock("12345") } returns PasscodeUnlockResult.Success
+        val model = viewModel()
+
+        model.textFieldState.type("12345")
+        advanceUntilIdle()
+
+        coVerify { passcodeRepository.unlock("12345") }
+        assertNull(model.state.value.error)
+    }
+
+    @Test
+    fun `a wrong passcode clears the field and reports the attempts left`() = runTest {
+        coEvery { passcodeRepository.unlock(any()) } returns PasscodeUnlockResult.Wrong(3)
+        val model = viewModel()
+
+        model.textFieldState.type("00000")
+        advanceUntilIdle()
+
+        assertEquals(PasscodeLockError.Wrong(3), model.state.value.error)
+        assertEquals("", model.textFieldState.text.toString())
+        assertTrue(model.state.value.isInputEnabled)
+    }
+
+    @Test
+    fun `the error clears once the user starts typing again`() = runTest {
+        coEvery { passcodeRepository.unlock(any()) } returns PasscodeUnlockResult.Wrong(3)
+        val model = viewModel()
+        model.textFieldState.type("00000")
+        advanceUntilIdle()
+
+        model.textFieldState.type("1")
+        advanceUntilIdle()
+
+        assertNull(model.state.value.error)
+    }
+
+    @Test
+    fun `a lockout disables input and counts down to zero`() = runTest {
+        coEvery { passcodeRepository.unlock(any()) } returns PasscodeUnlockResult.LockedOut(3_000L)
+        val model = viewModel()
+
+        model.textFieldState.type("00000")
+        // runCurrent, not advanceUntilIdle: the latter would fast-forward straight through the
+        // countdown's delays and land on the cleared state, testing nothing.
+        runCurrent()
+
+        assertEquals(PasscodeLockError.LockedOut(3), model.state.value.error)
+        assertFalse(model.state.value.isInputEnabled)
+
+        advanceTimeBy(1_100)
+        runCurrent()
+        assertEquals(PasscodeLockError.LockedOut(2), model.state.value.error)
+
+        advanceTimeBy(2_000)
+        runCurrent()
+        assertNull(model.state.value.error)
+        assertTrue(model.state.value.isInputEnabled)
+    }
+
+    @Test
+    fun `input stays disabled while an attempt is in flight`() = runTest {
+        coEvery { passcodeRepository.unlock(any()) } coAnswers
+            {
+                delay(1_000)
+                PasscodeUnlockResult.Success
+            }
+        val model = viewModel()
+
+        model.textFieldState.type("12345")
+        advanceTimeBy(100)
+
+        assertTrue(model.state.value.isVerifying)
+        assertFalse(model.state.value.isInputEnabled)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeLockViewModelTest.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshots.Snapshot
 import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
 import com.vultisig.wallet.data.passcode.PasscodeUnlockResult
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -17,6 +19,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,11 +36,14 @@ internal class PasscodeLockViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var passcodeRepository: PasscodeRepository
+    private val passcodeState = MutableStateFlow<PasscodeState>(PasscodeState.Unlocked)
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         passcodeRepository = mockk(relaxed = true)
+        passcodeState.value = PasscodeState.Unlocked
+        every { passcodeRepository.state } returns passcodeState
     }
 
     @AfterEach
@@ -46,6 +52,26 @@ internal class PasscodeLockViewModelTest {
     }
 
     private fun viewModel() = PasscodeLockViewModel(passcodeRepository)
+
+    @Test
+    fun `re-locking wipes whatever the previous prompt was left holding`() = runTest {
+        // The guard hosts this view model outside the nav graph, so it is activity-scoped and one
+        // instance serves every lock. A rejected attempt must not still be on screen next time.
+        coEvery { passcodeRepository.unlock(any()) } returns PasscodeUnlockResult.Wrong(3)
+        val model = viewModel()
+        model.textFieldState.type("00000")
+        advanceUntilIdle()
+        Snapshot.sendApplyNotifications()
+        advanceUntilIdle()
+        model.textFieldState.type("12")
+        advanceUntilIdle()
+
+        passcodeState.value = PasscodeState.Locked
+        advanceUntilIdle()
+
+        assertEquals("", model.textFieldState.text.toString())
+        assertNull(model.state.value.error)
+    }
 
     /**
      * Types [text] into the field the way the UI would. The view model observes the field through
@@ -90,6 +116,22 @@ internal class PasscodeLockViewModelTest {
         assertEquals(PasscodeLockError.Wrong(3), model.state.value.error)
         assertEquals("", model.textFieldState.text.toString())
         assertTrue(model.state.value.isInputEnabled)
+    }
+
+    @Test
+    fun `the error survives the field being cleared by the failure itself`() = runTest {
+        // The view model clears the field on a wrong passcode, and that clear is itself an emission
+        // from the field's flow. If the collector treats it like the user starting over, the error
+        // is wiped in the same frame it appears and nothing is ever shown.
+        coEvery { passcodeRepository.unlock(any()) } returns PasscodeUnlockResult.Wrong(3)
+        val model = viewModel()
+
+        model.textFieldState.type("00000")
+        advanceUntilIdle()
+        Snapshot.sendApplyNotifications()
+        advanceUntilIdle()
+
+        assertEquals(PasscodeLockError.Wrong(3), model.state.value.error)
     }
 
     @Test


### PR DESCRIPTION
Part 3 of 5 for #5343. Stacked on #5529.

Builds the lock screen to the Figma frame [79816-126646](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=79816-126646). Nothing routes to it yet — the guard that shows it and the settings that enable a passcode land in parts 4 and 5.

## Design

The five cells, the card that holds them, the type ramp and the backdrop wash all come from the design; tokens map 1:1 (`backgrounds.surface1`, `border.light`, `primary.accent4`, `headings.largeTitle`, `supplementary.footnote`). The card tint and the 10% white hairlines have no token, so they are named constants.

Only the filled and error states are mine: the frame ships a Default state alone, so a filled cell reuses the design's own accent treatment and a rejected passcode borrows the existing `alerts.error` token rather than inventing a colour.

## Why a new component

Entry is masked. `VsCodeInputField` renders the digits it holds, which is right for a backup code mailed to the user and wrong for a passcode guarding their vaults. This keeps that component's mechanic — an invisible 1dp `BasicTextField` owning input and keyboard, visible cells drawn from its text — so the two behave the same under focus and IME.

Verification fires on the fifth digit rather than behind a button, which is what the design implies with no CTA on the frame.

## Fixes found on device

The second commit fixes three things caught by running this on hardware:

- **The error never appeared.** Rejecting a passcode empties the field, and that empty is itself an emission from the field's flow — the collector read it as the user starting over and cleared the error in the same frame it was set. Only a non-empty field counts as starting over now. The original tests passed through this because `snapshotFlow` does not re-emit in a JVM test until snapshot changes are published, and they only published their own edits; they now publish the view model's clear too, and fail without the fix.
- **The prompt did not move when the keypad opened**, leaving it low and half-covered. It now insets by the IME and centres in what is visible.
- **Locking did not reset the prompt.** The guard hosts this view model outside the nav graph, so it is activity-scoped and one instance serves every lock; a half-typed attempt was still in the cells next time.

## Test plan

- `./gradlew :app:testDebugUnitTest` — 8 view-model tests: auto-submit on the fifth digit, attempt countdown, error persistence, throttle countdown, reset on re-lock.
- Rendered on an emulator via the debug preview harness (`adb shell am start -n com.vultisig.wallet/com.vultisig.wallet.debug.PreviewActivity -e screen passcode_lock_error`), keyboard open and closed.
- Strings land in all ten locales, using each one's established wording for a passcode rather than reusing the wallet-password term.