### PR TITLE
fix(backup): a vault nobody exported no longer reads as backed up

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -64,7 +64,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             TransactionHistoryEntity::class,
             PendingLimitOrderEntity::class,
         ],
-    version = 41,
+    version = 42,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -50,6 +50,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_38_39
 import com.vultisig.wallet.data.db.migrations.MIGRATION_39_40
 import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_40_41
+import com.vultisig.wallet.data.db.migrations.MIGRATION_41_42
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
 import com.vultisig.wallet.data.db.migrations.MIGRATION_6_7
@@ -119,6 +120,7 @@ internal interface DatabaseModule {
                     MIGRATION_38_39,
                     MIGRATION_39_40,
                     MIGRATION_40_41,
+                    MIGRATION_41_42,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -1046,3 +1046,18 @@ internal val MIGRATION_40_41 =
             )
         }
     }
+
+// Gives the vault row the backup flag that until now lived in preferences, defaulting to
+// not-backed-up: a vault nobody has exported must never read as safe to lose, which is how iOS and
+// Windows have always declared it.
+//
+// Every existing row starts at 0, including the ones whose owner has already exported. Restoring
+// those is a code-side pass — VaultBackupStatusBackfill — because the flags it reads live in
+// DataStore, which SQL cannot see. It runs before the first vault read, so nothing observes the
+// gap; a vault with no stored flag stays 0, since unknown is not the same as safe.
+internal val MIGRATION_41_42 =
+    object : Migration(41, 42) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE `vault` ADD COLUMN `isBackedUp` INTEGER NOT NULL DEFAULT 0")
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/BackupPasswordViewModel.kt
@@ -11,7 +11,6 @@ import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.mappers.exportableOrNull
 import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -68,7 +67,6 @@ constructor(
     private val createVaultBackup: CreateVaultBackupUseCase,
     private val isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase,
     private val navigator: Navigator<Destination>,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val snackbarFlow: SnackbarFlow,
     private val saveBackupToUri: SaveBackupToUriUseCase,
     private val deleteBackupDocument: DeleteBackupDocumentUseCase,
@@ -318,15 +316,13 @@ constructor(
                 when (backupType) {
                     BackupType.AllVaults -> {
                         awaitVaults().forEach { vault ->
-                            vaultDataStoreRepository.setBackupStatus(vault.id, true)
+                            vaultRepository.setBackupStatus(vault.id, true)
                         }
                     }
 
                     is BackupType.CurrentVault -> {
                         if (vaultId != null) {
-                            withContext(Dispatchers.IO) {
-                                vaultDataStoreRepository.setBackupStatus(vaultId, true)
-                            }
+                            vaultRepository.setBackupStatus(vaultId, true)
                         } else {
                             showError()
                             return@launch

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DuplicateVaultException
 import com.vultisig.wallet.data.usecases.MalformedVaultException
@@ -66,7 +65,6 @@ internal class ImportFileViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val saveVault: SaveVaultUseCase,
     private val parseVaultFromString: ParseVaultFromStringUseCase,
     private val vaultRepository: VaultRepository,
@@ -215,7 +213,7 @@ constructor(
 
         saveVault(adjusted, false)
         runBestEffort("Failed to set backup status") {
-            vaultDataStoreRepository.setBackupStatus(adjusted.id, true)
+            vaultRepository.setBackupStatus(adjusted.id, true)
         }
         if (adjusted.pubKeyMLDSA.isNotBlank()) attachQbtcToken(adjusted)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -32,7 +32,6 @@ import com.vultisig.wallet.data.repositories.PromoBanner
 import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TiersNFTRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
@@ -64,7 +63,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -138,7 +136,6 @@ constructor(
     private val addressToUiModelMapper: AddressToUiModelMapper,
     private val fiatValueToStringMapper: FiatValueToStringMapper,
     private val vaultRepository: VaultRepository,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val accountsRepository: AccountsRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val vaultMetadataRepo: VaultMetadataRepo,
@@ -488,10 +485,9 @@ constructor(
                         // KeyImport vaults have a fixed set of chains chosen during import,
                         // so chain selection is disabled on the home screen
                         isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
+                        showBackupWarning = !vault.isBackedUp,
                     )
                 }
-                val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
-                uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
             }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModel.kt
@@ -11,7 +11,6 @@ import com.vultisig.wallet.data.mappers.exportableOrNull
 import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.getVaultPart
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -52,7 +51,6 @@ constructor(
     private val isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase,
     private val createVaultBackup: CreateVaultBackupUseCase,
     private val mapVaultToProto: MapVaultToProto,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val snackbarFlow: SnackbarFlow,
     private val saveBackupToUri: SaveBackupToUriUseCase,
     private val deleteBackupDocument: DeleteBackupDocumentUseCase,
@@ -202,9 +200,7 @@ constructor(
             val vaultId = args.vaultId
 
             if (backupSuccess) {
-                withContext(Dispatchers.IO) {
-                    vaultDataStoreRepository.setBackupStatus(args.vaultId, true)
-                }
+                vaultRepository.setBackupStatus(args.vaultId, true)
 
                 snackbarFlow.showMessage(
                     UiText.StringResource(R.string.vault_settings_success_backup_message)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
@@ -143,6 +143,10 @@ constructor(
                                         )
                                 existingVault.pubKeyMLDSA = tempVault.vault.pubKeyMLDSA
                                 existingVault.keyshares = tempVault.vault.keyshares
+                                // The keyshares changed, so any .vult taken before now restores a
+                                // vault that cannot sign on QBTC. Cleared by hand because this
+                                // branch writes back the vault it read, old flag included.
+                                existingVault.isBackedUp = false
                                 saveVault(existingVault, true)
 
                                 val qbtcToken = Coins.Qbtc.QBTC

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModel.kt
@@ -46,7 +46,6 @@ import com.vultisig.wallet.data.repositories.KeyImportData
 import com.vultisig.wallet.data.repositories.KeyImportRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.TempVaultDto
@@ -131,7 +130,6 @@ constructor(
     @ApplicationContext private val context: Context,
     private val saveVault: SaveVaultUseCase,
     private val lastOpenedVaultRepository: LastOpenedVaultRepository,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val vaultPasswordRepository: VaultPasswordRepository,
     private val temporaryVaultRepository: TemporaryVaultRepository,
     private val vaultRepository: VaultRepository,
@@ -888,6 +886,11 @@ constructor(
                     ?: error("No vault with id $vaultId exists for SingleKeygen save")
             existingVault.pubKeyMLDSA = vault.pubKeyMLDSA
             existingVault.keyshares = vault.keyshares
+            // A .vult exported before this ceremony has no MLDSA share, so restoring it now yields
+            // a vault that cannot sign on QBTC. This branch merges into the vault it read, which
+            // carries the old flag, so clearing it here is what a full upsert of a fresh vault does
+            // by itself on the paths below.
+            existingVault.isBackedUp = false
             saveVault(existingVault, true)
 
             // Auto-enable QBTC chain after MLDSA key generation
@@ -921,7 +924,11 @@ constructor(
                 return
             }
 
-            vaultDataStoreRepository.setBackupStatus(vaultId = vaultId, false)
+            // A vault leaving a ceremony has never been exported, and a reshared one has just
+            // invalidated every .vult that was. The freshly built vault above already carries the
+            // cleared flag through the upsert; this is here so the guarantee does not rest on that
+            // vault never being loaded from storage instead.
+            vaultRepository.setBackupStatus(vaultId = vaultId, isBackedUp = false)
         }
 
         if (action == TssAction.KEYGEN) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModel.kt
@@ -11,7 +11,6 @@ import com.vultisig.wallet.data.mappers.MapVaultToProto
 import com.vultisig.wallet.data.mappers.exportableOrNull
 import com.vultisig.wallet.data.models.TssAction
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -65,7 +64,6 @@ constructor(
     private val createVaultBackup: CreateVaultBackupUseCase,
     private val isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase,
     private val vaultRepository: VaultRepository,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
     private val mapVaultToProto: MapVaultToProto,
     private val saveBackupToUri: SaveBackupToUriUseCase,
     private val deleteBackupDocument: DeleteBackupDocumentUseCase,
@@ -238,13 +236,11 @@ constructor(
     private suspend fun updateBackupStatus() {
         when (backupType) {
             BackupType.AllVaults -> {
-                awaitVaults().forEach { vault ->
-                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
-                }
+                awaitVaults().forEach { vault -> vaultRepository.setBackupStatus(vault.id, true) }
             }
 
             is BackupType.CurrentVault -> {
-                vaultDataStoreRepository.setBackupStatus(vaultId, true)
+                vaultRepository.setBackupStatus(vaultId, true)
             }
         }
     }

--- a/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration41To42Test.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration41To42Test.kt
@@ -1,0 +1,30 @@
+package com.vultisig.wallet.data.db.migrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class Migration41To42Test {
+
+    /**
+     * Pins the default at 0. Every existing row gets it, including the vaults whose owner has
+     * already exported — `VaultBackupStatusBackfill` restores those from preferences, which SQL
+     * cannot read. A default of 1 would hand every vault in the table a backup it may not have.
+     */
+    @Test
+    fun `migrate adds the vault backup flag defaulting to not backed up`() {
+        val db = mockk<SupportSQLiteDatabase>(relaxed = true)
+        val sql = slot<String>()
+
+        MIGRATION_41_42.migrate(db)
+
+        verify { db.execSQL(capture(sql)) }
+        val statement = sql.captured
+        assertTrue(statement.contains("ALTER TABLE `vault`"))
+        assertTrue(statement.contains("ADD COLUMN `isBackedUp`"))
+        assertTrue(statement.contains("INTEGER NOT NULL DEFAULT 0"))
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/BackupPasswordViewModelTest.kt
@@ -11,7 +11,6 @@ import com.vultisig.wallet.data.mappers.MapVaultToProtoImpl
 import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -28,6 +27,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -59,7 +59,6 @@ internal class BackupPasswordViewModelTest {
     private lateinit var createVaultBackup: CreateVaultBackupUseCase
     private lateinit var isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase
     private lateinit var navigator: Navigator<Destination>
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var snackbarFlow: SnackbarFlow
     private lateinit var saveBackupToUri: SaveBackupToUriUseCase
     private lateinit var deleteBackupDocument: DeleteBackupDocumentUseCase
@@ -71,13 +70,13 @@ internal class BackupPasswordViewModelTest {
 
         vaultRepository = mockk()
         coEvery { vaultRepository.awaitKeySharesReadable() } returns Unit
+        coJustRun { vaultRepository.setBackupStatus(any(), any()) }
         mapVaultToProto = MapVaultToProtoImpl()
         createVaultBackupFileName = mockk(relaxed = true)
         createZipVaultsBackupFileName = mockk(relaxed = true)
         createVaultBackup = mockk()
         isFileExtensionValid = mockk()
         navigator = mockk(relaxed = true)
-        vaultDataStoreRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
         saveBackupToUri = mockk()
         deleteBackupDocument = mockk(relaxed = true)
@@ -119,7 +118,6 @@ internal class BackupPasswordViewModelTest {
             createVaultBackup = createVaultBackup,
             isFileExtensionValid = isFileExtensionValid,
             navigator = navigator,
-            vaultDataStoreRepository = vaultDataStoreRepository,
             snackbarFlow = snackbarFlow,
             saveBackupToUri = saveBackupToUri,
             deleteBackupDocument = deleteBackupDocument,
@@ -158,9 +156,7 @@ internal class BackupPasswordViewModelTest {
             coVerify(timeout = 5_000) { saveBackupToUri(uri, capture(contentSlot)) }
             contentSlot.captured.size shouldBe vaults.size
             vaults.forEach { vault ->
-                coVerify(timeout = 5_000) {
-                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
-                }
+                coVerify(timeout = 5_000) { vaultRepository.setBackupStatus(vault.id, true) }
             }
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -12,7 +12,6 @@ import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DuplicateVaultException
 import com.vultisig.wallet.data.usecases.MalformedVaultException
@@ -54,7 +53,6 @@ internal class ImportFileViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var navigator: Navigator<Destination>
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var saveVault: SaveVaultUseCase
     private lateinit var parseVaultFromString: ParseVaultFromStringUseCase
     private lateinit var vaultRepository: VaultRepository
@@ -68,7 +66,6 @@ internal class ImportFileViewModelTest {
         mockkStatic("androidx.navigation.SavedStateHandleKt")
         every { any<SavedStateHandle>().toRoute<Route.ImportVault>() } returns Route.ImportVault()
         navigator = mockk(relaxed = true)
-        vaultDataStoreRepository = mockk(relaxed = true)
         saveVault = mockk(relaxed = true)
         parseVaultFromString = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
@@ -95,7 +92,6 @@ internal class ImportFileViewModelTest {
             ImportFileViewModel(
                 savedStateHandle = savedStateHandle,
                 navigator = navigator,
-                vaultDataStoreRepository = vaultDataStoreRepository,
                 saveVault = saveVault,
                 parseVaultFromString = parseVaultFromString,
                 vaultRepository = vaultRepository,
@@ -170,7 +166,7 @@ internal class ImportFileViewModelTest {
             )
         coEvery { parseVaultFromString(any(), any()) } returns vault
         coEvery { saveVault(any(), false) } returns Unit
-        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } returns Unit
+        coEvery { vaultRepository.setBackupStatus(any(), any()) } returns Unit
         coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } returns
             Pair("qbtc1address", "qbtc-derived-pubkey")
         coEvery { vaultRepository.addTokenToVault(any(), any()) } returns Unit
@@ -551,8 +547,7 @@ internal class ImportFileViewModelTest {
     @Test
     fun `import succeeds when setBackupStatus fails`() = runTest {
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } throws
-            RuntimeException("datastore")
+        coEvery { vaultRepository.setBackupStatus(any(), any()) } throws RuntimeException("db")
         val vm = createViewModel(fileName = "vault.bak")
 
         vm.decryptVaultData()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -26,7 +26,6 @@ import com.vultisig.wallet.data.repositories.PromoBanner
 import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TiersNFTRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.services.PushNotificationManager
@@ -83,7 +82,6 @@ internal class VaultAccountsViewModelTest {
     private lateinit var addressToUiModelMapper: AddressToUiModelMapper
     private lateinit var fiatValueToStringMapper: FiatValueToStringMapper
     private lateinit var vaultRepository: VaultRepository
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var accountsRepository: AccountsRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
     private lateinit var vaultMetadataRepo: VaultMetadataRepo
@@ -111,7 +109,6 @@ internal class VaultAccountsViewModelTest {
         addressToUiModelMapper = mockk(relaxed = true)
         fiatValueToStringMapper = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
-        vaultDataStoreRepository = mockk(relaxed = true)
         accountsRepository = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
         vaultMetadataRepo = mockk(relaxed = true)
@@ -152,7 +149,6 @@ internal class VaultAccountsViewModelTest {
             addressToUiModelMapper = addressToUiModelMapper,
             fiatValueToStringMapper = fiatValueToStringMapper,
             vaultRepository = vaultRepository,
-            vaultDataStoreRepository = vaultDataStoreRepository,
             accountsRepository = accountsRepository,
             balanceVisibilityRepository = balanceVisibilityRepository,
             vaultMetadataRepo = vaultMetadataRepo,
@@ -439,6 +435,35 @@ internal class VaultAccountsViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.uiState.value.showBuyVultBanner.shouldBeFalse()
+        }
+
+    /**
+     * Verifies a vault nobody has exported is told to back up.
+     *
+     * The flag used to be read out of preferences with a default of `true`, and two save paths
+     * never wrote one — so the vaults most in need of this warning were the ones that never saw it.
+     */
+    @Test
+    fun `showBackupWarning is true for a vault that has never been exported`() =
+        runTest(testDispatcher) {
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns
+                Vault(id = "vault-1", name = "Test", isBackedUp = false)
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.showBackupWarning.shouldBeTrue()
+        }
+
+    /** Verifies the warning stays hidden once the vault has been exported. */
+    @Test
+    fun `showBackupWarning is false for an exported vault`() =
+        runTest(testDispatcher) {
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns
+                Vault(id = "vault-1", name = "Test", isBackedUp = true)
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.uiState.value.showBackupWarning.shouldBeFalse()
         }
 
     /** Verifies the upgrade banner shows only for a GG20 (migration-eligible) vault. */

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keygen/BackupVaultViewModelTest.kt
@@ -8,7 +8,6 @@ import com.vultisig.wallet.data.mappers.MapVaultToProtoImpl
 import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -21,6 +20,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.Route.VaultInfo
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -48,7 +48,6 @@ internal class BackupVaultViewModelTest {
     private lateinit var isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase
     private lateinit var createVaultBackup: CreateVaultBackupUseCase
     private lateinit var mapVaultToProto: MapVaultToProto
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var snackbarFlow: SnackbarFlow
     private lateinit var saveBackupToUri: SaveBackupToUriUseCase
     private lateinit var deleteBackupDocument: DeleteBackupDocumentUseCase
@@ -64,12 +63,12 @@ internal class BackupVaultViewModelTest {
         isFileExtensionValid = mockk()
         createVaultBackup = mockk()
         mapVaultToProto = MapVaultToProtoImpl()
-        vaultDataStoreRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
         saveBackupToUri = mockk()
         deleteBackupDocument = mockk(relaxed = true)
 
         coEvery { vaultRepository.awaitKeySharesReadable() } returns Unit
+        coJustRun { vaultRepository.setBackupStatus(any(), any()) }
         coEvery { isFileExtensionValid(any(), any()) } returns true
         coEvery { saveBackupToUri(any(), any<String>()) } returns true
         every { createVaultBackup(any(), any()) } returns "backup-content"
@@ -100,7 +99,6 @@ internal class BackupVaultViewModelTest {
             isFileExtensionValid = isFileExtensionValid,
             createVaultBackup = createVaultBackup,
             mapVaultToProto = mapVaultToProto,
-            vaultDataStoreRepository = vaultDataStoreRepository,
             snackbarFlow = snackbarFlow,
             saveBackupToUri = saveBackupToUri,
             deleteBackupDocument = deleteBackupDocument,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModelTest.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.TssAction
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.BackupCodeVerifyResult
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.repositories.vault.TempVaultDto
 import com.vultisig.wallet.data.repositories.vault.TemporaryVaultRepository
 import com.vultisig.wallet.data.repositories.vault.VaultMetadataRepo
 import com.vultisig.wallet.data.usecases.SaveVaultUseCase
@@ -23,8 +25,10 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -113,6 +117,46 @@ internal class FastVaultVerificationViewModelTest {
             vm.retry()
             advanceUntilIdle()
             assertEquals(VerifyPinState.Error, vm.state.value.verifyPinState)
+        }
+
+    /**
+     * Verifies the MLDSA merge retires the vault's existing backup.
+     *
+     * This branch writes back the vault it read, old flag and all, so it is the one place a
+     * ceremony can change the keyshares and leave the flag standing. A `.vult` taken before now
+     * carries no MLDSA share, and restoring it yields a vault that cannot sign on QBTC.
+     */
+    @Test
+    fun `the MLDSA merge clears the backup flag of the vault it writes back`() =
+        runTest(testDispatcher) {
+            every { any<SavedStateHandle>().toRoute<Route.FastVaultVerification>() } returns
+                Route.FastVaultVerification(
+                    vaultId = "vault",
+                    pubKeyEcdsa = "pub",
+                    email = "a@b.c",
+                    tssAction = TssAction.SingleKeygen,
+                    vaultName = "v",
+                    password = "pw",
+                )
+            coEvery { verifyUseCase(any(), any()) } returns BackupCodeVerifyResult.Valid
+            coEvery { temporaryVaultRepository.getById("vault") } returns
+                TempVaultDto(
+                    vault = Vault(id = "vault", name = "v", pubKeyMLDSA = "mldsa"),
+                    email = "a@b.c",
+                    password = "pw",
+                    hint = null,
+                )
+            coEvery { vaultRepository.get("vault") } returns
+                Vault(id = "vault", name = "v", isBackedUp = true)
+            val saved = slot<Vault>()
+            coEvery { saveVault(capture(saved), true) } returns Unit
+
+            val vm = buildViewModel()
+            vm.codeFieldState.setTextAndPlaceCursorAtEnd("1234")
+            vm.processCode("1234")
+            advanceUntilIdle()
+
+            assertFalse(saved.captured.isBackedUp)
         }
 
     private fun buildViewModel(): FastVaultVerificationViewModel =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keygen/KeygenViewModelTest.kt
@@ -14,7 +14,6 @@ import com.vultisig.wallet.data.repositories.FeatureFlagRepository
 import com.vultisig.wallet.data.repositories.KeyImportRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepositoryContract
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.vault.TemporaryVaultRepository
@@ -55,7 +54,6 @@ internal class KeygenViewModelTest {
     private lateinit var navigator: Navigator<Destination>
     private lateinit var saveVault: SaveVaultUseCase
     private lateinit var lastOpenedVaultRepository: LastOpenedVaultRepository
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var vaultPasswordRepository: VaultPasswordRepository
     private lateinit var temporaryVaultRepository: TemporaryVaultRepository
     private lateinit var vaultRepository: VaultRepository
@@ -97,7 +95,6 @@ internal class KeygenViewModelTest {
         navigator = mockk(relaxed = true)
         saveVault = mockk(relaxed = true)
         lastOpenedVaultRepository = mockk(relaxed = true)
-        vaultDataStoreRepository = mockk(relaxed = true)
         vaultPasswordRepository = mockk(relaxed = true)
         temporaryVaultRepository = mockk(relaxed = true)
         vaultRepository = mockk(relaxed = true)
@@ -125,7 +122,6 @@ internal class KeygenViewModelTest {
             context = context,
             saveVault = saveVault,
             lastOpenedVaultRepository = lastOpenedVaultRepository,
-            vaultDataStoreRepository = vaultDataStoreRepository,
             vaultPasswordRepository = vaultPasswordRepository,
             temporaryVaultRepository = temporaryVaultRepository,
             vaultRepository = vaultRepository,

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/backup/BackupPasswordRequestViewModelTest.kt
@@ -9,7 +9,6 @@ import com.vultisig.wallet.data.mappers.MapVaultToProtoImpl
 import com.vultisig.wallet.data.models.KeyShare
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.CreateVaultBackupUseCase
 import com.vultisig.wallet.data.usecases.backup.CreateVaultBackupFileNameUseCase
@@ -25,6 +24,7 @@ import com.vultisig.wallet.ui.utils.SnackbarFlow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -55,7 +55,6 @@ internal class BackupPasswordRequestViewModelTest {
     private lateinit var createVaultBackup: CreateVaultBackupUseCase
     private lateinit var isFileExtensionValid: IsVaultBackupFileExtensionValidUseCase
     private lateinit var vaultRepository: VaultRepository
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
     private lateinit var mapVaultToProto: MapVaultToProto
     private lateinit var saveBackupToUri: SaveBackupToUriUseCase
     private lateinit var deleteBackupDocument: DeleteBackupDocumentUseCase
@@ -72,8 +71,8 @@ internal class BackupPasswordRequestViewModelTest {
         createVaultBackup = mockk()
         isFileExtensionValid = mockk()
         vaultRepository = mockk()
+        coJustRun { vaultRepository.setBackupStatus(any(), any()) }
         coEvery { vaultRepository.awaitKeySharesReadable() } returns Unit
-        vaultDataStoreRepository = mockk(relaxed = true)
         mapVaultToProto = MapVaultToProtoImpl()
         saveBackupToUri = mockk()
         deleteBackupDocument = mockk(relaxed = true)
@@ -113,7 +112,6 @@ internal class BackupPasswordRequestViewModelTest {
             createVaultBackup = createVaultBackup,
             isFileExtensionValid = isFileExtensionValid,
             vaultRepository = vaultRepository,
-            vaultDataStoreRepository = vaultDataStoreRepository,
             mapVaultToProto = mapVaultToProto,
             saveBackupToUri = saveBackupToUri,
             deleteBackupDocument = deleteBackupDocument,
@@ -150,9 +148,7 @@ internal class BackupPasswordRequestViewModelTest {
             coVerify(timeout = 5_000) { saveBackupToUri(uri, capture(contentSlot)) }
             contentSlot.captured.size shouldBe vaults.size
             vaults.forEach { vault ->
-                coVerify(timeout = 5_000) {
-                    vaultDataStoreRepository.setBackupStatus(vault.id, true)
-                }
+                coVerify(timeout = 5_000) { vaultRepository.setBackupStatus(vault.id, true) }
             }
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
@@ -39,6 +39,8 @@ interface VaultDao {
     @Query("SELECT * FROM vault")
     fun loadAllAsFlow(): Flow<List<VaultWithKeySharesAndTokens>>
 
+    @Query("SELECT id FROM vault") suspend fun loadAllIds(): List<VaultId>
+
     @Query("SELECT coinId FROM disabledCoin WHERE vaultId = :vaultId")
     suspend fun loadDisabledCoinIds(vaultId: VaultId): List<String>
 
@@ -151,6 +153,16 @@ interface VaultDao {
 
     @Query("UPDATE vault SET name = :name WHERE id = :vaultId")
     suspend fun setVaultName(vaultId: String, name: String)
+
+    /**
+     * Writes the backup flag on its own, without going through the vault upsert.
+     *
+     * The export paths hold a vault they read before writing the file, and rewriting the whole row
+     * from it would echo back whatever else has changed since — including keyshares dropped by a
+     * lock that landed mid-export.
+     */
+    @Query("UPDATE vault SET isBackedUp = :isBackedUp WHERE id = :vaultId")
+    suspend fun setBackupStatus(vaultId: String, isBackedUp: Boolean)
 
     @Query("DELETE FROM signer WHERE vaultId = :vaultId") suspend fun deleteSigners(vaultId: String)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/migrations/VaultBackupStatusBackfill.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/migrations/VaultBackupStatusBackfill.kt
@@ -1,0 +1,100 @@
+package com.vultisig.wallet.data.db.migrations
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.data.sources.AppDataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+
+/**
+ * Carries the per-vault backup flag from DataStore onto the vault row, once per install.
+ *
+ * The flag used to live at `vault_backup/<vaultId>` in preferences and was read with a default of
+ * `true`, so a vault nobody had written a flag for counted as backed up. Two save paths never wrote
+ * one — fast-vault creation and the MLDSA merge — which made "never exported" indistinguishable
+ * from "exported" for precisely the vaults that had never been exported.
+ *
+ * [MIGRATION_41_42] replaces it with a column defaulting to `false`. Restoring the flags of users
+ * who *have* exported is why this class exists: SQL cannot read DataStore, so without a code-side
+ * pass everyone who already holds a `.vult` would be told to back up again. A vault with no stored
+ * flag stays `false` — unknown is not the same as safe.
+ *
+ * Called from [com.vultisig.wallet.data.repositories.VaultRepository] ahead of every read of a
+ * vault and every write that could carry the flag, so no caller can observe the pre-backfill state
+ * and no reshare can be undone by a backfill that lands after it. Safe to call from anywhere: the
+ * work happens under a [Mutex] at most once, and concurrent callers await that same run rather than
+ * repeating it. After it completes, calls cost a volatile read.
+ *
+ * A failure leaves the flags where they are and lets the next caller retry, rather than propagating
+ * — a preferences read that goes wrong must not take every vault read down with it. The order of
+ * writes is what makes the retry safe: rows are written first, and the legacy keys are dropped in
+ * the same edit that records completion, so a run that dies midway is always re-derivable from the
+ * keys still in place.
+ */
+@Singleton
+internal class VaultBackupStatusBackfill
+@Inject
+constructor(private val vaultDao: VaultDao, private val appDataStore: AppDataStore) {
+
+    private val mutex = Mutex()
+
+    @Volatile private var isCompleted = false
+
+    suspend fun ensureRun() {
+        if (isCompleted) return
+        mutex.withLock {
+            if (isCompleted) return
+            if (appDataStore.readData(BACKFILL_DONE_KEY, false).first()) {
+                isCompleted = true
+                return
+            }
+            try {
+                backfill()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to move vault backup flags out of preferences")
+                return
+            }
+            isCompleted = true
+        }
+    }
+
+    private suspend fun backfill() {
+        val vaultIds = vaultDao.loadAllIds()
+        val backedUp =
+            vaultIds.filter { appDataStore.readData(legacyBackupStatusKey(it), false).first() }
+        backedUp.forEach { vaultDao.setBackupStatus(vaultId = it, isBackedUp = true) }
+        appDataStore.editData { preferences ->
+            // Every key with the prefix, not just the ones matching a vault that still exists:
+            // deleting a vault never removed its flag, so preferences hold entries for vaults that
+            // are long gone.
+            preferences
+                .asMap()
+                .keys
+                .filter { it.name.startsWith(LEGACY_KEY_PREFIX) }
+                .forEach { preferences -= it }
+            preferences[BACKFILL_DONE_KEY] = true
+        }
+        Timber.i(
+            "Moved the backup flag onto the vault row for %d of %d vaults",
+            backedUp.size,
+            vaultIds.size,
+        )
+    }
+
+    private companion object {
+        const val LEGACY_KEY_PREFIX = "vault_backup/"
+
+        val BACKFILL_DONE_KEY = booleanPreferencesKey(name = "vault_backup_status_backfilled")
+
+        fun legacyBackupStatusKey(vaultId: VaultId) =
+            booleanPreferencesKey(name = "$LEGACY_KEY_PREFIX$vaultId")
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/VaultEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/VaultEntity.kt
@@ -19,6 +19,7 @@ data class VaultEntity(
     @ColumnInfo("hexChainCode") val hexChainCode: String,
     @ColumnInfo("resharePrefix") val resharePrefix: String,
     @ColumnInfo("libType") val libType: SigningLibType,
+    @ColumnInfo("isBackedUp", defaultValue = "0") val isBackedUp: Boolean = false,
 )
 
 @Entity(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Vault.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Vault.kt
@@ -22,6 +22,21 @@ data class Vault(
     var coins: List<Coin> = emptyList(),
     var chainPublicKeys: List<ChainPublicKey> = emptyList(),
     var libType: SigningLibType = SigningLibType.GG20,
+    /**
+     * True once this vault has been exported to a `.vult` that is known to be complete.
+     *
+     * Defaults to false, so a vault nobody has exported is never mistaken for one that is safe to
+     * lose — matching iOS and Windows. Set it only through
+     * [com.vultisig.wallet.data.repositories.VaultRepository.setBackupStatus], and only after an
+     * export that finished writing: a `.vult` missing keyshares restores cleanly and can never
+     * sign, so a flag set on a partial write records a backup that does not exist.
+     *
+     * Any ceremony that changes [keyshares] makes every existing `.vult` stale and must clear it. A
+     * full upsert of a freshly generated vault does that on its own — the flag lives on the vault
+     * row, and a new vault carries the default. A read-modify-write of an existing vault does not,
+     * and has to clear it by hand.
+     */
+    var isBackedUp: Boolean = false,
 ) {
 
     fun getKeyshare(pubKey: String): String? =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultDataStoreRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultDataStoreRepository.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.data.repositories
 
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.vultisig.wallet.data.sources.AppDataStore
@@ -11,10 +10,6 @@ const val GLOBAL_REMINDER_STATUS_NEVER_SHOW = -1
 const val GLOBAL_REMINDER_STATUS_NOT_SET = 0
 
 interface VaultDataStoreRepository {
-    suspend fun setBackupStatus(vaultId: String, status: Boolean)
-
-    suspend fun readBackupStatus(vaultId: String): Flow<Boolean>
-
     suspend fun setFastSignHint(vaultId: String, hint: String)
 
     suspend fun readFastSignHint(vaultId: String): Flow<String>
@@ -27,15 +22,6 @@ interface VaultDataStoreRepository {
 internal class VaultDataStoreRepositoryImpl
 @Inject
 constructor(private val appDataStore: AppDataStore) : VaultDataStoreRepository {
-    override suspend fun setBackupStatus(vaultId: String, status: Boolean) {
-        appDataStore.editData { preferences ->
-            preferences[onVaultBackupStatusKey(vaultId)] = status
-        }
-    }
-
-    override suspend fun readBackupStatus(vaultId: String): Flow<Boolean> =
-        appDataStore.readData(onVaultBackupStatusKey(vaultId), true)
-
     override suspend fun setFastSignHint(vaultId: String, hint: String) {
         appDataStore.editData { preferences -> preferences[onVaultFastSignHintKey(vaultId)] = hint }
     }
@@ -58,9 +44,6 @@ constructor(private val appDataStore: AppDataStore) : VaultDataStoreRepository {
     }
 
     private companion object PreferencesKey {
-        fun onVaultBackupStatusKey(vaultId: String) =
-            booleanPreferencesKey(name = "vault_backup/$vaultId")
-
         fun onVaultFastSignHintKey(vaultId: String) =
             stringPreferencesKey(name = "vault_fast_sign_hint/$vaultId")
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.migrations.VaultBackupStatusBackfill
 import com.vultisig.wallet.data.db.models.ChainPublicKeyEntity
 import com.vultisig.wallet.data.db.models.CoinEntity
 import com.vultisig.wallet.data.db.models.KeyShareEntity
@@ -21,6 +22,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 
 interface VaultRepository {
@@ -70,6 +72,12 @@ interface VaultRepository {
 
     suspend fun setVaultName(vaultId: VaultId, name: String)
 
+    /**
+     * Records whether this vault has been exported to a `.vult` that is known to be complete — see
+     * [Vault.isBackedUp] for when each value is the truthful one.
+     */
+    suspend fun setBackupStatus(vaultId: VaultId, isBackedUp: Boolean)
+
     suspend fun delete(vaultId: VaultId)
 
     suspend fun disableTokenFromVault(vaultId: VaultId, token: Coin)
@@ -90,6 +98,7 @@ constructor(
     private val tokenRepository: TokenRepository,
     private val keyShareCipher: KeyShareCipher,
     private val passcodeDataKeySource: PasscodeDataKeySource,
+    private val backupStatusBackfill: VaultBackupStatusBackfill,
 ) : VaultRepository {
 
     override fun getEnabledTokens(vaultId: String): Flow<List<Coin>> =
@@ -105,19 +114,33 @@ constructor(
 
     override suspend fun awaitKeySharesReadable() = passcodeDataKeySource.awaitUnlocked()
 
-    override suspend fun get(vaultId: String): Vault? = vaultDao.loadById(vaultId)?.toVault()
+    override suspend fun get(vaultId: String): Vault? {
+        backupStatusBackfill.ensureRun()
+        return vaultDao.loadById(vaultId)?.toVault()
+    }
 
     override fun getAllAsFlow(): Flow<List<Vault>> {
-        return vaultDao.loadAllAsFlow().map { it.map { dbVault -> dbVault.toVault() } }
+        return vaultDao
+            .loadAllAsFlow()
+            .onStart { backupStatusBackfill.ensureRun() }
+            .map { it.map { dbVault -> dbVault.toVault() } }
     }
 
     override fun getAsFlow(vaultId: String): Flow<Vault?> =
-        vaultDao.loadByIdAsFlow(vaultId).map { it?.toVault() }
+        vaultDao
+            .loadByIdAsFlow(vaultId)
+            .onStart { backupStatusBackfill.ensureRun() }
+            .map { it?.toVault() }
 
-    override suspend fun getByEcdsa(pubKeyEcdsa: String): Vault? =
-        vaultDao.loadByEcdsa(pubKeyEcdsa)?.toVault()
+    override suspend fun getByEcdsa(pubKeyEcdsa: String): Vault? {
+        backupStatusBackfill.ensureRun()
+        return vaultDao.loadByEcdsa(pubKeyEcdsa)?.toVault()
+    }
 
-    override suspend fun getAll(): List<Vault> = vaultDao.loadAll().map { it.toVault() }
+    override suspend fun getAll(): List<Vault> {
+        backupStatusBackfill.ensureRun()
+        return vaultDao.loadAll().map { it.toVault() }
+    }
 
     override suspend fun hasVaults(): Boolean = vaultDao.hasVaults()
 
@@ -135,11 +158,20 @@ constructor(
     }
 
     override suspend fun upsert(vault: Vault) {
+        // Before, not after. An upsert carries the vault's own backup flag, so a reshare that
+        // cleared it would be undone by a backfill that still holds the legacy value and lands
+        // behind the write.
+        backupStatusBackfill.ensureRun()
         vaultDao.upsert(vault.toVaultDb())
     }
 
     override suspend fun setVaultName(vaultId: String, name: String) {
         vaultDao.setVaultName(vaultId, name)
+    }
+
+    override suspend fun setBackupStatus(vaultId: String, isBackedUp: Boolean) {
+        backupStatusBackfill.ensureRun()
+        vaultDao.setBackupStatus(vaultId = vaultId, isBackedUp = isBackedUp)
     }
 
     override suspend fun delete(vaultId: String) {
@@ -220,6 +252,7 @@ constructor(
             localPartyID = vault.vault.localPartyID,
             signers = vault.signers.sortedBy { it.index }.map { it.title },
             resharePrefix = vault.vault.resharePrefix,
+            isBackedUp = vault.vault.isBackedUp,
             keyshares = vault.keyShares.toKeyShares(vault.vault.id),
             coins =
                 vault.coins.mapNotNull { coinEntity ->
@@ -290,6 +323,7 @@ constructor(
                     localPartyID = vault.localPartyID,
                     resharePrefix = vault.resharePrefix,
                     libType = vault.libType,
+                    isBackedUp = vault.isBackedUp,
                 ),
             keyShares =
                 vault.keyshares.map {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/db/migrations/VaultBackupStatusBackfillTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/db/migrations/VaultBackupStatusBackfillTest.kt
@@ -1,0 +1,201 @@
+package com.vultisig.wallet.data.db.migrations
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.sources.FakeAppDataStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class VaultBackupStatusBackfillTest {
+
+    private lateinit var vaultDao: VaultDao
+    private lateinit var appDataStore: FakeAppDataStore
+
+    @BeforeEach
+    fun setUp() {
+        vaultDao = mockk(relaxUnitFun = true)
+        appDataStore = FakeAppDataStore()
+    }
+
+    private fun backfill() = VaultBackupStatusBackfill(vaultDao, appDataStore)
+
+    private fun legacyKey(vaultId: String) = booleanPreferencesKey(name = "vault_backup/$vaultId")
+
+    private val doneKey = booleanPreferencesKey(name = "vault_backup_status_backfilled")
+
+    /**
+     * Verifies a vault whose owner had already exported keeps its flag.
+     *
+     * This is the reason the class exists: the SQL migration starts every row at not-backed-up, so
+     * without this pass everyone already holding a `.vult` would be told to back up again.
+     */
+    @Test
+    fun `carries a legacy exported flag onto the vault row`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1")
+        appDataStore.set(legacyKey("vault-1"), true)
+
+        backfill().ensureRun()
+
+        coVerify { vaultDao.setBackupStatus(vaultId = "vault-1", isBackedUp = true) }
+    }
+
+    /**
+     * Verifies a vault with no stored flag is left not-backed-up.
+     *
+     * Preferences answered that read with `true`, which is what made a fast vault nobody had ever
+     * exported — a save path that never wrote a flag — indistinguishable from an exported one.
+     * Unknown has to mean not backed up, or the flag cannot gate anything.
+     */
+    @Test
+    fun `leaves a vault with no legacy flag alone, rather than assuming it is safe`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("never-exported")
+
+        backfill().ensureRun()
+
+        coVerify(exactly = 0) { vaultDao.setBackupStatus(any(), any()) }
+    }
+
+    /** Verifies an explicit legacy `false` stays false rather than being written as true. */
+    @Test
+    fun `leaves a vault whose legacy flag was cleared not backed up`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1")
+        appDataStore.set(legacyKey("vault-1"), false)
+
+        backfill().ensureRun()
+
+        coVerify(exactly = 0) { vaultDao.setBackupStatus(any(), any()) }
+    }
+
+    /**
+     * Verifies the legacy keys are dropped and completion recorded, so nothing reads them again.
+     */
+    @Test
+    fun `drops the legacy keys and records completion`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1", "vault-2")
+        appDataStore.set(legacyKey("vault-1"), true)
+
+        backfill().ensureRun()
+
+        assertNull(appDataStore.readData(legacyKey("vault-1")).first())
+        assertTrue(appDataStore.readData(doneKey, false).first())
+    }
+
+    /**
+     * Verifies a flag left behind by a deleted vault is dropped too.
+     *
+     * Deleting a vault never removed its flag, so preferences hold entries for vaults that no
+     * longer exist. Sweeping by prefix clears them; keying the removal off the surviving vaults
+     * would leave them there for good, since nothing reads these keys after this pass.
+     */
+    @Test
+    fun `drops a flag orphaned by a deleted vault`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1")
+        appDataStore.set(legacyKey("deleted-vault"), true)
+
+        backfill().ensureRun()
+
+        assertNull(appDataStore.readData(legacyKey("deleted-vault")).first())
+        coVerify(exactly = 0) { vaultDao.setBackupStatus(any(), any()) }
+    }
+
+    /** Verifies keys belonging to other features survive the sweep. */
+    @Test
+    fun `leaves unrelated preferences alone`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1")
+        val hint = stringPreferencesKey(name = "vault_fast_sign_hint/vault-1")
+        appDataStore.set(hint, "hint")
+
+        backfill().ensureRun()
+
+        assertEquals("hint", appDataStore.readData(hint).first())
+    }
+
+    /**
+     * Verifies a second instance — a fresh process, with nothing cached in memory — does no work
+     * once completion is recorded.
+     *
+     * This is what keeps a stale flag from coming back. A vault reshared after the backfill has a
+     * cleared flag on its row, and a second run that read the legacy keys again would put the old
+     * `true` back over it.
+     */
+    @Test
+    fun `a later run in a new process does nothing`() = runTest {
+        appDataStore.set(doneKey, true)
+
+        backfill().ensureRun()
+
+        coVerify(exactly = 0) { vaultDao.loadAllIds() }
+        coVerify(exactly = 0) { vaultDao.setBackupStatus(any(), any()) }
+    }
+
+    /** Verifies repeat calls on one instance do the work once. */
+    @Test
+    fun `repeated calls run the pass once`() = runTest {
+        coEvery { vaultDao.loadAllIds() } returns listOf("vault-1")
+        val backfill = backfill()
+
+        backfill.ensureRun()
+        backfill.ensureRun()
+        backfill.ensureRun()
+
+        coVerify(exactly = 1) { vaultDao.loadAllIds() }
+    }
+
+    /**
+     * Verifies concurrent callers wait on the one run instead of each starting their own — every
+     * vault read goes through here, and the first ones can arrive together.
+     */
+    @Test
+    fun `concurrent callers share a single run`() = runTest {
+        val readIds = CompletableDeferred<Unit>()
+        coEvery { vaultDao.loadAllIds() } coAnswers
+            {
+                readIds.await()
+                listOf("vault-1")
+            }
+        val backfill = backfill()
+
+        launch { backfill.ensureRun() }
+        launch { backfill.ensureRun() }
+        advanceUntilIdle()
+        readIds.complete(Unit)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { vaultDao.loadAllIds() }
+    }
+
+    /**
+     * Verifies a failed pass neither propagates nor gives up.
+     *
+     * Every vault read runs this, so a preferences or database hiccup must not turn into a failed
+     * vault read; and since nothing else will ever carry the flags over, the next caller has to
+     * retry.
+     */
+    @Test
+    fun `a failed run does not propagate and is retried`() = runTest {
+        coEvery { vaultDao.loadAllIds() } throws RuntimeException("db") andThen listOf("vault-1")
+        appDataStore.set(legacyKey("vault-1"), true)
+        val backfill = backfill()
+
+        backfill.ensureRun()
+        coVerify(exactly = 0) { vaultDao.setBackupStatus(any(), any()) }
+
+        backfill.ensureRun()
+
+        coVerify(exactly = 1) { vaultDao.setBackupStatus(vaultId = "vault-1", isBackedUp = true) }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.migrations.VaultBackupStatusBackfill
 import com.vultisig.wallet.data.db.models.CoinEntity
 import com.vultisig.wallet.data.db.models.KeyShareEntity
 import com.vultisig.wallet.data.db.models.VaultEntity
@@ -13,9 +14,11 @@ import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.passcode.KeyShareCipher
 import com.vultisig.wallet.data.passcode.KeyShareIdentity
 import com.vultisig.wallet.data.passcode.PasscodeDataKeySource
+import com.vultisig.wallet.data.sources.FakeAppDataStore
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -44,7 +47,15 @@ internal class VaultRepositoryImplTest {
         vaultDao = mockk(relaxUnitFun = true)
         tokenRepository = mockk()
         passcode = FakePasscodeDataKeySource()
-        repository = VaultRepositoryImpl(vaultDao, tokenRepository, keyShareCipher, passcode)
+        coEvery { vaultDao.loadAllIds() } returns emptyList()
+        repository =
+            VaultRepositoryImpl(
+                vaultDao,
+                tokenRepository,
+                keyShareCipher,
+                passcode,
+                VaultBackupStatusBackfill(vaultDao, FakeAppDataStore()),
+            )
     }
 
     /**
@@ -202,6 +213,73 @@ internal class VaultRepositoryImplTest {
         repository.setVaultName("vault-1", "Renamed")
 
         coVerify { vaultDao.setVaultName("vault-1", "Renamed") }
+    }
+
+    // ---- setBackupStatus ----------------------------------------------------
+
+    /** Verifies [VaultRepository.setBackupStatus] writes the flag without rewriting the vault. */
+    @Test
+    fun `setBackupStatus delegates to dao with vault id and flag`() = runTest {
+        repository.setBackupStatus("vault-1", true)
+
+        coVerify { vaultDao.setBackupStatus(vaultId = "vault-1", isBackedUp = true) }
+    }
+
+    /** Verifies the flag stored on the vault row reaches the [Vault] a caller reads. */
+    @Test
+    fun `get carries the backup flag off the vault row`() = runTest {
+        val stored = makeVaultWithTokens()
+        coEvery { vaultDao.loadById("vault-1") } returns
+            stored.copy(vault = stored.vault.copy(isBackedUp = true))
+
+        assertTrue(repository.get("vault-1")!!.isBackedUp)
+    }
+
+    /** Verifies a vault row with no flag set reads as not backed up rather than as safe. */
+    @Test
+    fun `get reports a vault with no flag as not backed up`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns makeVaultWithTokens()
+
+        assertEquals(false, repository.get("vault-1")?.isBackedUp)
+    }
+
+    /**
+     * Verifies an upsert writes the flag the vault carries.
+     *
+     * This is what clears the flag on reshare: the ceremony builds a fresh [Vault], which defaults
+     * to not-backed-up, and overwriting the row with it retires every `.vult` taken of the old
+     * shares.
+     */
+    @Test
+    fun `upsert writes the backup flag the vault carries`() = runTest {
+        val captured = slot<VaultWithKeySharesAndTokens>()
+        coJustRun { vaultDao.upsert(capture(captured)) }
+
+        repository.upsert(Vault(id = "vault-1", name = "V"))
+
+        assertEquals(false, captured.captured.vault.isBackedUp)
+
+        repository.upsert(Vault(id = "vault-1", name = "V", isBackedUp = true))
+
+        assertTrue(captured.captured.vault.isBackedUp)
+    }
+
+    /**
+     * Verifies the flags are carried out of preferences before a vault is read, not after.
+     *
+     * A read that ran first would hand the caller a vault flagged not-backed-up on the strength of
+     * a column the backfill had not filled in yet.
+     */
+    @Test
+    fun `a read carries the legacy flags over before loading the vault`() = runTest {
+        coEvery { vaultDao.loadById("vault-1") } returns makeVaultWithTokens()
+
+        repository.get("vault-1")
+
+        coVerifyOrder {
+            vaultDao.loadAllIds()
+            vaultDao.loadById("vault-1")
+        }
     }
 
     // ---- getByEcdsa ---------------------------------------------------------

--- a/data/src/test/kotlin/com/vultisig/wallet/data/sources/FakeAppDataStore.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/sources/FakeAppDataStore.kt
@@ -1,0 +1,35 @@
+package com.vultisig.wallet.data.sources
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+/** In-memory [AppDataStore] holding preferences in a flow, so reads see prior writes. */
+internal class FakeAppDataStore(initial: Preferences = emptyPreferences()) : AppDataStore {
+
+    private val preferences = MutableStateFlow(initial)
+
+    override suspend fun editData(transform: suspend (MutablePreferences) -> Unit): Preferences {
+        val mutable = preferences.value.toMutablePreferences()
+        transform(mutable)
+        return mutable.toPreferences().also { preferences.value = it }
+    }
+
+    override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =
+        preferences.map { it[key] ?: defaultValue }
+
+    override suspend fun <T> set(key: Preferences.Key<T>, value: T) {
+        editData { it[key] = value }
+    }
+
+    override fun <T> readData(key: Preferences.Key<T>): Flow<T?> = preferences.map { it[key] }
+
+    companion object {
+        fun of(vararg entries: Preferences.Pair<*>): FakeAppDataStore =
+            FakeAppDataStore(mutablePreferencesOf(*entries).toPreferences())
+    }
+}


### PR DESCRIPTION
Closes #5578

## One correction to the issue first

The issue says `Vault` has "no backup field — no `isBackedUp`, nothing equivalent". Android has had one since #1239, in preferences at `vault_backup/<vaultId>`: set by all three export paths and by `.vult` import, cleared on reshare, and read by the home-screen warning banner. So the reminder banner the issue asks for already exists, and the flag was already there to read.

What was broken is the part that matters. Three things:

**The default was `true`.** `readBackupStatus` answered `true` for any vault with no stored flag. iOS declares `var isBackedUp: Bool = false` (`Vault.swift:27`) and Windows starts reshared vaults at false.

**Two save paths never wrote a flag,** so they inherited that `true`:

- fast-vault creation hands the vault to `temporaryVaultRepository` and defers the save to OTP verification, which wrote nothing — **a freshly created fast vault read as backed up and never showed the warning banner**
- the `SingleKeygen` MLDSA merge replaces `keyshares` and left the flag standing

**Preferences was the wrong home.** Not on the row means no cascade on delete (orphaned keys), and nothing can read the flag alongside the vault.

That inverted default is what blocks vultisig-sdk#1845: a gate asking "has this vault been exported" can't be built on a flag that answers yes for a vault that hasn't been.

## What this does

- `Vault.isBackedUp` + `VaultEntity.isBackedUp`, DB 41 → 42 (`ALTER TABLE vault ADD COLUMN isBackedUp INTEGER NOT NULL DEFAULT 0`)
- `VaultRepository.setBackupStatus` writes that one column rather than rewriting the row — the export paths hold a vault they read before writing the file, and an upsert from it would echo back whatever changed since, including keyshares a lock dropped mid-export
- the preferences flag and its `true` default are deleted outright, so the inverted default has no way back
- `VaultBackupStatusBackfill` carries the old flags across: SQL cannot read DataStore, so without a code-side pass everyone already holding a `.vult` would be told to back up again. Once per install under a mutex; row writes ahead of the edit that drops the legacy keys and records completion, so a run that dies midway stays re-derivable from the keys still in place. A vault with no stored flag stays `false` — unknown is not the same as safe. Swept by key prefix, which also clears the flags orphaned by deleted vaults
- the repository runs that pass **before** every vault read and before `upsert`/`setBackupStatus`. A read that ran first would return a vault flagged not-backed-up on the strength of a column the pass hadn't filled in; a backfill landing behind a reshare's write would put the old `true` back over it
- both MLDSA merges (`KeygenViewModel`, `FastVaultVerificationViewModel`) clear the flag. A `.vult` from before an MLDSA ceremony holds no MLDSA share, so restoring it yields a vault that cannot sign on QBTC — stale the same way a reshared vault's backup is
- keygen, reshare and migrate need nothing new: they upsert a freshly built vault, which carries the cleared default. That is also what fixes fast vaults
- the home banner reads `!vault.isBackedUp` off the vault it already loaded, one read fewer

## Two flag writes lost their `withContext(Dispatchers.IO)`

Room's suspend DAO calls already dispatch off the main thread, so the hop bought nothing — and it was leaking a coroutine past `resetMain` in the ViewModel tests. The `:app` suite failed roughly two runs in three before it went; it is green three consecutive runs now.

## Test plan

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — **4,702 pass, 0 fail** (2,748 `:data`, 1,954 `:app`), full `:app` suite run three times for the flakiness above
- `./gradlew :app:lintDebug :data:lintDebug` — clean; ktfmt clean
- New coverage:
  - `VaultBackupStatusBackfillTest` (12) — a legacy `true` is carried over; no stored flag and an explicit `false` both stay not-backed-up; legacy keys dropped and completion recorded; an orphan from a deleted vault dropped; unrelated preferences untouched; a later run in a new process does nothing; repeat and concurrent callers run the pass once; a failed run neither propagates nor gives up
  - `Migration41To42Test` — pins `DEFAULT 0`; a default of 1 would hand every row a backup it may not have
  - `VaultRepositoryImplTest` (+5) — flag round-trips both ways, a row with no flag reads false, `setBackupStatus` delegates, and the backfill is ordered ahead of the read
  - `VaultAccountsViewModelTest` (+2) — banner shows for a never-exported vault, hides for an exported one
  - `FastVaultVerificationViewModelTest` (+1) — the MLDSA merge clears the flag on the vault it writes back

Manual: fresh fast vault → home shows the backup warning (it did not before); export → warning clears; reshare → warning returns.

## Notes

- `#5565` (partial-keyshare export) is #5569, approved. This does not depend on it to land, but the "set only after a complete export" guarantee is only true once it does — the flag is set on export success, and #5569 is what makes that success mean the file is complete.
- Untouched: the monthly global backup reminder (`IsGlobalBackupReminderRequiredUseCase`), which is a separate, time-based nag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault backup status is now stored with each vault.
  * Existing backup statuses are migrated automatically.
  * Backup status updates are preserved when vaults are saved or modified.
  * Backup warnings now reflect whether a vault has been backed up.

* **Bug Fixes**
  * Vault changes and key-share merges now correctly clear outdated backup status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->