### PR TITLE
fix(passcode): draw the app lock in a window of its own

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/app/activity/components/PopDialogDestinationsWhileLockedTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/app/activity/components/PopDialogDestinationsWhileLockedTest.kt
@@ -1,0 +1,122 @@
+package com.vultisig.wallet.app.activity.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
+import androidx.navigation.compose.rememberNavController
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The passcode lock draws in a window of its own, which only covers the windows that were already
+ * open when it was added. A `dialog<>` destination gets a window too, so one left open when the app
+ * locks has to go — and, because the routing collectors keep running behind a closed gate, so does
+ * one routed afterwards.
+ */
+class PopDialogDestinationsWhileLockedTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    private lateinit var navController: NavHostController
+    private var isLocked by mutableStateOf(false)
+
+    @Test
+    fun aDialogDestinationRoutedWhileAlreadyLockedIsPoppedAgain() {
+        start(locked = true)
+
+        navigateTo(Sheet)
+
+        assertSettlesOn(Home)
+    }
+
+    @Test
+    fun theDialogDestinationsOpenWhenTheLockArrivesAreAllPopped() {
+        start(locked = false)
+        navigateTo(Sheet)
+        navigateTo(OtherSheet)
+        assertSettlesOn(OtherSheet)
+
+        setLockState(true)
+
+        assertSettlesOn(Home)
+    }
+
+    @Test
+    fun aDialogDestinationIsLeftAloneWhileTheAppIsUnlocked() {
+        start(locked = false)
+
+        navigateTo(Sheet)
+
+        assertSettlesOn(Sheet)
+    }
+
+    /** Unlocking hands the back stack back, or every dialog would be one-shot from then on. */
+    @Test
+    fun aDialogDestinationRoutedAfterUnlockingSurvives() {
+        start(locked = true)
+
+        setLockState(false)
+        navigateTo(Sheet)
+
+        assertSettlesOn(Sheet)
+    }
+
+    private fun start(locked: Boolean) {
+        isLocked = locked
+        compose.setContent {
+            navController = rememberNavController()
+            PopDialogDestinationsWhileLocked(navController, isLocked)
+            NavHost(navController = navController, startDestination = Home) {
+                composable(Home) { Filler() }
+                dialog(Sheet) { Filler() }
+                dialog(OtherSheet) { Filler() }
+            }
+        }
+        assertSettlesOn(Home)
+    }
+
+    /**
+     * Waits for the change to reach composition, so the effect has started or stopped before the
+     * next step.
+     */
+    private fun setLockState(locked: Boolean) {
+        isLocked = locked
+        compose.waitForIdle()
+    }
+
+    private fun navigateTo(route: String) {
+        compose.runOnUiThread { navController.navigate(route) }
+    }
+
+    private fun assertSettlesOn(route: String) {
+        compose.waitForIdle()
+        compose.waitUntil(SettleTimeoutMillis) { currentRoute() == route }
+
+        assertEquals(route, currentRoute())
+    }
+
+    private fun currentRoute(): String? = navController.currentBackStackEntry?.destination?.route
+
+    @Composable
+    private fun Filler() {
+        Box(Modifier.fillMaxSize())
+    }
+
+    private companion object {
+        const val Home = "home"
+        const val Sheet = "sheet"
+        const val OtherSheet = "otherSheet"
+
+        const val SettleTimeoutMillis = 5_000L
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -93,6 +93,12 @@ internal fun MainActivityContent(
         snackbarFlow.collectMessage { (message, type) ->
             val resolved = message.asString(context)
             if (resolved.isBlank()) return@collectMessage
+            // Held rather than shown: the bar is a window of its own, so one raised while the gate
+            // is closed would be added after the lock's and drawn over it. Held rather than
+            // dropped, too — the bar's progress runs off its own scope whether or not anything is
+            // composed, so a message shown behind the lock would tick out unseen. The channel
+            // behind collectMessage buffers, so waiting here keeps it until there is a reader.
+            passcodeGuardModel.state.first { !it.isGateClosed }
             snackbarState.show(resolved, type)
         }
     }
@@ -142,14 +148,10 @@ internal fun MainActivityContent(
         overlayContent = {
             PasscodeGuard(model = passcodeGuardModel)
 
-            // The snackbar is a window of its own too, so one raised while the gate is up is added
-            // after the lock's and drawn over it.
-            if (!isGateClosed) {
-                VsSnackBar(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    snackbarState = snackbarState,
-                )
-            }
+            VsSnackBar(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                snackbarState = snackbarState,
+            )
         },
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
@@ -80,7 +81,11 @@ internal fun MainActivityContent(
     // tree at the same moment. Swallowing pointer input is only half a lock: everything behind the
     // gate stays composed, and TalkBack would happily walk it, read it out and activate it.
     val passcodeGuardModel: PasscodeGuardViewModel = hiltViewModel()
-    val isGateClosed = passcodeGuardModel.state.collectAsStateWithLifecycle().value.isGateClosed
+    val guardState by passcodeGuardModel.state.collectAsStateWithLifecycle()
+    val isGateClosed = guardState.isGateClosed
+    val isLocked = guardState.isLocked
+
+    PopDialogDestinationsWhileLocked(navController, isLocked)
 
     val context = LocalContext.current
     val snackbarState = mainViewModel.snackbarState
@@ -135,22 +140,16 @@ internal fun MainActivityContent(
             }
         },
         overlayContent = {
-            PasscodeGuard(
-                model = passcodeGuardModel,
-                // Dialog destinations render in their own window, above this overlay. Popping them
-                // as the gate closes is what stops a bottom sheet — a receive address, a QR — from
-                // sitting on top of the lock screen and still accepting taps.
-                onLocked = {
-                    while (navController.currentBackStackEntry.isDialog()) {
-                        if (!navController.popBackStack()) break
-                    }
-                },
-            )
+            PasscodeGuard(model = passcodeGuardModel)
 
-            VsSnackBar(
-                modifier = Modifier.align(Alignment.BottomCenter),
-                snackbarState = snackbarState,
-            )
+            // The snackbar is a window of its own too, so one raised while the gate is up is added
+            // after the lock's and drawn over it.
+            if (!isGateClosed) {
+                VsSnackBar(
+                    modifier = Modifier.align(Alignment.BottomCenter),
+                    snackbarState = snackbarState,
+                )
+            }
         },
     )
 }
