### PR TITLE
fix(ui): align top bar back button and show Continue as loading

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
@@ -138,7 +139,9 @@ import com.vultisig.wallet.ui.models.peer.PeerDiscoveryUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimMaturingUtxoUiModel
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUiState
 import com.vultisig.wallet.ui.models.qbtc.QbtcClaimUtxoUiModel
+import com.vultisig.wallet.ui.models.send.AmountFraction
 import com.vultisig.wallet.ui.models.send.GasSettingsUiModel
+import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
 import com.vultisig.wallet.ui.models.swap.LimitExpiryOption
@@ -183,6 +186,7 @@ import com.vultisig.wallet.ui.screens.select.AssetUiModel
 import com.vultisig.wallet.ui.screens.select.SelectAssetScreen
 import com.vultisig.wallet.ui.screens.select.SelectAssetUiModel
 import com.vultisig.wallet.ui.screens.send.GasSettingsScreen
+import com.vultisig.wallet.ui.screens.send.SendFormScreen
 import com.vultisig.wallet.ui.screens.send.VerifySendScreen
 import com.vultisig.wallet.ui.screens.settings.DiscountTiersScreenPreview
 import com.vultisig.wallet.ui.screens.settings.TierType
@@ -210,6 +214,7 @@ import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfoType
 import com.vultisig.wallet.ui.screens.transaction.toUiTransactionInfo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
