### PR TITLE
refactor(design-system): put the remaining corner radii on the scale (phase 3)

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -1271,7 +1271,7 @@ private fun SolanaDisplayPreview() {
                 .fillMaxSize()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -1321,10 +1321,7 @@ private fun SolanaInstructionMock(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .background(
-                    shape = RoundedCornerShape(8.dp),
-                    color = Theme.v2.colors.backgrounds.dark,
-                )
+                .background(shape = Theme.v2.radius.sm, color = Theme.v2.colors.backgrounds.dark)
                 .padding(6.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -1674,7 +1671,7 @@ private fun DeFiAccountListPreview() {
             modifier =
                 Modifier.background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
         ) {
             AccountList(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/Modifiers.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/Modifiers.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.ui.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.dp
@@ -12,10 +11,7 @@ import com.vultisig.wallet.ui.theme.Theme
 internal fun Modifier.vsStyledBackground() = composed {
     border(
             border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
-            shape = RoundedCornerShape(12.dp),
+            shape = Theme.v2.radius.md,
         )
-        .background(
-            color = Theme.v2.colors.backgrounds.secondary,
-            shape = RoundedCornerShape(12.dp),
-        )
+        .background(color = Theme.v2.colors.backgrounds.secondary, shape = Theme.v2.radius.md)
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignRippleDisplayView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -132,10 +131,7 @@ private val rowModifier: Modifier
     @Composable
     get() =
         Modifier.fillMaxWidth()
-            .background(
-                color = Theme.v2.colors.variables.bordersLight,
-                shape = RoundedCornerShape(12.dp),
-            )
+            .background(color = Theme.v2.colors.variables.bordersLight, shape = Theme.v2.radius.md)
             .padding(horizontal = 12.dp)
 
 private const val PREVIEW_RIPPLE_JSON =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignSolanaDisplayView.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -118,7 +117,7 @@ private fun InstructionsSummarySection(
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -189,7 +188,7 @@ private fun RawTransactionsSection(rawTransactions: List<String>) {
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 12.dp),
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignSuiDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignSuiDisplayView.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -136,7 +135,7 @@ private fun DecodedPtbSections(sender: String, transaction: ParsedSuiTransaction
                 Modifier.fillMaxWidth()
                     .background(
                         color = Theme.v2.colors.variables.bordersLight,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(horizontal = 12.dp),
         )
@@ -161,7 +160,7 @@ private fun GasSummarySection(sender: String, transaction: ParsedSuiTransaction)
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -214,7 +213,7 @@ private fun RawBytesFallback(sender: String, unsignedTxMsg: String) {
                 Modifier.fillMaxWidth()
                     .background(
                         color = Theme.v2.colors.variables.bordersLight,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(horizontal = 12.dp),
         )
@@ -226,7 +225,7 @@ private fun RawBytesFallback(sender: String, unsignedTxMsg: String) {
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 12.dp),
     )
@@ -239,7 +238,7 @@ private fun CommandsSummarySection(commands: List<SuiCommand>) {
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -308,7 +307,7 @@ private fun InputsSummarySection(inputs: List<SuiPtbInput>) {
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.variables.bordersLight,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -83,7 +82,7 @@ internal fun SignTonDisplayView(
                         .heightIn(max = 400.dp)
                         .background(
                             color = Theme.v2.colors.variables.bordersLight,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(8.dp)
                         .verticalScroll(rememberScrollState()),
@@ -102,10 +101,7 @@ private fun TonMessageRow(message: TonMessageUiModel, index: Int) {
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .background(
-                    shape = RoundedCornerShape(8.dp),
-                    color = Theme.v2.colors.backgrounds.dark,
-                )
+                .background(shape = Theme.v2.radius.sm, color = Theme.v2.colors.backgrounds.dark)
                 .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VaultCeil.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -197,7 +196,7 @@ internal fun VaultCeil(
                             color = Theme.v2.colors.text.tertiary,
                             modifier =
                                 Modifier.border(
-                                        shape = RoundedCornerShape(size = 8.dp),
+                                        shape = Theme.v2.radius.sm,
                                         color = Theme.v2.colors.border.light,
                                         width = 1.dp,
                                     )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VsCenterHighlightCarousel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VsCenterHighlightCarousel.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -213,7 +212,7 @@ fun VsCenterHighlightCarousel(
                         Modifier.align(Alignment.Center)
                             .width(itemWidth)
                             .height(50.dp)
-                            .clip(RoundedCornerShape(30.dp))
+                            .clip(Theme.v2.radius.pill)
                             .border(
                                 width = 2.dp,
                                 brush =
@@ -223,7 +222,7 @@ fun VsCenterHighlightCarousel(
                                             Theme.v2.colors.buttons.tertiary,
                                         )
                                     ),
-                                shape = RoundedCornerShape(30.dp),
+                                shape = Theme.v2.radius.pill,
                             )
                 )
             }
@@ -237,7 +236,7 @@ private fun CarouselChainItem(chain: Chain, logo: ImageModel, modifier: Modifier
         modifier =
             modifier
                 .height(50.dp)
-                .clip(RoundedCornerShape(30.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(Theme.v2.colors.backgrounds.secondary)
                 .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/banners/ForegroundNotificationBanner.kt
@@ -198,7 +198,7 @@ internal fun ForegroundNotificationBanner(
                     modifier =
                         Modifier.background(
                                 color = Theme.v2.colors.backgrounds.disabled,
-                                shape = RoundedCornerShape(99.dp),
+                                shape = Theme.v2.radius.pill,
                             )
                             .padding(horizontal = 12.dp, vertical = 6.dp),
                 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsButton.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -137,15 +136,8 @@ fun VsButton(
         contentAlignment = Alignment.Center,
         modifier =
             modifier
-                .background(
-                    color = backgroundColor,
-                    shape = shape ?: RoundedCornerShape(percent = 100),
-                )
-                .border(
-                    width = 1.dp,
-                    color = borderColor,
-                    shape = shape ?: RoundedCornerShape(percent = 100),
-                )
+                .background(color = backgroundColor, shape = shape ?: Theme.v2.radius.pill)
+                .border(width = 1.dp, color = borderColor, shape = shape ?: Theme.v2.radius.pill)
                 .clickable(enabled = state != Disabled && !isLoading, onClick = onClick)
                 .then(
                     when (size) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsHoldableButton.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -85,9 +84,9 @@ fun VsHoldableButton(
                     onClick = onClick,
                     onLongClick = onLongClick,
                 )
-                .background(backgroundColor, RoundedCornerShape(percent = 100))
+                .background(backgroundColor, Theme.v2.radius.pill)
     ) {
-        Box(modifier = Modifier.matchParentSize().clip(RoundedCornerShape(percent = 100))) {
+        Box(modifier = Modifier.matchParentSize().clip(Theme.v2.radius.pill)) {
             Box(
                 modifier =
                     Modifier.fillMaxHeight().fillMaxWidth(progress.value).background(fillColor)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsIconButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/buttons/VsIconButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,7 +64,7 @@ fun VsIconButton(
                                     Secondary -> Theme.v2.colors.buttons.disabled
                                 }
                         },
-                    shape = RoundedCornerShape(percent = 100),
+                    shape = Theme.v2.radius.pill,
                 )
                 .clickable(enabled = state == Enabled, onClick = clickOnce(onClick = onClick))
                 .then(

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/ChartRangePicker.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,7 +36,7 @@ internal fun ChartRangePicker(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(percent = 50))
+                .clip(Theme.v2.radius.pill)
                 .background(Theme.v2.colors.backgrounds.tertiary)
                 .padding(all = 4.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
@@ -75,7 +74,7 @@ private fun ChartRangeTab(
     Box(
         modifier =
             modifier
-                .clip(RoundedCornerShape(percent = 50))
+                .clip(Theme.v2.radius.pill)
                 .background(backgroundColor)
                 .selectable(
                     selected = isSelected,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/chart/PriceChartView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -272,7 +271,7 @@ private fun PriceChartCanvas(
                         modifier =
                             Modifier.fillMaxWidth()
                                 .height(CHART_HEIGHT)
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(Theme.v2.radius.md)
                                 .background(Theme.v2.colors.backgrounds.primary.copy(alpha = 0.4f))
                     )
                 }
@@ -283,7 +282,7 @@ private fun PriceChartCanvas(
                     modifier =
                         Modifier.fillMaxWidth()
                             .height(CHART_HEIGHT)
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(Theme.v2.radius.md)
                             .background(placeholderColor)
                 )
             }
@@ -296,7 +295,7 @@ private fun PriceChartCanvas(
                     modifier =
                         Modifier.fillMaxWidth()
                             .height(CHART_HEIGHT)
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(Theme.v2.radius.md)
                             .background(placeholderColor)
                             .clickable(onClick = onRetry),
                     contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/PasscodeInputField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/PasscodeInputField.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
@@ -43,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.passcode.PASSCODE_LENGTH
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.V2
 
 /** Whether the field is showing a plain entry or flagging a rejected passcode. */
 internal enum class PasscodeInputFieldState {
@@ -162,7 +162,7 @@ internal fun PasscodeInputField(
 }
 
 private val PASSCODE_CELL_HEIGHT = 51.dp
-private val PasscodeCellShape = RoundedCornerShape(12.dp)
+private val PasscodeCellShape = V2.radius.md
 
 /** Figma uses a flat 10% white hairline on the idle cells rather than a theme border token. */
 private val PasscodeCellBorder = Color.White.copy(alpha = 0.1f)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsSearchTextField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsSearchTextField.kt
@@ -25,6 +25,11 @@ internal fun VsSearchTextField(fieldState: TextFieldState) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier =
             Modifier.padding(all = 16.dp)
+                // Off the scale on purpose: the app has no single answer for an input's corner.
+                // This is 10, VsTextInputField and the passcode cells are 12, the code-entry
+                // boxes 24, and every v2 search surface is fully round — while the design file's
+                // input measures 16. Snapping this one to a token would pick a winner for the
+                // whole input family by accident, so it waits for that decision.
                 .background(
                     color = Theme.v2.colors.fills.primary,
                     shape = RoundedCornerShape(10.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsTextInputField.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/inputs/VsTextInputField.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicSecureTextField
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -119,7 +118,7 @@ internal fun VsTextInputField(
             }
         }
 
-        val textFieldBackgroundShape = RoundedCornerShape(12.dp)
+        val textFieldBackgroundShape = Theme.v2.radius.md
 
         Row(
             modifier =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/referral/AddReferralHeaderButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/referral/AddReferralHeaderButton.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,7 +27,7 @@ internal fun AddReferralHeaderButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val shape = RoundedCornerShape(12.dp)
+    val shape = Theme.v2.radius.md
     Row(
         modifier =
             modifier

--- a/app/src/main/java/com/vultisig/wallet/ui/components/referral/VsPromoBox.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/referral/VsPromoBox.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,12 +33,12 @@ fun VsPromoBox(
                 .fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(all = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -65,31 +65,17 @@ fun VsPromoBox(
 
 @Composable
 fun VsPromoTag(@DrawableRes icon: Int, text: String, modifier: Modifier = Modifier) {
+    // The tag runs off the start edge of the box, so only its end corners are drawn — and they are
+    // fully round. Both the fill and the border read the one shape: two spellings of it here is the
+    // drift this scale exists to stop.
+    val shape =
+        Theme.v2.radius.pill.shape.copy(topStart = CornerSize(0.dp), bottomStart = CornerSize(0.dp))
     Row(
         modifier =
             modifier
                 .padding(start = 16.dp)
-                .background(
-                    color = Theme.v2.colors.backgrounds.secondary,
-                    shape =
-                        RoundedCornerShape(
-                            topEnd = 50.dp,
-                            bottomEnd = 50.dp,
-                            topStart = 0.dp,
-                            bottomStart = 0.dp,
-                        ),
-                )
-                .border(
-                    width = 1.dp,
-                    color = Theme.v2.colors.border.light,
-                    shape =
-                        RoundedCornerShape(
-                            topEnd = 50.dp,
-                            bottomEnd = 50.dp,
-                            topStart = 0.dp,
-                            bottomStart = 0.dp,
-                        ),
-                )
+                .background(color = Theme.v2.colors.backgrounds.secondary, shape = shape)
+                .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = shape)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/DottySurface.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/DottySurface.kt
@@ -1,7 +1,6 @@
 package com.vultisig.wallet.ui.components.v2.bottomsheets
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.CacheDrawScope
@@ -11,7 +10,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.theme.v2.V2.colors
 
@@ -20,16 +18,14 @@ import com.vultisig.wallet.ui.theme.v2.V2.colors
 internal fun Modifier.dottySurface(): Modifier {
     val surfaceColor = Theme.v2.colors.backgrounds.primary
     val fadeColor = colors.backgrounds.secondary
-    return clip(shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
-        .background(surfaceColor)
-        .drawWithCache {
-            val dots = rememberDotsPath(stepSize = 72f, dotRadius = 2.5f, dotColor = DotColor)
-            val fadeBrush = Brush.verticalGradient(colors = listOf(Color.Transparent, fadeColor))
-            onDrawBehind {
-                drawPath(dots.path, color = dots.color)
-                drawRect(brush = fadeBrush)
-            }
+    return clip(shape = V2SheetShape).background(surfaceColor).drawWithCache {
+        val dots = rememberDotsPath(stepSize = 72f, dotRadius = 2.5f, dotColor = DotColor)
+        val fadeBrush = Brush.verticalGradient(colors = listOf(Color.Transparent, fadeColor))
+        onDrawBehind {
+            drawPath(dots.path, color = dots.color)
+            drawRect(brush = fadeBrush)
         }
+    }
 }
 
 private val DotColor = Color(0xff172854)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/V2BottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/bottomsheets/V2BottomSheet.kt
@@ -33,6 +33,17 @@ import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.theme.Theme
 
+/**
+ * The top corners of the app's bottom sheets.
+ *
+ * Deliberately off the radius scale, and the one shape the scale does not name: `Radii` stops at 24
+ * because the sheet frames in the design file are stock design-kit components (Apple's 38, Material
+ * 3's 28) rather than authored Vultisig surfaces, so there is no sheet step to reference. It is
+ * hoisted here rather than restated per sheet because it was already spelled out three times in
+ * this package alone — that is the drift the scale exists to stop, token or no token.
+ */
+internal val V2SheetShape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun V2BottomSheet(
@@ -57,7 +68,7 @@ fun V2BottomSheet(
                 Column(
                     modifier =
                         Modifier.fillMaxWidth()
-                            .clip(shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
+                            .clip(shape = V2SheetShape)
                             .background(Theme.v2.colors.backgrounds.primary)
                             .padding(all = 16.dp)
                 ) {
@@ -95,10 +106,7 @@ fun V2BottomSheet(
         containerColor = Color.Transparent,
         shape = RectangleShape,
         content = {
-            Box(
-                modifier =
-                    Modifier.clip(shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
-            ) {
+            Box(modifier = Modifier.clip(shape = V2SheetShape)) {
                 Box(
                     modifier =
                         Modifier.fillMaxWidth().background(Theme.v2.colors.backgrounds.primary),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ResourceStateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ResourceStateScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -92,8 +91,8 @@ fun ResourceTwoCardsRow(
             modifier
                 .fillMaxWidth()
                 .height(96.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .border(1.dp, colors.variables.bordersLight, RoundedCornerShape(12.dp)),
+                .clip(Theme.v2.radius.md)
+                .border(1.dp, colors.variables.bordersLight, Theme.v2.radius.md),
         color = colors.variables.backgroundsSurface1,
     ) {
         var display by remember { mutableStateOf(false) }
@@ -179,7 +178,7 @@ fun ResourceCard(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(
                     modifier =
-                        Modifier.size(32.dp).clip(RoundedCornerShape(8.dp)).background(containerBg),
+                        Modifier.size(32.dp).clip(Theme.v2.radius.sm).background(containerBg),
                     contentAlignment = Alignment.Center,
                 ) {
                     Image(
@@ -236,14 +235,14 @@ fun AnimatedProgressBar(value: Float, accent: Color, height: Dp = 8.dp) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(height)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(Theme.v2.radius.sm)
                 .background(colors.backgrounds.light)
     ) {
         Box(
             modifier =
                 Modifier.fillMaxHeight()
                     .fillMaxWidth(animated)
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(Theme.v2.radius.sm)
                     .background(accent)
         )
     }
@@ -291,7 +290,7 @@ fun BandwidthEnergyContent() {
                     Box(
                         modifier =
                             Modifier.size(24.dp)
-                                .clip(RoundedCornerShape(8.dp))
+                                .clip(Theme.v2.radius.sm)
                                 .background(colors.backgrounds.red),
                         contentAlignment = Alignment.Center,
                     ) {
@@ -386,7 +385,7 @@ fun BandwidthEnergyItem(
                         Box(
                             modifier =
                                 Modifier.size(32.dp)
-                                    .clip(RoundedCornerShape(8.dp))
+                                    .clip(Theme.v2.radius.sm)
                                     .background(containerBg),
                             contentAlignment = Alignment.Center,
                         ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/VaultDetailScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -238,15 +237,8 @@ private fun KeyItemPrev() {
 
 @Composable
 internal fun Modifier.itemModifier(): Modifier =
-    border(
-            width = 1.dp,
-            color = Theme.v2.colors.border.light,
-            shape = RoundedCornerShape(size = 12.dp),
-        )
-        .background(
-            shape = RoundedCornerShape(size = 12.dp),
-            color = Theme.v2.colors.backgrounds.disabled,
-        )
+    border(width = 1.dp, color = Theme.v2.colors.border.light, shape = Theme.v2.radius.md)
+        .background(shape = Theme.v2.radius.md, color = Theme.v2.colors.backgrounds.disabled)
         .padding(vertical = 24.dp, horizontal = 20.dp)
 
 @Composable

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/ServerBackupScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
@@ -57,6 +56,7 @@ import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldInnerState
 import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldType
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.theme.v2.V2
 import com.vultisig.wallet.ui.utils.asString
 
 /**
@@ -164,7 +164,7 @@ private fun ServerBackupScreen(
     }
 }
 
-private val SectionShape = RoundedCornerShape(12.dp)
+private val SectionShape = V2.radius.md
 
 private fun Modifier.sectionCard(): Modifier = composed {
     this.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -167,11 +166,11 @@ internal fun StakingAmountCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -216,7 +215,7 @@ internal fun BalanceAvailableRow(ticker: String, available: BigDecimal) {
             Modifier.fillMaxWidth()
                 .background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(all = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -246,11 +245,11 @@ internal fun ValidatorPickerField(selected: CosmosValidator?, onClick: () -> Uni
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
@@ -355,12 +354,12 @@ internal fun ValidatorPickerSheet(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(99.dp))
+                        .clip(Theme.v2.radius.pill)
                         .background(Theme.v2.colors.backgrounds.surface1)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(99.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .padding(horizontal = 12.dp, vertical = 12.dp),
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosRedelegateScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -154,11 +153,11 @@ private fun DstValidatorPickerRow(selected: CosmosValidator?, onClick: () -> Uni
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 14.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosUndelegateScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -145,11 +144,11 @@ private fun UnstakeAmountCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -221,7 +220,7 @@ private fun UnstakePercentSlider(percent: Float, onPercentChanged: (Float) -> Un
                                 .height(24.dp)
                                 .background(
                                     color = Theme.v2.colors.text.primary,
-                                    shape = RoundedCornerShape(100),
+                                    shape = Theme.v2.radius.pill,
                                 )
                     )
                 },
@@ -271,11 +270,11 @@ internal fun ValidatorReadonlyBlock(moniker: String, address: String) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 16.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -313,11 +312,11 @@ internal fun UnbondingLockNotice(message: String) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.alerts.warning,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosWithdrawRewardsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -147,11 +146,11 @@ private fun CapWarning(maxBatchSize: Int) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
+                .clip(Theme.v2.radius.sm)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.alerts.warning,
-                    shape = RoundedCornerShape(8.dp),
+                    shape = Theme.v2.radius.sm,
                 )
                 .padding(10.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -181,11 +180,11 @@ private fun CandidateRow(
         modifier =
             Modifier.fillMaxWidth()
                 .padding(vertical = 4.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .clickable(onClick = onToggle)
                 .padding(horizontal = 12.dp, vertical = 10.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/customrpc/CustomRpcDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/customrpc/CustomRpcDetailScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
@@ -135,13 +134,13 @@ private fun RpcEndpointField(
                 .heightIn(min = 120.dp)
                 .background(
                     color = Theme.v2.colors.backgrounds.surface1,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .border(
                     width = 1.dp,
                     color =
                         if (isError) Theme.v2.colors.alerts.error else Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -170,12 +169,12 @@ private fun DefaultEndpointCard(endpoint: String) {
                 Modifier.fillMaxWidth()
                     .background(
                         color = Theme.v2.colors.backgrounds.surface1,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(16.dp)
         ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/BondFormScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -434,7 +433,7 @@ private fun MayaBondFormContent(
                                         }
                                         .background(
                                             color = Theme.v2.colors.backgrounds.surface1,
-                                            shape = RoundedCornerShape(99.dp),
+                                            shape = Theme.v2.radius.pill,
                                         )
                                         .padding(
                                             start = 6.dp,
@@ -493,7 +492,7 @@ private fun MayaBondFormContent(
                                                     .background(
                                                         color =
                                                             Theme.v2.colors.backgrounds.secondary,
-                                                        shape = RoundedCornerShape(99.dp),
+                                                        shape = Theme.v2.radius.pill,
                                                     )
                                                     .padding(
                                                         start = 6.dp,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/governance/GovernanceScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/governance/GovernanceScreen.kt
@@ -179,7 +179,7 @@ private fun StatusPill(status: ProposalStatus) {
     val color = status.statusColor()
     Row(
         modifier =
-            Modifier.clip(RoundedCornerShape(8.dp))
+            Modifier.clip(Theme.v2.radius.sm)
                 .background(color.copy(alpha = 0.12f))
                 .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -194,6 +194,11 @@ private fun StatusPill(status: ProposalStatus) {
     }
 }
 
+// Both states of this bar are off the scale, and they disagree with each other: the empty bar
+// rounds
+// at 5 and the voted segments at 3, so the corner visibly changes the moment the first vote lands.
+// Left as found — reconciling them is a design call about how a segmented bar should read, not a
+// rename — but recorded here so the next sweep does not have to rediscover it.
 @Composable
 private fun TallyBar(tally: TallyUi, modifier: Modifier = Modifier) {
     if (!tally.hasVotes) {
@@ -369,9 +374,9 @@ private fun VoteOptionRow(
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .background(background)
-                .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+                .border(1.dp, borderColor, Theme.v2.radius.md)
                 .clickable(enabled = enabled, onClick = onClick)
                 .padding(16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultPasswordScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
@@ -261,9 +260,9 @@ private fun WarningCard(modifier: Modifier, onShowMoreInfo: () -> Unit) {
     Row(
         modifier =
             modifier
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .background(lightWarningColor)
-                .border(width = 1.dp, shape = RoundedCornerShape(12.dp), color = lightWarningColor)
+                .border(width = 1.dp, shape = Theme.v2.radius.md, color = lightWarningColor)
                 .padding(16.dp)
                 .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultVerificationScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keygen/FastVaultVerificationScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -164,12 +163,12 @@ internal fun FastVaultVerificationScreen(
                                 .height(46.dp)
                                 .background(
                                     color = Theme.v2.colors.backgrounds.secondary,
-                                    shape = RoundedCornerShape(size = 99.dp),
+                                    shape = Theme.v2.radius.pill,
                                 )
                                 .border(
                                     width = 1.dp,
                                     color = Theme.v2.colors.border.extraLight,
-                                    shape = RoundedCornerShape(size = 99.dp),
+                                    shape = Theme.v2.radius.pill,
                                 )
                                 .padding(horizontal = 12.dp, vertical = 12.dp)
                                 .clickable(
@@ -267,11 +266,11 @@ internal fun FastVaultVerificationScreen(
                                                     width = 1.dp,
                                                     color =
                                                         Theme.v2.colors.variables.bordersExtraLight,
-                                                    shape = RoundedCornerShape(12.dp),
+                                                    shape = Theme.v2.radius.md,
                                                 )
                                                 .background(
                                                     color = Theme.v2.colors.buttons.secondary,
-                                                    shape = RoundedCornerShape(12.dp),
+                                                    shape = Theme.v2.radius.md,
                                                 )
                                                 .padding(horizontal = 12.dp, vertical = 8.dp)
                                                 .clickOnce(
@@ -337,11 +336,11 @@ internal fun FastVaultVerificationScreen(
                                         Modifier.border(
                                                 width = 1.dp,
                                                 color = Theme.v2.colors.variables.bordersExtraLight,
-                                                shape = RoundedCornerShape(12.dp),
+                                                shape = Theme.v2.radius.md,
                                             )
                                             .background(
                                                 color = Theme.v2.colors.buttons.secondary,
-                                                shape = RoundedCornerShape(12.dp),
+                                                shape = Theme.v2.radius.md,
                                             )
                                             .padding(horizontal = 16.dp, vertical = 10.dp)
                                             .testTag("FastVaultVerificationScreen.retryButton")

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -365,7 +365,7 @@ internal fun PeerDiscoveryScreen(
 @Composable
 private fun ResendNotificationButton(remainingSeconds: Int, onClick: () -> Unit) {
     val isEnabled = remainingSeconds == 0
-    val shape = RoundedCornerShape(12.dp)
+    val shape = Theme.v2.radius.md
     val contentColor = if (isEnabled) Theme.v2.colors.alerts.info else Theme.v2.colors.text.tertiary
     val bgColor =
         if (isEnabled) Theme.v2.colors.backgrounds.disabled
@@ -465,6 +465,9 @@ private fun QrCodeContainer(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Off the scale by construction, not by drift: these two trace a frame drawn around the QR
+    // bitmap, so the inner corner has to sit a fixed inset inside the outer one. Rounding either to
+    // a step would break the concentricity the frame depends on.
     val outerShape = RoundedCornerShape(24.75.dp)
     val innerShape = RoundedCornerShape(18.56.dp)
 
@@ -686,7 +689,7 @@ private fun DeviceCountBadge(index: Int, maxLabel: String) {
         modifier =
             Modifier.background(
                     color = Theme.v2.colors.backgrounds.tertiary_2,
-                    shape = RoundedCornerShape(99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
@@ -767,7 +770,7 @@ private fun ExpandedQrOverlay(qrCode: BitmapPainter, onDismiss: () -> Unit) {
 
 @Composable
 private fun LocalModeHint() {
-    val shape = RoundedCornerShape(12.dp)
+    val shape = Theme.v2.radius.md
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -85,7 +84,7 @@ internal fun ClaimQbtcPromoBanner(onClaim: () -> Unit, modifier: Modifier = Modi
                 style = Theme.brockmann.button.semibold.medium,
                 color = Theme.v2.colors.text.primary,
                 modifier =
-                    Modifier.clip(PillShape)
+                    Modifier.clip(Theme.v2.radius.pill)
                         .background(Theme.v2.colors.buttons.ctaPrimary)
                         .clickable(onClick = onClaim)
                         .padding(horizontal = 24.dp, vertical = 12.dp),
@@ -185,7 +184,7 @@ internal fun ClaimQbtcBottomCta(onClaim: () -> Unit, modifier: Modifier = Modifi
             modifier =
                 Modifier.fillMaxWidth()
                     .padding(horizontal = 24.dp, vertical = 16.dp)
-                    .clip(PillShape)
+                    .clip(Theme.v2.radius.pill)
                     .background(Theme.v2.colors.buttons.ctaPrimary)
                     .clickable(onClick = onClaim)
                     .padding(horizontal = 24.dp, vertical = 12.dp),
@@ -194,4 +193,3 @@ internal fun ClaimQbtcBottomCta(onClaim: () -> Unit, modifier: Modifier = Modifi
 }
 
 private val QbtcBannerGlow = Color(0xFF0538C7)
-private val PillShape = RoundedCornerShape(99.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralCreateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralCreateScreen.kt
@@ -353,12 +353,12 @@ private fun SearchReferralTag(type: SearchStatusType) {
         modifier =
             Modifier.background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(50),
+                    shape = Theme.v2.radius.pill,
                 )
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(50),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
@@ -380,7 +380,7 @@ fun CounterYearExpiration(
     ) {
         Button(
             onClick = { if (count != defaultInitCounter) onDecrement() },
-            shape = RoundedCornerShape(12.dp),
+            shape = Theme.v2.radius.md,
             enabled = count != defaultInitCounter,
             colors =
                 ButtonDefaults.buttonColors(
@@ -393,7 +393,7 @@ fun CounterYearExpiration(
             modifier =
                 Modifier.weight(1f)
                     .height(height = 60.dp)
-                    .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(12.dp)),
+                    .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md),
         ) {
             Icon(painter = painterResource(R.drawable.circle_minus), contentDescription = null)
         }
@@ -402,7 +402,7 @@ fun CounterYearExpiration(
             modifier =
                 Modifier.weight(1f)
                     .height(height = 60.dp)
-                    .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(12.dp)),
+                    .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md),
             contentAlignment = Alignment.Center,
         ) {
             Text(
@@ -414,7 +414,7 @@ fun CounterYearExpiration(
 
         Button(
             onClick = { if (count < 100) onIncrement() },
-            shape = RoundedCornerShape(12.dp),
+            shape = Theme.v2.radius.md,
             colors =
                 ButtonDefaults.buttonColors(
                     containerColor = Theme.v2.colors.backgrounds.secondary,
@@ -423,7 +423,7 @@ fun CounterYearExpiration(
             modifier =
                 Modifier.weight(1f)
                     .height(height = 60.dp)
-                    .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(12.dp)),
+                    .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md),
         ) {
             Icon(painter = painterResource(R.drawable.circle_plus), contentDescription = null)
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -158,7 +157,7 @@ internal fun ReferralViewScreen(
                                         width = 1.dp,
                                         color = Theme.v2.colors.border.light,
                                     ),
-                                shape = RoundedCornerShape(12.dp),
+                                shape = Theme.v2.radius.md,
                             )
                             .padding(12.dp)
                 ) {
@@ -236,9 +235,9 @@ private fun ReferralExpirationItem(expiration: String = "25 May of 2027", isLoad
         modifier =
             Modifier.border(
                     border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .background(Theme.v2.colors.backgrounds.primary)
                 .fillMaxWidth()
                 .padding(all = 16.dp)
@@ -268,12 +267,12 @@ private fun FriendReferralBanner(isActive: Boolean, onClick: () -> Unit) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(100.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .clickable { onClick() }
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
     ) {
         Image(
@@ -319,15 +318,12 @@ private fun FriendActiveChip(modifier: Modifier = Modifier) {
     Row(
         modifier =
             modifier
-                .clip(RoundedCornerShape(999.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(Theme.v2.colors.primary.accent4.copy(alpha = 0.16f))
                 .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier =
-                Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(FRIEND_ACTIVE_DOT)
-        )
+        Box(modifier = Modifier.size(6.dp).clip(Theme.v2.radius.pill).background(FRIEND_ACTIVE_DOT))
         Spacer(modifier = Modifier.width(6.dp))
         Text(
             text = stringResource(R.string.referral_view_friend_active),
@@ -345,11 +341,11 @@ private fun ReferralRewardsBanner(rewards: String, isLoading: Boolean) {
         modifier =
             Modifier.fillMaxWidth()
                 .height(110.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
     ) {
         SetBackgroundBanner(backgroundImageResId = R.drawable.referral_data_banner)
@@ -443,12 +439,12 @@ internal fun ContentRow(text: String, icon: @Composable () -> Unit) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .background(Theme.v2.colors.backgrounds.primary)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -477,7 +473,7 @@ internal fun EmptyReferralBanner(onClickedCreateReferral: () -> Unit) {
                 .background(Theme.v2.colors.backgrounds.primary)
                 .border(
                     border = BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
@@ -213,12 +213,12 @@ private fun PillText(
         color = textColor,
         modifier =
             (if (background != null) {
-                    Modifier.background(color = background, shape = RoundedCornerShape(70.dp))
+                    Modifier.background(color = background, shape = Theme.v2.radius.pill)
                 } else {
                     Modifier.border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = RoundedCornerShape(70.dp),
+                        shape = Theme.v2.radius.pill,
                     )
                 })
                 .padding(horizontal = 12.dp, vertical = 8.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAddressSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAddressSection.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -165,11 +164,11 @@ internal fun FoldableDestinationAddressWidget(
                         .border(
                             border =
                                 BorderStroke(width = 1.dp, color = Theme.v2.colors.border.light),
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .background(
                             color = Theme.v2.colors.backgrounds.secondary,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormAmountSection.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Text
@@ -234,7 +233,7 @@ internal fun FoldableAmountWidget(
                     else
                         Modifier.background(
                                 color = Theme.v2.colors.backgrounds.secondary,
-                                shape = RoundedCornerShape(12.dp),
+                                shape = Theme.v2.radius.md,
                             )
                             .padding(all = 16.dp),
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormComponents.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -105,7 +104,7 @@ internal fun FoldableSection(
             Modifier.border(
                 width = 1.dp,
                 color = Theme.v2.colors.border.light,
-                shape = RoundedCornerShape(12.dp),
+                shape = Theme.v2.radius.md,
             )
     ) {
         Row(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifyTransactionDetailsSection.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifyTransactionDetailsSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -91,7 +90,7 @@ internal fun TransactionDetailsSection(
                 modifier =
                     Modifier.fillMaxWidth()
                         .padding(top = 12.dp)
-                        .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(12.dp))
+                        .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md)
                         .padding(16.dp),
             ) {
                 functionSignature?.let {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/NotificationsSettingsScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -135,7 +134,7 @@ private fun NotificationsSettingsScreen(
                     modifier =
                         Modifier.background(
                             color = Theme.v2.colors.backgrounds.surface1,
-                            shape = RoundedCornerShape(size = 12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                 ) {
                     state.vaults.forEachIndexed { index, vault ->
@@ -159,13 +158,13 @@ private fun SystemNotificationsBlockedWarning(onClick: () -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(size = 12.dp))
+                .clip(Theme.v2.radius.md)
                 .clickOnce(onClick = onClick)
                 .background(color = Theme.v2.colors.backgrounds.surface1)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.alerts.warning,
-                    shape = RoundedCornerShape(size = 12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(all = 16.dp),
     ) {
@@ -229,11 +228,11 @@ private fun VaultNotificationToggle(
                     Modifier.border(
                             width = 1.dp,
                             color = Theme.v2.colors.variables.bordersLight,
-                            shape = RoundedCornerShape(size = 99.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .background(
                             color = Theme.v2.colors.variables.backgroundsSurface12,
-                            shape = RoundedCornerShape(size = 99.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .padding(12.dp),
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/SettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -142,9 +141,9 @@ internal fun SettingsBox(
                 Modifier.fillMaxWidth()
                     .background(
                         color = Theme.v2.colors.backgrounds.secondary,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
         ) {
             content()
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/notifications/NotificationsIntroBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/notifications/NotificationsIntroBottomSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -167,7 +166,7 @@ internal fun VaultNotificationOptInBottomSheetContent(
                 modifier =
                     Modifier.background(
                         color = Theme.v2.colors.variables.backgroundsSurface12,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
             ) {
                 Row(
@@ -202,11 +201,11 @@ internal fun VaultNotificationOptInBottomSheetContent(
                                 Modifier.border(
                                         width = 1.dp,
                                         color = Theme.v2.colors.variables.bordersLight,
-                                        shape = RoundedCornerShape(size = 99.dp),
+                                        shape = Theme.v2.radius.pill,
                                     )
                                     .background(
                                         color = Theme.v2.colors.variables.backgroundsSurface12,
-                                        shape = RoundedCornerShape(size = 99.dp),
+                                        shape = Theme.v2.radius.pill,
                                     )
                                     .padding(12.dp),
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -189,7 +188,7 @@ internal fun AdvancedMenu(
         modifier =
             Modifier.fillMaxWidth()
                 .padding(top = 16.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .background(Theme.v2.colors.backgrounds.secondary)
     ) {
         AdvancedSwapSettingRow(
@@ -253,7 +252,7 @@ internal fun ExternalRecipientPage(
         Row(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
                     .background(Theme.v2.colors.backgrounds.secondary)
                     .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -301,7 +300,7 @@ internal fun SlippagePage(slippageBps: Int?, onSelect: (Int?) -> Unit) {
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
                     .background(Theme.v2.colors.backgrounds.secondary)
         ) {
             SlippageOptionRow(
@@ -473,7 +472,7 @@ internal fun GasLimitPage(gasLimitOverride: Long?, onSelect: (Long?) -> Unit) {
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
                     .background(Theme.v2.colors.backgrounds.secondary)
                     .padding(horizontal = 16.dp, vertical = 16.dp),
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/HintBox.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/HintBox.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -229,12 +229,13 @@ private fun HintBoxPopupContent(
                 Modifier.fillMaxWidth()
                     .background(
                         color = shapeColor,
+                        // The top-end corner is pulled in so the pointer triangle meets a
+                        // near-square
+                        // corner instead of cutting across a curve; every corner is still a step on
+                        // the scale.
                         shape =
-                            RoundedCornerShape(
-                                topStart = 16.dp,
-                                topEnd = 4.dp,
-                                bottomStart = 16.dp,
-                                bottomEnd = 16.dp,
+                            Theme.v2.radius.lg.shape.copy(
+                                topEnd = CornerSize(Theme.v2.radius.xs.size)
                             ),
                     )
                     .padding(horizontal = 16.dp, vertical = 12.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/LimitSwapForm.kt
@@ -291,9 +291,9 @@ private fun LimitPill(
     Box(
         modifier =
             modifier
-                .clip(RoundedCornerShape(100.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(background)
-                .border(1.dp, borderColor, RoundedCornerShape(100.dp))
+                .border(1.dp, borderColor, Theme.v2.radius.pill)
                 .clickable(onClick = onClick)
                 .padding(horizontal = 12.dp, vertical = 6.dp),
         contentAlignment = Alignment.Center,
@@ -348,7 +348,7 @@ private fun UnitToggleButton(
     Box(
         modifier =
             Modifier.size(32.dp)
-                .clip(RoundedCornerShape(18.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(if (selected) colors.primary.accent3 else Color.Transparent)
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/PercentagePicker.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/PercentagePicker.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -55,7 +54,7 @@ private fun RowScope.PercentageItem(title: String, onClick: () -> Unit) {
             Modifier.clickable(onClick = onClick)
                 .background(
                     color = Theme.v2.colors.backgrounds.tertiary_2,
-                    shape = RoundedCornerShape(99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(all = 8.dp)
                 .weight(1f),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -57,7 +56,7 @@ internal fun QuoteTimer(expiredAt: Instant, modifier: Modifier = Modifier) {
                 .height(44.dp)
                 .background(
                     color = Theme.v2.colors.backgrounds.secondary,
-                    shape = RoundedCornerShape(99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(horizontal = 16.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/TokenInput.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/TokenInput.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -301,7 +300,7 @@ internal fun TokenChip(
                 }
                 .background(
                     color = Theme.v2.colors.backgrounds.tertiary_2,
-                    shape = RoundedCornerShape(99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(all = 6.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/AdvancedSwapSettingsPreview.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/AdvancedSwapSettingsPreview.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.v2.bottomsheets.DragHandler
+import com.vultisig.wallet.ui.components.v2.bottomsheets.V2SheetShape
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
@@ -128,12 +128,7 @@ private fun PreviewAdvancedSheet(
         // Material's bottom-sheet scrim is black @ ~32% alpha.
         Box(modifier = Modifier.fillMaxSize().background(Color(0x52000000)))
 
-        Box(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .align(Alignment.BottomCenter)
-                    .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
-        ) {
+        Box(modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter).clip(V2SheetShape)) {
             Column(
                 modifier =
                     Modifier.fillMaxWidth()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookBottomSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -112,7 +111,7 @@ private fun AddressBookContent(
                                 .heightIn(min = 140.dp)
                                 .background(
                                     color = Theme.v2.colors.variables.backgroundsSurface1,
-                                    shape = RoundedCornerShape(size = 12.dp),
+                                    shape = Theme.v2.radius.md,
                                 )
                                 .padding(vertical = 20.dp, horizontal = 24.dp),
                             verticalArrangement = Arrangement.Center,
@@ -171,7 +170,7 @@ private fun AddressToggle(
                     Modifier.border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(size = 60.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .padding(4.dp)
                         .fillMaxWidth(),
@@ -209,7 +208,7 @@ private fun RowScope.PickerItem(title: String, onClick: () -> Unit, isSelected: 
                     color =
                         if (isSelected) Theme.v2.colors.variables.buttonsCTAPrimary
                         else Theme.v2.colors.backgrounds.transparent,
-                    shape = RoundedCornerShape(size = 99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .clickable(onClick = onClick)
                 .padding(vertical = 12.dp, horizontal = 20.dp),
@@ -231,7 +230,7 @@ private fun EntryItem(
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 20.dp, vertical = 12.dp)
                 .fillMaxWidth(),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressBookScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -242,12 +241,12 @@ private fun AddressItem(
                     .clickOnce(onClick = onClick)
                     .background(
                         color = Theme.v2.colors.backgrounds.secondary,
-                        shape = RoundedCornerShape(size = 12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = RoundedCornerShape(size = 12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(horizontal = 20.dp, vertical = 12.dp),
         ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressEntryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/AddressEntryScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
@@ -154,11 +153,11 @@ internal fun SelectChain(modifier: Modifier = Modifier, selectedChain: NetworkUi
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = RoundedCornerShape(size = 12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .background(
                         color = Theme.v2.colors.backgrounds.secondary,
-                        shape = RoundedCornerShape(size = 12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(all = 16.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/LimitOrderCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/LimitOrderCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -200,7 +199,7 @@ private fun LimitOrderStatusChip(status: LimitOrderHistoryStatus) {
         style = Theme.brockmann.supplementary.caption,
         color = color,
         modifier =
-            Modifier.background(color = color.copy(alpha = 0.12f), shape = RoundedCornerShape(8.dp))
+            Modifier.background(color = color.copy(alpha = 0.12f), shape = Theme.v2.radius.sm)
                 .padding(horizontal = 8.dp, vertical = 4.dp),
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTransactionCard.kt
@@ -172,7 +172,7 @@ private fun DappSummaryText(summary: String, modifier: Modifier = Modifier) {
 
 @Composable
 private fun SendAddressPill(address: String, modifier: Modifier = Modifier) {
-    val shape = RoundedCornerShape(100.dp)
+    val shape = Theme.v2.radius.pill
     Text(
         text =
             buildAnnotatedString {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
@@ -106,7 +106,7 @@ internal fun TransactionDetailBottomSheet(
                             .size(width = 36.dp, height = 4.dp)
                             .background(
                                 color = Theme.v2.colors.vibrant.primary,
-                                shape = RoundedCornerShape(100.dp),
+                                shape = Theme.v2.radius.pill,
                             )
                 )
 
@@ -134,11 +134,11 @@ internal fun TransactionDetailBottomSheet(
                                 .border(
                                     width = 1.dp,
                                     color = Color(0x08FFFFFF),
-                                    shape = RoundedCornerShape(size = 99.dp),
+                                    shape = Theme.v2.radius.pill,
                                 )
                                 .background(
                                     color = Theme.v2.colors.variables.bordersLight,
-                                    shape = RoundedCornerShape(size = 99.dp),
+                                    shape = Theme.v2.radius.pill,
                                 )
                                 .padding(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 16.dp),
                     ) {
@@ -311,10 +311,10 @@ private fun DetailInfoRows(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .border(1.dp, Theme.v2.colors.border.light, RoundedCornerShape(12.dp))
+                .border(1.dp, Theme.v2.colors.border.light, Theme.v2.radius.md)
                 .background(
                     color = Theme.v2.colors.variables.backgroundsSurface1,
-                    shape = RoundedCornerShape(size = 12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 4.dp)
     ) {
@@ -347,7 +347,7 @@ private fun DetailInfoRows(
                     modifier =
                         Modifier.background(
                                 color = Theme.v2.colors.variables.backgroundsSurface12,
-                                shape = RoundedCornerShape(size = 8.dp),
+                                shape = Theme.v2.radius.sm,
                             )
                             .padding(vertical = 3.dp, horizontal = 8.dp)
                 ) {
@@ -412,11 +412,11 @@ internal fun RefundReasonBanner(reason: String) {
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.alerts.warning.copy(alpha = 0.4f),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .background(
                     color = Theme.v2.colors.alerts.warning.copy(alpha = 0.10f),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
     )
@@ -447,7 +447,7 @@ private fun DetailValuePill(text: String, modifier: Modifier = Modifier, logo: I
             modifier
                 .background(
                     color = Theme.v2.colors.backgrounds.tertiary_2,
-                    shape = RoundedCornerShape(8.dp),
+                    shape = Theme.v2.radius.sm,
                 )
                 .padding(horizontal = 8.dp, vertical = 3.dp),
     ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -370,7 +369,7 @@ private fun SelectedAssetFiltersRow(
 
 @Composable
 private fun AssetFilterChip(asset: TransactionAssetUiModel, onRemove: () -> Unit) {
-    val shape = RoundedCornerShape(100.dp)
+    val shape = Theme.v2.radius.pill
     Row(
         modifier =
             Modifier.background(color = Theme.v2.colors.backgrounds.tertiary_2, shape = shape)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/components/TransactionHistoryComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/components/TransactionHistoryComponents.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -44,11 +43,11 @@ internal fun TypeBadge(iconRes: Int, label: String, modifier: Modifier = Modifie
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.alerts.info,
-                    shape = RoundedCornerShape(size = 99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .background(
                     color = Theme.v2.colors.alerts.info.copy(alpha = 0.10f),
-                    shape = RoundedCornerShape(size = 99.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -120,7 +119,7 @@ private fun InProgressPill(timestamp: Long, modifier: Modifier = Modifier) {
             modifier
                 .background(
                     color = Theme.v2.colors.backgrounds.primary,
-                    shape = RoundedCornerShape(100.dp),
+                    shape = Theme.v2.radius.pill,
                 )
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -191,7 +190,7 @@ internal fun ChainTokensScreen(
                     address = uiModel.chainAddress,
                     onAddressCopied = { snackbarState.show(addressCopiedMessage) },
                     modifier =
-                        Modifier.clip(RoundedCornerShape(size = 8.dp))
+                        Modifier.clip(Theme.v2.radius.sm)
                             .background(color = Theme.v2.colors.text.button.dim.copy(alpha = 0.12f))
                             .padding(horizontal = 6.dp, vertical = 4.dp),
                     tint = Theme.v2.colors.alerts.info,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainLogo.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.ui.screens.v2.chaintokens.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,12 +18,12 @@ internal fun ChainLogo(name: String, logo: ImageModel?) {
     SubcomposeAsyncImage(
         model = logo,
         contentDescription = null,
-        modifier = Modifier.size(24.dp).clip(RoundedCornerShape(size = 8.dp)),
+        modifier = Modifier.size(24.dp).clip(Theme.v2.radius.sm),
         error = {
             Box(
                 modifier =
                     Modifier.size(24.dp)
-                        .clip(RoundedCornerShape(size = 8.dp))
+                        .clip(Theme.v2.radius.sm)
                         .background(color = Theme.v2.colors.backgrounds.tertiary_2),
                 contentAlignment = Alignment.Center,
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -300,7 +299,7 @@ fun ActionButton(
                     )
                 }
             },
-        shape = RoundedCornerShape(50),
+        shape = Theme.v2.radius.pill,
         contentPadding = PaddingValues(horizontal = 4.dp, vertical = 6.dp),
         modifier = modifier.height(42.dp).actionButtonInnerBevel(enabled = enabled),
     ) {
@@ -315,7 +314,7 @@ fun ActionButton(
                             .background(
                                 if (enabled) iconCircleColor
                                 else iconCircleColor.copy(alpha = 0.5f),
-                                RoundedCornerShape(50),
+                                Theme.v2.radius.pill,
                             ),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -562,12 +561,12 @@ internal fun DeFiWarningBanner(text: String, onClickClose: (() -> Unit)? = null)
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
                     .background(Theme.v2.colors.backgrounds.secondary)
                     .border(
                         width = 1.dp,
                         color = Theme.v2.colors.border.light,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = Theme.v2.radius.md,
                     )
                     .padding(
                         start = 16.dp,
@@ -1039,7 +1038,7 @@ private fun CompleteNodeCardMockPreview() {
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .background(Theme.v2.colors.backgrounds.secondary, RoundedCornerShape(12.dp))
+                    .background(Theme.v2.colors.backgrounds.secondary, Theme.v2.radius.md)
                     .padding(16.dp)
         ) {
             // Node Address

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/AddLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/AddLpScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Text
@@ -128,11 +127,11 @@ private fun AddLpContent(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -236,7 +235,7 @@ private fun RemoveLpSlider(
                                 .height(24.dp)
                                 .background(
                                     color = Theme.v2.colors.text.primary,
-                                    shape = RoundedCornerShape(100),
+                                    shape = Theme.v2.radius.pill,
                                 )
                     )
                 },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/StakeCacaoScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/StakeCacaoScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Text
@@ -103,11 +102,11 @@ private fun StakeCacaoContent(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaDelegateScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -156,11 +155,11 @@ internal fun SolanaValidatorPickerField(selected: SolanaValidatorOption?, onClic
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
@@ -242,12 +241,12 @@ internal fun SolanaValidatorPickerSheet(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(99.dp))
+                        .clip(Theme.v2.radius.pill)
                         .background(Theme.v2.colors.backgrounds.surface1)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(99.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .padding(horizontal = 12.dp, vertical = 12.dp),
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaFinishMoveScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaFinishMoveScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -82,12 +81,12 @@ internal fun SolanaFinishMoveContent(
             Row(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -113,7 +112,7 @@ internal fun SolanaFinishMoveContent(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .padding(16.dp)
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaMoveStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaMoveStakeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -78,12 +77,12 @@ internal fun SolanaMoveStakeContent(
             Row(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -109,7 +108,7 @@ internal fun SolanaMoveStakeContent(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .padding(16.dp)
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaUnstakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaUnstakeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -58,12 +57,12 @@ internal fun SolanaUnstakeContent(state: SolanaUnstakeUiState, onContinue: () ->
             Row(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(12.dp),
+                            shape = Theme.v2.radius.md,
                         )
                         .padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -84,7 +83,7 @@ internal fun SolanaUnstakeContent(state: SolanaUnstakeUiState, onContinue: () ->
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
+                        .clip(Theme.v2.radius.md)
                         .background(Theme.v2.colors.backgrounds.secondary)
                         .padding(16.dp)
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -429,7 +428,7 @@ private fun TonUnlockNotice(data: TonStakingUiModel) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
+                .clip(Theme.v2.radius.sm)
                 .background(Theme.v2.colors.backgrounds.surface2)
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -139,11 +138,11 @@ private fun TonPoolPickerField(selected: TonPoolUiModel?, onClick: () -> Unit) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(Theme.v2.radius.md)
                 .border(
                     width = 1.dp,
                     color = Theme.v2.colors.border.light,
-                    shape = RoundedCornerShape(12.dp),
+                    shape = Theme.v2.radius.md,
                 )
                 .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
@@ -214,12 +213,12 @@ private fun TonPoolPickerSheet(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(99.dp))
+                        .clip(Theme.v2.radius.pill)
                         .background(Theme.v2.colors.backgrounds.surface1)
                         .border(
                             width = 1.dp,
                             color = Theme.v2.colors.border.light,
-                            shape = RoundedCornerShape(99.dp),
+                            shape = Theme.v2.radius.pill,
                         )
                         .padding(horizontal = 12.dp, vertical = 12.dp),
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -360,7 +360,7 @@ private fun TronPendingWithdrawalRow(
         if (isClaimable) {
             Box(
                 modifier =
-                    Modifier.clip(RoundedCornerShape(8.dp))
+                    Modifier.clip(Theme.v2.radius.sm)
                         .background(Theme.v2.colors.alerts.success.copy(alpha = 0.12f))
                         .padding(horizontal = 10.dp, vertical = 4.dp)
             ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -237,7 +236,7 @@ private fun TronFreezeActionButton(
                 disabledContentColor = contentColor.copy(alpha = 0.5f),
             ),
         border = resolvedBorder,
-        shape = RoundedCornerShape(50),
+        shape = Theme.v2.radius.pill,
         contentPadding = PaddingValues(start = 4.dp, top = 6.dp, end = 16.dp, bottom = 6.dp),
         modifier = modifier.height(46.dp).tronFreezeButtonBevel(enabled = enabled),
     ) {
@@ -246,7 +245,7 @@ private fun TronFreezeActionButton(
                 Modifier.size(34.dp)
                     .background(
                         if (enabled) iconCircleColor else iconCircleColor.copy(alpha = 0.5f),
-                        RoundedCornerShape(50),
+                        Theme.v2.radius.pill,
                     ),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronResourceTypeTab.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronResourceTypeTab.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -43,7 +42,7 @@ internal fun TronResourceTypeTab(
         Row(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(88.dp))
+                    .clip(Theme.v2.radius.pill)
                     .background(Theme.v2.colors.backgrounds.secondary)
                     .padding(4.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -86,7 +85,7 @@ private fun ResourceTypeSegment(
     Row(
         modifier =
             modifier
-                .clip(RoundedCornerShape(77.dp))
+                .clip(Theme.v2.radius.pill)
                 .background(background)
                 .semantics {
                     selected = isSelected

--- a/app/src/main/java/com/vultisig/wallet/ui/theme/Shape.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/Shape.kt
@@ -3,10 +3,14 @@ package com.vultisig.wallet.ui.theme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.theme.v2.V2
 
+// Material 3 types these as CornerBasedShape, so they read the token's `shape` rather than the
+// token itself. `large` is square — a zero corner is the absence of a radius, not a step on the
+// scale, so it has no token to reference.
 val Shapes: Shapes =
     Shapes(
-        small = RoundedCornerShape(4.dp),
-        medium = RoundedCornerShape(4.dp),
+        small = V2.radius.xs.shape,
+        medium = V2.radius.xs.shape,
         large = RoundedCornerShape(0.dp),
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Radius.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/theme/v2/Radius.kt
@@ -49,9 +49,20 @@ sealed class Radius(
      * Fully rounded, at every surface size the app can render.
      *
      * [CircleShape] is `RoundedCornerShape(percent = 50)` — it is defined relative to the surface,
-     * so unlike the "big number" idiom it cannot stop being round on a large surface. The app's
-     * fully-round literals (50, 70, 77, 88, 99, 100 dp and `percent = 50`) all mean this, and
-     * collapse onto it.
+     * so unlike the "big number" idiom it cannot stop being round on a large surface.
+     *
+     * Every fully-round literal in the app has been collapsed onto this. Two spellings existed. The
+     * obvious one is a number large enough to always clamp — 50, 60, 70, 77, 88, 99, 100, 999 dp,
+     * `percent = 50` and `percent = 100`. The other is a number that only *reads* as a radius: 30
+     * on a 50 dp-tall carousel item, 18 on a 32 dp box, 3 on a 6 dp dot, 100 on a 4 dp sheet
+     * grabber. Each of those exceeds half the surface's smaller side, so Compose scales it back to
+     * exactly half and draws a capsule — the author wrote "round", arithmetically. Both spellings
+     * are invisible to a grep for round numbers, which is why they are named here.
+     *
+     * The converse is the trap: a big number is *not* automatically this token. Compose only clamps
+     * while the surface's smaller dimension is under twice the radius, so
+     * `RoundedCornerShape(99.dp)` on a 320×240 surface really does draw 99. Check the surface
+     * before collapsing one.
      */
     @Immutable data object Pill : Radius(CircleShape)
 }
@@ -65,9 +76,9 @@ sealed class Radius(
  * token names would freeze a half-verified answer.
  *
  * [Radius.Pill] is the one semantic token, because "fully rounded" is not a number. The design file
- * expresses it as 50, 77 or 99 depending on the component and the app has 50, 70, 77, 88, 99 and
- * 100 in use; all of them mean the same thing, and the token collapses them so no call site imports
- * another magic number.
+ * expresses it as 50, 77 or 99 depending on the component, and the app had ten spellings of it; all
+ * of them mean the same thing, and the token has collapsed them so no call site imports another
+ * magic number.
  *
  * **There is deliberately no sheet token, and the scale stops at 24.** The two sheet frames in the
  * design file measure 38 and 28, but both are stock design-kit components dropped into the file

--- a/app/src/test/java/com/vultisig/wallet/ui/theme/v2/RadiusTokenTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/theme/v2/RadiusTokenTest.kt
@@ -106,6 +106,52 @@ internal class RadiusTokenTest {
                 (capsule plusOrMinus 0.001f)
         }
         RoundedCornerShape(percent = 50).drawnRadiusOn(searchFieldSized) shouldBe capsule
+        RoundedCornerShape(50).drawnRadiusOn(searchFieldSized) shouldBe capsule
+        listOf(60.dp, 999.dp).forEach { literal ->
+            RoundedCornerShape(literal).drawnRadiusOn(searchFieldSized) shouldBe
+                (capsule plusOrMinus 0.001f)
+        }
+    }
+
+    /**
+     * `percent = 100` is the one fully-round spelling that is not obviously equivalent, because
+     * Compose does not scale the four corners by a common factor — it clamps each to the surface's
+     * smaller dimension and then clamps the second corner of each edge to what is left of it.
+     * Asking for 100% therefore takes the whole smaller dimension and leaves the opposite corner
+     * nothing, which is a very different shape from asking for half of it twice.
+     *
+     * It survives that only because the clamp runs before the outline is built: both corners on the
+     * short edge want the full dimension, and the leftover rule splits it evenly between them. The
+     * app's primary button is drawn this way, so this is measured rather than assumed.
+     */
+    @Test
+    fun `percent = 100 collapses onto the same capsule as pill`() {
+        val buttonSized = Size(width = 328f, height = 48f)
+
+        RoundedCornerShape(percent = 100).drawnRadiusOn(buttonSized) shouldBe
+            radius.pill.drawnRadiusOn(buttonSized)
+    }
+
+    /**
+     * The other spelling of "fully round", and the one a census misses: a number that is not
+     * obviously large, on a surface small enough that it still clamps. Each pair below is a real
+     * call site this migration collapsed onto `pill` — a carousel item, the limit-swap unit toggle,
+     * the referral active dot and a sheet grabber. None of them reads as a fully-round literal, and
+     * all four draw a capsule.
+     */
+    @Test
+    fun `a literal over half the surface is already a capsule`() {
+        val clampedSites =
+            listOf(
+                30.dp to Size(width = 150f, height = 50f),
+                18.dp to Size(width = 32f, height = 32f),
+                3.dp to Size(width = 6f, height = 6f),
+                100.dp to Size(width = 36f, height = 4f),
+            )
+
+        clampedSites.forEach { (literal, size) ->
+            RoundedCornerShape(literal).drawnRadiusOn(size) shouldBe radius.pill.drawnRadiusOn(size)
+        }
     }
 
     /**


### PR DESCRIPTION
Phase 3 of 4 for #5503. Phase 1 (#5544) added the token scale, phase 2 (#5547) moved the container level onto 24. This is the rest of the sweep: every corner literal that was already a step on the scale now reads the token, so the scale is the only place a radius is written down. Phase 4 is the lint rule that keeps it that way.

**383 raw corner literals become 27**, and all 27 are named below.

## What changed

**Plain renames — 4, 8, 12 → `xs`, `sm`, `md`.** No value moves. The 12s are the largest population in the app and most are rows and fields rather than containers, which is why phase 2 left them: blanket-converting that group would have been a restyle, and reading them as `md` is not.

**Fully-round literals → `pill`.** The app had ten spellings of "round": 50, 60, 70, 77, 88, 99, 100 and 999 dp, `percent = 50` and `percent = 100`. They all draw the same capsule — but only because Compose clamps a corner to half the surface's smaller side, so the equivalence is a property of the *surface*, not of the number. Every site was checked against its own surface first. The bound is real: on a 320×240 surface `RoundedCornerShape(99.dp)` draws 99 and is not a capsule.

That check found the spelling a census misses — a number that doesn't read as fully-round but clamps anyway: **30 on a 50dp carousel item, 18 on a 32dp toggle, 3 on a 6dp dot**. Those were already drawing capsules; they now say so.

`RoundedCornerShape(percent = 100)` is the one collapse that isn't obvious. Compose clamps each corner separately rather than scaling all four, so asking for 100% takes the whole smaller dimension and leaves the opposite corner nothing — a very different shape from asking for half of it twice. It survives only because the leftover rule then splits the short edge evenly. That spelling carries `VsButton`, the app's primary button, so it is **measured in a test** rather than argued.

**`V2SheetShape` hoisted.** The V2 sheet frame was spelled out three times in one package. That's the drift the scale exists to stop, token or no token.

## What stays off the scale, and why

| Site | Value | Why |
|---|---|---|
| Bottom sheets | 32 / 34 / 38 / 40 | The scale stops at 24 — the design file's sheet frames are stock design-kit components (Apple's 38, Material 3's 28), so there is no step to reference. Phase-1 ruling. |
| QR frame (peer discovery) | 24.75 / 18.56 | Concentric by construction; the inner corner sits a fixed inset inside the outer one and rounding either breaks it. |
| Key-import chain row | 20 | Figma value sits equidistant from 16 and 24. iOS left the same row. |
| Search field | 10 | See below. |
| Checkbox, skeleton bars | 2 | Below `xs`; snapping to 4 is visible at that size. |
| Governance tally bar | 5 / 3 | See below. |
| ChooseVault container, limit-swap toggle | 15, 20 | No design source at all. Left bare on purpose so phase 4's rule surfaces them. |
| `Shapes.large`, square corners | 0 | A zero corner is the absence of a radius, not a step. |

## Two things that need a design call — not fixed here

**1. The input radius.** There is no single answer in the app: the search field is **10**, `VsTextInputField` and the passcode cells **12**, the code-entry boxes **24**, every v2 search surface **fully round** — and the design file's input measures **16**. Snapping the one off-scale input to a token would pick a winner for the whole family by accident, so it's left at 10 with the inventory recorded at the site. Worth settling before phase 4.

**2. A real drift bug in the governance tally bar.** It rounds at 5 when empty and 3 once voted, so the corner visibly changes the moment the first vote lands. Recorded in code rather than fixed, because which one is right is a design question.

## Test plan

- `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:lintDebug` — all green, 0 lint errors.
- `RadiusTokenTest` grew from 9 to 11 cases: one pins `percent = 100` against `pill` on a button-sized surface, one pins the four clamped call sites (carousel item, limit-swap toggle, referral dot, sheet grabber).
- **Pixel diff, 128 PreviewActivity screens, main vs branch on one emulator.** A rename sweep should move nothing, so the whole point is the noise floor: the branch was captured **twice** to find out what differs between two runs of identical code. 65 of 128 screens are unstable — status-bar icons, animations, a system clipboard toast, an IME tooltip. Exactly one screen (`swap_toolbar`) differed against main but not against itself; six fresh captures of it from the same APK differ from each other in the *same three pixels*, because it draws a live `CircularProgressIndicator` off `Clock.System.now()`.

  **Result: 0 screens differ beyond the measured noise.**

No before/after screenshots because there is nothing to show — that is the claim being made, and the diff above is the evidence for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized corner radii across wallet screens, forms, cards, buttons, charts, banners, and bottom sheets.
  * Improved visual consistency by applying shared theme shapes for medium, small, and pill-style elements.
  * Preserved intentional exceptions for specialized controls such as search fields and QR frames.

* **Tests**
  * Expanded coverage for recognizing equivalent fully rounded and capsule-shaped elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->