### PR TITLE
Passcode app-lock 4/5: gate the app and re-lock on idle

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -44,6 +45,7 @@ import com.google.android.play.core.install.model.AppUpdateType
 import com.vultisig.wallet.app.activity.components.AnimatedSplash
 import com.vultisig.wallet.app.activity.components.CheckDeeplink
 import com.vultisig.wallet.app.activity.components.MainActivityContent
+import com.vultisig.wallet.app.passcode.PasscodeAutoLock
 import com.vultisig.wallet.data.repositories.PreventScreenshotsRepository
 import com.vultisig.wallet.data.services.VultisigFirebaseMessagingService
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
@@ -65,6 +67,8 @@ class MainActivity : AppCompatActivity() {
     @Inject lateinit var preventScreenshotsRepository: PreventScreenshotsRepository
 
     @Inject internal lateinit var snackbarFlow: SnackbarFlow
+
+    @Inject internal lateinit var passcodeAutoLock: PasscodeAutoLock
 
     private val pushNotificationReceiver =
         object : BroadcastReceiver() {
@@ -107,6 +111,11 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge(statusBarStyle = systemBarStyle, navigationBarStyle = systemBarStyle)
 
         observePreventScreenshots()
+
+        // Observes the whole process, not this activity, so rotating or re-entering the task does
+        // not read as leaving the app. Registered here rather than at startup so it cannot pull the
+        // keystore-backed preferences onto the main thread before they are warmed.
+        passcodeAutoLock.start(ProcessLifecycleOwner.get().lifecycle)
 
         setContent {
             @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -43,7 +43,6 @@ import com.vultisig.wallet.app.activity.ForegroundNotificationState
 import com.vultisig.wallet.app.activity.MainViewModel
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
-import com.vultisig.wallet.ui.components.BiometryAuthScreen
 import com.vultisig.wallet.ui.components.banners.ForegroundNotificationBanner
 import com.vultisig.wallet.ui.components.banners.OfflineBanner
 import com.vultisig.wallet.ui.components.v2.snackbar.VsSnackBar
@@ -53,6 +52,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SetupNavGraph
 import com.vultisig.wallet.ui.navigation.route
 import com.vultisig.wallet.ui.screens.home.VaultAccountsScreen
+import com.vultisig.wallet.ui.screens.passcode.PasscodeGuard
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import com.vultisig.wallet.ui.utils.asString
@@ -119,7 +119,7 @@ internal fun MainActivityContent(
             SetupNavGraph(navController = navController, startDestination = startDestination)
         },
         overlayContent = {
-            BiometryAuthScreen()
+            PasscodeGuard()
 
             VsSnackBar(
                 modifier = Modifier.align(Alignment.BottomCenter),

--- a/app/src/main/java/com/vultisig/wallet/app/passcode/PasscodeAutoLock.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/passcode/PasscodeAutoLock.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.app.passcode
+
+import android.os.SystemClock
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.vultisig.wallet.data.passcode.AutoLockRepository
+import com.vultisig.wallet.data.passcode.AutoLockTimeout
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Re-locks the app once it has been out of the foreground for longer than the user's chosen
+ * timeout.
+ *
+ * Two mechanisms, because neither is sufficient alone. A timer started on background covers the
+ * common case and means the data key is not held in memory a moment longer than the user asked for.
+ * But a backgrounded process can be frozen or killed before that timer fires, so the elapsed time
+ * is also re-checked on return. Whichever notices first wins.
+ *
+ * [SystemClock.elapsedRealtime] is the clock for that check: it keeps counting through deep sleep,
+ * unlike uptime, and cannot be wound backwards by changing the system time.
+ */
+@Singleton
+internal class PasscodeAutoLock(
+    private val passcodeRepository: PasscodeRepository,
+    private val autoLockRepository: AutoLockRepository,
+    private val elapsedRealtimeMillis: () -> Long,
+    parentScope: CoroutineScope?,
+) : DefaultLifecycleObserver {
+
+    @Inject
+    constructor(
+        passcodeRepository: PasscodeRepository,
+        autoLockRepository: AutoLockRepository,
+    ) : this(passcodeRepository, autoLockRepository, SystemClock::elapsedRealtime, null)
+
+    // Main.immediate so the lock lands in the same frame the app leaves the foreground, before
+    // anything can screenshot the task for the recents list.
+    private val scope = parentScope ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /**
+     * Mirrors the persisted timeout so [onStop] can decide synchronously. Reading the flow at that
+     * moment would suspend, and the app can be frozen before the read completes.
+     */
+    @Volatile private var timeout: AutoLockTimeout = AutoLockTimeout.Default
+
+    private var backgroundedAtMillis: Long? = null
+    private var pendingLock: Job? = null
+
+    /** Starts mirroring the timeout and observing [lifecycle]. Safe to call once per process. */
+    fun start(lifecycle: Lifecycle) {
+        scope.launch { autoLockRepository.timeout.collect { timeout = it } }
+        lifecycle.addObserver(this)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        val current = timeout
+        if (current == AutoLockTimeout.Immediate) {
+            Timber.d("Auto-locking immediately on background")
+            passcodeRepository.lock()
+            return
+        }
+
+        backgroundedAtMillis = elapsedRealtimeMillis()
+        pendingLock?.cancel()
+        pendingLock =
+            scope.launch {
+                delay(current.minutes * MILLIS_PER_MINUTE)
+                Timber.d("Auto-locking after %d minute(s) in the background", current.minutes)
+                passcodeRepository.lock()
+            }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        pendingLock?.cancel()
+        pendingLock = null
+
+        val backgroundedAt = backgroundedAtMillis ?: return
+        backgroundedAtMillis = null
+
+        val awayMillis = elapsedRealtimeMillis() - backgroundedAt
+        if (awayMillis >= timeout.minutes * MILLIS_PER_MINUTE) {
+            Timber.d("Auto-locking: away for %d ms", awayMillis)
+            passcodeRepository.lock()
+        }
+    }
+
+    private companion object {
+        const val MILLIS_PER_MINUTE = 60_000L
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
@@ -1,0 +1,25 @@
+package com.vultisig.wallet.ui.models.passcode
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** Exposes the lock state that decides whether the app content or the lock screen is shown. */
+@HiltViewModel
+internal class PasscodeGuardViewModel
+@Inject
+constructor(private val passcodeRepository: PasscodeRepository) : ViewModel() {
+
+    val state: StateFlow<PasscodeState> = passcodeRepository.state
+
+    init {
+        // Reads the persisted credentials off the main thread; until it completes the state stays
+        // Unknown and the guard shows nothing rather than flashing unlocked content.
+        viewModelScope.launch { passcodeRepository.initialize() }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
@@ -1,0 +1,37 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vultisig.wallet.data.passcode.PasscodeState
+import com.vultisig.wallet.ui.components.BiometryAuthScreen
+import com.vultisig.wallet.ui.models.passcode.PasscodeGuardViewModel
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * The app's entry gate.
+ *
+ * A configured passcode takes over from the device-credential prompt entirely rather than stacking
+ * on top of it — two consecutive unlocks to open the app would be a worse experience than either
+ * alone, and the passcode is the stronger gate because it also holds the key to the encrypted
+ * keyshares.
+ */
+@Composable
+internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
+    val state by model.state.collectAsStateWithLifecycle()
+
+    when (state) {
+        // Persisted state is still loading. An opaque cover, not nothing: the alternative is a
+        // frame or two of unlocked content before the lock screen appears.
+        PasscodeState.Unknown ->
+            Box(Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary))
+        PasscodeState.Locked -> PasscodeLockScreen()
+        PasscodeState.Unlocked -> Unit
+        PasscodeState.Disabled -> BiometryAuthScreen()
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/app/passcode/PasscodeAutoLockTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/app/passcode/PasscodeAutoLockTest.kt
@@ -1,0 +1,156 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.app.passcode
+
+import androidx.lifecycle.LifecycleOwner
+import com.vultisig.wallet.data.passcode.AutoLockRepository
+import com.vultisig.wallet.data.passcode.AutoLockTimeout
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Unit tests for [PasscodeAutoLock]. */
+internal class PasscodeAutoLockTest {
+
+    private lateinit var passcodeRepository: PasscodeRepository
+    private lateinit var autoLockRepository: AutoLockRepository
+    private lateinit var owner: LifecycleOwner
+    private val timeout = MutableStateFlow(AutoLockTimeout.Default)
+    private var elapsedRealtime = 100_000L
+
+    @BeforeEach
+    fun setUp() {
+        passcodeRepository = mockk(relaxed = true)
+        autoLockRepository = mockk(relaxed = true)
+        owner = mockk(relaxed = true)
+        every { autoLockRepository.timeout } returns timeout
+        elapsedRealtime = 100_000L
+    }
+
+    private fun autoLock(scope: CoroutineScope) =
+        PasscodeAutoLock(
+            passcodeRepository = passcodeRepository,
+            autoLockRepository = autoLockRepository,
+            elapsedRealtimeMillis = { elapsedRealtime },
+            parentScope = scope,
+        )
+
+    /**
+     * Starts the mirror of the persisted timeout without registering a real lifecycle. Runs in
+     * [TestScope.backgroundScope] because the timeout collector never completes, and a never-ending
+     * child of the test scope itself would hang `runTest`.
+     */
+    private fun TestScope.started(): PasscodeAutoLock =
+        autoLock(backgroundScope).also { it.start(mockk(relaxed = true)) }.also { runCurrent() }
+
+    @Test
+    fun `the default timeout locks the moment the app is backgrounded`() = runTest {
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+
+        verify { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `a timed lock does not fire before the timeout elapses`() = runTest {
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+        advanceTimeBy(4 * 60_000L)
+        runCurrent()
+
+        verify(exactly = 0) { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `a timed lock fires once the timeout elapses in the background`() = runTest {
+        timeout.value = AutoLockTimeout.OneMinute
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+        advanceTimeBy(60_001L)
+        runCurrent()
+
+        verify { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `returning before the timeout cancels the pending lock`() = runTest {
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+        advanceTimeBy(60_000L)
+        elapsedRealtime += 60_000L
+        autoLock.onStart(owner)
+        advanceTimeBy(10 * 60_000L)
+        runCurrent()
+
+        verify(exactly = 0) { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `a process frozen past its timeout still locks on return`() = runTest {
+        // The scheduled job never got to run, so the elapsed-time check is the only thing standing
+        // between a frozen process and an unlocked app.
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+        elapsedRealtime += 6 * 60_000L
+        autoLock.onStart(owner)
+        runCurrent()
+
+        verify { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `a wound-back clock cannot shorten the away time`() = runTest {
+        // elapsedRealtime is monotonic, so a backwards jump yields a negative delta rather than a
+        // spuriously large one. Either way it must not read as "long enough to stay unlocked".
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        autoLock.onStop(owner)
+        elapsedRealtime -= 60 * 60_000L
+        autoLock.onStart(owner)
+        runCurrent()
+
+        verify(exactly = 0) { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `returning without having been backgrounded does not lock`() = runTest {
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        autoLock.onStart(owner)
+        runCurrent()
+
+        verify(exactly = 0) { passcodeRepository.lock() }
+    }
+
+    @Test
+    fun `changing the timeout takes effect without a restart`() = runTest {
+        timeout.value = AutoLockTimeout.FiveMinutes
+        val autoLock = started()
+
+        timeout.value = AutoLockTimeout.Immediate
+        runCurrent()
+        autoLock.onStop(owner)
+
+        verify { passcodeRepository.lock() }
+    }
+}


### PR DESCRIPTION
Part 4 of 5 for #5343. Stacked on #5530.

The commit that makes the feature real: the lock screen from part 3 now guards the app, and the app re-locks itself after the configured idle timeout. Setting a passcode is still only possible from part 5, so an install that has never set one is unaffected.

## Replacing, not stacking, the existing gate

A configured passcode takes over from the device-credential prompt rather than sitting on top of it. Two consecutive unlocks to open the app would be worse than either alone, and the passcode is the stronger of the two because it also holds the key to the encrypted keyshares. **With no passcode set, `BiometryAuthScreen` behaves exactly as before.**

While the persisted state is still loading the guard shows an opaque cover rather than nothing, otherwise a locked app flashes a frame or two of its contents before the lock screen arrives.

## Auto-lock

Runs off the **process** lifecycle, not an activity's, so rotating or re-entering the task is not mistaken for leaving the app.

It locks two ways because neither alone is enough: a timer fires in the background so the data key is not held a moment longer than the user asked for, and the elapsed time is re-checked on return to cover a process that was frozen or killed before that timer could run. The elapsed check reads `elapsedRealtime`, which keeps counting through deep sleep and cannot be wound backwards from Settings.

The chosen timeout is mirrored into a field rather than read when backgrounding, because reading the flow at that moment suspends and the process can be frozen before the read returns.

## Test plan

- `./gradlew :app:testDebugUnitTest` — 8 tests: immediate lock, timed lock firing and not firing early, cancellation on early return, the frozen-process path, a wound-back clock, and a timeout change taking effect without a restart.
- Manual, once part 5 lands: set a passcode, background the app past each timeout, confirm it locks; return within the timeout and confirm it does not.