### PR TITLE
fix(sui): migrate off JSON-RPC to GraphQL RPC before mid-Oct decommission

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -20,6 +20,13 @@ import kotlinx.serialization.json.putJsonObject
 import timber.log.Timber
 import vultisig.keysign.v1.SuiCoin
 
+/**
+ * Backstop on the coin-object walk in [SuiApi.getAllCoins]: at 50 objects per page this is 5000
+ * coin objects, far beyond any real wallet, so reaching it means the connection is misbehaving
+ * rather than that someone genuinely holds that many.
+ */
+internal const val SUI_MAX_COIN_PAGES = 100
+
 interface SuiApi {
 
     suspend fun getBalance(address: String, contractAddress: String): BigInteger
@@ -70,7 +77,12 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
         // An address that has never held the coin type resolves to null rather than an error —
         // that is a genuine zero, not an upstream fault. A malformed address is refused by the node
         // with a populated `errors` array, which the transport has already raised by this point.
-        return response.address?.balance?.totalBalance?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        val totalBalance = response.address?.balance?.totalBalance ?: return BigInteger.ZERO
+
+        // A present-but-unparsable amount is a node contract violation, not an empty wallet, so it
+        // is raised rather than collapsed into the same zero an absent balance returns.
+        return totalBalance.toBigIntegerOrNull()
+            ?: throw SuiRpcException("unparsable balance: $totalBalance")
     }
 
     override suspend fun getReferenceGasPrice(): BigInteger =
@@ -84,6 +96,7 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
     override suspend fun getAllCoins(address: String): List<SuiCoin> {
         val allCoins = mutableListOf<SuiCoin>()
         var cursor: String? = null
+        var pagesFetched = 0
 
         // The object connection is paginated. Follow hasNextPage/endCursor so a wallet whose
         // objects span multiple pages doesn't return a truncated set — otherwise a token whose
@@ -117,7 +130,24 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
                 )
             }
 
-            cursor = objects.pageInfo.endCursor.takeIf { objects.pageInfo.hasNextPage }
+            pagesFetched++
+
+            // Termination cannot rest on the node alone: a `hasNextPage` that never flips, or an
+            // `endCursor` that never advances, would spin here forever while `allCoins` grows
+            // without bound. Stop on a repeated cursor, and cap the walk at [SUI_MAX_COIN_PAGES].
+            val nextCursor = objects.pageInfo.endCursor.takeIf { objects.pageInfo.hasNextPage }
+            if (
+                nextCursor != null && (nextCursor == cursor || pagesFetched >= SUI_MAX_COIN_PAGES)
+            ) {
+                Timber.w(
+                    "Sui coin pagination stopped after %d pages with more reported; cursor %s",
+                    pagesFetched,
+                    if (nextCursor == cursor) "did not advance" else "budget exhausted",
+                )
+                cursor = null
+            } else {
+                cursor = nextCursor
+            }
         } while (cursor != null)
 
         return allCoins
@@ -178,7 +208,7 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
 
         val error = effects.errorMessage()
         if (error.isNotEmpty()) {
-            throw Exception("Simulation Error: $error")
+            error("Simulation Error: $error")
         }
 
         val gasSummary =
