### PR TITLE
fix(defi): key the Manage Positions selection per chain, not just per vault

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -279,27 +279,18 @@ constructor(
     private fun loadSavedPositions(): Job =
         viewModelScope.launch {
             defiPositionsRepository
-                .getSelectedPositions(vaultId)
-                .map { saved ->
-                    when {
-                        // A vault that never chose reads back as the store's own defaults, never
-                        // as an empty set, so empty is a selection the user cleared on purpose.
-                        // It has to be taken at face value: falling through to the Maya defaults
-                        // below would derive it back to what it just replaced, and the dedup would
-                        // then drop the reload it needs.
-                        saved.isEmpty() -> emptyList()
-                        // The THORChain screen writes this same key. A set holding nothing this
-                        // screen can show is that screen's selection, not a choice made here.
-                        saved.any { it in MAYA_STATIC_POSITION_KEYS || it.contains(".") } ->
-                            saved.toList()
-                        else -> MAYA_DEFAULT_SELECTED_POSITIONS
-                    }
-                }
-                // The store re-emits for writes that leave this vault's selection alone — the
-                // first-ever save flips the key from absent to present, which it cannot read as
-                // unchanged — and a reload for one of those would blank a settled header for
-                // nothing. Compared as sets: only membership decides what gets loaded, and a stored
-                // set can come back in a different order than the default list.
+                .getSelectedPositions(Chain.MayaChain, vaultId)
+                // Null is a vault that has never chosen on this chain, and it is the only case the
+                // defaults belong to. That is what makes an empty set unambiguous here: it is a
+                // selection the user cleared on purpose, and taking it at face value is safe now
+                // that no other screen can write this key.
+                .map { saved -> saved?.toList() ?: MAYA_DEFAULT_SELECTED_POSITIONS }
+                // The store re-emits for writes that leave this vault's selection alone — another
+                // screen saving into the same file, or this vault's first-ever save flipping the
+                // key from absent to present, which it cannot read as unchanged — and a reload for
+                // one of those would blank a settled header for nothing. Compared as sets: only
+                // membership decides what gets loaded, and a stored set can come back in a
+                // different order than the default list.
                 .distinctUntilChanged { old, new -> old.toSet() == new.toSet() }
                 .collect { positions ->
                     updateModel {
@@ -923,14 +914,17 @@ constructor(
         viewModelScope.launch {
             val selectedPositions = currentModel.tempSelectedPositions
 
-            // A Done that changed nothing has nothing to persist. Writing anyway would also clobber
-            // the stored selection this screen only reads through its Maya defaults.
+            // A Done that changed nothing has nothing to persist and nothing to refetch.
             if (selectedPositions.toSet() == currentModel.selectedPositions.toSet()) {
                 updateModel { it.copy(showPositionSelectionDialog = false) }
                 return@launch
             }
 
-            defiPositionsRepository.saveSelectedPositions(vaultId, selectedPositions)
+            defiPositionsRepository.saveSelectedPositions(
+                Chain.MayaChain,
+                vaultId,
+                selectedPositions,
+            )
             updateModel {
                 it.copy(showPositionSelectionDialog = false, selectedPositions = selectedPositions)
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -472,12 +472,15 @@ constructor(
 
     private fun loadSavedPositions() {
         viewModelScope.launch {
-            val savedPositions = defiPositionsRepository.getSelectedPositions(vaultId).first()
+            // Null is a vault that has never chosen on this chain, which is the only case the
+            // defaults belong to — an empty set is a selection the user cleared on purpose.
+            val savedPositions =
+                defiPositionsRepository
+                    .getSelectedPositions(Chain.ThorChain, vaultId)
+                    .first()
+                    ?.toList() ?: defaultSelectedPositionsDialog()
             state.update {
-                it.copy(
-                    selectedPositions = savedPositions.toList(),
-                    tempSelectedPositions = savedPositions.toList(),
-                )
+                it.copy(selectedPositions = savedPositions, tempSelectedPositions = savedPositions)
             }
 
             loadBondedNodes()
@@ -1266,7 +1269,11 @@ constructor(
 
             launch {
                 withContext(ioDispatcher) {
-                    defiPositionsRepository.saveSelectedPositions(vaultId, selectedPositions)
+                    defiPositionsRepository.saveSelectedPositions(
+                        Chain.ThorChain,
+                        vaultId,
+                        selectedPositions,
+                    )
                 }
             }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -124,9 +124,9 @@ internal class MayachainDefiPositionsViewModelTest {
     }
 
     @Test
-    fun `a saved selection holding no Maya key falls back to the Maya defaults`() = runTest {
-        // Selection persisted by the Thorchain screen: recognising it here would blank both tabs.
-        selectPositions("RUNE", "TCY")
+    fun `a vault that never chose on this chain gets the Maya defaults`() = runTest {
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            flowOf<Set<String>?>(null)
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
 
@@ -134,6 +134,18 @@ internal class MayachainDefiPositionsViewModelTest {
             listOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY),
             successData(vm).selectedPositions,
         )
+    }
+
+    @Test
+    fun `a stored selection is used verbatim even when no key in it is Maya-specific`() = runTest {
+        // The key carries the chain, so whatever is on it was written here. Reading a set of plain
+        // tickers as "the Thorchain screen's" and falling back to the defaults for it is what used
+        // to revive positions the user had turned off.
+        selectPositions("RUNE", "TCY")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(listOf("RUNE", "TCY"), successData(vm).selectedPositions)
     }
 
     @Test
@@ -146,8 +158,7 @@ internal class MayachainDefiPositionsViewModelTest {
     }
 
     @Test
-    fun `a dotted LP asset key counts as a Maya selection`() = runTest {
-        // "BTC.BTC" carries no Maya prefix; the dot is what marks it as an LP pool key.
+    fun `a dotted LP asset key is kept like any other stored key`() = runTest {
         selectPositions("BTC.BTC")
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
@@ -676,7 +687,9 @@ internal class MayachainDefiPositionsViewModelTest {
         vm.onPositionSelectionDone()
 
         val expected = listOf(MAYA_STAKE_CACAO_KEY, BTC_POOL)
-        coVerify(exactly = 1) { defiPositionsRepository.saveSelectedPositions(VAULT_ID, expected) }
+        coVerify(exactly = 1) {
+            defiPositionsRepository.saveSelectedPositions(Chain.MayaChain, VAULT_ID, expected)
+        }
         val data = successData(vm)
         assertFalse(data.showPositionSelectionDialog)
         assertEquals(expected, data.selectedPositions)
@@ -688,11 +701,11 @@ internal class MayachainDefiPositionsViewModelTest {
         // every leg for it — but left the legs holding their pre-selection values, so the header
         // read as a settled total, short by the pool just added, for the whole refetch.
         val saved = MutableStateFlow(setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY))
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns saved
-        coEvery { defiPositionsRepository.saveSelectedPositions(VAULT_ID, any()) } answers
-            {
-                saved.value = secondArg<List<String>>().toSet()
-            }
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            saved
+        coEvery {
+            defiPositionsRepository.saveSelectedPositions(Chain.MayaChain, VAULT_ID, any())
+        } answers { saved.value = thirdArg<List<String>>().toSet() }
         givenLpPool(liquidityUnits = "100", units = "1000")
         val loadedMemberDetails = memberDetails(liquidityUnits = "100")
         val heldMemberDetails = MutableStateFlow<MayaMemberDetails?>(loadedMemberDetails)
@@ -722,11 +735,11 @@ internal class MayachainDefiPositionsViewModelTest {
 
     @Test
     fun `confirming a selection nothing changed in writes nothing`() = runTest {
-        // Done is reachable without touching a checkbox. Writing anyway would clobber the stored
-        // selection this screen only ever reads through its Maya defaults, and the write would come
-        // back through the collector as a reload of all three legs.
+        // Done is reachable without touching a checkbox, and the write would come back through the
+        // collector as a reload of all three legs.
         val saved = MutableStateFlow(setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY))
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns saved
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            saved
         val vm = createViewModel().also { it.setData(VAULT_ID) }
         val settled = successData(vm)
         settled.isTotalAmountLoading shouldBe false
@@ -734,7 +747,9 @@ internal class MayachainDefiPositionsViewModelTest {
         vm.setPositionSelectionDialogVisibility(true)
         vm.onPositionSelectionDone()
 
-        coVerify(exactly = 0) { defiPositionsRepository.saveSelectedPositions(VAULT_ID, any()) }
+        coVerify(exactly = 0) {
+            defiPositionsRepository.saveSelectedPositions(Chain.MayaChain, VAULT_ID, any())
+        }
         val data = successData(vm)
         assertFalse(data.showPositionSelectionDialog)
         data.isTotalAmountLoading shouldBe false
@@ -746,8 +761,9 @@ internal class MayachainDefiPositionsViewModelTest {
         // A vault's first-ever save flips the key from absent to present, which the store cannot
         // read as unchanged even though both sides map to the same Maya defaults — and the stored
         // set need not come back in the order the default list has.
-        val saved = MutableStateFlow(setOf("RUNE", "TCY"))
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns saved
+        val saved = MutableStateFlow<Set<String>?>(null)
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            saved
         val heldStaking =
             MutableStateFlow<MayaCacaoStakingDetails?>(
                 MayaCacaoStakingDetails(BigInteger.ZERO, apr = null, canUnstake = false)
@@ -771,16 +787,15 @@ internal class MayachainDefiPositionsViewModelTest {
 
     @Test
     fun `clearing every position settles the header instead of freezing it`() = runTest {
-        // An empty selection is what the store hands back for a vault that has one of its own, so
-        // deriving it to the Maya defaults produced the same set the collector last saw and the
-        // dedup dropped the emission — the tabs cleared while the header kept the total of the
-        // positions just removed.
+        // An empty set is a selection this screen cleared, so deriving it to the Maya defaults
+        // produced the same set the collector last saw and the dedup dropped the emission — the
+        // tabs cleared while the header kept the total of the positions just removed.
         val saved = MutableStateFlow(setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY))
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns saved
-        coEvery { defiPositionsRepository.saveSelectedPositions(VAULT_ID, any()) } answers
-            {
-                saved.value = secondArg<List<String>>().toSet()
-            }
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            saved
+        coEvery {
+            defiPositionsRepository.saveSelectedPositions(Chain.MayaChain, VAULT_ID, any())
+        } answers { saved.value = thirdArg<List<String>>().toSet() }
         coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
             flowOf(listOf(bondedNode(amount = HUNDRED_CACAO)))
 
@@ -802,10 +817,11 @@ internal class MayachainDefiPositionsViewModelTest {
 
     @Test
     fun `an emptied stored selection is honoured, not re-derived to the defaults`() = runTest {
-        // The store returns its own defaults for a vault that never chose, so an empty set can only
-        // be one this screen cleared — the Maya fallback must not claim it back.
+        // The store returns null for a vault that never chose, so an empty set can only be one this
+        // screen cleared — the defaults must not claim it back.
         val saved = MutableStateFlow(setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY))
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns saved
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            saved
         coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
             flowOf(listOf(bondedNode(amount = HUNDRED_CACAO)))
 
@@ -837,8 +853,37 @@ internal class MayachainDefiPositionsViewModelTest {
         data.totalAmountPrice shouldBe "$0.00"
     }
 
+    @Test
+    fun `a Thorchain save for the same vault leaves this screen's selection alone`() = runTest {
+        // Both screens used to write one key per vault, so a Thorchain save landed on the selection
+        // this screen reads. Unchecking everything there persisted an empty set, which this screen
+        // read as its own clearing and zeroed Bond, Staking and LP for; any plain-ticker save there
+        // held nothing this screen could show, so it fell back to the Maya defaults and revived a
+        // position the user had turned off. Neither reaches this screen now the key carries the
+        // chain.
+        val mayaSaved = MutableStateFlow<Set<String>?>(setOf(MAYA_STAKE_CACAO_KEY))
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            mayaSaved
+        val thorchainSaved = MutableStateFlow<Set<String>?>(setOf("RUNE", "TCY"))
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.ThorChain, VAULT_ID) } returns
+            thorchainSaved
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val settled = successData(vm)
+        settled.isTotalAmountLoading shouldBe false
+
+        // Every Thorchain position unchecked, then its selection edited again.
+        thorchainSaved.value = emptySet()
+        thorchainSaved.value = setOf("RUNE")
+
+        val data = successData(vm)
+        assertEquals(listOf(MAYA_STAKE_CACAO_KEY), data.selectedPositions)
+        data.isTotalAmountLoading shouldBe false
+        data.totalAmountPrice shouldBe settled.totalAmountPrice
+    }
+
     private fun selectPositions(vararg keys: String) {
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
             flowOf(keys.toSet())
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -145,7 +145,7 @@ internal class MayachainDefiPositionsViewModelTest {
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
 
-        assertEquals(listOf("RUNE", "TCY"), successData(vm).selectedPositions)
+        successData(vm).selectedPositions shouldBe listOf("RUNE", "TCY")
     }
 
     @Test
@@ -877,7 +877,7 @@ internal class MayachainDefiPositionsViewModelTest {
         thorchainSaved.value = setOf("RUNE")
 
         val data = successData(vm)
-        assertEquals(listOf(MAYA_STAKE_CACAO_KEY), data.selectedPositions)
+        data.selectedPositions shouldBe listOf(MAYA_STAKE_CACAO_KEY)
         data.isTotalAmountLoading shouldBe false
         data.totalAmountPrice shouldBe settled.totalAmountPrice
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -1147,7 +1147,7 @@ internal class ThorchainDefiPositionsViewModelTest {
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
 
-        assertEquals(defaultSelectedPositionsDialog(), vm.state.value.selectedPositions)
+        vm.state.value.selectedPositions shouldBe defaultSelectedPositionsDialog()
     }
 
     private fun selectPositions(vararg keys: String) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -30,6 +30,7 @@ import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.defaultSelectedPositionsDialog
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
 import io.kotest.matchers.shouldBe
@@ -1035,7 +1036,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         vm.onPositionSelectionDone()
 
         coVerify(exactly = 1) {
-            defiPositionsRepository.saveSelectedPositions(VAULT_ID, listOf("TCY"))
+            defiPositionsRepository.saveSelectedPositions(Chain.ThorChain, VAULT_ID, listOf("TCY"))
         }
         val state = vm.state.value
         assertFalse(state.showPositionSelectionDialog)
@@ -1115,7 +1116,9 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertFalse(vm.state.value.showPositionSelectionDialog)
         vm.state.value.isTotalAmountLoading shouldBe false
         vm.state.value.totalAmountPrice shouldBe "$6.00"
-        coVerify(exactly = 0) { defiPositionsRepository.saveSelectedPositions(VAULT_ID, any()) }
+        coVerify(exactly = 0) {
+            defiPositionsRepository.saveSelectedPositions(Chain.ThorChain, VAULT_ID, any())
+        }
     }
 
     @Test
@@ -1135,8 +1138,20 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertEquals(before.bonded, after.bonded)
     }
 
+    @Test
+    fun `a vault that never chose on this chain gets the default selection`() = runTest {
+        // The store no longer holds defaults of its own: null is "never chose", and it is the only
+        // case they apply to. An empty set is a selection the user cleared and stays empty.
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.ThorChain, VAULT_ID) } returns
+            flowOf<Set<String>?>(null)
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        assertEquals(defaultSelectedPositionsDialog(), vm.state.value.selectedPositions)
+    }
+
     private fun selectPositions(vararg keys: String) {
-        coEvery { defiPositionsRepository.getSelectedPositions(VAULT_ID) } returns
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.ThorChain, VAULT_ID) } returns
             flowOf(keys.toSet())
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -45,15 +45,26 @@ private fun selectedPositionsKey(chain: Chain, vaultId: String) =
  * the Bonded tab and its header leg would stay on with no row in the dialog able to switch them
  * off.
  *
- * Pool keys are the one thing the shape cannot attribute — both chains write `CHAIN.TICKER` and
- * both list pools like `BTC.BTC` — so they go to both chains. Landing on a chain the user did not
- * pick them on shows a pool card they can uncheck; dropping them would silently shorten the header
- * total instead.
+ * A chain's key is only written when the set holds something that chain can own. Left out, it reads
+ * back as null — never chose — and the screen answers with its own defaults, which is what that
+ * vault was already being shown. Writing an empty set instead would call it a clearing and blank a
+ * screen the vault never configured: a set of only `maya:` keys lit both THORChain legs before the
+ * upgrade, since `hasBondPositions` and `hasStakingPositions` match the Cacao keys too.
  *
- * MayaChain is skipped for the one shape it cannot have authored: a set of plain tickers and
- * nothing else, which is what that screen already answered with its defaults before the upgrade. An
- * empty set is not that shape. It is a selection cleared on purpose, and leaving it out would hand
- * back the Bond and Staking rows the user had switched off.
+ * An empty set is written to both. That one is a clearing both screens saw, and leaving it out
+ * would hand back every row the user had switched off.
+ *
+ * Pool keys are the one thing the shape cannot attribute — both chains write `CHAIN.TICKER` and
+ * both list pools like `BTC.BTC` — so they ride along to MayaChain whenever a `maya:` key is
+ * already carrying it, and a set of nothing but pools counts as a MayaChain choice on its own,
+ * because that is exactly what the Maya dialog leaves behind when both Cacao rows are unchecked.
+ * Alongside plain tickers the set reads as THORChain's, and MayaChain's own Bond and Staking
+ * defaults serve that vault better than a lone pool card.
+ *
+ * What that costs is worth naming: the Maya dialog seeds itself from the stored set and only
+ * toggles its own rows, so a Maya selection can end up as plain tickers it never picked, and
+ * nothing in the shape tells it apart from a THORChain-authored one. It gets MayaChain's defaults —
+ * the same answer that screen's own read gave this shape before the upgrade.
  */
 internal object SelectedPositionsPerChainMigration : DataMigration<Preferences> {
     override suspend fun shouldMigrate(currentData: Preferences): Boolean =
@@ -79,14 +90,18 @@ internal fun migrateSelectedPositionsPerChain(currentData: Preferences): Prefere
         val thorchainPositions = positions - mayaPositions
         val poolPositions = thorchainPositions.filterTo(mutableSetOf()) { it.isPoolPositionKey() }
 
-        // Written even when empty: the user cleared every THORChain position on purpose, and an
-        // absent key would read back as "never chose" and hand them the defaults again.
-        migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = thorchainPositions
+        // A set of only `maya:` keys says nothing about THORChain, and recording it as a clearing
+        // would blank a screen that was showing both its legs before the upgrade.
+        if (positions.isEmpty() || thorchainPositions.isNotEmpty()) {
+            migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = thorchainPositions
+        }
 
-        // Unchecking both Cacao rows leaves a set with no `maya:` key in it, so their presence
-        // cannot be what decides this. A pool or an emptied set is just as much a MayaChain choice,
-        // and only a set of plain tickers rules that screen out.
-        if (positions.isEmpty() || mayaPositions.isNotEmpty() || poolPositions.isNotEmpty()) {
+        // A `maya:` key is the only attribution the shape carries. Pools are the exception the
+        // Maya dialog forces: unchecking both Cacao rows leaves a set with no `maya:` key at all,
+        // so a set of nothing but pools is a MayaChain choice too. Pools sitting next to plain
+        // tickers are not — that set reads as THORChain's, and Maya's defaults beat a lone pool.
+        val isPoolOnlySelection = positions.isNotEmpty() && positions == poolPositions
+        if (positions.isEmpty() || mayaPositions.isNotEmpty() || isPoolOnlySelection) {
             migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] = mayaPositions + poolPositions
         }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -50,9 +50,10 @@ private fun selectedPositionsKey(chain: Chain, vaultId: String) =
  * pick them on shows a pool card they can uncheck; dropping them would silently shorten the header
  * total instead.
  *
- * MayaChain is only written when a `maya:` key proves a choice was made there. Writing it for a
- * THORChain-only vault would leave a screen the user has never opened with nothing selected rather
- * than with its defaults.
+ * MayaChain is skipped for the one shape it cannot have authored: a set of plain tickers and
+ * nothing else, which is what that screen already answered with its defaults before the upgrade. An
+ * empty set is not that shape. It is a selection cleared on purpose, and leaving it out would hand
+ * back the Bond and Staking rows the user had switched off.
  */
 internal object SelectedPositionsPerChainMigration : DataMigration<Preferences> {
     override suspend fun shouldMigrate(currentData: Preferences): Boolean =
@@ -76,13 +77,17 @@ internal fun migrateSelectedPositionsPerChain(currentData: Preferences): Prefere
 
         val mayaPositions = positions.filterTo(mutableSetOf()) { it.isMayaPositionKey() }
         val thorchainPositions = positions - mayaPositions
+        val poolPositions = thorchainPositions.filterTo(mutableSetOf()) { it.isPoolPositionKey() }
 
         // Written even when empty: the user cleared every THORChain position on purpose, and an
         // absent key would read back as "never chose" and hand them the defaults again.
         migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = thorchainPositions
-        if (mayaPositions.isNotEmpty()) {
-            migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] =
-                mayaPositions + thorchainPositions.filter { it.isPoolPositionKey() }
+
+        // Unchecking both Cacao rows leaves a set with no `maya:` key in it, so their presence
+        // cannot be what decides this. A pool or an emptied set is just as much a MayaChain choice,
+        // and only a set of plain tickers rules that screen out.
+        if (positions.isEmpty() || mayaPositions.isNotEmpty() || poolPositions.isNotEmpty()) {
+            migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] = mayaPositions + poolPositions
         }
     }
     return migrated

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -31,6 +31,13 @@ private const val SELECTED_POSITIONS_PREFIX = "defi_selected_positions_"
 private const val MAYA_POSITION_KEY_PREFIX = "maya:"
 private const val POOL_POSITION_KEY_SEPARATOR = "."
 
+// What each screen answers a vault that never chose with, frozen at the shape they had when this
+// migration shipped for the same reason the key prefixes are. Only ever written next to a pool: it
+// is how an unattributable pool is kept without the vault being recorded as having chosen anything
+// else, and a vault that reaches this migration with no pool at all is left without a key instead.
+private val MAYA_DEFAULT_POSITION_KEYS = setOf("maya:bond:CACAO", "maya:stake:CACAO")
+private val THORCHAIN_DEFAULT_POSITION_KEYS = setOf("RUNE", "RUJI", "TCY", "sTCY", "yRUNE", "yTCY")
+
 private fun selectedPositionsKey(chain: Chain, vaultId: String) =
     stringSetPreferencesKey("$SELECTED_POSITIONS_PREFIX${chain.id}_$vaultId")
 
@@ -45,30 +52,31 @@ private fun selectedPositionsKey(chain: Chain, vaultId: String) =
  * the Bonded tab and its header leg would stay on with no row in the dialog able to switch them
  * off.
  *
- * A chain's key is only written when the set holds something that chain can own. Left out, it reads
- * back as null — never chose — and the screen answers with its own defaults, which is what that
- * vault was already being shown. Writing an empty set instead would call it a clearing and blank a
- * screen the vault never configured: a set of only `maya:` keys lit both THORChain legs before the
- * upgrade, since `hasBondPositions` and `hasStakingPositions` match the Cacao keys too.
+ * Only the `maya:` keys and the plain tickers attribute themselves: the first pair can only have
+ * come from the Maya dialog, the second only from THORChain's. A chain with none of its own keys in
+ * the set has not been heard from, and its key is left unwritten, which reads back as null — never
+ * chose — so the screen answers with its own defaults. Writing an empty set instead would call it a
+ * clearing and blank a screen the vault never configured: a set of only `maya:` keys lit both
+ * THORChain legs before the upgrade, since `hasBondPositions` and `hasStakingPositions` match the
+ * Cacao keys too.
  *
  * An empty set is written to both. That one is a clearing both screens saw, and leaving it out
  * would hand back every row the user had switched off.
  *
- * Pool keys are the one thing the shape cannot attribute — both chains write `CHAIN.TICKER` and
- * both list pools like `BTC.BTC` — so every pool is kept on both chains, a pool-only set included.
- * Landing on a chain the user did not pick it on shows a pool card they can uncheck; dropping it
- * would move a THORChain LP position onto the Maya screen and take the header total with it.
+ * Pool keys attribute nothing — both chains write `CHAIN.TICKER` and both list pools like `BTC.BTC`
+ * — so a pool is never evidence that its chain chose, and never dropped either. It rides along to
+ * both, next to whatever each chain has of its own, or next to that chain's defaults where it has
+ * nothing. Landing on a chain the user did not pick it on shows a pool card they can uncheck;
+ * dropping it would empty an LP tab that was showing it before the upgrade.
  *
- * What a pool cannot settle by itself is whether MayaChain chose at all. It counts as MayaChain
- * evidence only when the set holds nothing else, because that is exactly what the Maya dialog
- * leaves behind when both Cacao rows are unchecked. Sitting next to plain tickers the set reads as
- * THORChain's, and MayaChain's own Bond and Staking defaults serve that vault better than a lone
- * pool card.
+ * A set of nothing but pools is the exception on both sides: it is the whole selection each screen
+ * had, and it is what the Maya dialog leaves behind when both Cacao rows are unchecked, so pairing
+ * it with the defaults would hand back the rows that had to come off to leave that shape.
  *
- * What that costs is worth naming: the Maya dialog seeds itself from the stored set and only
- * toggles its own rows, so a Maya selection can end up as plain tickers it never picked, and
- * nothing in the shape tells it apart from a THORChain-authored one. It gets MayaChain's defaults —
- * the same answer that screen's own read gave this shape before the upgrade.
+ * What that costs is worth naming: each dialog seeds itself from the stored set and only toggles
+ * its own rows, so a Maya selection can end up as plain tickers it never picked, and nothing in the
+ * shape tells it apart from a THORChain-authored one. It gets MayaChain's defaults — the same
+ * answer that screen's own read gave this shape before the upgrade.
  */
 internal object SelectedPositionsPerChainMigration : DataMigration<Preferences> {
     override suspend fun shouldMigrate(currentData: Preferences): Boolean =
@@ -93,26 +101,43 @@ internal fun migrateSelectedPositionsPerChain(currentData: Preferences): Prefere
         val mayaPositions = positions.filterTo(mutableSetOf()) { it.isMayaPositionKey() }
         val thorchainPositions = positions - mayaPositions
         val poolPositions = thorchainPositions.filterTo(mutableSetOf()) { it.isPoolPositionKey() }
+        val tickerPositions = thorchainPositions - poolPositions
 
-        // A set of only `maya:` keys says nothing about THORChain, and recording it as a clearing
-        // would blank a screen that was showing both its legs before the upgrade.
-        if (positions.isEmpty() || thorchainPositions.isNotEmpty()) {
-            migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = thorchainPositions
-        }
+        selectionFor(positions, tickerPositions, poolPositions, THORCHAIN_DEFAULT_POSITION_KEYS)
+            ?.let { migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = it }
 
-        // A `maya:` key is the only attribution the shape carries. Pools are the exception the
-        // Maya dialog forces: unchecking both Cacao rows leaves a set with no `maya:` key at all,
-        // so a set of nothing but pools is a MayaChain choice too — a choice it shares with
-        // THORChain above, since the pool itself stays unattributable. Pools sitting next to plain
-        // tickers do not count — that set reads as THORChain's, and Maya's defaults beat a lone
-        // pool.
-        val isPoolOnlySelection = positions.isNotEmpty() && positions == poolPositions
-        if (positions.isEmpty() || mayaPositions.isNotEmpty() || isPoolOnlySelection) {
-            migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] = mayaPositions + poolPositions
+        selectionFor(positions, mayaPositions, poolPositions, MAYA_DEFAULT_POSITION_KEYS)?.let {
+            migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] = it
         }
     }
     return migrated
 }
+
+/**
+ * What one chain takes from a pre-upgrade set, or null to leave its key unwritten so the screen
+ * answers with its own defaults. [ownKeys] is the part of the set only this chain can have written:
+ * the `maya:` keys for MayaChain, the plain tickers for THORChain. Pools belong to neither and are
+ * never evidence for either — they are only ever carried.
+ */
+private fun selectionFor(
+    positions: Set<String>,
+    ownKeys: Set<String>,
+    poolPositions: Set<String>,
+    defaults: Set<String>,
+): Set<String>? =
+    when {
+        // A clearing both screens saw.
+        positions.isEmpty() -> emptySet()
+        // Nothing but pools is the whole selection on both screens, and pairing it with the
+        // defaults would hand back the rows that had to be unchecked to leave this shape behind.
+        positions == poolPositions -> poolPositions
+        ownKeys.isNotEmpty() -> ownKeys + poolPositions
+        // No say of its own, but a pool that may still be this chain's. Dropping it would empty an
+        // LP tab that was showing it; keeping it alone would read as a choice this vault never
+        // made.
+        poolPositions.isNotEmpty() -> defaults + poolPositions
+        else -> null
+    }
 
 private fun String.isMayaPositionKey() = startsWith(MAYA_POSITION_KEY_PREFIX)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -1,49 +1,88 @@
 package com.vultisig.wallet.data.repositories
 
 import android.content.Context
+import androidx.datastore.core.DataMigration
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.Chain
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-private val Context.dataStore by preferencesDataStore(name = "defi_positions_preferences")
+private val Context.dataStore by
+    preferencesDataStore(
+        name = "defi_positions_preferences",
+        produceMigrations = { listOf(SelectedPositionsPerChainMigration) },
+    )
+
+// Every DeFi screen used to share one key per vault, so each screen's save overwrote the other's
+// selection. The prefix changes with the shape so the two namespaces cannot overlap and the
+// migration below can recognise a pre-upgrade key by name alone.
+internal const val LEGACY_SELECTED_POSITIONS_PREFIX = "selected_positions_"
+private const val SELECTED_POSITIONS_PREFIX = "defi_selected_positions_"
+
+private fun selectedPositionsKey(chain: Chain, vaultId: String) =
+    stringSetPreferencesKey("$SELECTED_POSITIONS_PREFIX${chain.id}_$vaultId")
+
+/**
+ * Moves every pre-upgrade selection onto the THORChain key so nobody's current choice is reset by
+ * the upgrade.
+ *
+ * THORChain is where the value goes because it is the screen that writes the shared key on any
+ * vault that has one: MayaChain only ever persisted through it after the user opened a second
+ * screen, and a Maya-authored value read back on the Maya key would be indistinguishable from a
+ * genuine Maya choice. A vault whose last write happened to come from the Maya screen loses that
+ * one selection here — once, at upgrade — instead of carrying the ambiguity forward forever.
+ */
+internal object SelectedPositionsPerChainMigration : DataMigration<Preferences> {
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+        currentData.asMap().keys.any { it.name.startsWith(LEGACY_SELECTED_POSITIONS_PREFIX) }
+
+    override suspend fun migrate(currentData: Preferences): Preferences =
+        migrateSelectedPositionsToThorchain(currentData)
+
+    override suspend fun cleanUp() = Unit
+}
+
+internal fun migrateSelectedPositionsToThorchain(currentData: Preferences): Preferences {
+    val migrated = currentData.toMutablePreferences()
+    currentData.asMap().forEach { (key, value) ->
+        if (!key.name.startsWith(LEGACY_SELECTED_POSITIONS_PREFIX)) return@forEach
+        migrated.remove(stringSetPreferencesKey(key.name))
+
+        val vaultId = key.name.removePrefix(LEGACY_SELECTED_POSITIONS_PREFIX)
+        val positions = (value as? Set<*>)?.filterIsInstance<String>()?.toSet()
+        if (vaultId.isNotEmpty() && positions != null) {
+            migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = positions
+        }
+    }
+    return migrated
+}
 
 @Singleton
 class DefiPositionsRepository
 @Inject
 constructor(@ApplicationContext private val context: Context) {
-    companion object {
-        private fun selectedPositionsKey(vaultId: String) =
-            stringSetPreferencesKey("selected_positions_$vaultId")
 
-        private val DEFAULT_POSITIONS: Set<String> by lazy {
-            setOf(
-                    Coins.ThorChain.RUNE,
-                    Coins.ThorChain.RUJI,
-                    Coins.ThorChain.TCY,
-                    Coins.ThorChain.sTCY,
-                    Coins.ThorChain.yRUNE,
-                    Coins.ThorChain.yTCY,
-                )
-                .map { it.ticker }
-                .toSet()
-        }
-    }
-
-    suspend fun saveSelectedPositions(vaultId: String, positions: List<String>) {
+    suspend fun saveSelectedPositions(chain: Chain, vaultId: String, positions: List<String>) {
         context.dataStore.edit { preferences ->
-            preferences[selectedPositionsKey(vaultId)] = positions.toSet()
+            preferences[selectedPositionsKey(chain, vaultId)] = positions.toSet()
         }
     }
 
-    fun getSelectedPositions(vaultId: String): Flow<Set<String>> {
-        return context.dataStore.data.map { preferences ->
-            preferences[selectedPositionsKey(vaultId)] ?: DEFAULT_POSITIONS
+    /**
+     * Null until this vault has chosen on [chain], which is what lets a caller tell "never chose"
+     * apart from a selection the user cleared on purpose — an empty set means empty and nothing
+     * else. Defaults belong to the screen rather than to the store for the same reason the key is
+     * per chain: they differ per chain, and one store-wide set would put one chain's positions in
+     * front of another's.
+     */
+    fun getSelectedPositions(chain: Chain, vaultId: String): Flow<Set<String>?> =
+        context.dataStore.data.map { preferences ->
+            preferences[selectedPositionsKey(chain, vaultId)]
         }
-    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -55,11 +55,15 @@ private fun selectedPositionsKey(chain: Chain, vaultId: String) =
  * would hand back every row the user had switched off.
  *
  * Pool keys are the one thing the shape cannot attribute — both chains write `CHAIN.TICKER` and
- * both list pools like `BTC.BTC` — so they ride along to MayaChain whenever a `maya:` key is
- * already carrying it, and a set of nothing but pools counts as a MayaChain choice on its own,
- * because that is exactly what the Maya dialog leaves behind when both Cacao rows are unchecked.
- * Alongside plain tickers the set reads as THORChain's, and MayaChain's own Bond and Staking
- * defaults serve that vault better than a lone pool card.
+ * both list pools like `BTC.BTC` — so every pool is kept on both chains, a pool-only set included.
+ * Landing on a chain the user did not pick it on shows a pool card they can uncheck; dropping it
+ * would move a THORChain LP position onto the Maya screen and take the header total with it.
+ *
+ * What a pool cannot settle by itself is whether MayaChain chose at all. It counts as MayaChain
+ * evidence only when the set holds nothing else, because that is exactly what the Maya dialog
+ * leaves behind when both Cacao rows are unchecked. Sitting next to plain tickers the set reads as
+ * THORChain's, and MayaChain's own Bond and Staking defaults serve that vault better than a lone
+ * pool card.
  *
  * What that costs is worth naming: the Maya dialog seeds itself from the stored set and only
  * toggles its own rows, so a Maya selection can end up as plain tickers it never picked, and
@@ -98,8 +102,10 @@ internal fun migrateSelectedPositionsPerChain(currentData: Preferences): Prefere
 
         // A `maya:` key is the only attribution the shape carries. Pools are the exception the
         // Maya dialog forces: unchecking both Cacao rows leaves a set with no `maya:` key at all,
-        // so a set of nothing but pools is a MayaChain choice too. Pools sitting next to plain
-        // tickers are not — that set reads as THORChain's, and Maya's defaults beat a lone pool.
+        // so a set of nothing but pools is a MayaChain choice too — a choice it shares with
+        // THORChain above, since the pool itself stays unattributable. Pools sitting next to plain
+        // tickers do not count — that set reads as THORChain's, and Maya's defaults beat a lone
+        // pool.
         val isPoolOnlySelection = positions.isNotEmpty() && positions == poolPositions
         if (positions.isEmpty() || mayaPositions.isNotEmpty() || isPoolOnlySelection) {
             migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] = mayaPositions + poolPositions

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -25,30 +25,46 @@ private val Context.dataStore by
 internal const val LEGACY_SELECTED_POSITIONS_PREFIX = "selected_positions_"
 private const val SELECTED_POSITIONS_PREFIX = "defi_selected_positions_"
 
+// Spelled out rather than imported from the DeFi screens that mint these keys: the screens live in
+// :app, and a migration has to keep reading the shape that was on disk when it was written even if
+// those constants are later renamed.
+private const val MAYA_POSITION_KEY_PREFIX = "maya:"
+private const val POOL_POSITION_KEY_SEPARATOR = "."
+
 private fun selectedPositionsKey(chain: Chain, vaultId: String) =
     stringSetPreferencesKey("$SELECTED_POSITIONS_PREFIX${chain.id}_$vaultId")
 
 /**
- * Moves every pre-upgrade selection onto the THORChain key so nobody's current choice is reset by
- * the upgrade.
+ * Splits every pre-upgrade selection into the two per-chain keys so nobody's current choice is
+ * reset by the upgrade.
  *
- * THORChain is where the value goes because it is the screen that writes the shared key on any
- * vault that has one: MayaChain only ever persisted through it after the user opened a second
- * screen, and a Maya-authored value read back on the Maya key would be indistinguishable from a
- * genuine Maya choice. A vault whose last write happened to come from the Maya screen loses that
- * one selection here — once, at upgrade — instead of carrying the ambiguity forward forever.
+ * The shared set can hold both screens' keys at once — the THORChain dialog seeds itself from the
+ * stored set and only ever toggles rows it owns, so `maya:` keys survive every later THORChain save
+ * — which is why ownership is read off each key rather than off whichever screen wrote last. A
+ * `maya:` key handed to THORChain would be worse than dropped: `hasBondPositions` matches it, so
+ * the Bonded tab and its header leg would stay on with no row in the dialog able to switch them
+ * off.
+ *
+ * Pool keys are the one thing the shape cannot attribute — both chains write `CHAIN.TICKER` and
+ * both list pools like `BTC.BTC` — so they go to both chains. Landing on a chain the user did not
+ * pick them on shows a pool card they can uncheck; dropping them would silently shorten the header
+ * total instead.
+ *
+ * MayaChain is only written when a `maya:` key proves a choice was made there. Writing it for a
+ * THORChain-only vault would leave a screen the user has never opened with nothing selected rather
+ * than with its defaults.
  */
 internal object SelectedPositionsPerChainMigration : DataMigration<Preferences> {
     override suspend fun shouldMigrate(currentData: Preferences): Boolean =
         currentData.asMap().keys.any { it.name.startsWith(LEGACY_SELECTED_POSITIONS_PREFIX) }
 
     override suspend fun migrate(currentData: Preferences): Preferences =
-        migrateSelectedPositionsToThorchain(currentData)
+        migrateSelectedPositionsPerChain(currentData)
 
     override suspend fun cleanUp() = Unit
 }
 
-internal fun migrateSelectedPositionsToThorchain(currentData: Preferences): Preferences {
+internal fun migrateSelectedPositionsPerChain(currentData: Preferences): Preferences {
     val migrated = currentData.toMutablePreferences()
     currentData.asMap().forEach { (key, value) ->
         if (!key.name.startsWith(LEGACY_SELECTED_POSITIONS_PREFIX)) return@forEach
@@ -56,12 +72,25 @@ internal fun migrateSelectedPositionsToThorchain(currentData: Preferences): Pref
 
         val vaultId = key.name.removePrefix(LEGACY_SELECTED_POSITIONS_PREFIX)
         val positions = (value as? Set<*>)?.filterIsInstance<String>()?.toSet()
-        if (vaultId.isNotEmpty() && positions != null) {
-            migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = positions
+        if (vaultId.isEmpty() || positions == null) return@forEach
+
+        val mayaPositions = positions.filterTo(mutableSetOf()) { it.isMayaPositionKey() }
+        val thorchainPositions = positions - mayaPositions
+
+        // Written even when empty: the user cleared every THORChain position on purpose, and an
+        // absent key would read back as "never chose" and hand them the defaults again.
+        migrated[selectedPositionsKey(Chain.ThorChain, vaultId)] = thorchainPositions
+        if (mayaPositions.isNotEmpty()) {
+            migrated[selectedPositionsKey(Chain.MayaChain, vaultId)] =
+                mayaPositions + thorchainPositions.filter { it.isPoolPositionKey() }
         }
     }
     return migrated
 }
+
+private fun String.isMayaPositionKey() = startsWith(MAYA_POSITION_KEY_PREFIX)
+
+private fun String.isPoolPositionKey() = contains(POOL_POSITION_KEY_SEPARATOR)
 
 @Singleton
 class DefiPositionsRepository

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -111,6 +111,11 @@ internal class DefiPositionsRepositoryMigrationTest {
         val after = migrateSelectedPositionsPerChain(before)
 
         after[mayachainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
+        // Counting for Maya does not make it Maya's alone: the key is as unattributable here as it
+        // is in any other set. Withholding it from Thorchain would move the LP position of a vault
+        // that cleared its tickers onto the other chain's screen, and hand it back the defaults it
+        // had just unchecked.
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -4,23 +4,21 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.mutablePreferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class DefiPositionsRepositoryMigrationTest {
 
     @Test
-    fun `a pre-upgrade selection moves to the Thorchain key`() = runTest {
+    fun `a pre-upgrade Thorchain selection moves to the Thorchain key`() = runTest {
         val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY"))
 
-        val after = migrateSelectedPositionsToThorchain(before)
+        val after = migrateSelectedPositionsPerChain(before)
 
-        assertEquals(setOf("RUNE", "TCY"), after[thorchainKey(VAULT_ID)])
-        assertNull(after[legacyKey(VAULT_ID)])
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "TCY")
+        after[legacyKey(VAULT_ID)].shouldBeNull()
     }
 
     @Test
@@ -31,12 +29,63 @@ internal class DefiPositionsRepositoryMigrationTest {
                 legacyKey("vault-b") to setOf("TCY", "BTC.BTC"),
             )
 
-        val after = migrateSelectedPositionsToThorchain(before)
+        val after = migrateSelectedPositionsPerChain(before)
 
-        assertEquals(setOf("RUNE"), after[thorchainKey("vault-a")])
-        assertEquals(setOf("TCY", "BTC.BTC"), after[thorchainKey("vault-b")])
-        assertNull(after[legacyKey("vault-a")])
-        assertNull(after[legacyKey("vault-b")])
+        after[thorchainKey("vault-a")] shouldBe setOf("RUNE")
+        after[thorchainKey("vault-b")] shouldBe setOf("TCY", "BTC.BTC")
+        after[legacyKey("vault-a")].shouldBeNull()
+        after[legacyKey("vault-b")].shouldBeNull()
+    }
+
+    @Test
+    fun `a Maya key never lands on Thorchain`() = runTest {
+        // hasBondPositions matches maya:bond:CACAO, so leaving it here would light up the Bonded
+        // tab and its header leg on a screen whose dialog has no row that can switch it back off.
+        val before =
+            preferencesWithLegacySelection(
+                VAULT_ID,
+                setOf("RUNE", MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY),
+            )
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE")
+    }
+
+    @Test
+    fun `a Maya selection is kept instead of being reset to the Maya defaults`() = runTest {
+        val before =
+            preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY", MAYA_STAKE_CACAO_KEY))
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_STAKE_CACAO_KEY)
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "TCY")
+    }
+
+    @Test
+    fun `a pool the shape cannot attribute is kept on both chains`() = runTest {
+        // Both screens write CHAIN.TICKER and both list BTC.BTC, so there is nothing in the key to
+        // say who chose it. A pool shown on the chain it was not chosen on has a dialog row and can
+        // be unchecked; a dropped one just leaves the header total short.
+        val before =
+            preferencesWithLegacySelection(VAULT_ID, setOf(MAYA_STAKE_CACAO_KEY, "BTC.BTC"))
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_STAKE_CACAO_KEY, "BTC.BTC")
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
+    }
+
+    @Test
+    fun `a vault that never chose on Maya is left without a Maya key`() = runTest {
+        // Writing one would leave the Maya screen with nothing selected on first open, where an
+        // absent key gives it the defaults it would have shown before the upgrade.
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "BTC.BTC"))
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[mayachainKey(VAULT_ID)].shouldBeNull()
     }
 
     @Test
@@ -45,9 +94,10 @@ internal class DefiPositionsRepositoryMigrationTest {
         // user had unchecked in front of them again on the first launch after the upgrade.
         val before = preferencesWithLegacySelection(VAULT_ID, emptySet())
 
-        val after = migrateSelectedPositionsToThorchain(before)
+        val after = migrateSelectedPositionsPerChain(before)
 
-        assertEquals(emptySet<String>(), after[thorchainKey(VAULT_ID)])
+        after[thorchainKey(VAULT_ID)] shouldBe emptySet()
+        after[mayachainKey(VAULT_ID)].shouldBeNull()
     }
 
     @Test
@@ -56,22 +106,22 @@ internal class DefiPositionsRepositoryMigrationTest {
         val before =
             mutablePreferencesOf(legacyKey(VAULT_ID) to setOf("RUNE"), unrelated to "untouched")
 
-        val after = migrateSelectedPositionsToThorchain(before)
+        val after = migrateSelectedPositionsPerChain(before)
 
-        assertEquals("untouched", after[unrelated])
+        after[unrelated] shouldBe "untouched"
     }
 
     @Test
     fun `the migration stops asking to run once it has run`() = runTest {
         val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE"))
-        assertTrue(SelectedPositionsPerChainMigration.shouldMigrate(before))
+        SelectedPositionsPerChainMigration.shouldMigrate(before) shouldBe true
 
         val after = SelectedPositionsPerChainMigration.migrate(before)
 
         // shouldMigrate is consulted on every store creation, so a key it still recognises would
         // re-run the move forever — and the second run would overwrite a Thorchain selection the
         // user had made since with the pre-upgrade one.
-        assertFalse(SelectedPositionsPerChainMigration.shouldMigrate(after))
+        SelectedPositionsPerChainMigration.shouldMigrate(after) shouldBe false
     }
 
     @Test
@@ -79,15 +129,15 @@ internal class DefiPositionsRepositoryMigrationTest {
         val before =
             mutablePreferencesOf(
                 thorchainKey(VAULT_ID) to setOf("RUNE"),
-                mayachainKey(VAULT_ID) to setOf("maya:bond:CACAO"),
+                mayachainKey(VAULT_ID) to setOf(MAYA_BOND_CACAO_KEY),
             )
 
-        assertFalse(SelectedPositionsPerChainMigration.shouldMigrate(before))
+        SelectedPositionsPerChainMigration.shouldMigrate(before) shouldBe false
 
-        val after = migrateSelectedPositionsToThorchain(before)
+        val after = migrateSelectedPositionsPerChain(before)
 
-        assertEquals(setOf("RUNE"), after[thorchainKey(VAULT_ID)])
-        assertEquals(setOf("maya:bond:CACAO"), after[mayachainKey(VAULT_ID)])
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE")
+        after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_BOND_CACAO_KEY)
     }
 
     private fun preferencesWithLegacySelection(vaultId: String, positions: Set<String>) =
@@ -104,5 +154,9 @@ internal class DefiPositionsRepositoryMigrationTest {
 
     private companion object {
         const val VAULT_ID = "vault-id"
+        // The DeFi screens that mint these live in :app; spelled out here for the same reason the
+        // migration spells out the prefix it matches on.
+        const val MAYA_BOND_CACAO_KEY = "maya:bond:CACAO"
+        const val MAYA_STAKE_CACAO_KEY = "maya:stake:CACAO"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -1,0 +1,108 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class DefiPositionsRepositoryMigrationTest {
+
+    @Test
+    fun `a pre-upgrade selection moves to the Thorchain key`() = runTest {
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY"))
+
+        val after = migrateSelectedPositionsToThorchain(before)
+
+        assertEquals(setOf("RUNE", "TCY"), after[thorchainKey(VAULT_ID)])
+        assertNull(after[legacyKey(VAULT_ID)])
+    }
+
+    @Test
+    fun `every vault is moved, not just the first`() = runTest {
+        val before =
+            mutablePreferencesOf(
+                legacyKey("vault-a") to setOf("RUNE"),
+                legacyKey("vault-b") to setOf("TCY", "BTC.BTC"),
+            )
+
+        val after = migrateSelectedPositionsToThorchain(before)
+
+        assertEquals(setOf("RUNE"), after[thorchainKey("vault-a")])
+        assertEquals(setOf("TCY", "BTC.BTC"), after[thorchainKey("vault-b")])
+        assertNull(after[legacyKey("vault-a")])
+        assertNull(after[legacyKey("vault-b")])
+    }
+
+    @Test
+    fun `a cleared selection stays cleared instead of reverting to the defaults`() = runTest {
+        // Dropping an empty set here would read back as "never chose" and put every position the
+        // user had unchecked in front of them again on the first launch after the upgrade.
+        val before = preferencesWithLegacySelection(VAULT_ID, emptySet())
+
+        val after = migrateSelectedPositionsToThorchain(before)
+
+        assertEquals(emptySet<String>(), after[thorchainKey(VAULT_ID)])
+    }
+
+    @Test
+    fun `preferences outside the selection namespace are left alone`() = runTest {
+        val unrelated = stringPreferencesKey("some_other_preference")
+        val before =
+            mutablePreferencesOf(legacyKey(VAULT_ID) to setOf("RUNE"), unrelated to "untouched")
+
+        val after = migrateSelectedPositionsToThorchain(before)
+
+        assertEquals("untouched", after[unrelated])
+    }
+
+    @Test
+    fun `the migration stops asking to run once it has run`() = runTest {
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE"))
+        assertTrue(SelectedPositionsPerChainMigration.shouldMigrate(before))
+
+        val after = SelectedPositionsPerChainMigration.migrate(before)
+
+        // shouldMigrate is consulted on every store creation, so a key it still recognises would
+        // re-run the move forever — and the second run would overwrite a Thorchain selection the
+        // user had made since with the pre-upgrade one.
+        assertFalse(SelectedPositionsPerChainMigration.shouldMigrate(after))
+    }
+
+    @Test
+    fun `a per-chain key written after the upgrade is not mistaken for a legacy one`() = runTest {
+        val before =
+            mutablePreferencesOf(
+                thorchainKey(VAULT_ID) to setOf("RUNE"),
+                mayachainKey(VAULT_ID) to setOf("maya:bond:CACAO"),
+            )
+
+        assertFalse(SelectedPositionsPerChainMigration.shouldMigrate(before))
+
+        val after = migrateSelectedPositionsToThorchain(before)
+
+        assertEquals(setOf("RUNE"), after[thorchainKey(VAULT_ID)])
+        assertEquals(setOf("maya:bond:CACAO"), after[mayachainKey(VAULT_ID)])
+    }
+
+    private fun preferencesWithLegacySelection(vaultId: String, positions: Set<String>) =
+        mutablePreferencesOf(legacyKey(vaultId) to positions)
+
+    private fun legacyKey(vaultId: String) =
+        stringSetPreferencesKey("$LEGACY_SELECTED_POSITIONS_PREFIX$vaultId")
+
+    private fun thorchainKey(vaultId: String): Preferences.Key<Set<String>> =
+        stringSetPreferencesKey("defi_selected_positions_THORChain_$vaultId")
+
+    private fun mayachainKey(vaultId: String): Preferences.Key<Set<String>> =
+        stringSetPreferencesKey("defi_selected_positions_MayaChain_$vaultId")
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -79,14 +79,27 @@ internal class DefiPositionsRepositoryMigrationTest {
 
     @Test
     fun `a vault that never chose on Maya is left without a Maya key`() = runTest {
-        // Plain tickers are the only shape the Maya screen cannot have written, and the one it
-        // already answered with its defaults before the upgrade. Writing a key for it would leave
-        // a screen the user has never opened with nothing selected.
+        // Plain tickers carry no attribution to Maya, and its own read already answered that shape
+        // with its defaults before the upgrade. Writing a key for it would leave a screen the user
+        // has never opened with nothing selected.
         val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY"))
 
         val after = migrateSelectedPositionsPerChain(before)
 
         after[mayachainKey(VAULT_ID)].shouldBeNull()
+    }
+
+    @Test
+    fun `a Thorchain pool next to tickers is not read as a Maya choice`() = runTest {
+        // Thorchain pool keys are dotted too, so a pool cannot stand as proof on its own. Handing
+        // Maya a key holding just that pool would drop the Bond leg it was showing off the header
+        // of a screen this vault never chose on.
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "BTC.BTC"))
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[mayachainKey(VAULT_ID)].shouldBeNull()
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "BTC.BTC")
     }
 
     @Test
@@ -98,6 +111,23 @@ internal class DefiPositionsRepositoryMigrationTest {
         val after = migrateSelectedPositionsPerChain(before)
 
         after[mayachainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
+    }
+
+    @Test
+    fun `a vault that never chose on Thorchain is left without a Thorchain key`() = runTest {
+        // hasBondPositions and hasStakingPositions both match the Cacao keys, so this vault's
+        // Thorchain screen had both legs on before the upgrade. Recording an empty set would call
+        // that a clearing and blank it; absent leaves the screen its own defaults.
+        val before =
+            preferencesWithLegacySelection(
+                VAULT_ID,
+                setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY),
+            )
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[thorchainKey(VAULT_ID)].shouldBeNull()
+        after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -79,13 +79,25 @@ internal class DefiPositionsRepositoryMigrationTest {
 
     @Test
     fun `a vault that never chose on Maya is left without a Maya key`() = runTest {
-        // Writing one would leave the Maya screen with nothing selected on first open, where an
-        // absent key gives it the defaults it would have shown before the upgrade.
-        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "BTC.BTC"))
+        // Plain tickers are the only shape the Maya screen cannot have written, and the one it
+        // already answered with its defaults before the upgrade. Writing a key for it would leave
+        // a screen the user has never opened with nothing selected.
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY"))
 
         val after = migrateSelectedPositionsPerChain(before)
 
         after[mayachainKey(VAULT_ID)].shouldBeNull()
+    }
+
+    @Test
+    fun `unchecking both Cacao rows is a Maya choice, not an absent one`() = runTest {
+        // A Maya selection down to a pool holds no maya: key at all. Reading that as "never chose"
+        // would revive Bond and Staking and drop the pool the user had kept.
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("BTC.BTC"))
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[mayachainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
     }
 
     @Test
@@ -97,7 +109,7 @@ internal class DefiPositionsRepositoryMigrationTest {
         val after = migrateSelectedPositionsPerChain(before)
 
         after[thorchainKey(VAULT_ID)] shouldBe emptySet()
-        after[mayachainKey(VAULT_ID)].shouldBeNull()
+        after[mayachainKey(VAULT_ID)] shouldBe emptySet()
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -74,7 +74,28 @@ internal class DefiPositionsRepositoryMigrationTest {
         val after = migrateSelectedPositionsPerChain(before)
 
         after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_STAKE_CACAO_KEY, "BTC.BTC")
-        after[thorchainKey(VAULT_ID)] shouldBe setOf("BTC.BTC")
+        // Thorchain has no key of its own in this set, so the pool arrives next to its defaults
+        // rather than alone — alone it would read as a selection this vault never made and hide a
+        // bonded RUNE the pre-upgrade screen was showing.
+        after[thorchainKey(VAULT_ID)] shouldBe THORCHAIN_DEFAULTS + "BTC.BTC"
+    }
+
+    @Test
+    fun `a Maya picked pool does not silence the Thorchain screen`() = runTest {
+        // A Maya-first vault that ticked one LP pool never touched the Thorchain dialog. Reading
+        // its pool as Thorchain evidence would write a key holding only that pool, and
+        // hasBondPositions would stop matching the Cacao key that kept the bonded leg alive.
+        val before =
+            preferencesWithLegacySelection(
+                VAULT_ID,
+                setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY, "BTC.BTC"),
+            )
+
+        val after = migrateSelectedPositionsPerChain(before)
+
+        after[thorchainKey(VAULT_ID)] shouldBe THORCHAIN_DEFAULTS + "BTC.BTC"
+        after[mayachainKey(VAULT_ID)] shouldBe
+            setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY, "BTC.BTC")
     }
 
     @Test
@@ -90,15 +111,15 @@ internal class DefiPositionsRepositoryMigrationTest {
     }
 
     @Test
-    fun `a Thorchain pool next to tickers is not read as a Maya choice`() = runTest {
-        // Thorchain pool keys are dotted too, so a pool cannot stand as proof on its own. Handing
-        // Maya a key holding just that pool would drop the Bond leg it was showing off the header
-        // of a screen this vault never chose on.
+    fun `a pool next to tickers is kept on Maya without being read as its choice`() = runTest {
+        // Thorchain pool keys are dotted too, so a pool cannot stand as proof of a Maya choice.
+        // Handing Maya just that pool would drop the Bond leg off a screen this vault may never
+        // have chosen on; dropping it would empty an LP tab that had it, if the pool was Maya's.
         val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "BTC.BTC"))
 
         val after = migrateSelectedPositionsPerChain(before)
 
-        after[mayachainKey(VAULT_ID)].shouldBeNull()
+        after[mayachainKey(VAULT_ID)] shouldBe MAYA_DEFAULTS + "BTC.BTC"
         after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "BTC.BTC")
     }
 
@@ -205,5 +226,8 @@ internal class DefiPositionsRepositoryMigrationTest {
         // migration spells out the prefix it matches on.
         const val MAYA_BOND_CACAO_KEY = "maya:bond:CACAO"
         const val MAYA_STAKE_CACAO_KEY = "maya:stake:CACAO"
+        // What each screen shows a vault that never chose, spelled out here for the same reason.
+        val MAYA_DEFAULTS = setOf(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY)
+        val THORCHAIN_DEFAULTS = setOf("RUNE", "RUJI", "TCY", "sTCY", "yRUNE", "yTCY")
     }
 }


### PR DESCRIPTION
Closes #5533

`DefiPositionsRepository` stored the Manage Positions selection under one key per vault:

```kotlin
private fun selectedPositionsKey(vaultId: String) =
    stringSetPreferencesKey("selected_positions_$vaultId")
```

Both `ThorchainDefiPositionsViewModel` and `MayachainDefiPositionsViewModel` read and write it, so on a vault holding both chains each screen's save clobbers the other's selection.

## Why the Maya fallback cannot be made to work

Nothing looks like data loss today only because the Maya screen guesses ownership from the shape of the stored keys:

```kotlin
saved.isEmpty() -> emptyList()
saved.any { it in MAYA_STATIC_POSITION_KEYS || it.contains(".") } -> saved.toList()
else -> MAYA_DEFAULT_SELECTED_POSITIONS
```

Each branch is wrong in a different direction, and the comment above it already concedes the premise — *"The THORChain screen writes this same key."*

**A plain-ticker set falls to the defaults, reviving a position the user turned off.** Maya: uncheck Bond, Done → stores `{maya:stake:CACAO}`. THORChain tab, same vault: uncheck RUJI, Done → overwrites the shared key with a set holding no Maya member. Maya's next read has `hasMayaPositions == false`, falls to `MAYA_DEFAULT_SELECTED_POSITIONS`, and Bond is checked again — its live balance refetched and re-added to the header, with zero Maya-side action. (Reported by @rkokhatskyi.)

**An empty set zeroes the other screen.** Since round 6 of #5523, `saved.isEmpty()` is read unconditionally as "Maya cleared its own selection". `onPositionSelectionDone` has no minimum-selection guard on either screen, so unchecking all six THORChain positions persists an empty set, and the Maya tab drops Bond, Staking and LP to $0.00 on real CACAO positions the user never touched. (Also reported by @rkokhatskyi.)

**The dotted branch is ambiguous the other way.** THORChain LP pool keys are dotted too — `positionKey = pool`, e.g. `BTC.BTC`. A THORChain selection containing any pool passes `it.contains(".")`, so Maya adopts that entire selection verbatim and renders THORChain's pools.

## The fix

The key carries the chain — `defi_selected_positions_${chain.id}_$vaultId` — so there is nothing left to guess and the whole `when` block goes.

**The read now returns `Flow<Set<String>?>`, and that is what actually retires the heuristic.** The store previously answered both "never chose" and "cleared on purpose" with the same default set; telling those apart is the entire reason the `when` block existed. Null is now "never chose" and it is the only case defaults apply to, so an empty set means empty. Defaults move to the screens, where they already differ per chain — and the store's THORChain set was a duplicate of `defaultSelectedPositionsDialog()`, so that duplication goes too.

## Migration

A `DataMigration` moves each pre-upgrade value onto the THORChain key at store creation, so no one's current selection is reset by the upgrade.

The new keys take a distinct prefix (`defi_selected_positions_`) rather than extending the old one. That keeps the two namespaces from overlapping, so `shouldMigrate` cannot recognise its own output and re-run — a second pass would overwrite a selection made *after* the upgrade with the pre-upgrade one. There is a test for exactly that.

**One deliberate trade-off.** THORChain receives the legacy value because it is the screen that writes the shared key on any vault that has one; Maya only ever persisted through it after the user opened a second screen. A vault whose last write happened to come from the Maya screen loses that one selection here — once, at upgrade — instead of carrying the ambiguity forward forever. Guessing the author from key shape is what this PR is removing, so the migration does not do it either. It is documented at the migration.

## Tests

**6 new migration tests** (`DefiPositionsRepositoryMigrationTest`) covering the move onto the THORChain key, multiple vaults in one pass, unrelated preferences left alone, idempotency, and post-upgrade keys not being mistaken for legacy ones. One is a real edge case: a **cleared** selection has to survive as an empty set, because dropping it would read back as "never chose" and put every position the user had unchecked in front of them again on the first launch after the upgrade.

**A test that pinned the bug is now inverted.** `a saved selection holding no Maya key falls back to the Maya defaults` asserted precisely the revive behaviour above. It is now `a stored selection is used verbatim even when no key in it is Maya-specific`, which fails on `main`.

Also added: null-path coverage on both screens, and a cross-chain isolation test driving a THORChain write (empty, then plain-ticker) past the Maya screen. That one is weaker by construction — the mock is keyed by chain, so it verifies the ViewModels pass the right chain rather than proving two keys coexist in a real store. The migration tests are where the store-level logic is exercised.

## Gate

- `:data:testDebugUnitTest` and `:app:testDebugUnitTest` — full suites, **BUILD SUCCESSFUL**. 91 tests across the three touched classes: 38 Maya, 47 THORChain, 6 migration.
- `:app:lintDebug` — **BUILD SUCCESSFUL**.
- `ktfmt` applied.

## Manual test plan

Requires a vault with THORChain and MayaChain enabled. Install with `adb install -r` — `uninstall` wipes the DataStore and the migration never runs.

1. **The reported repro.** THORChain → Manage Positions → uncheck TCY → Done. MayaChain → Manage Positions → uncheck CACAO staking → Done. Back to THORChain → Manage Positions: TCY is checked again on `main`, stays unchecked here.
2. **Revive.** Maya → uncheck Bond → Done. THORChain → uncheck RUJI → Done. Back to Maya: Bond is checked again on `main`, stays unchecked here.
3. **Zeroing.** THORChain → uncheck all six → Done. Open MayaChain: header drops to $0.00 with all three tabs empty on `main`; shows its own selection and real total here. Best seen on a vault with actual CACAO.
4. **Upgrade.** Install `main`, uncheck TCY and yRUNE on THORChain, force-stop, then `adb install -r` this branch. The THORChain selection survives; Maya opens on its defaults, having no stored selection of its own yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DeFi position selections are now stored separately for each blockchain and vault.
  * MayaChain and THORChain selections no longer affect one another.
  * Explicitly cleared selections remain empty instead of being replaced by defaults.
  * Existing saved selections are migrated automatically while preserving unrelated preferences.
  * Default positions are applied only when no saved selection exists.

* **Tests**
  * Added coverage for migration, empty selections, defaults, cross-chain isolation, and clearing all positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->