### PR TITLE
refactor(design-system): standardise container corner radii on 24 (phase 2)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -97,6 +97,7 @@ import com.vultisig.wallet.ui.models.TokenInfoUiModel
 import com.vultisig.wallet.ui.models.TokenSelectionUiModel
 import com.vultisig.wallet.ui.models.TokenUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
+import com.vultisig.wallet.ui.models.TransactionHistoryGroupUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryTab
 import com.vultisig.wallet.ui.models.TransactionHistoryUiState
@@ -307,6 +308,7 @@ class PreviewActivity : ComponentActivity() {
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
+                    "swaps_tab" -> SwapsTabPreview()
                     "limit_order_cancel_verify" -> LimitOrderCancelVerifyPreview()
                     "limit_order_cancel_done" -> LimitOrderCancelDonePreview()
                     "limit_orders_tab_empty" -> LimitOrdersTabPreview(orders = emptyList())
@@ -3745,6 +3747,80 @@ private fun LimitOrdersTabPreview(orders: List<LimitOrderHistoryUiModel> = previ
                 isLoading = false,
                 limitOrders = orders,
                 isLimitTabVisible = true,
+            ),
+        onBack = {},
+        onTabSelected = {},
+        onRefresh = {},
+        onItemClick = {},
+    )
+}
+
+/**
+ * The Swaps tab of TX History. Exists so the "via" badge is verifiable: it is anchored to the
+ * card's bottom-end corner and traces it, so a card radius change has to be looked at here.
+ */
+@Composable
+private fun SwapsTabPreview() {
+    TransactionHistoryScreen(
+        state =
+            TransactionHistoryUiState(
+                selectedTab = TransactionHistoryTab.SWAP,
+                isLoading = false,
+                groups =
+                    listOf(
+                        TransactionHistoryGroupUiModel(
+                            datePrefix = UiText.DynamicString("Today"),
+                            dateSuffix = UiText.DynamicString(""),
+                            dateKey = "today",
+                            transactions =
+                                listOf(
+                                    TransactionHistoryItemUiModel.Swap(
+                                        id = "S1",
+                                        txHash = "0xabc",
+                                        chain = "THORChain",
+                                        status = TransactionStatusUiModel.Confirmed,
+                                        explorerUrl = "",
+                                        timestamp = 0L,
+                                        fromToken = "RUNE",
+                                        fromAmount = "125.5",
+                                        fromChain = "THORChain",
+                                        fromTokenLogo = R.drawable.rune,
+                                        toToken = "BTC",
+                                        toAmount = "0.0261",
+                                        toChain = "Bitcoin",
+                                        toTokenLogo = R.drawable.bitcoin,
+                                        provider = "THORChain",
+                                        providerLogo = R.drawable.rune,
+                                        fiatValue = "$1,204.00",
+                                        fromAddress = "thor1abc",
+                                        toAddress = "bc1qxyz",
+                                        feeEstimate = "$0.42",
+                                    ),
+                                    TransactionHistoryItemUiModel.Swap(
+                                        id = "S2",
+                                        txHash = "0xdef",
+                                        chain = "Ethereum",
+                                        status = TransactionStatusUiModel.Broadcasted,
+                                        explorerUrl = "",
+                                        timestamp = 0L,
+                                        fromToken = "ETH",
+                                        fromAmount = "0.5",
+                                        fromChain = "Ethereum",
+                                        fromTokenLogo = R.drawable.ethereum,
+                                        toToken = "USDC",
+                                        toAmount = "1,610.20",
+                                        toChain = "Ethereum",
+                                        toTokenLogo = R.drawable.usdc,
+                                        provider = "1inch",
+                                        providerLogo = null,
+                                        fiatValue = "$1,610.20",
+                                        fromAddress = "0xAb...234",
+                                        toAddress = "0xAb...234",
+                                        feeEstimate = "$1.10",
+                                    ),
+                                ),
+                        )
+                    ),
             ),
         onBack = {},
         onTabSelected = {},

--- a/app/src/main/java/com/vultisig/wallet/ui/components/GradientInfoCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/GradientInfoCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -27,7 +26,7 @@ internal fun GradientInfoCard(text: String, gradient: Brush = Brush.vultiGradien
     Card(
         modifier =
             Modifier.padding(bottom = 16.dp)
-                .border(width = 1.dp, brush = gradient, shape = RoundedCornerShape(12.dp)),
+                .border(width = 1.dp, brush = gradient, shape = Theme.v2.radius.xl),
         colors = CardDefaults.cardColors(containerColor = Theme.v2.colors.backgrounds.transparent),
     ) {
         Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SelectionItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SelectionItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.SwitchDefaults
@@ -26,7 +25,7 @@ internal fun SelectionItem(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        shape = Theme.v2.radius.md,
         colors = CardDefaults.cardColors(containerColor = Theme.v2.colors.backgrounds.secondary),
     ) {
         Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SettingsItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SettingsItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -34,7 +33,7 @@ internal fun SettingsItem(
 ) {
     Card(
         modifier = Modifier.clickOnce(onClick = onClick).fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        shape = Theme.v2.radius.md,
         colors = CardDefaults.cardColors(containerColor = Theme.v2.colors.backgrounds.secondary),
     ) {
         Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignMessageCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignMessageCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -34,11 +33,11 @@ internal fun SignMessageCard(
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .background(
                     color = Theme.v2.colors.backgrounds.disabled,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/Banner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/Banner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -69,7 +68,7 @@ internal fun Banner(
     variant: BannerVariant = BannerVariant.Info,
     @SuppressLint("ComposableLambdaParameterNaming") actions: (@Composable () -> Unit)? = null,
 ) {
-    val shape = RoundedCornerShape(12.dp)
+    val shape = Theme.v2.radius.xl
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/UpgradeBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/UpgradeBanner.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,7 +21,7 @@ import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
 fun UpgradeBanner(modifier: Modifier = Modifier) {
-    val shape = RoundedCornerShape(12.dp)
+    val shape = Theme.v2.radius.xl
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/bottomsheet/VsBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/bottomsheet/VsBottomSheet.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -27,10 +26,7 @@ object VsBottomSheet {
             modifier =
                 Modifier.padding(all = 12.dp)
                     .size(width = 36.dp, height = 6.dp)
-                    .background(
-                        color = Theme.v2.colors.neutrals.n600,
-                        shape = RoundedCornerShape(16.dp),
-                    )
+                    .background(color = Theme.v2.colors.neutrals.n600, shape = Theme.v2.radius.pill)
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/dapp/DappRequestBanner.kt
@@ -60,9 +60,12 @@ internal fun DappRequestBanner(metadata: DAppMetadata, modifier: Modifier = Modi
         modifier =
             modifier
                 .fillMaxWidth()
+                // A banner on the page background at all four of its call sites — it sits above
+                // the summary card rather than inside it, unlike the iOS twin, so it takes the
+                // container step alongside the card rather than a nested one.
                 .background(
                     color = Theme.v2.colors.backgrounds.surface2,
-                    shape = Theme.v2.radius.lg,
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(20.dp)
                 .semantics(mergeDescendants = true) { contentDescription = announcement },

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorMessageBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorMessageBottomSheet.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -56,12 +55,12 @@ internal fun ErrorMessageBottomSheet(rawError: String, onDismissRequest: () -> U
                         .heightIn(max = 420.dp)
                         .background(
                             color = Theme.v2.colors.backgrounds.disabled,
-                            shape = RoundedCornerShape(24.dp),
+                            shape = Theme.v2.radius.xl,
                         )
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(24.dp),
+                            shape = Theme.v2.radius.xl,
                         )
                         .verticalScroll(rememberScrollState())
                         .padding(20.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsCodeInputField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsCodeInputField.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
@@ -92,7 +91,7 @@ internal fun VsCodeInputField(
             repeat(maxCharacters) { index ->
                 val isActiveBox = focusedState.value && index == value.length
 
-                val inputBoxShape = RoundedCornerShape(24.dp)
+                val inputBoxShape = Theme.v2.radius.xl
                 val inputManager = LocalSoftwareKeyboardController.current
 
                 Box(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/library/form/Form.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/library/form/Form.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicSecureTextField
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -471,7 +470,7 @@ internal fun FormCard(
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(containerColor = Theme.v2.colors.backgrounds.secondary),
-        shape = RoundedCornerShape(10.dp),
+        shape = Theme.v2.radius.md,
         content = content,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/referral/ReferralCodeBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/referral/ReferralCodeBottomSheet.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -38,7 +37,7 @@ internal fun ReferralCodeBottomSheet(onContinue: () -> Unit, onDismissRequest: (
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         containerColor = Theme.v2.colors.backgrounds.secondary,
-        shape = RoundedCornerShape(24.dp),
+        shape = Theme.v2.radius.xl,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = null,
     ) {
@@ -57,7 +56,7 @@ internal fun ReferralCodeBottomSheetContent(onContinue: () -> Unit) {
             Image(
                 painter = painterResource(id = R.drawable.referralcodeiphone),
                 contentDescription = null,
-                modifier = Modifier.fillMaxWidth().height(200.dp).clip(RoundedCornerShape(24.dp)),
+                modifier = Modifier.fillMaxWidth().height(200.dp).clip(Theme.v2.radius.xl),
             )
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/TopShineContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/TopShineContainer.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.ui.components.v2.containers
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -13,16 +12,25 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.ui.screens.send.FadingHorizontalDivider
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.Radius
 
+/**
+ * A card with a shine along its top edge.
+ *
+ * [radius] follows the same rule as [V2Container]: the container step by default, an explicitly
+ * smaller one where a call site renders this inside another container — the home screen nests one
+ * of these inside another via [NotEnabledContainer].
+ */
 @Composable
 internal fun TopShineContainer(
     modifier: Modifier = Modifier,
     backgroundColor: Color = Theme.v2.colors.backgrounds.secondary,
+    radius: Radius = Theme.v2.radius.xl,
     content: @Composable () -> Unit,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(size = 12.dp),
+        shape = radius,
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
     ) {
         FadingHorizontalDivider()

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/V2Container.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/containers/V2Container.kt
@@ -30,12 +30,22 @@ internal sealed interface ContainerBorderType {
     data class Bordered(val color: Color = colors.border.light) : ContainerBorderType
 }
 
+/**
+ * The app's container chrome: a fill, an optional hairline border, and a clip.
+ *
+ * [radius] defaults to the container step, because that is what the common case is — a card, banner
+ * or list group sitting on the page background. A container rendered *inside* another one is
+ * content rather than a container, and has to say so by passing a smaller step: equal radii nested
+ * one inside the other read flat, and the mismatch grows with the radius. Decide which one a call
+ * site is from the call site, not from this declaration — several of the views that go through here
+ * are the outer surface in one usage and nested in another.
+ */
 @Composable
 internal fun V2Container(
     modifier: Modifier = Modifier,
     type: ContainerType = ContainerType.PRIMARY,
     borderType: ContainerBorderType = ContainerBorderType.Borderless,
-    radius: Radius = Theme.v2.radius.md,
+    radius: Radius = Theme.v2.radius.xl,
     content: @Composable () -> Unit,
 ) {
     val containerColor =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
@@ -120,7 +120,7 @@ internal fun GridPlus(modifier: Modifier = Modifier, model: GridPlusUiModel) {
                     .dashedBorder(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        cornerRadius = 24.dp,
+                        cornerRadius = Theme.v2.radius.xl.size,
                         dashLength = 4.dp,
                         intervalLength = 4.dp,
                     ),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -76,7 +75,7 @@ internal fun GridItem(
             contentAlignment = Alignment.Center,
             modifier =
                 Modifier.size(74.dp)
-                    .clip(shape = RoundedCornerShape(size = 24.dp))
+                    .clip(shape = Theme.v2.radius.xl)
                     .background(
                         color =
                             if (checked) Theme.v2.colors.backgrounds.secondary
@@ -116,7 +115,7 @@ internal fun GridPlus(modifier: Modifier = Modifier, model: GridPlusUiModel) {
             contentAlignment = Alignment.Center,
             modifier =
                 Modifier.size(74.dp)
-                    .clip(shape = RoundedCornerShape(size = 24.dp))
+                    .clip(shape = Theme.v2.radius.xl)
                     .background(color = Theme.v2.colors.backgrounds.disabled)
                     .dashedBorder(
                         width = 1.dp,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/RoundedBorderWithLeaf.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/RoundedBorderWithLeaf.kt
@@ -26,7 +26,8 @@ internal fun RoundedBorderWithLeaf(
     leafColor: Color = Theme.v2.colors.border.light,
     checkMarkColor: Color = Theme.v2.colors.alerts.success,
     borderWidth: Dp = 1.5.dp,
-    cornerRadius: Dp = 24.dp,
+    // Drawn into the chain tile, which clips at the container step — same rect, same token.
+    cornerRadius: Dp = Theme.v2.radius.xl.size,
     leafXLength: Dp = 32.dp,
     leafYLength: Dp = 24.dp,
     checkMarkScale: Float = 2f,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/TokenMetaRow.kt
@@ -37,7 +37,7 @@ internal fun TokenMetaRow(
                 .padding(all = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        V2Container {
+        V2Container(radius = Theme.v2.radius.md) {
             Text(
                 text = key,
                 color = Theme.v2.colors.text.primary,
@@ -46,7 +46,7 @@ internal fun TokenMetaRow(
             )
         }
         UiSpacer(weight = 1f)
-        V2Container(type = ContainerType.TERTIARY) {
+        V2Container(type = ContainerType.TERTIARY, radius = Theme.v2.radius.md) {
             LoadableValue(
                 value = value,
                 color = Theme.v2.colors.text.primary,
@@ -73,7 +73,7 @@ internal fun TokenMetaAddressRow(key: String, address: String, modifier: Modifie
                 .padding(all = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        V2Container {
+        V2Container(radius = Theme.v2.radius.md) {
             Text(
                 text = key,
                 color = Theme.v2.colors.text.primary,
@@ -82,7 +82,7 @@ internal fun TokenMetaAddressRow(key: String, address: String, modifier: Modifie
             )
         }
         UiSpacer(weight = 1f)
-        V2Container(type = ContainerType.TERTIARY) {
+        V2Container(type = ContainerType.TERTIARY, radius = Theme.v2.radius.md) {
             Row(
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ImportFileScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ImportFileScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -129,7 +128,7 @@ private fun ImportFileScreen(
                                         Theme.v2.colors.backgrounds.success
                                     else -> Theme.v2.colors.backgrounds.secondary
                                 },
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .dashedBorder(
                             width = 1.dp,
@@ -140,7 +139,7 @@ private fun ImportFileScreen(
                                         Theme.v2.colors.alerts.success
                                     else -> Theme.v2.colors.border.light
                                 },
-                            cornerRadius = 12.dp,
+                            cornerRadius = Theme.v2.radius.md.size,
                             dashLength = 4.dp,
                             intervalLength = 4.dp,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TransactionDoneScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -119,7 +118,7 @@ internal fun TransactionDoneView(
                                         header =
                                             stringResource(R.string.tx_overview_screen_tx_send),
                                         valuedToken = transaction.token,
-                                        shape = RoundedCornerShape(24.dp),
+                                        shape = Theme.v2.radius.xl,
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -100,9 +99,9 @@ private fun BackupPasswordRequestScreen(
                     Modifier.size(64.dp)
                         .background(
                             color = Theme.v2.colors.backgrounds.tertiary_2,
-                            shape = RoundedCornerShape(16.dp),
+                            shape = Theme.v2.radius.lg,
                         )
-                        .clip(shape = RoundedCornerShape(16.dp))
+                        .clip(shape = Theme.v2.radius.lg)
                         .padding(all = 16.dp),
                 drawableResId = R.drawable.ic_passkeys,
                 size = 32.dp,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/VaultsToBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/VaultsToBackupScreen.kt
@@ -197,6 +197,9 @@ private fun BackupVaultContainer(
                     type = ContainerType.SECONDARY,
                     borderType = ContainerBorderType.Borderless,
                     modifier = Modifier.fillMaxWidth().heightIn(max = vaultListMaxHeight),
+                    // Inside BackupVaultContainer's card, so this group is content, not a
+                    // container.
+                    radius = Theme.v2.radius.md,
                 ) {
                     BoxWithConstraints {
                         val containerMaxHeight = this.maxHeight
@@ -242,6 +245,8 @@ private fun BackupVaultContainer(
                     type = ContainerType.SECONDARY,
                     borderType = ContainerBorderType.Borderless,
                     modifier = Modifier.fillMaxWidth(),
+                    // Same group as above, in the branch that has no height cap to apply.
+                    radius = Theme.v2.radius.md,
                 ) {
                     Column {
                         vaults.forEachIndexed { index, vault ->
@@ -303,7 +308,12 @@ internal fun VaultToBackup(model: VaultToBackupUiModel, isLastItem: Boolean) {
 
 @Composable
 private fun VaultMetaInfo(model: VaultToBackupUiModel) {
-    V2Container(type = ContainerType.SECONDARY, borderType = ContainerBorderType.Bordered()) {
+    V2Container(
+        type = ContainerType.SECONDARY,
+        borderType = ContainerBorderType.Bordered(),
+        // A meta chip inside a vault row, two levels inside the card.
+        radius = Theme.v2.radius.md,
+    ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/VaultsToBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/VaultsToBackupScreen.kt
@@ -311,8 +311,9 @@ private fun VaultMetaInfo(model: VaultToBackupUiModel) {
     V2Container(
         type = ContainerType.SECONDARY,
         borderType = ContainerBorderType.Bordered(),
-        // A meta chip inside a vault row, two levels inside the card.
-        radius = Theme.v2.radius.md,
+        // A small inline tag, two levels inside the card and one inside the vault-list group
+        // that already takes md — so it steps down again rather than matching its parent.
+        radius = Theme.v2.radius.sm,
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -500,7 +500,10 @@ private fun ValidatorPickerRow(
         }
     // Figma (node 75918:75259 / 75918:75266): spaced rounded-16 cards on surface-1. The selected
     // card carries a success-tinted fill + border; unselected cards are borderless.
-    val shape = RoundedCornerShape(16.dp)
+    //
+    // Rows in a picker list, not cards on a page, so they keep the inner step rather than taking
+    // the container one — and the design file names 16 for this row specifically.
+    val shape = Theme.v2.radius.lg
     Row(
         modifier =
             Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -475,11 +474,11 @@ private fun PositionRow(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -664,11 +663,11 @@ internal fun StakingPositionSkeleton() {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -694,11 +693,11 @@ private fun UnbondingCard(unbonding: CosmosUnbondingDelegation) {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -393,11 +393,11 @@ private fun TotalStakedCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -814,11 +814,11 @@ private fun CosmosStakingBalanceBanner(
         modifier =
             Modifier.fillMaxWidth()
                 .height(118.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = CosmosBannerTeal.copy(alpha = 0.17f),
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .background(
                     androidx.compose.ui.graphics.Brush.verticalGradient(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -133,11 +132,11 @@ private fun SummaryCard(state: CosmosStakingVerifyUiState) {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/customrpc/CustomRpcListScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/customrpc/CustomRpcListScreen.kt
@@ -105,14 +105,14 @@ private fun CustomRpcChainTile(chain: CustomRpcChainUiModel, onClick: () -> Unit
             modifier =
                 Modifier.fillMaxWidth()
                     .aspectRatio(1f)
-                    .clip(RoundedCornerShape(24.dp))
+                    .clip(Theme.v2.radius.xl)
                     .background(Theme.v2.colors.backgrounds.surface1)
                     .then(
                         if (chain.isCustom)
                             Modifier.border(
                                 width = 1.5.dp,
                                 color = Theme.v2.colors.border.light,
-                                shape = RoundedCornerShape(24.dp),
+                                shape = Theme.v2.radius.xl,
                             )
                         else Modifier
                     ),
@@ -127,7 +127,13 @@ private fun CustomRpcChainTile(chain: CustomRpcChainUiModel, onClick: () -> Unit
                 Box(
                     modifier =
                         Modifier.align(Alignment.BottomEnd)
-                            .clip(RoundedCornerShape(topStart = 16.dp, bottomEnd = 24.dp))
+                            // bottomEnd traces the tile this badge is anchored into.
+                            .clip(
+                                RoundedCornerShape(
+                                    topStart = Theme.v2.radius.lg.size,
+                                    bottomEnd = Theme.v2.radius.xl.size,
+                                )
+                            )
                             .background(Theme.v2.colors.border.light)
                             .padding(8.dp)
                 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
@@ -70,6 +70,7 @@ import com.vultisig.wallet.ui.theme.slideInFromEndEnterTransition
 import com.vultisig.wallet.ui.theme.slideInFromStartEnterTransition
 import com.vultisig.wallet.ui.theme.slideOutToEndExitTransition
 import com.vultisig.wallet.ui.theme.slideOutToStartExitTransition
+import com.vultisig.wallet.ui.theme.v2.V2
 import com.vultisig.wallet.ui.utils.asString
 
 @Composable
@@ -238,8 +239,8 @@ internal fun BondFormContent(
     }
 }
 
-private val cardShape = RoundedCornerShape(12.dp)
-private val inputShape = RoundedCornerShape(12.dp)
+private val cardShape = V2.radius.xl
+private val inputShape = V2.radius.md
 
 private fun String.toDisplayAsset(): String =
     substringBefore("-").substringAfterLast("/").substringAfterLast(".")

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
@@ -486,7 +486,7 @@ internal fun DepositFormScreen(
                             color = Theme.v2.colors.text.tertiary,
                         )
 
-                        V2Container(type = ContainerType.TERTIARY) {
+                        V2Container(type = ContainerType.TERTIARY, radius = Theme.v2.radius.md) {
                             Text(
                                 text =
                                     stringResource(
@@ -507,7 +507,7 @@ internal fun DepositFormScreen(
                             color = Theme.v2.colors.text.tertiary,
                         )
 
-                        V2Container(type = ContainerType.TERTIARY) {
+                        V2Container(type = ContainerType.TERTIARY, radius = Theme.v2.radius.md) {
                             Text(
                                 text = thorAddress.text.toString(),
                                 style = Theme.brockmann.body.s.regular,
@@ -522,7 +522,7 @@ internal fun DepositFormScreen(
                             color = Theme.v2.colors.text.tertiary,
                         )
 
-                        V2Container(type = ContainerType.TERTIARY) {
+                        V2Container(type = ContainerType.TERTIARY, radius = Theme.v2.radius.md) {
                             Text(
                                 text = stringResource(R.string.secure, thorAddress.text),
                                 style = Theme.brockmann.body.s.regular,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -136,7 +135,7 @@ internal fun VerifyDepositScreen(
                     modifier =
                         Modifier.background(
                                 color = Theme.v2.colors.backgrounds.secondary,
-                                shape = RoundedCornerShape(16.dp),
+                                shape = Theme.v2.radius.xl,
                             )
                             .padding(all = 24.dp)
                 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/governance/GovernanceScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/governance/GovernanceScreen.kt
@@ -91,9 +91,9 @@ private fun ProposalCard(proposal: ProposalUi, onVoteClick: () -> Unit) {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface1)
-                .border(1.dp, Theme.v2.colors.border.normal, RoundedCornerShape(20.dp))
+                .border(1.dp, Theme.v2.colors.border.normal, Theme.v2.radius.xl)
                 .padding(18.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
@@ -291,7 +291,7 @@ private fun YourVoteBadge(option: VoteOption) {
     val color = option.voteColor()
     Row(
         modifier =
-            Modifier.clip(RoundedCornerShape(10.dp))
+            Modifier.clip(Theme.v2.radius.sm)
                 .background(color.copy(alpha = 0.12f))
                 .padding(horizontal = 10.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -397,9 +397,9 @@ private fun ProposalSkeletonCard() {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface1)
-                .border(1.dp, Theme.v2.colors.border.normal, RoundedCornerShape(20.dp))
+                .border(1.dp, Theme.v2.colors.border.normal, Theme.v2.radius.xl)
                 .padding(18.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -328,7 +328,12 @@ internal fun VaultAccountsScreen(
                                         title =
                                             stringResource(R.string.home_page_no_chains_enabled),
                                         content =
-                                            stringResource(R.string.home_page_no_chain_enabled_desc),
+                                            stringResource(
+                                                R.string.home_page_no_chain_enabled_desc
+                                            ),
+                                        // Rendered inside the chain-list container above, so it
+                                        // steps down rather than matching it.
+                                        radius = Theme.v2.radius.md,
                                     )
                                 } else {
                                     AccountList(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportChainsSetupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/KeyImportChainsSetupScreen.kt
@@ -338,6 +338,14 @@ private fun CustomizeChainsContent(
     }
 }
 
+/**
+ * Deliberately off the radius scale.
+ *
+ * The 20 below is a Figma value for this row specifically, and it is equidistant from `lg` and `xl`
+ * — no reading of the scale picks one over the other, so snapping it would be a guess rather than a
+ * standardisation. iOS reached the same conclusion for the same row. Left for a designer call
+ * rather than re-derived by the next sweep.
+ */
 @Composable
 private fun ActiveChainItem(chain: Chain) {
     Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/StartScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -246,7 +245,7 @@ private fun ChooseImportTypeButton(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(shape = RoundedCornerShape(size = 16.dp))
+                .clip(shape = Theme.v2.radius.xl)
                 .clickable(onClick = onClick)
                 .background(color = Theme.v2.colors.backgrounds.tertiary)
                 .padding(all = 24.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -296,7 +295,7 @@ private fun QbtcClaimConsentContent(
 
         UiSpacer(size = 24.dp)
 
-        val shape = RoundedCornerShape(16.dp)
+        val shape = Theme.v2.radius.xl
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
             modifier =
@@ -338,7 +337,7 @@ private fun QbtcClaimAccountRow(logo: Painter, label: String, address: String) {
             Image(
                 painter = logo,
                 contentDescription = null,
-                modifier = Modifier.size(20.dp).clip(RoundedCornerShape(50)),
+                modifier = Modifier.size(20.dp).clip(Theme.v2.radius.pill),
             )
             Text(
                 text = label,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeLockScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,6 +33,7 @@ import com.vultisig.wallet.ui.models.passcode.PasscodeLockError
 import com.vultisig.wallet.ui.models.passcode.PasscodeLockUiModel
 import com.vultisig.wallet.ui.models.passcode.PasscodeLockViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.V2
 
 /** Full-screen gate shown whenever the app is locked behind a passcode. */
 @Composable
@@ -153,7 +153,7 @@ private val GLOW_RING_WIDTH = 1.dp
 
 /** Figma seats the content block this far above the frame's vertical midpoint. */
 private val FIGMA_CENTRE_OFFSET = 28.dp
-private val CardShape = RoundedCornerShape(12.dp)
+private val CardShape = V2.radius.xl
 
 /** Figma tints the card with 10% of the normal border blue; there is no background token for it. */
 private val CardBackground = Color(0xFF1B3F73).copy(alpha = 0.1f)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -624,7 +624,7 @@ private fun DevicePeerCard(
     selected: Boolean = true,
     onClick: (() -> Unit)? = null,
 ) {
-    val shape = RoundedCornerShape(24.dp)
+    val shape = Theme.v2.radius.xl
     val accentColor = if (selected) Theme.v2.colors.alerts.success else Theme.v2.colors.border.light
 
     Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
@@ -41,7 +41,7 @@ internal fun ClaimQbtcPromoBanner(onClaim: () -> Unit, modifier: Modifier = Modi
             modifier
                 .fillMaxWidth()
                 .height(156.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface2)
                 .drawBehind {
                     drawRect(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimDoneContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimDoneContent.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,7 +62,7 @@ internal fun QbtcClaimDoneContent(
 
 @Composable
 private fun ClaimedAmountCard(totalSats: Long) {
-    val shape = RoundedCornerShape(24.dp)
+    val shape = Theme.v2.radius.xl
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/QbtcClaimScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -207,7 +206,7 @@ private fun SelectingContent(state: QbtcClaimUiState.Selecting, onToggle: (Strin
 
 @Composable
 private fun QbtcClaimHeroCard(totalEligibleSats: Long) {
-    val shape = RoundedCornerShape(16.dp)
+    val shape = Theme.v2.radius.xl
     Box(
         modifier =
             Modifier.fillMaxWidth()
@@ -327,7 +326,7 @@ private fun QbtcClaimUtxoRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.lg)
                 .background(Theme.v2.colors.backgrounds.surface1)
                 .clickable(onClick = onToggle)
                 .padding(16.dp),
@@ -397,7 +396,7 @@ private fun MaturingInfoCard() {
         verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface1)
                 .padding(horizontal = 24.dp, vertical = 20.dp),
     ) {
@@ -428,7 +427,7 @@ private fun MaturingUtxoRow(utxo: QbtcClaimMaturingUtxoUiModel) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.lg)
                 .background(Theme.v2.colors.backgrounds.surface1)
                 .padding(16.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralMainScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralMainScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -115,7 +114,7 @@ private fun CreateReferralCard(titleRes: Int, enabled: Boolean, onClick: () -> U
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface1)
                 .clickable(enabled = enabled, onClick = onClick)
                 .alpha(if (enabled) 1f else DISABLED_CARD_ALPHA)
@@ -177,7 +176,7 @@ private fun ReferralEntryCard(
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface1)
                 .clickable(enabled = enabled, onClick = onClick)
                 .alpha(if (enabled) 1f else DISABLED_CARD_ALPHA)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralVaultListScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralVaultListScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -88,7 +87,7 @@ internal fun ReferralVaultListContentScreen(
                     modifier =
                         Modifier.background(
                             Theme.v2.colors.backgrounds.secondary,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.xl,
                         )
                 ) {
                     itemsIndexed(state.vaults, key = { _, vault -> vault.id }) { index, vault ->
@@ -131,11 +130,11 @@ internal fun VaultRow(vault: VaultItem, onVaultClicked: (String) -> Unit) {
             modifier =
                 Modifier.background(
                         Theme.v2.colors.backgrounds.secondary,
-                        shape = RoundedCornerShape(20.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .border(
                         border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
-                        shape = RoundedCornerShape(20.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(horizontal = 10.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -400,12 +400,12 @@ fun VaultItem(name: String, onVaultClicked: () -> Unit) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(56.dp)
-                .clip(RoundedCornerShape(28.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(Theme.v2.colors.backgrounds.primary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(28.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .clickable { onVaultClicked() }
                 .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/reshare/ReshareStartScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/reshare/ReshareStartScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -115,12 +114,12 @@ private fun ReshareOptionCard(title: String, subtitle: String, onClick: () -> Un
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .clickOnce(onClick = onClick)
                 .padding(all = 24.dp),
@@ -226,12 +225,12 @@ private fun ReshareWarningCard(icon: Int, title: String, body: String) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(all = 20.dp),
         verticalAlignment = Alignment.Top,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/GasSettingsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -84,7 +83,7 @@ internal fun GasSettingsScreen(
         modifier =
             Modifier.background(
                     color = Theme.v2.colors.backgrounds.primary,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(all = 24.dp)
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -203,7 +203,7 @@ internal fun VerifySendScreen(
                                 r.riskLevel == SecurityRiskLevel.LOW)
                     } == true
 
-                val cardShape = RoundedCornerShape(16.dp)
+                val cardShape = Theme.v2.radius.xl
                 val cardModifier =
                     Modifier.background(
                             color = Theme.v2.colors.backgrounds.secondary,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
@@ -219,12 +219,12 @@ private fun ActiveTierCard(style: TierStyle, shape: Shape) {
 
             Box(
                 modifier =
-                    Modifier.clip(RoundedCornerShape(16.dp))
+                    Modifier.clip(Theme.v2.radius.lg)
                         .background(Theme.v2.colors.backgrounds.surface1)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(16.dp),
+                            shape = Theme.v2.radius.lg,
                         )
                         .padding(horizontal = 10.dp, vertical = 8.dp)
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/DiscountTiersScreen.kt
@@ -131,7 +131,7 @@ private fun TierBanner() {
                 Modifier.align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .height(BannerCardHeight)
-                    .clip(RoundedCornerShape(24.dp))
+                    .clip(Theme.v2.radius.xl)
                     .background(
                         Brush.linearGradient(
                             colors = listOf(BannerGradientStart, Theme.v2.colors.primary.accent1)
@@ -173,8 +173,15 @@ private fun TierBanner() {
 @Composable
 private fun TierCard(tierType: TierType, isActive: Boolean, onClick: () -> Unit) {
     val style = getStyleByTier(tierType)
+    // The 24/20 asymmetry is deliberate — the top is the container step, the bottom is a design
+    // decision the footer bar behind the card is drawn to sit under. Only the top is on the scale.
     val shape =
-        RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 20.dp, bottomEnd = 20.dp)
+        RoundedCornerShape(
+            topStart = Theme.v2.radius.xl.size,
+            topEnd = Theme.v2.radius.xl.size,
+            bottomStart = 20.dp,
+            bottomEnd = 20.dp,
+        )
 
     if (isActive) {
         ActiveTierCard(style = style, shape = shape)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/FeatureGateBottomSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -146,8 +145,8 @@ private fun RequiresCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(20.dp))
+                .clip(Theme.v2.radius.xl)
+                .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.xl)
     ) {
         Column(
             modifier =
@@ -223,9 +222,9 @@ private fun BalanceRow(balanceText: String, isBelowThreshold: Boolean) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
+                .clip(Theme.v2.radius.md)
                 .background(Theme.v2.colors.backgrounds.tertiary)
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(14.dp))
+                .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md)
                 .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/ShareBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/ShareBottomSheet.kt
@@ -99,6 +99,8 @@ private fun ShareLinkContent(
             modifier = Modifier.padding(horizontal = 20.dp),
             type = ContainerType.SECONDARY,
             borderType = ContainerBorderType.Bordered(),
+            // A read-only link with a copy button — the row a user acts on, not a card on a page.
+            radius = Theme.v2.radius.md,
         ) {
             Row(
                 modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/TierDiscountBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/TierDiscountBottomSheet.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -46,7 +46,7 @@ internal fun TierDiscountBottomSheet(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         containerColor = Theme.v2.colors.backgrounds.secondary,
-        shape = RoundedCornerShape(24.dp),
+        shape = Theme.v2.radius.xl,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = null,
     ) {
@@ -99,7 +99,12 @@ internal fun TierDiscountBottomSheetContent(tier: TierType, onContinue: () -> Un
                         }
                     }
                 }
-                .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                .clip(
+                    Theme.v2.radius.xl.shape.copy(
+                        bottomStart = CornerSize(0.dp),
+                        bottomEnd = CornerSize(0.dp),
+                    )
+                )
     ) {
         Column(
             modifier = Modifier.padding(32.dp).fillMaxWidth().navigationBarsPadding(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/VerifySwapScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -209,7 +208,7 @@ private fun VerifySwapScreen(
                     modifier =
                         Modifier.background(
                                 color = Theme.v2.colors.backgrounds.secondary,
-                                shape = RoundedCornerShape(16.dp),
+                                shape = Theme.v2.radius.xl,
                             )
                             .padding(all = 24.dp)
                 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
@@ -135,9 +135,9 @@ private fun ExecuteWhenCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(24.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(colors.backgrounds.background)
-                .border(1.dp, colors.border.light, RoundedCornerShape(24.dp))
+                .border(1.dp, colors.border.light, Theme.v2.radius.xl)
                 .padding(start = 14.dp, end = 14.dp, top = 16.dp, bottom = 14.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
@@ -389,9 +389,9 @@ private fun AssetEditorCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(24.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(colors.backgrounds.background)
-                .border(1.dp, colors.border.light, RoundedCornerShape(24.dp))
+                .border(1.dp, colors.border.light, Theme.v2.radius.xl)
                 .padding(start = 14.dp, end = 14.dp, top = 16.dp, bottom = 14.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
@@ -535,9 +535,9 @@ private fun SummaryRow(
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(24.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(colors.backgrounds.background)
-                .border(1.dp, colors.border.light, RoundedCornerShape(24.dp))
+                .border(1.dp, colors.border.light, Theme.v2.radius.xl)
                 .clickable(onClick = onEdit)
                 .padding(horizontal = 16.dp, vertical = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
@@ -254,9 +254,9 @@ private fun ExpiryRow(selected: LimitExpiryOption, onExpiryClick: (LimitExpiryOp
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.lg)
                 .background(colors.backgrounds.disabled)
-                .border(1.dp, colors.border.light, RoundedCornerShape(16.dp))
+                .border(1.dp, colors.border.light, Theme.v2.radius.lg)
                 .padding(14.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -552,8 +552,7 @@ private fun SummaryRow(
             modifier = Modifier.size(16.dp),
         )
         Box(
-            modifier =
-                Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).clickable(onClick = onEdit),
+            modifier = Modifier.size(40.dp).clip(Theme.v2.radius.pill).clickable(onClick = onEdit),
             contentAlignment = Alignment.Center,
         ) {
             Icon(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
@@ -194,8 +194,15 @@ private fun SendAddressPill(address: String, modifier: Modifier = Modifier) {
 
 @Composable
 private fun SendProviderChip(provider: String, modifier: Modifier = Modifier) {
+    // Anchored to the card's bottom-end corner: the outer corner traces the card, so it reads the
+    // card's token rather than a number that happened to match it.
     val shape =
-        RoundedCornerShape(topStart = 12.dp, topEnd = 0.dp, bottomEnd = 16.dp, bottomStart = 0.dp)
+        RoundedCornerShape(
+            topStart = Theme.v2.radius.md.size,
+            topEnd = 0.dp,
+            bottomEnd = Theme.v2.radius.xl.size,
+            bottomStart = 0.dp,
+        )
     Text(
         text =
             buildAnnotatedString {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -146,7 +145,7 @@ internal fun SendTxOverviewScreen(
                                     stringResource(R.string.tx_overview_screen_tx_deposit)
                                 },
                             valuedToken = tx.token,
-                            shape = RoundedCornerShape(24.dp),
+                            shape = Theme.v2.radius.xl,
                             modifier = Modifier.fillMaxWidth(),
                         )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
@@ -168,8 +168,16 @@ private fun SwapAmountText(amount: String, token: String, modifier: Modifier = M
 
 @Composable
 private fun ViaBadge(provider: String, providerLogo: ImageModel?, modifier: Modifier = Modifier) {
+    // The badge is anchored to the card's bottom-end corner, so its outer corner is not its own
+    // geometry — it is the card's, and has to be read from the same token or the badge cuts across
+    // the curve it is meant to follow.
     val shape =
-        RoundedCornerShape(topStart = 12.dp, topEnd = 0.dp, bottomEnd = 0.dp, bottomStart = 0.dp)
+        RoundedCornerShape(
+            topStart = Theme.v2.radius.md.size,
+            topEnd = 0.dp,
+            bottomEnd = Theme.v2.radius.xl.size,
+            bottomStart = 0.dp,
+        )
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
@@ -170,12 +170,12 @@ private fun SendDetailContent(item: TransactionHistoryItemUiModel.Send) {
             Modifier.border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(size = 16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.surface2,
-                    shape = RoundedCornerShape(size = 16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(vertical = 16.dp, horizontal = 20.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -298,12 +297,12 @@ private fun SuccessTransaction(
             modifier =
                 Modifier.background(
                         color = Theme.v2.colors.backgrounds.disabled,
-                        shape = RoundedCornerShape(16.dp),
+                        shape = Theme.v2.radius.xl,
                     )
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+                        shape = Theme.v2.radius.xl,
                     )
                     .padding(horizontal = 24.dp, vertical = 8.dp)
         ) {
@@ -415,7 +414,7 @@ private fun SuccessTransactionPreview() {
                 VsOverviewToken(
                     header = "token header",
                     valuedToken = ValuedToken.Empty,
-                    shape = RoundedCornerShape(24.dp),
+                    shape = Theme.v2.radius.xl,
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BondedTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BondedTabComponents.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -74,12 +73,12 @@ internal fun ActiveNodesWidget(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp)
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -90,11 +90,11 @@ internal fun BalanceBanner(
         modifier =
             Modifier.fillMaxWidth()
                 .height(118.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
     ) {
         SetBackgroundBanner(backgroundImageResId = image)
@@ -620,12 +620,12 @@ internal fun HeaderDeFiWidget(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp)
     ) {
@@ -774,12 +774,12 @@ internal fun HeaderDeFiWidget(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp)
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -62,12 +61,12 @@ internal fun LpWidget(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp)
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -80,12 +79,12 @@ internal fun StakingWidget(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(16.dp)
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
@@ -82,7 +82,7 @@ internal fun RemoveLpScreenContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Amount card
-        val amountCardShape = RoundedCornerShape(12.dp)
+        val amountCardShape = Theme.v2.radius.xl
         Column(
             modifier =
                 Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/UnstakeCacaoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/UnstakeCacaoScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Text
@@ -88,7 +87,7 @@ private fun UnstakeCacaoContent(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        val amountCardShape = RoundedCornerShape(12.dp)
+        val amountCardShape = Theme.v2.radius.xl
         Column(
             modifier =
                 Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaDelegateScreen.kt
@@ -309,7 +309,9 @@ private fun SolanaValidatorRow(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
-    val shape = RoundedCornerShape(16.dp)
+    // Rows in a picker list, not cards on a page: they keep the inner step rather than
+    // taking the container one. Figma measures this row at 16 specifically.
+    val shape = Theme.v2.radius.lg
     Row(
         modifier =
             Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -184,12 +183,12 @@ private fun StakeAccountsWidget(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(16.dp))
+                        .clip(Theme.v2.radius.xl)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(16.dp),
+                            shape = Theme.v2.radius.xl,
                         )
                         .padding(16.dp)
             ) {
@@ -370,12 +369,12 @@ private fun SolanaHeaderBanner(totalValue: String?, isLoading: Boolean, isBalanc
         modifier =
             Modifier.fillMaxWidth()
                 .height(118.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
     ) {
         Box(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
@@ -261,13 +261,13 @@ private fun TonDeFiBanner(isLoading: Boolean, totalValue: String, isBalanceVisib
         modifier =
             Modifier.fillMaxWidth()
                 .height(118.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(
                     Brush.verticalGradient(
                         colors = listOf(TonBannerGradientTop, TonBannerGradientBottom)
                     )
                 )
-                .border(1.dp, TonBannerBorder, RoundedCornerShape(16.dp))
+                .border(1.dp, TonBannerBorder, Theme.v2.radius.xl)
     ) {
         Column(
             horizontalAlignment = Alignment.Start,
@@ -313,9 +313,9 @@ private fun TonStakingPositionCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(16.dp))
+                .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.xl)
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
@@ -312,7 +312,9 @@ private fun TonPoolRow(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
-    val shape = RoundedCornerShape(16.dp)
+    // Rows in a picker list, not cards on a page: they keep the inner step rather than
+    // taking the container one. Figma measures this row at 16 specifically.
+    val shape = Theme.v2.radius.lg
     Row(
         modifier =
             Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonUnstakeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -50,9 +49,9 @@ internal fun TonUnstakeScreen(viewModel: TonUnstakeViewModel = hiltViewModel()) 
                 Column(
                     modifier =
                         Modifier.fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
+                            .clip(Theme.v2.radius.xl)
                             .background(Theme.v2.colors.backgrounds.secondary)
-                            .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(16.dp))
+                            .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.xl)
                             .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiBanner.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -40,13 +39,13 @@ internal fun TronDeFiBanner(isLoading: Boolean, totalValue: String, isBalanceVis
         modifier =
             Modifier.fillMaxWidth()
                 .height(118.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(
                     Brush.verticalGradient(
                         colors = listOf(TronBannerGradientTop, TronBannerGradientBottom)
                     )
                 )
-                .border(1.dp, TronBannerBorder, RoundedCornerShape(16.dp))
+                .border(1.dp, TronBannerBorder, Theme.v2.radius.xl)
     ) {
         Column(
             horizontalAlignment = Alignment.Start,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -328,7 +328,7 @@ private fun TronPendingWithdrawalRow(
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .padding(16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
@@ -103,9 +103,9 @@ internal fun TronFreezePositionCard(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.secondary)
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(16.dp))
+                .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.xl)
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -78,11 +77,11 @@ fun AssetActionButton(
         Box(
             modifier =
                 Modifier.size(size = IconBoxSize)
-                    .clip(shape = RoundedCornerShape(16.dp))
+                    .clip(shape = Theme.v2.radius.lg)
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.neutrals.n100.copy(alpha = 0.03f),
-                        shape = RoundedCornerShape(16.dp),
+                        shape = Theme.v2.radius.lg,
                     )
                     .background(backgroundColor),
             contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/DefiExpandedTopbarContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/DefiExpandedTopbarContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,9 +30,9 @@ internal fun DefiExpandedTopbarContent(
             Modifier.border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(size = 16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
-                .clip(shape = RoundedCornerShape(size = 16.dp))
+                .clip(shape = Theme.v2.radius.xl)
     ) {
         CoinsAround()
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/NotEnabledContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/NotEnabledContainer.kt
@@ -32,8 +32,8 @@ import com.vultisig.wallet.ui.theme.v2.Radius
 internal fun NotEnabledContainer(
     title: String,
     content: String,
-    action: @Composable (() -> Unit)? = null,
     radius: Radius = Theme.v2.radius.xl,
+    action: @Composable (() -> Unit)? = null,
 ) {
     TopShineContainer(radius = radius) {
         Column(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/NotEnabledContainer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/NotEnabledContainer.kt
@@ -20,14 +20,22 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.Radius
 
+/**
+ * Empty-state panel.
+ *
+ * Outer on the DeFi tab and nested inside the home screen's chain list, so one default cannot serve
+ * both: [radius] defaults to the container step and the nested call site passes a smaller one.
+ */
 @Composable
 internal fun NotEnabledContainer(
     title: String,
     content: String,
     action: @Composable (() -> Unit)? = null,
+    radius: Radius = Theme.v2.radius.xl,
 ) {
-    TopShineContainer {
+    TopShineContainer(radius = radius) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/BuyVultBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/BuyVultBanner.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,11 +25,13 @@ internal fun BuyVultBanner(onBuyVultClick: () -> Unit) {
     Box(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                // Rendered inside HomePagePagerContainer, whose clip is drawn on this exact
+                // rect — so this reads the same token rather than its own number.
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.xl,
                 )
     ) {
         SetBackgroundBanner(backgroundImageResId = R.drawable.buy_vult_banner)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/FollowXBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/pager/banner/FollowXBanner.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -27,11 +26,13 @@ internal fun FollowXBanner(onFollowXClick: () -> Unit) {
     Box(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(16.dp))
+                // Rendered inside HomePagePagerContainer, whose clip is drawn on this exact
+                // rect — so this reads the same token rather than its own number.
+                .clip(Theme.v2.radius.xl)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
     ) {
         SetBackgroundBanner(backgroundImageResId = R.drawable.follow_banner)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ReviewVaultDevicesScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/ReviewVaultDevicesScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -154,7 +153,7 @@ private fun VaultDeviceItem(label: String, subtitle: String, modifier: Modifier 
                 .fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(16.dp),
+                    shape = Theme.v2.radius.xl,
                 )
                 .padding(horizontal = 16.dp, vertical = 14.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultHeader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v3/onboarding/components/SetupVaultHeader.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,13 +21,13 @@ import com.vultisig.wallet.ui.theme.Theme
 fun SetupVaultHeader(logo: Int, title: String, subTitle: String) {
     Box(
         modifier =
-            Modifier.clip(shape = RoundedCornerShape(size = 16.dp))
+            Modifier.clip(shape = Theme.v2.radius.lg)
                 .background(color = Theme.v2.colors.border.light)
                 .padding(top = 1.dp)
     ) {
         Row(
             modifier =
-                Modifier.clip(shape = RoundedCornerShape(size = 16.dp))
+                Modifier.clip(shape = Theme.v2.radius.lg)
                     .background(color = Theme.v2.colors.backgrounds.secondary)
                     .padding(all = 8.dp),
             verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
Part of #5503 — **phase 2 of 4.** Follows #5544, which added the token layer and changed nothing on screen. This is where the design lands.

Ports vultisig-ios#5046.

---

## The problem phase 1 did not solve

Phase 1 gave every rounded surface a vocabulary. It did not make them agree. The app still spelled its container geometry as ~100 numeric literals with no relationship between them:

| Surface | Was |
|---|---|
| send / swap / deposit verify summaries | 16 |
| done-screen detail card | 16 |
| signed-message cards | 12 |
| DeFi cards and banners (every one) | 16 |
| governance proposal cards | 20 |
| settings list rows | 10 |
| transaction-history cards | 12 |
| home banners | 12 and 16 |
| swap pickers, peer cells, custom-RPC tiles | 24 |

Six roundings for one idiom, on screens the user walks through in a single sitting.

## The rule

The iOS ruling ports directly:

> **The outer surface on a page is the container and takes 24. Anything nested inside a container is content and takes an explicitly smaller step. The two levels must differ.**

with one Android corollary, because Compose lets a clip and a border be written as two independent literals for one rect:

> **Surfaces drawn onto the same rect — a clip and its border, a child filling its parent, a badge tracing a corner — read the same token, not the same number.**

The container/content call is made **from the call site, not the declaration**. That is the whole of the work, and it is where iOS reversed itself twice.

---

## Commits

Each is one surface class, reviewable on its own.

**1. `V2Container` defaults to the container step.** Android's `containerStyle` equivalent — fill, hairline border, clip, ~40 call sites, previously defaulting to 12, which also meant no grep for a radius literal could see any of them. Of the 22 sites taking the default, 14 are the outer surface on their page and inherit the new one; 8 are nested and now say so: the three DepositForm value boxes, the share-sheet link row, both `TokenMetaRow` pills, and the two vault-list groups plus meta chip inside `BackupVaultContainer`.

**2. Verify and done cards.** Send, swap and deposit verify summaries, the done-screen detail card, the signed-message cards, the gas-settings dialog panel. `DappRequestBanner` moves with them: the iOS twin deliberately stays small because both of its call sites nest it inside a summary card, but all four Android call sites render it *above* the card as a sibling on the page.

**3. Keygen and keysign panels.** QBTC co-sign consent, review-devices cells, import-type option cards. The JoinKeysign peer logo also stops spelling "circle" as `RoundedCornerShape(50)` — percent-50, the one form a dp-literal search cannot see.

**4. DeFi.** The largest block and uniformly 16: balance banners, yield and staking cards, the Bonded / LP / Staking tab cards, Cosmos / Solana / Ton / Tron positions, the Tron freeze card and banner, the DeFi top bar.

**5. The rest.** Reshare and referral option cards, governance proposals, QBTC hero and maturing cards, the feature-gate sheet, the transaction-detail amount card, the shared `Banner` and `GradientInfoCard`, the QBTC promo banner, the passcode lock card, the bond form card, the Maya amount cards, the Cosmos position cards, the referral vault list.

**6. The 21 surfaces already at 24** stop restating the number. They are what everything else was standardised *to*, and nothing about them changes on screen.

---

## What the call-site rule actually caught

Three cases that read as containers from their own source and are not one at their call site — none of which is visible from the declaration:

- **`TopShineContainer` nests inside itself.** The home screen's chain-list card renders `NotEnabledContainer` — another `TopShineContainer` — inside it when no chains are enabled. Both grew a `radius`, defaulting to the container step, and the home screen's empty state passes the smaller one. `NotEnabledContainer` is genuinely outer on the DeFi tab and nested on home, so one default could never have served both.
- **The three home-pager banners clip and border themselves on the exact rect `HomePagePagerContainer` already clips.** `FollowXBanner` was drawing a 16 border inside a 12 clip — a live mismatch, already on `main`. All three read the container's token now, so the two cannot disagree.
- **The "via" badge was about to break.** It is anchored to the transaction card's bottom-end corner and traces it, but spelled that corner as its own number (0 on the swap card, 16 on the send chip) against a card at 12. Moving the card to 24 would have left the badge cutting across the curve it is supposed to follow. Its outer corner now reads the card's token and its inner corner the nested step. Same for the custom-RPC edit badge, whose `bottomEnd` matched its tile by coincidence.

## Deliberately left alone, each with a note in place

- **Sheets** (28 / 32 / 34 / 38 / 40) — the scale has no sheet step, and phase 1 recorded why: those are Apple's and Material's numbers, not ours.
- **Inputs and form fields** (the remaining 12s, and the search field's 10) — Figma says 16, the app says 12. Real drift, needs a designer call, and iOS deferred it to its phase 3 as well.
- **The key-import chain row (20)** — a Figma value for that row, exactly equidistant from 16 and 24, so no reading of the scale picks one. iOS left the same row for the same reason.
- **The tier card's 24-top / 20-bottom asymmetry** — the top is the container step and now says so; the bottom is a design decision, not a number to snap.
- **The validator / pool picker rows (Cosmos, Solana, Ton) and the QBTC UTXO rows** — rows inside a picker rather than cards on a page, and Figma names 16 for that row specifically (node `75918:75259`). They keep the inner step and read it from the token, so the one-step gap between them and the cards is now deliberate rather than accidental.
- **The limit-swap price-unit toggle (20)** — a control, ruled on with the inputs.

## Numbers that turned out to be an idiom

Four sites were the pill written arithmetically, and are pixel-identical as `pill`: the sheet grabber's 16 on a 6dp bar, the referral vault row's 28 on a 56dp row, the limit-swap pencil's 20 on a 40dp box, and `RoundedCornerShape(50)` on the peer logo.

---

## Verification

- `:app:testDebugUnitTest` and `:data:test` — green. `RadiusTokenTest` is token-level and unaffected; nothing in this branch changes a token's value.
- `:app:lintDebug` and `:data:lintDebug` — green.
- `ktfmt` applied.
- **Before / after captured on device.** Both APKs were built and driven through 18 `PreviewActivity` screens on the same emulator with the status bar frozen, then compared pixel by pixel. 14 differ, which is the point of the phase — and each was looked at rather than counted. The four that do not are correct: the transaction-history empty state and the DeFi account list contain no surface this branch moves; the tier screen's card was already at 24; and the gas-settings preview renders the panel on a background of the same colour, so its corner is invisible there (it is over a scrim in the app).
- `PreviewActivity` gained a **Swaps history tab** preview, because the via badge is the one surface here whose radius is not its own and there was nothing that rendered it. The capture confirms the badge now traces the card's corner instead of cutting across it.

Per the repo's screenshot rule this is described rather than embedded — no images are committed to the branch.

## After this

**Phase 3** tokenises every remaining on-scale literal and rules on inputs. **Phase 4** is the lint rule banning new numeric radius literals, which is the only thing that makes "drift can't re-accumulate" true — it can only land once the outliers above are reconciled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preview of the swaps tab with sample confirmed and broadcasted transactions across multiple chains and providers.

* **Style**
  * Standardized rounded corners across cards, banners, forms, dialogs, transaction views, and DeFi screens using shared theme styling.
  * Improved consistency for nested containers, badges, inputs, and bottom sheets.
  * Added configurable corner-radius support for select container components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->