@@ -306,6 +305,26 @@ private fun MainActivityContentPreview() {
             )
         },
     )
+}
+
+/**
+ * Keeps `dialog<>` destinations off the back stack for as long as [isLocked].
+ *
+ * They draw in a window of their own, and the passcode lock's window only covers the windows that
+ * were open before it, so one routed after the app locks opens on top of the lock — still visible,
+ * still taking input. Driven by the state rather than by the moment it changes, because routing
+ * carries on behind a closed gate.
+ */
+@Composable
+internal fun PopDialogDestinationsWhileLocked(navController: NavController, isLocked: Boolean) {
+    LaunchedEffect(navController, isLocked) {
+        if (!isLocked) return@LaunchedEffect
+        navController.currentBackStackEntryFlow.collect {
+            while (navController.currentBackStackEntry.isDialog()) {
+                if (!navController.popBackStack()) break
+            }
+        }
+    }
 }
 
 /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
@@ -27,6 +27,21 @@ internal data class PasscodeGuardUiModel(
     val isIdentityProven: Boolean = false,
 ) {
     /**
+     * True while a lock the user has to answer is up. Narrower than [isGateClosed], which also
+     * covers the not-yet-read moment every launch passes through, passcode or not.
+     */
+    val isLocked: Boolean
+        get() =
+            when (passcodeState) {
+                PasscodeState.Locked,
+                PasscodeState.KeyUnavailable,
+                PasscodeState.StoreUnavailable -> true
+                PasscodeState.Unknown,
+                PasscodeState.Unlocked,
+                PasscodeState.Disabled -> false
+            }
+
+    /**
      * True while the gate covers the app, including before the persisted state has been read.
      *
      * What is behind the cover is still composed and still in the semantics tree, so this decides
@@ -34,15 +49,7 @@ internal data class PasscodeGuardUiModel(
      * too, or the lock is only a lock to someone looking at the screen.
      */
     val isGateClosed: Boolean
-        get() =
-            when (passcodeState) {
-                PasscodeState.Unknown,
-                PasscodeState.Locked,
-                PasscodeState.KeyUnavailable,
-                PasscodeState.StoreUnavailable -> true
-                PasscodeState.Unlocked,
-                PasscodeState.Disabled -> false
-            }
+        get() = isLocked || passcodeState == PasscodeState.Unknown
 }
 
 /** Exposes the lock state that decides whether the app content or the lock screen is shown. */

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
@@ -47,38 +47,50 @@ internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
     // which is what puts it first in line.
     BackHandler(enabled = state.isGateClosed) {}
 
