### PR TITLE
fix(backup): refuse a vault whose keyshares only partly decoded

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
@@ -44,6 +44,11 @@ internal class MapVaultToProtoImpl @Inject constructor() : MapVaultToProto {
         // of storage because the data key was unavailable. Exporting that would hand the user a
         // .vult that reports success, restores cleanly, and can never sign — the worst shape a
         // backup failure can take, because it is only discovered when the backup is needed.
+        //
+        // Empty is enough to test for because the read is all-or-nothing: a vault that could not
+        // be fully decrypted arrives with none of its shares rather than the ones that happened to
+        // open. Storage owns that guarantee — see VaultRepositoryImpl.toKeyShares — because the
+        // count of shares a vault *should* have exists only there.
         if (from.keyshares.isEmpty()) throw VaultKeysharesUnavailableException()
         return VaultProto(
             name = from.name,

--- a/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/mappers/MapVaultToProtoImplTest.kt
@@ -146,4 +146,22 @@ internal class MapVaultToProtoImplTest {
         assertNull(mapper.exportableOrNull(vault().copy(keyshares = emptyList())))
         assertNotNull(mapper.exportableOrNull(vault()))
     }
+
+    /**
+     * A vault whose stored rows were part plaintext, part encrypted, read with no data key, is
+     * refused.
+     *
+     * The other half of this claim lives in `VaultRepositoryImplTest.get drops every keyshare when
+     * only some can be read while locked`, which is where that vault is actually produced —
+     * `VaultRepositoryImpl` is internal to the data module, so the two halves cannot meet in one
+     * test. This one pins the side the mapper owns: given the all-or-nothing read, checking for
+     * emptiness is what refuses a partial keyshare set, and it must keep doing so.
+     */
+    @Test
+    fun `a partially readable keyshare set reaches the mapper as empty and is refused`() {
+        val fromPartialLockedRead = vault().copy(keyshares = emptyList())
+
+        assertFailsWith<VaultKeysharesUnavailableException> { mapper(fromPartialLockedRead) }
+        assertNull(mapper.exportableOrNull(fromPartialLockedRead))
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -169,16 +169,24 @@ constructor(
     }
 
     /**
-     * Decrypts stored keyshares, dropping any that cannot be opened *while the app is locked*.
+     * Decrypts stored keyshares, dropping *all* of them when any cannot be opened while the app is
+     * locked.
      *
      * A locked read is expected and harmless: background work (notifications, balance sync) still
      * reads vaults and only needs public keys and addresses. Returning the vault without its shares
      * keeps that work alive, and the write path refuses to persist a vault in that state, so a
      * locked read can never be echoed back as data loss.
      *
+     * All-or-nothing, because a table holding both plaintext and encrypted rows is a state the app
+     * supports — a `protectAll` interrupted by process death leaves exactly that mix. Keeping the
+     * rows that happened to be readable would return a vault with *some* shares, which no caller
+     * can use and every caller mistakes for a complete one: export writes a .vult that restores
+     * cleanly and can never sign, and a reshare merges the survivors and writes the truncated set
+     * back over the real one. Empty is the shape callers already check for.
+     *
      * A failure with the data key in hand is a different thing entirely — a damaged row, or one
-     * written for another vault — and returning a partial vault there would let the caller act as
-     * if the share simply did not exist. That fails loudly instead.
+     * written for another vault — and silently returning nothing there would hide a real defect.
+     * That fails loudly instead.
      */
     private fun List<KeyShareEntity>.toKeyShares(vaultId: VaultId): List<KeyShare> {
         val dataKey = passcodeDataKeySource.dataKeyOrNull()
@@ -191,7 +199,13 @@ constructor(
             check(dataKey == null) {
                 "Failed to decrypt ${size - shares.size} keyshare(s) for vault $vaultId"
             }
-            Timber.w("Dropped %d locked keyshare(s) for vault %s", size - shares.size, vaultId)
+            Timber.w(
+                "Dropped all %d keyshare(s) for vault %s: %d could not be read while locked",
+                size,
+                vaultId,
+                size - shares.size,
+            )
+            return emptyList()
         }
         return shares
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -509,6 +509,80 @@ internal class VaultRepositoryImplTest {
         assertEquals("ecdsa-vault-1", vault.pubKeyECDSA)
     }
 
+    /** Returns a stored vault carrying one plaintext row and one encrypted row, in that order. */
+    private fun vaultWithMixedKeyShares() =
+        makeVaultWithTokens()
+            .copy(
+                keyShares =
+                    listOf(
+                        KeyShareEntity(
+                            vaultId = "vault-1",
+                            pubKey = "pub-1",
+                            keyShare = "plaintext-share-1",
+                        ),
+                        KeyShareEntity(
+                            vaultId = "vault-1",
+                            pubKey = "pub-2",
+                            keyShare =
+                                keyShareCipher.encrypt(
+                                    "share-2",
+                                    dataKey,
+                                    KeyShareIdentity(vaultId = "vault-1", pubKey = "pub-2"),
+                                ),
+                        ),
+                    )
+            )
+
+    /**
+     * Verifies a table holding both plaintext and encrypted rows comes back with *no* shares while
+     * locked, not just the plaintext one that happened to be readable.
+     *
+     * That mix is a supported state — a `protectAll` interrupted by process death leaves exactly it
+     * — so the partial read was reachable in normal use. A vault carrying some of its shares is
+     * useless to every caller and indistinguishable from a complete one to all of them: export
+     * checks only for emptiness and would write a .vult that restores cleanly and can never sign.
+     */
+    @Test
+    fun `get drops every keyshare when only some can be read while locked`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns vaultWithMixedKeyShares()
+        passcode.dataKey = null
+        passcode.locked = true
+
+        val vault = repository.get("vault-1")
+
+        assertNotNull(vault)
+        assertEquals(emptyList(), vault.keyshares)
+        assertEquals("ecdsa-vault-1", vault.pubKeyECDSA)
+    }
+
+    /**
+     * Verifies the same mix loads complete once the key is available, so the all-or-nothing rule
+     * costs nothing in the state it exists to protect.
+     */
+    @Test
+    fun `get returns both rows of a mixed table while unlocked`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns vaultWithMixedKeyShares()
+        passcode.dataKey = dataKey
+
+        assertEquals(
+            listOf("plaintext-share-1", "share-2"),
+            repository.get("vault-1")?.keyshares?.map { it.keyShare },
+        )
+    }
+
+    /**
+     * Verifies a mixed table with the key in hand still fails loudly when a row will not open.
+     * Returning nothing there would hide a damaged row behind the same silence as a locked read.
+     */
+    @Test
+    fun `get fails when a mixed table has an undecryptable row and the key is available`() =
+        runTest {
+            coEvery { vaultDao.loadById("vault-1") } returns vaultWithMixedKeyShares()
+            passcode.dataKey = ByteArray(32) { (it + 1).toByte() }
+
+            assertFailsWith<IllegalStateException> { repository.get("vault-1") }
+        }
+
     /** Verifies keyshares are encrypted on the way into the database while unlocked. */
     @Test
     fun `add encrypts keyshares while unlocked`() = runTest {


### PR DESCRIPTION
Closes #5565

## Problem

`MapVaultToProto` refuses an export when the keyshare list is empty. A half-full list is not empty, so it passes.

The list can be half-full because a keyshare table holding both plaintext and `vlpc1:` rows is a state the app supports — `VaultKeyShareProtection`'s own contract says an interrupted `protectAll` "leaves a readable mix rather than a corrupt table". Reading that mix without the data key dropped the encrypted rows and returned the plaintext ones (`VaultRepository.kt:183-197`), warning rather than reporting.

Nothing downstream can tell a partial vault from a complete one:

- **Export** writes a `.vult` that saves, restores cleanly, and can never sign — the worst shape a backup failure takes, because it is only discovered when the backup is needed.
- **Reshare** merges the survivors at `KeygenViewModel.kt:502` and writes the truncated set back over the real rows. That one is permanent.

## Fix

Make the locked read all-or-nothing: if any row fails to decode while the data key is unavailable, return none.

Empty is the shape callers already check for, so the existing export guard starts working with no new exception type or plumbing, and the reshare merge sees an empty set — which an empty upsert leaves alone rather than overwriting. Background sync, the reason a locked read returns a vault at all, only ever needed public keys and addresses.

A failure *with the key in hand* still throws. That is a damaged row or one written for another vault — a real defect, not an expected read — and hiding it behind the same silence would be wrong.

`MapVaultToProto` gains a comment and no logic: the count of shares a vault *should* have exists only in the repository, so completeness cannot be checked at the mapper.

## Not currently reachable through the UI

Worth stating plainly, since the issue reads as though it is live. Every route from a partial read to an export is already closed:

- `Locked` — the lock screen covers the app.
- `KeyUnavailable` / `StoreUnavailable` — `PasscodeGuard.kt:80` shows a full-screen dead end.
- `Disabled` — `resolveInitialState` only returns it when no encrypted rows exist, so nothing can fail to decode.
- Stale vault read behind the lock screen — all three backup ViewModels call `awaitKeySharesReadable()` before reading (`BackupPasswordViewModel.kt:127`, `BackupVaultViewModel.kt:115`, `BackupPasswordRequestViewModel.kt:102`).

This is the last line of defence being made correct, not a live user-facing bug. It matters because it is the layer that is supposed to hold when one of those upstream guards is changed or missed.

## On the issue's checklist

Three of four items are addressed here. The fourth — `isBackedUp` set only after a complete export — needed no change: all three backup paths already gate `setBackupStatus(id, true)` behind `backupSuccess` (`BackupPasswordViewModel.kt:319`, `BackupVaultViewModel.kt:201`, `BackupPasswordRequestViewModel.kt:196`), so a refused export could never mark a vault backed up.

## Test plan

Four new tests. In `VaultRepositoryImplTest`:

- mixed table, no key → **no** shares (the bug)
- mixed table, key available → both shares load, so the rule costs nothing in the normal case
- mixed table, wrong key → still throws

In `MapVaultToProtoImplTest`: pins the mapper's half of the contract, with a comment pointing at the repository test that owns the other half — `VaultRepositoryImpl` is `internal` to `:data`, so the two halves cannot meet in one test.

Falsification check: removing `return emptyList()` fails `get drops every keyshare when only some can be read while locked` and nothing else — the other 38 tests in the class stay green.

Ran green:

```
./gradlew :data:testDebugUnitTest :app:testDebugUnitTest --offline
./gradlew :data:lintDebug :app:lintDebug --offline
```

Not manually verified on a device — reaching the state requires forcing it, per the section above. Suggested manual pass, since the change touches every vault read: backup and reimport a vault both with and without a passcode set, send a transaction after unlocking (signing needs a complete set), and confirm balances still refresh while locked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault reads now follow an all-or-nothing approach for key shares.
  * If any encrypted share cannot be read while a vault is locked, all shares are discarded instead of returning incomplete data.
  * Unlocked vaults continue to return available shares, while unreadable shares correctly trigger an error.
  * Improved handling prevents partially reconstructed vault data from being exported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->