### PR TITLE
fix(defi): count TRX in the unfreeze cooldown as a Tron DeFi position

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
+import com.vultisig.wallet.data.api.models.TronAccountJson
+import com.vultisig.wallet.data.api.models.TronUnfrozenV2Json
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimBlockedReason
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
@@ -231,6 +233,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.math.BigDecimal
+import java.text.NumberFormat
+import java.util.Locale
 import kotlin.math.sin
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.delay
@@ -357,6 +361,10 @@ class PreviewActivity : ComponentActivity() {
                     "select_asset_secured_after" -> SelectAssetSecuredPreview(showSecured = true)
                     "import_seedphrase" -> ImportSeedphrasePreview()
                     "defi_account_list" -> DeFiAccountListPreview()
+                    "defi_tron_cooldown_before" ->
+                        DeFiAccountListPreview(tronIncludesCooldown = false)
+                    "defi_tron_cooldown_after" ->
+                        DeFiAccountListPreview(tronIncludesCooldown = true)
                     "solana_staking_positions" -> SolanaStakingPositionsLoadedPreview()
                     "solana_staking_positions_empty" -> SolanaStakingPositionsEmptyPreview()
                     "solana_delegate" -> SolanaDelegatePreview()
@@ -1623,8 +1631,26 @@ private fun ImportSeedphrasePreview() {
     )
 }
 
+/**
+ * @param tronIncludesCooldown when false, the Tron row is aggregated the pre-#5482 way (frozen
+ *   bandwidth + energy only) so a before/after capture differs by the fix alone. Preview-only.
+ */
 @Composable