-    // The whole gate while the persisted state is still loading, and the cover over the app for
-    // the frame between the state that raises the lock and the lock's own window being added.
     if (state.isGateClosed) {
+        // Covers the app for the frame between the state that closes the gate and the window below
+        // being added, which is the only moment the window cannot cover for itself.
         Box(
             Modifier.fillMaxSize()
                 .background(Theme.v2.colors.backgrounds.primary)
                 .swallowPointerInput()
         )
+
+        // One call site for the whole closed gate rather than one per state: a second would be a
+        // second composition slot, and moving between them would take the window down and put a new
+        // one up at exactly the moment the lock appears.
+        LockWindow { GateContent(state.passcodeState) }
     }
 
-    when (state.passcodeState) {
-        PasscodeState.Locked -> LockWindow { PasscodeLockScreen() }
+    // The passcode was just turned off, so the user has already identified themselves this session;
+    // sending them straight into a device-credential prompt would be a non sequitur.
+    if (state.passcodeState == PasscodeState.Disabled && !state.isIdentityProven) {
+        BiometryAuthScreen()
+    }
+}
+
+/** What the gate shows, once there is something to show. */
+@Composable
+private fun GateContent(passcodeState: PasscodeState) {
+    when (passcodeState) {
+        PasscodeState.Locked -> PasscodeLockScreen()
         PasscodeState.KeyUnavailable ->
-            LockWindow {
-                DeadEndScreen(
-                    title = stringResource(R.string.passcode_key_unavailable_title),
-                    message = stringResource(R.string.passcode_key_unavailable_message),
-                )
-            }
+            DeadEndScreen(
+                title = stringResource(R.string.passcode_key_unavailable_title),
+                message = stringResource(R.string.passcode_key_unavailable_message),
+            )
         PasscodeState.StoreUnavailable ->
-            LockWindow {
-                DeadEndScreen(
-                    title = stringResource(R.string.passcode_store_unavailable_title),
-                    message = stringResource(R.string.passcode_store_unavailable_message),
-                )
-            }
-        // Persisted state is still loading; the cover above is the gate until it resolves.
+            DeadEndScreen(
+                title = stringResource(R.string.passcode_store_unavailable_title),
+                message = stringResource(R.string.passcode_store_unavailable_message),
+            )
+        // Persisted state is still loading. The window is up regardless, because a dialog
+        // destination restored with the back stack opens its own window while this read is still
+        // running, and only another window can cover that one.
         PasscodeState.Unknown -> Unit
-        PasscodeState.Unlocked -> Unit
-        // The passcode was just turned off, so the user has already identified themselves this
-        // session; sending them straight into a device-credential prompt would be a non sequitur.
-        PasscodeState.Disabled -> if (!state.isIdentityProven) BiometryAuthScreen()
+        // The gate is open in both, so this is not composed.
+        PasscodeState.Unlocked,
+        PasscodeState.Disabled -> Unit
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
@@ -5,13 +5,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,6 +19,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vultisig.wallet.R
@@ -35,24 +36,10 @@ import com.vultisig.wallet.ui.theme.Theme
  * on top of it — two consecutive unlocks to open the app would be a worse experience than either
  * alone, and the passcode is the stronger gate because it also holds the key to the encrypted
  * keyshares.
- *
- * @param onLocked invoked when the gate closes, so the host can clear anything drawing in its own
- *   window. This composable is drawn inside the activity's window, and a `dialog<>` destination is
- *   not: without this, locking with a bottom sheet open leaves that sheet on top of the lock
- *   screen, visible and still taking input.
  */
 @Composable
-internal fun PasscodeGuard(
-    onLocked: () -> Unit = {},
-    model: PasscodeGuardViewModel = hiltViewModel(),
-) {
+internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
     val state by model.state.collectAsStateWithLifecycle()
-
-    val isLocked =
-        state.passcodeState == PasscodeState.Locked ||
-            state.passcodeState == PasscodeState.KeyUnavailable ||
-            state.passcodeState == PasscodeState.StoreUnavailable
-    LaunchedEffect(isLocked) { if (isLocked) onLocked() }
 
     // Swallowed rather than passed on. The navigation content behind the gate is still composed
     // and still has its own back handling, so back would walk that graph unseen and leave the user
@@ -60,37 +47,72 @@ internal fun PasscodeGuard(
     // which is what puts it first in line.
     BackHandler(enabled = state.isGateClosed) {}
 
+    // The whole gate while the persisted state is still loading, and the cover over the app for
+    // the frame between the state that raises the lock and the lock's own window being added.
+    if (state.isGateClosed) {
+        Box(
+            Modifier.fillMaxSize()
+                .background(Theme.v2.colors.backgrounds.primary)
+                .swallowPointerInput()
+        )
+    }
+
     when (state.passcodeState) {
-        // Persisted state is still loading. An opaque cover, not nothing: the alternative is a
-        // frame or two of unlocked content before the lock screen appears.
-        PasscodeState.Unknown ->
-            Box(
-                Modifier.fillMaxSize()
-                    .background(Theme.v2.colors.backgrounds.primary)
-                    .swallowPointerInput()
-            )
-        PasscodeState.Locked ->
-            Box(Modifier.fillMaxSize()) {
-                // Drawn under the lock screen, so the prompt keeps its own taps while anything
-                // aimed past it is swallowed here rather than reaching the navigation content
-                // this gate is composed over.
-                Spacer(Modifier.fillMaxSize().swallowPointerInput())
-                PasscodeLockScreen()
-            }
+        PasscodeState.Locked -> LockWindow { PasscodeLockScreen() }
         PasscodeState.KeyUnavailable ->
-            DeadEndScreen(
-                title = stringResource(R.string.passcode_key_unavailable_title),
-                message = stringResource(R.string.passcode_key_unavailable_message),
-            )
+            LockWindow {
+                DeadEndScreen(
+                    title = stringResource(R.string.passcode_key_unavailable_title),
+                    message = stringResource(R.string.passcode_key_unavailable_message),
+                )
+            }
         PasscodeState.StoreUnavailable ->
-            DeadEndScreen(
-                title = stringResource(R.string.passcode_store_unavailable_title),
-                message = stringResource(R.string.passcode_store_unavailable_message),
-            )
+            LockWindow {
+                DeadEndScreen(
+                    title = stringResource(R.string.passcode_store_unavailable_title),
+                    message = stringResource(R.string.passcode_store_unavailable_message),
+                )
+            }
+        // Persisted state is still loading; the cover above is the gate until it resolves.
+        PasscodeState.Unknown -> Unit
         PasscodeState.Unlocked -> Unit
         // The passcode was just turned off, so the user has already identified themselves this
         // session; sending them straight into a device-credential prompt would be a non sequitur.
         PasscodeState.Disabled -> if (!state.isIdentityProven) BiometryAuthScreen()
+    }
+}
+
+/**
+ * Hosts [content] in a window of its own.
+ *
+ * A `ModalBottomSheet` and a `dialog<>` destination each get a window too, and one activity's
+ * windows stack in the order they were added — so nothing drawn in the activity's own window can be
+ * above them, however opaque. Adding the lock's window when the app locks is what puts it over a
+ * sheet that was already open.
+ */
+@Composable
+private fun LockWindow(content: @Composable () -> Unit) {
+    Dialog(
+        onDismissRequest = {},
+        properties =
+            DialogProperties(
+                // Back and outside taps belong to this window once it is up; declining both leaves
+                // no way past it but the state that stops composing it.
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = false,
+                // Lays the window out over the system bars, so the background below reaches them
+                // and the content is inset back off them, as the activity does with its own.
+                decorFitsSystemWindows = false,
+            ),
+    ) {
+        Box(
+            Modifier.fillMaxSize()
+                .background(Theme.v2.colors.backgrounds.primary)
+                .safeDrawingPadding()
+        ) {
+            content()
+        }
     }
 }
 
@@ -105,10 +127,7 @@ internal fun PasscodeGuard(
 private fun DeadEndScreen(title: String, message: String) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier =
-            Modifier.fillMaxSize()
-                .background(Theme.v2.colors.backgrounds.primary)
-                .swallowPointerInput(),
+        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModelTest.kt
@@ -90,6 +90,38 @@ internal class PasscodeGuardViewModelTest {
     }
 
     @Test
+    fun `the lock only goes up over a gate that is already closed`() = runTest {
+        // Two windows: the lock draws in one of its own, the cover the gate draws is in the
+        // activity's. A state that locked without closing the gate would leave the app live behind
+        // the lock — walkable by TalkBack, and tappable for the frame before the lock's window is
+        // added.
+        val model = PasscodeGuardViewModel(passcodeRepository)
+        advanceUntilIdle()
+
+        val locking =
+            listOf(
+                PasscodeState.Locked,
+                PasscodeState.KeyUnavailable,
+                PasscodeState.StoreUnavailable,
+            )
+        val notLocking =
+            listOf(PasscodeState.Unknown, PasscodeState.Unlocked, PasscodeState.Disabled)
+
+        locking.forEach { locked ->
+            state.value = locked
+            advanceUntilIdle()
+            assertTrue(model.state.value.isLocked, "$locked must read as locked")
+            assertTrue(model.state.value.isGateClosed, "$locked must lock behind a closed gate")
+        }
+
+        notLocking.forEach { open ->
+            state.value = open
+            advanceUntilIdle()
+            assertFalse(model.state.value.isLocked, "$open must not read as locked")
+        }
+    }
+
+    @Test
     fun `an unlock this session is remembered once the passcode is turned off`() = runTest {
         // Disabling flips straight to Disabled, which composes the device-credential gate for the
         // first time this process. The user has just proved who they are; asking again is a non


### PR DESCRIPTION
## Problem

The lock was drawn inside the activity's window. A `ModalBottomSheet` and a `dialog<>` destination each get a window of their own, and one activity's windows stack in the order they are added — so nothing drawn in the activity's window can be above them. Lock the app with a transaction sheet open and the sheet stayed on top, readable and still taking taps. The `dialog<>` pop that mitigated this fired once, on the edge the gate closed, so a destination routed while already locked was never cleared.

## Fix

- `PasscodeGuard` hosts the lock in a full-screen `Dialog`, opened when the app locks, which puts it over anything already open. The in-window cover stays for the frame before that window is added and for the state that is still loading.
- The `dialog<>` pop follows the locked state instead of the edge, so a destination routed behind a closed gate is popped too.
- `VsSnackBar` is a `Dialog` as well and the global `SnackbarFlow` has async producers, so it is no longer composed while the gate is closed.
- `isGateClosed` is derived from a new `isLocked` rather than repeating the truth table, so the cover and the lock cannot disagree.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/extqEem.png) | ![after](https://i.imgur.com/XjEWd1N.png) |

Same emulator and mock state: the vault screen with a transaction sheet open, then locked. Before, the sheet draws over a dimmed lock screen and holds focus; after, the lock covers it and owns the keyboard.

## Testing

- `:app:assembleDebug`, `:app:lintDebug`, `:app:ktfmtCheck`, `:data:ktfmtCheck`
- `:app:testDebugUnitTest` — full suite, 1941 tests
- `:app:connectedDebugAndroidTest` — new `PopDialogDestinationsWhileLockedTest`, 4/4
- On device, both repro paths from the issue on API 35 and API 26: the lock covers an open sheet, the keypad opens and takes digits inside the dialog window, and back is swallowed.

Closes #5551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app locking behavior by preventing interaction with underlying content while the lock screen is displayed.
  * Automatically closes open dialogs when the app becomes locked.
  * Ensures dialogs opened after unlocking remain available.
  * Delays snackbar messages until the app is ready for interaction.

* **Tests**
  * Added coverage for dialog handling across locked, unlocked, and transitioning app states.
  * Added validation for passcode lock and gate status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->