### PR TITLE
fix(passcode): non-destructive credential reads, durable writes

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -356,8 +356,8 @@ internal class PasscodeRepositoryImpl(
                 // The data key is unchanged, so stored keyshares stay valid: only the wrap is
                 // rewritten. This is why changing the passcode is instant on a large vault set.
                 //
-                // Nothing has changed yet at this point, so a wrap that never reached the disk
-                // simply leaves the old passcode in force.
+                // Nothing else has been touched yet, so a wrap that did not land leaves the old
+                // passcode in force.
                 val persisted = runCatching { persistWrappedKey(key, newPasscode) }
                 persisted.exceptionOrNull()?.let { cause ->
                     if (cause is CancellationException) throw cause
@@ -391,10 +391,6 @@ internal class PasscodeRepositoryImpl(
                 // One unit, uncancellable. Stopping between the two leaves the key live and the
                 // state Unlocked with no wrap on disk: every keyshare written afterwards would be
                 // sealed under a key the next launch has no way to recover.
-                //
-                // A clear that never reached the disk throws before any of this, so the passcode
-                // stays in force — but unprotectAll has already put every share back in the
-                // clear, so they have to be sealed again before the failure is reported.
                 val cleared = runCatching {
                     withContext(NonCancellable) {
                         withContext(dispatcher) { store.clearCredentials() }
@@ -409,6 +405,7 @@ internal class PasscodeRepositoryImpl(
                         cause,
                         "Refusing to disable the passcode: the credentials are still there",
                     )
+                    // The shares are already back in the clear under a passcode still in force.
                     protectAllOrLog(key)
                     key.fill(0)
                     return@verifyLocked PasscodeUnlockResult.Failed

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -356,12 +356,15 @@ internal class PasscodeRepositoryImpl(
                 // The data key is unchanged, so stored keyshares stay valid: only the wrap is
                 // rewritten. This is why changing the passcode is instant on a large vault set.
                 //
-                // Nothing else has been touched yet, so a wrap that did not land leaves the old
-                // passcode in force.
-                val persisted = runCatching { persistWrappedKey(key, newPasscode) }
-                persisted.exceptionOrNull()?.let { cause ->
-                    if (cause is CancellationException) throw cause
-                    Timber.e(cause, "Failed to store the new passcode")
+                // Nothing else has been touched yet, and the store puts back what it had, so a
+                // wrap that did not land leaves the old passcode in force.
+                try {
+                    persistWrappedKey(key, newPasscode)
+                } catch (e: CancellationException) {
+                    key.fill(0)
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to store the new passcode")
                     key.fill(0)
                     return@verifyLocked PasscodeUnlockResult.Failed
                 }
@@ -391,23 +394,25 @@ internal class PasscodeRepositoryImpl(
                 // One unit, uncancellable. Stopping between the two leaves the key live and the
                 // state Unlocked with no wrap on disk: every keyshare written afterwards would be
                 // sealed under a key the next launch has no way to recover.
-                val cleared = runCatching {
+                try {
                     withContext(NonCancellable) {
                         withContext(dispatcher) { store.clearCredentials() }
                         swapDataKey(null)
-                        key.fill(0)
                         _state.value = PasscodeState.Disabled
+                        key.fill(0)
                     }
-                }
-                cleared.exceptionOrNull()?.let { cause ->
-                    if (cause is CancellationException) throw cause
-                    Timber.e(
-                        cause,
-                        "Refusing to disable the passcode: the credentials are still there",
-                    )
-                    // The shares are already back in the clear under a passcode still in force.
-                    protectAllOrLog(key)
+                } catch (e: CancellationException) {
                     key.fill(0)
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Refusing to disable the passcode: the credentials are still there")
+                    // unprotectAll has already put every share back in the clear, and the passcode
+                    // that guards them is still in force. Uncancellable because they stay exposed
+                    // until this finishes.
+                    withContext(NonCancellable) {
+                        protectAllOrLog(key)
+                        key.fill(0)
+                    }
                     return@verifyLocked PasscodeUnlockResult.Failed
                 }
                 PasscodeUnlockResult.Success

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -355,7 +355,16 @@ internal class PasscodeRepositoryImpl(
             verifyLocked(currentPasscode) { key ->
                 // The data key is unchanged, so stored keyshares stay valid: only the wrap is
                 // rewritten. This is why changing the passcode is instant on a large vault set.
-                persistWrappedKey(key, newPasscode)
+                //
+                // Nothing has changed yet at this point, so a wrap that never reached the disk
+                // simply leaves the old passcode in force.
+                val persisted = runCatching { persistWrappedKey(key, newPasscode) }
+                persisted.exceptionOrNull()?.let { cause ->
+                    if (cause is CancellationException) throw cause
+                    Timber.e(cause, "Failed to store the new passcode")
+                    key.fill(0)
+                    return@verifyLocked PasscodeUnlockResult.Failed
+                }
                 swapDataKey(key)
                 publishUnlockedUnlessLocked()
                 PasscodeUnlockResult.Success
@@ -382,11 +391,26 @@ internal class PasscodeRepositoryImpl(
                 // One unit, uncancellable. Stopping between the two leaves the key live and the
                 // state Unlocked with no wrap on disk: every keyshare written afterwards would be
                 // sealed under a key the next launch has no way to recover.
-                withContext(NonCancellable) {
-                    withContext(dispatcher) { store.clearCredentials() }
-                    swapDataKey(null)
+                //
+                // A clear that never reached the disk throws before any of this, so the passcode
+                // is still in place — over shares unprotectAll has already put back in the clear,
+                // which the next unlock re-encrypts.
+                val cleared = runCatching {
+                    withContext(NonCancellable) {
+                        withContext(dispatcher) { store.clearCredentials() }
+                        swapDataKey(null)
+                        key.fill(0)
+                        _state.value = PasscodeState.Disabled
+                    }
+                }
+                cleared.exceptionOrNull()?.let { cause ->
+                    if (cause is CancellationException) throw cause
+                    Timber.e(
+                        cause,
+                        "Refusing to disable the passcode: the credentials are still there",
+                    )
                     key.fill(0)
-                    _state.value = PasscodeState.Disabled
+                    return@verifyLocked PasscodeUnlockResult.Failed
                 }
                 PasscodeUnlockResult.Success
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -393,8 +393,8 @@ internal class PasscodeRepositoryImpl(
                 // sealed under a key the next launch has no way to recover.
                 //
                 // A clear that never reached the disk throws before any of this, so the passcode
-                // is still in place — over shares unprotectAll has already put back in the clear,
-                // which the next unlock re-encrypts.
+                // stays in force — but unprotectAll has already put every share back in the
+                // clear, so they have to be sealed again before the failure is reported.
                 val cleared = runCatching {
                     withContext(NonCancellable) {
                         withContext(dispatcher) { store.clearCredentials() }
@@ -409,6 +409,7 @@ internal class PasscodeRepositoryImpl(
                         cause,
                         "Refusing to disable the passcode: the credentials are still there",
                     )
+                    protectAllOrLog(key)
                     key.fill(0)
                     return@verifyLocked PasscodeUnlockResult.Failed
                 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
@@ -72,21 +72,36 @@ constructor(private val prefs: SharedPreferences) : PasscodeStore {
     }
 
     override fun writeCredentials(credentials: PasscodeCredentials) {
-        // The wrap has to be on disk before setPasscode seals the keyshares under it. androidx's
-        // edit(commit = true) discards commit()'s result, so the editor is driven directly.
-        val committed =
-            prefs
-                .edit()
-                .putString(KEY_SALT, encode(credentials.salt))
-                .putString(KEY_WRAPPED_KEY, encode(credentials.wrappedDataKey))
-                .commit()
-        check(committed) { "Passcode credentials were not written to disk" }
+        // The wrap has to be on disk before setPasscode seals the keyshares under it.
+        commitBothHalves("Passcode credentials were not written to disk") {
+            putString(KEY_SALT, encode(credentials.salt))
+            putString(KEY_WRAPPED_KEY, encode(credentials.wrappedDataKey))
+        }
     }
 
     override fun clearCredentials() {
         // A clear that did not land brings back a passcode the user removed.
-        val committed = prefs.edit().remove(KEY_SALT).remove(KEY_WRAPPED_KEY).commit()
-        check(committed) { "Passcode credentials were not removed from disk" }
+        commitBothHalves("Passcode credentials were not removed from disk") {
+            remove(KEY_SALT)
+            remove(KEY_WRAPPED_KEY)
+        }
+    }
+
+    /**
+     * Applies [mutation] to both halves, or puts back what they held and throws [failure].
+     *
+     * `commit` updates the in-memory map before it writes the file and leaves it updated when that
+     * write fails, while the file keeps its previous contents. Putting the map back is what makes a
+     * refused write change nothing.
+     */
+    private fun commitBothHalves(failure: String, mutation: SharedPreferences.Editor.() -> Unit) {
+        val salt = prefs.getString(KEY_SALT, null)
+        val wrapped = prefs.getString(KEY_WRAPPED_KEY, null)
+        val editor = prefs.edit()
+        editor.mutation()
+        if (editor.commit()) return
+        prefs.edit().putString(KEY_SALT, salt).putString(KEY_WRAPPED_KEY, wrapped).apply()
+        error(failure)
     }
 
     override fun readLockout(): PasscodeLockoutState =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
@@ -37,8 +37,10 @@ internal interface PasscodeStore {
 
     fun readCredentials(): PasscodeCredentials?
 
+    /** @throws IllegalStateException if the credentials did not reach the disk. */
     fun writeCredentials(credentials: PasscodeCredentials)
 
+    /** @throws IllegalStateException if the credentials are still on the disk afterwards. */
     fun clearCredentials()
 
     fun readLockout(): PasscodeLockoutState
@@ -70,20 +72,24 @@ constructor(private val prefs: SharedPreferences) : PasscodeStore {
     }
 
     override fun writeCredentials(credentials: PasscodeCredentials) {
-        // commit, not apply: setPasscode durably seals every keyshare under this key straight
-        // afterwards, so an apply() lost to a process kill leaves ciphertext with no wrap.
-        prefs.edit(commit = true) {
-            putString(KEY_SALT, encode(credentials.salt))
-            putString(KEY_WRAPPED_KEY, encode(credentials.wrappedDataKey))
-        }
+        // commit, not apply, and the result is checked: setPasscode durably seals every keyshare
+        // under this key straight afterwards, so a write that was only queued — or refused
+        // outright — leaves ciphertext with no key. androidx's edit(commit = true) discards
+        // commit()'s result.
+        val committed =
+            prefs
+                .edit()
+                .putString(KEY_SALT, encode(credentials.salt))
+                .putString(KEY_WRAPPED_KEY, encode(credentials.wrappedDataKey))
+                .commit()
+        check(committed) { "Passcode credentials were not written to disk" }
     }
 
     override fun clearCredentials() {
-        // Committed too: a lost clear brings back a passcode the user removed.
-        prefs.edit(commit = true) {
-            remove(KEY_SALT)
-            remove(KEY_WRAPPED_KEY)
-        }
+        // Checked for the same reason: a clear that did not land brings back a passcode the user
+        // removed.
+        val committed = prefs.edit().remove(KEY_SALT).remove(KEY_WRAPPED_KEY).commit()
+        check(committed) { "Passcode credentials were not removed from disk" }
     }
 
     override fun readLockout(): PasscodeLockoutState =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
@@ -65,17 +65,15 @@ constructor(private val prefs: SharedPreferences) : PasscodeStore {
     override fun readCredentials(): PasscodeCredentials? {
         val salt = prefs.getString(KEY_SALT, null)?.let(::decodeOrNull)
         val wrapped = prefs.getString(KEY_WRAPPED_KEY, null)?.let(::decodeOrNull)
-        // A read never deletes. A half that failed to decrypt this launch reads exactly like one
-        // that was never stored, and the wrap it pairs with opens every encrypted keyshare.
+        // A half that failed to decrypt is indistinguishable from one that was never stored, so it
+        // is never grounds for deleting the other.
         if (salt == null || wrapped == null) return null
         return PasscodeCredentials(salt = salt, wrappedDataKey = wrapped)
     }
 
     override fun writeCredentials(credentials: PasscodeCredentials) {
-        // commit, not apply, and the result is checked: setPasscode durably seals every keyshare
-        // under this key straight afterwards, so a write that was only queued — or refused
-        // outright — leaves ciphertext with no key. androidx's edit(commit = true) discards
-        // commit()'s result.
+        // The wrap has to be on disk before setPasscode seals the keyshares under it. androidx's
+        // edit(commit = true) discards commit()'s result, so the editor is driven directly.
         val committed =
             prefs
                 .edit()
@@ -86,8 +84,7 @@ constructor(private val prefs: SharedPreferences) : PasscodeStore {
     }
 
     override fun clearCredentials() {
-        // Checked for the same reason: a clear that did not land brings back a passcode the user
-        // removed.
+        // A clear that did not land brings back a passcode the user removed.
         val committed = prefs.edit().remove(KEY_SALT).remove(KEY_WRAPPED_KEY).commit()
         check(committed) { "Passcode credentials were not removed from disk" }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeStore.kt
@@ -63,25 +63,24 @@ constructor(private val prefs: SharedPreferences) : PasscodeStore {
     override fun readCredentials(): PasscodeCredentials? {
         val salt = prefs.getString(KEY_SALT, null)?.let(::decodeOrNull)
         val wrapped = prefs.getString(KEY_WRAPPED_KEY, null)?.let(::decodeOrNull)
-        if (salt == null || wrapped == null) {
-            // Half a credential is not a passcode, it is a torn write or a corrupted store. Drop
-            // the remaining half so the app reports "no passcode" consistently rather than leaving
-            // a stray salt that a later write would pair with a mismatched key.
-            if (salt != null || wrapped != null) clearCredentials()
-            return null
-        }
+        // A read never deletes. A half that failed to decrypt this launch reads exactly like one
+        // that was never stored, and the wrap it pairs with opens every encrypted keyshare.
+        if (salt == null || wrapped == null) return null
         return PasscodeCredentials(salt = salt, wrappedDataKey = wrapped)
     }
 
     override fun writeCredentials(credentials: PasscodeCredentials) {
-        prefs.edit {
+        // commit, not apply: setPasscode durably seals every keyshare under this key straight
+        // afterwards, so an apply() lost to a process kill leaves ciphertext with no wrap.
+        prefs.edit(commit = true) {
             putString(KEY_SALT, encode(credentials.salt))
             putString(KEY_WRAPPED_KEY, encode(credentials.wrappedDataKey))
         }
     }
 
     override fun clearCredentials() {
-        prefs.edit {
+        // Committed too: a lost clear brings back a passcode the user removed.
+        prefs.edit(commit = true) {
             remove(KEY_SALT)
             remove(KEY_WRAPPED_KEY)
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -313,6 +313,46 @@ internal class PasscodeRepositoryImplTest {
     }
 
     @Test
+    fun `setPasscode encrypts nothing when the wrap does not reach the disk`() = runTest {
+        val repository = repository()
+        store.writeFailure = IllegalStateException("credentials were not written to disk")
+
+        assertEquals(PasscodeUnlockResult.Failed, repository.setPasscode("123456"))
+
+        assertEquals(emptyList(), protection.calls, "nothing may be encrypted")
+        assertNull(store.readCredentials())
+    }
+
+    @Test
+    fun `changePasscode leaves the old passcode in force when the new wrap is not stored`() =
+        runTest {
+            val repository = repository()
+            repository.setPasscode("123456")
+            val credentials = store.readCredentials()
+            store.writeFailure = IllegalStateException("credentials were not written to disk")
+
+            assertEquals(PasscodeUnlockResult.Failed, repository.changePasscode("123456", "654321"))
+
+            store.writeFailure = null
+            assertEquals(credentials, store.readCredentials())
+            repository.lock()
+            assertEquals(PasscodeUnlockResult.Success, repository.unlock("123456"))
+        }
+
+    @Test
+    fun `disablePasscode keeps the passcode when the credentials are not removed`() = runTest {
+        val repository = repository()
+        repository.setPasscode("123456")
+        val credentials = store.readCredentials()
+        store.writeFailure = IllegalStateException("credentials were not removed from disk")
+
+        assertEquals(PasscodeUnlockResult.Failed, repository.disablePasscode("123456"))
+
+        assertEquals(credentials, store.readCredentials())
+        assertEquals(PasscodeState.Unlocked, repository.state.value)
+    }
+
+    @Test
     fun `setPasscode survives an encryption failure with a working passcode`() = runTest {
         // The wrap is already stored and the app is unlocked by the time protectAll runs, so a
         // failed row is not a reason to fail the operation around it — the next unlock sweeps it.
@@ -618,6 +658,9 @@ internal class FakePasscodeStore : PasscodeStore {
     /** Set to stand in for a keystore that throws rather than returning nothing. */
     var readFailure: Throwable? = null
 
+    /** Set to stand in for a store whose write or removal never reaches the disk. */
+    var writeFailure: Throwable? = null
+
     override fun isPersistent(): Boolean = persistent
 
     @Synchronized
@@ -629,11 +672,13 @@ internal class FakePasscodeStore : PasscodeStore {
 
     @Synchronized
     override fun writeCredentials(credentials: PasscodeCredentials) {
+        writeFailure?.let { throw it }
         this.credentials = credentials
     }
 
     @Synchronized
     override fun clearCredentials() {
+        writeFailure?.let { throw it }
         credentials = null
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -340,7 +340,9 @@ internal class PasscodeRepositoryImplTest {
         }
 
     @Test
-    fun `disablePasscode keeps the passcode when the credentials are not removed`() = runTest {
+    fun `disablePasscode reseals the keyshares when the credentials are not removed`() = runTest {
+        // The shares are decrypted before the credentials are dropped, so a passcode that stays in
+        // force must not be left guarding a table that is already in the clear.
         val repository = repository()
         repository.setPasscode("123456")
         val credentials = store.readCredentials()
@@ -350,6 +352,7 @@ internal class PasscodeRepositoryImplTest {
 
         assertEquals(credentials, store.readCredentials())
         assertEquals(PasscodeState.Unlocked, repository.state.value)
+        assertEquals(listOf("protect", "unprotect", "protect"), protection.calls)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -352,6 +352,7 @@ internal class PasscodeRepositoryImplTest {
         assertEquals(credentials, store.readCredentials())
         assertEquals(PasscodeState.Unlocked, repository.state.value)
         assertEquals(listOf("protect", "unprotect", "protect"), protection.calls)
+        assertContentEquals(repository.dataKeyOrNull(), protection.protectedWith)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -341,8 +341,7 @@ internal class PasscodeRepositoryImplTest {
 
     @Test
     fun `disablePasscode reseals the keyshares when the credentials are not removed`() = runTest {
-        // The shares are decrypted before the credentials are dropped, so a passcode that stays in
-        // force must not be left guarding a table that is already in the clear.
+        // The shares are decrypted before the credentials are dropped.
         val repository = repository()
         repository.setPasscode("123456")
         val credentials = store.readCredentials()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
@@ -83,8 +83,8 @@ internal class SharedPreferencesPasscodeStoreTest {
 
     @Test
     fun `a half that did not decrypt on one read still opens on the next`() {
-        // Over a store that remembers what it was given, so a read that deleted a half would show
-        // up as a wrap that is no longer there once the fault clears.
+        // A store that remembers what it was given, so a deleted half shows up once the fault
+        // clears.
         val flakyPrefs = FlakyPreferences(InMemorySharedPreferences(), KEY_WRAPPED_KEY)
         val flakyStore = SharedPreferencesPasscodeStore(flakyPrefs)
         val credentials =
@@ -112,8 +112,6 @@ internal class SharedPreferencesPasscodeStoreTest {
 
         verify { editor.putString(KEY_SALT, encode(salt)) }
         verify { editor.putString(KEY_WRAPPED_KEY, encode(wrapped)) }
-        // An apply() would let a process kill drop the wrap while the keyshare ciphertext
-        // setPasscode writes next survives.
         verify { editor.commit() }
         verify(exactly = 0) { editor.apply() }
     }
@@ -146,10 +144,7 @@ internal class SharedPreferencesPasscodeStoreTest {
         assertFailsWith<IllegalStateException> { store.clearCredentials() }
     }
 
-    /**
-     * Preferences whose reads of [failingKey] come back empty while [failing] is set, standing in
-     * for a keystore that decrypts one stored value this launch but not the other.
-     */
+    /** Preferences whose reads of [failingKey] come back empty while [failing] is set. */
     private class FlakyPreferences(
         private val delegate: SharedPreferences,
         private val failingKey: String,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
@@ -1,11 +1,13 @@
 package com.vultisig.wallet.data.passcode
 
 import android.content.SharedPreferences
+import com.vultisig.wallet.data.utils.InMemorySharedPreferences
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Base64
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +37,14 @@ internal class SharedPreferencesPasscodeStoreTest {
 
     private fun encode(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
 
+    private fun assertReadLeavesTheStoreAlone(salt: String?, wrapped: String?) {
+        storedAs(salt, wrapped)
+
+        assertNull(store.readCredentials())
+
+        verify(exactly = 0) { prefs.edit() }
+    }
+
     @Test
     fun `both halves present decode into credentials`() {
         val salt = ByteArray(16) { it.toByte() }
@@ -46,58 +56,88 @@ internal class SharedPreferencesPasscodeStoreTest {
         assertNotNull(credentials)
         assertContentEquals(salt, credentials.salt)
         assertContentEquals(wrapped, credentials.wrappedDataKey)
-        verify(exactly = 0) { editor.remove(any()) }
+        verify(exactly = 0) { prefs.edit() }
     }
 
     @Test
-    fun `nothing stored reads as no passcode without touching the store`() {
-        storedAs(null, null)
-
-        assertNull(store.readCredentials())
-
-        // No half to clean up, so a read of an untouched install must not write anything.
-        verify(exactly = 0) { editor.remove(any()) }
+    fun `nothing stored reads as no passcode`() {
+        assertReadLeavesTheStoreAlone(salt = null, wrapped = null)
     }
 
     @Test
-    fun `a stray salt with no wrapped key is discarded`() {
-        // A torn write. Leaving the salt behind risks a later write pairing it with a key it does
-        // not belong to, so the read drops both halves.
-        storedAs(encode(ByteArray(16)), null)
+    fun `a salt whose partner does not read back is left in place`() {
+        assertReadLeavesTheStoreAlone(salt = encode(ByteArray(16)), wrapped = null)
+    }
 
-        assertNull(store.readCredentials())
+    @Test
+    fun `a wrapped key whose partner does not read back is left in place`() {
+        assertReadLeavesTheStoreAlone(salt = null, wrapped = encode(ByteArray(60)))
+    }
+
+    @Test
+    fun `an undecodable half is left in place`() {
+        assertReadLeavesTheStoreAlone(salt = encode(ByteArray(16)), wrapped = "not-base64!!")
+    }
+
+    @Test
+    fun `a half that did not decrypt on one read still opens on the next`() {
+        // Over a store that remembers what it was given, so a read that deleted a half would show
+        // up as a wrap that is no longer there once the fault clears.
+        val flakyPrefs = FlakyPreferences(InMemorySharedPreferences(), KEY_WRAPPED_KEY)
+        val flakyStore = SharedPreferencesPasscodeStore(flakyPrefs)
+        val credentials =
+            PasscodeCredentials(
+                salt = ByteArray(16) { it.toByte() },
+                wrappedDataKey = ByteArray(60) { (it * 3).toByte() },
+            )
+        flakyStore.writeCredentials(credentials)
+
+        flakyPrefs.failing = true
+
+        assertNull(flakyStore.readCredentials())
+
+        flakyPrefs.failing = false
+
+        assertEquals(credentials, flakyStore.readCredentials())
+    }
+
+    @Test
+    fun `writing credentials commits both halves before returning`() {
+        val salt = ByteArray(16) { it.toByte() }
+        val wrapped = ByteArray(60) { (it * 3).toByte() }
+
+        store.writeCredentials(PasscodeCredentials(salt = salt, wrappedDataKey = wrapped))
+
+        verify { editor.putString(KEY_SALT, encode(salt)) }
+        verify { editor.putString(KEY_WRAPPED_KEY, encode(wrapped)) }
+        // An apply() would let a process kill drop the wrap while the keyshare ciphertext
+        // setPasscode writes next survives.
+        verify { editor.commit() }
+        verify(exactly = 0) { editor.apply() }
+    }
+
+    @Test
+    fun `clearing credentials commits both removals before returning`() {
+        store.clearCredentials()
 
         verify { editor.remove(KEY_SALT) }
         verify { editor.remove(KEY_WRAPPED_KEY) }
-        // Staging the removals on a relaxed editor mock proves nothing on its own — without the
-        // apply() the half-credential survives the process and the next read repeats this.
-        verify { editor.apply() }
+        verify { editor.commit() }
+        verify(exactly = 0) { editor.apply() }
     }
 
-    @Test
-    fun `a wrapped key with no salt is discarded`() {
-        storedAs(null, encode(ByteArray(60)))
+    /**
+     * Preferences whose reads of [failingKey] come back empty while [failing] is set, standing in
+     * for a keystore that decrypts one stored value this launch but not the other.
+     */
+    private class FlakyPreferences(
+        private val delegate: SharedPreferences,
+        private val failingKey: String,
+    ) : SharedPreferences by delegate {
+        var failing = false
 
-        assertNull(store.readCredentials())
-
-        verify { editor.remove(KEY_SALT) }
-        verify { editor.remove(KEY_WRAPPED_KEY) }
-        // Staging the removals on a relaxed editor mock proves nothing on its own — without the
-        // apply() the half-credential survives the process and the next read repeats this.
-        verify { editor.apply() }
-    }
-
-    @Test
-    fun `an undecodable half is discarded like a missing one`() {
-        storedAs(encode(ByteArray(16)), "not-base64!!")
-
-        assertNull(store.readCredentials())
-
-        verify { editor.remove(KEY_SALT) }
-        verify { editor.remove(KEY_WRAPPED_KEY) }
-        // Staging the removals on a relaxed editor mock proves nothing on its own — without the
-        // apply() the half-credential survives the process and the next read repeats this.
-        verify { editor.apply() }
+        override fun getString(key: String, defValue: String?): String? =
+            if (failing && key == failingKey) defValue else delegate.getString(key, defValue)
     }
 
     private companion object {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
@@ -39,6 +39,12 @@ internal class SharedPreferencesPasscodeStoreTest {
 
     private fun encode(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
 
+    private fun credentials(fill: Int = 0) =
+        PasscodeCredentials(
+            salt = ByteArray(16) { (it + fill).toByte() },
+            wrappedDataKey = ByteArray(60) { (it * 3 + fill).toByte() },
+        )
+
     private fun assertReadLeavesTheStoreAlone(salt: String?, wrapped: String?) {
         storedAs(salt, wrapped)
 
@@ -87,11 +93,7 @@ internal class SharedPreferencesPasscodeStoreTest {
         // clears.
         val flakyPrefs = FlakyPreferences(InMemorySharedPreferences(), KEY_WRAPPED_KEY)
         val flakyStore = SharedPreferencesPasscodeStore(flakyPrefs)
-        val credentials =
-            PasscodeCredentials(
-                salt = ByteArray(16) { it.toByte() },
-                wrappedDataKey = ByteArray(60) { (it * 3).toByte() },
-            )
+        val credentials = credentials()
         flakyStore.writeCredentials(credentials)
 
         flakyPrefs.failing = true
@@ -127,21 +129,51 @@ internal class SharedPreferencesPasscodeStoreTest {
     }
 
     @Test
-    fun `a write the disk refused is reported, not passed off as stored`() {
-        every { editor.commit() } returns false
+    fun `a write the disk refused is reported and changes nothing`() {
+        val stored = InMemorySharedPreferences()
+        val original = credentials()
+        SharedPreferencesPasscodeStore(stored).writeCredentials(original)
+        val refusing = SharedPreferencesPasscodeStore(RefusingPreferences(stored))
 
-        assertFailsWith<IllegalStateException> {
-            store.writeCredentials(
-                PasscodeCredentials(salt = ByteArray(16), wrappedDataKey = ByteArray(60))
-            )
-        }
+        assertFailsWith<IllegalStateException> { refusing.writeCredentials(credentials(fill = 9)) }
+
+        assertEquals(original, SharedPreferencesPasscodeStore(stored).readCredentials())
     }
 
     @Test
-    fun `a clear the disk refused is reported, not passed off as removed`() {
-        every { editor.commit() } returns false
+    fun `a clear the disk refused is reported and changes nothing`() {
+        val stored = InMemorySharedPreferences()
+        val original = credentials()
+        SharedPreferencesPasscodeStore(stored).writeCredentials(original)
+        val refusing = SharedPreferencesPasscodeStore(RefusingPreferences(stored))
 
-        assertFailsWith<IllegalStateException> { store.clearCredentials() }
+        assertFailsWith<IllegalStateException> { refusing.clearCredentials() }
+
+        assertEquals(original, SharedPreferencesPasscodeStore(stored).readCredentials())
+    }
+
+    /**
+     * Preferences that apply an edit to memory and then report the disk write as refused, the way
+     * `SharedPreferencesImpl.commit` does when the file cannot be written.
+     */
+    private class RefusingPreferences(private val delegate: SharedPreferences) :
+        SharedPreferences by delegate {
+        override fun edit(): SharedPreferences.Editor = RefusingEditor(delegate.edit())
+    }
+
+    /** The mutators return `this`, so a chained call cannot escape back to [editor]. */
+    private class RefusingEditor(private val editor: SharedPreferences.Editor) :
+        SharedPreferences.Editor by editor {
+        override fun putString(key: String, value: String?) = also { editor.putString(key, value) }
+
+        override fun remove(key: String) = also { editor.remove(key) }
+
+        override fun apply() = editor.apply()
+
+        override fun commit(): Boolean {
+            editor.commit()
+            return false
+        }
     }
 
     /** Preferences whose reads of [failingKey] come back empty while [failing] is set. */

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/SharedPreferencesPasscodeStoreTest.kt
@@ -8,6 +8,7 @@ import io.mockk.verify
 import java.util.Base64
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -27,6 +28,7 @@ internal class SharedPreferencesPasscodeStoreTest {
         every { prefs.edit() } returns editor
         every { editor.remove(any()) } returns editor
         every { editor.putString(any(), any()) } returns editor
+        every { editor.commit() } returns true
         store = SharedPreferencesPasscodeStore(prefs)
     }
 
@@ -124,6 +126,24 @@ internal class SharedPreferencesPasscodeStoreTest {
         verify { editor.remove(KEY_WRAPPED_KEY) }
         verify { editor.commit() }
         verify(exactly = 0) { editor.apply() }
+    }
+
+    @Test
+    fun `a write the disk refused is reported, not passed off as stored`() {
+        every { editor.commit() } returns false
+
+        assertFailsWith<IllegalStateException> {
+            store.writeCredentials(
+                PasscodeCredentials(salt = ByteArray(16), wrappedDataKey = ByteArray(60))
+            )
+        }
+    }
+
+    @Test
+    fun `a clear the disk refused is reported, not passed off as removed`() {
+        every { editor.commit() } returns false
+
+        assertFailsWith<IllegalStateException> { store.clearCredentials() }
     }
 
     /**


### PR DESCRIPTION
Closes #5549
Closes #5550

Both changes are in `SharedPreferencesPasscodeStore`, so they ship together rather than conflicting on rebase.

**A failed read no longer deletes the credentials (#5549).** `readCredentials()` called `clearCredentials()` whenever exactly one of the two stored halves came back null. `EncryptingSharedPreferences.getString` swallows a decryption failure into null, so a transient AndroidKeyStore fault on one of the two values destroyed the only record of the data key that opens every at-rest-encrypted keyshare — the next launch resolved to `KeyUnavailable` and told the user to reinstall. The repair also guarded a state nothing produces: `writeCredentials` writes both keys in one editor and `clearCredentials` removes both, so no path leaves a stray half behind. A read now reports unreadable credentials by returning nothing.

**Credential writes are durable, and a refused write changes nothing (#5550).** `setPasscode` persists the wrap and then encrypts every keyshare in one Room transaction, so a queued `apply()` dropped by a process kill left durable ciphertext with no key. Both credential mutations now commit synchronously through the editor rather than androidx's `edit(commit = true)`, which discards the `Boolean`.

Reporting the refusal was not enough on its own. `SharedPreferencesImpl.commit` runs `commitToMemory()` before it writes the file and leaves the map updated when that write fails, while `writeToFile` deletes the partly-written file and leaves the backup for the next load to restore. The in-memory copy was therefore the only thing that had diverged, and it made the recovery paths lie: a failed change accepted only the new passcode until the next launch, and a failed disable rejected the correct one outright. Both mutations now put the two keys back before throwing.

`setPasscode` already turned that failure into `Failed` before encrypting anything; `changePasscode` and `disablePasscode` now do the same instead of letting it escape into a `viewModelScope.launch`. `disablePasscode` decrypts the shares before dropping the credentials, so its failure path reseals them under the same key, inside `NonCancellable` so a cancellation cannot leave them in the clear.

`writeLockout` keeps `edit(commit = true)`: nothing downstream depends on that write having landed, so a lost attempt counter costs one uncharged attempt rather than the keyshares.

iOS lands on the same two rules: `KeychainReadResult` keeps "absent" apart from "unreadable" so a read failure never deletes, and `storeWrappedDataKey` persists the wrapper synchronously — and verifies it by read-back — before any share is sealed.

## Testing

```
./gradlew :data:testDebugUnitTest    # 2734 pass, 0 failures
./gradlew :data:ktfmtCheck :data:lintDebug
```

The three tests that pinned the old wiping behaviour now assert the store is left untouched, and new tests cover a half-readable store that recovers on the next read, a refused write and a refused clear over a store that applies edits to memory and then reports the disk write as refused, and the three repository paths that report them. Checked against the pre-change store: the read tests and both refusal tests fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved incomplete or malformed credential data instead of deleting it during reads.
  * Improved reliability when credential data is temporarily unavailable, allowing successful retries.
  * Ensured credential saves and clears are completed immediately and reliably.
  * Improved passcode setup, change, and disable behavior when credential persistence fails.
  * Prevented failed operations from leaving passcode data in an inconsistent state and provided clearer failure results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->