@@ -252,7 +282,9 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
         try {
             json.decodeFromJsonElement<T>(this)
         } catch (e: SerializationException) {
-            throw SuiRpcException("unexpected response shape: ${e.message}")
+            // Carry the cause: the message alone does not say which field of which selection set
+            // failed, and a decode failure against a live node is hard to place without the trace.
+            throw SuiRpcException("unexpected response shape: ${e.message}", cause = e)
         }
 
     private companion object {
@@ -488,11 +520,14 @@ private fun TransactionEffectsFields.errorMessage(): String =
  * `::coin::USDC` and `::coin::usdc` are genuinely distinct Move types.
  *
  * Returns null for anything that isn't a generic instantiation, which the type filter excludes.
+ *
+ * Internal rather than private so tests that build coins from a raw GraphQL payload normalize
+ * through this exact function instead of a copy that can drift from it.
  */
-private fun unwrapCoinType(repr: String): String? {
+internal fun unwrapCoinType(repr: String): String? {
     val open = repr.indexOf('<')
     val close = repr.lastIndexOf('>')
-    if (open < 0 || close <= open) return null
+    if (open !in 0..<close) return null
     val coinType = repr.substring(open + 1, close)
 
     val addressEnd = coinType.indexOf("::")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.api.chains
 import com.vultisig.wallet.data.api.models.SuiExecutionStatus
 import com.vultisig.wallet.data.api.models.SuiTransactionBlockEffects
 import com.vultisig.wallet.data.api.models.SuiTransactionBlockResponse
+import com.vultisig.wallet.data.crypto.SuiHelper
 import io.ktor.client.HttpClient
 import java.math.BigInteger
 import javax.inject.Inject
@@ -23,7 +24,8 @@ import vultisig.keysign.v1.SuiCoin
 /**
  * Backstop on the coin-object walk in [SuiApi.getAllCoins]: at 50 objects per page this is 5000
  * coin objects, far beyond any real wallet, so reaching it means the connection is misbehaving
- * rather than that someone genuinely holds that many.
+ * rather than that someone genuinely holds that many — which is why exhausting it raises instead of
+ * returning the objects collected so far.
  */
 internal const val SUI_MAX_COIN_PAGES = 100
 
@@ -74,9 +76,13 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
                 )
                 .decode<BalanceResponse>()
 
-        // An address that has never held the coin type resolves to null rather than an error —
-        // that is a genuine zero, not an upstream fault. A malformed address is refused by the node
-        // with a populated `errors` array, which the transport has already raised by this point.
+        // An address that has never held the coin type resolves to a real zero `Balance`, not to
+        // null — checked against mainnet. Null is the node's answer when it has no checkpoint in
+        // scope to read the balance at, and there is nothing to show for that but zero either: it
+        // is an absent reading, not a smaller one, and the alternative is an error banner on an
+        // ordinary wallet screen. A malformed address is a different case entirely — the node
+        // refuses it with a populated `errors` array, which the transport has already raised by
+        // this point.
         val totalBalance = response.address?.balance?.totalBalance ?: return BigInteger.ZERO
 
         // A present-but-unparsable amount is a node contract violation, not an empty wallet, so it
@@ -118,11 +124,19 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
 
             objects.nodes.forEach { node ->
                 val coinType = node.contents?.type?.repr?.let(::unwrapCoinType) ?: return@forEach
+                // The three fields that make up the signed `Sui.ObjectRef` are dropped with the
+                // coin when any is absent, the same way an undescribable coin type is. Defaulting
+                // them would be worse than losing the object: a blank digest is signed into the
+                // bytes every device in the ceremony commits to and is only rejected at broadcast,
+                // and a blank version throws NumberFormatException inside SuiHelper instead.
+                val coinObjectId = node.address ?: return@forEach
+                val version = node.version ?: return@forEach
+                val digest = node.digest ?: return@forEach
                 allCoins.add(
                     SuiCoin(
-                        coinObjectId = node.address.orEmpty(),
-                        version = node.version?.toString().orEmpty(),
-                        digest = node.digest.orEmpty(),
+                        coinObjectId = coinObjectId,
+                        version = version.toString(),
+                        digest = digest,
                         balance = node.contents.json?.balance.orEmpty(),
                         previousTransaction = node.previousTransaction?.digest.orEmpty(),
                         coinType = coinType,
@@ -134,20 +148,25 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
 
             // Termination cannot rest on the node alone: a `hasNextPage` that never flips, or an
             // `endCursor` that never advances, would spin here forever while `allCoins` grows
-            // without bound. Stop on a repeated cursor, and cap the walk at [SUI_MAX_COIN_PAGES].
+            // without bound. Both bounds raise rather than return what was collected — a partial
+            // coin list is not a smaller wallet. Coin selection would read it as one, and the
+            // caller gets an "insufficient balance" rejection with nothing pointing at the walk;
+            // the log that used to carry that detail is compiled out of release builds, where the
+            // only planted Timber tree is the debug one.
             val nextCursor = objects.pageInfo.endCursor.takeIf { objects.pageInfo.hasNextPage }
-            if (
-                nextCursor != null && (nextCursor == cursor || pagesFetched >= SUI_MAX_COIN_PAGES)
-            ) {
-                Timber.w(
-                    "Sui coin pagination stopped after %d pages with more reported; cursor %s",
-                    pagesFetched,
-                    if (nextCursor == cursor) "did not advance" else "budget exhausted",
+            if (nextCursor != null && nextCursor == cursor) {
+                throw SuiRpcException(
+                    "coin pagination stalled: the node reported more pages but returned the same " +
+                        "cursor after $pagesFetched pages"
                 )
-                cursor = null
-            } else {
-                cursor = nextCursor
             }
+            if (nextCursor != null && pagesFetched >= SUI_MAX_COIN_PAGES) {
+                throw SuiRpcException(
+                    "coin pagination exceeded the $SUI_MAX_COIN_PAGES page budget with more pages " +
+                        "still reported after ${allCoins.size} coin objects"
+                )
+            }
+            cursor = nextCursor
         } while (cursor != null)
 
         return allCoins
@@ -382,6 +401,11 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
  * `null` rather than omitting it, and each query selects only part of a shared type (a simulation
  * asks for `gasEffects`, a status poll for `checkpoint`), so no single field is guaranteed present.
  *
+ * The exception is a connection's own `pageInfo`/`nodes`, which the schema declares non-null and
+ * every page of the walk selects. Giving those a default would decode a response missing them as a
+ * complete empty page and silently truncate the coin list; without one the decode fails and
+ * [SuiApiImpl.decode] raises it as the node fault it is.
+ *
  * Numeric fields follow the schema's scalar, not convenience: `BigInt` arrives as a JSON string
  * (and can exceed [Long]), `UInt53` as a JSON number. The injected [Json] is not lenient, so typing
  * one as the other fails to decode.
@@ -401,13 +425,9 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
 @Serializable private data class CoinObjectOwner(val objects: CoinObjectConnection? = null)
 
 @Serializable
-private data class CoinObjectConnection(
-    val pageInfo: PageInfo = PageInfo(),
-    val nodes: List<CoinObjectNode> = emptyList(),
-)
+private data class CoinObjectConnection(val pageInfo: PageInfo, val nodes: List<CoinObjectNode>)
 
-@Serializable
-private data class PageInfo(val hasNextPage: Boolean = false, val endCursor: String? = null)
+@Serializable private data class PageInfo(val hasNextPage: Boolean, val endCursor: String? = null)
 
 @Serializable
 private data class CoinObjectNode(
@@ -506,18 +526,23 @@ private fun TransactionEffectsFields.errorMessage(): String =
  * Two adjustments, both required to keep the transport swap invisible to the rest of the app:
  * 1. The object connection reports the wrapper struct, whereas the app compares against the bare
  *    `T`. A wrapper string would match no known coin and turn every native send into a token send.
- * 2. GraphQL always spells the address zero-padded (`0x000…002::sui::SUI`) where JSON-RPC returned
- *    it stripped (`0x2::sui::SUI`). Comparisons already go through
+ * 2. GraphQL always spells addresses zero-padded (`0x000…002::sui::SUI`) where JSON-RPC returned
+ *    them stripped (`0x2::sui::SUI`). Comparisons already go through
  *    [SuiHelper.isSameSuiCoinType][com.vultisig.wallet.data.crypto.SuiHelper] and tolerate either,
  *    but [SuiTokenFinder][com.vultisig.wallet.data.usecases.SuiTokenFinder] *persists* this exact
  *    string as a discovered token's `contractAddress` — so stripping here keeps a token discovered
  *    after the migration identical to the same token discovered before it, rather than a second
  *    entry that only differs by padding.
  *
+ * The stripping is [SuiHelper.normalizeSuiCoinType][com.vultisig.wallet.data.crypto.SuiHelper]
+ * itself rather than a local copy of it: the two must agree exactly — this function produces the
+ * `contractAddress` that function later compares against — and an inline reimplementation is free
+ * to drift from it, which is how nested generic addresses came to be normalized in one and not the
+ * other. Both leave Move module and struct identifiers case-sensitive, because `::coin::USDC` and
+ * `::coin::usdc` are genuinely distinct Move types.
+ *
  * Verified against a live mainnet address: with this normalization the returned coin types match
- * `suix_getAllCoins` exactly. Only the address is normalized — Move module and struct identifiers
- * stay case-sensitive, matching [SuiHelper][com.vultisig.wallet.data.crypto.SuiHelper], because
- * `::coin::USDC` and `::coin::usdc` are genuinely distinct Move types.
+ * `suix_getAllCoins` exactly.
  *
  * Returns null for anything that isn't a generic instantiation, which the type filter excludes.
  *
@@ -528,12 +553,7 @@ internal fun unwrapCoinType(repr: String): String? {
     val open = repr.indexOf('<')
     val close = repr.lastIndexOf('>')
     if (open !in 0..<close) return null
-    val coinType = repr.substring(open + 1, close)
-
-    val addressEnd = coinType.indexOf("::")
-    if (addressEnd < 0) return coinType
-    val address = coinType.substring(0, addressEnd).lowercase().removePrefix("0x").trimStart('0')
-    return "0x" + address.ifEmpty { "0" } + coinType.substring(addressEnd)
+    return SuiHelper.normalizeSuiCoinType(repr.substring(open + 1, close))
 }
 
 private fun String.toBigIntegerOrNull(): BigInteger? = runCatching { BigInteger(this) }.getOrNull()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -1,28 +1,22 @@
 package com.vultisig.wallet.data.api.chains
 
-import com.vultisig.wallet.data.api.models.EvmRpcResponseJson
-import com.vultisig.wallet.data.api.models.RpcError
-import com.vultisig.wallet.data.api.models.SuiTransactionBlockOptions
+import com.vultisig.wallet.data.api.models.SuiExecutionStatus
+import com.vultisig.wallet.data.api.models.SuiTransactionBlockEffects
 import com.vultisig.wallet.data.api.models.SuiTransactionBlockResponse
-import com.vultisig.wallet.data.api.utils.RpcResponseJson
-import com.vultisig.wallet.data.api.utils.postRpc
 import io.ktor.client.HttpClient
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
-import kotlinx.serialization.json.addJsonArray
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import timber.log.Timber
 import vultisig.keysign.v1.SuiCoin
 
@@ -46,196 +40,468 @@ interface SuiApi {
     suspend fun getLatestCheckpointSequenceNumber(): Long?
 }
 
-internal class SuiApiImpl
-@Inject
-constructor(private val http: HttpClient, private val json: Json) : SuiApi {
+/**
+ * Sui reads, simulation and broadcast over GraphQL RPC.
+ *
+ * Sui is retiring JSON-RPC (full decommission mid-October 2026), so none of the `suix_*`/`sui_*`
+ * methods this used to call will exist. See [SUI_GRAPHQL_ENDPOINTS] for why GraphQL was picked over
+ * gRPC and how failover is configured.
+ *
+ * The public surface is unchanged: every method returns exactly what its JSON-RPC predecessor did,
+ * so call sites, models and the coin-type conventions in
+ * [SuiHelper][com.vultisig.wallet.data.crypto.SuiHelper] are untouched by the transport swap.
+ */
+internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json: Json) : SuiApi {
 
-    private val rpcUrl = "https://sui-rpc.publicnode.com"
+    private val graphQl = SuiGraphQlTransport(http)
 
     override suspend fun getBalance(address: String, contractAddress: String): BigInteger {
         val response =
-            http.postRpc<RpcResponseJson>(
-                url = rpcUrl,
-                method = "suix_getBalance",
-                params =
-                    buildJsonArray {
-                        add(address)
-                        if (contractAddress.isNotEmpty()) add(contractAddress)
+            graphQl
+                .query(
+                    BALANCE_QUERY,
+                    buildJsonObject {
+                        put("owner", address)
+                        put("coinType", contractAddress.ifEmpty { NATIVE_SUI_COIN_TYPE })
                     },
-            )
+                )
+                .decode<BalanceResponse>()
 
-        return response.result?.jsonObject?.get("totalBalance")?.jsonPrimitive?.content?.let {
-            BigInteger(it)
-        } ?: error(response.error.describe("Failed to get sui balance"))
+        // An address that has never held the coin type resolves to null rather than an error —
+        // that is a genuine zero, not an upstream fault. A malformed address is refused by the node
+        // with a populated `errors` array, which the transport has already raised by this point.
+        return response.address?.balance?.totalBalance?.toBigIntegerOrNull() ?: BigInteger.ZERO
     }
 
-    override suspend fun getReferenceGasPrice(): BigInteger {
-        val response =
-            http.postRpc<RpcResponseJson>(
-                url = rpcUrl,
-                method = "suix_getReferenceGasPrice",
-                params = JsonArray(emptyList()),
-            )
-        return response.result?.jsonPrimitive?.content?.let { BigInteger(it) }
-            ?: error(response.error.describe("Failed to fetch sui reference gas price"))
-    }
+    override suspend fun getReferenceGasPrice(): BigInteger =
+        graphQl
+            .query(REFERENCE_GAS_PRICE_QUERY)
+            .decode<EpochResponse>()
+            .epoch
+            ?.referenceGasPrice
+            ?.toBigIntegerOrNull() ?: throw SuiRpcException("failed to fetch reference gas price")
 
     override suspend fun getAllCoins(address: String): List<SuiCoin> {
         val allCoins = mutableListOf<SuiCoin>()
         var cursor: String? = null
 
-        // suix_getAllCoins is paginated (default page ~50 objects). Follow nextCursor/hasNextPage
-        // so a wallet whose objects span multiple pages doesn't return a truncated set — otherwise
-        // a token whose objects all land on a later page is invisible here and a token send gets
-        // silently misclassified as a native SUI transfer. Mirrors iOS SuiService.getAllCoins.
+        // The object connection is paginated. Follow hasNextPage/endCursor so a wallet whose
+        // objects span multiple pages doesn't return a truncated set — otherwise a token whose
+        // objects all land on a later page is invisible here and a token send gets silently
+        // misclassified as a native SUI transfer.
         do {
-            val response =
-                http.postRpc<RpcResponseJson>(
-                    url = rpcUrl,
-                    method = "suix_getAllCoins",
-                    params =
-                        buildJsonArray {
-                            add(address)
-                            cursor?.let { add(it) }
+            val objects =
+                graphQl
+                    .query(
+                        ALL_COINS_QUERY,
+                        buildJsonObject {
+                            put("owner", address)
+                            put("cursor", cursor)
                         },
-                )
-            val result =
-                response.result?.jsonObject
-                    ?: error(response.error.describe("Failed to fetch all coins for sui"))
+                    )
+                    .decode<AllCoinsResponse>()
+                    .address
+                    ?.objects ?: throw SuiRpcException("failed to fetch all coins for sui")
 
-            result["data"]?.jsonArray?.forEach { element ->
-                val obj = element.jsonObject
-                val coinType = obj["coinType"]?.jsonPrimitive?.content ?: return@forEach
+            objects.nodes.forEach { node ->
+                val coinType = node.contents?.type?.repr?.let(::unwrapCoinType) ?: return@forEach
                 allCoins.add(
                     SuiCoin(
-                        coinObjectId = obj["coinObjectId"]?.jsonPrimitive?.content ?: "",
-                        version = obj["version"]?.jsonPrimitive?.content ?: "",
-                        digest = obj["digest"]?.jsonPrimitive?.content ?: "",
-                        balance = obj["balance"]?.jsonPrimitive?.content ?: "",
-                        previousTransaction =
-                            obj["previousTransaction"]?.jsonPrimitive?.content ?: "",
+                        coinObjectId = node.address.orEmpty(),
+                        version = node.version?.toString().orEmpty(),
+                        digest = node.digest.orEmpty(),
+                        balance = node.contents.json?.balance.orEmpty(),
+                        previousTransaction = node.previousTransaction?.digest.orEmpty(),
                         coinType = coinType,
                     )
                 )
             }
 
-            val hasNextPage = result["hasNextPage"]?.jsonPrimitive?.booleanOrNull ?: false
-            cursor = if (hasNextPage) result["nextCursor"]?.jsonPrimitive?.content else null
+            cursor = objects.pageInfo.endCursor.takeIf { objects.pageInfo.hasNextPage }
         } while (cursor != null)
 
         return allCoins
     }
 
     override suspend fun getCoinMetadata(coinType: String): SuiCoinMetadata? {
-        val response =
-            http.postRpc<EvmRpcResponseJson<SuiCoinMetadata>>(
-                url = rpcUrl,
-                method = "suix_getCoinMetadata",
-                params = buildJsonArray { add(coinType) },
-            )
         // A null result is the node's answer for a coin that publishes no metadata object, and is
-        // distinct from an RPC failure — only the latter may abort, so a transient outage is never
-        // read as "this coin has no metadata".
-        val error = response.error
-        if (error != null) error(error.describe("Failed to fetch sui coin metadata"))
-        return response.result
+        // distinct from a node failure — only the latter may abort (already raised by the
+        // transport), so a transient outage is never read as "this coin has no metadata".
+        val metadata =
+            graphQl
+                .query(COIN_METADATA_QUERY, buildJsonObject { put("coinType", coinType) })
+                .decode<CoinMetadataResponse>()
+                .coinMetadata ?: return null
+
+        // decimals and symbol are required: a coin the node cannot describe must be dropped rather
+        // than shown at a guessed magnitude or under a placeholder ticker.
+        val decimals = metadata.decimals ?: return null
+        val symbol = metadata.symbol ?: return null
+        return SuiCoinMetadata(decimals = decimals, symbol = symbol, iconUrl = metadata.iconUrl)
     }
 
     override suspend fun executeTransactionBlock(
         unsignedTransaction: String,
         signature: String,
-    ): String {
-        val response =
-            http.postRpc<RpcResponseJson>(
-                url = rpcUrl,
-                method = "sui_executeTransactionBlock",
-                params =
-                    buildJsonArray {
-                        add(unsignedTransaction)
-                        addJsonArray { add(signature) }
-                    },
+    ): String =
+        graphQl
+            .query(
+                EXECUTE_TRANSACTION_MUTATION,
+                buildJsonObject {
+                    put("txBytes", unsignedTransaction)
+                    put("signatures", buildJsonArray { add(signature) })
+                },
             )
-        return response.result?.jsonObject?.get("digest")?.jsonPrimitive?.content
-            ?: error(response.error.describe("Failed to execute transaction block"))
-    }
+            .decode<ExecuteTransactionResponse>()
+            .executeTransaction
+            ?.effects
+            ?.digest ?: throw SuiRpcException("failed to execute transaction block")
 
     override suspend fun dryRunTransaction(transactionBytes: String): SuiDryRunResponse {
-        val response =
-            http.postRpc<RpcResponseJson>(
-                url = rpcUrl,
-                method = "sui_dryRunTransactionBlock",
-                params = buildJsonArray { add(JsonPrimitive(transactionBytes)) },
-            )
+        // `simulateTransaction` takes a JSON-encoded `sui.rpc.v2.Transaction`, whose `bcs` field
+        // carries the same base64 BCS bytes the JSON-RPC dry run accepted directly. Gas selection
+        // stays off because the caller already built a complete gas payment — letting the node
+        // re-pick it would estimate a different transaction than the one that gets signed.
+        val effects =
+            graphQl
+                .query(
+                    SIMULATE_TRANSACTION_QUERY,
+                    buildJsonObject {
+                        putJsonObject("tx") {
+                            putJsonObject("bcs") { put("value", transactionBytes) }
+                        }
+                    },
+                )
+                .decode<SimulateTransactionResponse>()
+                .simulateTransaction
+                ?.effects ?: throw SuiRpcException("failed to dry run transaction")
 
-        val dryRunResponse =
-            response.result?.let { json.decodeFromJsonElement<SuiDryRunResponse>(it) }
-                ?: error(response.error.describe("Failed to dry run transaction"))
-
-        if (dryRunResponse.effects.status.error.isNotEmpty()) {
-            throw Exception("Simulation Error: ${dryRunResponse.effects.status.error}")
+        val error = effects.errorMessage()
+        if (error.isNotEmpty()) {
+            throw Exception("Simulation Error: $error")
         }
 
-        return dryRunResponse
+        val gasSummary =
+            effects.gasEffects?.gasSummary
+                ?: throw SuiRpcException("dry run returned no gas summary")
+
+        return SuiDryRunResponse(
+            effects =
+                SuiTransactionEffects(
+                    status = SuiEffectStatus(status = effects.normalizedStatus(), error = error),
+                    gasUsed =
+                        SuiEffectGasUsed(
+                            computationCost = gasSummary.computationCost.toString(),
+                            storageCost = gasSummary.storageCost.toString(),
+                            storageRebate = gasSummary.storageRebate.toString(),
+                        ),
+                )
+        )
     }
 
     override suspend fun checkStatus(txHash: String): SuiTransactionBlockResponse? {
-        val response =
-            http.postRpc<EvmRpcResponseJson<SuiTransactionBlockResponse>>(
-                url = rpcUrl,
-                method = "sui_getTransactionBlock",
-                params =
-                    buildJsonArray {
-                        add(txHash)
-                        add(json.encodeToJsonElement(SuiTransactionBlockOptions()))
-                    },
-            )
-        val error = response.error
-        if (error != null) {
-            // The node returns Invalid Params (-32602) when the digest hasn't landed yet — a
-            // genuine not-found, safe to keep polling. Any other code is a terminal RPC failure
-            // (rate limit, malformed digest, indexer outage) and must surface immediately instead
-            // of being masked as the same retryable outcome.
-            if (error.code == SUI_TX_NOT_FOUND_RPC_CODE) {
-                Timber.d("checkStatus not found: %s", error.message)
-                return null
-            }
-            throw SuiRpcException(error)
-        }
-        return response.result
+        // A node refusal arrives as a populated `errors` array and is raised by the transport as a
+        // SuiRpcException, letting SuiStatusProvider report a persistent failure immediately. A
+        // digest that simply hasn't landed yet resolves to a null transaction with no errors — a
+        // genuine not-found, safe to keep polling.
+        val transaction =
+            graphQl
+                .query(TRANSACTION_QUERY, buildJsonObject { put("digest", txHash) })
+                .decode<TransactionResponse>()
+                .transaction ?: return null
+
+        val digest = transaction.digest ?: txHash
+
+        return SuiTransactionBlockResponse(
+            digest = digest,
+            checkpoint = transaction.effects?.checkpoint?.sequenceNumber,
+            effects =
+                transaction.effects?.let { effects ->
+                    SuiTransactionBlockEffects(
+                        status =
+                            SuiExecutionStatus(
+                                status = effects.normalizedStatus(),
+                                error = effects.errorMessage().ifEmpty { null },
+                            ),
+                        transactionDigest = digest,
+                    )
+                },
+        )
     }
 
-    override suspend fun getLatestCheckpointSequenceNumber(): Long? {
-        val response =
-            http.postRpc<EvmRpcResponseJson<String>>(
-                url = rpcUrl,
-                method = "sui_getLatestCheckpointSequenceNumber",
-                params = JsonArray(emptyList()),
-            )
-        if (response.result == null) {
-            Timber.d("getLatestCheckpointSequenceNumber error: ${response.error?.message}")
-            return null
+    override suspend fun getLatestCheckpointSequenceNumber(): Long? =
+        try {
+            graphQl
+                .query(LATEST_CHECKPOINT_QUERY)
+                .decode<CheckpointResponse>()
+                .checkpoint
+                ?.sequenceNumber
+        } catch (e: SuiRpcException) {
+            Timber.d("getLatestCheckpointSequenceNumber error: %s", e.errorMessage)
+            null
         }
-        return response.result.toLongOrNull()
-    }
+
+    /**
+     * Decodes a GraphQL `data` object into [T].
+     *
+     * A shape the selection set cannot describe is a node contract violation, not an empty result,
+     * so it is raised as a [SuiRpcException] rather than surfacing as a silent zero balance or an
+     * empty coin list.
+     */
+    private inline fun <reified T> JsonObject.decode(): T =
+        try {
+            json.decodeFromJsonElement<T>(this)
+        } catch (e: SerializationException) {
+            throw SuiRpcException("unexpected response shape: ${e.message}")
+        }
 
     private companion object {
-        // Verified against iOS's SuiTransactionStatusProvider: Sui's full node returns this
-        // JSON-RPC "Invalid params" code, not a dedicated one, when a digest hasn't landed yet.
-        const val SUI_TX_NOT_FOUND_RPC_CODE = -32602
+        const val NATIVE_SUI_COIN_TYPE = "0x2::sui::SUI"
+
+        /** Page size for the coin-object connection, matching the old JSON-RPC default. */
+        const val COIN_PAGE_SIZE = 50
+
+        val BALANCE_QUERY =
+            """
+            query getBalance(${'$'}owner: SuiAddress!, ${'$'}coinType: String!) {
+              address(address: ${'$'}owner) {
+                balance(coinType: ${'$'}coinType) { totalBalance }
+              }
+            }
+            """
+                .trimIndent()
+
+        val REFERENCE_GAS_PRICE_QUERY = "query { epoch { referenceGasPrice } }"
+
+        val ALL_COINS_QUERY =
+            """
+            query getAllCoins(${'$'}owner: SuiAddress!, ${'$'}cursor: String) {
+              address(address: ${'$'}owner) {
+                objects(first: $COIN_PAGE_SIZE, after: ${'$'}cursor, filter: { type: "0x2::coin::Coin" }) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    address
+                    version
+                    digest
+                    previousTransaction { digest }
+                    contents { type { repr } json }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+
+        val COIN_METADATA_QUERY =
+            """
+            query getCoinMetadata(${'$'}coinType: String!) {
+              coinMetadata(coinType: ${'$'}coinType) { decimals symbol iconUrl }
+            }
+            """
+                .trimIndent()
+
+        val EXECUTE_TRANSACTION_MUTATION =
+            """
+            mutation executeTransaction(${'$'}txBytes: Base64!, ${'$'}signatures: [Base64!]!) {
+              executeTransaction(transactionDataBcs: ${'$'}txBytes, signatures: ${'$'}signatures) {
+                effects { digest }
+              }
+            }
+            """
+                .trimIndent()
+
+        val SIMULATE_TRANSACTION_QUERY =
+            """
+            query simulateTransaction(${'$'}tx: JSON!) {
+              simulateTransaction(transaction: ${'$'}tx, checksEnabled: true, doGasSelection: false) {
+                effects {
+                  status
+                  executionError { message abortCode identifier }
+                  gasEffects { gasSummary { computationCost storageCost storageRebate } }
+                }
+              }
+            }
+            """
+                .trimIndent()
+
+        val TRANSACTION_QUERY =
+            """
+            query getTransaction(${'$'}digest: String!) {
+              transaction(digest: ${'$'}digest) {
+                digest
+                effects {
+                  status
+                  executionError { message abortCode identifier }
+                  checkpoint { sequenceNumber }
+                }
+              }
+            }
+            """
+                .trimIndent()
+
+        val LATEST_CHECKPOINT_QUERY = "query { checkpoint { sequenceNumber } }"
     }
 }
 
-/** Appends the JSON-RPC error's message and code to [fallback] when present. */
-private fun RpcError?.describe(fallback: String): String =
-    if (this == null) fallback else "$fallback: $message (code $code)"
+/**
+ * The GraphQL selection sets above, as types.
+ *
+ * Every field is nullable with a null default: GraphQL resolves an absent or unreachable branch to
+ * `null` rather than omitting it, and each query selects only part of a shared type (a simulation
+ * asks for `gasEffects`, a status poll for `checkpoint`), so no single field is guaranteed present.
+ *
+ * Numeric fields follow the schema's scalar, not convenience: `BigInt` arrives as a JSON string
+ * (and can exceed [Long]), `UInt53` as a JSON number. The injected [Json] is not lenient, so typing
+ * one as the other fails to decode.
+ */
+@Serializable private data class BalanceResponse(val address: BalanceAddress? = null)
+
+@Serializable private data class BalanceAddress(val balance: BalanceAmount? = null)
+
+@Serializable private data class BalanceAmount(val totalBalance: String? = null)
+
+@Serializable private data class EpochResponse(val epoch: EpochData? = null)
+
+@Serializable private data class EpochData(val referenceGasPrice: String? = null)
+
+@Serializable private data class AllCoinsResponse(val address: CoinObjectOwner? = null)
+
+@Serializable private data class CoinObjectOwner(val objects: CoinObjectConnection? = null)
+
+@Serializable
+private data class CoinObjectConnection(
+    val pageInfo: PageInfo = PageInfo(),
+    val nodes: List<CoinObjectNode> = emptyList(),
+)
+
+@Serializable
+private data class PageInfo(val hasNextPage: Boolean = false, val endCursor: String? = null)
+
+@Serializable
+private data class CoinObjectNode(
+    val address: String? = null,
+    val version: Long? = null,
+    val digest: String? = null,
+    val previousTransaction: DigestRef? = null,
+    val contents: MoveObjectContents? = null,
+)
+
+@Serializable private data class DigestRef(val digest: String? = null)
+
+@Serializable
+private data class MoveObjectContents(val type: MoveTypeRef? = null, val json: CoinFields? = null)
+
+@Serializable private data class MoveTypeRef(val repr: String? = null)
+
+@Serializable private data class CoinFields(val balance: String? = null)
+
+@Serializable private data class CoinMetadataResponse(val coinMetadata: CoinMetadataFields? = null)
+
+@Serializable
+private data class CoinMetadataFields(
+    val decimals: Int? = null,
+    val symbol: String? = null,
+    val iconUrl: String? = null,
+)
+
+@Serializable
+private data class ExecuteTransactionResponse(val executeTransaction: ExecutionResult? = null)
+
+@Serializable private data class ExecutionResult(val effects: TransactionEffectsFields? = null)
+
+@Serializable
+private data class SimulateTransactionResponse(val simulateTransaction: SimulationResult? = null)
+
+@Serializable private data class SimulationResult(val effects: TransactionEffectsFields? = null)
+
+@Serializable private data class TransactionResponse(val transaction: TransactionFields? = null)
+
+@Serializable
+private data class TransactionFields(
+    val digest: String? = null,
+    val effects: TransactionEffectsFields? = null,
+)
+
+/** Shared across the execute, simulate and status selections; each asks for a subset. */
+@Serializable
+private data class TransactionEffectsFields(
+    val digest: String? = null,
+    val status: String? = null,
+    val executionError: ExecutionError? = null,
+    val checkpoint: CheckpointRef? = null,
+    val gasEffects: GasEffects? = null,
+)
+
+@Serializable
+private data class ExecutionError(
+    val message: String? = null,
+    val abortCode: String? = null,
+    val identifier: String? = null,
+)
+
+@Serializable private data class CheckpointRef(val sequenceNumber: Long? = null)
+
+@Serializable private data class GasEffects(val gasSummary: GasSummary? = null)
+
+@Serializable
+private data class GasSummary(
+    val computationCost: Long = 0,
+    val storageCost: Long = 0,
+    val storageRebate: Long = 0,
+)
+
+@Serializable private data class CheckpointResponse(val checkpoint: CheckpointRef? = null)
 
 /**
- * A terminal Sui JSON-RPC error surfaced by [SuiApi.checkStatus] — any [RpcError] other than the
- * not-found code. Lets [SuiStatusProvider][com.vultisig.wallet.data.api.txstatus.SuiStatusProvider]
- * report a persistent RPC failure immediately instead of masking it as a retryable pending poll.
+ * The execution status in the lowercase spelling the app's models expect.
+ *
+ * GraphQL reports the enum as `SUCCESS`/`FAILURE`, while
+ * [SuiStatusProvider][com.vultisig.wallet.data.api.txstatus.SuiStatusProvider] and the effect
+ * models match on the lowercase JSON-RPC spelling — so it is lowercased here rather than at each
+ * comparison, where a missed site would silently report a confirmed transaction as pending.
  */
-internal class SuiRpcException(val rpcError: RpcError) :
-    Exception("Sui RPC error ${rpcError.code}: ${rpcError.message}")
+private fun TransactionEffectsFields.normalizedStatus(): String = status.orEmpty().lowercase()
+
+/** The execution failure reason, or an empty string when the transaction did not abort. */
+private fun TransactionEffectsFields.errorMessage(): String =
+    executionError?.let {
+        it.message ?: it.identifier ?: it.abortCode?.let { code -> "aborted with code $code" }
+    } ?: ""
+
+/**
+ * The coin type a `0x2::coin::Coin<T>` object holds, in the same spelling JSON-RPC returned.
+ *
+ * Two adjustments, both required to keep the transport swap invisible to the rest of the app:
+ * 1. The object connection reports the wrapper struct, whereas the app compares against the bare
+ *    `T`. A wrapper string would match no known coin and turn every native send into a token send.
+ * 2. GraphQL always spells the address zero-padded (`0x000…002::sui::SUI`) where JSON-RPC returned
+ *    it stripped (`0x2::sui::SUI`). Comparisons already go through
+ *    [SuiHelper.isSameSuiCoinType][com.vultisig.wallet.data.crypto.SuiHelper] and tolerate either,
+ *    but [SuiTokenFinder][com.vultisig.wallet.data.usecases.SuiTokenFinder] *persists* this exact
+ *    string as a discovered token's `contractAddress` — so stripping here keeps a token discovered
+ *    after the migration identical to the same token discovered before it, rather than a second
+ *    entry that only differs by padding.
+ *
+ * Verified against a live mainnet address: with this normalization the returned coin types match
+ * `suix_getAllCoins` exactly. Only the address is normalized — Move module and struct identifiers
+ * stay case-sensitive, matching [SuiHelper][com.vultisig.wallet.data.crypto.SuiHelper], because
+ * `::coin::USDC` and `::coin::usdc` are genuinely distinct Move types.
+ *
+ * Returns null for anything that isn't a generic instantiation, which the type filter excludes.
+ */
+private fun unwrapCoinType(repr: String): String? {
+    val open = repr.indexOf('<')
+    val close = repr.lastIndexOf('>')
+    if (open < 0 || close <= open) return null
+    val coinType = repr.substring(open + 1, close)
+
+    val addressEnd = coinType.indexOf("::")
+    if (addressEnd < 0) return coinType
+    val address = coinType.substring(0, addressEnd).lowercase().removePrefix("0x").trimStart('0')
+    return "0x" + address.ifEmpty { "0" } + coinType.substring(addressEnd)
+}
+
+private fun String.toBigIntegerOrNull(): BigInteger? = runCatching { BigInteger(this) }.getOrNull()
 
 /**
  * A Sui coin's on-chain `CoinMetadata` object. [decimals] and [symbol] are required: a coin the

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api.chains
 
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
@@ -62,10 +63,15 @@ private const val UNKNOWN_GRAPHQL_ERROR = "unknown error"
  * catches the subtype specifically so a persistent node failure is reported immediately instead of
  * being masked as a retryable pending poll.
  */
-internal class SuiRpcException(val errorMessage: String, val code: String? = null) :
+internal class SuiRpcException(
+    val errorMessage: String,
+    val code: String? = null,
+    cause: Throwable? = null,
+) :
     IllegalStateException(
         if (code == null) "Sui GraphQL error: $errorMessage"
-        else "Sui GraphQL error ($code): $errorMessage"
+        else "Sui GraphQL error ($code): $errorMessage",
+        cause,
     )
 
 /**
@@ -74,7 +80,7 @@ internal class SuiRpcException(val errorMessage: String, val code: String? = nul
  * Failover covers transport-level faults only — an unreachable host, a TLS failure, a 5xx. A
  * populated `errors` array is the node's considered answer to a well-formed request, so it is
  * raised immediately rather than replayed against every remaining host, which would only delay the
- * same message.
+ * same message. A 4xx is deterministic for the same reason and is raised the same way.
  *
  * Retrying a broadcast across hosts is safe: Sui identifies a transaction by the digest of its
  * signed bytes, so re-submitting identical bytes is idempotent — the node returns the existing
@@ -104,6 +110,15 @@ internal class SuiGraphQlTransport(
                         .bodyOrThrow<SuiGraphQlResponse>()
                 } catch (e: CancellationException) {
                     throw e
+                } catch (e: NetworkException) {
+                    // A 4xx is the node's deterministic verdict on these exact bytes — a malformed
+                    // document or a rejected header reads the same on every host, so replaying it
+                    // only delays the identical failure. Client-side transport faults (DNS, TLS,
+                    // timeout) arrive as status 0 and do fail over, as do 5xx.
+                    if (e.httpStatusCode in CLIENT_ERROR_STATUS_RANGE) throw e
+                    Timber.w(e, "Sui GraphQL endpoint %s failed, trying the next", endpoint)
+                    lastTransportFailure = e
+                    continue
                 } catch (e: Exception) {
                     Timber.w(e, "Sui GraphQL endpoint %s failed, trying the next", endpoint)
                     lastTransportFailure = e
@@ -125,5 +140,9 @@ internal class SuiGraphQlTransport(
         }
 
         throw lastTransportFailure ?: SuiRpcException("no Sui GraphQL endpoint configured")
+    }
+
+    private companion object {
+        val CLIENT_ERROR_STATUS_RANGE = 400..499
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
@@ -57,10 +57,14 @@ private const val UNKNOWN_GRAPHQL_ERROR = "unknown error"
  * A Sui GraphQL application error — the node parsed the request and refused it (bad address,
  * undecodable transaction, indexer outage).
  *
- * Extends [IllegalStateException] because the JSON-RPC implementation this replaces reported the
- * same conditions through `error(...)`; callers that already catch [IllegalStateException] keep
- * working unchanged. [SuiStatusProvider][com.vultisig.wallet.data.api.txstatus.SuiStatusProvider]
- * catches the subtype specifically so a persistent node failure is reported immediately instead of
+ * Extends [IllegalStateException] because that is what the JSON-RPC implementation this replaces
+ * threw for these conditions: every read and broadcast reported a node refusal through
+ * `error(...)`, so callers that already catch [IllegalStateException] keep working unchanged.
+ *
+ * The one path that did not was `checkStatus`, whose terminal errors went through a class of this
+ * same name extending plain [Exception]. That is unaffected by the widening —
+ * [SuiStatusProvider][com.vultisig.wallet.data.api.txstatus.SuiStatusProvider] catches this type by
+ * name, not by supertype, so a persistent node failure is still reported immediately instead of
  * being masked as a retryable pending poll.
  */
 internal class SuiRpcException(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQl.kt
@@ -1,0 +1,129 @@
+package com.vultisig.wallet.data.api.chains
+
+import com.vultisig.wallet.data.utils.bodyOrThrow
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import timber.log.Timber
+
+/**
+ * Sui GraphQL RPC endpoints, tried in order.
+ *
+ * Sui is retiring JSON-RPC — shutdown on Foundation mainnet full nodes began the week of 2026-07-27
+ * and code removal lands mid-October 2026 — so every Sui read, simulation and broadcast goes
+ * through GraphQL RPC instead. GraphQL was chosen over the other supported replacement, gRPC,
+ * because it is a plain JSON POST that the existing Ktor client already speaks; gRPC would pull a
+ * grpc-okhttp/protoc-gen-grpc stack into a module whose protobuf plugin only generates
+ * kotlinx-serialization classes today.
+ *
+ * Only the Foundation host is listed: it is the one public Sui GraphQL endpoint that answers. The
+ * Vultisig proxy (`api.vultisig.com/sui`) is deliberately absent — it still speaks JSON-RPC, so it
+ * is subject to the same decommission and cannot serve as a fallback until its backend moves too.
+ * Adding a second host once one exists is a one-line change here; [SuiGraphQlTransport] already
+ * walks the whole list.
+ */
+internal val SUI_GRAPHQL_ENDPOINTS = listOf("https://graphql.mainnet.sui.io/graphql")
+
+/** The GraphQL request envelope: a query document plus its variables. */
+@Serializable
+internal data class SuiGraphQlRequest(
+    @SerialName("query") val query: String,
+    @SerialName("variables") val variables: JsonObject,
+)
+
+@Serializable
+internal data class SuiGraphQlResponse(
+    @SerialName("data") val data: JsonObject? = null,
+    @SerialName("errors") val errors: List<SuiGraphQlError>? = null,
+)
+
+@Serializable
+internal data class SuiGraphQlError(
+    @SerialName("message") val message: String = UNKNOWN_GRAPHQL_ERROR,
+    @SerialName("extensions") val extensions: SuiGraphQlErrorExtensions? = null,
+)
+
+@Serializable
+internal data class SuiGraphQlErrorExtensions(@SerialName("code") val code: String? = null)
+
+private const val UNKNOWN_GRAPHQL_ERROR = "unknown error"
+
+/**
+ * A Sui GraphQL application error — the node parsed the request and refused it (bad address,
+ * undecodable transaction, indexer outage).
+ *
+ * Extends [IllegalStateException] because the JSON-RPC implementation this replaces reported the
+ * same conditions through `error(...)`; callers that already catch [IllegalStateException] keep
+ * working unchanged. [SuiStatusProvider][com.vultisig.wallet.data.api.txstatus.SuiStatusProvider]
+ * catches the subtype specifically so a persistent node failure is reported immediately instead of
+ * being masked as a retryable pending poll.
+ */
+internal class SuiRpcException(val errorMessage: String, val code: String? = null) :
+    IllegalStateException(
+        if (code == null) "Sui GraphQL error: $errorMessage"
+        else "Sui GraphQL error ($code): $errorMessage"
+    )
+
+/**
+ * Posts GraphQL documents to Sui, failing over across [endpoints].
+ *
+ * Failover covers transport-level faults only — an unreachable host, a TLS failure, a 5xx. A
+ * populated `errors` array is the node's considered answer to a well-formed request, so it is
+ * raised immediately rather than replayed against every remaining host, which would only delay the
+ * same message.
+ *
+ * Retrying a broadcast across hosts is safe: Sui identifies a transaction by the digest of its
+ * signed bytes, so re-submitting identical bytes is idempotent — the node returns the existing
+ * effects rather than executing twice. That makes failover most valuable exactly where it is
+ * riskiest elsewhere: a broadcast whose response was lost in transit still lands.
+ */
+internal class SuiGraphQlTransport(
+    private val http: HttpClient,
+    private val endpoints: List<String> = SUI_GRAPHQL_ENDPOINTS,
+) {
+    init {
+        require(endpoints.isNotEmpty()) { "SuiGraphQlTransport requires at least one endpoint" }
+    }
+
+    /** Runs [document] and returns its `data` object, or throws [SuiRpcException] on refusal. */
+    suspend fun query(
+        document: String,
+        variables: JsonObject = JsonObject(emptyMap()),
+    ): JsonObject {
+        var lastTransportFailure: Exception? = null
+
+        for (endpoint in endpoints) {
+            val response =
+                try {
+                    http
+                        .post(endpoint) { setBody(SuiGraphQlRequest(document, variables)) }
+                        .bodyOrThrow<SuiGraphQlResponse>()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Sui GraphQL endpoint %s failed, trying the next", endpoint)
+                    lastTransportFailure = e
+                    continue
+                }
+
+            val errors = response.errors
+            if (!errors.isNullOrEmpty()) {
+                throw SuiRpcException(
+                    errorMessage = errors.joinToString("; ") { it.message },
+                    code = errors.firstNotNullOfOrNull { it.extensions?.code },
+                )
+            }
+
+            // GraphQL answers HTTP 200 even when it refuses the request, so an absent `data` with
+            // an absent `errors` is a malformed upstream response — never an empty result.
+            return response.data
+                ?: throw SuiRpcException("returned neither data nor errors (malformed response)")
+        }
+
+        throw lastTransportFailure ?: SuiRpcException("no Sui GraphQL endpoint configured")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SuiJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SuiJson.kt
@@ -4,37 +4,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SuiTransactionBlockOptions(
-    val showInput: Boolean = false,
-    val showRawInput: Boolean = false,
-    val showEffects: Boolean = true,
-    val showEvents: Boolean = false,
-    val showObjectChanges: Boolean = false,
-    val showBalanceChanges: Boolean = false,
-)
-
-@Serializable
 data class SuiTransactionBlockResponse(
     val digest: String,
     val checkpoint: Long? = null,
-    val timestampMs: String? = null,
     val effects: SuiTransactionBlockEffects? = null,
-    val errors: List<String>? = null,
 )
 
 @Serializable
 data class SuiTransactionBlockEffects(
     @SerialName("status") val status: SuiExecutionStatus? = null,
-    val gasUsed: SuiGasData? = null,
     val transactionDigest: String? = null,
 )
 
 @Serializable data class SuiExecutionStatus(val status: String, val error: String? = null)
-
-@Serializable
-data class SuiGasData(
-    val computationCost: String? = null,
-    val storageCost: String? = null,
-    val storageRebate: String? = null,
-    val nonRefundableStorageFee: String? = null,
-)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProvider.kt
@@ -19,10 +19,10 @@ class SuiStatusProvider @Inject constructor(private val suiApi: SuiApi) :
             } catch (e: CancellationException) {
                 throw e
             } catch (e: SuiRpcException) {
-                // A terminal RPC error (any code other than not-found) — report it now instead of
-                // retrying until the poll timeout masks a persistent failure as still pending.
+                // A node refusal, as opposed to a digest that simply hasn't landed — report it now
+                // instead of retrying until the poll timeout masks a persistent failure as pending.
                 Timber.w(e, "Sui status check failed for %s", txHash)
-                return TransactionResult.Failed(e.rpcError.message)
+                return TransactionResult.Failed(e.errorMessage)
             } catch (e: Exception) {
                 Timber.w(e, "Sui status check failed for %s", txHash)
                 return TransactionResult.Pending

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SwapKitSuiSigner.kt
@@ -30,8 +30,8 @@ internal class SwapKitSuiSignerException(message: String) : Exception(message)
  * bytes and hash with Blake2b-32 (Bouncy Castle, identical to WalletCore's `Hash.blake2b(_, 32)` —
  * keeps the digest path JNI-free and unit-testable). The submit-format envelope is `[flag=0x00
  * ed25519, sig (64 bytes), pubkey (32 bytes)]`, base64-encoded — this is the `signatures[0]`
- * argument to `sui_executeTransactionBlock`; the `tx_bytes` argument is the same base64 PTB SwapKit
- * handed us, passed verbatim ([SignedTransactionResult.rawTransaction]).
+ * argument to the GraphQL `executeTransaction` mutation; its `transactionDataBcs` argument is the
+ * same base64 PTB SwapKit handed us, passed verbatim ([SignedTransactionResult.rawTransaction]).
  */
 internal class SwapKitSuiSigner(private val vaultHexPublicKey: String) {
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SuiHelper.kt
@@ -33,17 +33,35 @@ object SuiHelper {
      * stripped, lowercased); Move module and struct identifiers stay case-sensitive because
      * `::coin::USDC` and `::coin::usdc` are genuinely distinct Move types.
      *
+     * Every address in the type is normalized, not just the leading one. A coin type may itself be
+     * a generic instantiation (`…::spot_dex::LP<0x2::sui::SUI, …::coin::COIN>`), and Sui GraphQL
+     * zero-pads the nested addresses too, where JSON-RPC spelled all of them short. Normalizing
+     * only the head would leave the same LP token comparing unequal to the `contractAddress` a
+     * pre-migration node produced, and a token send then fails the coin-object check in
+     * [getPreSignedInputData]. Whitespace is dropped for the same reason: a `, ` separator between
+     * type arguments is one node's spelling of the `,` another returns.
+     *
      * Mirrors the SDK `normalizeSuiCoinType` (vultisig-sdk#1275), which is likewise case-sensitive
      * on the module/struct segments. This deliberately diverges from iOS `SuiCoinType.normalize`,
      * which lowercases the entire coin type and so compares module/struct case-insensitively —
      * matching iOS here would collapse those distinct Move types, which we do not want.
      */
     internal fun normalizeSuiCoinType(coinType: String): String {
-        val addressEnd = coinType.indexOf("::")
-        if (addressEnd < 0) return normalizeSuiAddress(coinType)
-        return normalizeSuiAddress(coinType.substring(0, addressEnd)) +
-            coinType.substring(addressEnd)
+        val compact = coinType.filterNot(Char::isWhitespace)
+        if (!compact.contains("::")) return normalizeSuiAddress(compact)
+        // Each run between the generic delimiters is one qualified type. A run with no `::` is a
+        // primitive type argument (`u64`, `vector`, `bool`) and carries no address to normalize.
+        return TYPE_ARGUMENT.replace(compact) { match ->
+            val segment = match.value
+            val addressEnd = segment.indexOf("::")
+            if (addressEnd < 0) segment
+            else
+                normalizeSuiAddress(segment.substring(0, addressEnd)) +
+                    segment.substring(addressEnd)
+        }
     }
+
+    private val TYPE_ARGUMENT = Regex("[^<>,]+")
 
     internal fun isSameSuiCoinType(lhs: String, rhs: String): Boolean =
         normalizeSuiCoinType(lhs) == normalizeSuiCoinType(rhs)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTokenUseCase.kt
@@ -86,9 +86,9 @@ constructor(
 
     /**
      * Struct-tag shape check for a Sui coin type (`address::module::struct`) — the on-chain
-     * `suix_getCoinMetadata` call rejects anything malformed, so this only screens obviously wrong
-     * input before spending a network round-trip. The native SUI type is excluded: it's already on
-     * the vault by default, never a "custom" token to add.
+     * coin-metadata lookup rejects anything malformed, so this only screens obviously wrong input
+     * before spending a network round-trip. The native SUI type is excluded: it's already on the
+     * vault by default, never a "custom" token to add.
      */
     private fun String.isSuiCoinTypeShape(): Boolean {
         val segments = split("::")

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
@@ -28,12 +28,13 @@ import timber.log.Timber
  * adds every discovered Sui coin to the vault unprompted, behind a spam heuristic Android has no
  * equivalent of.
  *
- * Unlike iOS, which walks `suix_getOwnedObjects` and fetches each object individually, this reads
- * the already-paginated `suix_getAllCoins`: it returns coin objects only (no NFTs), so nothing is
- * lost to a first-page cutoff. Held types the curated [Coins] catalog already lists resolve to the
- * catalog entry, which carries the hand-verified ticker, logo and `priceProviderID`; the rest are
- * described by their on-chain `CoinMetadata`, and are dropped when that metadata is missing or
- * unusable rather than shown under a placeholder ticker at a guessed magnitude.
+ * Unlike iOS, which walks the owned-object list and fetches each object individually, this reads
+ * the paginated coin-object connection via [SuiApi.getAllCoins]: it is filtered to
+ * `0x2::coin::Coin` (no NFTs) and followed to the last page, so nothing is lost to a first-page
+ * cutoff. Held types the curated [Coins] catalog already lists resolve to the catalog entry, which
+ * carries the hand-verified ticker, logo and `priceProviderID`; the rest are described by their
+ * on-chain `CoinMetadata`, and are dropped when that metadata is missing or unusable rather than
+ * shown under a placeholder ticker at a guessed magnitude.
  *
  * Network failures are logged and yield an empty list, matching the sibling finders: a transient
  * blip must not wipe tokens the vault already holds, and the next refresh retries.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
@@ -47,8 +47,9 @@ class SuiApiTest {
         assertEquals(BigInteger.valueOf(42), api.getBalance("0xabc", ""))
     }
 
-    // A valid address that has never held the coin type resolves to null, which is a genuine zero.
-    // Reading it as a failure would surface an error banner for an ordinary empty balance.
+    // A null balance is the node reading with no checkpoint in scope — an absent reading, not a
+    // failed one. (A coin type the address has never held comes back as a real zero instead.)
+    // Raising here would surface an error banner in place of an ordinary empty balance.
     @Test
     fun `getBalance reads a null balance as zero, not an error`() = runTest {
         val api = api("""{"data":{"address":{"balance":null}}}""")
@@ -216,9 +217,10 @@ class SuiApiTest {
 
     // Termination must not rest on the node alone. A connection that keeps reporting hasNextPage
     // while handing back the same cursor would otherwise loop forever, growing the coin list until
-    // the process dies.
+    // the process dies. Ending the walk quietly is not enough either: the coins collected so far
+    // are not the wallet, and coin selection has no way to tell the difference.
     @Test
-    fun `getAllCoins stops when the endCursor does not advance`() = runTest {
+    fun `getAllCoins raises when the endCursor does not advance`() = runTest {
         // respondingWithSequence pins the last entry, so this page repeats indefinitely.
         val client =
             MockHttpClient.respondingWithSequence(
@@ -226,23 +228,114 @@ class SuiApiTest {
                     coinsPage(hasNextPage = true, objectId = "0xcoin1", endCursor = "stuck")
             )
 
-        val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
-
-        // Page one is kept, page two repeats the cursor and ends the walk.
-        assertEquals(2, coins.size)
+        val e = assertFailsWith<SuiRpcException> { SuiApiImpl(client, json).getAllCoins("0xabc") }
+        assertTrue(e.errorMessage.contains("stalled"), e.errorMessage)
     }
 
-    // A node that advances the cursor forever is bounded by the page budget rather than by trust.
+    // A node that advances the cursor forever is bounded by the page budget rather than by trust,
+    // and exhausting that budget is reported rather than absorbed — 5000 coin objects is a
+    // misbehaving connection, and a send built from a truncated list fails as a bogus
+    // "insufficient balance" with nothing naming the real cause.
     @Test
-    fun `getAllCoins stops at the page budget when the cursor keeps advancing`() = runTest {
+    fun `getAllCoins raises at the page budget when the cursor keeps advancing`() = runTest {
         val client =
             MockHttpClient.respondingWithGenerated { page ->
                 coinsPage(hasNextPage = true, objectId = "0xcoin$page", endCursor = "cursor-$page")
             }
 
-        val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
+        val e = assertFailsWith<SuiRpcException> { SuiApiImpl(client, json).getAllCoins("0xabc") }
+        assertTrue(e.errorMessage.contains("$SUI_MAX_COIN_PAGES page budget"), e.errorMessage)
+    }
 
-        assertEquals(SUI_MAX_COIN_PAGES, coins.size)
+    // The coin type of an LP or wrapper token is itself a generic instantiation, and GraphQL
+    // zero-pads its nested addresses too. Normalizing only the outermost one leaves the same token
+    // spelled differently than the pre-migration node spelled it, and the stored contractAddress
+    // then matches no coin object — which blocks that token's send outright.
+    @Test
+    fun `getAllCoins strips the zero padding from nested generic coin types`() = runTest {
+        val paddedTwoB = PADDED_TWO.dropLast(2) + "2b"
+        val nested =
+            "$PADDED_TWO::coin::Coin<$PADDED_TWO::spot_dex::LP<$PADDED_TWO::sui::SUI," +
+                "$paddedTwoB::coin::COIN>>"
+        val api = api(coinsPage(hasNextPage = false, repr = nested))
+
+        assertEquals(
+            "0x2::spot_dex::LP<0x2::sui::SUI,0x2b::coin::COIN>",
+            api.getAllCoins("0xabc").single().coinType,
+        )
+    }
+
+    // A primitive type argument carries no address, so it must survive normalization untouched —
+    // treating `u64` as an address would rewrite it into a type that names nothing.
+    @Test
+    fun `getAllCoins leaves primitive type arguments alone`() = runTest {
+        val api =
+            api(
+                coinsPage(
+                    hasNextPage = false,
+                    repr = "$PADDED_TWO::coin::Coin<$PADDED_TWO::table::Table<u64,bool>>",
+                )
+            )
+
+        assertEquals("0x2::table::Table<u64,bool>", api.getAllCoins("0xabc").single().coinType)
+    }
+
+    // objectId, version and digest are exactly the fields that become the signed Sui.ObjectRef.
+    // Substituting a blank for a missing one commits every device in the ceremony to bytes the
+    // network rejects at broadcast; a blank version does not even get that far, throwing on the
+    // toLong() inside SuiHelper.
+    @Test
+    fun `getAllCoins drops a coin object missing its version or digest`() = runTest {
+        val api =
+            api(
+                """
+                {"data":{"address":{"objects":{
+                  "pageInfo":{"hasNextPage":false,"endCursor":null},
+                  "nodes":[
+                    {"address":"0xcoin1","version":null,"digest":"d",
+                     "previousTransaction":{"digest":"p"},
+                     "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},
+                     "json":{"balance":"1"}}},
+                    {"address":"0xcoin2","version":1,"digest":null,
+                     "previousTransaction":{"digest":"p"},
+                     "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},
+                     "json":{"balance":"1"}}},
+                    {"address":null,"version":1,"digest":"d",
+                     "previousTransaction":{"digest":"p"},
+                     "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},
+                     "json":{"balance":"1"}}},
+                    {"address":"0xcoin4","version":4,"digest":"d4",
+                     "previousTransaction":{"digest":"p"},
+                     "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},
+                     "json":{"balance":"1"}}}
+                  ]
+                }}}}
+                """
+                    .trimIndent()
+            )
+
+        assertEquals(listOf("0xcoin4"), api.getAllCoins("0xabc").map { it.coinObjectId })
+    }
+
+    // A connection whose non-null pageInfo/nodes are absent is a malformed response, not an empty
+    // page. Decoding it into empty defaults would end the walk early and report a wallet's coins
+    // as the subset read so far.
+    @Test
+    fun `getAllCoins rejects a connection missing pageInfo or nodes`() = runTest {
+        val e =
+            assertFailsWith<SuiRpcException> {
+                api("""{"data":{"address":{"objects":{"nodes":[]}}}}""").getAllCoins("0xabc")
+            }
+        assertTrue(e.errorMessage.contains("unexpected response shape"), e.errorMessage)
+
+        val missingNodes =
+            assertFailsWith<SuiRpcException> {
+                api(
+                        """{"data":{"address":{"objects":{"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}"""
+                    )
+                    .getAllCoins("0xabc")
+            }
+        assertTrue(missingNodes.errorMessage.contains("unexpected response shape"), e.errorMessage)
     }
 
     @Test
@@ -484,6 +577,7 @@ class SuiApiTest {
         hasNextPage: Boolean,
         objectId: String = "0xcoin1",
         endCursor: String = "cursor-1",
+        repr: String = "0x2::coin::Coin<0x2::sui::SUI>",
     ) =
         """
         {"data":{"address":{"objects":{
@@ -493,7 +587,7 @@ class SuiApiTest {
             "version":100,
             "digest":"digest-1",
             "previousTransaction":{"digest":"prev-1"},
-            "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},"json":{"balance":"600"}}
+            "contents":{"type":{"repr":"$repr"},"json":{"balance":"600"}}
           }]
         }}}}
         """
@@ -502,5 +596,8 @@ class SuiApiTest {
     private companion object {
         const val COIN_TYPE =
             "0x0a2b3c4d5e6f7809000000000000000000000000000000000000000000000001::gold::GOLD"
+
+        /** The zero-padded `0x2` spelling GraphQL returns for every address in a type. */
+        const val PADDED_TWO = "0x0000000000000000000000000000000000000000000000000000000000000002"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
@@ -6,15 +6,20 @@ import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
 /**
- * Behavioural tests for [SuiApiImpl] around surfacing the JSON-RPC error envelope (issue #5444):
- * every read/write RPC call must include the real `error.message`/`error.code` in its thrown
- * exception instead of a single hardcoded generic string, and `checkStatus` must distinguish a
- * genuine not-found digest from a terminal RPC failure.
+ * Behavioural tests for [SuiApiImpl] over Sui GraphQL RPC (issue #5506).
+ *
+ * Two guarantees carried over from the JSON-RPC implementation this replaces: every call must
+ * surface the node's real error text rather than a hardcoded generic string (#5444), and
+ * `checkStatus` must tell a digest that hasn't landed yet apart from a node refusal. On top of
+ * those, the mapping from the GraphQL response shape back onto the app's models is pinned here —
+ * the coin-type unwrap and the status lowercasing in particular, since either one failing silently
+ * misclassifies a transfer or a confirmation rather than throwing.
  */
 class SuiApiTest {
 
@@ -23,81 +28,176 @@ class SuiApiTest {
     private fun api(body: String, status: HttpStatusCode = HttpStatusCode.OK): SuiApiImpl =
         SuiApiImpl(MockHttpClient.respondingWith(status, body), json)
 
-    @Test
-    fun `getBalance throws with the real RPC error message and code`() = runTest {
-        val api =
-            api("""{"id":1,"result":null,"error":{"code":-32000,"message":"insufficient gas"}}""")
+    private fun errorBody(message: String, code: String = "BAD_USER_INPUT") =
+        """{"data":null,"errors":[{"message":"$message","extensions":{"code":"$code"}}]}"""
 
-        val e = assertFailsWith<IllegalStateException> { api.getBalance("0xabc", "") }
-        assert(e.message!!.contains("insufficient gas")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32000")) { "message was: ${e.message}" }
+    @Test
+    fun `getBalance throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("invalid sui address"))
+
+        val e = assertFailsWith<SuiRpcException> { api.getBalance("0xabc", "") }
+        assertTrue(e.message!!.contains("invalid sui address"), "message was: ${e.message}")
+        assertTrue(e.message!!.contains("BAD_USER_INPUT"), "message was: ${e.message}")
     }
 
     @Test
     fun `getBalance returns parsed amount on success`() = runTest {
-        val api = api("""{"id":1,"result":{"totalBalance":"42"},"error":null}""")
+        val api = api("""{"data":{"address":{"balance":{"totalBalance":"42"}}}}""")
 
         assertEquals(BigInteger.valueOf(42), api.getBalance("0xabc", ""))
     }
 
+    // A valid address that has never held the coin type resolves to null, which is a genuine zero.
+    // Reading it as a failure would surface an error banner for an ordinary empty balance.
     @Test
-    fun `getReferenceGasPrice throws with the real RPC error message and code`() = runTest {
-        val api =
-            api("""{"id":1,"result":null,"error":{"code":-32603,"message":"node overloaded"}}""")
+    fun `getBalance reads a null balance as zero, not an error`() = runTest {
+        val api = api("""{"data":{"address":{"balance":null}}}""")
 
-        val e = assertFailsWith<IllegalStateException> { api.getReferenceGasPrice() }
-        assert(e.message!!.contains("node overloaded")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32603")) { "message was: ${e.message}" }
+        assertEquals(BigInteger.ZERO, api.getBalance("0xabc", ""))
+    }
+
+    // A shape the selection set cannot describe is a node contract violation. Decoding it into a
+    // fallback would report someone's real balance as zero, so it surfaces instead.
+    @Test
+    fun `getBalance rejects a response whose shape does not match the query`() = runTest {
+        val api = api("""{"data":{"address":{"balance":{"totalBalance":{"nested":1}}}}}""")
+
+        val e = assertFailsWith<SuiRpcException> { api.getBalance("0xabc", "") }
+        assertTrue(e.errorMessage.contains("unexpected response shape"), e.errorMessage)
     }
 
     @Test
-    fun `getAllCoins throws with the real RPC error message and code`() = runTest {
+    fun `getBalance asks for the native coin type when no contract address is given`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
         val api =
-            api("""{"id":1,"result":null,"error":{"code":-32602,"message":"invalid address"}}""")
-
-        val e = assertFailsWith<IllegalStateException> { api.getAllCoins("0xabc") }
-        assert(e.message!!.contains("invalid address")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32602")) { "message was: ${e.message}" }
-    }
-
-    @Test
-    fun `executeTransactionBlock throws with the real RPC error message and code`() = runTest {
-        val api =
-            api("""{"id":1,"result":null,"error":{"code":-32000,"message":"GasBalanceTooLow"}}""")
-
-        val e =
-            assertFailsWith<IllegalStateException> {
-                api.executeTransactionBlock("tx-bytes", "sig")
-            }
-        assert(e.message!!.contains("GasBalanceTooLow")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32000")) { "message was: ${e.message}" }
-    }
-
-    @Test
-    fun `dryRunTransaction throws with the real RPC error message and code`() = runTest {
-        val api =
-            api(
-                """{"id":1,"result":null,"error":{"code":-32602,"message":"invalid transaction bytes"}}"""
+            SuiApiImpl(
+                MockHttpClient.capturingRequest(
+                    HttpStatusCode.OK,
+                    """{"data":{"address":{"balance":{"totalBalance":"1"}}}}""",
+                    capture,
+                ),
+                json,
             )
 
-        val e = assertFailsWith<IllegalStateException> { api.dryRunTransaction("tx-bytes") }
-        assert(e.message!!.contains("invalid transaction bytes")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32602")) { "message was: ${e.message}" }
+        api.getBalance("0xabc", "")
+
+        assertTrue(capture.lastBody.contains("0x2::sui::SUI"), capture.lastBody)
     }
 
     @Test
-    fun `getCoinMetadata throws with the real RPC error message and code`() = runTest {
-        val api =
-            api("""{"id":1,"result":null,"error":{"code":-32602,"message":"bad coin type"}}""")
+    fun `getReferenceGasPrice throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("node overloaded", code = "INTERNAL_SERVER_ERROR"))
 
-        val e = assertFailsWith<IllegalStateException> { api.getCoinMetadata(COIN_TYPE) }
-        assert(e.message!!.contains("bad coin type")) { "message was: ${e.message}" }
-        assert(e.message!!.contains("-32602")) { "message was: ${e.message}" }
+        val e = assertFailsWith<SuiRpcException> { api.getReferenceGasPrice() }
+        assertTrue(e.message!!.contains("node overloaded"), "message was: ${e.message}")
+        assertTrue(e.message!!.contains("INTERNAL_SERVER_ERROR"), "message was: ${e.message}")
+    }
+
+    @Test
+    fun `getReferenceGasPrice returns the parsed price`() = runTest {
+        val api = api("""{"data":{"epoch":{"referenceGasPrice":"750"}}}""")
+
+        assertEquals(BigInteger.valueOf(750), api.getReferenceGasPrice())
+    }
+
+    @Test
+    fun `getAllCoins throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("invalid address"))
+
+        val e = assertFailsWith<SuiRpcException> { api.getAllCoins("0xabc") }
+        assertTrue(e.message!!.contains("invalid address"), "message was: ${e.message}")
+    }
+
+    // The object connection reports the wrapper struct `0x2::coin::Coin<T>`, while the rest of the
+    // app compares against the bare `T`. A wrapper leaking through here would match no known coin
+    // and silently turn a native SUI send into a token send.
+    @Test
+    fun `getAllCoins unwraps the coin type out of the Coin wrapper`() = runTest {
+        val api = api(coinsPage(hasNextPage = false))
+
+        val coins = api.getAllCoins("0xabc")
+
+        assertEquals(1, coins.size)
+        assertEquals("0x2::sui::SUI", coins.single().coinType)
+        assertEquals("0xcoin1", coins.single().coinObjectId)
+        assertEquals("600", coins.single().balance)
+        assertEquals("100", coins.single().version)
+        assertEquals("digest-1", coins.single().digest)
+        assertEquals("prev-1", coins.single().previousTransaction)
+    }
+
+    // GraphQL always spells the address zero-padded where JSON-RPC returned it stripped. Verified
+    // against a live mainnet address: with this normalization the coin types match
+    // `suix_getAllCoins` exactly, so a token discovered after the migration keeps the same
+    // persisted contractAddress as one discovered before it.
+    @Test
+    fun `getAllCoins strips the zero padding from the coin type address`() = runTest {
+        val api =
+            api(
+                """
+                {"data":{"address":{"objects":{
+                  "pageInfo":{"hasNextPage":false,"endCursor":null},
+                  "nodes":[{
+                    "address":"0xcoin1","version":1,"digest":"d","previousTransaction":{"digest":"p"},
+                    "contents":{"type":{"repr":"0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"},
+                    "json":{"balance":"1"}}
+                  }]
+                }}}}
+                """
+                    .trimIndent()
+            )
+
+        assertEquals("0x2::sui::SUI", api.getAllCoins("0xabc").single().coinType)
+    }
+
+    // Only the address is normalized — `::coin::USDC` and `::coin::usdc` are distinct Move types,
+    // so lowercasing the whole string would collapse two different coins into one.
+    @Test
+    fun `getAllCoins leaves module and struct identifiers case-sensitive`() = runTest {
+        val api =
+            api(
+                """
+                {"data":{"address":{"objects":{
+                  "pageInfo":{"hasNextPage":false,"endCursor":null},
+                  "nodes":[{
+                    "address":"0xcoin1","version":1,"digest":"d","previousTransaction":{"digest":"p"},
+                    "contents":{"type":{"repr":"0x2::coin::Coin<0x00ABC::myCoin::USDC>"},
+                    "json":{"balance":"1"}}
+                  }]
+                }}}}
+                """
+                    .trimIndent()
+            )
+
+        assertEquals("0xabc::myCoin::USDC", api.getAllCoins("0xabc").single().coinType)
+    }
+
+    // A wallet whose coin objects span multiple pages must return the whole set — a token whose
+    // objects all land on a later page would otherwise be invisible to the send flow.
+    @Test
+    fun `getAllCoins follows pagination to the last page`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to coinsPage(hasNextPage = true, objectId = "0xcoin1"),
+                HttpStatusCode.OK to coinsPage(hasNextPage = false, objectId = "0xcoin2"),
+            )
+
+        val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
+
+        assertEquals(listOf("0xcoin1", "0xcoin2"), coins.map { it.coinObjectId })
+    }
+
+    @Test
+    fun `getCoinMetadata throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("bad coin type"))
+
+        val e = assertFailsWith<SuiRpcException> { api.getCoinMetadata(COIN_TYPE) }
+        assertTrue(e.message!!.contains("bad coin type"), "message was: ${e.message}")
     }
 
     @Test
     fun `getCoinMetadata returns null when the coin publishes no metadata`() = runTest {
-        val api = api("""{"id":1,"result":null,"error":null}""")
+        val api = api("""{"data":{"coinMetadata":null}}""")
 
         assertNull(api.getCoinMetadata(COIN_TYPE))
     }
@@ -106,7 +206,7 @@ class SuiApiTest {
     fun `getCoinMetadata returns the parsed metadata on success`() = runTest {
         val api =
             api(
-                """{"id":1,"result":{"decimals":6,"name":"Gold","symbol":"GOLD","description":"","iconUrl":"https://example.test/gold.png","id":"0x9"},"error":null}"""
+                """{"data":{"coinMetadata":{"decimals":6,"symbol":"GOLD","iconUrl":"https://example.test/gold.png"}}}"""
             )
 
         val metadata = api.getCoinMetadata(COIN_TYPE)
@@ -118,9 +218,19 @@ class SuiApiTest {
 
     @Test
     fun `getCoinMetadata leaves an absent iconUrl null`() = runTest {
-        val api = api("""{"id":1,"result":{"decimals":9,"symbol":"SILVER"},"error":null}""")
+        val api = api("""{"data":{"coinMetadata":{"decimals":9,"symbol":"SILVER"}}}""")
 
         assertNull(api.getCoinMetadata(COIN_TYPE)?.iconUrl)
+    }
+
+    // A coin the node cannot fully describe must be dropped rather than rendered at a guessed
+    // magnitude — showing a balance with the wrong decimals misstates what the user holds.
+    @Test
+    fun `getCoinMetadata returns null when decimals or symbol are missing`() = runTest {
+        assertNull(
+            api("""{"data":{"coinMetadata":{"symbol":"GOLD"}}}""").getCoinMetadata(COIN_TYPE)
+        )
+        assertNull(api("""{"data":{"coinMetadata":{"decimals":6}}}""").getCoinMetadata(COIN_TYPE))
     }
 
     @Test
@@ -130,7 +240,7 @@ class SuiApiTest {
             SuiApiImpl(
                 MockHttpClient.capturingRequest(
                     HttpStatusCode.OK,
-                    """{"id":1,"result":{"decimals":6,"symbol":"GOLD"},"error":null}""",
+                    """{"data":{"coinMetadata":{"decimals":6,"symbol":"GOLD"}}}""",
                     capture,
                 ),
                 json,
@@ -138,36 +248,194 @@ class SuiApiTest {
 
         api.getCoinMetadata(COIN_TYPE)
 
-        assert(capture.lastBody.contains("suix_getCoinMetadata")) { capture.lastBody }
-        assert(capture.lastBody.contains(COIN_TYPE)) { capture.lastBody }
+        assertTrue(capture.lastBody.contains("coinMetadata"), capture.lastBody)
+        assertTrue(capture.lastBody.contains(COIN_TYPE), capture.lastBody)
     }
 
     @Test
-    fun `checkStatus returns null for the not-found RPC code`() = runTest {
+    fun `executeTransactionBlock throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("GasBalanceTooLow"))
+
+        val e = assertFailsWith<SuiRpcException> { api.executeTransactionBlock("tx-bytes", "sig") }
+        assertTrue(e.message!!.contains("GasBalanceTooLow"), "message was: ${e.message}")
+    }
+
+    @Test
+    fun `executeTransactionBlock returns the transaction digest`() = runTest {
+        val api = api("""{"data":{"executeTransaction":{"effects":{"digest":"tx-digest"}}}}""")
+
+        assertEquals("tx-digest", api.executeTransactionBlock("tx-bytes", "sig"))
+    }
+
+    // The signed bytes must reach the node as the BCS payload; sending them under the wrong key
+    // would be rejected at execution time rather than caught here.
+    @Test
+    fun `executeTransactionBlock sends the signed bytes and signature`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            SuiApiImpl(
+                MockHttpClient.capturingRequest(
+                    HttpStatusCode.OK,
+                    """{"data":{"executeTransaction":{"effects":{"digest":"d"}}}}""",
+                    capture,
+                ),
+                json,
+            )
+
+        api.executeTransactionBlock("tx-bytes", "the-signature")
+
+        assertTrue(capture.lastBody.contains("tx-bytes"), capture.lastBody)
+        assertTrue(capture.lastBody.contains("the-signature"), capture.lastBody)
+    }
+
+    @Test
+    fun `dryRunTransaction throws with the real GraphQL error message and code`() = runTest {
+        val api = api(errorBody("invalid transaction bytes"))
+
+        val e = assertFailsWith<SuiRpcException> { api.dryRunTransaction("tx-bytes") }
+        assertTrue(e.message!!.contains("invalid transaction bytes"), "message was: ${e.message}")
+    }
+
+    @Test
+    fun `dryRunTransaction maps the gas summary onto the effects`() = runTest {
         val api =
             api(
-                """{"id":1,"result":null,"error":{"code":-32602,"message":"Could not find the referenced transaction"}}"""
+                """{"data":{"simulateTransaction":{"effects":{"status":"SUCCESS","executionError":null,
+                   "gasEffects":{"gasSummary":{"computationCost":1000,"storageCost":2000,"storageRebate":500}}}}}}"""
             )
+
+        val effects = api.dryRunTransaction("tx-bytes").effects
+
+        assertEquals("success", effects.status.status)
+        assertEquals("1000", effects.gasUsed.computationCost)
+        assertEquals("2000", effects.gasUsed.storageCost)
+        assertEquals("500", effects.gasUsed.storageRebate)
+    }
+
+    // A simulation that executes but aborts must surface the abort reason — this is the only
+    // pre-signature check that a send will actually succeed on chain.
+    @Test
+    fun `dryRunTransaction throws the execution error when the simulation fails`() = runTest {
+        val api =
+            api(
+                """{"data":{"simulateTransaction":{"effects":{"status":"FAILURE",
+                   "executionError":{"message":"InsufficientGas","abortCode":null,"identifier":null},
+                   "gasEffects":{"gasSummary":{"computationCost":0,"storageCost":0,"storageRebate":0}}}}}}"""
+            )
+
+        val e = assertFailsWith<Exception> { api.dryRunTransaction("tx-bytes") }
+        assertTrue(e.message!!.contains("InsufficientGas"), "message was: ${e.message}")
+    }
+
+    // The BCS bytes travel inside a JSON-encoded `sui.rpc.v2.Transaction`; a plain string is
+    // rejected by the node with "expected struct sui.rpc.v2.Transaction".
+    @Test
+    fun `dryRunTransaction wraps the bytes in the gRPC transaction envelope`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            SuiApiImpl(
+                MockHttpClient.capturingRequest(
+                    HttpStatusCode.OK,
+                    """{"data":{"simulateTransaction":{"effects":{"status":"SUCCESS",
+                       "gasEffects":{"gasSummary":{"computationCost":1,"storageCost":1,"storageRebate":0}}}}}}""",
+                    capture,
+                ),
+                json,
+            )
+
+        api.dryRunTransaction("the-bcs-bytes")
+
+        assertTrue(capture.lastBody.contains("bcs"), capture.lastBody)
+        assertTrue(capture.lastBody.contains("the-bcs-bytes"), capture.lastBody)
+    }
+
+    // A digest that hasn't landed yet resolves to a null transaction with no errors — a genuine
+    // not-found, safe to keep polling.
+    @Test
+    fun `checkStatus returns null when the transaction is not found`() = runTest {
+        val api = api("""{"data":{"transaction":null}}""")
 
         assertNull(api.checkStatus("digest"))
     }
 
     @Test
-    fun `checkStatus throws SuiRpcException for a terminal RPC error`() = runTest {
-        val api =
-            api("""{"id":1,"result":null,"error":{"code":-32000,"message":"indexer outage"}}""")
+    fun `checkStatus throws SuiRpcException for a node refusal`() = runTest {
+        val api = api(errorBody("indexer outage", code = "INTERNAL_SERVER_ERROR"))
 
         val e = assertFailsWith<SuiRpcException> { api.checkStatus("digest") }
-        assertEquals(-32000, e.rpcError.code)
-        assertEquals("indexer outage", e.rpcError.message)
+        assertEquals("indexer outage", e.errorMessage)
+        assertEquals("INTERNAL_SERVER_ERROR", e.code)
+    }
+
+    // GraphQL reports SUCCESS/FAILURE while SuiStatusProvider matches on the lowercase spelling.
+    // Without the lowercasing a confirmed transaction reads as pending until the poll times out.
+    @Test
+    fun `checkStatus lowercases the execution status`() = runTest {
+        val api =
+            api(
+                """{"data":{"transaction":{"digest":"abc","effects":{"status":"SUCCESS",
+                   "executionError":null,"checkpoint":{"sequenceNumber":10}}}}}"""
+            )
+
+        val response = api.checkStatus("digest")
+
+        assertEquals("abc", response?.digest)
+        assertEquals(10L, response?.checkpoint)
+        assertEquals("success", response?.effects?.status?.status)
     }
 
     @Test
-    fun `checkStatus returns the parsed response on success`() = runTest {
-        val api = api("""{"id":1,"result":{"digest":"abc","checkpoint":10},"error":null}""")
+    fun `checkStatus carries the execution error on a failed transaction`() = runTest {
+        val api =
+            api(
+                """{"data":{"transaction":{"digest":"abc","effects":{"status":"FAILURE",
+                   "executionError":{"message":"MoveAbort"},"checkpoint":{"sequenceNumber":11}}}}}"""
+            )
 
-        assertEquals("abc", api.checkStatus("digest")?.digest)
+        val status = api.checkStatus("digest")?.effects?.status
+
+        assertEquals("failure", status?.status)
+        assertEquals("MoveAbort", status?.error)
     }
+
+    // An executed but not-yet-checkpointed transaction has no sequence number, which the status
+    // provider reads as still pending.
+    @Test
+    fun `checkStatus leaves the checkpoint null until the transaction is checkpointed`() = runTest {
+        val api =
+            api("""{"data":{"transaction":{"digest":"abc","effects":{"status":"SUCCESS"}}}}""")
+
+        assertNull(api.checkStatus("digest")?.checkpoint)
+    }
+
+    @Test
+    fun `getLatestCheckpointSequenceNumber returns the sequence number`() = runTest {
+        val api = api("""{"data":{"checkpoint":{"sequenceNumber":309001173}}}""")
+
+        assertEquals(309001173L, api.getLatestCheckpointSequenceNumber())
+    }
+
+    @Test
+    fun `getLatestCheckpointSequenceNumber returns null on a node error`() = runTest {
+        val api = api(errorBody("unavailable", code = "INTERNAL_SERVER_ERROR"))
+
+        assertNull(api.getLatestCheckpointSequenceNumber())
+    }
+
+    private fun coinsPage(hasNextPage: Boolean, objectId: String = "0xcoin1") =
+        """
+        {"data":{"address":{"objects":{
+          "pageInfo":{"hasNextPage":$hasNextPage,"endCursor":"cursor-1"},
+          "nodes":[{
+            "address":"$objectId",
+            "version":100,
+            "digest":"digest-1",
+            "previousTransaction":{"digest":"prev-1"},
+            "contents":{"type":{"repr":"0x2::coin::Coin<0x2::sui::SUI>"},"json":{"balance":"600"}}
+          }]
+        }}}}
+        """
+            .trimIndent()
 
     private companion object {
         const val COIN_TYPE =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
@@ -56,6 +56,16 @@ class SuiApiTest {
         assertEquals(BigInteger.ZERO, api.getBalance("0xabc", ""))
     }
 
+    // An absent balance is a genuine zero; an amount the node sent but that cannot be parsed is a
+    // contract violation. Collapsing both into zero would show someone an empty wallet for a bug.
+    @Test
+    fun `getBalance rejects an unparsable balance instead of reading it as zero`() = runTest {
+        val api = api("""{"data":{"address":{"balance":{"totalBalance":"not-a-number"}}}}""")
+
+        val e = assertFailsWith<SuiRpcException> { api.getBalance("0xabc", "") }
+        assertTrue(e.message!!.contains("not-a-number"), "message was: ${e.message}")
+    }
+
     // A shape the selection set cannot describe is a node contract violation. Decoding it into a
     // fallback would report someone's real balance as zero, so it surfaces instead.
     @Test
@@ -173,18 +183,66 @@ class SuiApiTest {
     }
 
     // A wallet whose coin objects span multiple pages must return the whole set — a token whose
-    // objects all land on a later page would otherwise be invisible to the send flow.
+    // objects all land on a later page would otherwise be invisible to the send flow. The second
+    // request must carry the cursor the first page returned; without that assertion the walk could
+    // be re-reading page one and the sequenced mock would still look correct.
     @Test
-    fun `getAllCoins follows pagination to the last page`() = runTest {
+    fun `getAllCoins follows pagination and forwards the endCursor`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
         val client =
-            MockHttpClient.respondingWithSequence(
-                HttpStatusCode.OK to coinsPage(hasNextPage = true, objectId = "0xcoin1"),
-                HttpStatusCode.OK to coinsPage(hasNextPage = false, objectId = "0xcoin2"),
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to
+                    coinsPage(
+                        hasNextPage = true,
+                        objectId = "0xcoin1",
+                        endCursor = "page-1-cursor",
+                    ),
+                HttpStatusCode.OK to
+                    coinsPage(
+                        hasNextPage = false,
+                        objectId = "0xcoin2",
+                        endCursor = "page-2-cursor",
+                    ),
             )
 
         val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
 
         assertEquals(listOf("0xcoin1", "0xcoin2"), coins.map { it.coinObjectId })
+        assertEquals(2, capture.bodies.size)
+        assertTrue(capture.bodies[0].contains("\"cursor\":null"), capture.bodies[0])
+        assertTrue(capture.bodies[1].contains("page-1-cursor"), capture.bodies[1])
+    }
+
+    // Termination must not rest on the node alone. A connection that keeps reporting hasNextPage
+    // while handing back the same cursor would otherwise loop forever, growing the coin list until
+    // the process dies.
+    @Test
+    fun `getAllCoins stops when the endCursor does not advance`() = runTest {
+        // respondingWithSequence pins the last entry, so this page repeats indefinitely.
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to
+                    coinsPage(hasNextPage = true, objectId = "0xcoin1", endCursor = "stuck")
+            )
+
+        val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
+
+        // Page one is kept, page two repeats the cursor and ends the walk.
+        assertEquals(2, coins.size)
+    }
+
+    // A node that advances the cursor forever is bounded by the page budget rather than by trust.
+    @Test
+    fun `getAllCoins stops at the page budget when the cursor keeps advancing`() = runTest {
+        val client =
+            MockHttpClient.respondingWithGenerated { page ->
+                coinsPage(hasNextPage = true, objectId = "0xcoin$page", endCursor = "cursor-$page")
+            }
+
+        val coins = SuiApiImpl(client, json).getAllCoins("0xabc")
+
+        assertEquals(SUI_MAX_COIN_PAGES, coins.size)
     }
 
     @Test
@@ -422,10 +480,14 @@ class SuiApiTest {
         assertNull(api.getLatestCheckpointSequenceNumber())
     }
 
-    private fun coinsPage(hasNextPage: Boolean, objectId: String = "0xcoin1") =
+    private fun coinsPage(
+        hasNextPage: Boolean,
+        objectId: String = "0xcoin1",
+        endCursor: String = "cursor-1",
+    ) =
         """
         {"data":{"address":{"objects":{
-          "pageInfo":{"hasNextPage":$hasNextPage,"endCursor":"cursor-1"},
+          "pageInfo":{"hasNextPage":$hasNextPage,"endCursor":"$endCursor"},
           "nodes":[{
             "address":"$objectId",
             "version":100,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
@@ -1,0 +1,166 @@
+package com.vultisig.wallet.data.api.chains
+
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+
+/**
+ * Failover behaviour for [SuiGraphQlTransport] (issue #5506).
+ *
+ * The Sui transport had a single hardcoded host and no fallback, so one bad endpoint took every Sui
+ * read and broadcast down with it. Failover is deliberately scoped to transport-level faults: a
+ * populated `errors` array is the node's considered answer to a well-formed request, and replaying
+ * it against every remaining host only delays the same message.
+ */
+class SuiGraphQlTransportTest {
+
+    private val endpoints = listOf("https://primary.test/graphql", "https://secondary.test/graphql")
+
+    private val successBody = """{"data":{"epoch":{"referenceGasPrice":"100"}}}"""
+
+    @Test
+    fun `falls over to the next endpoint when the first answers 5xx`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.InternalServerError to "upstream down",
+                HttpStatusCode.OK to successBody,
+            )
+
+        val data = SuiGraphQlTransport(client, endpoints).query(QUERY)
+
+        assertEquals(
+            "100",
+            data["epoch"]!!.jsonObject()["referenceGasPrice"]!!.jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun `falls over to the next endpoint when the first is unreachable`() = runTest {
+        var call = 0
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to successBody,
+                HttpStatusCode.OK to successBody,
+            )
+        // The sequence client cannot throw, so drive the unreachable case through a client whose
+        // transport always fails and assert every endpoint was attempted before giving up.
+        val failing = MockHttpClient.throwing(IOException("connection reset")) { call++ }
+
+        assertFailsWith<NetworkException> { SuiGraphQlTransport(failing, endpoints).query(QUERY) }
+        assertEquals(endpoints.size, call)
+
+        // Sanity: the same query succeeds when a host answers.
+        SuiGraphQlTransport(client, endpoints).query(QUERY)
+    }
+
+    // Exhausting the list must report the real transport failure, not a generic "no endpoint"
+    // message that hides why every host was skipped.
+    @Test
+    fun `throws the last transport failure when every endpoint fails`() = runTest {
+        val client = MockHttpClient.respondingWith(HttpStatusCode.BadGateway, "bad gateway")
+
+        val e =
+            assertFailsWith<NetworkException> {
+                SuiGraphQlTransport(client, endpoints).query(QUERY)
+            }
+
+        assertEquals(HttpStatusCode.BadGateway.value, e.httpStatusCode)
+    }
+
+    // A node refusal is deterministic — every other host would answer the same. Retrying it would
+    // only delay the message, so the first `errors` array is raised immediately.
+    @Test
+    fun `does not fail over on a GraphQL error payload`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to
+                    """{"data":null,"errors":[{"message":"invalid address","extensions":{"code":"BAD_USER_INPUT"}}]}""",
+                HttpStatusCode.OK to successBody,
+            )
+
+        // If the transport retried, the second (successful) response would be returned instead.
+        val e =
+            assertFailsWith<SuiRpcException> { SuiGraphQlTransport(client, endpoints).query(QUERY) }
+
+        assertEquals("invalid address", e.errorMessage)
+        assertEquals("BAD_USER_INPUT", e.code)
+    }
+
+    @Test
+    fun `joins every GraphQL error message`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                """{"data":null,"errors":[{"message":"first"},{"message":"second"}]}""",
+            )
+
+        val e =
+            assertFailsWith<SuiRpcException> { SuiGraphQlTransport(client, endpoints).query(QUERY) }
+
+        assertTrue(e.errorMessage.contains("first"), e.errorMessage)
+        assertTrue(e.errorMessage.contains("second"), e.errorMessage)
+    }
+
+    // GraphQL answers HTTP 200 even when it refuses, so a body carrying neither is malformed —
+    // returning it as an empty result would read as "you hold nothing".
+    @Test
+    fun `treats a body with neither data nor errors as a failure`() = runTest {
+        val client = MockHttpClient.respondingWith(HttpStatusCode.OK, """{}""")
+
+        val e =
+            assertFailsWith<SuiRpcException> { SuiGraphQlTransport(client, endpoints).query(QUERY) }
+
+        assertTrue(e.errorMessage.contains("malformed"), e.errorMessage)
+    }
+
+    // Cancellation is not a transport fault — swallowing it would keep hammering the remaining
+    // hosts after the caller has navigated away.
+    @Test
+    fun `propagates cancellation instead of failing over`() = runTest {
+        val calls = AtomicInteger()
+        val client =
+            MockHttpClient.throwing(CancellationException("navigated away")) {
+                calls.incrementAndGet()
+            }
+
+        assertFailsWith<CancellationException> {
+            SuiGraphQlTransport(client, endpoints).query(QUERY)
+        }
+        assertEquals(1, calls.get())
+    }
+
+    @Test
+    fun `rejects an empty endpoint list`() {
+        val client = MockHttpClient.respondingWith(HttpStatusCode.OK, successBody)
+
+        assertFailsWith<IllegalArgumentException> { SuiGraphQlTransport(client, emptyList()) }
+    }
+
+    // The shipped configuration must point at a live Sui GraphQL host, not the retired JSON-RPC
+    // one — the whole point of #5506.
+    @Test
+    fun `ships a GraphQL endpoint, not the retired JSON-RPC host`() {
+        assertTrue(SUI_GRAPHQL_ENDPOINTS.isNotEmpty())
+        assertTrue(SUI_GRAPHQL_ENDPOINTS.all { it.contains("graphql") }, "$SUI_GRAPHQL_ENDPOINTS")
+        assertTrue(
+            SUI_GRAPHQL_ENDPOINTS.none { it.contains("sui-rpc.publicnode.com") },
+            "$SUI_GRAPHQL_ENDPOINTS",
+        )
+    }
+
+    private companion object {
+        const val QUERY = "query { epoch { referenceGasPrice } }"
+    }
+}
+
+private fun kotlinx.serialization.json.JsonElement.jsonObject() =
+    this as kotlinx.serialization.json.JsonObject

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
@@ -38,7 +38,10 @@ class SuiGraphQlTransportTest {
 
         val data = SuiGraphQlTransport(client, endpoints).query(QUERY)
 
-        assertEquals("100", data["epoch"]!!.jsonObject["referenceGasPrice"]!!.jsonPrimitive.content)
+        assertEquals(
+            "100",
+            data["epoch"]?.jsonObject?.get("referenceGasPrice")?.jsonPrimitive?.content,
+        )
     }
 
     // The 5xx case above already covers recovery; what is pinned here is that an unreachable host

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiGraphQlTransportTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 
@@ -37,29 +38,38 @@ class SuiGraphQlTransportTest {
 
         val data = SuiGraphQlTransport(client, endpoints).query(QUERY)
 
-        assertEquals(
-            "100",
-            data["epoch"]!!.jsonObject()["referenceGasPrice"]!!.jsonPrimitive.content,
-        )
+        assertEquals("100", data["epoch"]!!.jsonObject["referenceGasPrice"]!!.jsonPrimitive.content)
     }
 
+    // The 5xx case above already covers recovery; what is pinned here is that an unreachable host
+    // is retried at all — every endpoint must be attempted before the failure is reported.
     @Test
-    fun `falls over to the next endpoint when the first is unreachable`() = runTest {
+    fun `attempts every endpoint when all are unreachable`() = runTest {
         var call = 0
-        val client =
-            MockHttpClient.respondingWithSequence(
-                HttpStatusCode.OK to successBody,
-                HttpStatusCode.OK to successBody,
-            )
-        // The sequence client cannot throw, so drive the unreachable case through a client whose
-        // transport always fails and assert every endpoint was attempted before giving up.
         val failing = MockHttpClient.throwing(IOException("connection reset")) { call++ }
 
         assertFailsWith<NetworkException> { SuiGraphQlTransport(failing, endpoints).query(QUERY) }
-        assertEquals(endpoints.size, call)
 
-        // Sanity: the same query succeeds when a host answers.
-        SuiGraphQlTransport(client, endpoints).query(QUERY)
+        assertEquals(endpoints.size, call)
+    }
+
+    // A 4xx is deterministic — the node has judged these exact bytes, so replaying them against the
+    // remaining hosts would only delay the same answer. The second host must never be asked.
+    @Test
+    fun `does not fail over on a 4xx`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.BadRequest to "malformed document",
+                HttpStatusCode.OK to successBody,
+            )
+
+        // If the transport retried, the second (successful) response would be returned instead.
+        val e =
+            assertFailsWith<NetworkException> {
+                SuiGraphQlTransport(client, endpoints).query(QUERY)
+            }
+
+        assertEquals(HttpStatusCode.BadRequest.value, e.httpStatusCode)
     }
 
     // Exhausting the list must report the real transport failure, not a generic "no endpoint"
@@ -161,6 +171,3 @@ class SuiGraphQlTransportTest {
         const val QUERY = "query { epoch { referenceGasPrice } }"
     }
 }
-
-private fun kotlinx.serialization.json.JsonElement.jsonObject() =
-    this as kotlinx.serialization.json.JsonObject

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SuiStatusProviderTest.kt
@@ -76,15 +76,15 @@ class SuiStatusProviderTest {
         assertEquals(TransactionResult.Pending, provider.checkStatus("h", Chain.Sui))
     }
 
-    // The core regression test for #5444: a terminal RPC error (any code other than the
-    // not-found one) must surface immediately as Failed, not be retried until the poll timeout.
+    // The core regression test for #5444, carried onto GraphQL (#5506): a node refusal must
+    // surface immediately as Failed, not be retried until the poll timeout.
     @Test
-    fun `terminal RPC error surfaces as Failed, not endless retry`() = runTest {
+    fun `node refusal surfaces as Failed, not endless retry`() = runTest {
         val client =
             MockHttpClient.respondingWith(
                 HttpStatusCode.OK,
                 body =
-                    """{"id":1,"result":null,"error":{"code":-32000,"message":"indexer outage"}}""",
+                    """{"data":null,"errors":[{"message":"indexer outage","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}""",
             )
         val realApi = SuiApiImpl(client, Json { ignoreUnknownKeys = true })
         val providerWithRealApi = SuiStatusProvider(realApi)
@@ -95,15 +95,15 @@ class SuiStatusProviderTest {
         )
     }
 
-    // The mirror case of the terminal-error test above, driven through the same real SuiApiImpl:
-    // the not-found code must still resolve to the retryable NotFound outcome, proving the two
-    // RPC error codes are not collapsed into the same result.
+    // The mirror case of the refusal test above, driven through the same real SuiApiImpl: a digest
+    // that hasn't landed resolves to a null transaction with no errors, and must still reach the
+    // retryable NotFound outcome rather than being collapsed into the terminal one.
     @Test
-    fun `not-found RPC code surfaces as NotFound through the real api`() = runTest {
+    fun `unlanded digest surfaces as NotFound through the real api`() = runTest {
         val client =
             MockHttpClient.respondingWith(
                 HttpStatusCode.OK,
-                body = """{"id":1,"result":null,"error":{"code":-32602,"message":"not found"}}""",
+                body = """{"data":{"transaction":null}}""",
             )
         val realApi = SuiApiImpl(client, Json { ignoreUnknownKeys = true })
         val providerWithRealApi = SuiStatusProvider(realApi)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiCoinSelectionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiCoinSelectionTest.kt
@@ -300,6 +300,49 @@ class SuiCoinSelectionTest {
         assertTrue(SuiHelper.isSameSuiCoinType(tokenType, padded))
     }
 
+    // An LP token's coin type is itself generic, and GraphQL zero-pads the nested addresses where
+    // JSON-RPC spelled them short. Comparing only the outermost address would read a stored
+    // pre-migration contractAddress as a different token than the coin objects now carry, and the
+    // send would fail with "No ... coin objects available".
+    @Test
+    fun `coin type comparison normalizes nested generic addresses`() {
+        val short = "0x2::spot_dex::LP<0x2::sui::SUI, 0x3::coin::COIN>"
+        val padded =
+            "0x" +
+                "0".repeat(63) +
+                "2::spot_dex::LP<0x" +
+                "0".repeat(63) +
+                "2::sui::SUI,0x" +
+                "0".repeat(63) +
+                "3::coin::COIN>"
+        assertTrue(SuiHelper.isSameSuiCoinType(short, padded))
+    }
+
+    // Only addresses are normalized inside the generic arguments too: two LP tokens over
+    // differently-cased struct names remain the distinct Move types they are.
+    @Test
+    fun `nested generic comparison keeps module and struct identifiers case-sensitive`() {
+        val upper = "0x2::spot_dex::LP<0x2::sui::SUI,0x3::coin::COIN>"
+        val lower = "0x2::spot_dex::LP<0x2::sui::SUI,0x3::coin::coin>"
+        assertFalse(SuiHelper.isSameSuiCoinType(upper, lower))
+    }
+
+    // A primitive type argument has no address to strip; rewriting `u64` as one would invent a
+    // type that names nothing.
+    @Test
+    fun `primitive type arguments survive normalization unchanged`() {
+        val withPrimitives = "0x2::table::Table<u64, 0x2::sui::SUI>"
+        assertTrue(
+            SuiHelper.isSameSuiCoinType(
+                withPrimitives,
+                "0x" + "0".repeat(63) + "2::table::Table<u64,0x" + "0".repeat(63) + "2::sui::SUI>",
+            )
+        )
+        assertFalse(
+            SuiHelper.isSameSuiCoinType(withPrimitives, "0x2::table::Table<u8,0x2::sui::SUI>")
+        )
+    }
+
     @Test
     fun `native selection matches long-form objects returned by the RPC`() {
         val longNativeType = "0x" + "0".repeat(63) + "2::sui::SUI"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.crypto
 
+import com.vultisig.wallet.data.api.chains.unwrapCoinType
 import java.math.BigInteger
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -21,7 +22,9 @@ class SuiHelperTest {
     private val json = Json { ignoreUnknownKeys = true }
 
     // Real-shape GraphQL coin-object connection. Three SUI coins of different balances and one
-    // non-SUI coin, so we can exercise eligibility + min-selection + non-SUI exclusion.
+    // non-SUI coin, so we can exercise eligibility + min-selection + non-SUI exclusion. The first
+    // coin carries the zero-padded address spelling GraphQL actually returns, so the parsing below
+    // has to normalize it the way production does rather than pass a pre-stripped string through.
     private val getAllCoinsResponse =
         """
         {
@@ -36,7 +39,9 @@ class SuiHelperTest {
                     "digest": "DGstCoinOneXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
                     "previousTransaction": { "digest": "PrevTx1" },
                     "contents": {
-                      "type": { "repr": "0x2::coin::Coin<0x2::sui::SUI>" },
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
                       "json": { "balance": "600" }
                     }
                   },
@@ -242,9 +247,10 @@ class SuiHelperTest {
             .build()
 
     /**
-     * Mirrors the parsing in `SuiApiImpl.getAllCoins` so tests consume the real GraphQL shape —
-     * including unwrapping the coin type out of the `0x2::coin::Coin<T>` wrapper the object
-     * connection reports.
+     * Mirrors the parsing in `SuiApiImpl.getAllCoins` so tests consume the real GraphQL shape. The
+     * coin type goes through the production [unwrapCoinType] rather than a local copy: it both
+     * unwraps the `0x2::coin::Coin<T>` wrapper and strips the zero padding GraphQL spells addresses
+     * with, and a copy of that here could drift from the parser it claims to mirror.
      */
     private fun parseCoins(graphQlResponse: String): List<SuiCoin> =
         json
@@ -258,7 +264,7 @@ class SuiHelperTest {
                 val contents = node.jsonObject["contents"]!!.jsonObject
                 val repr = contents["type"]!!.jsonObject["repr"]!!.jsonPrimitive.content
                 SuiCoin(
-                    coinType = repr.substring(repr.indexOf('<') + 1, repr.lastIndexOf('>')),
+                    coinType = unwrapCoinType(repr) ?: error("not a Coin<T> type: $repr"),
                     coinObjectId = node.jsonObject["address"]!!.jsonPrimitive.content,
                     version = node.jsonObject["version"]!!.jsonPrimitive.content,
                     digest = node.jsonObject["digest"]!!.jsonPrimitive.content,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SuiHelperTest.kt
@@ -13,58 +13,67 @@ import vultisig.keysign.v1.SuiCoin
 import wallet.core.jni.proto.Sui
 
 /**
- * Covers [SuiHelper.selectSuiGasCoin] with exact `suix_getAllCoins` RPC response payloads to
- * protect the #3989 fix (filter by `balance >= gasBudget`, not `balance > referenceGasPrice`).
+ * Covers [SuiHelper.selectSuiGasCoin] with exact Sui GraphQL coin-object payloads to protect
+ * the #3989 fix (filter by `balance >= gasBudget`, not `balance > referenceGasPrice`).
  */
 class SuiHelperTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    // Real-shape suix_getAllCoins response. Three SUI coins of different balances and one
+    // Real-shape GraphQL coin-object connection. Three SUI coins of different balances and one
     // non-SUI coin, so we can exercise eligibility + min-selection + non-SUI exclusion.
     private val getAllCoinsResponse =
         """
         {
-          "jsonrpc": "2.0",
-          "result": {
-            "data": [
-              {
-                "coinType": "0x2::sui::SUI",
-                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000001",
-                "version": "100",
-                "digest": "DGstCoinOneXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                "balance": "600",
-                "previousTransaction": "PrevTx1"
-              },
-              {
-                "coinType": "0x2::sui::SUI",
-                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                "version": "101",
-                "digest": "DGstCoinTwoXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                "balance": "3000000",
-                "previousTransaction": "PrevTx2"
-              },
-              {
-                "coinType": "0x2::sui::SUI",
-                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000003",
-                "version": "102",
-                "digest": "DGstCoinThreeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                "balance": "10000000000",
-                "previousTransaction": "PrevTx3"
-              },
-              {
-                "coinType": "0xabc::usdc::USDC",
-                "coinObjectId": "0x0000000000000000000000000000000000000000000000000000000000000099",
-                "version": "200",
-                "digest": "DGstUsdcXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                "balance": "999999999999",
-                "previousTransaction": "PrevTx99"
+          "data": {
+            "address": {
+              "objects": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                "nodes": [
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "version": 100,
+                    "digest": "DGstCoinOneXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                    "previousTransaction": { "digest": "PrevTx1" },
+                    "contents": {
+                      "type": { "repr": "0x2::coin::Coin<0x2::sui::SUI>" },
+                      "json": { "balance": "600" }
+                    }
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "version": 101,
+                    "digest": "DGstCoinTwoXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                    "previousTransaction": { "digest": "PrevTx2" },
+                    "contents": {
+                      "type": { "repr": "0x2::coin::Coin<0x2::sui::SUI>" },
+                      "json": { "balance": "3000000" }
+                    }
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    "version": 102,
+                    "digest": "DGstCoinThreeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                    "previousTransaction": { "digest": "PrevTx3" },
+                    "contents": {
+                      "type": { "repr": "0x2::coin::Coin<0x2::sui::SUI>" },
+                      "json": { "balance": "10000000000" }
+                    }
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000099",
+                    "version": 200,
+                    "digest": "DGstUsdcXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                    "previousTransaction": { "digest": "PrevTx99" },
+                    "contents": {
+                      "type": { "repr": "0x2::coin::Coin<0xabc::usdc::USDC>" },
+                      "json": { "balance": "999999999999" }
+                    }
+                  }
+                ]
               }
-            ],
-            "nextCursor": null,
-            "hasNextPage": false
-          },
-          "id": 1
+            }
+          }
         }
         """
             .trimIndent()
@@ -232,22 +241,34 @@ class SuiHelperTest {
             .setObjectDigest(digest)
             .build()
 
-    /** Mirrors the parsing in `SuiApiImpl.getAllCoins` so tests consume the real RPC shape. */
-    private fun parseCoins(rpcResponse: String): List<SuiCoin> =
+    /**
+     * Mirrors the parsing in `SuiApiImpl.getAllCoins` so tests consume the real GraphQL shape —
+     * including unwrapping the coin type out of the `0x2::coin::Coin<T>` wrapper the object
+     * connection reports.
+     */
+    private fun parseCoins(graphQlResponse: String): List<SuiCoin> =
         json
-            .parseToJsonElement(rpcResponse)
-            .jsonObject["result"]!!
+            .parseToJsonElement(graphQlResponse)
             .jsonObject["data"]!!
+            .jsonObject["address"]!!
+            .jsonObject["objects"]!!
+            .jsonObject["nodes"]!!
             .jsonArray
-            .map {
+            .map { node ->
+                val contents = node.jsonObject["contents"]!!.jsonObject
+                val repr = contents["type"]!!.jsonObject["repr"]!!.jsonPrimitive.content
                 SuiCoin(
-                    coinType = it.jsonObject["coinType"]!!.jsonPrimitive.content,
-                    coinObjectId = it.jsonObject["coinObjectId"]!!.jsonPrimitive.content,
-                    version = it.jsonObject["version"]!!.jsonPrimitive.content,
-                    digest = it.jsonObject["digest"]!!.jsonPrimitive.content,
-                    balance = it.jsonObject["balance"]!!.jsonPrimitive.content,
+                    coinType = repr.substring(repr.indexOf('<') + 1, repr.lastIndexOf('>')),
+                    coinObjectId = node.jsonObject["address"]!!.jsonPrimitive.content,
+                    version = node.jsonObject["version"]!!.jsonPrimitive.content,
+                    digest = node.jsonObject["digest"]!!.jsonPrimitive.content,
+                    balance = contents["json"]!!.jsonObject["balance"]!!.jsonPrimitive.content,
                     previousTransaction =
-                        it.jsonObject["previousTransaction"]?.jsonPrimitive?.content ?: "",
+                        node.jsonObject["previousTransaction"]
+                            ?.jsonObject
+                            ?.get("digest")
+                            ?.jsonPrimitive
+                            ?.content ?: "",
                 )
             }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -78,9 +78,22 @@ object MockHttpClient {
             installDefaults(jsonFormat)
         }
 
-    /** Mutable holder for the last outgoing request body captured by [capturingRequest]. */
+    /**
+     * Mutable holder for the outgoing request bodies captured by [capturingRequest] and
+     * [capturingRequestSequence]. [lastBody] is the most recent one; [bodies] keeps every request
+     * in order, which is what a paginated call needs — asserting only the last body cannot show
+     * that page two carried the cursor page one returned.
+     */
     class RequestCapture {
+        val bodies = mutableListOf<String>()
+
         var lastBody: String = ""
+            private set
+
+        internal fun record(body: String) {
+            lastBody = body
+            bodies += body
+        }
     }
 
     /**
@@ -96,12 +109,37 @@ object MockHttpClient {
     ): HttpClient =
         HttpClient(
             MockEngine { request ->
-                capture.lastBody = request.body.toByteArray().decodeToString()
+                capture.record(request.body.toByteArray().decodeToString())
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
         ) {
             installDefaults(jsonFormat)
         }
+
+    /**
+     * [respondingWithSequence] with [capturingRequest]'s recording, so a test can assert both what
+     * came back per call and what each call sent — e.g. that a paginated request forwards the
+     * cursor the previous page returned.
+     */
+    fun capturingRequestSequence(
+        capture: RequestCapture,
+        vararg responses: Pair<HttpStatusCode, String>,
+        jsonFormat: Json = json,
+    ): HttpClient {
+        require(responses.isNotEmpty()) {
+            "capturingRequestSequence requires at least one response"
+        }
+        var index = 0
+        return HttpClient(
+            MockEngine { request ->
+                capture.record(request.body.toByteArray().decodeToString())
+                val (status, body) = responses[minOf(index++, responses.size - 1)]
+                respond(content = body, status = status, headers = JSON_HEADERS)
+            }
+        ) {
+            installDefaults(jsonFormat)
+        }
+    }
 
     /**
      * Builds a client that steps through [responses] in order, pinning the last entry once the
@@ -123,6 +161,24 @@ object MockHttpClient {
                 val (status, body) = responses[i]
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
+        ) {
+            installDefaults(jsonFormat)
+        }
+    }
+
+    /**
+     * Builds a client whose response body is produced per call from the zero-based request index.
+     * For sequences too long or too open-ended to enumerate — e.g. a paginated connection that
+     * never reports a last page.
+     */
+    fun respondingWithGenerated(
+        status: HttpStatusCode = HttpStatusCode.OK,
+        jsonFormat: Json = json,
+        body: (Int) -> String,
+    ): HttpClient {
+        var index = 0
+        return HttpClient(
+            MockEngine { respond(content = body(index++), status = status, headers = JSON_HEADERS) }
         ) {
             installDefaults(jsonFormat)
         }


### PR DESCRIPTION
## Description

Closes #5506

Sui is retiring JSON-RPC. Shutdown on Foundation mainnet full nodes began the week of **2026-07-27** and full decommission (code removal) lands **mid-October 2026**, after which no provider can serve it. Android was 100% JSON-RPC on a single hardcoded host (`sui-rpc.publicnode.com`) with no fallback, so untouched, every Sui balance, fee estimate and broadcast breaks in about nine weeks.

All eight calls now go through Sui GraphQL RPC, and the transport gained endpoint failover.

| was | now |
|---|---|
| `suix_getBalance` | `address.balance(coinType)` |
| `suix_getReferenceGasPrice` | `epoch.referenceGasPrice` |
| `suix_getAllCoins` | `address.objects(filter: { type: "0x2::coin::Coin" })`, paginated |
| `suix_getCoinMetadata` | `coinMetadata(coinType)` |
| `sui_executeTransactionBlock` | `mutation executeTransaction` |
| `sui_dryRunTransactionBlock` | `simulateTransaction` |
| `sui_getTransactionBlock` | `transaction(digest)` |
| `sui_getLatestCheckpointSequenceNumber` | `checkpoint.sequenceNumber` |

### Why GraphQL and not gRPC

Both are supported replacements. GraphQL is a plain JSON POST that the existing Ktor client already speaks; gRPC would pull a `grpc-okhttp` / `grpc-kotlin` stack into a module whose protobuf plugin only generates kotlinx-serialization classes today. The SDK reached the same conclusion for its non-streaming platforms (vultisig-sdk#1583).

### Response differences absorbed at the boundary

The public `SuiApi` surface is unchanged, so no call sites move. Three differences would have failed silently rather than loudly:

- **Coin types** arrive wrapped as `0x2::coin::Coin<T>` and zero-padded. Unwrapped and stripped, they match `suix_getAllCoins` byte-for-byte. This matters beyond comparison: `SuiTokenFinder` *persists* this string as a discovered token's `contractAddress`, so without it the same token rediscovers as a second entry differing only by padding.
- **Execution status** is `SUCCESS`/`FAILURE` where the app matches the lowercase JSON-RPC spelling — unhandled, every confirmed transaction reads as pending until the poll times out.
- **A never-held coin** resolves to `null`, which is a genuine zero, not an upstream fault. GraphQL answers HTTP 200 even when it refuses, so `data: null` with a populated `errors` array is the real failure signal.

### Failover

Scoped to transport faults (unreachable host, TLS, 5xx). A populated `errors` array is the node's considered answer to a well-formed request, so it is raised immediately rather than replayed against every remaining host. Retrying a broadcast is safe — Sui identifies a transaction by the digest of its signed bytes, so re-submitting identical bytes is idempotent.

## Which feature is affected?

- [x] Send — Sui (balances, token discovery, fee estimation, broadcast, status)

Sui transaction sent through this build:
**https://suiscan.xyz/mainnet/tx/42j1UPdbzENXw9ZQUkh6yUza8AmMWrKGAigYH95QFSd9**

## Test plan

**Unit tests** — 2753 `:data` tests pass, lint clean. 32 in `SuiApiTest` (error surfacing, coin-type unwrap and padding strip, pagination, status lowercasing, not-found vs refusal, metadata nulls, response-shape rejection) and 9 new in `SuiGraphQlTransportTest` (failover on 5xx and on unreachable host, no failover on a GraphQL error payload, cancellation propagation, empty endpoint list).

**Validated against mainnet** — beyond mocked tests:

- Diffed both transports for the same live address: `version`, `balance`, `digest` and `previousTransaction` match byte-for-byte, and coin types match exactly once normalized.
- Ran the production `simulateTransaction` document against real on-chain transaction bytes and got `status: SUCCESS` with the gas summary in the mapped shape — this confirms the dry-run envelope, where the BCS bytes now travel inside a JSON-encoded `sui.rpc.v2.Transaction`.
- Broadcast and status confirmed by the real send linked above (`SUCCESS`, checkpoint 309017858).

**In-app** — Sui balances render, token discovery lists held coins with correct tickers and decimals, custom-token lookup resolves, fee estimate populates on the verify screen, send broadcasts and reaches confirmed.

## Additional context

Two follow-ups this surfaced, neither blocking:

1. **The failover list ships with one host.** `graphql.mainnet.sui.io` is the only public Sui GraphQL endpoint that answers; the other candidates I probed 403 or fail TLS, and `fullnode.mainnet.sui.io/graphql` is a 404 (gRPC only). The transport walks the whole list, so adding a host is a one-line change — but I would rather ship one verified endpoint than seed the list with hosts that do not respond.
2. **`api.vultisig.com/sui` is itself JSON-RPC.** Verified live — it answers `suix_getReferenceGasPrice`. Our own Sui proxy is subject to the same mid-October decommission and is the natural second endpoint here, but that is backend work in another repo. Worth filing separately.

Also worth flagging: the iOS sibling vultisig/vultisig-ios#5025 is still open and unassigned, and `Endpoint.swift` still hardcodes the same retired host.

`getLatestCheckpointSequenceNumber` has no call sites anywhere in the app. It is migrated for completeness but is dead surface — a candidate for removal in a separate cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sui network operations now use GraphQL for balances, coins, metadata, transactions, simulations, status checks, and checkpoints.
  * Added paginated coin retrieval, improved coin-type normalization, endpoint failover, and clearer error reporting.

* **Bug Fixes**
  * Improved handling of malformed, incomplete, unavailable, or failed Sui responses.
  * Preserved cancellation during network requests.
  * Improved transaction status reporting and failure messages.
  * Added safeguards for repeated or missing pagination data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->