### PR TITLE
feat(design-system): add the corner-radius token scale

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
@@ -194,7 +194,7 @@ private fun BadgeText(text: String) {
         modifier =
             Modifier.background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(4.dp),
+                    shape = Theme.v2.radius.xs,
                 )
                 .padding(horizontal = 6.dp, vertical = 2.dp),
         color = Theme.v2.colors.text.primary,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.library.form.FormCard
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.icons.VaultIcon
 import com.vultisig.wallet.ui.theme.Theme
@@ -62,10 +61,7 @@ internal fun VaultCeil(
 
     val (logoBackground, logoBorder) = logo
     FormCard {
-        V2Container(
-            type = containerType,
-            cornerType = CornerType.RoundedCornerShape(size = 12.dp),
-        ) {
+        V2Container(type = containerType, radius = Theme.v2.radius.md) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,7 +62,7 @@ internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modi
                 .fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.surface2,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.lg,
                 )
                 .padding(20.dp)
                 .semantics(mergeDescendants = true) { contentDescription = announcement },

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -119,12 +118,12 @@ private fun ShowExactErrorRow(modifier: Modifier = Modifier, onClick: () -> Unit
                 .fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.surface1,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.lg,
                 )
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.lg,
                 )
                 .clickable(onClick = onClick)
                 .padding(20.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/library/form/Form.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/library/form/Form.kt
@@ -119,7 +119,7 @@ internal fun TokenCard(
                             .border(
                                 width = 1.dp,
                                 color = Theme.v2.colors.neutrals.n50,
-                                shape = RoundedCornerShape(4.dp),
+                                shape = Theme.v2.radius.xs,
                             )
                             .align(BottomEnd),
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/V2Container.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/V2Container.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -15,9 +13,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.Radius
 import com.vultisig.wallet.ui.theme.v2.V2.colors
 
 internal enum class ContainerType {
@@ -32,18 +30,12 @@ internal sealed interface ContainerBorderType {
     data class Bordered(val color: Color = colors.border.light) : ContainerBorderType
 }
 
-internal sealed interface CornerType {
-    object Circular : CornerType
-
-    data class RoundedCornerShape(val size: Dp = 12.dp) : CornerType
-}
-
 @Composable
 internal fun V2Container(
     modifier: Modifier = Modifier,
     type: ContainerType = ContainerType.PRIMARY,
     borderType: ContainerBorderType = ContainerBorderType.Borderless,
-    cornerType: CornerType = CornerType.RoundedCornerShape(),
+    radius: Radius = Theme.v2.radius.md,
     content: @Composable () -> Unit,
 ) {
     val containerColor =
@@ -59,18 +51,12 @@ internal fun V2Container(
             is ContainerBorderType.Bordered -> borderType.color
         }
 
-    val shape =
-        when (cornerType) {
-            CornerType.Circular -> CircleShape
-            is CornerType.RoundedCornerShape -> RoundedCornerShape(size = cornerType.size)
-        }
-
     val containerColorAnimated by animateColorAsState(containerColor)
     val borderColorAnimated by animateColorAsState(borderColor)
 
     Card(
         modifier = modifier,
-        shape = shape,
+        shape = radius,
         colors = CardDefaults.cardColors(containerColor = containerColorAnimated),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         border = BorderStroke(width = 1.dp, color = borderColorAnimated),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/fastselection/components/FastSelectionModalContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/fastselection/components/FastSelectionModalContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -191,7 +190,7 @@ internal fun <T : Any> FastSelectionModalContent(
                                 Modifier.wrapContentHeight()
                             }
                         )
-                        .clip(RoundedCornerShape(24.dp))
+                        .clip(Theme.v2.radius.xl)
                         .background(
                             color = Theme.v2.colors.backgrounds.tertiary_2.copy(alpha = 0.5f)
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/searchbar/SearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/searchbar/SearchBar.kt
@@ -36,7 +36,6 @@ import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -69,7 +68,7 @@ internal fun SearchBar(
                     ContainerBorderType.Bordered(color = Theme.v2.colors.border.light)
                 else ContainerBorderType.Borderless,
             modifier = Modifier.weight(1f),
-            cornerType = CornerType.Circular,
+            radius = Theme.v2.radius.pill,
         ) {
             BasicTextField(
                 state = state,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/snackbar/VsSnackbar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/snackbar/VsSnackbar.kt
@@ -22,7 +22,6 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.loading.V2ProgressiveLoading
 import com.vultisig.wallet.ui.theme.Theme
@@ -56,7 +55,7 @@ private fun VsSnackBarContent(modifier: Modifier, snackbarState: ProgressState) 
         modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp),
         type = ContainerType.TERTIARY,
         borderType = ContainerBorderType.Bordered(color = Theme.v2.colors.border.light),
-        cornerType = CornerType.RoundedCornerShape(size = 24.dp),
+        radius = Theme.v2.radius.xl,
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(16.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
@@ -230,16 +231,16 @@ private fun androidx.compose.foundation.layout.BoxScope.FooterSummary(
     isValidForm: Boolean,
     onSubmit: () -> Unit,
 ) {
+    // Docked to the bottom edge, so only the top corners are drawn. Derived from the token rather
+    // than restated, so the clip and the border that traces it cannot drift apart.
+    val topCornersOnly =
+        Theme.v2.radius.lg.shape.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
     Column(
         modifier =
             Modifier.align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-                .border(
-                    width = 1.dp,
-                    color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-                )
+                .clip(topCornersOnly)
+                .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = topCornersOnly)
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/folder/CreateFolderScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/folder/CreateFolderScreen.kt
@@ -61,7 +61,6 @@ import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.models.folder.CreateFolderUiModel
@@ -359,7 +358,7 @@ fun FolderNameTextField(textFieldState: TextFieldState) {
         borderType =
             if (isFocusedState) ContainerBorderType.Bordered(color = Theme.v2.colors.border.normal)
             else ContainerBorderType.Borderless,
-        cornerType = CornerType.RoundedCornerShape(size = 12.dp),
+        radius = Theme.v2.radius.md,
     ) {
         BasicTextField(
             state = textFieldState,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
@@ -52,7 +52,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
@@ -192,7 +191,7 @@ internal fun TransactionHistoryScreen(
                 UiSpacer(weight = 1f)
                 V2Container(
                     modifier = Modifier.clickOnce(onClick = onSearchClick),
-                    cornerType = CornerType.Circular,
+                    radius = Theme.v2.radius.pill,
                     type = ContainerType.SECONDARY,
                     borderType = ContainerBorderType.Borderless,
                 ) {
@@ -454,13 +453,17 @@ internal fun TransactionHistoryEmptyState(modifier: Modifier = Modifier) {
                     1.0f to Theme.v2.colors.backgrounds.surface1,
                 )
         )
+    // The border is drawn onto the canvas, which takes a raw radius rather than a shape, so this is
+    // one of the few places the token's size is read directly. It has to stay the same token as the
+    // background below or the stroke stops tracing the surface it outlines.
+    val radius = Theme.v2.radius.md
     Box(
         modifier =
             modifier.drawWithContent {
                 drawContent()
                 drawRoundRect(
                     brush = borderBrush,
-                    cornerRadius = CornerRadius(12.dp.toPx()),
+                    cornerRadius = CornerRadius(radius.size.toPx()),
                     style = Stroke(width = 1.dp.toPx()),
                 )
             },
@@ -469,10 +472,7 @@ internal fun TransactionHistoryEmptyState(modifier: Modifier = Modifier) {
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .background(
-                        color = Theme.v2.colors.backgrounds.surface1,
-                        shape = RoundedCornerShape(12.dp),
-                    )
+                    .background(color = Theme.v2.colors.backgrounds.surface1, shape = radius)
                     .padding(horizontal = 40.dp, vertical = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainAccount.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainAccount.kt
@@ -31,7 +31,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.texts.LoadableValue
 import com.vultisig.wallet.ui.theme.Theme
@@ -98,7 +97,7 @@ internal fun ChainAccount(
             V2Container(
                 type = ContainerType.TERTIARY,
                 borderType = ContainerBorderType.Borderless,
-                cornerType = CornerType.RoundedCornerShape(size = 8.dp),
+                radius = Theme.v2.radius.sm,
             ) {
                 LoadableValue(
                     value = price,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainTokensTabMenuAndSearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainTokensTabMenuAndSearchBar.kt
@@ -20,7 +20,6 @@ import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.TabMenuAndSearchBar
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
@@ -66,7 +65,7 @@ fun ChainTokensTabMenuAndSearchBar(
 
                 V2Container(
                     type = ContainerType.SECONDARY,
-                    cornerType = CornerType.Circular,
+                    radius = Theme.v2.radius.pill,
                     modifier = Modifier.clickOnce(onClick = onSearchClick),
                 ) {
                     UiIcon(
@@ -80,7 +79,7 @@ fun ChainTokensTabMenuAndSearchBar(
 
                 V2Container(
                     type = ContainerType.SECONDARY,
-                    cornerType = CornerType.Circular,
+                    radius = Theme.v2.radius.pill,
                     modifier = Modifier.clickOnce(onClick = onEditClick),
                 ) {
                     UiIcon(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/CustomTokenSearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/CustomTokenSearchBar.kt
@@ -29,7 +29,6 @@ import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -45,7 +44,7 @@ internal fun CustomTokenSearchBar(
         V2Container(
             modifier = Modifier.weight(1f).height(40.dp),
             type = ContainerType.SECONDARY,
-            cornerType = CornerType.Circular,
+            radius = Theme.v2.radius.pill,
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/LoadingSearchCustomToken.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/LoadingSearchCustomToken.kt
@@ -15,7 +15,6 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.loading.V2Loading
 import com.vultisig.wallet.ui.theme.Theme
@@ -24,7 +23,7 @@ import com.vultisig.wallet.ui.theme.Theme
 internal fun LoadingSearchCustomToken() {
     V2Container(
         type = ContainerType.TERTIARY,
-        cornerType = CornerType.RoundedCornerShape(size = 24.dp),
+        radius = Theme.v2.radius.xl,
         borderType = ContainerBorderType.Bordered(color = Theme.v2.colors.border.light),
     ) {
         Column(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/TokenNotFoundError.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/customtoken/components/TokenNotFoundError.kt
@@ -19,16 +19,12 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
 internal fun TokenNotFoundError(onRetryClick: () -> Unit) {
-    V2Container(
-        type = ContainerType.SECONDARY,
-        cornerType = CornerType.RoundedCornerShape(size = 12.dp),
-    ) {
+    V2Container(type = ContainerType.SECONDARY, radius = Theme.v2.radius.md) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -64,7 +64,6 @@ import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tokenitem.GridTokenUiModel
 import com.vultisig.wallet.ui.components.v2.tokenitem.NoFoundContent
@@ -528,7 +527,7 @@ internal fun ManagePositionsButton(
 ) {
     V2Container(
         type = ContainerType.SECONDARY,
-        cornerType = CornerType.Circular,
+        radius = Theme.v2.radius.pill,
         modifier = modifier.clickOnce(enabled = isEnabled, onClick = onClick),
     ) {
         UiIcon(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/ChooseVaultButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/ChooseVaultButton.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType.Bordered
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType.SECONDARY
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -29,7 +28,7 @@ internal fun ChooseVaultButton(
 ) {
     V2Container(
         modifier = modifier.clickOnce(onClick = onClick),
-        cornerType = CornerType.Circular,
+        radius = Theme.v2.radius.pill,
         borderType = Bordered(),
         type = SECONDARY,
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/HomePageTabMenu.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/HomePageTabMenu.kt
@@ -23,7 +23,6 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
@@ -65,7 +64,7 @@ internal fun HomePageTabMenu(
         ) {
             V2Container(
                 modifier = Modifier.clickOnce(onClick = onSearchClick),
-                cornerType = CornerType.Circular,
+                radius = Theme.v2.radius.pill,
                 type = ContainerType.SECONDARY,
                 borderType = ContainerBorderType.Borderless,
             ) {
@@ -81,7 +80,7 @@ internal fun HomePageTabMenu(
             if (isEditVisible) {
                 V2Container(
                     modifier = Modifier.clickOnce(onClick = onEditClick),
-                    cornerType = CornerType.Circular,
+                    radius = Theme.v2.radius.pill,
                     type = ContainerType.SECONDARY,
                     borderType = ContainerBorderType.Borderless,
                 ) {
@@ -111,10 +110,7 @@ private fun HomepageTab(
 
             Spacer(modifier = Modifier.width(6.dp))
 
-            V2Container(
-                type = ContainerType.SECONDARY,
-                cornerType = CornerType.RoundedCornerShape(8.dp),
-            ) {
+            V2Container(type = ContainerType.SECONDARY, radius = Theme.v2.radius.sm) {
                 Text(
                     text = stringResource(R.string.search_bar_soon),
                     color = Theme.v2.colors.alerts.info,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/receive/ReceiveBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/receive/ReceiveBottomSheet.kt
@@ -30,7 +30,6 @@ import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
-import com.vultisig.wallet.ui.components.v2.containers.CornerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.searchbar.SearchBar
 import com.vultisig.wallet.ui.models.ChainToReceiveUiModel
@@ -99,7 +98,7 @@ private fun ReceiveContent(
                             UiSpacer(size = 24.dp)
 
                             V2Container(
-                                cornerType = CornerType.Circular,
+                                radius = Theme.v2.radius.pill,
                                 borderType = ContainerBorderType.Bordered(),
                                 type = ContainerType.SECONDARY,
                             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Radius.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Radius.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.ui.theme.v2
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * One step of the app's corner-radius scale.
+ *
+ * A token carries the whole shape, not just a number, and it *is* a [Shape] — so it drops straight
+ * into `shape =`, [androidx.compose.ui.draw.clip], `background(...)` and `border(...)` without a
+ * call site ever naming a radius or a corner geometry. That is the point of the layer: changing the
+ * app's corner geometry becomes an edit inside [Radii] rather than a sweep across every rounded
+ * surface.
+ *
+ * Values live in [Radii]; this type is only the primitive, the same way a `TextStyle` is the
+ * primitive behind the typography scale.
+ */
+@Immutable
+sealed class Radius(
+    /**
+     * The shape this token describes.
+     *
+     * Deliberately a [CornerBasedShape] rather than a bare [Shape]: it keeps `copy(topStart = ...)`
+     * available to the surfaces that round only some of their corners, so those sites can still
+     * derive from the token instead of restating its number.
+     */
+    val shape: CornerBasedShape
+) : Shape by shape {
+
+    /** A numeric step on the scale. */
+    @Immutable
+    data class Fixed(
+        /**
+         * Radius in dp.
+         *
+         * Use this only where a [Shape] will not fit — a `Canvas` corner radius, a shadow, an inset
+         * computed off the surface it sits in. Everywhere else pass the token itself, so the corner
+         * geometry travels with the number.
+         */
+        val size: Dp
+    ) : Radius(RoundedCornerShape(size))
+
+    /**
+     * Fully rounded, at every surface size the app can render.
+     *
+     * [CircleShape] is `RoundedCornerShape(percent = 50)` — it is defined relative to the surface,
+     * so unlike the "big number" idiom it cannot stop being round on a large surface. The app's
+     * fully-round literals (50, 70, 77, 88, 99, 100 dp and `percent = 50`) all mean this, and
+     * collapse onto it.
+     */
+    @Immutable data object Pill : Radius(CircleShape)
+}
+
+/**
+ * The app's corner-radius scale.
+ *
+ * The numeric steps are named by size, not by surface: `md` means "12 from the scale", nothing
+ * more. Which surface class should use which step is documentation (see the comments below), not a
+ * contract — that mapping is still being reconciled against the design file, and encoding it in the
+ * token names would freeze a half-verified answer.
+ *
+ * [Radius.Pill] is the one semantic token, because "fully rounded" is not a number. The design file
+ * expresses it as 50, 77 or 99 depending on the component and the app has 50, 70, 77, 88, 99 and
+ * 100 in use; all of them mean the same thing, and the token collapses them so no call site imports
+ * another magic number.
+ *
+ * **There is deliberately no sheet token, and the scale stops at 24.** The two sheet frames in the
+ * design file measure 38 and 28, but both are stock design-kit components dropped into the file
+ * rather than authored Vultisig surfaces — the 38 one is Apple's iOS 26 sheet, the 28 one is
+ * Material 3's default. Neither number is ours to own. Adding a step for them would encode a
+ * platform default as a design decision and invite a real sheet to diverge from the platform.
+ *
+ * Values are shared with iOS and Windows — identical numbers, units per platform. `md`, `lg` and
+ * `xl` are read off rendered frames in Figma file `puB2fsVpPrBx3Sup7gaa3v`, section "Main View
+ * (Mobile) - iOS 26": the banner is 24, the inner icon tile and the input field are 16, the asset
+ * list row is 12, and the chip / coin logo / glass-close family is fully round. Radii are **not**
+ * Figma variables — `get_variable_defs` on that section returns colours, fonts, a stroke width and
+ * `dimensions/3 = 8`, so there is no authored radius scale to import. `xs` and `sm` are therefore
+ * inferred from existing app usage and that `dimensions/3`, and are lower-confidence than the rest.
+ */
+@Immutable
+data class Radii(
+    /** 4 — progress tracks, skeleton bars, hairline chips. */
+    val xs: Radius.Fixed = Radius.Fixed(4.dp),
+    /** 8 — small inline tags. */
+    val sm: Radius.Fixed = Radius.Fixed(8.dp),
+    /** 12 — list rows, compact containers. */
+    val md: Radius.Fixed = Radius.Fixed(12.dp),
+    /** 16 — input fields, inner icon tiles. */
+    val lg: Radius.Fixed = Radius.Fixed(16.dp),
+    /** 24 — cards, banners, list containers. */
+    val xl: Radius.Fixed = Radius.Fixed(24.dp),
+    /** Fully rounded. */
+    val pill: Radius = Radius.Pill,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/theme/v2/V2.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/v2/V2.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 
 object V2 {
     val colors: Colors = Colors()
+    val radius: Radii = Radii()
 }
 
 val LocalV2Theme = staticCompositionLocalOf { V2 }

--- a/app/src/test/java/com/vultisig/wallet/ui/theme/v2/RadiusTokenTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/theme/v2/RadiusTokenTest.kt
@@ -1,0 +1,179 @@
+package com.vultisig.wallet.ui.theme.v2
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the corner-radius scale, and pins the geometry the tokens produce against the numeric
+ * literals they replace. A change to either is then a deliberate, visible edit rather than a silent
+ * restyle of every surface that reads a token.
+ */
+internal class RadiusTokenTest {
+
+    private val radius = V2.radius
+
+    // 1dp == 1px keeps the assertions below readable.
+    private val density = Density(density = 1f)
+
+    /** Wide and tall enough that no token on the numeric scale is clamped by it. */
+    private val surface = Size(width = 320f, height = 120f)
+
+    @Test
+    fun `scale values match the design scale`() {
+        radius.xs.size shouldBe 4.dp
+        radius.sm.size shouldBe 8.dp
+        radius.md.size shouldBe 12.dp
+        radius.lg.size shouldBe 16.dp
+        radius.xl.size shouldBe 24.dp
+    }
+
+    @Test
+    fun `numeric scale is strictly increasing`() {
+        val scale = numericScale.map { it.size }
+        scale shouldBe scale.sorted()
+        scale.toSet().size shouldBe scale.size
+    }
+
+    /**
+     * The tokens have to render exactly what the untokenised call sites render, or migrating a site
+     * is a visual change rather than a rename. Every literal in the app spells the radius out as
+     * `RoundedCornerShape(n.dp)`, so this compares each token's outline against exactly that.
+     */
+    @Test
+    fun `token outlines match the literals they replace`() {
+        val migrated =
+            listOf(
+                radius.xs to 4.dp,
+                radius.sm to 8.dp,
+                radius.md to 12.dp,
+                radius.lg to 16.dp,
+                radius.xl to 24.dp,
+            )
+
+        migrated.forEach { (token, literal) ->
+            token.outline(surface) shouldBe RoundedCornerShape(literal).outline(surface)
+        }
+    }
+
+    /**
+     * `pill` is [CircleShape], which is `RoundedCornerShape(percent = 50)` — defined relative to
+     * the surface rather than as a large constant, so unlike the "big number" idiom it cannot stop
+     * being round on a large surface. The sizes below bracket everything the app can render.
+     */
+    @Test
+    fun `pill is fully round at every size the app can render`() {
+        val sizes =
+            listOf(
+                Size(320f, 44f), // search field
+                Size(100f, 52f), // chip / counter row
+                Size(56f, 56f), // circular icon button
+                Size(1366f, 1024f), // tablet landscape
+            )
+
+        sizes.forEach { size ->
+            radius.pill.drawnRadiusOn(size) shouldBe (minOf(size.width, size.height) / 2f)
+        }
+    }
+
+    /**
+     * The app expresses "fully round" as 50, 70, 77, 88, 99 and 100dp as well as `percent = 50`.
+     * Compose scales adjacent corner radii down until they fit the surface, so all of those
+     * collapse onto the same capsule — which is what lets one semantic token replace every one of
+     * them without moving a pixel.
+     */
+    @Test
+    fun `pill renders the same capsule as every fully-round literal in use`() {
+        val searchFieldSized = Size(width = 320f, height = 44f)
+        val capsule = radius.pill.drawnRadiusOn(searchFieldSized)
+
+        capsule shouldBe 22f
+        listOf(50.dp, 70.dp, 77.dp, 88.dp, 99.dp, 100.dp).forEach { literal ->
+            // The clamp divides the surface by the literal, so the result lands a rounding error
+            // away from the capsule rather than exactly on it. That difference is sub-pixel and not
+            // what the migration turns on.
+            RoundedCornerShape(literal).drawnRadiusOn(searchFieldSized) shouldBe
+                (capsule plusOrMinus 0.001f)
+        }
+        RoundedCornerShape(percent = 50).drawnRadiusOn(searchFieldSized) shouldBe capsule
+    }
+
+    /**
+     * The bound that governs which fully-round literals may become `pill`, measured rather than
+     * assumed: a literal only clamps to a capsule while the surface's smaller dimension stays under
+     * twice the literal. Above that it draws its own number and is *not* a capsule, so migrating it
+     * to `pill` would be a visual change. This is why the phase-1 slice only converts fully-round
+     * literals on surfaces that are provably bounded.
+     */
+    @Test
+    fun `a fully-round literal stops being a capsule once the surface out-runs it`() {
+        val tall = Size(width = 320f, height = 240f) // 240 > 2 x 99
+
+        RoundedCornerShape(99.dp).drawnRadiusOn(tall) shouldBe 99f
+        radius.pill.drawnRadiusOn(tall) shouldBe 120f
+    }
+
+    @Test
+    fun `pill is not a step on the numeric scale`() {
+        numericScale.forEach { step -> radius.pill shouldNotBe step }
+    }
+
+    /**
+     * Surfaces that round only some of their corners derive from the token's shape instead of
+     * restating its number, so a change to the scale still reaches them.
+     */
+    @Test
+    fun `a partially rounded shape derived from a token matches the literal it replaces`() {
+        val topCornersOnly =
+            radius.lg.shape.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
+
+        topCornersOnly.cornersOn(surface) shouldBe
+            RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp).cornersOn(surface)
+        topCornersOnly.cornersOn(surface) shouldBe listOf(16f, 16f, 0f, 0f)
+    }
+
+    /**
+     * A token is itself a [Shape], which is what lets a call site pass it straight to `shape =`,
+     * `clip` or `background` without naming any geometry. That has to stay in step with the [shape]
+     * it exposes for the derive-from-token cases above.
+     */
+    @Test
+    fun `a token draws the same outline as the shape it exposes`() {
+        allTokens.forEach { token -> token.outline(surface) shouldBe token.shape.outline(surface) }
+    }
+
+    private val numericScale: List<Radius.Fixed>
+        get() = listOf(radius.xs, radius.sm, radius.md, radius.lg, radius.xl)
+
+    private val allTokens: List<Radius>
+        get() = numericScale + radius.pill
+
+    private fun Shape.outline(size: Size): Outline =
+        createOutline(size, LayoutDirection.Ltr, density)
+
+    /**
+     * The radius Compose actually draws at [size], after the fit-to-surface clamping that turns a
+     * large radius into a capsule. Only valid for shapes whose four corners are equal.
+     */
+    private fun Shape.drawnRadiusOn(size: Size): Float =
+        (outline(size) as Outline.Rounded).roundRect.topLeftCornerRadius.x
+
+    /**
+     * The four corner radii in `topStart, topEnd, bottomEnd, bottomStart` order, read before
+     * clamping — so callers must pass a [size] large enough that no clamping applies. Reading them
+     * off the shape rather than off an [Outline] keeps this a plain JVM test: an outline with
+     * unequal corners builds an `android.graphics.Path`, which is not available here.
+     */
+    private fun CornerBasedShape.cornersOn(size: Size): List<Float> =
+        listOf(topStart, topEnd, bottomEnd, bottomStart).map { it.toPx(size, density) }
+}


### PR DESCRIPTION
Part of #5503 — **phase 1 of 4.** This PR defines the token layer only. It does not close the issue.

`ui/theme/` has `Colors`, `Typography` and `Theme` and **no radius concept at all**, so every rounded surface in the app spells its geometry out as a numeric literal: 384 of them across 23 distinct values, plus six different ways to say "fully round". This adds the missing layer and migrates a small, deliberately-chosen slice of call sites to prove the API works end to end.

**Zero visual change is the acceptance criterion for this phase**, and it is measured rather than asserted — see below.

Ports vultisig-ios#5040. The scale is the same one; the API is not, because Compose is not SwiftUI — the differences are called out where they matter.

---

## The scale

| Token | dp | Surface class | Source |
|---|---|---|---|
| `xs` | 4 | progress tracks, skeleton bars | inferred |
| `sm` | 8 | small inline tags | inferred |
| `md` | 12 | list rows, compact containers | Figma — asset list row |
| `lg` | 16 | input fields, inner icon tiles | Figma — input, inner tile |
| `xl` | 24 | cards, banners, list containers | Figma — banner |
| `pill` | — | chips, search fields, capsules | Figma — 50 / 77 / 99 |

**There is deliberately no sheet token, and the scale stops at 24.** The two sheet frames in the design file measure 38 and 28, but both are stock design-kit components pasted into the file rather than authored Vultisig surfaces — 38 is Apple's iOS 26 sheet, 28 is Material 3's default. Neither is ours, and adding a step for them would encode a platform default as a design decision. A comment at the scale declaration records this so nobody "completes" the scale later.

### Where these came from

Read off rendered frames in Figma file `puB2fsVpPrBx3Sup7gaa3v`, section **"Main View (Mobile) - iOS 26"** — these were re-measured for this PR rather than taken from the iOS port:

- banner `68734:97487` → `rounded-[24px]`
- inner icon tile `68734:97489` and input field `26557:15834` → `rounded-[16px]`
- asset list row `51141:203613` → `rounded-tl-[12px] rounded-tr-[12px]`
- vault-type chip `rounded-[99px]`, coin logo `rounded-[50px]`, glass-close `rounded-[77px]`

Two caveats worth stating plainly:

1. **Radii are not Figma variables.** `get_variable_defs` on that section returns colours, fonts, a stroke width and `dimensions/3 = 8` — there is no authored radius scale to import. These values were measured off rendered frames.
2. **`4` and `8` are lower-confidence than the rest** — inferred from existing app usage and that `dimensions/3`, not read off a frame. Any outlier found during phase 2 should go back to the designer rather than be rounded to the nearest token.

Values are shared with iOS and Windows — identical numbers, units per platform.

---

## The token API

```kotlin
Theme.v2.radius.xl              // the token — reads like Theme.v2.colors.*
Modifier.clip(Theme.v2.radius.xl)
Modifier.background(color, Theme.v2.radius.xl)
Card(shape = Theme.v2.radius.xl)

Theme.v2.radius.md.size         // Dp, only where a Shape will not fit (Canvas, insets)
Theme.v2.radius.lg.shape.copy(...)   // derive partial corners from the token
```

**The token *is* a `Shape`.** That is the one design decision everything else follows from: a call site names neither a radius nor a corner geometry, so changing the app's corner shape is one line inside `Radii` instead of another 384-site sweep. It also means the token drops into `shape =`, `clip`, `background` and `border` with no wrapper and no `.shape` noise at the point of use.

`Radius.Fixed.size` stays for the cases a `Shape` cannot reach — a `Canvas` corner radius, an inset computed off the surface. `Radius.shape` is a `CornerBasedShape` rather than a bare `Shape` so partial-corner surfaces can `copy(...)` from the token instead of restating its number. Both have a call site in this PR; nothing ships unused.

### `pill` is `CircleShape`, and that is better than the iOS equivalent

iOS needs a clamping *bound* — a 100,000pt constant, measured to still produce a capsule at 5120×2880 — because SwiftUI clamps a large radius down to half the smaller dimension. Compose's `CircleShape` is `RoundedCornerShape(percent = 50)`, which is defined *relative to the surface*. It cannot stop being round no matter how large the surface gets, so the Android token needs no magic number at all.

The app's fully-round idioms (50, 70, 77, 88, 99, 100 dp and `percent = 50`) all collapse onto it.

---

## `CornerType` is replaced by the token type

`V2Container` had its own two-case corner vocabulary — `CornerType.Circular` and `CornerType.RoundedCornerShape(size = 12.dp)` — across 17 call sites. It is deleted; `V2Container` now takes `radius: Radius` directly, so there is one corner concept in the app rather than two. `Circular` → `pill` is identical by construction (both produce `CircleShape`), and each numeric site maps to its own step.

---

## Migrated sites — every one pixel-neutral

26 token references across 21 files, chosen so each site's current literal **already equals** the token's value. Nothing was re-valued.

| File | Before | After |
|---|---|---|
| `components/v2/containers/V2Container.kt` | `CornerType` | `radius: Radius`, defaulting to `md` |
| 17 `V2Container` call sites | `CornerType.Circular` ×10, `12.dp` ×3, `24.dp` ×2, `8.dp` ×2 | `pill` / `md` / `xl` / `sm` |
| `components/SignTonDisplayView.kt` | `RoundedCornerShape(4.dp)` | `xs` |
| `components/library/form/Form.kt` | `RoundedCornerShape(4.dp)` | `xs` |
| `components/errors/ErrorView.kt` ×2 | `RoundedCornerShape(16.dp)` | `lg` |
| `components/dapp/DappRequestBanner.kt` | `RoundedCornerShape(16.dp)` | `lg` |
| `components/v2/fastselection/…/FastSelectionModalContent.kt` | `clip(RoundedCornerShape(24.dp))` | `clip(xl)` |
| `screens/transaction/TransactionHistoryScreen.kt` ×2 | `CornerRadius(12.dp.toPx())` + `RoundedCornerShape(12.dp)` | `md.size` + `md` |
| `screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt` ×2 | `RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)` | `lg.shape.copy(...)` |

Between them these cover every scale step the app uses, and every form a radius takes in Compose: `Card(shape =)`, `Modifier.clip`, `Modifier.background`, `Modifier.border`, a `DrawScope` corner radius, and the partial-corner case.

### Two of them fixed latent drift

Both are the bug class that no lint rule will ever catch, because it is invisible in the declaration and only shows at the call site:

- **`TransactionHistoryEmptyState`** drew its border on a canvas at `CornerRadius(12.dp.toPx())` and its background at `RoundedCornerShape(12.dp)` — two independent literals for one surface. The stroke would have stopped tracing the card the first time either moved. Both now read one token.
- **`CosmosWithdrawRewardsScreen`**'s docked footer restated `topStart = 16.dp, topEnd = 16.dp` in its clip and again in its border. Now derived once from `lg`.

### Deliberately not migrated

- **Sheets.** Out of scope entirely, not just out of phase 1 — the scale has no step for them.
- **Text inputs.** Figma says 16; the app's fields are at 12. Real drift, needs a designer call rather than a silent rounding.
- **Fully-round literals on unbounded surfaces.** See the clamping test below — converting one of those is a visual change, not a rename.

---

## How pixel-neutrality is proven

**1. Geometry, not eyeballs.** `RadiusTokenTest` (9 cases) asserts each token's `createOutline` is identical to the outline of the exact literal expression it replaced, pins the scale values and their ordering, and checks the derived partial-corner shape against the literal it replaces.

It also **measures the clamping bound** rather than assuming it, which is the rule phase 2 needs: a fully-round literal only collapses to a capsule while the surface's smaller dimension stays under twice the literal. `RoundedCornerShape(99.dp)` on a 320×240 surface draws 99, not a capsule — so migrating a fully-round literal is only safe on a surface that is provably bounded. That is why this PR converts `CornerType.Circular` (already `CircleShape`, identical by construction) and leaves the numeric fully-round literals for phase 2.

Two of these tests failed on their first run and both were worth having:
- `Outline` equality is float-exact, and a 70dp literal clamps to 22.000002 rather than 22 — so the pill assertions compare drawn radii with a sub-pixel tolerance instead of comparing outline objects.
- An outline with unequal corners builds an `android.graphics.Path`, which a plain JVM test cannot touch — so the partial-corner case reads the four corner sizes off the shape instead.

**2. A pixel diff of the whole preview surface.** Both APKs were built, installed on the same emulator, and driven through **all 128 `PreviewActivity` screens** with the status bar frozen via SystemUI demo mode. The two capture sets were then compared pixel by pixel.

A raw before/after comparison is not conclusive on its own, because some previews render non-deterministically — animated heroes, async coin logos, the soft keyboard. So the branch was captured **twice**, giving a measured noise floor to compare the result against:

| | |
|---|---|
| Preview screens compared | 128 |
| Unstable across two runs of **identical** code | 11 |
| Deterministic screens | 117 |
| Of those, differing `main` → this branch | **0** |
| Differences not explained by that instability | **0** |

Every screen that differs between `main` and this branch also differs between two runs of this branch against itself. The 11 unstable ones are animation phase (`keysign_signing_lunc`, `review_vault_devices`' pulsing ring), async image loads (`blockaid_hero_done_*`, `sui_token_selection_*`, `swap_toolbar`) and the IME (`edit_folder`'s diff is entirely the keyboard suggestion strip and text cursor).

All 128 were compared rather than only the screens I touched, because the failure mode that matters for a token layer is not the site you edited — it is a shared component you did not realise fed a dozen other screens.

---

## What phases 2–4 cover

**Phase 2 — migrate by surface class**, one PR per batch, ordered by descending confidence. The two largest populations in the app are 12 (×138 including `size =` form) and 16 (×74), and **most of them are not containers**, so blanket-converting either would be visually destructive. The iOS phase-2 ruling — *containers take 24, anything nested inside one takes an explicitly smaller step, and the two levels must differ* — ports directly and is derived from call sites, not declarations.

**Phase 3 — the lint rule** banning new numeric radius literals, which is the only mechanism that makes the issue's "drift can't re-accumulate" actually true. It can only land after the outliers are reconciled.

**Phase 4 — corner geometry.** Compose has no continuous-corner primitive, so the iOS finding (the SDK silently moved every surface to `.continuous`) has no Android equivalent — Android corners are circular arcs and always have been. If the design language wants squircles, that becomes a custom `CornerBasedShape` swapped in at one line inside `Radii`, which is exactly what this layer exists to make possible.

---

## Gate

- `:app:testDebugUnitTest` — full suite, **BUILD SUCCESSFUL**, including 9 new `RadiusTokenTest` cases.
- `:app:lintDebug` — **BUILD SUCCESSFUL**.
- `ktfmt` applied.
- The 128-preview pixel diff above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Standardized corner rounding across cards, buttons, search bars, banners, dialogs, snackbars, and empty states.
  - Updated surfaces to use consistent theme-defined radius sizes, including small, medium, large, extra-large, and pill shapes.
  - Improved consistency for partially rounded sections, such as withdrawal summaries and bordered error areas.
  - Refined visual alignment across wallet, token, staking, transaction, and home screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->