+import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
@@ -308,6 +313,7 @@ class PreviewActivity : ComponentActivity() {
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
                     "limit_order_cancel_verify" -> LimitOrderCancelVerifyPreview()
+                    "withdraw_usdc_circle" -> WithdrawUsdcCirclePreview()
                     "limit_order_cancel_done" -> LimitOrderCancelDonePreview()
                     "limit_orders_tab_empty" -> LimitOrdersTabPreview(orders = emptyList())
                     "empty_referral" -> EmptyReferralBanner(onClickedCreateReferral = {})
@@ -3829,5 +3835,63 @@ private fun LimitOrderCancelDonePreview() {
         onUriClick = {},
         transactionTypeUiModel = TransactionTypeUiModel.Deposit(previewCancelDeposit),
         showToolbar = true,
+    )
+}
+
+/** The Circle USDC withdraw form, with a percentage picked and its fee recompute still running. */
+@Composable
+private fun WithdrawUsdcCirclePreview() {
+    val usdc = Coins.Ethereum.USDC
+    val account = Account(token = usdc, tokenValue = null, fiatValue = null, price = null)
+    SendFormScreen(
+        state =
+            SendFormUiModel(
+                defiType = DeFiNavActions.WITHDRAW_USDC_CIRCLE,
+                fiatCurrency = "USD",
+                selectedCoin =
+                    TokenBalanceUiModel(
+                        model =
+                            SendSrc(
+                                address =
+                                    Address(
+                                        chain = Chain.Ethereum,
+                                        address = "0x14F6Ed6b2b1d05C1F7Fd0Eb46E9C61a19c89B6",
+                                        accounts = listOf(account),
+                                    ),
+                                account = account,
+                            ),
+                        title = "USDC",
+                        balance = "0.701331",
+                        fiatValue = "$0.70",
+                        isNativeToken = false,
+                        isLayer2 = false,
+                        tokenStandard = "ERC20",
+                        tokenLogo = usdc.logo,
+                        chainLogo = Chain.Ethereum.logo,
+                    ),
+                selectedAmountFraction = AmountFraction.F50,
+                hasAmountInput = true,
+                isGasFeeLoading = true,
+            ),
+        addressFieldState = rememberTextFieldState(),
+        addressFocusRequester = remember { FocusRequester() },
+        amountFocusRequester = remember { FocusRequester() },
+        tokenAmountFieldState = rememberTextFieldState("0.350665"),
+        fiatAmountFieldState = rememberTextFieldState(),
+        memoFieldState = rememberTextFieldState(),
+        destinationTagFieldState = rememberTextFieldState(),
+        onNetworkDragStart = {},
+        onNetworkDrag = {},
+        onNetworkDragEnd = {},
+        onNetworkDragCancel = {},
+        onNetworkLongPressStarted = {},
+        onAssetDragStart = {},
+        onAssetDrag = {},
+        onAssetDragEnd = {},
+        onAssetDragCancel = {},
+        onAssetLongPressStarted = {},
+        operatorFeeFieldState = rememberTextFieldState(),
+        providerFieldState = rememberTextFieldState(),
+        slippageFieldState = rememberTextFieldState(),
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/topbar/VsTopAppBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/topbar/VsTopAppBar.kt
@@ -5,6 +5,7 @@ package com.vultisig.wallet.ui.components.topbar
 import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,11 +20,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.DashedProgressIndicator
+import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.buttons.DesignType
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Inset added on top of the 4.dp the top bar already reserves around its icon slots, so the back
+ * and action buttons land on the same 16.dp screen margin as the rest of the app.
+ */
+private val EDGE_SPACING = 12.dp
 
 @Composable
 fun VsTopAppBar(
@@ -59,6 +67,7 @@ fun VsTopAppBar(
         actions = {
             if (iconRight != null) {
                 VsTopAppBarAction(icon = iconRight, onClick = onIconRightClick)
+                UiSpacer(size = EDGE_SPACING)
             }
         },
         modifier = modifier,
@@ -77,7 +86,10 @@ fun VsTopAppBar(
         title = title,
         navigationContent = {
             if (iconLeft != null) {
-                VsTopAppBarAction(icon = iconLeft, onClick = onIconLeftClick)
+                Row {
+                    UiSpacer(size = EDGE_SPACING)
+                    VsTopAppBarAction(icon = iconLeft, onClick = onIconLeftClick)
+                }
             }
         },
         actions = actions,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -467,6 +467,11 @@ internal class SendFormGraph(
                 }
                 .collect { error -> uiState.update { it.copy(memoError = error) } }
         }
+        scope.launch {
+            tokenAmountFieldState.textAsFlow().collect { amount ->
+                uiState.update { it.copy(hasAmountInput = amount.isNotBlank()) }
+            }
+        }
         // Only the TRON freeze/unfreeze branch of isContinueDisabled reads isAmountValid, so limit
         // this per-keystroke validation to staking flows instead of paying it on every send screen.
         if (tronStakingService.isStakingType()) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormUiModel.kt
@@ -85,6 +85,10 @@ internal data class SendFormUiModel(
     // Whether the entered token amount is present and valid. Used to gate Continue on the TRON
     // freeze/unfreeze screens, where the network fee is amount-independent and resolves on entry.
     val isAmountValid: Boolean = false,
+    // Whether the amount field holds any text. Separates a fee estimate that is genuinely in
+    // flight from the pre-entry state, where isGasFeeLoading still sits at its initial true and
+    // no estimate has been armed yet.
+    val hasAmountInput: Boolean = false,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val isAmountSelectionLoading: Boolean = false,
@@ -132,6 +136,10 @@ internal val SendFormUiModel.isMemoBlocking: Boolean
  * including the recompute triggered by tapping a percentage/MAX button — Continue must stay
  * disabled so it can't submit against a fee still shown as loading.
  *
+ * The percentage/MAX calculation itself ([isAmountSelectionLoading]) gates for the same reason: it
+ * is about to overwrite the amount field, so submitting mid-calculation would sign the amount the
+ * user just replaced.
+ *
  * TRON freeze/unfreeze pays a fixed, amount-independent fee that the orchestrator resolves on entry
  * with a zero-amount placeholder (see GasFeeOrchestrator), so [isGasFeeLoading] clears before any
  * amount is entered and can no longer stand in for "an amount is present". These flows are
@@ -151,10 +159,29 @@ internal val SendFormUiModel.isMemoBlocking: Boolean
  */
 internal fun SendFormUiModel.isContinueDisabled(): Boolean =
     isLoading ||
+        isAmountSelectionLoading ||
         isDstAddressBlocking ||
         isMemoBlocking ||
         (showGasFee && isGasFeeLoading) ||
         (tronResourceType != null && (!isAmountValid || isTronFrozenBalancesLoading))
+
+/**
+ * Whether Continue is disabled because work is in flight rather than because the form holds
+ * something the user has to fix — the button then shows its loading indicator instead of greying
+ * out with no stated reason.
+ *
+ * Covers the submit itself, the percentage/MAX calculation, and the fee recompute that selection
+ * triggers: tapping a percentage is the case the user actually waits on, and on the flows that hide
+ * the fee row (Circle withdraw) the shimmering fee is not even on screen to explain the wait.
+ *
+ * The fee window is additionally gated on [hasAmountInput]: [isGasFeeLoading] also holds its
+ * initial true before any amount exists, and no estimate is armed there — nothing is loading, so
+ * Continue stays plainly disabled until the user enters an amount.
+ *
+ * @return true when Continue should render as loading.
+ */
+internal fun SendFormUiModel.isContinueLoading(): Boolean =
+    isLoading || isAmountSelectionLoading || (hasAmountInput && showGasFee && isGasFeeLoading)
 
 /**
  * Validates a memo against the chain's published ceiling ([Chain.maxMemoCharacters]).

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
@@ -49,6 +49,7 @@ import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendFormViewModel
 import com.vultisig.wallet.ui.models.send.SendSections
 import com.vultisig.wallet.ui.models.send.isContinueDisabled
+import com.vultisig.wallet.ui.models.send.isContinueLoading
 import com.vultisig.wallet.ui.models.send.isDstAddressEditable
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
@@ -137,7 +138,7 @@ internal fun NavGraphBuilder.sendScreen(navController: NavHostController) {
 }
 
 @Composable
-private fun SendFormScreen(
+internal fun SendFormScreen(
     state: SendFormUiModel,
     addressFieldState: TextFieldState,
     addressFocusRequester: FocusRequester,
@@ -228,7 +229,7 @@ private fun SendFormScreen(
             VsButton(
                 label = stringResource(R.string.send_continue_button),
                 state = if (isContinueDisabled) VsButtonState.Disabled else VsButtonState.Enabled,
-                isLoading = state.isLoading,
+                isLoading = state.isContinueLoading(),
                 onClick = {
                     if (!isContinueDisabled) {
                         focusManager.clearFocus()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormContinueGateTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormContinueGateTest.kt
@@ -21,13 +21,20 @@ internal class SendFormContinueGateTest {
         defiType: DeFiNavActions? = null,
         memoError: UiText? = null,
         hasMemo: Boolean = false,
+        isGasFeeLoading: Boolean = false,
+        hasAmountInput: Boolean = false,
+        isAmountSelectionLoading: Boolean = false,
+        isLoading: Boolean = false,
     ): SendFormUiModel =
         SendFormUiModel(
             dstAddressError = dstAddressError,
             defiType = defiType,
             memoError = memoError,
             hasMemo = hasMemo,
-            isGasFeeLoading = false,
+            isGasFeeLoading = isGasFeeLoading,
+            hasAmountInput = hasAmountInput,
+            isAmountSelectionLoading = isAmountSelectionLoading,
+            isLoading = isLoading,
         )
 
     @Test
@@ -61,6 +68,58 @@ internal class SendFormContinueGateTest {
 
         assertTrue(state.isDstAddressEditable)
         assertTrue(state.isContinueDisabled())
+    }
+
+    @Test
+    fun `percentage selection blocks continue and shows it as loading`() {
+        // The calculation is about to overwrite the amount field, so Continue must not submit the
+        // amount the user just replaced — and it says so with the spinner instead of greying out.
+        val state = model(isAmountSelectionLoading = true)
+
+        assertTrue(state.isContinueDisabled())
+        assertTrue(state.isContinueLoading())
+    }
+
+    @Test
+    fun `fee recompute after an amount is entered shows continue as loading`() {
+        val state = model(isGasFeeLoading = true, hasAmountInput = true)
+
+        assertTrue(state.isContinueDisabled())
+        assertTrue(state.isContinueLoading())
+    }
+
+    @Test
+    fun `no amount entered leaves continue plainly disabled`() {
+        // isGasFeeLoading starts true before any amount exists, but no estimate is armed there —
+        // a spinner would claim work that isn't running.
+        val state = model(isGasFeeLoading = true)
+
+        assertTrue(state.isContinueDisabled())
+        assertFalse(state.isContinueLoading())
+    }
+
+    @Test
+    fun `submit in flight shows continue as loading`() {
+        val state = model(isLoading = true)
+
+        assertTrue(state.isContinueDisabled())
+        assertTrue(state.isContinueLoading())
+    }
+
+    @Test
+    fun `input the user must fix disables continue without a spinner`() {
+        val state = model(dstAddressError = invalidRecipient)
+
+        assertTrue(state.isContinueDisabled())
+        assertFalse(state.isContinueLoading())
+    }
+
+    @Test
+    fun `a settled form shows no loading`() {
+        val state = model(hasAmountInput = true)
+
+        assertFalse(state.isContinueDisabled())
+        assertFalse(state.isContinueLoading())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two fixes reported on the DeFi withdraw flow.

**Top bar padding.** `VsTopAppBar` dropped its back and action buttons straight into the Material3 icon slots, which only reserve 4dp, so the back button sat against the screen edge instead of the app's 16dp margin. It now applies the same 12dp inset `V2Topbar` uses, so both bars line up. Affects `VerifyDepositScreen` ("Function overview") and `VerifySignMessageScreen`.

**Continue button greyed out instead of loading.** Tapping a percentage chip runs the fraction calculation and then writes the amount, which arms a gas-fee recompute. Both windows disabled Continue with nothing to explain the wait — and the Circle withdraw screen hides the fee row entirely, so the shimmering fee wasn't even on screen. Continue now shows its loading indicator for that work.

- `isContinueLoading()` drives the spinner: submit in flight, percentage/MAX calculation, or the fee recompute that selection triggers.
- The fee window is gated on a new `hasAmountInput` flag, because `isGasFeeLoading` also holds its initial `true` before any amount exists — no estimate is armed there, so Continue stays plainly disabled until the user enters an amount rather than spinning forever on entry.
- `isAmountSelectionLoading` was added to `isContinueDisabled()` too. It keeps the button one colour across the whole wait instead of flipping blue → grey → blue, and closes a real hole: the soft-keyboard submit path could fire mid-calculation and sign the amount the chip was about to overwrite.

## Before / After

Top bar — back button at 4dp vs the app's 16dp margin:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/ypwsfNP.png) | ![after](https://i.imgur.com/eqDP3ZC.png) |

Continue while the fee recomputes after tapping 50%:

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/M4yCegp.png) | ![after](https://i.imgur.com/5SDnwGx.png) |

## Test plan

- 7 new cases in `SendFormContinueGateTest` cover each window: percentage selection, the fee recompute with an amount present, the pre-entry state (disabled, no spinner), submit in flight, and an invalid recipient (disabled, no spinner).
- `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.send.*"` — 344 tests, 0 failures.
- Screenshots captured on the emulator via `PreviewActivity`; a `withdraw_usdc_circle` entry was added there for the Circle withdraw form.
- Worth a manual pass on Send and the TRON freeze/unfreeze screens, which share the same Continue gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a preview for withdrawing USDC through Circle, including account selection, amount entry, and fee loading states.
- **Bug Fixes**
  - Improved the Continue button behavior across send flows:
    - Prevents continuation when amount selection or required validation is incomplete.
    - Shows loading feedback during amount selection, fee updates, and submission.
    - Avoids displaying misleading loading indicators during initial fee estimation.
- **Style**
  - Added consistent spacing around top-bar navigation and action controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->