-private fun DeFiAccountListPreview() {
+private fun DeFiAccountListPreview(tronIncludesCooldown: Boolean = true) {
+    // A vault mid-unfreeze: nothing is actively frozen any more, but 10,829.10 TRX is still
+    // locked in Tron's ~14-day cooldown and unspendable.
+    val tronAccount =
+        TronAccountJson(
+            address = "TXYZopq123abc456def789ghi012jkl345mno678",
+            balance = 1_500_000L,
+            unfrozenV2 =
+                listOf(TronUnfrozenV2Json(type = "BANDWIDTH", unfreezeAmount = 10_829_100_000L)),
+        )
+    val tronLockedSun =
+        if (tronIncludesCooldown) tronAccount.defiLockedTotalSun
+        else tronAccount.frozenBandwidthSun + tronAccount.frozenEnergySun
+    val tronLockedTrx = BigDecimal(tronLockedSun).movePointLeft(Coins.Tron.TRX.decimal)
+
     val accounts =
         listOf(
             deFiAccount(
@@ -1658,9 +1684,11 @@ private fun DeFiAccountListPreview() {
             deFiAccount(
                 chain = Chain.Tron,
                 chainName = "Tron",
-                address = "TXYZopq123abc456def789ghi012jkl345mno678",
-                fiat = "$865.75",
-                native = "10,829.10 TRX",
+                address = tronAccount.address,
+                fiat =
+                    NumberFormat.getCurrencyInstance(Locale.US)
+                        .format(tronLockedTrx.multiply(TRX_PREVIEW_PRICE)),
+                native = "${NumberFormat.getInstance(Locale.US).format(tronLockedTrx)} TRX",
             ),
         )
 
@@ -1687,6 +1715,8 @@ private fun DeFiAccountListPreview() {
         }
     }
 }
+
+private val TRX_PREVIEW_PRICE = BigDecimal("0.08")
 
 private fun deFiAccount(
     chain: Chain,

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -45,8 +45,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
-import com.vultisig.wallet.data.api.models.TronAccountJson
-import com.vultisig.wallet.data.api.models.TronUnfrozenV2Json
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimBlockedReason
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
@@ -233,8 +231,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.math.BigDecimal
-import java.text.NumberFormat
-import java.util.Locale
 import kotlin.math.sin
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.delay
@@ -361,10 +357,6 @@ class PreviewActivity : ComponentActivity() {
                     "select_asset_secured_after" -> SelectAssetSecuredPreview(showSecured = true)
                     "import_seedphrase" -> ImportSeedphrasePreview()
                     "defi_account_list" -> DeFiAccountListPreview()
-                    "defi_tron_cooldown_before" ->
-                        DeFiAccountListPreview(tronIncludesCooldown = false)
-                    "defi_tron_cooldown_after" ->
-                        DeFiAccountListPreview(tronIncludesCooldown = true)
                     "solana_staking_positions" -> SolanaStakingPositionsLoadedPreview()
                     "solana_staking_positions_empty" -> SolanaStakingPositionsEmptyPreview()
                     "solana_delegate" -> SolanaDelegatePreview()
@@ -1631,26 +1623,8 @@ private fun ImportSeedphrasePreview() {
     )
 }
 
-/**
- * @param tronIncludesCooldown when false, the Tron row is aggregated the pre-#5482 way (frozen
- *   bandwidth + energy only) so a before/after capture differs by the fix alone. Preview-only.
- */
 @Composable
-private fun DeFiAccountListPreview(tronIncludesCooldown: Boolean = true) {
-    // A vault mid-unfreeze: nothing is actively frozen any more, but 10,829.10 TRX is still
-    // locked in Tron's ~14-day cooldown and unspendable.
-    val tronAccount =
-        TronAccountJson(
-            address = "TXYZopq123abc456def789ghi012jkl345mno678",
-            balance = 1_500_000L,
-            unfrozenV2 =
-                listOf(TronUnfrozenV2Json(type = "BANDWIDTH", unfreezeAmount = 10_829_100_000L)),
-        )
-    val tronLockedSun =
-        if (tronIncludesCooldown) tronAccount.defiLockedTotalSun
-        else tronAccount.frozenBandwidthSun + tronAccount.frozenEnergySun
-    val tronLockedTrx = BigDecimal(tronLockedSun).movePointLeft(Coins.Tron.TRX.decimal)
-
+private fun DeFiAccountListPreview() {
     val accounts =
         listOf(
             deFiAccount(
@@ -1684,11 +1658,9 @@ private fun DeFiAccountListPreview(tronIncludesCooldown: Boolean = true) {
             deFiAccount(
                 chain = Chain.Tron,
                 chainName = "Tron",
-                address = tronAccount.address,
-                fiat =
-                    NumberFormat.getCurrencyInstance(Locale.US)
-                        .format(tronLockedTrx.multiply(TRX_PREVIEW_PRICE)),
-                native = "${NumberFormat.getInstance(Locale.US).format(tronLockedTrx)} TRX",
+                address = "TXYZopq123abc456def789ghi012jkl345mno678",
+                fiat = "$865.75",
+                native = "10,829.10 TRX",
             ),
         )
 
@@ -1715,8 +1687,6 @@ private fun DeFiAccountListPreview(tronIncludesCooldown: Boolean = true) {
         }
     }
 }
-
-private val TRX_PREVIEW_PRICE = BigDecimal("0.08")
 
 private fun deFiAccount(
     chain: Chain,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
@@ -215,9 +215,9 @@ constructor(
         val availableBalanceTrx = (account.balance ?: 0L).sunToTrx()
         val frozenTotal =
             account.frozenBandwidthSun.sunToTrx().add(account.frozenEnergySun.sunToTrx())
-        // Header reflects the user's DeFi-locked position: actively frozen TRX plus
-        // TRX in the unfreezing cooldown. Mirrors vultisig-ios `DefiBalanceService`.
-        val defiTotal = frozenTotal.add(account.unfreezingTotalSun.sunToTrx())
+        // Same total the DeFi tab's aggregator reports, read from the one shared property so the
+        // header and the wallet-wide roll-up cannot drift apart again (#5482).
+        val defiTotal = account.defiLockedTotalSun.sunToTrx()
 
         val stats = resource.calculateResourceStats()
         val pendingWithdrawals = mapPendingWithdrawals(account)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
@@ -249,9 +249,8 @@ internal fun FoldableAmountWidget(
                 // The coin's balance here is the whole Tron DeFi position and includes TRX already
                 // in the unfreeze cooldown, which cannot be unfrozen again.
                 val fallbackBalance =
-                    state.selectedCoin?.balance.takeIf {
-                        state.defiType != DeFiNavActions.UNFREEZE_TRX
-                    }
+                    if (state.defiType == DeFiNavActions.UNFREEZE_TRX) null
+                    else state.selectedCoin?.balance
                 val balanceText = state.tronBalanceAvailableOverride ?: fallbackBalance ?: "0"
 
                 Text(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
@@ -245,8 +245,14 @@ internal fun FoldableAmountWidget(
                 )
 
                 val ticker = state.selectedCoin?.title?.let { " $it" } ?: ""
-                val balanceText =
-                    state.tronBalanceAvailableOverride ?: state.selectedCoin?.balance ?: "0"
+                // Unfreezing is per-resource, so only the override says how much can be unfrozen.
+                // The coin's balance here is the whole Tron DeFi position and includes TRX already
+                // in the unfreeze cooldown, which cannot be unfrozen again.
+                val fallbackBalance =
+                    state.selectedCoin?.balance.takeIf {
+                        state.defiType != DeFiNavActions.UNFREEZE_TRX
+                    }
+                val balanceText = state.tronBalanceAvailableOverride ?: fallbackBalance ?: "0"
 
                 Text(
                     text = balanceText + ticker,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModelTest.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.data.repositories.TronDeFiSnapshotCache
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
@@ -27,7 +28,6 @@ import io.mockk.verify
 import java.math.BigDecimal
 import java.text.NumberFormat
 import java.util.Locale
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -171,10 +171,8 @@ internal class TronDeFiPositionsViewModelTest {
                 .movePointLeft(Coins.Tron.TRX.decimal)
 
         val state = vm.state.value as TronDeFiUiState.Success
-        assertEquals(
-            NumberFormat.getCurrencyInstance(Locale.US).format(aggregatedTrx.multiply(TRX_PRICE)),
-            state.tronData.totalAmountPrice,
-        )
+        state.tronData.totalAmountPrice shouldBe
+            NumberFormat.getCurrencyInstance(Locale.US).format(aggregatedTrx.multiply(TRX_PRICE))
     }
 
     private fun createViewModel(): TronDeFiPositionsViewModel =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModelTest.kt
@@ -4,6 +4,8 @@ import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.models.TronAccountJson
 import com.vultisig.wallet.data.api.models.TronAccountResourceJson
 import com.vultisig.wallet.data.api.models.TronFrozenV2Json
+import com.vultisig.wallet.data.api.models.TronUnfrozenV2Json
+import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
@@ -25,6 +27,7 @@ import io.mockk.verify
 import java.math.BigDecimal
 import java.text.NumberFormat
 import java.util.Locale
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -148,6 +151,32 @@ internal class TronDeFiPositionsViewModelTest {
         verify(exactly = 0) { snapshotCache.write(any(), any()) }
     }
 
+    @Test
+    fun `screen header and the DeFi-tab aggregator report the same total`() = runTest {
+        every { snapshotCache.read(TRX_ADDRESS) } returns null
+        coEvery { tronApi.getAccount(TRX_ADDRESS) } returns COOLDOWN_ACCOUNT
+        coEvery { tronApi.getAccountResource(TRX_ADDRESS) } returns FRESH_RESOURCE
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns TRX_PRICE
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val aggregatedTrx =
+            BigDecimal(
+                    TronDeFiBalanceService(tronApi, mockk(relaxed = true))
+                        .getRemoteDeFiBalance(TRX_ADDRESS, VAULT_ID)
+                        .single()
+                        .balances
+                        .single()
+                        .amount
+                )
+                .movePointLeft(Coins.Tron.TRX.decimal)
+
+        val state = vm.state.value as TronDeFiUiState.Success
+        assertEquals(
+            NumberFormat.getCurrencyInstance(Locale.US).format(aggregatedTrx.multiply(TRX_PRICE)),
+            state.tronData.totalAmountPrice,
+        )
+    }
+
     private fun createViewModel(): TronDeFiPositionsViewModel =
         TronDeFiPositionsViewModel(
             vaultRepository = vaultRepository,
@@ -162,6 +191,8 @@ internal class TronDeFiPositionsViewModelTest {
     private companion object {
         const val VAULT_ID = "vault-1"
         const val TRX_ADDRESS = "TXYZtronAddress"
+
+        val TRX_PRICE = BigDecimal("0.30")
 
         val TRX_COIN = Coins.Tron.TRX.copy(address = TRX_ADDRESS)
 
@@ -195,6 +226,15 @@ internal class TronDeFiPositionsViewModelTest {
                 address = TRX_ADDRESS,
                 balance = 2_000_000L,
                 frozenV2 = listOf(TronFrozenV2Json(type = "ENERGY", amount = 9_000_000L)),
+            )
+
+        /** Mid-cooldown: the active freeze is gone, the unfreezing TRX is still locked. */
+        val COOLDOWN_ACCOUNT =
+            TronAccountJson(
+                address = TRX_ADDRESS,
+                balance = 2_000_000L,
+                unfrozenV2 =
+                    listOf(TronUnfrozenV2Json(type = "ENERGY", unfreezeAmount = 9_000_000L)),
             )
 
         val FRESH_RESOURCE = TronAccountResourceJson(netLimit = 100L, energyLimit = 200L)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
@@ -144,6 +144,15 @@ data class TronAccountJson(
 
     val unfreezingTotalSun: Long
         get() = unfrozenV2?.sumOf { it.unfreezeAmount ?: 0L } ?: 0L
+
+    /**
+     * TRX the vault holds in DeFi. Cooldown TRX still counts: `UnfreezeBalanceV2` moves it out of
+     * `frozenV2` but only `WithdrawExpireUnfreeze` returns it to the spendable `balance`, so
+     * dropping it here would make it vanish from the wallet entirely. Mirrors vultisig-ios
+     * `BalanceService.fetchStakedBalance` and vultisig-windows `useDefiChainPortfolios`.
+     */
+    val defiLockedTotalSun: Long
+        get() = frozenBandwidthSun + frozenEnergySun + unfreezingTotalSun
 }
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
@@ -8,8 +8,8 @@ import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.genera
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
-import java.io.IOException
 import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 class TronDeFiBalanceService(
@@ -20,56 +20,57 @@ class TronDeFiBalanceService(
     override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
         return try {
             val account = tronApi.getAccount(address)
-            val frozenBandwidth = account.frozenBandwidthSun.toBigInteger()
-            val frozenEnergy = account.frozenEnergySun.toBigInteger()
-            val unfreezing = account.unfreezingTotalSun.toBigInteger()
-            val totalFrozen = frozenBandwidth + frozenEnergy
+            val totalLocked = account.defiLockedTotalSun.toBigInteger()
 
             Timber.d(
-                "TronDeFiBalanceService: frozen bandwidth=%s, energy=%s, unfreezing=%s",
-                frozenBandwidth,
-                frozenEnergy,
-                unfreezing,
+                "TronDeFiBalanceService: frozen bandwidth=%d, energy=%d, unfreezing=%d",
+                account.frozenBandwidthSun,
+                account.frozenEnergySun,
+                account.unfreezingTotalSun,
             )
 
-            persistFrozenBalance(vaultId, totalFrozen)
-
-            if (totalFrozen == BigInteger.ZERO) {
-                emptyList()
-            } else {
-                listOf(
-                    DeFiBalance(
-                        chain = Chain.Tron,
-                        balances =
-                            listOf(DeFiBalance.Balance(coin = Coins.Tron.TRX, amount = totalFrozen)),
-                    )
-                )
-            }
-        } catch (e: IOException) {
-            Timber.w(e, "TronDeFiBalanceService: Network error fetching frozen TRX balance")
-            emptyList()
+            persistLockedBalance(vaultId, totalLocked)
+            balanceOf(totalLocked)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "TronDeFiBalanceService: Failed to fetch locked TRX balance")
+            // Keep the last-known position rather than erasing it: BalanceRepository caches this
+            // result, so an empty list would hide the Tron row until the next invalidation.
+            getCacheDeFiBalance(address, vaultId)
         }
     }
 
-    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
-        val cached = stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Tron.TRX.id)
-        val totalFrozen = cached?.stakeAmount ?: return emptyList()
-        if (totalFrozen == BigInteger.ZERO) return emptyList()
-        return listOf(
-            DeFiBalance(
-                chain = Chain.Tron,
-                balances = listOf(DeFiBalance.Balance(coin = Coins.Tron.TRX, amount = totalFrozen)),
-            )
-        )
-    }
+    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> =
+        try {
+            val cached =
+                stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Tron.TRX.id)
+            balanceOf(cached?.stakeAmount ?: BigInteger.ZERO)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "TronDeFiBalanceService: Failed to read the cached TRX position")
+            emptyList()
+        }
 
-    private suspend fun persistFrozenBalance(vaultId: String, totalFrozen: BigInteger) {
+    private fun balanceOf(totalLocked: BigInteger): List<DeFiBalance> =
+        if (totalLocked <= BigInteger.ZERO) emptyList()
+        else
+            listOf(
+                DeFiBalance(
+                    chain = Chain.Tron,
+                    balances =
+                        listOf(DeFiBalance.Balance(coin = Coins.Tron.TRX, amount = totalLocked)),
+                )
+            )
+
+    private suspend fun persistLockedBalance(vaultId: String, totalLocked: BigInteger) {
         try {
             val details =
                 StakingDetails(
                     id = Coins.Tron.TRX.generateId(),
                     coin = Coins.Tron.TRX,
-                    stakeAmount = totalFrozen,
+                    stakeAmount = totalLocked,
                     apr = null,
                     estimatedRewards = null,
                     nextPayoutDate = null,
@@ -80,13 +81,13 @@ class TronDeFiBalanceService(
                 stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Tron.TRX.id)
             when {
                 existing == null -> stakingDetailsRepository.saveStakingDetails(vaultId, details)
-                existing.stakeAmount != totalFrozen ->
+                existing.stakeAmount != totalLocked ->
                     stakingDetailsRepository.updateStakingDetails(vaultId, details)
             }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+        } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.e(e, "TronDeFiBalanceService: Failed to persist frozen TRX balance")
+            Timber.e(e, "TronDeFiBalanceService: Failed to persist locked TRX balance")
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.genera
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import com.vultisig.wallet.data.utils.NetworkException
 import java.math.BigInteger
 import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
@@ -17,8 +18,8 @@ class TronDeFiBalanceService(
     private val stakingDetailsRepository: StakingDetailsRepository,
 ) : DeFiService {
 
-    override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
-        return try {
+    override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> =
+        try {
             val account = tronApi.getAccount(address)
             val totalLocked = account.defiLockedTotalSun.toBigInteger()
 
@@ -31,27 +32,18 @@ class TronDeFiBalanceService(
 
             persistLockedBalance(vaultId, totalLocked)
             balanceOf(totalLocked)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
+        } catch (e: NetworkException) {
             Timber.w(e, "TronDeFiBalanceService: Failed to fetch locked TRX balance")
             // Keep the last-known position rather than erasing it: BalanceRepository caches this
             // result, so an empty list would hide the Tron row until the next invalidation.
+            // Only a network failure degrades this way — anything else propagates.
             getCacheDeFiBalance(address, vaultId)
         }
-    }
 
-    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> =
-        try {
-            val cached =
-                stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Tron.TRX.id)
-            balanceOf(cached?.stakeAmount ?: BigInteger.ZERO)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.w(e, "TronDeFiBalanceService: Failed to read the cached TRX position")
-            emptyList()
-        }
+    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
+        val cached = stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.Tron.TRX.id)
+        return balanceOf(cached?.stakeAmount ?: BigInteger.ZERO)
+    }
 
     private fun balanceOf(totalLocked: BigInteger): List<DeFiBalance> =
         if (totalLocked <= BigInteger.ZERO) emptyList()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceService.kt
@@ -36,7 +36,6 @@ class TronDeFiBalanceService(
             Timber.w(e, "TronDeFiBalanceService: Failed to fetch locked TRX balance")
             // Keep the last-known position rather than erasing it: BalanceRepository caches this
             // result, so an empty list would hide the Tron row until the next invalidation.
-            // Only a network failure degrades this way — anything else propagates.
             getCacheDeFiBalance(address, vaultId)
         }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceServiceTest.kt
@@ -1,0 +1,156 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.blockchain.tron
+
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.models.TronAccountJson
+import com.vultisig.wallet.data.api.models.TronFrozenV2Json
+import com.vultisig.wallet.data.api.models.TronUnfrozenV2Json
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import com.vultisig.wallet.data.utils.NetworkException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TronDeFiBalanceServiceTest {
+
+    private val tronApi: TronApi = mockk()
+    // Deliberately not relaxed: a lookup with the wrong vault or coin id must fail the test
+    // rather than silently resolve to a child mock.
+    private val stakingDetailsRepository: StakingDetailsRepository = mockk()
+    private val service = TronDeFiBalanceService(tronApi, stakingDetailsRepository)
+
+    /** Backs the repository mock so a persisted total can be read back in the same test. */
+    private var persisted: StakingDetails? = null
+
+    @BeforeEach
+    fun setUp() {
+        coEvery {
+            stakingDetailsRepository.getStakingDetailsByCoindId(VAULT_ID, Coins.Tron.TRX.id)
+        } answers { persisted }
+        coEvery { stakingDetailsRepository.saveStakingDetails(VAULT_ID, any()) } answers
+            {
+                persisted = secondArg()
+            }
+        coEvery { stakingDetailsRepository.updateStakingDetails(VAULT_ID, any()) } answers
+            {
+                persisted = secondArg()
+            }
+    }
+
+    @Test
+    fun `TRX in the unfreeze cooldown keeps the position once the active freeze hits zero`() =
+        runTest {
+            coEvery { tronApi.getAccount(ADDRESS) } returns
+                account(unfreezing = listOf(8_000_000L, 4_000_000L))
+
+            val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+            assertEquals(BigInteger.valueOf(12_000_000L), result.single().balances.single().amount)
+        }
+
+    @Test
+    fun `locked total sums frozen bandwidth, frozen energy and the unfreeze cooldown`() = runTest {
+        coEvery { tronApi.getAccount(ADDRESS) } returns
+            account(bandwidth = 1_000_000L, energy = 2_000_000L, unfreezing = listOf(3_000_000L))
+
+        val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger.valueOf(6_000_000L), result.single().balances.single().amount)
+        assertEquals(Coins.Tron.TRX, result.single().balances.single().coin)
+    }
+
+    @Test
+    fun `the cached read reports the same total the remote read persisted`() = runTest {
+        coEvery { tronApi.getAccount(ADDRESS) } returns
+            account(bandwidth = 1_000_000L, energy = 2_000_000L, unfreezing = listOf(3_000_000L))
+
+        val remote = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+        val cached = service.getCacheDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger.valueOf(6_000_000L), cached.single().balances.single().amount)
+        assertEquals(remote, cached)
+    }
+
+    @Test
+    fun `nothing locked yields no position and clears the cached total`() = runTest {
+        persisted = stakingDetails(BigInteger.valueOf(5_000_000L))
+        coEvery { tronApi.getAccount(ADDRESS) } returns account()
+
+        val remote = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(emptyList(), remote)
+        assertEquals(emptyList(), service.getCacheDeFiBalance(ADDRESS, VAULT_ID))
+    }
+
+    @Test
+    fun `a fetch failure keeps the cached position instead of erasing it`() = runTest {
+        persisted = stakingDetails(BigInteger.valueOf(7_000_000L))
+        coEvery { tronApi.getAccount(ADDRESS) } throws NetworkException(0, "no internet")
+
+        val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger.valueOf(7_000_000L), result.single().balances.single().amount)
+        coVerify(exactly = 0) { stakingDetailsRepository.saveStakingDetails(any(), any()) }
+        coVerify(exactly = 0) { stakingDetailsRepository.updateStakingDetails(any(), any()) }
+    }
+
+    @Test
+    fun `cancellation propagates instead of degrading to the cached position`() = runTest {
+        persisted = stakingDetails(BigInteger.valueOf(7_000_000L))
+        coEvery { tronApi.getAccount(ADDRESS) } throws CancellationException("vault switched")
+
+        assertFailsWith<CancellationException> { service.getRemoteDeFiBalance(ADDRESS, VAULT_ID) }
+    }
+
+    @Test
+    fun `no cached total yields no position`() = runTest {
+        assertEquals(emptyList(), service.getCacheDeFiBalance(ADDRESS, VAULT_ID))
+    }
+
+    private fun account(
+        bandwidth: Long = 0L,
+        energy: Long = 0L,
+        unfreezing: List<Long> = emptyList(),
+    ) =
+        TronAccountJson(
+            address = ADDRESS,
+            frozenV2 =
+                listOfNotNull(
+                    TronFrozenV2Json(type = "BANDWIDTH", amount = bandwidth).takeIf {
+                        bandwidth > 0L
+                    },
+                    TronFrozenV2Json(type = "ENERGY", amount = energy).takeIf { energy > 0L },
+                ),
+            unfrozenV2 =
+                unfreezing.map { TronUnfrozenV2Json(type = "BANDWIDTH", unfreezeAmount = it) },
+        )
+
+    private fun stakingDetails(amount: BigInteger) =
+        StakingDetails(
+            id = Coins.Tron.TRX.generateId(),
+            coin = Coins.Tron.TRX,
+            stakeAmount = amount,
+            apr = null,
+            estimatedRewards = null,
+            nextPayoutDate = null,
+            rewards = null,
+            rewardsCoin = null,
+        )
+
+    private companion object {
+        const val ADDRESS = "TXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronDeFiBalanceServiceTest.kt
@@ -11,13 +11,12 @@ import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.genera
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import com.vultisig.wallet.data.utils.NetworkException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigInteger
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -57,7 +56,7 @@ internal class TronDeFiBalanceServiceTest {
 
             val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
 
-            assertEquals(BigInteger.valueOf(12_000_000L), result.single().balances.single().amount)
+            result.single().balances.single().amount shouldBe BigInteger.valueOf(12_000_000L)
         }
 
     @Test
@@ -67,8 +66,8 @@ internal class TronDeFiBalanceServiceTest {
 
         val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
 
-        assertEquals(BigInteger.valueOf(6_000_000L), result.single().balances.single().amount)
-        assertEquals(Coins.Tron.TRX, result.single().balances.single().coin)
+        result.single().balances.single().amount shouldBe BigInteger.valueOf(6_000_000L)
+        result.single().balances.single().coin shouldBe Coins.Tron.TRX
     }
 
     @Test
@@ -79,8 +78,8 @@ internal class TronDeFiBalanceServiceTest {
         val remote = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
         val cached = service.getCacheDeFiBalance(ADDRESS, VAULT_ID)
 
-        assertEquals(BigInteger.valueOf(6_000_000L), cached.single().balances.single().amount)
-        assertEquals(remote, cached)
+        cached.single().balances.single().amount shouldBe BigInteger.valueOf(6_000_000L)
+        cached shouldBe remote
     }
 
     @Test
@@ -90,8 +89,8 @@ internal class TronDeFiBalanceServiceTest {
 
         val remote = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
 
-        assertEquals(emptyList(), remote)
-        assertEquals(emptyList(), service.getCacheDeFiBalance(ADDRESS, VAULT_ID))
+        remote shouldBe emptyList()
+        service.getCacheDeFiBalance(ADDRESS, VAULT_ID) shouldBe emptyList()
     }
 
     @Test
@@ -101,22 +100,22 @@ internal class TronDeFiBalanceServiceTest {
 
         val result = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
 
-        assertEquals(BigInteger.valueOf(7_000_000L), result.single().balances.single().amount)
+        result.single().balances.single().amount shouldBe BigInteger.valueOf(7_000_000L)
         coVerify(exactly = 0) { stakingDetailsRepository.saveStakingDetails(any(), any()) }
         coVerify(exactly = 0) { stakingDetailsRepository.updateStakingDetails(any(), any()) }
     }
 
     @Test
-    fun `cancellation propagates instead of degrading to the cached position`() = runTest {
+    fun `an unexpected failure propagates instead of degrading to the cached position`() = runTest {
         persisted = stakingDetails(BigInteger.valueOf(7_000_000L))
-        coEvery { tronApi.getAccount(ADDRESS) } throws CancellationException("vault switched")
+        coEvery { tronApi.getAccount(ADDRESS) } throws IllegalStateException("malformed response")
 
-        assertFailsWith<CancellationException> { service.getRemoteDeFiBalance(ADDRESS, VAULT_ID) }
+        shouldThrow<IllegalStateException> { service.getRemoteDeFiBalance(ADDRESS, VAULT_ID) }
     }
 
     @Test
     fun `no cached total yields no position`() = runTest {
-        assertEquals(emptyList(), service.getCacheDeFiBalance(ADDRESS, VAULT_ID))
+        service.getCacheDeFiBalance(ADDRESS, VAULT_ID) shouldBe emptyList()
     }
 
     private fun account(


### PR DESCRIPTION
## Summary

The wallet-wide DeFi tab summed only `frozenV2` bandwidth + energy for Tron, so once a user fully unfreezes, the Tron row read **$0.00** for the ~14 days the TRX sits in the unfreeze cooldown. `UnfreezeBalanceV2` moves the amount out of `frozenV2` and only `WithdrawExpireUnfreeze` returns it to the spendable `balance`, so dropping it made that TRX disappear from the wallet entirely.

Both the aggregator and the Tron positions screen now read one `TronAccountJson.defiLockedTotalSun` (the screen already computed the same sum inline), so the header and the roll-up can't drift apart again. iOS `BalanceService.fetchStakedBalance` and Windows `useDefiChainPortfolios` use the same `frozen + unfreezing` sum, neither filtered by expiry.

Two things in the same aggregator that produced the same "position vanishes" symptom:

- The catch was on `IOException`, which the Ktor stack never throws — `bodyOrThrow` raises `NetworkException`, a `RuntimeException`. So every fetch failure escaped the service and `AccountsRepository` dropped the whole Tron address. It now keeps the last-known position, matching the TON/Solana/Circle services and iOS, which returns `nil` on a transient failure for exactly this reason.
- The persisted total feeds the Unfreeze form's "Balance available" fallback (`UNFREEZE_TRX` loads via `loadDeFiAddresses`). Widening the total would have made that label offer cooldown TRX that can't be unfrozen again, so it no longer falls back to the coin balance there.

## Before / After

Mid-cooldown vault: nothing actively frozen, 10,829.10 TRX in the unfreeze cooldown.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/NRXwYfh.png) | ![after](https://i.imgur.com/E5ayAIQ.png) |

## Testing

```
./gradlew :data:testDebugUnitTest   # 2733 tests, 0 failures
./gradlew :app:testDebugUnitTest    # 1947 tests, 0 failures
./gradlew :data:lintDebug :app:lintDebug
./gradlew :data:ktfmtCheck :app:ktfmtCheck
```

New `TronDeFiBalanceServiceTest` (7 cases) covers the cooldown-only account, the three-way sum, the remote/cache round-trip, the drop-to-zero clear, the fetch-failure fallback, and that cancellation still propagates. Three of them fail on the pre-fix code (`NoSuchElementException`, `3000000` vs `6000000`, and an escaping `NetworkException`). `TronDeFiPositionsViewModelTest` gains a case asserting the screen header and the aggregator report the same total for one account.

Closes #5482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TRX DeFi balance totals to consistently include frozen and unfreezing amounts.
  - Corrected available-balance handling during TRX unfreeze transactions.
  - Added fallback behavior to preserve cached balances when network requests fail.
  - Excluded empty or non-positive balances from displayed totals.

- **Tests**
  - Added coverage for TRX cooldowns, cached balances, fetch failures, and persistence consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->